### PR TITLE
Type CLI kwargs explicitly

### DIFF
--- a/scinoephile/cli/analysis/analysis_cer_cli.py
+++ b/scinoephile/cli/analysis/analysis_cer_cli.py
@@ -5,15 +5,26 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
-from typing import ClassVar, Unpack
+from pathlib import Path
+from typing import ClassVar, TypedDict, Unpack
 
 from scinoephile.analysis.character_error_rate import SeriesCER
-from scinoephile.common import CLIKwargs
 from scinoephile.common.argument_parsing import get_arg_groups_by_name, input_file_arg
 from scinoephile.common.exception import ArgumentConflictError
 from scinoephile.core.cli import ScinoephileCliBase, read_series
 
 __all__ = ["AnalysisCerCli"]
+
+
+class _AnalysisCerCliKwargs(TypedDict, total=False):
+    """Keyword arguments for AnalysisCerCli."""
+
+    _parser: ArgumentParser
+    """Argument parser."""
+    reference_infile: Path | str
+    """Subtitle infile for reference series or stdin sentinel."""
+    candidate_infile: Path | str
+    """Subtitle infile for candidate series or stdin sentinel."""
 
 
 class AnalysisCerCli(ScinoephileCliBase):
@@ -87,7 +98,7 @@ class AnalysisCerCli(ScinoephileCliBase):
         return "cer"
 
     @classmethod
-    def _main(cls, **kwargs: Unpack[CLIKwargs]):
+    def _main(cls, **kwargs: Unpack[_AnalysisCerCliKwargs]):
         """Execute with provided keyword arguments.
 
         Arguments:

--- a/scinoephile/cli/analysis/analysis_cli.py
+++ b/scinoephile/cli/analysis/analysis_cli.py
@@ -5,15 +5,22 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
-from typing import Unpack
+from typing import TypedDict, Unpack
 
-from scinoephile.common import CLIKwargs, CommandLineInterface
+from scinoephile.common import CommandLineInterface
 from scinoephile.core.cli import ScinoephileCliBase
 
 from .analysis_cer_cli import AnalysisCerCli
 from .analysis_diff_cli import AnalysisDiffCli
 
 __all__ = ["AnalysisCli"]
+
+
+class _AnalysisCliKwargs(TypedDict, total=False):
+    """Keyword arguments for AnalysisCli."""
+
+    analysis_subcommand: str
+    """Selected analysis subcommand."""
 
 
 class AnalysisCli(ScinoephileCliBase):
@@ -56,7 +63,7 @@ class AnalysisCli(ScinoephileCliBase):
         }
 
     @classmethod
-    def _main(cls, **kwargs: Unpack[CLIKwargs]):
+    def _main(cls, **kwargs: Unpack[_AnalysisCliKwargs]):
         """Execute with provided keyword arguments.
 
         Arguments:

--- a/scinoephile/cli/analysis/analysis_diff_cli.py
+++ b/scinoephile/cli/analysis/analysis_diff_cli.py
@@ -6,10 +6,9 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import ClassVar, Unpack
+from typing import ClassVar, TypedDict, Unpack
 
 from scinoephile.analysis.diff import SeriesDiff
-from scinoephile.common import CLIKwargs
 from scinoephile.common.argument_parsing import (
     float_arg,
     get_arg_groups_by_name,
@@ -21,7 +20,7 @@ from scinoephile.core.cli import ScinoephileCliBase, read_series
 __all__ = ["AnalysisDiffCli"]
 
 
-class _AnalysisDiffCliKwargs(CLIKwargs, total=False):
+class _AnalysisDiffCliKwargs(TypedDict, total=False):
     """Keyword arguments for AnalysisDiffCli."""
 
     _parser: ArgumentParser

--- a/scinoephile/cli/dictionary/build/dictionary_build_cli.py
+++ b/scinoephile/cli/dictionary/build/dictionary_build_cli.py
@@ -5,9 +5,8 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
-from typing import ClassVar, Unpack
+from typing import ClassVar, TypedDict, Unpack
 
-from scinoephile.common import CLIKwargs
 from scinoephile.core.cli import ScinoephileCliBase
 
 from .dictionary_build_cuhk_cli import DictionaryBuildCuhkCli
@@ -17,6 +16,13 @@ from .dictionary_build_unihan_cli import DictionaryBuildUnihanCli
 from .dictionary_build_wiktionary_cli import DictionaryBuildWiktionaryCli
 
 __all__ = ["DictionaryBuildCli"]
+
+
+class _DictionaryBuildCliKwargs(TypedDict, total=False):
+    """Keyword arguments for DictionaryBuildCli."""
+
+    dictionary_build_subcommand: str
+    """Selected dictionary build subcommand."""
 
 
 class DictionaryBuildCli(ScinoephileCliBase):
@@ -76,7 +82,7 @@ class DictionaryBuildCli(ScinoephileCliBase):
         }
 
     @classmethod
