### PR TITLE
Add text classification detectors and tests

### DIFF
--- a/scinoephile/core/text.py
+++ b/scinoephile/core/text.py
@@ -21,7 +21,6 @@ __all__ = [
     "half_to_full_punc",
     "full_to_half_punc",
     "RE_HANZI",
-    "RE_HANZI_RARE",
     "RE_PRIVATE_USE_AREA_BMP",
     "RE_WESTERN",
     "get_char_type",
@@ -154,11 +153,32 @@ half_to_full_punc = {
 full_to_half_punc = {v: k for k, v in half_to_full_punc.items()}
 """Mapping from full-width to half-width punctuation characters."""
 
-RE_HANZI = re.compile(r"[\u4e00-\u9fff]")
-"""Regular expression for Hanzi characters."""
+RE_HANZI = re.compile(
+    r"[\u4e00-\u9fff"
+    r"\u3400-\u4DBF"
+    r"\U00020000-\U0002A6DF"
+    r"\U0002A700-\U0002B73F"
+    r"\U0002B740-\U0002B81F"
+    r"\U0002B820-\U0002CEAF"
+    r"\U0002CEB0-\U0002EBEF"
+    r"\U0002EBF0-\U0002EE5D"
+    r"\U00030000-\U0003134A"
+    r"\U00031350-\U000323AF]"
+)
+"""Regular expression for Hanzi characters.
 
-RE_HANZI_RARE = re.compile(r"[\u3400-\u4DBF]")
-"""Regular expression for rare Hanzi characters."""
+Includes the following Unicode blocks:
+  - CJK Unified Ideographs (U+4E00–U+9FFF)
+  - CJK Unified Ideographs Extension A (U+3400–U+4DBF)
+  - CJK Unified Ideographs Extension B (U+20000–U+2A6DF)
+  - CJK Unified Ideographs Extension C (U+2A700–U+2B73F)
+  - CJK Unified Ideographs Extension D (U+2B740–U+2B81F)
+  - CJK Unified Ideographs Extension E (U+2B820–U+2CEAF)
+  - CJK Unified Ideographs Extension F (U+2CEB0–U+2EBEF)
+  - CJK Unified Ideographs Extension I (U+2EBF0–U+2EE5D)
+  - CJK Unified Ideographs Extension G (U+30000–U+3134A)
+  - CJK Unified Ideographs Extension H (U+31350–U+323AF)
+"""
 
 RE_PRIVATE_USE_AREA_BMP = re.compile(r"[\ue000-\uf8ff]")
 """Regular expression for BMP private-use area code points."""
@@ -195,6 +215,9 @@ def get_char_type(char: str) -> str:
             "\U0002b740" <= char <= "\U0002b81f",  # CJK Unified Ideographs Ext D
             "\U0002b820" <= char <= "\U0002ceaf",  # CJK Unified Ideographs Ext E
             "\U0002ceb0" <= char <= "\U0002ebef",  # CJK Unified Ideographs Ext F
+            "\U0002ebf0" <= char <= "\U0002ee5d",  # CJK Unified Ideographs Ext I
+            "\U00030000" <= char <= "\U0003134a",  # CJK Unified Ideographs Ext G
+            "\U00031350" <= char <= "\U000323af",  # CJK Unified Ideographs Ext H
             "\u3000" <= char <= "\u303f",  # CJK Symbols and Punctuation
         ]
     ):

--- a/scinoephile/lang/cmn/romanization.py
+++ b/scinoephile/lang/cmn/romanization.py
@@ -40,34 +40,6 @@ RE_CMN_PINYIN_NUMBERED = re.compile(rf"^{RE_CMN_PINYIN_BASE}[1-5]$")
 RE_CMN_PROHIBITED_TOKEN = re.compile(r"^(gw|kw|ng)|h$", re.IGNORECASE)
 
 
