### PR TITLE
Handle OpenAI rate limit wait times

### DIFF
--- a/scinoephile/core/__init__.py
+++ b/scinoephile/core/__init__.py
@@ -11,7 +11,7 @@ Many functions herein follow the naming convention:
 from __future__ import annotations
 
 from scinoephile.core.block import Block
-from scinoephile.core.exceptions import ScinoephileError
+from scinoephile.core.exceptions import RateLimitError, ScinoephileError
 from scinoephile.core.series import Series
 from scinoephile.core.subtitle import Subtitle
 
@@ -57,6 +57,7 @@ def get_sub_merged(subs: list[Subtitle], *, text: str | None = None) -> Subtitle
 
 __all__ = [
     "Block",
+    "RateLimitError",
     "ScinoephileError",
     "Series",
     "Subtitle",

--- a/scinoephile/core/exceptions.py
+++ b/scinoephile/core/exceptions.py
@@ -7,3 +7,21 @@ from __future__ import annotations
 
 class ScinoephileError(Exception):
     """Scinoephile error."""
+
+
+class RateLimitError(ScinoephileError):
+    """Raised when a rate limit is encountered.
+
+    Attributes:
+        wait_time: Number of seconds to wait before retrying if provided.
+    """
+
+    def __init__(self, message: str, wait_time: float | None = None):
+        """Initialize.
+
+        Arguments:
+            message: Description of the rate limit error.
+            wait_time: Number of seconds to wait before retrying if available.
+        """
+        super().__init__(message)
+        self.wait_time = wait_time


### PR DESCRIPTION
## Summary
- add a RateLimitError that stores a retry wait time
- raise rate limit errors from the OpenAI provider with any retry-after hint
- pause retries in the LLM queryer based on the provided wait time for sync and async calls

## Testing
- uv run ruff format scinoephile/core/exceptions.py scinoephile/core/__init__.py scinoephile/openai/openai_provider.py scinoephile/core/abcs/llm_queryer.py
- uv run ruff check --fix scinoephile/core/exceptions.py scinoephile/core/__init__.py scinoephile/openai/openai_provider.py scinoephile/core/abcs/llm_queryer.py *(fails: pre-existing complexity warnings in LLMQueryer)*
- uv run pyright scinoephile/core/exceptions.py scinoephile/core/__init__.py scinoephile/openai/openai_provider.py scinoephile/core/abcs/llm_queryer.py *(fails: pre-existing typing issues in OpenAI provider and LLMQueryer)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69303e9a573c8325bc27e43a879245b0)