### PR TITLE
Ignore pydub invalid escape warnings in pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dev = [
 log_cli = true
 log_cli_level = "INFO"
 filterwarnings = [
-    "ignore:invalid escape sequence:SyntaxWarning:pydub\\.utils",
+    'ignore:invalid escape sequence .*\\\(:SyntaxWarning',
     "ignore:Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work:RuntimeWarning:pydub\\.utils",
 ]
 


### PR DESCRIPTION
## Summary

- Update pytest warning filtering for the pydub `invalid escape sequence '\('` `SyntaxWarning`
- Match the warning by message instead of `pydub.utils` module name, because import-time compile warnings do not expose a stable module for pytest filtering

## Validation

- `git diff --check`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` (`782 passed` with no pydub warning summary)

Closes #752