-def _get_cmn_text_romanized(text: str) -> str:
-    """Get the Mandarin pinyin romanization of Hanzi text.
-
-    Arguments:
-        text: Hanzi text
-    Returns:
-        Mandarin pinyin romanization
-    """
-    text_romanization = ""
-    for line in text.split("\n"):
-        line_romanization = ""
-        for section in line.split():
-            section_romanization = ""
-            for word in jieba.cut(section):
-                if word in full_to_half_punc:
-                    if word in {"＜", "＞"}:
-                        section_romanization += word
-                    else:
-                        section_romanization += full_to_half_punc[word]
-                else:
-                    section_romanization += " " + "".join([a[0] for a in pinyin(word)])
-            line_romanization += "  " + section_romanization.strip()
-        text_romanization += "\n" + line_romanization.strip()
-    text_romanization = text_romanization.strip()
-
-    return text_romanization
-
-
 def get_cmn_pinyin_query_strings(text: str) -> list[str]:
     """Get normalized pinyin query strings for text.
 
@@ -182,3 +154,31 @@ def is_numbered_pinyin(text: str) -> bool:
     if any(RE_CMN_PROHIBITED_TOKEN.search(token) for token in tokens):
         return False
     return all(RE_CMN_PINYIN_NUMBERED.fullmatch(token) for token in tokens)
+
+
+def _get_cmn_text_romanized(text: str) -> str:
+    """Get the Mandarin pinyin romanization of Hanzi text.
+
+    Arguments:
+        text: Hanzi text
+    Returns:
+        Mandarin pinyin romanization
+    """
+    text_romanization = ""
+    for line in text.split("\n"):
+        line_romanization = ""
+        for section in line.split():
+            section_romanization = ""
+            for word in jieba.cut(section):
+                if word in full_to_half_punc:
+                    if word in {"＜", "＞"}:
+                        section_romanization += word
+                    else:
+                        section_romanization += full_to_half_punc[word]
+                else:
+                    section_romanization += " " + "".join([a[0] for a in pinyin(word)])
+            line_romanization += "  " + section_romanization.strip()
+        text_romanization += "\n" + line_romanization.strip()
+    text_romanization = text_romanization.strip()
+
+    return text_romanization

--- a/scinoephile/lang/cmn/romanization.py
+++ b/scinoephile/lang/cmn/romanization.py
@@ -33,7 +33,10 @@ RE_CMN_PINYIN_BASE = (
     r"[A-Za-züÜvV:āáǎàēéěèīíǐìōóǒòūúǔù"
     r"ĀÁǍÀĒÉĚÈĪÍǏÌŌÓǑÒŪÚǓÙêÊḿḾńŃňŇǹǸ]+"
 )
-RE_CMN_PINYIN_TONE_MARKS = re.compile(r"[\u0300\u0301\u0302\u0304\u0308\u030C]")
+# Combining tone marks used for accented pinyin.
+# Note: U+0308 COMBINING DIAERESIS is excluded so numbered inputs like "lüe4"
+# (NFD: "lu" + U+0308) are not treated as accented pinyin.
+RE_CMN_PINYIN_TONE_MARKS = re.compile(r"[\u0300\u0301\u0302\u0304\u030C]")
 RE_CMN_PINYIN = re.compile(rf"^{RE_CMN_PINYIN_BASE}[1-5]?$")
 RE_CMN_PINYIN_ACCENTED = re.compile(rf"^{RE_CMN_PINYIN_BASE}$")
 RE_CMN_PINYIN_NUMBERED = re.compile(rf"^{RE_CMN_PINYIN_BASE}[1-5]$")
@@ -44,8 +47,8 @@ def get_cmn_pinyin_query_strings(text: str) -> list[str]:
     """Get normalized pinyin query strings for text.
 
     Arguments:
-        text: Hanyu Pinyin query text with tone marks and optional apostrophes; tone
-          numbers like ni3 hao3 are not accepted
+        text: Hanyu Pinyin query text with tone marks or tone numbers and optional
+          apostrophes
     Returns:
         normalized pinyin query strings using tone numbers
     """

--- a/scinoephile/lang/cmn/romanization.py
+++ b/scinoephile/lang/cmn/romanization.py
@@ -25,29 +25,64 @@ if TYPE_CHECKING:
 __all__ = [
     "get_cmn_pinyin_query_strings",
     "get_cmn_romanized",
+    "is_accented_pinyin",
+    "is_numbered_pinyin",
 ]
 
-RE_CMN_PINYIN = re.compile(
-    r"^[A-Za-züÜvV:āáǎàēéěèīíǐìōóǒòūúǔù"
-    r"ĀÁǍÀĒÉĚÈĪÍǏÌŌÓǑÒŪÚǓÙêÊḿḾńŃňŇǹǸ]+[1-5]?$"
+RE_CMN_PINYIN_BASE = (
+    r"[A-Za-züÜvV:āáǎàēéěèīíǐìōóǒòūúǔù"
+    r"ĀÁǍÀĒÉĚÈĪÍǏÌŌÓǑÒŪÚǓÙêÊḿḾńŃňŇǹǸ]+"
 )
+RE_CMN_PINYIN_TONE_MARKS = re.compile(r"[\u0300\u0301\u0302\u0304\u0308\u030C]")
+RE_CMN_PINYIN = re.compile(rf"^{RE_CMN_PINYIN_BASE}[1-5]?$")
+RE_CMN_PINYIN_ACCENTED = re.compile(rf"^{RE_CMN_PINYIN_BASE}$")
+RE_CMN_PINYIN_NUMBERED = re.compile(rf"^{RE_CMN_PINYIN_BASE}[1-5]$")
+RE_CMN_PROHIBITED_TOKEN = re.compile(r"^(gw|kw|ng)|h$", re.IGNORECASE)
+
+
+def _get_cmn_text_romanized(text: str) -> str:
+    """Get the Mandarin pinyin romanization of Hanzi text.
+
+    Arguments:
+        text: Hanzi text
+    Returns:
+        Mandarin pinyin romanization
+    """
+    text_romanization = ""
+    for line in text.split("\n"):
+        line_romanization = ""
+        for section in line.split():
+            section_romanization = ""
+            for word in jieba.cut(section):
+                if word in full_to_half_punc:
+                    if word in {"＜", "＞"}:
+                        section_romanization += word
+                    else:
+                        section_romanization += full_to_half_punc[word]
+                else:
+                    section_romanization += " " + "".join([a[0] for a in pinyin(word)])
+            line_romanization += "  " + section_romanization.strip()
+        text_romanization += "\n" + line_romanization.strip()
+    text_romanization = text_romanization.strip()
+
+    return text_romanization
 
 
 def get_cmn_pinyin_query_strings(text: str) -> list[str]:
     """Get normalized pinyin query strings for text.
 
     Arguments:
-        text: raw query text
+        text: Hanyu Pinyin query text with tone marks and optional apostrophes; tone
+          numbers like ni3 hao3 are not accepted
     Returns:
-        normalized pinyin query strings
+        normalized pinyin query strings using tone numbers
     """
-    text = (
-        unicodedata.normalize("NFC", text).replace("’", "'").replace("'", " ").strip()
-    )
-    if not text:
+    nfc_text = unicodedata.normalize("NFC", text).replace("’", "'").replace("'", " ")
+    nfc_text = nfc_text.strip()
+    if not nfc_text:
         return []
 
-    tokens = text.split()
+    tokens = nfc_text.split()
     if not all(RE_CMN_PINYIN.fullmatch(token) for token in tokens):
         return []
 
@@ -88,29 +123,62 @@ def get_cmn_romanized(series: Series, append: bool = True) -> Series:
     return series
 
 
-def _get_cmn_text_romanized(text: str) -> str:
-    """Get the Mandarin pinyin romanization of Hanzi text.
+def is_accented_pinyin(text: str) -> bool:
+    """Check whether text is accented Hanyu Pinyin.
 
     Arguments:
-        text: Hanzi text
+        text: query text
     Returns:
-        Mandarin pinyin romanization
+        whether text appears to be accented pinyin
     """
