### PR TITLE
Abstract LLM provider

### DIFF
--- a/scinoephile/core/abcs/__init__.py
+++ b/scinoephile/core/abcs/__init__.py
@@ -5,12 +5,14 @@
 from __future__ import annotations
 
 from scinoephile.core.abcs.answer import Answer
+from scinoephile.core.abcs.llm_provider import LLMProvider
 from scinoephile.core.abcs.llm_queryer import LLMQueryer
 from scinoephile.core.abcs.query import Query
 from scinoephile.core.abcs.test_case import TestCase
 
 __all__ = [
     "Answer",
+    "LLMProvider",
     "LLMQueryer",
     "Query",
     "TestCase",

--- a/scinoephile/core/abcs/llm_provider.py
+++ b/scinoephile/core/abcs/llm_provider.py
@@ -17,6 +17,8 @@ class LLMProvider(ABC):
         model: str,
         messages: list[dict[str, Any]],
         temperature: float = 0.0,
+        seed: int | None = None,
+        response_format: Any | None = None,
     ) -> str:
         """Return chat completion text."""
         raise NotImplementedError()

--- a/scinoephile/core/abcs/llm_provider.py
+++ b/scinoephile/core/abcs/llm_provider.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any
 
+from scinoephile.core.abcs.answer import Answer
+
 
 class LLMProvider(ABC):
     """Abstract base class for LLM providers."""
@@ -18,7 +20,7 @@ class LLMProvider(ABC):
         messages: list[dict[str, Any]],
         temperature: float = 0.0,
         seed: int | None = None,
-        response_format: Any | None = None,
+        response_format: type[Answer] | None = None,
     ) -> str:
         """Return chat completion text."""
         raise NotImplementedError()

--- a/scinoephile/core/abcs/llm_provider.py
+++ b/scinoephile/core/abcs/llm_provider.py
@@ -1,0 +1,22 @@
+# Copyright 2017-2025 Karl T Debiec. All rights reserved. This software may be modified
+# and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Interfaces for large language model providers."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class LLMProvider(ABC):
+    """Abstract base class for LLM providers."""
+
+    @abstractmethod
+    def chat_completion(
+        self,
+        model: str,
+        messages: list[dict[str, Any]],
+        temperature: float = 0.0,
+    ) -> str:
+        """Return chat completion text."""
+        raise NotImplementedError()

--- a/scinoephile/core/abcs/llm_queryer.py
+++ b/scinoephile/core/abcs/llm_queryer.py
@@ -11,11 +11,11 @@ from logging import error, info
 from pathlib import Path
 from textwrap import dedent
 
-from openai import OpenAI
 from pydantic import ValidationError
 
 from scinoephile.common.validation import validate_output_directory
 from scinoephile.core.abcs.answer import Answer
+from scinoephile.core.abcs.llm_provider import LLMProvider
 from scinoephile.core.abcs.query import Query
 from scinoephile.core.abcs.test_case import TestCase
 
@@ -29,16 +29,18 @@ class LLMQueryer[TQuery: Query, TAnswer: Answer, TTestCase: TestCase](ABC):
         examples: list[TTestCase] | None = None,
         print_test_case: bool = False,
         cache_dir_path: str | None = None,
+        provider: LLMProvider | None = None,
     ):
         """Initialize.
 
         Arguments:
-            model: OpenAI model to use
+            model: Model to use
             examples: Examples of inputs and expected outputs for few-shot learning
             print_test_case: Whether to print test case after merging
             cache_dir_path: Directory in which to cache
+            provider: Provider to use for queries
         """
-        self.client = OpenAI()
+        self.provider = provider
         self.model = model
         self.print_test_case = print_test_case
 
@@ -85,19 +87,15 @@ class LLMQueryer[TQuery: Query, TAnswer: Answer, TTestCase: TestCase](ABC):
                     print(test_case.to_source())
                 return answer
 
-        # Process using OpenAI API
-        response = self.client.beta.chat.completions.parse(
+        # Query provider
+        content = self.provider.chat_completion(
             model=self.model,
             messages=[
                 {"role": "system", "content": self.system_prompt},
                 {"role": "user", "content": query_prompt},
             ],
             temperature=0,
-            seed=0,
-            response_format=self.answer_cls,
         )
-        message = response.choices[0].message
-        content = message.content
 
         # Validate answer
         try:

--- a/scinoephile/core/abcs/llm_queryer.py
+++ b/scinoephile/core/abcs/llm_queryer.py
@@ -95,6 +95,8 @@ class LLMQueryer[TQuery: Query, TAnswer: Answer, TTestCase: TestCase](ABC):
                 {"role": "user", "content": query_prompt},
             ],
             temperature=0,
+            seed=0,
+            response_format={"type": "json_object"},
         )
 
         # Validate answer

--- a/scinoephile/core/abcs/llm_queryer.py
+++ b/scinoephile/core/abcs/llm_queryer.py
@@ -16,6 +16,7 @@ from pydantic import ValidationError
 from scinoephile.common.validation import validate_output_directory
 from scinoephile.core.abcs.answer import Answer
 from scinoephile.core.abcs.llm_provider import LLMProvider
+from scinoephile.openai.openai_provider import OpenAIProvider
 from scinoephile.core.abcs.query import Query
 from scinoephile.core.abcs.test_case import TestCase
 
