### PR TITLE
Add git hook setup and pre-commit enforcement

### DIFF
--- a/scripts/git_hooks/pre-commit
+++ b/scripts/git_hooks/pre-commit
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Pre-commit hook to enforce branch naming rules
+
+branch=$(git symbolic-ref --quiet --short HEAD)
+
+if [[ "$branch" == "master" || "$branch" == "main" ]]; then
+    echo "Direct commits to master are not allowed. Create a feature branch." >&2
+    exit 1
+fi
+
+if [[ ! "$branch" =~ ^feature/.* ]]; then
+    echo "Branch names must start with 'feature/'. Current branch: '$branch'." >&2
+    exit 1
+fi
+
+exit 0

--- a/scripts/git_hooks/pre-commit
+++ b/scripts/git_hooks/pre-commit
@@ -3,12 +3,17 @@
 
 branch=$(git symbolic-ref --quiet --short HEAD)
 
-if [[ "$branch" == "master" || "$branch" == "main" ]]; then
+# Skip check if not on a branch (e.g., during rebase)
+if [[ -z $branch ]]; then
+    exit 0
+fi
+
+if [[ $branch == master || $branch == main ]]; then
     echo "Direct commits to master are not allowed. Create a feature branch." >&2
     exit 1
 fi
 
-if [[ ! "$branch" =~ ^feature/.* ]]; then
+if [[ $branch != feature/* ]]; then
     echo "Branch names must start with 'feature/'. Current branch: '$branch'." >&2
     exit 1
 fi

--- a/scripts/setup_git_hooks.ps1
+++ b/scripts/setup_git_hooks.ps1
@@ -1,0 +1,13 @@
+#!/usr/bin/env pwsh
+$ErrorActionPreference = "Stop"
+
+$scriptDir = $PSScriptRoot
+$projectRoot = Join-Path $scriptDir ".." | Resolve-Path | Select-Object -ExpandProperty Path
+$hooksSrc = Join-Path $projectRoot "scripts/git_hooks"
+$hooksDest = Join-Path $projectRoot ".git/hooks"
+
+Get-ChildItem $hooksSrc | ForEach-Object {
+    $dest = Join-Path $hooksDest $_.Name
+    Copy-Item $_.FullName $dest -Force
+    Write-Host "Installed $($_.Name)" 1>&2
+}

--- a/scripts/setup_git_hooks.sh
+++ b/scripts/setup_git_hooks.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+set -o pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+project_root="$(cd "$script_dir/.." && pwd)"
+
+hooks_src="$project_root/scripts/git_hooks"
+hooks_dest="$project_root/.git/hooks"
+
+for hook in "$hooks_src"/*; do
+    hook_name="$(basename "$hook")"
+    cp "$hook" "$hooks_dest/$hook_name"
+    chmod +x "$hooks_dest/$hook_name"
+    echo "Installed $hook_name" >&2
+done


### PR DESCRIPTION
## Summary
- add pre-commit hook that blocks commits to `master`/`main` and enforces `feature/*` naming
- add shell and PowerShell scripts to install git hooks
- move git_hooks folder under `scripts/`
- document running the setup scripts
- remove README hook instructions

## Testing
- `uv run pytest` *(fails: 101 failed, 308 passed, 101 xfailed)*

------
https://chatgpt.com/codex/tasks/task_e_687f72e6e6e083258143c3ebe29c2695