### PR TITLE
Add placeholder Cantonese audio tests for MNT and T

### DIFF
--- a/test/audio/cantonese/test_distribution.py
+++ b/test/audio/cantonese/test_distribution.py
@@ -10,6 +10,8 @@ from scinoephile.audio.cantonese.distribution import DistributeTestCase, Distrib
 from scinoephile.testing import test_data_root
 from scinoephile.testing.mark import skip_if_ci
 from test.data.mlamd import mlamd_distribute_test_cases  # noqa: F401
+from test.data.mnt.distribution import mnt_distribute_test_cases  # noqa: F401
+from test.data.t.distribution import t_distribute_test_cases  # noqa: F401
 
 
 @pytest.fixture
@@ -76,6 +78,98 @@ def test_distribution_mlamd_difficult(
     request: pytest.FixtureRequest, fixture_name: str, test_case: DistributeTestCase
 ):
     """Test with MLAMD test cases.
+
+    Arguments:
+        request: Pytest fixture request
+        fixture_name: Name of fixture with which to test
+        test_case: Query and expected answer
+    """
+    distributor: Distributor = request.getfixturevalue(fixture_name)
+    _test_distribution(distributor, test_case)
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        skip_if_ci()("distributor_few_shot"),
+        # skip_if_ci(flaky())("distributor_zero_shot"),
+    ],
+)
+@pytest.mark.parametrize("test_case", mnt_distribute_test_cases)
+def test_distribution_mnt(
+    request: pytest.FixtureRequest, fixture_name: str, test_case: DistributeTestCase
+):
+    """Test with MNT test cases.
+
+    Arguments:
+        request: Pytest fixture request
+        fixture_name: Name of fixture with which to test
+        test_case: Query and expected answer
+    """
+    distributor: Distributor = request.getfixturevalue(fixture_name)
+    _test_distribution(distributor, test_case)
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        skip_if_ci()("distributor_few_shot"),
+        # skip_if_ci(flaky())("distributor_zero_shot"),
+    ],
+)
+@pytest.mark.parametrize(
+    "test_case", [tc for tc in mnt_distribute_test_cases if tc.difficulty >= 1]
+)
+def test_distribution_mnt_difficult(
+    request: pytest.FixtureRequest, fixture_name: str, test_case: DistributeTestCase
+):
+    """Test with MNT test cases.
+
+    Arguments:
+        request: Pytest fixture request
+        fixture_name: Name of fixture with which to test
+        test_case: Query and expected answer
+    """
+    distributor: Distributor = request.getfixturevalue(fixture_name)
+    _test_distribution(distributor, test_case)
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        skip_if_ci()("distributor_few_shot"),
+        # skip_if_ci(flaky())("distributor_zero_shot"),
+    ],
+)
+@pytest.mark.parametrize("test_case", t_distribute_test_cases)
+def test_distribution_t(
+    request: pytest.FixtureRequest, fixture_name: str, test_case: DistributeTestCase
+):
+    """Test with T test cases.
+
+    Arguments:
+        request: Pytest fixture request
+        fixture_name: Name of fixture with which to test
+        test_case: Query and expected answer
+    """
+    distributor: Distributor = request.getfixturevalue(fixture_name)
+    _test_distribution(distributor, test_case)
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        skip_if_ci()("distributor_few_shot"),
+        # skip_if_ci(flaky())("distributor_zero_shot"),
+    ],
+)
+@pytest.mark.parametrize(
+    "test_case", [tc for tc in t_distribute_test_cases if tc.difficulty >= 1]
+)
+def test_distribution_t_difficult(
+    request: pytest.FixtureRequest, fixture_name: str, test_case: DistributeTestCase
+):
+    """Test with T test cases.
 
     Arguments:
         request: Pytest fixture request

--- a/test/audio/cantonese/test_merging.py
+++ b/test/audio/cantonese/test_merging.py
@@ -10,6 +10,8 @@ from scinoephile.audio.cantonese.merging import Merger, MergeTestCase
 from scinoephile.testing import test_data_root
 from scinoephile.testing.mark import skip_if_ci
 from test.data.mlamd import mlamd_merge_test_cases  # noqa: F401
+from test.data.mnt.merging import mnt_merge_test_cases  # noqa: F401
+from test.data.t.merging import t_merge_test_cases  # noqa: F401
 
 
 @pytest.fixture
@@ -74,6 +76,98 @@ def test_merging_mlamd_difficult(
     request: pytest.FixtureRequest, fixture_name: str, test_case: MergeTestCase
 ):
     """Test with MLAMD test cases.
