### PR TITLE
Add language navigation links to READMEs

### DIFF
--- a/README.yue-hans.md
+++ b/README.yue-hans.md
@@ -3,10 +3,10 @@
 [![Code Style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![License: BSD 3-Clause](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 
-Scinoephile is a package for working with Chinese/English bilingual subtitles, with a 
-focus on combining separate Chinese and English subtitles into synchronized bilingual
-subtitles.
-
-Other languages: [English](README.md) | [简体中文](README.zh-hans.md) |
+其他语言: [English](README.md) | [简体中文](README.zh-hans.md) |
 [繁體中文](README.zh-hant.md) | [繁體粵文](README.yue-hant.md) |
 [简体粵文](README.yue-hans.md)
+
+Scinoephile 是一个用嚟处理中英文双语字幕嘅套件，
+重点係将分开嘅中文同英文字幕结合成
+同步嘅双语字幕。

--- a/README.yue-hant.md
+++ b/README.yue-hant.md
@@ -3,10 +3,10 @@
 [![Code Style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![License: BSD 3-Clause](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 
-Scinoephile is a package for working with Chinese/English bilingual subtitles, with a 
-focus on combining separate Chinese and English subtitles into synchronized bilingual
-subtitles.
-
-Other languages: [English](README.md) | [简体中文](README.zh-hans.md) |
+其他語言: [English](README.md) | [简体中文](README.zh-hans.md) |
 [繁體中文](README.zh-hant.md) | [繁體粵文](README.yue-hant.md) |
 [简体粵文](README.yue-hans.md)
+
+Scinoephile 係一個用嚟處理中英文雙語字幕嘅套件，
+重點係將分開嘅中文同英文字幕結合成
+同步嘅雙語字幕。

--- a/README.zh-hans.md
+++ b/README.zh-hans.md
@@ -3,10 +3,10 @@
 [![Code Style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![License: BSD 3-Clause](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 
-Scinoephile is a package for working with Chinese/English bilingual subtitles, with a 
-focus on combining separate Chinese and English subtitles into synchronized bilingual
-subtitles.
-
-Other languages: [English](README.md) | [简体中文](README.zh-hans.md) |
+其他语言: [English](README.md) | [简体中文](README.zh-hans.md) |
 [繁體中文](README.zh-hant.md) | [繁體粵文](README.yue-hant.md) |
 [简体粵文](README.yue-hans.md)
+
+Scinoephile 是一个用于处理中英文双语字幕的软件包，
+重点在于将分开的中文和英文字幕合成为
+同步的双语字幕。

--- a/README.zh-hant.md
+++ b/README.zh-hant.md
@@ -3,10 +3,10 @@
 [![Code Style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![License: BSD 3-Clause](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 
-Scinoephile is a package for working with Chinese/English bilingual subtitles, with a 
-focus on combining separate Chinese and English subtitles into synchronized bilingual
-subtitles.
-
-Other languages: [English](README.md) | [简体中文](README.zh-hans.md) |
+其他語言: [English](README.md) | [简体中文](README.zh-hans.md) |
 [繁體中文](README.zh-hant.md) | [繁體粵文](README.yue-hant.md) |
 [简体粵文](README.yue-hans.md)
+
+Scinoephile 是一個用於處理中英文雙語字幕的軟件包，
+重點在於將分開的中文和英文字幕合成為
+同步的雙語字幕。


### PR DESCRIPTION
## Summary
- update links to translated READMEs on the main README
- add language navigation section to each translated README

## Testing
- `uv run ruff format`
- `uv run ruff check` *(fails: D101, PERF401, F841, PLR0912, etc.)*
- `uv run pyright` *(fails with many type errors)*
- `uv run pytest -q` *(fails: OpenAI API key missing)*

------
https://chatgpt.com/codex/tasks/task_e_6874e9f76a2083258968b015e529c30b