-    def _main(cls, **kwargs: Unpack[CLIKwargs]):
+    def _main(cls, **kwargs: Unpack[_DictionaryBuildCliKwargs]):
         """Execute with provided keyword arguments.
 
         Arguments:

--- a/scinoephile/cli/dictionary/build/dictionary_build_cuhk_cli.py
+++ b/scinoephile/cli/dictionary/build/dictionary_build_cuhk_cli.py
@@ -7,9 +7,8 @@ from __future__ import annotations
 from argparse import ArgumentParser
 from logging import getLogger
 from pathlib import Path
-from typing import Any, ClassVar, Unpack, cast
+from typing import ClassVar, TypedDict, Unpack
 
-from scinoephile.common import CLIKwargs
 from scinoephile.common.argument_parsing import (
     float_arg,
     get_arg_groups_by_name,
@@ -24,6 +23,27 @@ from .dictionary_build_cli_base import DictionaryBuildCliBase
 __all__ = ["DictionaryBuildCuhkCli"]
 
 logger = getLogger(__name__)
+
+
+class _DictionaryBuildCuhkCliKwargs(TypedDict, total=False):
+    """Keyword arguments for DictionaryBuildCuhkCli."""
+
+    cache_dir: Path | None
+    """Cache directory for scraped HTML and link data."""
+    database_path: Path | None
+    """SQLite database output path."""
+    max_words: int | None
+    """Maximum number of discovered words to build."""
+    overwrite: bool
+    """Whether to overwrite the existing SQLite database."""
+    min_delay_seconds: float
+    """Minimum delay between HTTP requests."""
+    max_delay_seconds: float
+    """Maximum delay between HTTP requests."""
+    max_retries: int
+    """Maximum retries per HTTP request."""
+    request_timeout_seconds: float
+    """Per-request timeout in seconds."""
 
 
 class DictionaryBuildCuhkCli(DictionaryBuildCliBase):
@@ -158,21 +178,20 @@ class DictionaryBuildCuhkCli(DictionaryBuildCliBase):
             logger.info(f"Building at most {max_words} discovered CUHK words")
 
     @classmethod
-    def _main(cls, **kwargs: Unpack[CLIKwargs]):
+    def _main(cls, **kwargs: Unpack[_DictionaryBuildCuhkCliKwargs]):
         """Execute with provided keyword arguments.
 
         Arguments:
             **kwargs: keyword arguments
         """
-        kwargs_dict = cast(dict[str, Any], kwargs)
-        cache_dir_path = kwargs_dict.pop("cache_dir")
-        database_path = kwargs_dict.pop("database_path")
-        max_words = kwargs_dict.pop("max_words", None)
-        overwrite = kwargs_dict.pop("overwrite")
-        min_delay_seconds = kwargs_dict.pop("min_delay_seconds")
-        max_delay_seconds = kwargs_dict.pop("max_delay_seconds")
-        max_retries = kwargs_dict.pop("max_retries")
-        request_timeout_seconds = kwargs_dict.pop("request_timeout_seconds")
+        cache_dir_path = kwargs.pop("cache_dir")
+        database_path = kwargs.pop("database_path")
+        max_words = kwargs.pop("max_words", None)
+        overwrite = kwargs.pop("overwrite")
+        min_delay_seconds = kwargs.pop("min_delay_seconds")
+        max_delay_seconds = kwargs.pop("max_delay_seconds")
+        max_retries = kwargs.pop("max_retries")
+        request_timeout_seconds = kwargs.pop("request_timeout_seconds")
 
         service = CuhkDictionaryService(
             database_path=database_path,

--- a/scinoephile/cli/dictionary/build/dictionary_build_gzzj_cli.py
+++ b/scinoephile/cli/dictionary/build/dictionary_build_gzzj_cli.py
@@ -6,9 +6,9 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 from logging import getLogger
-from typing import Any, ClassVar, Unpack, cast
+from pathlib import Path
+from typing import ClassVar, TypedDict, Unpack
 
-from scinoephile.common import CLIKwargs
 from scinoephile.common.argument_parsing import get_arg_groups_by_name, input_file_arg
 from scinoephile.dictionaries.gzzj import GzzjDictionaryService
 from scinoephile.dictionaries.gzzj.constants import GZZJ_SOURCE
@@ -18,6 +18,17 @@ from .dictionary_build_cli_base import DictionaryBuildCliBase
 __all__ = ["DictionaryBuildGzzjCli"]
 
 logger = getLogger(__name__)
+
+
+class _DictionaryBuildGzzjCliKwargs(TypedDict, total=False):
+    """Keyword arguments for DictionaryBuildGzzjCli."""
+
+    database_path: Path | None
+    """SQLite database output path."""
+    overwrite: bool
+    """Whether to overwrite the existing SQLite database."""
+    source_json_path: Path | None
+    """Path to manually downloaded GZZJ source JSON."""
 
 
 class DictionaryBuildGzzjCli(DictionaryBuildCliBase):
@@ -75,16 +86,15 @@ class DictionaryBuildGzzjCli(DictionaryBuildCliBase):
         cls.add_common_output_arguments(parser)
 
     @classmethod
-    def _main(cls, **kwargs: Unpack[CLIKwargs]):
+    def _main(cls, **kwargs: Unpack[_DictionaryBuildGzzjCliKwargs]):
         """Execute with provided keyword arguments.
 
         Arguments:
             **kwargs: keyword arguments
         """
-        kwargs_dict = cast(dict[str, Any], kwargs)
-        database_path = kwargs_dict.pop("database_path")
-        overwrite = kwargs_dict.pop("overwrite")
-        source_json_path = kwargs_dict.pop("source_json_path")
+        database_path = kwargs.pop("database_path")
+        overwrite = kwargs.pop("overwrite")
+        source_json_path = kwargs.pop("source_json_path")
 
         service = GzzjDictionaryService(
             database_path=database_path,

--- a/scinoephile/cli/dictionary/build/dictionary_build_kaifangcidian_cli.py
+++ b/scinoephile/cli/dictionary/build/dictionary_build_kaifangcidian_cli.py
@@ -6,11 +6,11 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 from logging import getLogger
-from typing import Any, ClassVar, Unpack, cast
+from pathlib import Path
+from typing import ClassVar, TypedDict, Unpack
 
 import requests
 
-from scinoephile.common import CLIKwargs
 from scinoephile.common.argument_parsing import get_arg_groups_by_name
 from scinoephile.dictionaries.kaifangcidian import KaifangcidianDictionaryService
 from scinoephile.dictionaries.kaifangcidian.constants import KAIFANGCIDIAN_SOURCE
@@ -20,6 +20,19 @@ from .dictionary_build_cli_base import DictionaryBuildCliBase
 __all__ = ["DictionaryBuildKaifangcidianCli"]
 
 logger = getLogger(__name__)
+
+
+class _DictionaryBuildKaifangcidianCliKwargs(TypedDict, total=False):
+    """Keyword arguments for DictionaryBuildKaifangcidianCli."""
+
+    database_path: Path | None
+    """SQLite database output path."""
+    overwrite: bool
+    """Whether to overwrite the existing SQLite database."""
+    force_download: bool
+    """Whether to download fresh Kaifangcidian payloads before building."""
+    update_local_data: bool
+    """Whether to update the canonical CSV under package data."""
 
 
 class DictionaryBuildKaifangcidianCli(DictionaryBuildCliBase):
@@ -89,17 +102,16 @@ class DictionaryBuildKaifangcidianCli(DictionaryBuildCliBase):
         cls.add_common_output_arguments(parser)
 
     @classmethod
-    def _main(cls, **kwargs: Unpack[CLIKwargs]):
+    def _main(cls, **kwargs: Unpack[_DictionaryBuildKaifangcidianCliKwargs]):
         """Execute with provided keyword arguments.
 
         Arguments:
             **kwargs: keyword arguments
         """
-        kwargs_dict = cast(dict[str, Any], kwargs)
-        database_path = kwargs_dict.pop("database_path")
-        overwrite = kwargs_dict.pop("overwrite")
-        force_download = kwargs_dict.pop("force_download")
-        update_local_data = kwargs_dict.pop("update_local_data")
+        database_path = kwargs.pop("database_path")
+        overwrite = kwargs.pop("overwrite")
+        force_download = kwargs.pop("force_download")
+        update_local_data = kwargs.pop("update_local_data")
 
         service = KaifangcidianDictionaryService(database_path=database_path)
         cls.log_config(

--- a/scinoephile/cli/dictionary/build/dictionary_build_unihan_cli.py
+++ b/scinoephile/cli/dictionary/build/dictionary_build_unihan_cli.py
@@ -7,11 +7,11 @@ from __future__ import annotations
 import zipfile
 from argparse import ArgumentParser
 from logging import getLogger
-from typing import Any, ClassVar, Unpack, cast
+from pathlib import Path
+from typing import ClassVar, TypedDict, Unpack
 
 import requests
 
-from scinoephile.common import CLIKwargs
 from scinoephile.common.argument_parsing import get_arg_groups_by_name, input_file_arg
 from scinoephile.dictionaries.unihan import UnihanDictionaryService
 from scinoephile.dictionaries.unihan.constants import UNIHAN_SOURCE
@@ -21,6 +21,25 @@ from .dictionary_build_cli_base import DictionaryBuildCliBase
 __all__ = ["DictionaryBuildUnihanCli"]
 
 logger = getLogger(__name__)
+
+
+class _DictionaryBuildUnihanCliKwargs(TypedDict, total=False):
+    """Keyword arguments for DictionaryBuildUnihanCli."""
+
+    database_path: Path | None
+    """SQLite database output path."""
+    overwrite: bool
+    """Whether to overwrite the existing SQLite database."""
+    force_download: bool
+    """Whether to download fresh Unihan data before building."""
+    update_local_data: bool
+    """Whether to update source files under package data."""
+    source_dictionary_like_data_path: Path | None
+    """Path to Unihan_DictionaryLikeData.txt."""
+    source_readings_path: Path | None
+    """Path to Unihan_Readings.txt."""
+    source_variants_path: Path | None
+    """Path to Unihan_Variants.txt."""
 
 
 class DictionaryBuildUnihanCli(DictionaryBuildCliBase):
@@ -119,22 +138,21 @@ class DictionaryBuildUnihanCli(DictionaryBuildCliBase):
         cls.add_common_output_arguments(parser)
 
     @classmethod
-    def _main(cls, **kwargs: Unpack[CLIKwargs]):
+    def _main(cls, **kwargs: Unpack[_DictionaryBuildUnihanCliKwargs]):
         """Execute with provided keyword arguments.
 
         Arguments:
             **kwargs: keyword arguments
         """
-        kwargs_dict = cast(dict[str, Any], kwargs)
-        database_path = kwargs_dict.pop("database_path")
-        overwrite = kwargs_dict.pop("overwrite")
-        force_download = kwargs_dict.pop("force_download")
-        update_local_data = kwargs_dict.pop("update_local_data")
-        source_dictionary_like_data_path = kwargs_dict.pop(
+        database_path = kwargs.pop("database_path")
+        overwrite = kwargs.pop("overwrite")
+        force_download = kwargs.pop("force_download")
+        update_local_data = kwargs.pop("update_local_data")
+        source_dictionary_like_data_path = kwargs.pop(
             "source_dictionary_like_data_path"
         )
-        source_readings_path = kwargs_dict.pop("source_readings_path")
-        source_variants_path = kwargs_dict.pop("source_variants_path")
+        source_readings_path = kwargs.pop("source_readings_path")
+        source_variants_path = kwargs.pop("source_variants_path")
 
         service = UnihanDictionaryService(database_path=database_path)
         cls.log_config(

--- a/scinoephile/cli/dictionary/build/dictionary_build_wiktionary_cli.py
+++ b/scinoephile/cli/dictionary/build/dictionary_build_wiktionary_cli.py
@@ -6,11 +6,11 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 from logging import getLogger
-from typing import Any, ClassVar, Unpack, cast
+from pathlib import Path
+from typing import ClassVar, TypedDict, Unpack
 
 import requests
 
-from scinoephile.common import CLIKwargs
 from scinoephile.common.argument_parsing import get_arg_groups_by_name, input_file_arg
 from scinoephile.dictionaries.wiktionary import WiktionaryDictionaryService
 from scinoephile.dictionaries.wiktionary.constants import WIKTIONARY_SOURCE
@@ -20,6 +20,21 @@ from .dictionary_build_cli_base import DictionaryBuildCliBase
 __all__ = ["DictionaryBuildWiktionaryCli"]
 
 logger = getLogger(__name__)
+
+
+class _DictionaryBuildWiktionaryCliKwargs(TypedDict, total=False):
+    """Keyword arguments for DictionaryBuildWiktionaryCli."""
+
+    database_path: Path | None
+    """SQLite database output path."""
+    overwrite: bool
+    """Whether to overwrite the existing SQLite database."""
+    force_download: bool
+    """Whether to download fresh Kaikki JSONL before building."""
+    source_jsonl_path: Path | None
+    """Path to Kaikki Chinese Wiktionary JSONL dump."""
+    update_local_data: bool
+    """Whether to update the source file under package data."""
 
 
 class DictionaryBuildWiktionaryCli(DictionaryBuildCliBase):
@@ -102,18 +117,17 @@ class DictionaryBuildWiktionaryCli(DictionaryBuildCliBase):
         cls.add_common_output_arguments(parser)
 
     @classmethod
-    def _main(cls, **kwargs: Unpack[CLIKwargs]):
+    def _main(cls, **kwargs: Unpack[_DictionaryBuildWiktionaryCliKwargs]):
         """Execute with provided keyword arguments.
 
         Arguments:
             **kwargs: keyword arguments
         """
-        kwargs_dict = cast(dict[str, Any], kwargs)
-        database_path = kwargs_dict.pop("database_path")
-        overwrite = kwargs_dict.pop("overwrite")
-        force_download = kwargs_dict.pop("force_download")
-        source_jsonl_path = kwargs_dict.pop("source_jsonl_path")
-        update_local_data = kwargs_dict.pop("update_local_data")
+        database_path = kwargs.pop("database_path")
+        overwrite = kwargs.pop("overwrite")
+        force_download = kwargs.pop("force_download")
+        source_jsonl_path = kwargs.pop("source_jsonl_path")
+        update_local_data = kwargs.pop("update_local_data")
 
         service = WiktionaryDictionaryService(database_path=database_path)
         cls.log_config(

--- a/scinoephile/cli/dictionary/dictionary_cli.py
+++ b/scinoephile/cli/dictionary/dictionary_cli.py
@@ -5,15 +5,22 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
-from typing import Unpack
+from typing import TypedDict, Unpack
 
-from scinoephile.common import CLIKwargs, CommandLineInterface
+from scinoephile.common import CommandLineInterface
 from scinoephile.core.cli import ScinoephileCliBase
 
 from .build.dictionary_build_cli import DictionaryBuildCli
 from .dictionary_search_cli import DictionarySearchCli
 
 __all__ = ["DictionaryCli"]
+
+
+class _DictionaryCliKwargs(TypedDict, total=False):
+    """Keyword arguments for DictionaryCli."""
+
+    dictionary_subcommand: str
+    """Selected dictionary subcommand."""
 
 
 class DictionaryCli(ScinoephileCliBase):
@@ -62,7 +69,7 @@ class DictionaryCli(ScinoephileCliBase):
         }
 
     @classmethod
-    def _main(cls, **kwargs: Unpack[CLIKwargs]):
+    def _main(cls, **kwargs: Unpack[_DictionaryCliKwargs]):
         """Execute with provided keyword arguments.
 
         Arguments:

--- a/scinoephile/cli/dictionary/dictionary_search_cli.py
+++ b/scinoephile/cli/dictionary/dictionary_search_cli.py
@@ -7,9 +7,8 @@ from __future__ import annotations
 from argparse import ArgumentParser
 from logging import getLogger
 from pathlib import Path
-from typing import Unpack
+from typing import TypedDict, Unpack
 
-from scinoephile.common import CLIKwargs
 from scinoephile.common.argument_parsing import (
     get_arg_groups_by_name,
     input_file_arg,
@@ -26,6 +25,19 @@ from scinoephile.dictionaries.lookup import (
 __all__ = ["DictionarySearchCli"]
 
 logger = getLogger(__name__)
+
+
+class _DictionarySearchCliKwargs(TypedDict, total=False):
+    """Keyword arguments for DictionarySearchCli."""
+
+    database_path: Path | None
+    """SQLite database input path."""
+    dictionary_name: str
+    """Dictionary selector."""
+    query: str
+    """Lookup query."""
+    limit: int
+    """Maximum number of matches to show per dictionary."""
 
 
 class DictionarySearchCli(ScinoephileCliBase):
@@ -135,7 +147,7 @@ class DictionarySearchCli(ScinoephileCliBase):
                 logger.info(f"   - {label_prefix}{definition.text}")
 
     @classmethod
-    def _main(cls, **kwargs: Unpack[CLIKwargs]):
+    def _main(cls, **kwargs: Unpack[_DictionarySearchCliKwargs]):
         """Execute with provided keyword arguments.
 
         Arguments:

--- a/scinoephile/cli/eng/eng_cli.py
+++ b/scinoephile/cli/eng/eng_cli.py
@@ -5,9 +5,9 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
-from typing import Unpack
+from typing import TypedDict, Unpack
 
-from scinoephile.common import CLIKwargs, CommandLineInterface
+from scinoephile.common import CommandLineInterface
 from scinoephile.core.cli import ScinoephileCliBase
 
 from .eng_fuse_cli import EngFuseCli
@@ -15,6 +15,13 @@ from .eng_process_cli import EngProcessCli
 from .eng_validate_ocr_cli import EngValidateOcrCli
 
 __all__ = ["EngCli"]
+
+
+class _EngCliKwargs(TypedDict, total=False):
+    """Keyword arguments for EngCli."""
+
+    eng_subcommand: str
+    """Selected English subtitle subcommand."""
 
 
 class EngCli(ScinoephileCliBase):
@@ -68,7 +75,7 @@ class EngCli(ScinoephileCliBase):
         }
 
     @classmethod
-    def _main(cls, **kwargs: Unpack[CLIKwargs]):
+    def _main(cls, **kwargs: Unpack[_EngCliKwargs]):
         """Execute with provided keyword arguments.
 
         Arguments:

--- a/scinoephile/cli/eng/eng_fuse_cli.py
+++ b/scinoephile/cli/eng/eng_fuse_cli.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import ClassVar, TypedDict, Unpack
 
 from scinoephile.common.argument_parsing import (
     get_arg_groups_by_name,
@@ -19,6 +19,23 @@ from scinoephile.lang.eng.cleaning import get_eng_cleaned
 from scinoephile.lang.eng.ocr_fusion import get_eng_ocr_fused
 
 __all__ = ["EngFuseCli"]
+
+
+class _EngFuseCliKwargs(TypedDict, total=False):
+    """Keyword arguments for EngFuseCli."""
+
+    _parser: ArgumentParser
+    """Argument parser."""
+    lens_infile: Path | str
+    """English subtitles OCRed using Google Lens or stdin sentinel."""
+    tesseract_infile: Path | str
+    """English subtitles OCRed using Tesseract or stdin sentinel."""
+    clean: bool
+    """Whether to clean both OCR subtitle infiles before fusing."""
+    outfile: Path | None
+    """English subtitle outfile path."""
+    overwrite: bool
+    """Whether to overwrite an existing outfile."""
 
 
 class EngFuseCli(ScinoephileCliBase):
@@ -131,7 +148,7 @@ class EngFuseCli(ScinoephileCliBase):
         return "fuse"
 
     @classmethod
-    def _main(cls, **kwargs: Any):
+    def _main(cls, **kwargs: Unpack[_EngFuseCliKwargs]):
         """Execute with provided keyword arguments.
 
         Arguments:

--- a/scinoephile/cli/eng/eng_process_cli.py
+++ b/scinoephile/cli/eng/eng_process_cli.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import Any
+from typing import TypedDict, Unpack
 
 from scinoephile.common.argument_parsing import (
     get_arg_groups_by_name,
@@ -20,6 +20,25 @@ from scinoephile.lang.eng.cleaning import get_eng_cleaned
 from scinoephile.lang.eng.flattening import get_eng_flattened
 
 __all__ = ["EngProcessCli"]
+
+
+class _EngProcessCliKwargs(TypedDict, total=False):
+    """Keyword arguments for EngProcessCli."""
+
+    _parser: ArgumentParser
+    """Argument parser."""
+    infile: Path | str
+    """English subtitle infile path or stdin sentinel."""
+    outfile: Path | None
+    """English subtitle outfile path."""
+    clean: bool
+    """Whether to clean subtitles."""
+    flatten: bool
+    """Whether to flatten multi-line subtitles."""
+    proofread: bool
+    """Whether to proofread subtitles."""
+    overwrite: bool
+    """Whether to overwrite an existing outfile."""
 
 
 class EngProcessCli(ScinoephileCliBase):
@@ -118,7 +137,7 @@ class EngProcessCli(ScinoephileCliBase):
         return "process"
 
     @classmethod
-    def _main(cls, **kwargs: Any):
+    def _main(cls, **kwargs: Unpack[_EngProcessCliKwargs]):
         """Execute with provided keyword arguments.
 
         Arguments:

--- a/scinoephile/cli/eng/eng_validate_ocr_cli.py
+++ b/scinoephile/cli/eng/eng_validate_ocr_cli.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import ClassVar, TypedDict, Unpack
 
 from scinoephile.common import DirectoryNotFoundError
 from scinoephile.common.argument_parsing import (
@@ -20,6 +20,23 @@ from scinoephile.image.subtitles import ImageSeries
 from scinoephile.lang.eng.ocr_validation import validate_eng_ocr
 
 __all__ = ["EngValidateOcrCli"]
+
+
+class _EngValidateOcrCliKwargs(TypedDict, total=False):
+    """Keyword arguments for EngValidateOcrCli."""
+
+    _parser: ArgumentParser
+    """Argument parser."""
+    infile: Path
+    """English OCR image subtitle infile path."""
+    stop_at_idx: int | None
+    """Subtitle index after which validation should stop."""
+    interactive: bool
+    """Whether to prompt for interactive validation decisions."""
+    outfile: Path
+    """Directory in which to save validation image outputs."""
+    overwrite: bool
+    """Whether to overwrite the outfile directory."""
 
 
 class EngValidateOcrCli(ScinoephileCliBase):
@@ -116,7 +133,7 @@ class EngValidateOcrCli(ScinoephileCliBase):
         return "validate-ocr"
 
     @classmethod
-    def _main(cls, **kwargs: Any):
+    def _main(cls, **kwargs: Unpack[_EngValidateOcrCliKwargs]):
         """Execute with provided keyword arguments.
 
         Arguments:

--- a/scinoephile/cli/scinoephile_cli.py
+++ b/scinoephile/cli/scinoephile_cli.py
@@ -5,9 +5,9 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
-from typing import Unpack
+from typing import TypedDict, Unpack
 
-from scinoephile.common import CLIKwargs, CommandLineInterface
+from scinoephile.common import CommandLineInterface
 from scinoephile.core.cli import ScinoephileCliBase
 
 from .analysis import AnalysisCli
@@ -19,6 +19,13 @@ from .yue import YueCli
 from .zho import ZhoCli
 
 __all__ = ["ScinoephileCli"]
+
+
+class _ScinoephileCliKwargs(TypedDict, total=False):
+    """Keyword arguments for ScinoephileCli."""
+
+    subcommand: str
+    """Selected top-level subcommand."""
 
 
 class ScinoephileCli(ScinoephileCliBase):
@@ -104,7 +111,7 @@ class ScinoephileCli(ScinoephileCliBase):
         }
 
     @classmethod
-    def _main(cls, **kwargs: Unpack[CLIKwargs]):
+    def _main(cls, **kwargs: Unpack[_ScinoephileCliKwargs]):
         """Execute with provided keyword arguments.
 
         Arguments:

--- a/scinoephile/cli/sync_cli.py
+++ b/scinoephile/cli/sync_cli.py
@@ -6,9 +6,8 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import Unpack
+from typing import TypedDict, Unpack
 
-from scinoephile.common import CLIKwargs
 from scinoephile.common.argument_parsing import (
     get_arg_groups_by_name,
     input_file_arg,
@@ -19,6 +18,21 @@ from scinoephile.core.cli import ScinoephileCliBase, read_series, write_series
 from scinoephile.core.synchronization import get_synced_series
 
 __all__ = ["SyncCli"]
+
+
+class _SyncCliKwargs(TypedDict, total=False):
+    """Keyword arguments for SyncCli."""
+
+    _parser: ArgumentParser
+    """Argument parser."""
+    top_infile: Path | str
+    """Subtitle infile for top line or stdin sentinel."""
+    bottom_infile: Path | str
+    """Subtitle infile for bottom line or stdin sentinel."""
+    outfile: Path | None
+    """Synchronized subtitle outfile path."""
+    overwrite: bool
+    """Whether to overwrite an existing outfile."""
 
 
 class SyncCli(ScinoephileCliBase):
@@ -83,7 +97,7 @@ class SyncCli(ScinoephileCliBase):
         parser.set_defaults(_parser=parser)
 
     @classmethod
-    def _main(cls, **kwargs: Unpack[CLIKwargs]):
+    def _main(cls, **kwargs: Unpack[_SyncCliKwargs]):
         """Execute with provided keyword arguments.
 
         Arguments:

--- a/scinoephile/cli/timewarp_cli.py
+++ b/scinoephile/cli/timewarp_cli.py
@@ -6,9 +6,8 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import Unpack
+from typing import TypedDict, Unpack
 
-from scinoephile.common import CLIKwargs
 from scinoephile.common.argument_parsing import (
     get_arg_groups_by_name,
     input_file_arg,
@@ -21,6 +20,29 @@ from scinoephile.core.cli import ScinoephileCliBase, read_series, write_series
 from scinoephile.core.timing import get_series_timewarped
 
 __all__ = ["TimewarpCli"]
+
+
+class _TimewarpCliKwargs(TypedDict, total=False):
+    """Keyword arguments for TimewarpCli."""
+
+    _parser: ArgumentParser
+    """Argument parser."""
+    anchor_infile: Path | str
+    """Subtitle infile used as anchor timing reference or stdin sentinel."""
+    mobile_infile: Path | str
+    """Mobile subtitle infile to be timewarped or stdin sentinel."""
+    one_start_idx: int | None
+    """One-based start index in anchor series."""
+    one_end_idx: int | None
+    """One-based end index in anchor series."""
+    two_start_idx: int | None
+    """One-based start index in moving series."""
+    two_end_idx: int | None
+    """One-based end index in moving series."""
+    outfile: Path | None
+    """Timewarped subtitle outfile path."""
+    overwrite: bool
+    """Whether to overwrite an existing outfile."""
 
 
 class TimewarpCli(ScinoephileCliBase):
@@ -112,7 +134,7 @@ class TimewarpCli(ScinoephileCliBase):
         parser.set_defaults(_parser=parser)
 
     @classmethod
-    def _main(cls, **kwargs: Unpack[CLIKwargs]):
+    def _main(cls, **kwargs: Unpack[_TimewarpCliKwargs]):
         """Execute with provided keyword arguments.
 
         Arguments:

--- a/scinoephile/cli/yue/yue_cli.py
+++ b/scinoephile/cli/yue/yue_cli.py
@@ -5,9 +5,9 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
-from typing import Unpack
+from typing import TypedDict, Unpack
 
-from scinoephile.common import CLIKwargs, CommandLineInterface
+from scinoephile.common import CommandLineInterface
 from scinoephile.core.cli import ScinoephileCliBase
 
 from .yue_process_cli import YueProcessCli
@@ -16,6 +16,13 @@ from .yue_transcribe_vs_zho_cli import YueTranscribeVsZhoCli
 from .yue_translate_vs_zho_cli import YueTranslateVsZhoCli
 
 __all__ = ["YueCli"]
+
+
+class _YueCliKwargs(TypedDict, total=False):
+    """Keyword arguments for YueCli."""
+
+    yue_subcommand: str
+    """Selected written Cantonese subtitle subcommand."""
 
 
 class YueCli(ScinoephileCliBase):
@@ -71,7 +78,7 @@ class YueCli(ScinoephileCliBase):
         }
 
     @classmethod
-    def _main(cls, **kwargs: Unpack[CLIKwargs]):
+    def _main(cls, **kwargs: Unpack[_YueCliKwargs]):
         """Execute with provided keyword arguments.
 
         Arguments:

--- a/scinoephile/cli/yue/yue_process_cli.py
+++ b/scinoephile/cli/yue/yue_process_cli.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import Any
+from typing import TypedDict, Unpack
 
 from scinoephile.cli.conversion import (
     add_opencc_convert_argument,
@@ -37,6 +37,29 @@ from scinoephile.lang.zho.conversion import (
 from scinoephile.lang.zho.flattening import get_zho_flattened
 
 __all__ = ["YueProcessCli"]
+
+
+class _YueProcessCliKwargs(TypedDict, total=False):
+    """Keyword arguments for YueProcessCli."""
+
+    _parser: ArgumentParser
+    """Argument parser."""
+    infile: Path | str
+    """Written Cantonese subtitle infile path or stdin sentinel."""
+    outfile: Path | None
+    """Written Cantonese subtitle outfile path."""
+    clean: bool
+    """Whether to clean subtitles."""
+    flatten: bool
+    """Whether to flatten multi-line subtitles."""
+    convert: OpenCCConfig | None
+    """OpenCC conversion configuration."""
+    proofread: str | None
+    """Selected proofreading script."""
+    romanize: bool
+    """Whether to append Cantonese romanization."""
+    overwrite: bool
+    """Whether to overwrite an existing outfile."""
 
 
 class YueProcessCli(ScinoephileCliBase):
@@ -170,7 +193,7 @@ class YueProcessCli(ScinoephileCliBase):
         return "process"
 
     @classmethod
-    def _main(cls, **kwargs: Any):
+    def _main(cls, **kwargs: Unpack[_YueProcessCliKwargs]):
         """Execute with provided keyword arguments.
 
         Arguments:

--- a/scinoephile/cli/yue/yue_review_vs_zho_cli.py
+++ b/scinoephile/cli/yue/yue_review_vs_zho_cli.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import Any
+from typing import TypedDict, Unpack
 
 from scinoephile.common.argument_parsing import (
     get_arg_groups_by_name,
@@ -30,6 +30,25 @@ from scinoephile.multilang.yue_zho.line_review import (
 )
 
 __all__ = ["YueReviewVsZhoCli"]
+
+
+class _YueReviewVsZhoCliKwargs(TypedDict, total=False):
+    """Keyword arguments for YueReviewVsZhoCli."""
+
+    _parser: ArgumentParser
+    """Argument parser."""
+    yue_infile: Path | str
+    """Target written Cantonese subtitle infile path or stdin sentinel."""
+    zho_infile: Path | str
+    """Reference standard Chinese subtitle infile path or stdin sentinel."""
+    mode: str
+    """Selected review mode."""
+    script: str
+    """Selected prompt script."""
+    outfile: Path | None
+    """Reviewed written Cantonese subtitle outfile path."""
+    overwrite: bool
+    """Whether to overwrite an existing outfile."""
 
 
 class YueReviewVsZhoCli(ScinoephileCliBase):
@@ -191,7 +210,7 @@ class YueReviewVsZhoCli(ScinoephileCliBase):
         return YueVsZhoYueHansBlockReviewPrompt
 
     @classmethod
-    def _main(cls, **kwargs: Any):
+    def _main(cls, **kwargs: Unpack[_YueReviewVsZhoCliKwargs]):
         """Execute with provided keyword arguments.
 
         Arguments:

--- a/scinoephile/cli/yue/yue_transcribe_vs_zho_cli.py
+++ b/scinoephile/cli/yue/yue_transcribe_vs_zho_cli.py
@@ -6,14 +6,13 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import Unpack
+from typing import TypedDict, Unpack
 
 from scinoephile.audio.subtitles import AudioSeries
 from scinoephile.cli.conversion import (
     add_opencc_convert_argument,
     merge_conversion_localizations,
 )
-from scinoephile.common import CLIKwargs
 from scinoephile.common.argument_parsing import (
     get_arg_groups_by_name,
     input_file_arg,
@@ -25,6 +24,7 @@ from scinoephile.common.exception import ArgumentConflictError, NotAFileError
 from scinoephile.common.file import get_temp_file_path
 from scinoephile.core.cli import ScinoephileCliBase, read_series, write_series
 from scinoephile.core.exceptions import ScinoephileError
+from scinoephile.lang.zho.conversion import OpenCCConfig
 from scinoephile.multilang.yue_zho.transcription import (
     DemucsMode,
     VADMode,
@@ -41,6 +41,31 @@ from scinoephile.multilang.yue_zho.transcription.punctuation import (
 )
 
 __all__ = ["YueTranscribeVsZhoCli"]
+
+
+class _YueTranscribeVsZhoCliKwargs(TypedDict, total=False):
+    """Keyword arguments for YueTranscribeVsZhoCli."""
+
+    _parser: ArgumentParser
+    """Argument parser."""
+    media_infile: str
+    """Video or audio media input path used for transcription."""
+    zhongwen_infile: Path | str
+    """Standard Chinese subtitle infile or stdin sentinel."""
+    stream_index: int
+    """Audio stream index in media input."""
+    script: str
+    """Selected prompt script."""
+    convert: OpenCCConfig | None
+    """OpenCC conversion configuration."""
+    demucs: str
+    """Demucs vocal-separation mode."""
+    vad: str
+    """Whisper voice activity detection mode."""
+    outfile: Path | None
+    """Written Cantonese subtitle outfile path."""
+    overwrite: bool
+    """Whether to overwrite an existing outfile."""
 
 
 class YueTranscribeVsZhoCli(ScinoephileCliBase):
@@ -205,7 +230,7 @@ class YueTranscribeVsZhoCli(ScinoephileCliBase):
         return YueVsZhoYueHansDeliniationPrompt, YueVsZhoYueHansPunctuationPrompt
 
     @classmethod
-    def _main(cls, **kwargs: Unpack[CLIKwargs]):
+    def _main(cls, **kwargs: Unpack[_YueTranscribeVsZhoCliKwargs]):
         """Execute with provided keyword arguments.
 
         Arguments:

--- a/scinoephile/cli/yue/yue_translate_vs_zho_cli.py
+++ b/scinoephile/cli/yue/yue_translate_vs_zho_cli.py
@@ -9,9 +9,8 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import Unpack
+from typing import TypedDict, Unpack
 
-from scinoephile.common import CLIKwargs
 from scinoephile.common.argument_parsing import (
     get_arg_groups_by_name,
     input_file_arg,
@@ -28,6 +27,23 @@ from scinoephile.multilang.yue_zho.translation import (
 )
 
 __all__ = ["YueTranslateVsZhoCli"]
+
+
+class _YueTranslateVsZhoCliKwargs(TypedDict, total=False):
+    """Keyword arguments for YueTranslateVsZhoCli."""
+
+    _parser: ArgumentParser
+    """Argument parser."""
+    yue_infile: Path | str
+    """Target written Cantonese subtitle infile or stdin sentinel."""
+    zho_infile: Path | str
+    """Reference standard Chinese subtitle infile or stdin sentinel."""
+    script: str
+    """Selected prompt script."""
+    outfile: Path | None
+    """Translated written Cantonese subtitle outfile path."""
+    overwrite: bool
+    """Whether to overwrite an existing outfile."""
 
 
 class YueTranslateVsZhoCli(ScinoephileCliBase):
@@ -161,7 +177,7 @@ class YueTranslateVsZhoCli(ScinoephileCliBase):
         return YueVsZhoYueHansTranslationPrompt
 
     @classmethod
-    def _main(cls, **kwargs: Unpack[CLIKwargs]):
+    def _main(cls, **kwargs: Unpack[_YueTranslateVsZhoCliKwargs]):
         """Execute with provided keyword arguments.
 
         Arguments:

--- a/scinoephile/cli/zho/zho_cli.py
+++ b/scinoephile/cli/zho/zho_cli.py
@@ -5,9 +5,9 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
-from typing import Unpack
+from typing import TypedDict, Unpack
 
-from scinoephile.common import CLIKwargs, CommandLineInterface
+from scinoephile.common import CommandLineInterface
 from scinoephile.core.cli import ScinoephileCliBase
 
 from .zho_fuse_cli import ZhoFuseCli
@@ -15,6 +15,13 @@ from .zho_process_cli import ZhoProcessCli
 from .zho_validate_ocr_cli import ZhoValidateOcrCli
 
 __all__ = ["ZhoCli"]
+
+
+class _ZhoCliKwargs(TypedDict, total=False):
+    """Keyword arguments for ZhoCli."""
+
+    zho_subcommand: str
+    """Selected standard Chinese subtitle subcommand."""
 
 
 class ZhoCli(ScinoephileCliBase):
@@ -69,7 +76,7 @@ class ZhoCli(ScinoephileCliBase):
         }
 
     @classmethod
-    def _main(cls, **kwargs: Unpack[CLIKwargs]):
+    def _main(cls, **kwargs: Unpack[_ZhoCliKwargs]):
         """Execute with provided keyword arguments.
 
         Arguments:

--- a/scinoephile/cli/zho/zho_fuse_cli.py
+++ b/scinoephile/cli/zho/zho_fuse_cli.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import Any
+from typing import TypedDict, Unpack
 
 from scinoephile.cli.conversion import (
     add_opencc_convert_argument,
@@ -34,6 +34,25 @@ from scinoephile.lang.zho.ocr_fusion import (
 from scinoephile.llms.dual_single.ocr_fusion import OcrFusionProcessor
 
 __all__ = ["ZhoFuseCli"]
+
+
+class _ZhoFuseCliKwargs(TypedDict, total=False):
+    """Keyword arguments for ZhoFuseCli."""
+
+    _parser: ArgumentParser
+    """Argument parser."""
+    lens_infile: Path | str
+    """Standard Chinese subtitles OCRed using Google Lens or stdin sentinel."""
+    paddle_infile: Path | str
+    """Standard Chinese subtitles OCRed using PaddleOCR or stdin sentinel."""
+    clean: bool
+    """Whether to clean both OCR inputs before fusion."""
+    convert: OpenCCConfig | None
+    """OpenCC conversion configuration."""
+    outfile: Path | None
+    """Standard Chinese subtitle outfile path."""
+    overwrite: bool
+    """Whether to overwrite an existing outfile."""
 
 
 class ZhoFuseCli(ScinoephileCliBase):
@@ -127,7 +146,7 @@ class ZhoFuseCli(ScinoephileCliBase):
         return "fuse"
 
     @classmethod
-    def _main(cls, **kwargs: Any):
+    def _main(cls, **kwargs: Unpack[_ZhoFuseCliKwargs]):
         """Execute with provided keyword arguments.
 
         Arguments:

--- a/scinoephile/cli/zho/zho_process_cli.py
+++ b/scinoephile/cli/zho/zho_process_cli.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import Any
+from typing import TypedDict, Unpack
 
 from scinoephile.cli.conversion import (
     add_opencc_convert_argument,
@@ -37,6 +37,29 @@ from scinoephile.lang.zho.conversion import (
 from scinoephile.lang.zho.flattening import get_zho_flattened
 
 __all__ = ["ZhoProcessCli"]
+
+
+class _ZhoProcessCliKwargs(TypedDict, total=False):
+    """Keyword arguments for ZhoProcessCli."""
+
+    _parser: ArgumentParser
+    """Argument parser."""
+    infile: Path | str
+    """Standard Chinese subtitle infile path or stdin sentinel."""
+    outfile: Path | None
+    """Standard Chinese subtitle outfile path."""
+    clean: bool
+    """Whether to clean subtitles."""
+    flatten: bool
+    """Whether to flatten multi-line subtitles."""
+    convert: OpenCCConfig | None
+    """OpenCC conversion configuration."""
+    proofread: str | None
+    """Selected proofreading script."""
+    romanize: bool
+    """Whether to append Mandarin romanization."""
+    overwrite: bool
+    """Whether to overwrite an existing outfile."""
 
 
 class ZhoProcessCli(ScinoephileCliBase):
@@ -170,7 +193,7 @@ class ZhoProcessCli(ScinoephileCliBase):
         return "process"
 
     @classmethod
-    def _main(cls, **kwargs: Any):
+    def _main(cls, **kwargs: Unpack[_ZhoProcessCliKwargs]):
         """Execute with provided keyword arguments.
 
         Arguments:

--- a/scinoephile/cli/zho/zho_validate_ocr_cli.py
+++ b/scinoephile/cli/zho/zho_validate_ocr_cli.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import Any
+from typing import TypedDict, Unpack
 
 from scinoephile.common import DirectoryNotFoundError
 from scinoephile.common.argument_parsing import (
@@ -20,6 +20,23 @@ from scinoephile.image.subtitles import ImageSeries
 from scinoephile.lang.zho.ocr_validation import validate_zho_ocr
 
 __all__ = ["ZhoValidateOcrCli"]
+
+
+class _ZhoValidateOcrCliKwargs(TypedDict, total=False):
+    """Keyword arguments for ZhoValidateOcrCli."""
+
+    _parser: ArgumentParser
+    """Argument parser."""
+    infile: Path
+    """Standard Chinese OCR image subtitle infile path."""
+    stop_at_idx: int | None
+    """Subtitle index after which validation should stop."""
+    interactive: bool
+    """Whether to prompt for interactive validation decisions."""
+    outfile: Path
+    """Directory in which to save validation image outputs."""
+    overwrite: bool
+    """Whether to overwrite the outfile directory."""
 
 
 class ZhoValidateOcrCli(ScinoephileCliBase):
@@ -104,7 +121,7 @@ class ZhoValidateOcrCli(ScinoephileCliBase):
         return "validate-ocr"
 
     @classmethod
-    def _main(cls, **kwargs: Any):
+    def _main(cls, **kwargs: Unpack[_ZhoValidateOcrCliKwargs]):
         """Execute with provided keyword arguments.
 
         Arguments:

--- a/scinoephile/common/__init__.py
+++ b/scinoephile/common/__init__.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from .command_line_interface import CLIKwargs, CommandLineInterface
+from .command_line_interface import CommandLineInterface
 from .exception import (
     ArgumentConflictError,
     DirectoryExistsError,
@@ -31,7 +31,6 @@ If this file is '/path/to/package/common/__init__.py', the value is
 
 __all__ = [
     "ArgumentConflictError",
-    "CLIKwargs",
     "CommandLineInterface",
     "DirectoryExistsError",
     "DirectoryNotFoundError",

--- a/scinoephile/common/command_line_interface.py
+++ b/scinoephile/common/command_line_interface.py
@@ -16,22 +16,15 @@ from inspect import cleandoc
 from logging import FileHandler, Formatter, getLogger
 from pathlib import Path
 from sys import argv
-from typing import Any, Unpack
-
-from typing_extensions import TypedDict
+from typing import Any
 
 from .logs import DEFAULT_LOG_FORMAT, configure_logging
 
 __all__ = [
-    "CLIKwargs",
     "CommandLineInterface",
 ]
 
 logger = getLogger(__name__)
-
-
-class CLIKwargs(TypedDict, total=False, extra_items=Any):
-    """Keyword arguments for command-line interface _main methods."""
 
 
 class CommandLineInterface(ABC):
@@ -153,6 +146,6 @@ class CommandLineInterface(ABC):
 
     @classmethod
     @abstractmethod
-    def _main(cls, **kwargs: Unpack[CLIKwargs]):
+    def _main(cls, **kwargs: Any):
         """Execute with provided keyword arguments."""
         raise NotImplementedError()


### PR DESCRIPTION
Closes #754

## Summary

- Remove the global `CLIKwargs` export and loosen the abstract base `_main` signature to accept arbitrary keyword values.
- Add command-specific `TypedDict` kwargs types across CLI wrapper and leaf command modules.
- Replace remaining CLI `Any`/`cast(dict[str, Any], kwargs)` workarounds with typed `Unpack[...]` annotations.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format <changed Python files>`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix <changed Python files>`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check <changed Python files>`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` (782 passed, 4 pydub warnings)
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check` still reports 32 diagnostics outside this CLI kwargs scope.