+
+    Arguments:
+        request: Pytest fixture request
+        fixture_name: Name of fixture with which to test
+        test_case: Query and expected answer
+    """
+    merger: Merger = request.getfixturevalue(fixture_name)
+    _test_merging(merger, test_case)
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        skip_if_ci()("merger_few_shot"),
+        # skip_if_ci(flaky())("merger_zero_shot"),
+    ],
+)
+@pytest.mark.parametrize("test_case", mnt_merge_test_cases)
+def test_merging_mnt(
+    request: pytest.FixtureRequest, fixture_name: str, test_case: MergeTestCase
+):
+    """Test with MNT test cases.
+
+    Arguments:
+        request: Pytest fixture request
+        fixture_name: Name of fixture with which to test
+        test_case: Query and expected answer
+    """
+    merger: Merger = request.getfixturevalue(fixture_name)
+    _test_merging(merger, test_case)
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        skip_if_ci()("merger_few_shot"),
+        # skip_if_ci(flaky())("merger_zero_shot"),
+    ],
+)
+@pytest.mark.parametrize(
+    "test_case", [tc for tc in mnt_merge_test_cases if tc.difficulty > 1]
+)
+def test_merging_mnt_difficult(
+    request: pytest.FixtureRequest, fixture_name: str, test_case: MergeTestCase
+):
+    """Test with MNT test cases.
+
+    Arguments:
+        request: Pytest fixture request
+        fixture_name: Name of fixture with which to test
+        test_case: Query and expected answer
+    """
+    merger: Merger = request.getfixturevalue(fixture_name)
+    _test_merging(merger, test_case)
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        skip_if_ci()("merger_few_shot"),
+        # skip_if_ci(flaky())("merger_zero_shot"),
+    ],
+)
+@pytest.mark.parametrize("test_case", t_merge_test_cases)
+def test_merging_t(
+    request: pytest.FixtureRequest, fixture_name: str, test_case: MergeTestCase
+):
+    """Test with T test cases.
+
+    Arguments:
+        request: Pytest fixture request
+        fixture_name: Name of fixture with which to test
+        test_case: Query and expected answer
+    """
+    merger: Merger = request.getfixturevalue(fixture_name)
+    _test_merging(merger, test_case)
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        skip_if_ci()("merger_few_shot"),
+        # skip_if_ci(flaky())("merger_zero_shot"),
+    ],
+)
+@pytest.mark.parametrize(
+    "test_case", [tc for tc in t_merge_test_cases if tc.difficulty > 1]
+)
+def test_merging_t_difficult(
+    request: pytest.FixtureRequest, fixture_name: str, test_case: MergeTestCase
+):
+    """Test with T test cases.
 
     Arguments:
         request: Pytest fixture request

--- a/test/audio/cantonese/test_proofing.py
+++ b/test/audio/cantonese/test_proofing.py
@@ -10,6 +10,8 @@ from scinoephile.audio.cantonese.proofing import Proofer, ProofTestCase
 from scinoephile.testing import test_data_root
 from scinoephile.testing.mark import skip_if_ci
 from test.data.mlamd import mlamd_proof_test_cases  # noqa: F401
+from test.data.mnt.proofing import mnt_proof_test_cases  # noqa: F401
+from test.data.t.proofing import t_proof_test_cases  # noqa: F401
 
 
 @pytest.fixture
