### PR TITLE
Add audio subtitle extraction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "pysubs2>=1.8.0",
     "setuptools>=76.0.0",
     "snownlp>=0.12.3",
+    "pydub>=0.25.1",
 ]
 
 [dependency-groups]

--- a/scinoephile/audio/__init__.py
+++ b/scinoephile/audio/__init__.py
@@ -1,0 +1,11 @@
+"""Audio utilities."""
+
+from __future__ import annotations
+
+from scinoephile.audio.audio_series import AudioSubtitleSeries
+from scinoephile.audio.audio_subtitle import AudioSubtitle
+
+__all__ = [
+    "AudioSubtitle",
+    "AudioSubtitleSeries",
+]

--- a/scinoephile/audio/audio_series.py
+++ b/scinoephile/audio/audio_series.py
@@ -1,0 +1,87 @@
+# Copyright 2017-2025 Karl T Debiec. All rights reserved. This software may be modified
+# and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Series of subtitles with audio clips."""
+from __future__ import annotations
+
+from logging import info
+from pathlib import Path
+from typing import Any
+
+from pydub import AudioSegment
+
+from scinoephile.audio.audio_subtitle import AudioSubtitle
+from scinoephile.common.validation import (
+    validate_input_file,
+    validate_output_directory,
+    validate_output_file,
+)
+from scinoephile.core import Series
+
+
+class AudioSubtitleSeries(Series):
+    """Series of subtitles with audio clips."""
+
+    event_class = AudioSubtitle
+    events: list[AudioSubtitle]  # pyright: ignore[reportIncompatibleVariableOverride]
+
+    @classmethod
+    def from_video(
+        cls, video_path: str | Path, subtitles: Series
+    ) -> AudioSubtitleSeries:
+        """Load audio from a video file and slice into clips.
+
+        Arguments:
+            video_path: Path to video or audio file
+            subtitles: Subtitle series providing timing and text
+        Returns:
+            AudioSubtitleSeries with audio clips for each subtitle
+        """
+        video_path = validate_input_file(video_path)
+        audio = AudioSegment.from_file(str(video_path))
+
+        series = cls()
+        series.events = []
+        for sub in subtitles.events:
+            clip = audio[sub.start : sub.end]
+            series.events.append(
+                cls.event_class(
+                    start=sub.start,
+                    end=sub.end,
+                    text=sub.text,
+                    audio=clip,
+                    series=series,
+                )
+            )
+        return series
+
+    def save(self, path: str | Path, format_: str | None = None, **kwargs: Any) -> None:
+        """Save series to an output file or directory of audio clips."""
+        path = Path(path)
+
+        if format_ == "wav" or (not format_ and path.suffix == ""):
+            path = validate_output_directory(path)
+            self._save_wav(path)
+            info(f"Saved series to {path}")
+            return
+
+        path = validate_output_file(path)
+        super().save(str(path), format_=format_, **kwargs)
+        info(f"Saved series to {path}")
+
+    def _save_wav(self, fp: Path) -> None:
+        """Save series as a directory of wav files with accompanying srt."""
+        if fp.exists() and fp.is_dir():
+            for file in fp.iterdir():
+                file.unlink()
+                info(f"Deleted {file}")
+        else:
+            fp.mkdir(parents=True)
+            info(f"Created directory {fp}")
+
+        for i, event in enumerate(self.events, 1):
+            outfile = fp / f"{i:04d}_{event.start:08d}_{event.end:08d}.wav"
+            event.audio.export(outfile, format="wav")
+            info(f"Saved audio to {outfile}")
+
+        outfile = fp / f"{fp.stem}.srt"
+        Series.save(self, str(outfile), format_="srt")

--- a/scinoephile/audio/audio_subtitle.py
+++ b/scinoephile/audio/audio_subtitle.py
@@ -1,0 +1,28 @@
+# Copyright 2017-2025 Karl T Debiec. All rights reserved. This software may be modified
+# and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Individual subtitle with audio clip."""
+from __future__ import annotations
+
+from dataclasses import fields
+from typing import Any
+
+from pydub.audio_segment import AudioSegment
+
+from scinoephile.core import Subtitle
+
+
+class AudioSubtitle(Subtitle):
+    """Individual subtitle with audio clip."""
+
+    def __init__(self, audio: AudioSegment, **kwargs: Any) -> None:
+        """Initialize.
+
+        Arguments:
+            audio: Audio segment for this subtitle
+            **kwargs: Additional keyword arguments
+        """
+        super_field_names = {f.name for f in fields(Subtitle)}
+        super_kwargs = {k: v for k, v in kwargs.items() if k in super_field_names}
+        super().__init__(**super_kwargs)
+
+        self.audio = audio

--- a/test/audio/__init__.py
+++ b/test/audio/__init__.py
@@ -1,0 +1,1 @@
+"""Fixtures and tests for audio utilities."""

--- a/test/audio/test_audio_series.py
+++ b/test/audio/test_audio_series.py
@@ -1,0 +1,57 @@
+"""Tests for :mod:`scinoephile.audio`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydub.generators import Sine
+
+from scinoephile.audio import AudioSubtitleSeries
+from scinoephile.core import Series, Subtitle
+
+
+@pytest.fixture()
+def sample_audio_file(tmp_path: Path) -> Path:
+    """Create a small sine wave audio file for testing."""
+    path = tmp_path / "sample.wav"
+    tone = Sine(440).to_audio_segment(duration=3000)
+    tone.export(path, format="wav")
+    return path
+
+
+@pytest.fixture()
+def sample_series() -> Series:
+    """Series of three one-second subtitles."""
+    series = Series()
+    series.events = [
+        Subtitle(start=0, end=1000, text="one", series=series),
+        Subtitle(start=1000, end=2000, text="two", series=series),
+        Subtitle(start=2000, end=3000, text="three", series=series),
+    ]
+    return series
+
+
+def test_audio_subtitle_series_creation(
+    sample_audio_file: Path, sample_series: Series
+) -> None:
+    """Audio clips match subtitle durations."""
+    audio_series = AudioSubtitleSeries.from_video(str(sample_audio_file), sample_series)
+    assert len(audio_series.events) == 3
+    for event in audio_series.events:
+        assert abs(len(event.audio) - 1000) <= 1
+
+
+def test_audio_subtitle_series_save(
+    tmp_path: Path, sample_audio_file: Path, sample_series: Series
+) -> None:
+    """Saving produces individual clips and an ``.srt`` file."""
+    audio_series = AudioSubtitleSeries.from_video(str(sample_audio_file), sample_series)
+    out_dir = tmp_path / "clips"
+    audio_series.save(out_dir, format_="wav")
+
+    files = list(out_dir.glob("*.wav"))
+    assert len(files) == 3
+    srt_file = out_dir / f"{out_dir.stem}.srt"
+    assert srt_file.exists()
+    assert srt_file.stat().st_size > 0


### PR DESCRIPTION
## Summary
- support audio clip subtitles
- save audio subtitle series as wav files
- test AudioSubtitle and AudioSubtitleSeries
- include pydub dependency

## Testing
- `ruff check scinoephile/audio test/audio`
- `pyright scinoephile/audio test/audio/test_audio_series.py`
- `pytest test/audio/test_audio_series.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847a85c68b8832583d69fffd7201195