-    text_romanization = ""
-    for line in text.split("\n"):
-        line_romanization = ""
-        for section in line.split():
-            section_romanization = ""
-            for word in jieba.cut(section):
-                if word in full_to_half_punc:
-                    if word in {"＜", "＞"}:
-                        section_romanization += word
-                    else:
-                        section_romanization += full_to_half_punc[word]
-                else:
-                    section_romanization += " " + "".join([a[0] for a in pinyin(word)])
-            line_romanization += "  " + section_romanization.strip()
-        text_romanization += "\n" + line_romanization.strip()
-    text_romanization = text_romanization.strip()
+    # NFC (Normalization Form C) composes characters so tone vowels like ǎ are
+    # represented as a single code point instead of a base letter + combining mark.
+    nfc_text = unicodedata.normalize("NFC", text)
+    # Apostrophes are treated as syllable separators in pinyin, so normalize them
+    # to spaces for tokenization.
+    nfc_text = nfc_text.replace("’", "'").replace("'", " ").strip()
+    if not nfc_text:
+        return False
+    tokens = nfc_text.split()
+    if any(any(char.isdigit() for char in token) for token in tokens):
+        return False
+    if any(RE_CMN_PROHIBITED_TOKEN.search(token) for token in tokens):
+        return False
+    if not all(RE_CMN_PINYIN_ACCENTED.fullmatch(token) for token in tokens):
+        return False
+    # Use NFD so precomposed characters (e.g., ǎ) expose combining tone marks.
+    # NFD (Normalization Form D) decomposes precomposed tone vowels into base
+    # letter + combining tone mark so we can detect tone marks reliably.
+    nfd_text = unicodedata.normalize("NFD", nfc_text)
+    return bool(RE_CMN_PINYIN_TONE_MARKS.search(nfd_text))
 
-    return text_romanization
+
+def is_numbered_pinyin(text: str) -> bool:
+    """Check whether text is numbered Hanyu Pinyin.
+
+    Arguments:
+        text: query text
+    Returns:
+        whether text appears to be numbered pinyin
+    """
+    # NFC (Normalization Form C) composes characters so tone vowels like ǎ are
+    # represented as a single code point instead of a base letter + combining mark.
+    nfc_text = unicodedata.normalize("NFC", text)
+    # Apostrophes are treated as syllable separators in pinyin, so normalize them
+    # to spaces for tokenization.
+    nfc_text = nfc_text.replace("’", "'").replace("'", " ").strip()
+    if not nfc_text:
+        return False
+    tokens = nfc_text.split()
+    # NFD (Normalization Form D) decomposes precomposed tone vowels into base
+    # letter + combining tone mark so we can detect tone marks reliably.
+    nfd_text = unicodedata.normalize("NFD", nfc_text)
+    if RE_CMN_PINYIN_TONE_MARKS.search(nfd_text):
+        return False
+    if any(token.endswith("5") for token in tokens) and any(
+        token[-1] in {"1", "2", "3", "4"} for token in tokens if token[-1].isdigit()
+    ):
+        return False
+    if any(RE_CMN_PROHIBITED_TOKEN.search(token) for token in tokens):
+        return False
+    return all(RE_CMN_PINYIN_NUMBERED.fullmatch(token) for token in tokens)

--- a/scinoephile/lang/yue/romanization.py
+++ b/scinoephile/lang/yue/romanization.py
@@ -28,6 +28,9 @@ from scinoephile.lang.zho.conversion import get_zho_converter
 __all__ = [
     "get_yue_jyutping_query_strings",
     "get_yue_romanized",
+    "is_accented_yale",
+    "is_numbered_jyutping",
+    "yale_to_jyutping",
 ]
 
 logger = getLogger(__name__)
@@ -36,6 +39,7 @@ data_root = package_root / "data/yue/"
 MAX_YUE_JYUTPING_VARIANTS = 16
 RE_YALE_SEPARATOR = re.compile(r"[\s'’]+")
 RE_YALE_TONE_MARK = re.compile(r"[\u0300\u0301\u0304]")
+RE_YALE_PROHIBITED_CHARACTERS = re.compile(r"[üÜ'’:]")
 YUE_JYUTPING_ONSETS = (
     "b",
     "d",
@@ -181,9 +185,9 @@ def get_yue_jyutping_query_strings(text: str) -> list[str]:
                 )
             ]
 
-    if not _is_yale_query(text):
+    if not is_accented_yale(text):
         return []