@@ -76,6 +78,98 @@ def test_proofing_mlamd_difficult(
     request: pytest.FixtureRequest, fixture_name: str, test_case: ProofTestCase
 ):
     """Test with MLAMD test cases.
+
+    Arguments:
+        request: Pytest fixture request
+        fixture_name: Name of fixture with which to test
+        test_case: Query and expected answer
+    """
+    proofer: Proofer = request.getfixturevalue(fixture_name)
+    _test_proofing(proofer, test_case)
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        skip_if_ci()("proofer_few_shot"),
+        # skip_if_ci(flaky())("proofer_zero_shot"),
+    ],
+)
+@pytest.mark.parametrize("test_case", mnt_proof_test_cases)
+def test_proofing_mnt(
+    request: pytest.FixtureRequest, fixture_name: str, test_case: ProofTestCase
+):
+    """Test with MNT test cases.
+
+    Arguments:
+        request: Pytest fixture request
+        fixture_name: Name of fixture with which to test
+        test_case: Query and expected answer
+    """
+    proofer: Proofer = request.getfixturevalue(fixture_name)
+    _test_proofing(proofer, test_case)
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        skip_if_ci()("proofer_few_shot"),
+        # skip_if_ci(flaky())("proofer_zero_shot"),
+    ],
+)
+@pytest.mark.parametrize(
+    "test_case", [tc for tc in mnt_proof_test_cases if tc.difficulty > 1]
+)
+def test_proofing_mnt_difficult(
+    request: pytest.FixtureRequest, fixture_name: str, test_case: ProofTestCase
+):
+    """Test with MNT test cases.
+
+    Arguments:
+        request: Pytest fixture request
+        fixture_name: Name of fixture with which to test
+        test_case: Query and expected answer
+    """
+    proofer: Proofer = request.getfixturevalue(fixture_name)
+    _test_proofing(proofer, test_case)
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        skip_if_ci()("proofer_few_shot"),
+        # skip_if_ci(flaky())("proofer_zero_shot"),
+    ],
+)
+@pytest.mark.parametrize("test_case", t_proof_test_cases)
+def test_proofing_t(
+    request: pytest.FixtureRequest, fixture_name: str, test_case: ProofTestCase
+):
+    """Test with T test cases.
+
+    Arguments:
+        request: Pytest fixture request
+        fixture_name: Name of fixture with which to test
+        test_case: Query and expected answer
+    """
+    proofer: Proofer = request.getfixturevalue(fixture_name)
+    _test_proofing(proofer, test_case)
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        skip_if_ci()("proofer_few_shot"),
+        # skip_if_ci(flaky())("proofer_zero_shot"),
+    ],
+)
+@pytest.mark.parametrize(
+    "test_case", [tc for tc in t_proof_test_cases if tc.difficulty > 1]
+)
+def test_proofing_t_difficult(
+    request: pytest.FixtureRequest, fixture_name: str, test_case: ProofTestCase
+):
+    """Test with T test cases.
 
     Arguments:
         request: Pytest fixture request

--- a/test/audio/cantonese/test_review.py
+++ b/test/audio/cantonese/test_review.py
@@ -11,6 +11,8 @@ from scinoephile.audio.cantonese.review.abcs import ReviewTestCase
 from scinoephile.testing import test_data_root
 from scinoephile.testing.mark import flaky, skip_if_ci
 from test.data.mlamd import mlamd_review_test_cases  # noqa: F401
+from test.data.mnt.review import mnt_review_test_cases  # noqa: F401
+from test.data.t.review import t_review_test_cases  # noqa: F401
 
 
 @pytest.fixture
@@ -63,6 +65,50 @@ def test_review_mlamd(
     request: pytest.FixtureRequest, fixture_name: str, test_case: ReviewTestCase
 ):
     """Test with MLAMD test cases.
+
+    Arguments:
+        request: Pytest fixture request
+        fixture_name: Name of fixture with which to test
+        test_case: Query and expected answer
+    """
+    reviewer: Reviewer = request.getfixturevalue(fixture_name)
+    _test_review(reviewer, test_case)
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        # skip_if_ci()("reviewer_few_shot"),
+        skip_if_ci(flaky())("reviewer_zero_shot"),
+    ],
+)
+@pytest.mark.parametrize("test_case", mnt_review_test_cases)
+def test_review_mnt(
+    request: pytest.FixtureRequest, fixture_name: str, test_case: ReviewTestCase
+):
+    """Test with MNT test cases.
+
+    Arguments:
+        request: Pytest fixture request
+        fixture_name: Name of fixture with which to test
+        test_case: Query and expected answer
+    """
+    reviewer: Reviewer = request.getfixturevalue(fixture_name)
+    _test_review(reviewer, test_case)
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        # skip_if_ci()("reviewer_few_shot"),
+        skip_if_ci(flaky())("reviewer_zero_shot"),
+    ],
+)
+@pytest.mark.parametrize("test_case", t_review_test_cases)
+def test_review_t(
+    request: pytest.FixtureRequest, fixture_name: str, test_case: ReviewTestCase
+):
+    """Test with T test cases.
 
     Arguments:
         request: Pytest fixture request

