### PR TITLE
Add async querying support

### DIFF
--- a/scinoephile/core/abcs/dynamic_llm_queryer.py
+++ b/scinoephile/core/abcs/dynamic_llm_queryer.py
@@ -14,7 +14,7 @@ from scinoephile.core.abcs.test_case import TestCase
 
 
 class DynamicLLMQueryer[TQuery: Query, TAnswer: Answer, TTestCase: TestCase](
-    LLMQueryer[Query, Answer, TestCase], ABC
+    LLMQueryer[TQuery, TAnswer, TTestCase], ABC
 ):
     """Abstract base class for LLM queryers whose classes vary between requests."""
 
@@ -23,7 +23,7 @@ class DynamicLLMQueryer[TQuery: Query, TAnswer: Answer, TTestCase: TestCase](
         query: Query,
         answer_cls: type[TAnswer],
         test_case_cls: type[TTestCase],
-    ) -> Answer:
+    ) -> TAnswer:
         """Query LLM.
 
         Arguments:
@@ -34,6 +34,29 @@ class DynamicLLMQueryer[TQuery: Query, TAnswer: Answer, TTestCase: TestCase](
             LLM's answer
         """
         answer = self._call(
+            system_prompt=self.get_system_prompt(answer_cls),
+            query=query,
+            answer_cls=answer_cls,
+            test_case_cls=test_case_cls,
+        )
+        return answer
+
+    async def acall(
+        self,
+        query: Query,
+        answer_cls: type[TAnswer],
+        test_case_cls: type[TTestCase],
+    ) -> TAnswer:
+        """Query LLM asynchronously.
+
+        Arguments:
+            query: Query for LLM
+            answer_cls: Class of answer to return
+            test_case_cls: Class of test case to return
+        Returns:
+            LLM's answer
+        """
+        answer = await self._acall(
             system_prompt=self.get_system_prompt(answer_cls),
             query=query,
             answer_cls=answer_cls,

--- a/scinoephile/core/abcs/fixed_llm_queryer.py
+++ b/scinoephile/core/abcs/fixed_llm_queryer.py
@@ -15,7 +15,7 @@ from scinoephile.core.abcs.test_case import TestCase
 
 
 class FixedLLMQueryer[TQuery: Query, TAnswer: Answer, TTestCase: TestCase](
-    LLMQueryer[Query, Answer, TestCase], ABC
+    LLMQueryer[TQuery, TAnswer, TTestCase], ABC
 ):
     """Abstract base class for LLM queryers whose classes are fixed for all requests."""
 
@@ -28,6 +28,22 @@ class FixedLLMQueryer[TQuery: Query, TAnswer: Answer, TTestCase: TestCase](
             LLM's answer
         """
         answer = self._call(
+            system_prompt=self.system_prompt,
+            query=query,
+            answer_cls=self.answer_cls,
+            test_case_cls=self.test_case_cls,
+        )
+        return answer
+
+    async def acall(self, query: TQuery) -> TAnswer:
+        """Query LLM asynchronously.
+
+        Arguments:
+            query: query for LLM
+        Returns:
+            LLM's answer
+        """
+        answer = await self._acall(
             system_prompt=self.system_prompt,
             query=query,
             answer_cls=self.answer_cls,

--- a/scinoephile/core/abcs/llm_provider.py
+++ b/scinoephile/core/abcs/llm_provider.py
@@ -36,3 +36,27 @@ class LLMProvider(ABC):
             ScinoephileError: Error during chat completion
         """
         raise NotImplementedError()
+
+    @abstractmethod
+    async def achat_completion(
+        self,
+        model: str,
+        messages: list[dict[str, Any]],
+        temperature: float = 0.0,
+        seed: int = 0,
+        response_format: type[Answer] | None = None,
+    ) -> str:
+        """Return chat completion text asynchronously.
+
+        Arguments:
+            model: Model to use for completion
+            messages: Messages to send
+            temperature: Sampling temperature for randomness
+            seed: Seed for reproducibility
+            response_format: Response format
+        Returns:
+            Completion text from the model
+        Raises:
+            ScinoephileError: Error during chat completion
+        """
+        raise NotImplementedError()

--- a/scinoephile/openai/openai_provider.py
+++ b/scinoephile/openai/openai_provider.py
@@ -4,10 +4,11 @@
 
 from __future__ import annotations
 
+import asyncio
 from time import sleep
-from typing import Any, override
+from typing import Any, cast, override
 
-from openai import OpenAI, OpenAIError
+from openai import AsyncOpenAI, OpenAI, OpenAIError
 
 from scinoephile.core import ScinoephileError
 from scinoephile.core.abcs.answer import Answer
@@ -17,13 +18,17 @@ from scinoephile.core.abcs.llm_provider import LLMProvider
 class OpenAIProvider(LLMProvider):
     """OpenAI LLM Provider."""
 
-    def __init__(self, client: OpenAI | None = None):
+    def __init__(
+        self, client: OpenAI | None = None, aclient: AsyncOpenAI | None = None
+    ):
         """Initialize.
 
         Arguments:
             client: OpenAI client
+            aclient: Asynchronous OpenAI client
         """
         self.client = client or OpenAI()
+        self.aclient = aclient or AsyncOpenAI()
 
     @override
     def chat_completion(
@@ -51,7 +56,7 @@ class OpenAIProvider(LLMProvider):
             if response_format:
                 completion = self.client.beta.chat.completions.parse(
                     model=model,
-                    messages=messages,
+                    messages=cast(Any, messages),
                     temperature=temperature,
                     seed=seed,
                     response_format=response_format,
@@ -59,17 +64,66 @@ class OpenAIProvider(LLMProvider):
             else:
                 completion = self.client.chat.completions.create(
                     model=model,
-                    messages=messages,
+                    messages=cast(Any, messages),
                     temperature=temperature,
                     seed=seed,
                 )
-            return completion.choices[0].message.content
+            return cast(str, completion.choices[0].message.content)
         except OpenAIError as exc:
             exc_code = getattr(exc, "code", None)
             exc_type = getattr(exc, "type", None)
             exc_param = getattr(exc, "param", None)
             if exc_code == "rate_limit_exceeded":
                 sleep(1)
+            raise ScinoephileError(
+                f"OpenAI API error ({exc_code=}, {exc_type=} {exc_param=}): {exc}"
+            ) from exc
+
+    @override
+    async def achat_completion(
+        self,
+        model: str,
+        messages: list[dict[str, Any]],
+        temperature: float = 0.0,
+        seed: int = 0,
+        response_format: type[Answer] | None = None,
+    ) -> str:
+        """Complete chat message asynchronously.
+
+        Arguments:
+            model: Model to use for completion
+            messages: Messages to send
+            temperature: Sampling temperature
+            seed: Seed for reproducibility
+            response_format: Response format
+        Returns:
+            Completion text from the model
+        Raises:
+            ScinoephileError: Error during chat completion
+        """
+        try:
+            if response_format:
+                completion = await self.aclient.beta.chat.completions.parse(
+                    model=model,
+                    messages=cast(Any, messages),
+                    temperature=temperature,
+                    seed=seed,
+                    response_format=response_format,
+                )
+            else:
+                completion = await self.aclient.chat.completions.create(
+                    model=model,
+                    messages=cast(Any, messages),
+                    temperature=temperature,
+                    seed=seed,
+                )
+            return cast(str, completion.choices[0].message.content)
+        except OpenAIError as exc:
+            exc_code = getattr(exc, "code", None)
+            exc_type = getattr(exc, "type", None)
+            exc_param = getattr(exc, "param", None)
+            if exc_code == "rate_limit_exceeded":
+                await asyncio.sleep(1)
             raise ScinoephileError(
                 f"OpenAI API error ({exc_code=}, {exc_type=} {exc_param=}): {exc}"
             ) from exc

--- a/test/core/test_llm_queryer_async.py
+++ b/test/core/test_llm_queryer_async.py
@@ -1,0 +1,84 @@
+#  Copyright 2017-2025 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests for asynchronous LLMQueryer."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from functools import cached_property
+from typing import Any
+
+from scinoephile.core.abcs import Answer, FixedLLMQueryer, LLMProvider, Query, TestCase
+
+
+class _StubProvider(LLMProvider):
+    """Stub provider returning a canned response."""
+
+    def __init__(self, response: dict[str, str]):
+        """Initialize.
+
+        Arguments:
+            response: Response to return for any query
+        """
+        self._response = json.dumps(response)
+
+    def chat_completion(
+        self,
+        model: str,
+        messages: list[dict[str, Any]],
+        temperature: float = 0.0,
+        seed: int = 0,
+        response_format: type[Answer] | None = None,
+    ) -> str:
+        """Return canned response."""
+        return self._response
+
+    async def achat_completion(
+        self,
+        model: str,
+        messages: list[dict[str, Any]],
+        temperature: float = 0.0,
+        seed: int = 0,
+        response_format: type[Answer] | None = None,
+    ) -> str:
+        """Return canned response asynchronously."""
+        await asyncio.sleep(0)
+        return self._response
+
+
+class _EchoQuery(Query):
+    """Simple echo query."""
+
+    text: str
+
+
+class _EchoAnswer(Answer):
+    """Simple echo answer."""
+
+    reply: str
+
+
+class _EchoTestCase(TestCase[_EchoQuery, _EchoAnswer], _EchoQuery, _EchoAnswer):
+    """Test case combining query and answer."""
+
+
+class _EchoQueryer(FixedLLMQueryer[_EchoQuery, _EchoAnswer, _EchoTestCase]):
+    """Queryer for echo tests."""
+
+    @cached_property
+    def base_system_prompt(self) -> str:
+        """Base system prompt."""
+        return "Echo the provided text."
+
+
+def test_acall_returns_answer() -> None:
+    """Ensure asynchronous call returns expected answer."""
+
+    async def _run() -> None:
+        provider = _StubProvider({"reply": "pong"})
+        queryer = _EchoQueryer(provider=provider)
+        answer = await queryer.acall(_EchoQuery(text="ping"))
+        assert answer.reply == "pong"
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- support asynchronous chat completions in `LLMProvider` and `OpenAIProvider`
- add async `_acall` in `LLMQueryer` and expose `acall` in dynamic and fixed queryers
- cover new async interface with a dedicated test

## Testing
- `uv run ruff format scinoephile/openai/openai_provider.py scinoephile/core/abcs/llm_queryer.py scinoephile/core/abcs/dynamic_llm_queryer.py scinoephile/core/abcs/fixed_llm_queryer.py test/core/test_llm_queryer_async.py scinoephile/core/abcs/llm_provider.py`
- `uv run ruff check --fix scinoephile/core/abcs/llm_queryer.py scinoephile/core/abcs/dynamic_llm_queryer.py scinoephile/core/abcs/fixed_llm_queryer.py scinoephile/openai/openai_provider.py test/core/test_llm_queryer_async.py scinoephile/core/abcs/llm_provider.py` *(fails: PLR0913, PLR0915)*
- `uv run pyright scinoephile/core/abcs/llm_queryer.py scinoephile/core/abcs/dynamic_llm_queryer.py scinoephile/core/abcs/fixed_llm_queryer.py scinoephile/openai/openai_provider.py scinoephile/core/abcs/llm_provider.py test/core/test_llm_queryer_async.py`
- `uv run pytest test/core/test_llm_queryer_async.py`


------
https://chatgpt.com/codex/tasks/task_e_6894ee3495a08325b03bfe91a6302800