### PR TITLE
Lazy load transcription backends

### DIFF
--- a/scinoephile/audio/transcription/__init__.py
+++ b/scinoephile/audio/transcription/__init__.py
@@ -5,12 +5,12 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from importlib import import_module
 from logging import getLogger
+from typing import Any
 
-from scinoephile.audio.transcription.demucs_separator import DemucsSeparator
 from scinoephile.audio.transcription.transcribed_segment import TranscribedSegment
 from scinoephile.audio.transcription.transcribed_word import TranscribedWord
-from scinoephile.audio.transcription.whisper_transcriber import WhisperTranscriber
 from scinoephile.lang.zho.conversion import OpenCCConfig, get_zho_text_converted
 
 __all__ = [
@@ -25,6 +25,29 @@ __all__ = [
 ]
 
 logger = getLogger(__name__)
+
+
+def __getattr__(name: str) -> Any:
+    """Load optional transcription classes lazily.
+
+    Arguments:
+        name: attribute name to load
+    Returns:
+        lazily imported attribute
+    """
+    if name == "DemucsSeparator":
+        attribute = getattr(
+            import_module("scinoephile.audio.transcription.demucs_separator"), name
+        )
+        globals()[name] = attribute
+        return attribute
+    if name == "WhisperTranscriber":
+        attribute = getattr(
+            import_module("scinoephile.audio.transcription.whisper_transcriber"), name
+        )
+        globals()[name] = attribute
+        return attribute
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def get_segment_zho_converted(

--- a/scinoephile/multilang/yue_zho/transcription/transcriber.py
+++ b/scinoephile/multilang/yue_zho/transcription/transcriber.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from enum import StrEnum
+from importlib import import_module
 from logging import getLogger
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -14,9 +15,7 @@ from scinoephile.audio.subtitles import (
     get_series_from_segments,
 )
 from scinoephile.audio.transcription import (
-    DemucsSeparator,
     TranscribedSegment,
-    WhisperTranscriber,
     get_segment_split_on_whitespace,
     get_segment_zho_converted,
 )
@@ -37,6 +36,9 @@ from .aligner import Aligner
 
 if TYPE_CHECKING:
     from pydub import AudioSegment
+
+    from scinoephile.audio.transcription.demucs_separator import DemucsSeparator
+    from scinoephile.audio.transcription.whisper_transcriber import WhisperTranscriber
 
 __all__ = [
     "DemucsMode",
@@ -102,7 +104,7 @@ class YueTranscriber:
             provider = get_default_provider()
         self.demucs_separator = None
         if demucs_mode == DemucsMode.ON:
-            self.demucs_separator = DemucsSeparator()
+            self.demucs_separator = _get_demucs_separator_cls()()
         self.vad_transcriber = None
         if vad_mode in (VADMode.AUTO, VADMode.ON):
             self.vad_transcriber = self._get_whisper_transcriber(use_vad=True)
@@ -242,7 +244,8 @@ class YueTranscriber:
         Returns:
             configured Whisper transcriber
         """
-        return WhisperTranscriber(
+        whisper_transcriber_cls = _get_whisper_transcriber_cls()
+        return whisper_transcriber_cls(
             model_name=self.model_name,
             cache_dir_path=get_runtime_cache_dir_path("whisper"),
             use_demucs=self.demucs_mode == DemucsMode.ON,
@@ -282,3 +285,25 @@ class YueTranscriber:
         logger.info("Retrying block transcription without VAD after empty result")
         assert self.no_vad_transcriber is not None
         return self.no_vad_transcriber(audio, cache_audio=cache_audio)
+
+
+def _get_demucs_separator_cls() -> type[DemucsSeparator]:
+    """Load the Demucs separator class on demand.
+
+    Returns:
+        Demucs separator class
+    """
+    return import_module(
+        "scinoephile.audio.transcription.demucs_separator"
+    ).DemucsSeparator
+
+
+def _get_whisper_transcriber_cls() -> type[WhisperTranscriber]:
+    """Load the Whisper transcriber class on demand.
+
+    Returns:
+        Whisper transcriber class
+    """
+    return import_module(
+        "scinoephile.audio.transcription.whisper_transcriber"
+    ).WhisperTranscriber

--- a/test/cli/dictionary/test_dictionary_search_cli.py
+++ b/test/cli/dictionary/test_dictionary_search_cli.py
@@ -8,6 +8,7 @@ from collections.abc import Generator
 from contextlib import AbstractContextManager, nullcontext
 from os import environ
 from pathlib import Path
+from shlex import quote
 from unittest.mock import patch
 
 import pytest
@@ -192,6 +193,7 @@ def test_dictionary_search_cli(
         / "cuhk.db"
     )
     with get_temp_file_path(".log") as log_file_path:
+        quoted_query = quote(query)
         with expectation:
             run_cli_with_args(
                 DictionarySearchCli,
@@ -199,7 +201,7 @@ def test_dictionary_search_cli(
                 f"--log-file {log_file_path} "
                 "--dictionary-name cuhk "
                 f"--database-path {database_path} "
-                f"--limit 3 {query}",
+                f"--limit 3 {quoted_query}",
             )
         output = log_file_path.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

- Lazy-load `DemucsSeparator` and `WhisperTranscriber` from `scinoephile.audio.transcription`.
- Keep lightweight transcription data classes and helper functions importable during pytest collection without loading native audio backend extensions.

## Root Cause

`scinoephile.audio.transcription.__init__` eagerly imported `DemucsSeparator`, which imports `torchaudio.functional`. In CI this caused pytest collection to fail while loading `test/conftest.py` because `torchaudio` could not load its native `_torchaudio.abi3.so` extension.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/audio/transcription/__init__.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/audio/transcription/__init__.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/audio/transcription/__init__.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run python -c "import sys; import scinoephile.audio.subtitles; import scinoephile.audio.transcription; print('demucs_separator' in sys.modules); print('ok')"`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest multilang/yue_zho/test_yue_transcriber.py audio/transcription/test_whisper_transcriber.py -q`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest` reached collection and ran the suite; it reported `729 passed, 1 failed`. The remaining failure is unrelated: `cli/dictionary/test_dictionary_search_cli.py` passes an unquoted `shān'kēng` argument to `shlex.split`, causing `ValueError: No closing quotation`.