--- a/test/audio/cantonese/test_shifting.py
+++ b/test/audio/cantonese/test_shifting.py
@@ -10,6 +10,8 @@ from scinoephile.audio.cantonese.shifting import Shifter, ShiftTestCase
 from scinoephile.testing import test_data_root
 from scinoephile.testing.mark import skip_if_ci
 from test.data.mlamd import mlamd_shift_test_cases  # noqa: F401
+from test.data.mnt.shifting import mnt_shift_test_cases  # noqa: F401
+from test.data.t.shifting import t_shift_test_cases  # noqa: F401
 
 
 @pytest.fixture
@@ -75,6 +77,98 @@ def test_shifting_mlamd_difficult(
     request: pytest.FixtureRequest, fixture_name: str, test_case: ShiftTestCase
 ):
     """Test with MLAMD test cases.
+
+    Arguments:
+        request: Pytest fixture request
+        fixture_name: Name of fixture with which to test
+        test_case: Query and expected answer
+    """
+    shifter: Shifter = request.getfixturevalue(fixture_name)
+    _test_shifting(shifter, test_case)
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        skip_if_ci()("shifter_few_shot"),
+        # skip_if_ci(flaky())("shifter_zero_shot"),
+    ],
+)
+@pytest.mark.parametrize("test_case", mnt_shift_test_cases)
+def test_shifting_mnt(
+    request: pytest.FixtureRequest, fixture_name: str, test_case: ShiftTestCase
+):
+    """Test with MNT test cases.
+
+    Arguments:
+        request: Pytest fixture request
+        fixture_name: Name of fixture with which to test
+        test_case: Query and expected answer
+    """
+    shifter: Shifter = request.getfixturevalue(fixture_name)
+    _test_shifting(shifter, test_case)
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        skip_if_ci()("shifter_few_shot"),
+        # skip_if_ci(flaky())("shifter_zero_shot"),
+    ],
+)
+@pytest.mark.parametrize(
+    "test_case", [tc for tc in mnt_shift_test_cases if tc.difficulty >= 1]
+)
+def test_shifting_mnt_difficult(
+    request: pytest.FixtureRequest, fixture_name: str, test_case: ShiftTestCase
+):
+    """Test with MNT test cases.
+
+    Arguments:
+        request: Pytest fixture request
+        fixture_name: Name of fixture with which to test
+        test_case: Query and expected answer
+    """
+    shifter: Shifter = request.getfixturevalue(fixture_name)
+    _test_shifting(shifter, test_case)
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        skip_if_ci()("shifter_few_shot"),
+        # skip_if_ci(flaky())("shifter_zero_shot"),
+    ],
+)
+@pytest.mark.parametrize("test_case", t_shift_test_cases)
+def test_shifting_t(
+    request: pytest.FixtureRequest, fixture_name: str, test_case: ShiftTestCase
+):
+    """Test with T test cases.
+
+    Arguments:
+        request: Pytest fixture request
+        fixture_name: Name of fixture with which to test
+        test_case: Query and expected answer
+    """
+    shifter: Shifter = request.getfixturevalue(fixture_name)
+    _test_shifting(shifter, test_case)
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        skip_if_ci()("shifter_few_shot"),
+        # skip_if_ci(flaky())("shifter_zero_shot"),
+    ],
+)
+@pytest.mark.parametrize(
+    "test_case", [tc for tc in t_shift_test_cases if tc.difficulty >= 1]
+)
+def test_shifting_t_difficult(
+    request: pytest.FixtureRequest, fixture_name: str, test_case: ShiftTestCase
+):
+    """Test with T test cases.
 
     Arguments:
         request: Pytest fixture request

--- a/test/audio/cantonese/test_translation.py
+++ b/test/audio/cantonese/test_translation.py
@@ -11,6 +11,8 @@ from scinoephile.audio.cantonese.translation.abcs import TranslateTestCase
 from scinoephile.testing import test_data_root
 from scinoephile.testing.mark import flaky, skip_if_ci
 from test.data.mlamd import mlamd_translate_test_cases  # noqa: F401
+from test.data.mnt.translation import mnt_translate_test_cases  # noqa: F401
+from test.data.t.translation import t_translate_test_cases  # noqa: F401
 
 
 @pytest.fixture
@@ -63,6 +65,50 @@ def test_translation_mlamd(
     request: pytest.FixtureRequest, fixture_name: str, test_case: TranslateTestCase
 ):
     """Test with MLAMD test cases.