-    return _get_yale_query_strings(text)
+    return yale_to_jyutping(text)
 
 
 def get_yue_romanized(series: Series, append: bool = True) -> Series:
@@ -289,7 +293,7 @@ def _get_yale_jyutping_syllables() -> tuple[
     return sorted_yale_syllables, sorted_mapping
 
 
-def _get_yale_query_strings(text: str) -> list[str]:
+def yale_to_jyutping(text: str) -> list[str]:
     """Get candidate Jyutping query strings from Yale text.
 
     Arguments:
@@ -319,7 +323,7 @@ def _get_yale_query_strings(text: str) -> list[str]:
     return [" ".join(variant) for variant in variants]
 
 
-def _is_yale_query(text: str) -> bool:
+def is_accented_yale(text: str) -> bool:
     """Check whether text appears to be Yale romanization.
 
     Arguments:
@@ -327,9 +331,41 @@ def _is_yale_query(text: str) -> bool:
     Returns:
         whether text appears to be Yale romanization
     """
-    if "'" in text:
-        return True
-    return RE_YALE_TONE_MARK.search(unicodedata.normalize("NFD", text)) is not None
+    # NFC (Normalization Form C) composes characters so tone vowels are represented
+    # as single code points instead of base letters + combining marks.
+    normalized = unicodedata.normalize("NFC", text).strip()
+    if not normalized:
+        return False
+    if RE_YALE_PROHIBITED_CHARACTERS.search(normalized) is not None:
+        return False
+    # NFD (Normalization Form D) decomposes precomposed tone vowels into base
+    # letters + combining tone marks so we can detect tone marks reliably.
+    return (
+        RE_YALE_TONE_MARK.search(unicodedata.normalize("NFD", normalized)) is not None
+    )
+
+
+def is_numbered_jyutping(text: str) -> bool:
+    """Check whether text appears to be numbered Jyutping.
+
+    Arguments:
+        text: query text
+    Returns:
+        whether text appears to be numbered Jyutping
+    """
+    # NFC (Normalization Form C) composes characters so tone vowels are represented
+    # as single code points instead of base letters + combining marks.
+    normalized = unicodedata.normalize("NFC", text)
+    normalized = normalized.replace("’", "'").strip().lower()
+    if not normalized:
+        return False
+    condensed = normalized.replace(" ", "").replace("'", "")
+    # Delegate to pycantonese
+    try:
+        parsed = pycantonese.parse_jyutping(condensed)
+    except ValueError:
+        return False
+    return bool(parsed)
 
 
 def _get_yue_character_romanized(hanzi: str) -> str | None:  # noqa: PLR0912, PLR0915

--- a/scinoephile/lang/yue/romanization.py
+++ b/scinoephile/lang/yue/romanization.py
@@ -39,7 +39,7 @@ data_root = package_root / "data/yue/"
 MAX_YUE_JYUTPING_VARIANTS = 16
 RE_YALE_SEPARATOR = re.compile(r"[\s'’]+")
 RE_YALE_TONE_MARK = re.compile(r"[\u0300\u0301\u0304]")
-RE_YALE_PROHIBITED_CHARACTERS = re.compile(r"[üÜ'’:]")
+RE_YALE_PROHIBITED_CHARACTERS = re.compile(r"[üÜ:]")
 YUE_JYUTPING_ONSETS = (
     "b",
     "d",

--- a/scinoephile/lang/zho/conversion/__init__.py
+++ b/scinoephile/lang/zho/conversion/__init__.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING
 
 from opencc import OpenCC
 
+from scinoephile.core.text import RE_HANZI
+
 from .opencc_config import OpenCCConfig
 
 if TYPE_CHECKING:
@@ -20,6 +22,8 @@ __all__ = [
     "get_zho_converted",
     "get_zho_converter",
     "get_zho_text_converted",
+    "is_simplified",
+    "is_traditional",
 ]
 
 conversion_exclusions = {
@@ -109,3 +113,31 @@ def get_zho_text_converted(
                     converted_text = converted_text.replace(trad_char, simp_char)
 
     return converted_text
+
+
+def is_simplified(text: str) -> bool:
+    """Check whether text is simplified Chinese.
+
+    Arguments:
+        text: text to classify
+    Returns:
+        whether text is simplified Chinese
+    """
+    if RE_HANZI.search(text) is None:
+        return False
+    simplified = get_zho_text_converted(text, OpenCCConfig.t2s)
+    return text == simplified
+
+
+def is_traditional(text: str) -> bool:
+    """Check whether text is traditional Chinese.
+
+    Arguments:
+        text: text to classify
+    Returns:
+        whether text is traditional Chinese
+    """
+    if RE_HANZI.search(text) is None:
+        return False
+    traditional = get_zho_text_converted(text, OpenCCConfig.s2t)
+    return text == traditional

--- a/scinoephile/lang/zho/conversion/__init__.py
+++ b/scinoephile/lang/zho/conversion/__init__.py
@@ -125,7 +125,11 @@ def is_simplified(text: str) -> bool:
     """
     if RE_HANZI.search(text) is None:
         return False
-    simplified = get_zho_text_converted(text, OpenCCConfig.t2s)
+    simplified = get_zho_text_converted(
+        text,
+        OpenCCConfig.t2s,
+        apply_exclusions=False,
+    )
     return text == simplified
 
 
@@ -139,5 +143,9 @@ def is_traditional(text: str) -> bool:
     """
     if RE_HANZI.search(text) is None:
         return False
-    traditional = get_zho_text_converted(text, OpenCCConfig.s2t)
+    traditional = get_zho_text_converted(
+        text,
+        OpenCCConfig.s2t,
+        apply_exclusions=False,
+    )
     return text == traditional

--- a/test/lang/cmn/test_is_accented_pinyin.py
+++ b/test/lang/cmn/test_is_accented_pinyin.py
@@ -1,0 +1,24 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests of scinoephile.lang.cmn.romanization.is_accented_pinyin."""
+
+from __future__ import annotations
+
+import pytest
+
+from scinoephile.lang.cmn.romanization import is_accented_pinyin
+from test.lang.detection_cases import DETECTION_CASES
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [(case.text, case.is_accented_pinyin) for case in DETECTION_CASES],
+)
+def test_is_accented_pinyin(text: str, expected: bool):
+    """Detect accented pinyin tokens.
+
+    Arguments:
+        text: text to classify
+        expected: expected accented classification
+    """
+    assert is_accented_pinyin(text) is expected

