### PR TITLE
Add future annotations imports

### DIFF
--- a/scinoephile/__init__.py
+++ b/scinoephile/__init__.py
@@ -1,3 +1,5 @@
 #  Copyright 2017-2025 Karl T Debiec. All rights reserved. This software may be modified
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
 """Code for scinoephile."""
+
+from __future__ import annotations

--- a/scinoephile/audio/models/transcribed_segment.py
+++ b/scinoephile/audio/models/transcribed_segment.py
@@ -2,6 +2,8 @@
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
 """Transcribed segment."""
 
+from __future__ import annotations
+
 from pydantic import BaseModel, Field
 
 from scinoephile.audio.models.transcribed_word import TranscribedWord

--- a/scinoephile/audio/models/transcribed_word.py
+++ b/scinoephile/audio/models/transcribed_word.py
@@ -2,6 +2,8 @@
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
 """Single word within a transcribed segment."""
 
+from __future__ import annotations
+
 from pydantic import BaseModel, Field
 
 


### PR DESCRIPTION
## Summary
- import `annotations` future in `__init__.py`
- import `annotations` future in audio models

## Testing
- `uv run ruff format scinoephile/__init__.py scinoephile/audio/models/transcribed_word.py scinoephile/audio/models/transcribed_segment.py`
- `uv run ruff check --fix scinoephile/__init__.py scinoephile/audio/models/transcribed_word.py scinoephile/audio/models/transcribed_segment.py`
- `uv run pyright scinoephile/__init__.py scinoephile/audio/models/transcribed_word.py scinoephile/audio/models/transcribed_segment.py`
- `uv run pytest` *(fails: cantonese proofreader tests)*

------
https://chatgpt.com/codex/tasks/task_e_6877fa55c890832590a2c4fd7402507b