+
+    Arguments:
+        request: Pytest fixture request
+        fixture_name: Name of fixture with which to test
+        test_case: Query and expected answer
+    """
+    translator: Translator = request.getfixturevalue(fixture_name)
+    _test_translation(translator, test_case)
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        skip_if_ci(flaky())("translator_few_shot"),
+        # skip_if_ci(flaky())("translator_zero_shot"),
+    ],
+)
+@pytest.mark.parametrize("test_case", mnt_translate_test_cases)
+def test_translation_mnt(
+    request: pytest.FixtureRequest, fixture_name: str, test_case: TranslateTestCase
+):
+    """Test with MNT test cases.
+
+    Arguments:
+        request: Pytest fixture request
+        fixture_name: Name of fixture with which to test
+        test_case: Query and expected answer
+    """
+    translator: Translator = request.getfixturevalue(fixture_name)
+    _test_translation(translator, test_case)
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        skip_if_ci(flaky())("translator_few_shot"),
+        # skip_if_ci(flaky())("translator_zero_shot"),
+    ],
+)
+@pytest.mark.parametrize("test_case", t_translate_test_cases)
+def test_translation_t(
+    request: pytest.FixtureRequest, fixture_name: str, test_case: TranslateTestCase
+):
+    """Test with T test cases.
 
     Arguments:
         request: Pytest fixture request

--- a/test/data/mnt/distribution.py
+++ b/test/data/mnt/distribution.py
@@ -1,0 +1,16 @@
+#  Copyright 2017-2025 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Test data for MNT."""
+
+from __future__ import annotations
+
+from scinoephile.audio.cantonese.distribution import DistributeTestCase
+
+distribute_test_cases_block_0: list[DistributeTestCase] = []
+
+mnt_distribute_test_cases: list[DistributeTestCase] = sum(
+    (globals()[f"distribute_test_cases_block_{i}"] for i in range(1)), []
+)
+"""MNT 粤文 distribute test cases."""
+
+__all__ = ["mnt_distribute_test_cases"]

--- a/test/data/mnt/merging.py
+++ b/test/data/mnt/merging.py
@@ -1,0 +1,16 @@
+#  Copyright 2017-2025 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Test data for MNT."""
+
+from __future__ import annotations
+
+from scinoephile.audio.cantonese.merging import MergeTestCase
+
+merge_test_cases_block_0: list[MergeTestCase] = []
+
+mnt_merge_test_cases: list[MergeTestCase] = sum(
+    (globals()[f"merge_test_cases_block_{i}"] for i in range(1)), []
+)
+"""MNT 粤文 merging test cases."""
+
+__all__ = ["mnt_merge_test_cases"]

--- a/test/data/mnt/proofing.py
+++ b/test/data/mnt/proofing.py
@@ -1,0 +1,16 @@
+#  Copyright 2017-2025 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Test data for MNT."""
+
+from __future__ import annotations
+
+from scinoephile.audio.cantonese.proofing import ProofTestCase
+
+proof_test_cases_block_0: list[ProofTestCase] = []
+
+mnt_proof_test_cases: list[ProofTestCase] = sum(
+    (globals()[f"proof_test_cases_block_{i}"] for i in range(1)), []
+)
+"""MNT 粤文 proof test cases."""
+
+__all__ = ["mnt_proof_test_cases"]