--- a/test/lang/cmn/test_is_numbered_pinyin.py
+++ b/test/lang/cmn/test_is_numbered_pinyin.py
@@ -1,0 +1,24 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests of scinoephile.lang.cmn.romanization.is_numbered_pinyin."""
+
+from __future__ import annotations
+
+import pytest
+
+from scinoephile.lang.cmn.romanization import is_numbered_pinyin
+from test.lang.detection_cases import DETECTION_CASES
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [(case.text, case.is_numbered_pinyin) for case in DETECTION_CASES],
+)
+def test_is_numbered_pinyin(text: str, expected: bool):
+    """Detect numbered pinyin tokens.
+
+    Arguments:
+        text: text to classify
+        expected: expected numbered classification
+    """
+    assert is_numbered_pinyin(text) is expected

--- a/test/lang/detection_cases.py
+++ b/test/lang/detection_cases.py
@@ -1,0 +1,191 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Shared test cases for script and romanization detection helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class DetectionCase:
+    """Test case for script and romanization detection helpers.
+
+    Attributes:
+        text: input text to classify
+        is_accented_pinyin: expected accented pinyin classification
+        is_numbered_pinyin: expected numbered pinyin classification
+        is_accented_yale: expected accented Yale classification
+        is_numbered_jyutping: expected numbered Jyutping classification
+        is_simplified: expected simplified Chinese classification
+        is_traditional: expected traditional Chinese classification
+    """
+
+    text: str
+    """Input text to classify."""
+
+    is_accented_pinyin: bool
+    """Expected accented pinyin classification."""
+
+    is_numbered_pinyin: bool
+    """Expected numbered pinyin classification."""
+
+    is_accented_yale: bool
+    """Expected accented Yale classification."""
+
+    is_numbered_jyutping: bool
+    """Expected numbered Jyutping classification."""
+
+    is_simplified: bool
+    """Expected simplified Chinese classification."""
+
+    is_traditional: bool
+    """Expected traditional Chinese classification."""
+
+
+DETECTION_CASES: list[DetectionCase] = [
+    DetectionCase(
+        text="nǐ hǎo",
+        is_accented_pinyin=True,
+        is_numbered_pinyin=False,
+        is_accented_yale=False,
+        is_numbered_jyutping=False,
+        is_simplified=False,
+        is_traditional=False,
+    ),
+    DetectionCase(
+        text="lüè",
+        is_accented_pinyin=True,
+        is_numbered_pinyin=False,
+        is_accented_yale=False,
+        is_numbered_jyutping=False,
+        is_simplified=False,
+        is_traditional=False,
+    ),
+    DetectionCase(
+        text="ni3 hao3",
+        is_accented_pinyin=False,
+        is_numbered_pinyin=True,
+        is_accented_yale=False,
+        is_numbered_jyutping=False,
+        is_simplified=False,
+        is_traditional=False,
+    ),
+    DetectionCase(
+        text="lu:e4",
+        is_accented_pinyin=False,
+        is_numbered_pinyin=True,
+        is_accented_yale=False,
+        is_numbered_jyutping=False,
+        is_simplified=False,
+        is_traditional=False,
+    ),
+    DetectionCase(
+        text="lv4",
+        is_accented_pinyin=False,
+        is_numbered_pinyin=True,
+        is_accented_yale=False,
+        is_numbered_jyutping=False,
+        is_simplified=False,
+        is_traditional=False,
+    ),
+    DetectionCase(
+        text="ni hao",
+        is_accented_pinyin=False,
+        is_numbered_pinyin=False,
+        is_accented_yale=False,
+        is_numbered_jyutping=False,
+        is_simplified=False,
+        is_traditional=False,
+    ),
+    DetectionCase(
+        text="néih hóu",
+        is_accented_pinyin=False,
+        is_numbered_pinyin=False,
+        is_accented_yale=True,
+        is_numbered_jyutping=False,
+        is_simplified=False,
+        is_traditional=False,
+    ),
+    DetectionCase(
+        text="gwóngdūngwá",
+        is_accented_pinyin=False,
+        is_numbered_pinyin=False,
+        is_accented_yale=True,
+        is_numbered_jyutping=False,
+        is_simplified=False,
+        is_traditional=False,
+    ),
+    DetectionCase(
+        text="nei5 hou2",
+        is_accented_pinyin=False,
+        is_numbered_pinyin=False,
+        is_accented_yale=False,
+        is_numbered_jyutping=True,
+        is_simplified=False,
+        is_traditional=False,
+    ),
+    DetectionCase(
+        text="gwong2 dung1 waa2",
+        is_accented_pinyin=False,
+        is_numbered_pinyin=False,
+        is_accented_yale=False,
+        is_numbered_jyutping=True,
+        is_simplified=False,
+        is_traditional=False,
+    ),
+    DetectionCase(
+        text="简体中文",
+        is_accented_pinyin=False,
+        is_numbered_pinyin=False,
+        is_accented_yale=False,
+        is_numbered_jyutping=False,
+        is_simplified=True,
+        is_traditional=False,
+    ),
+    DetectionCase(
+        text="汉字",
+        is_accented_pinyin=False,
+        is_numbered_pinyin=False,
+        is_accented_yale=False,
+        is_numbered_jyutping=False,
+        is_simplified=True,
+        is_traditional=False,
+    ),
+    DetectionCase(
+        text="繁體中文",
+        is_accented_pinyin=False,
+        is_numbered_pinyin=False,
+        is_accented_yale=False,
+        is_numbered_jyutping=False,
+        is_simplified=False,
+        is_traditional=True,
+    ),
+    DetectionCase(
+        text="漢字",
+        is_accented_pinyin=False,
+        is_numbered_pinyin=False,
+        is_accented_yale=False,
+        is_numbered_jyutping=False,
+        is_simplified=False,
+        is_traditional=True,
+    ),
+    DetectionCase(
+        text="中文",
+        is_accented_pinyin=False,
+        is_numbered_pinyin=False,
+        is_accented_yale=False,
+        is_numbered_jyutping=False,
+        is_simplified=True,
+        is_traditional=True,
+    ),
+    DetectionCase(
+        text="",
+        is_accented_pinyin=False,
+        is_numbered_pinyin=False,
+        is_accented_yale=False,
+        is_numbered_jyutping=False,
+        is_simplified=False,
+        is_traditional=False,
+    ),
+]

--- a/test/lang/yue/test_is_accented_yale.py
+++ b/test/lang/yue/test_is_accented_yale.py
@@ -1,0 +1,24 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests of scinoephile.lang.yue.romanization.is_accented_yale."""
+
+from __future__ import annotations
+
+import pytest
+
+from scinoephile.lang.yue.romanization import is_accented_yale
+from test.lang.detection_cases import DETECTION_CASES
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [(case.text, case.is_accented_yale) for case in DETECTION_CASES],
+)
+def test_is_accented_yale(text: str, expected: bool):
+    """Detect accented Yale tokens.
+
+    Arguments:
+        text: text to classify
+        expected: expected accented classification
+    """
+    assert is_accented_yale(text) is expected

