### PR TITLE
Add Language alias and update signatures

### DIFF
--- a/scinoephile/audio/transcription/whisper_transcriber.py
+++ b/scinoephile/audio/transcription/whisper_transcriber.py
@@ -19,6 +19,7 @@ with catch_warnings():
 from scinoephile.audio.models import TranscribedSegment
 from scinoephile.common.file import get_temp_file_path
 from scinoephile.common.validation import validate_output_directory
+from scinoephile.core.language import Language
 
 
 class WhisperTranscriber:
@@ -27,7 +28,7 @@ class WhisperTranscriber:
     def __init__(
         self,
         model_name: str = "khleeloo/whisper-large-v3-cantonese",
-        language: str = "yue",
+        language: Language = "yue",
         cache_dir_path: str | None = None,
     ):
         """Initialize.

--- a/scinoephile/core/__init__.py
+++ b/scinoephile/core/__init__.py
@@ -12,12 +12,14 @@ from __future__ import annotations
 
 from scinoephile.core.block import Block
 from scinoephile.core.exceptions import ScinoephileError
+from scinoephile.core.language import Language
 from scinoephile.core.series import Series
 from scinoephile.core.subtitle import Subtitle
 
 __all__ = [
     "Block",
     "ScinoephileError",
+    "Language",
     "Series",
     "Subtitle",
 ]

--- a/scinoephile/core/language.py
+++ b/scinoephile/core/language.py
@@ -1,0 +1,19 @@
+# Copyright 2017-2025 Karl T Debiec. All rights reserved. This software may be modified
+# and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Language constants used throughout scinoephile."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+type Language = Literal[
+    "English",
+    "Simplified Chinese",
+    "Traditional Chinese",
+    "yue",
+    "zhongwen",
+    "yuewen",
+]
+"""Supported languages."""
+
+__all__ = ["Language"]

--- a/scinoephile/image/ocr.py
+++ b/scinoephile/image/ocr.py
@@ -9,6 +9,7 @@ from logging import error, info, warning
 from openai import OpenAIError
 
 from scinoephile.core.blocks import get_blocks_by_pause, get_concatenated_series
+from scinoephile.core.language import Language
 from scinoephile.core.pairs import get_pair_blocks_by_pause
 from scinoephile.image import ImageSeries
 from scinoephile.image.base64 import get_base64_image
@@ -18,7 +19,7 @@ from scinoephile.openai import OpenAiService
 def get_transcriptions(
     openai_service: OpenAiService,
     series: ImageSeries,
-    language: str = "English",
+    language: Language = "English",
 ) -> ImageSeries:
     """Get transcriptions of text from images.
 

--- a/scinoephile/openai/openai_service.py
+++ b/scinoephile/openai/openai_service.py
@@ -9,6 +9,8 @@ import json
 from openai import OpenAI
 from pydantic import BaseModel
 
+from scinoephile.core.language import Language
+
 
 class OpenAiService:
     """Service for interacting with OpenAI API."""
@@ -24,7 +26,9 @@ class OpenAiService:
         self.temperature = temperature
         self.client = OpenAI()
 
-    def get_transcription(self, base64_image: str, language: str = "English") -> str:
+    def get_transcription(
+        self, base64_image: str, language: Language = "English"
+    ) -> str:
         """Get transcription of text from an image.
 
         Arguments:
@@ -83,7 +87,7 @@ class OpenAiService:
         return transcription
 
     def get_revision(
-        self, base64_image: str, current_text: str, language: str = "English"
+        self, base64_image: str, current_text: str, language: Language = "English"
     ) -> str:
         """Get revised transcription of text from an image.
 


### PR DESCRIPTION
## Summary
- add `Language` typed alias in new `scinoephile.core.language`
- export `Language` from `scinoephile.core`
- use `Language` for OpenAI transcription functions
- use `Language` in `WhisperTranscriber`
- type the language option in OCR utilities

## Testing
- `uv run ruff format scinoephile/core/language.py scinoephile/core/__init__.py scinoephile/openai/openai_service.py scinoephile/audio/transcription/whisper_transcriber.py scinoephile/image/ocr.py`
- `uv run ruff check --fix scinoephile/core/language.py scinoephile/core/__init__.py scinoephile/openai/openai_service.py scinoephile/audio/transcription/whisper_transcriber.py scinoephile/image/ocr.py`
- `uv run pyright scinoephile/core/language.py scinoephile/core/__init__.py scinoephile/openai/openai_service.py scinoephile/audio/transcription/whisper_transcriber.py scinoephile/image/ocr.py`
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68791e253ca483259ba8f3341dda1df9