--- a/test/data/mnt/review.py
+++ b/test/data/mnt/review.py
@@ -1,0 +1,16 @@
+#  Copyright 2017-2025 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Test data for MNT."""
+
+from __future__ import annotations
+
+from scinoephile.audio.cantonese.review.abcs import ReviewTestCase
+
+review_test_case_block_0: list[ReviewTestCase] = []
+
+mnt_review_test_cases: list[ReviewTestCase] = sum(
+    (globals()[f"review_test_case_block_{i}"] for i in range(1)), []
+)
+"""MNT 粤文 review test cases."""
+
+__all__ = ["mnt_review_test_cases"]

--- a/test/data/mnt/shifting.py
+++ b/test/data/mnt/shifting.py
@@ -1,0 +1,16 @@
+#  Copyright 2017-2025 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Test data for MNT."""
+
+from __future__ import annotations
+
+from scinoephile.audio.cantonese.shifting import ShiftTestCase
+
+shift_test_cases_block_0: list[ShiftTestCase] = []
+
+mnt_shift_test_cases: list[ShiftTestCase] = sum(
+    (globals()[f"shift_test_cases_block_{i}"] for i in range(1)), []
+)
+"""MNT 粤文 shifting test cases."""
+
+__all__ = ["mnt_shift_test_cases"]

--- a/test/data/mnt/translation.py
+++ b/test/data/mnt/translation.py
@@ -1,0 +1,16 @@
+#  Copyright 2017-2025 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Test data for MNT."""
+
+from __future__ import annotations
+
+from scinoephile.audio.cantonese.translation.abcs import TranslateTestCase
+
+translate_test_case_block_0: list[TranslateTestCase] = []
+
+mnt_translate_test_cases: list[TranslateTestCase] = sum(
+    (globals()[f"translate_test_case_block_{i}"] for i in range(1)), []
+)
+"""MNT 粤文 translation test cases."""
+
+__all__ = ["mnt_translate_test_cases"]

--- a/test/data/t/distribution.py
+++ b/test/data/t/distribution.py
@@ -1,0 +1,16 @@
+#  Copyright 2017-2025 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Test data for T."""
+
+from __future__ import annotations
+
+from scinoephile.audio.cantonese.distribution import DistributeTestCase
+
+distribute_test_cases_block_0: list[DistributeTestCase] = []
+
+t_distribute_test_cases: list[DistributeTestCase] = sum(
+    (globals()[f"distribute_test_cases_block_{i}"] for i in range(1)), []
+)
+"""T 粤文 distribute test cases."""
+
+__all__ = ["t_distribute_test_cases"]

--- a/test/data/t/merging.py
+++ b/test/data/t/merging.py
@@ -1,0 +1,16 @@
+#  Copyright 2017-2025 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Test data for T."""
+
+from __future__ import annotations
+
+from scinoephile.audio.cantonese.merging import MergeTestCase
+
+merge_test_cases_block_0: list[MergeTestCase] = []
+
+t_merge_test_cases: list[MergeTestCase] = sum(
+    (globals()[f"merge_test_cases_block_{i}"] for i in range(1)), []
+)
+"""T 粤文 merging test cases."""
+
+__all__ = ["t_merge_test_cases"]

--- a/test/data/t/proofing.py
+++ b/test/data/t/proofing.py
@@ -1,0 +1,16 @@
+#  Copyright 2017-2025 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Test data for T."""
+
+from __future__ import annotations
+
+from scinoephile.audio.cantonese.proofing import ProofTestCase
+
+proof_test_cases_block_0: list[ProofTestCase] = []
+
+t_proof_test_cases: list[ProofTestCase] = sum(
+    (globals()[f"proof_test_cases_block_{i}"] for i in range(1)), []
+)
+"""T 粤文 proof test cases."""
+
+__all__ = ["t_proof_test_cases"]