--- a/test/lang/yue/test_is_numbered_jyutping.py
+++ b/test/lang/yue/test_is_numbered_jyutping.py
@@ -1,0 +1,24 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests of scinoephile.lang.yue.romanization.is_numbered_jyutping."""
+
+from __future__ import annotations
+
+import pytest
+
+from scinoephile.lang.yue.romanization import is_numbered_jyutping
+from test.lang.detection_cases import DETECTION_CASES
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [(case.text, case.is_numbered_jyutping) for case in DETECTION_CASES],
+)
+def test_is_numbered_jyutping(text: str, expected: bool):
+    """Detect numbered Jyutping tokens.
+
+    Arguments:
+        text: Jyutping text to classify
+        expected: expected numbered classification
+    """
+    assert is_numbered_jyutping(text) is expected

--- a/test/lang/zho/test_is_simplified.py
+++ b/test/lang/zho/test_is_simplified.py
@@ -1,0 +1,24 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests of scinoephile.lang.zho.conversion.is_simplified."""
+
+from __future__ import annotations
+
+import pytest
+
+from scinoephile.lang.zho.conversion import is_simplified
+from test.lang.detection_cases import DETECTION_CASES
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [(case.text, case.is_simplified) for case in DETECTION_CASES],
+)
+def test_is_simplified(text: str, expected: bool):
+    """Detect simplified Chinese text.
+
+    Arguments:
+        text: text to classify
+        expected: expected simplified classification
+    """
+    assert is_simplified(text) is expected

