### PR TITLE
Add registry for default LLM providers

### DIFF
--- a/scinoephile/core/abcs/__init__.py
+++ b/scinoephile/core/abcs/__init__.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from .answer import Answer
 from .llm_provider import LLMProvider
-from .llm_queryer import LLMQueryer
+from .llm_queryer import LLMQueryer, LLMQueryerOptions
 from .prompt import Prompt
 from .query import Query
 from .test_case import TestCase
@@ -15,6 +15,7 @@ __all__ = [
     "Answer",
     "LLMProvider",
     "LLMQueryer",
+    "LLMQueryerOptions",
     "Prompt",
     "Query",
     "TestCase",

--- a/scinoephile/core/english/proofreading/proofreader.py
+++ b/scinoephile/core/english/proofreading/proofreader.py
@@ -11,6 +11,7 @@ from textwrap import dedent
 
 from scinoephile.common.validation import val_output_path
 from scinoephile.core import Series
+from scinoephile.core.abcs import LLMQueryerOptions
 from scinoephile.core.blocks import get_concatenated_series
 from scinoephile.testing import (
     get_test_cases_from_file_path,
@@ -53,7 +54,7 @@ class EnglishProofreader:
             prompt_test_cases=[tc for tc in test_cases if tc.prompt],
             verified_test_cases=[tc for tc in test_cases if tc.verified],
             cache_dir_path=test_data_root / "cache",
-            auto_verify=auto_verify,
+            query_options=LLMQueryerOptions(auto_verify=auto_verify),
         )
         """Proofreads English subtitles."""
 
@@ -144,12 +145,15 @@ class EnglishProofreader:
         Arguments:
             test_case_path: path to file to create
         """
-        contents = dedent('''
+        contents = dedent(
+            '''
             """English proofreading test cases."""
 
             from __future__ import annotations
 
-            from scinoephile.core.english.proofreading import EnglishProofreadingTestCase
+            from scinoephile.core.english.proofreading import (
+                EnglishProofreadingTestCase,
+            )
 
             # noinspection PyArgumentList
             test_cases = []  # test_cases
@@ -157,7 +161,9 @@ class EnglishProofreader:
 
             __all__ = [
                 "test_cases",
-            ]''').strip()
+            ]
+            '''
+        ).strip()
         test_case_path.parent.mkdir(parents=True, exist_ok=True)
         test_case_path.write_text(contents, encoding="utf-8")
         info(f"Created test case file at {test_case_path}.")

--- a/scinoephile/core/providers.py
+++ b/scinoephile/core/providers.py
@@ -1,0 +1,54 @@
+#  Copyright 2017-2025 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Provider registry for default LLM providers."""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Callable
+
+from scinoephile.core.abcs.llm_provider import LLMProvider
+from scinoephile.core.exceptions import ScinoephileError
+
+__all__ = ["get_default_provider", "register_default_provider"]
+
+
+class _ProviderRegistry:
+    def __init__(self):
+        self.factory: Callable[[], LLMProvider] | None = None
+
+
+_provider_registry = _ProviderRegistry()
+
+
+def register_default_provider(
+    factory: Callable[[], LLMProvider], *, override: bool = False
+):
+    """Register a factory to create the default LLM provider.
+
+    Arguments:
+        factory: Callable that returns an :class:`LLMProvider` instance.
+        override: If True, replace an existing default provider factory.
+    """
+    if _provider_registry.factory is None or override:
+        _provider_registry.factory = factory
+
+
+def get_default_provider() -> LLMProvider:
+    """Return the default LLM provider.
+
+    Returns:
+        Registered default :class:`LLMProvider` instance.
+
+    Raises:
+        ScinoephileError: If no default provider factory has been registered.
+    """
+    if _provider_registry.factory is None:
+        try:
+            importlib.import_module("scinoephile.openai")
+        except ImportError:
+            pass
+
+    if _provider_registry.factory is None:
+        raise ScinoephileError("No default LLMProvider has been registered.")
+    return _provider_registry.factory()

--- a/scinoephile/core/zhongwen/proofreading/proofreader.py
+++ b/scinoephile/core/zhongwen/proofreading/proofreader.py
@@ -11,6 +11,7 @@ from textwrap import dedent
 
 from scinoephile.common.validation import val_output_path
 from scinoephile.core import Series
+from scinoephile.core.abcs import LLMQueryerOptions
 from scinoephile.core.blocks import get_concatenated_series
 from scinoephile.testing import (
     get_test_cases_from_file_path,
@@ -53,7 +54,7 @@ class ZhongwenProofreader:
             prompt_test_cases=[tc for tc in test_cases if tc.prompt],
             verified_test_cases=[tc for tc in test_cases if tc.verified],
             cache_dir_path=test_data_root / "cache",
-            auto_verify=auto_verify,
+            query_options=LLMQueryerOptions(auto_verify=auto_verify),
         )
         """Proofreads 中文 subtitles."""
 
@@ -144,12 +145,15 @@ class ZhongwenProofreader:
         Arguments:
             test_case_path: path to file to create
         """
-        contents = dedent('''
+        contents = dedent(
+            '''
             """中文 proofreading test cases."""
 
             from __future__ import annotations
 
-            from scinoephile.core.zhongwen.proofreading import ZhongwenProofreadingTestCase
+            from scinoephile.core.zhongwen.proofreading import (
+                ZhongwenProofreadingTestCase,
+            )
 
             # noinspection PyArgumentList
             test_cases = []  # test_cases
@@ -157,7 +161,9 @@ class ZhongwenProofreader:
 
             __all__ = [
                 "test_cases",
-            ]''').strip()
+            ]
+            '''
+        ).strip()
         test_case_path.parent.mkdir(parents=True, exist_ok=True)
         test_case_path.write_text(contents, encoding="utf-8")
         info(f"Created test case file at {test_case_path}.")

--- a/scinoephile/image/english/fusion/fuser.py
+++ b/scinoephile/image/english/fusion/fuser.py
@@ -10,6 +10,7 @@ from textwrap import dedent
 
 from scinoephile.common.validation import val_output_path
 from scinoephile.core import ScinoephileError, Series, Subtitle
+from scinoephile.core.abcs import LLMQueryerOptions
 from scinoephile.core.synchronization import are_series_one_to_one
 from scinoephile.testing import (
     get_test_cases_from_file_path,
@@ -52,7 +53,7 @@ class EnglishFuser:
             prompt_test_cases=[tc for tc in test_cases if tc.prompt],
             verified_test_cases=[tc for tc in test_cases if tc.verified],
             cache_dir_path=test_data_root / "cache",
-            auto_verify=auto_verify,
+            query_options=LLMQueryerOptions(auto_verify=auto_verify),
         )
         """Queries LLM to fuse OCRed English subtitles from Google Lens and
         Tesseract."""

--- a/scinoephile/image/zhongwen/fusion/fuser.py
+++ b/scinoephile/image/zhongwen/fusion/fuser.py
@@ -10,6 +10,7 @@ from textwrap import dedent
 
 from scinoephile.common.validation import val_output_path
 from scinoephile.core import ScinoephileError, Series, Subtitle
+from scinoephile.core.abcs import LLMQueryerOptions
 from scinoephile.core.synchronization import are_series_one_to_one
 from scinoephile.testing import (
     get_test_cases_from_file_path,
@@ -52,7 +53,7 @@ class ZhongwenFuser:
             prompt_test_cases=[tc for tc in test_cases if tc.prompt],
             verified_test_cases=[tc for tc in test_cases if tc.verified],
             cache_dir_path=test_data_root / "cache",
-            auto_verify=auto_verify,
+            query_options=LLMQueryerOptions(auto_verify=auto_verify),
         )
         """Queries LLM to fuse OCRed 中文 subtitles from Google Lens and PaddleOCR."""
 

--- a/scinoephile/openai/openai_provider.py
+++ b/scinoephile/openai/openai_provider.py
@@ -13,6 +13,7 @@ from openai import AsyncOpenAI, OpenAI, OpenAIError
 from scinoephile.core import ScinoephileError
 from scinoephile.core.abcs.answer import Answer
 from scinoephile.core.abcs.llm_provider import LLMProvider
+from scinoephile.core.providers import register_default_provider
 
 __all__ = ["OpenAIProvider"]
 
@@ -125,3 +126,6 @@ class OpenAIProvider(LLMProvider):
             raise ScinoephileError(
                 f"OpenAI API error ({exc_code=}, {exc_type=} {exc_param=}): {exc}"
             ) from exc
+
+
+register_default_provider(lambda: OpenAIProvider())


### PR DESCRIPTION
## Summary
- add a core provider registry and expose configuration options for LLM queryers
- switch LLMQueryer to pull default providers from the registry and remove direct OpenAI dependency
- register the OpenAI provider and update callers to pass query options explicitly

## Testing
- uv run ruff check --fix scinoephile/core/abcs/llm_queryer.py scinoephile/core/providers.py scinoephile/openai/openai_provider.py scinoephile/image/english/fusion/fuser.py scinoephile/image/zhongwen/fusion/fuser.py scinoephile/core/english/proofreading/proofreader.py scinoephile/core/zhongwen/proofreading/proofreader.py
- uv run pyright scinoephile/core/abcs/llm_queryer.py scinoephile/core/providers.py scinoephile/openai/openai_provider.py scinoephile/image/english/fusion/fuser.py scinoephile/image/zhongwen/fusion/fuser.py scinoephile/core/english/proofreading/proofreader.py scinoephile/core/zhongwen/proofreading/proofreader.py (fails: existing typing issues)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931c8182204832582002ff4bf5b63b5)