--- a/test/data/t/review.py
+++ b/test/data/t/review.py
@@ -1,0 +1,16 @@
+#  Copyright 2017-2025 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Test data for T."""
+
+from __future__ import annotations
+
+from scinoephile.audio.cantonese.review.abcs import ReviewTestCase
+
+review_test_case_block_0: list[ReviewTestCase] = []
+
+t_review_test_cases: list[ReviewTestCase] = sum(
+    (globals()[f"review_test_case_block_{i}"] for i in range(1)), []
+)
+"""T 粤文 review test cases."""
+
+__all__ = ["t_review_test_cases"]

--- a/test/data/t/shifting.py
+++ b/test/data/t/shifting.py
@@ -1,0 +1,16 @@
+#  Copyright 2017-2025 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Test data for T."""
+
+from __future__ import annotations
+
+from scinoephile.audio.cantonese.shifting import ShiftTestCase
+
+shift_test_cases_block_0: list[ShiftTestCase] = []
+
+t_shift_test_cases: list[ShiftTestCase] = sum(
+    (globals()[f"shift_test_cases_block_{i}"] for i in range(1)), []
+)
+"""T 粤文 shifting test cases."""
+
+__all__ = ["t_shift_test_cases"]

--- a/test/data/t/translation.py
+++ b/test/data/t/translation.py
@@ -1,0 +1,16 @@
+#  Copyright 2017-2025 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Test data for T."""
+
+from __future__ import annotations
+
+from scinoephile.audio.cantonese.translation.abcs import TranslateTestCase
+
+translate_test_case_block_0: list[TranslateTestCase] = []
+
+t_translate_test_cases: list[TranslateTestCase] = sum(
+    (globals()[f"translate_test_case_block_{i}"] for i in range(1)), []
+)
+"""T 粤文 translation test cases."""
+
+__all__ = ["t_translate_test_cases"]


### PR DESCRIPTION
## Summary
- scaffold empty Cantonese audio test case modules for MNT and T data sets
- extend Cantonese audio distribution, merging, proofing, review, shifting, and translation tests to include MNT and T

## Testing
- `uv run ruff format test/audio/cantonese/test_distribution.py test/audio/cantonese/test_merging.py test/audio/cantonese/test_proofing.py test/audio/cantonese/test_review.py test/audio/cantonese/test_shifting.py test/audio/cantonese/test_translation.py test/data/mnt/distribution.py test/data/mnt/merging.py test/data/mnt/proofing.py test/data/mnt/review.py test/data/mnt/shifting.py test/data/mnt/translation.py test/data/t/distribution.py test/data/t/merging.py test/data/t/proofing.py test/data/t/review.py test/data/t/shifting.py test/data/t/translation.py`
- `uv run ruff check test/audio/cantonese/test_distribution.py test/audio/cantonese/test_merging.py test/audio/cantonese/test_proofing.py test/audio/cantonese/test_review.py test/audio/cantonese/test_shifting.py test/audio/cantonese/test_translation.py test/data/mnt/distribution.py test/data/mnt/merging.py test/data/mnt/proofing.py test/data/mnt/review.py test/data/mnt/shifting.py test/data/mnt/translation.py test/data/t/distribution.py test/data/t/merging.py test/data/t/proofing.py test/data/t/review.py test/data/t/shifting.py test/data/t/translation.py`
- `uv run pyright test/audio/cantonese/test_distribution.py test/audio/cantonese/test_merging.py test/audio/cantonese/test_proofing.py test/audio/cantonese/test_review.py test/audio/cantonese/test_shifting.py test/audio/cantonese/test_translation.py test/data/mnt/distribution.py test/data/mnt/merging.py test/data/mnt/proofing.py test/data/mnt/review.py test/data/mnt/shifting.py test/data/mnt/translation.py test/data/t/distribution.py test/data/t/merging.py test/data/t/proofing.py test/data/t/review.py test/data/t/shifting.py test/data/t/translation.py` *(fails: Argument of type "Path" cannot be assigned to parameter "cache_dir_path" of type "str | None")*
- `uv run pytest test/audio/cantonese/test_distribution.py test/audio/cantonese/test_merging.py test/audio/cantonese/test_proofing.py test/audio/cantonese/test_review.py test/audio/cantonese/test_shifting.py test/audio/cantonese/test_translation.py` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6890329128a883258db0b1a7bef0cef3