@@ -38,9 +39,9 @@ class LLMQueryer[TQuery: Query, TAnswer: Answer, TTestCase: TestCase](ABC):
             examples: Examples of inputs and expected outputs for few-shot learning
             print_test_case: Whether to print test case after merging
             cache_dir_path: Directory in which to cache
-            provider: Provider to use for queries
+            provider: Provider to use for queries, defaults to ``OpenAIProvider``
         """
-        self.provider = provider
+        self.provider = provider or OpenAIProvider()
         self.model = model
         self.print_test_case = print_test_case
 
@@ -96,7 +97,7 @@ class LLMQueryer[TQuery: Query, TAnswer: Answer, TTestCase: TestCase](ABC):
             ],
             temperature=0,
             seed=0,
-            response_format={"type": "json_object"},
+            response_format=self.answer_cls,
         )
 
         # Validate answer

--- a/scinoephile/openai/__init__.py
+++ b/scinoephile/openai/__init__.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from scinoephile.openai.openai_provider import OpenAiProvider
+from scinoephile.openai.openai_provider import OpenAIProvider
 from scinoephile.openai.openai_service import OpenAiService
 
 __all__ = [
-    "OpenAiProvider",
+    "OpenAIProvider",
     "OpenAiService",
 ]

--- a/scinoephile/openai/__init__.py
+++ b/scinoephile/openai/__init__.py
@@ -4,8 +4,10 @@
 
 from __future__ import annotations
 
+from scinoephile.openai.openai_provider import OpenAiProvider
 from scinoephile.openai.openai_service import OpenAiService
 
 __all__ = [
+    "OpenAiProvider",
     "OpenAiService",
 ]

--- a/scinoephile/openai/openai_provider.py
+++ b/scinoephile/openai/openai_provider.py
@@ -1,0 +1,34 @@
+# Copyright 2017-2025 Karl T Debiec. All rights reserved. This software may be modified
+# and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""LLM provider that uses the OpenAI API."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from openai import OpenAI
+
+from scinoephile.core.abcs.llm_provider import LLMProvider
+
+
+class OpenAiProvider(LLMProvider):
+    """Provider using OpenAI chat completions."""
+
+    def __init__(self, client: OpenAI | None = None):
+        """Initialize provider."""
+        self.client = client or OpenAI()
+
+    def chat_completion(
+        self,
+        model: str,
+        messages: list[dict[str, Any]],
+        temperature: float = 0.0,
+    ) -> str:
+        """Return chat completion text."""
+        completion = self.client.chat.completions.create(
+            model=model,
+            messages=messages,
+            temperature=temperature,
+            response_format={"type": "json_object"},
+        )
+        return completion.choices[0].message.content

--- a/scinoephile/openai/openai_provider.py
+++ b/scinoephile/openai/openai_provider.py
@@ -11,11 +11,15 @@ from openai import OpenAI
 from scinoephile.core.abcs.llm_provider import LLMProvider
 
 
-class OpenAiProvider(LLMProvider):
+class OpenAIProvider(LLMProvider):
     """Provider using OpenAI chat completions."""
 
     def __init__(self, client: OpenAI | None = None):
-        """Initialize provider."""
+        """Initialize.
+
+        Arguments:
+            client: Optional OpenAI client
+        """
         self.client = client or OpenAI()
 
     def chat_completion(
@@ -23,12 +27,15 @@ class OpenAiProvider(LLMProvider):
         model: str,
         messages: list[dict[str, Any]],
         temperature: float = 0.0,
+        seed: int | None = None,
+        response_format: Any | None = None,
     ) -> str:
         """Return chat completion text."""
         completion = self.client.chat.completions.create(
             model=model,
             messages=messages,
             temperature=temperature,
-            response_format={"type": "json_object"},
+            seed=seed,
+            response_format=response_format or {"type": "json_object"},
         )
         return completion.choices[0].message.content

--- a/scinoephile/openai/openai_provider.py
+++ b/scinoephile/openai/openai_provider.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from openai import OpenAI
 
+from scinoephile.core.abcs.answer import Answer
 from scinoephile.core.abcs.llm_provider import LLMProvider
 
 
@@ -28,14 +29,22 @@ class OpenAIProvider(LLMProvider):
         messages: list[dict[str, Any]],
         temperature: float = 0.0,
         seed: int | None = None,
-        response_format: Any | None = None,
+        response_format: type[Answer] | None = None,
     ) -> str:
         """Return chat completion text."""
-        completion = self.client.chat.completions.create(
-            model=model,
-            messages=messages,
-            temperature=temperature,
-            seed=seed,
-            response_format=response_format or {"type": "json_object"},
-        )
+        if response_format:
+            completion = self.client.beta.chat.completions.parse(
+                model=model,
+                messages=messages,
+                temperature=temperature,
+                seed=seed,
+                response_format=response_format,
+            )
+        else:
+            completion = self.client.chat.completions.create(
+                model=model,
+                messages=messages,
+                temperature=temperature,
+                seed=seed,
+            )
         return completion.choices[0].message.content


### PR DESCRIPTION
## Summary
- introduce `LLMProvider` interface to handle LLM queries
- add `OpenAiProvider` implementing the interface
- update `LLMQueryer` to accept a provider implementation
- expose new provider from `scinoephile.openai`

## Testing
- `uv run ruff check | head`
- `uv run pyright | head`
- `uv run pytest -q | tail -n 2`

------
https://chatgpt.com/codex/tasks/task_e_6873896493e483259ca136b5a7ddce3f