--- a/test/lang/zho/test_is_traditional.py
+++ b/test/lang/zho/test_is_traditional.py
@@ -1,0 +1,24 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests of scinoephile.lang.zho.conversion.is_traditional."""
+
+from __future__ import annotations
+
+import pytest
+
+from scinoephile.lang.zho.conversion import is_traditional
+from test.lang.detection_cases import DETECTION_CASES
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [(case.text, case.is_traditional) for case in DETECTION_CASES],
+)
+def test_is_traditional(text: str, expected: bool):
+    """Detect traditional Chinese text.
+
+    Arguments:
+        text: text to classify
+        expected: expected traditional classification
+    """
+    assert is_traditional(text) is expected


### PR DESCRIPTION
## Summary
- add shared detection cases and per-function tests for pinyin, yale, jyutping, simplified, and traditional classifiers
- refine pinyin and yale/jyutping detection heuristics
- expand Hanzi detection ranges and align character classification

## Testing
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest lang/cmn/test_is_accented_pinyin.py lang/cmn/test_is_numbered_pinyin.py lang/yue/test_is_accented_yale.py lang/yue/test_is_numbered_jyutping.py lang/zho/test_is_simplified.py lang/zho/test_is_traditional.py`

## Linting
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format ...`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix ...`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check ...`