### PR TITLE
Resolve static review findings

### DIFF
--- a/scinoephile/cli/dictionary/build/dictionary_build_cuhk_cli.py
+++ b/scinoephile/cli/dictionary/build/dictionary_build_cuhk_cli.py
@@ -28,7 +28,7 @@ logger = getLogger(__name__)
 class _DictionaryBuildCuhkCliKwargs(TypedDict, total=False):
     """Keyword arguments for DictionaryBuildCuhkCli."""
 
-    cache_dir: Path | None
+    cache_dir_path: Path | None
     """Cache directory for scraped HTML and link data."""
     database_path: Path | None
     """SQLite database output path."""
@@ -109,6 +109,7 @@ class DictionaryBuildCuhkCli(DictionaryBuildCliBase):
         # Input arguments
         arg_groups["input arguments"].add_argument(
             "--cache-dir",
+            dest="cache_dir_path",
             default=None,
             type=output_dir_arg(),
             help="cache directory for scraped HTML and link data",
@@ -184,7 +185,7 @@ class DictionaryBuildCuhkCli(DictionaryBuildCliBase):
         Arguments:
             **kwargs: keyword arguments
         """
-        cache_dir_path = kwargs.pop("cache_dir")
+        cache_dir_path = kwargs.pop("cache_dir_path")
         database_path = kwargs.pop("database_path")
         max_words = kwargs.pop("max_words", None)
         overwrite = kwargs.pop("overwrite")

--- a/scinoephile/core/llms/openai_provider_base.py
+++ b/scinoephile/core/llms/openai_provider_base.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Mapping
 from logging import getLogger
 from time import sleep
 from typing import Any, Unpack, cast
@@ -259,7 +260,7 @@ class OpenAIProviderBase(LLMProvider):
     def _build_request_kwargs(
         response_format: type[Answer] | None,
         openai_tools: list[dict[str, object]] | None,
-        kwargs: dict[str, Any],
+        kwargs: Mapping[str, Any],
     ) -> dict[str, Any]:
         """Build request kwargs for one completion call.
 

--- a/scinoephile/image/ocr/char_cursor.py
+++ b/scinoephile/image/ocr/char_cursor.py
@@ -33,6 +33,13 @@ class CharCursor:
     """Current bbox index."""
 
     @property
+    def bboxes(self) -> list[Bbox]:
+        """Subtitle bboxes after OCR extraction."""
+        bboxes = self.sub.bboxes
+        assert bboxes is not None
+        return bboxes
+
+    @property
     def char(self) -> str:
         """Current character."""
         return self.sub.text_with_newline[self.char_idx]
@@ -61,9 +68,7 @@ class CharCursor:
         Returns:
             bbox group
         """
-        bboxes = self.sub.bboxes
-        assert bboxes is not None
-        return bboxes[self.bbox_idx : self.bbox_idx + n_bboxes]
+        return self.bboxes[self.bbox_idx : self.bbox_idx + n_bboxes]
 
     def char_grp(self, n_chars: int) -> str:
         """Current character group.

--- a/scinoephile/image/ocr/gap_cursor.py
+++ b/scinoephile/image/ocr/gap_cursor.py
@@ -61,17 +61,22 @@ class GapCursor:
     """Observed gap characters."""
 
     @property
+    def bboxes(self) -> list[Bbox]:
+        """Subtitle bboxes after OCR extraction."""
+        bboxes = self.sub.bboxes
+        assert bboxes is not None
+        return bboxes
+
+    @property
     def bbox_1_current(self) -> Bbox | None:
         """Get the current bbox_1.
 
         Returns:
             bbox_1 or None if out of range
         """
-        bboxes = self.sub.bboxes
-        assert bboxes is not None
-        if self.bbox_1_idx >= len(bboxes):
+        if self.bbox_1_idx >= len(self.bboxes):
             return None
-        return bboxes[self.bbox_1_idx]
+        return self.bboxes[self.bbox_1_idx]
 
     @property
     def bbox_2_current(self) -> Bbox | None:
@@ -81,11 +86,9 @@ class GapCursor:
             bbox_2 or None if out of range
         """
         self.bbox_2_idx = self.bbox_1_idx + 1
-        bboxes = self.sub.bboxes
-        assert bboxes is not None
-        if self.bbox_2_idx >= len(bboxes):
+        if self.bbox_2_idx >= len(self.bboxes):
             return None
-        return bboxes[self.bbox_2_idx]
+        return self.bboxes[self.bbox_2_idx]
 
     @property
     def char_pair(self) -> tuple[str, str]:
@@ -146,9 +149,7 @@ class GapCursor:
         Returns:
             bbox group
         """
-        bboxes = self.sub.bboxes
-        assert bboxes is not None
-        return bboxes[self.bbox_1_idx : self.bbox_1_idx + n_bboxes]
+        return self.bboxes[self.bbox_1_idx : self.bbox_1_idx + n_bboxes]
 
     def prepare_gap(self) -> tuple[Bbox, Bbox] | None:
         """Prepare gap by seeking characters and bboxes.

--- a/scinoephile/image/ocr/validation_manager.py
+++ b/scinoephile/image/ocr/validation_manager.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from scinoephile.common import package_root
 from scinoephile.core.text import whitespace_chars
+from scinoephile.image.bbox import Bbox
 from scinoephile.image.bboxes import get_bboxes, get_merged_bbox
 from scinoephile.image.drawing import get_img_with_bboxes
 from scinoephile.image.subtitles import ImageSeries, ImageSubtitle
@@ -100,8 +101,9 @@ class ValidationManager:
         for sub_idx, sub in enumerate(series.events):
             if sub_idx > stop_at_idx:
                 break
-            messages.extend(self._validate_sub(sub, sub_idx, interactive))
-            annotated_img = get_img_with_bboxes(sub.img, sub.bboxes)
+            sub_messages, bboxes = self._validate_sub(sub, sub_idx, interactive)
+            messages.extend(sub_messages)
+            annotated_img = get_img_with_bboxes(sub.img, bboxes)
             events.append(
                 ImageSubtitle(
                     img=annotated_img,
@@ -117,7 +119,7 @@ class ValidationManager:
 
     def _validate_sub(
         self, sub: ImageSubtitle, sub_idx: int, interactive: bool = True
-    ) -> list[str]:
+    ) -> tuple[list[str], list[Bbox]]:
         """Validate per-character bboxes for a subtitle.
 
         Arguments:
@@ -125,17 +127,18 @@ class ValidationManager:
             sub_idx: subtitle index for logging
             interactive: whether to prompt user for confirmations
         Returns:
-            list of validation messages
+            validation messages and validated bboxes
         """
         sub.bboxes = get_bboxes(sub.img)
+        bboxes = sub.bboxes
 
         char_messages = self._validate_chars(sub, sub_idx, interactive)
         if len(char_messages) > 0:
-            return char_messages
+            return char_messages, bboxes
 
         gap_messages = self._validate_gaps(sub, sub_idx, interactive)
 
-        return char_messages + gap_messages
+        return char_messages + gap_messages, bboxes
 
     def _validate_chars(
         self,
@@ -162,7 +165,7 @@ class ValidationManager:
                 continue
 
             # Cannot validate without bboxes
-            if cursor.bbox_idx >= len(sub.bboxes):
+            if cursor.bbox_idx >= len(cursor.bboxes):
                 messages.append(
                     f"{cursor.intro_msg} | ran out of bboxes at '{cursor.char}'"
                 )
@@ -196,10 +199,10 @@ class ValidationManager:
             messages.append(f"{cursor.intro_msg} | unexpected state at '{cursor.char}'")
 
         # Cannot have leftover bboxes
-        if cursor.bbox_idx != len(sub.bboxes):
+        if cursor.bbox_idx != len(cursor.bboxes):
             messages.append(
                 f"{cursor.intro_msg} | "
-                f"{len(sub.bboxes) - cursor.bbox_idx} leftover bboxes"
+                f"{len(cursor.bboxes) - cursor.bbox_idx} leftover bboxes"
             )
 
         return messages
@@ -218,7 +221,7 @@ class ValidationManager:
             char_grp = cursor.char_grp(n_chars)
             if any(c in whitespace_chars for c in char_grp) or "\n" in char_grp:
                 continue
-            dims = get_dims_tuple(cursor.sub.bboxes[cursor.bbox_idx])
+            dims = get_dims_tuple(cursor.bboxes[cursor.bbox_idx])
             ok_dims = self.char_grp_dims_by_n[n_chars].get(char_grp, set())
 
             # Exact match
@@ -245,7 +248,7 @@ class ValidationManager:
             whether a match was found
         """
         for n_bboxes in self.char_dims_by_n.keys():
-            if cursor.bbox_idx + n_bboxes > len(cursor.sub.bboxes):
+            if cursor.bbox_idx + n_bboxes > len(cursor.bboxes):
                 break
             dims = get_dims_tuple(cursor.bbox_grp(n_bboxes))
             ok_dims = self.char_dims_by_n[n_bboxes].get(cursor.char, set())
@@ -254,7 +257,7 @@ class ValidationManager:
             if dims in ok_dims:
                 bbox_grp = cursor.bbox_grp(n_bboxes)
                 merged_bbox = get_merged_bbox(bbox_grp)
-                cursor.sub.bboxes[cursor.bbox_idx : cursor.bbox_idx + n_bboxes] = [
+                cursor.bboxes[cursor.bbox_idx : cursor.bbox_idx + n_bboxes] = [
                     merged_bbox
                 ]
                 cursor.advance(n_chars=1, n_bboxes=1)
@@ -267,7 +270,7 @@ class ValidationManager:
                 if max_diff <= 2:
                     bbox_grp = cursor.bbox_grp(n_bboxes)
                     merged_bbox = get_merged_bbox(bbox_grp)
-                    cursor.sub.bboxes[cursor.bbox_idx : cursor.bbox_idx + n_bboxes] = [
+                    cursor.bboxes[cursor.bbox_idx : cursor.bbox_idx + n_bboxes] = [
                         merged_bbox
                     ]
                     self._update_char_dims(cursor.char, dims)
@@ -286,7 +289,7 @@ class ValidationManager:
         messages: list[str] = []
 
         for n_bboxes in self.char_dims_by_n.keys():
-            if cursor.bbox_idx + n_bboxes > len(cursor.sub.bboxes):
+            if cursor.bbox_idx + n_bboxes > len(cursor.bboxes):
                 break
             dims = get_dims_tuple(cursor.bbox_grp(n_bboxes))
 
@@ -312,7 +315,7 @@ class ValidationManager:
             if extend:
                 bbox_grp = cursor.bbox_grp(n_bboxes)
                 merged_bbox = get_merged_bbox(bbox_grp)
-                cursor.sub.bboxes[cursor.bbox_idx : cursor.bbox_idx + n_bboxes] = [
+                cursor.bboxes[cursor.bbox_idx : cursor.bbox_idx + n_bboxes] = [
                     merged_bbox
                 ]
                 self._update_char_dims(cursor.char, dims)
@@ -361,11 +364,11 @@ class ValidationManager:
         while cursor.char_1_idx < len(sub.text_with_newline) - 1:
             prepared = cursor.prepare_gap()
             if prepared is None:
-                if cursor.bbox_1_idx >= len(sub.bboxes) and cursor.char_1:
+                if cursor.bbox_1_idx >= len(cursor.bboxes) and cursor.char_1:
                     messages.append(
                         f"{cursor.intro_msg} | ran out of bboxes at '{cursor.char_1}'"
                     )
-                elif cursor.bbox_2_idx >= len(sub.bboxes) and cursor.char_2:
+                elif cursor.bbox_2_idx >= len(cursor.bboxes) and cursor.char_2:
                     messages.append(
                         f"{cursor.intro_msg} | "
                         f"Ran out of bboxes when checking gap between "

--- a/scinoephile/image/subtitles/subtitle.py
+++ b/scinoephile/image/subtitles/subtitle.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from dataclasses import fields
-from typing import Unpack, override
+from typing import Unpack, cast, override
 
 import numpy as np
 from PIL import Image
@@ -34,7 +34,10 @@ class ImageSubtitle(Subtitle):
             **kwargs: Additional keyword arguments
         """
         super_field_names = {f.name for f in fields(Subtitle)}
-        super_kwargs = {k: v for k, v in kwargs.items() if k in super_field_names}
+        super_kwargs = cast(
+            SubtitleKwargs,
+            {k: v for k, v in kwargs.items() if k in super_field_names},
+        )
         super().__init__(**super_kwargs)
 
         self.img = img

--- a/scinoephile/image/subtitles/sup.py
+++ b/scinoephile/image/subtitles/sup.py
@@ -119,7 +119,7 @@ def read_sup_palette(bytes_: np.ndarray) -> np.ndarray:
 
 
 @nb.jit(nopython=True, nogil=True, cache=True, fastmath=True)
-def read_sup_series(
+def read_sup_series(  # noqa: PLR0912, PLR0915
     bytes_: np.ndarray,
 ) -> tuple[list[float], list[float], list[np.ndarray]]:
     """Read subtitle images and times from a block of bytes.

--- a/scinoephile/llms/dual_block/manager.py
+++ b/scinoephile/llms/dual_block/manager.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from functools import cache
-from typing import Any, ClassVar, Unpack
+from typing import Any, ClassVar, Unpack, cast
 
 from pydantic import Field, create_model
 
@@ -146,6 +146,7 @@ class DualBlockManager(Manager):
         """
         if (prompt_cls := kwargs.get("prompt_cls")) is None:
             raise ScinoephileError("prompt_cls must be provided as a keyword argument")
+        prompt_cls = cast(type[DualBlockPrompt], prompt_cls)
         size = sum(1 for key in data["query"] if key.startswith(prompt_cls.src_1_pfx))
         return cls.get_test_case_cls(size=size, prompt_cls=prompt_cls)
 

--- a/scinoephile/llms/dual_block_gapped/manager.py
+++ b/scinoephile/llms/dual_block_gapped/manager.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from functools import cache
-from typing import Any, ClassVar, Unpack
+from typing import Any, ClassVar, Unpack, cast
 
 from pydantic import Field, create_model
 
@@ -183,6 +183,7 @@ class DualBlockGappedManager(Manager):
         """
         if (prompt_cls := kwargs.get("prompt_cls")) is None:
             raise ScinoephileError("prompt_cls must be provided as a keyword argument")
+        prompt_cls = cast(type[DualBlockGappedPrompt], prompt_cls)
         size = sum(1 for key in data["query"] if key.startswith(prompt_cls.src_2_pfx))
         source_one_idxs = [
             int(key.removeprefix(prompt_cls.src_1_pfx)) - 1

--- a/scinoephile/llms/mono_block/manager.py
+++ b/scinoephile/llms/mono_block/manager.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import re
 from functools import cache
-from typing import Any, ClassVar, Unpack
+from typing import Any, ClassVar, Unpack, cast
 
 from pydantic import Field, create_model
 
@@ -144,6 +144,7 @@ class MonoBlockManager(Manager):
         """
         if (prompt_cls := kwargs.get("prompt_cls")) is None:
             raise ScinoephileError("prompt_cls must be provided as a keyword argument")
+        prompt_cls = cast(type[MonoBlockPrompt], prompt_cls)
         pattern = re.compile(rf"^{re.escape(prompt_cls.input_pfx)}\d+$")
         size = sum(1 for field in data["query"] if pattern.match(field))
         return cls.get_test_case_cls(size=size, prompt_cls=prompt_cls)

--- a/test/dictionaries/test_dictionary_tools.py
+++ b/test/dictionaries/test_dictionary_tools.py
@@ -182,7 +182,7 @@ def test_get_dictionary_tools_uses_prompt_text():
     ]
     assert tool_box.handler_names == [StubDictionaryToolPrompt.dictionary_tool_name]
 
-    parameters = tool_box.specs[0]["parameters"]
+    parameters = cast(dict[str, object], tool_box.specs[0]["parameters"])
     properties = cast(dict[str, object], parameters["properties"])
     query_schema = cast(dict[str, object], properties["query"])
 

--- a/test/helpers/__init__.py
+++ b/test/helpers/__init__.py
@@ -15,7 +15,7 @@ from typing import Any
 import pytest
 from pytest import fixture, mark
 
-from scinoephile.common import package_root
+from scinoephile.common import CommandLineInterface, package_root
 from scinoephile.common.testing import run_cli_with_args
 
 from .series_cer_result import SeriesCERResult
@@ -38,7 +38,7 @@ __all__ = [
 test_data_root = package_root.parent / "test" / "data"
 
 
-def assert_cli_help(cli: tuple[type, ...]):
+def assert_cli_help(cli: tuple[type[CommandLineInterface], ...]):
     """Assert that a CLI tuple shows help text.
 
     Arguments:
@@ -56,7 +56,7 @@ def assert_cli_help(cli: tuple[type, ...]):
     assert stderr.getvalue() == ""
 
 
-def assert_cli_usage(cli: tuple[type, ...]):
+def assert_cli_usage(cli: tuple[type[CommandLineInterface], ...]):
     """Assert that a CLI tuple shows usage on missing args.
 
     Arguments:
@@ -92,7 +92,7 @@ def assert_expected_warnings(warnings: list[str], expected: list[str], label: st
         )
 
 
-def build_subcommands(cli: tuple[type, ...]) -> str:
+def build_subcommands(cli: tuple[type[CommandLineInterface], ...]) -> str:
     """Build subcommand string for a CLI tuple.
 
     Arguments:
@@ -103,7 +103,7 @@ def build_subcommands(cli: tuple[type, ...]) -> str:
     return " ".join(f"{command.name()}" for command in cli[1:])
 
 
-def get_usage_prefix(cli: tuple[type, ...]) -> str:
+def get_usage_prefix(cli: tuple[type[CommandLineInterface], ...]) -> str:
     """Get expected usage prefix for a CLI tuple.
 
     Arguments:


### PR DESCRIPTION
## Summary
- Add explicit OCR bbox narrowing for validation cursors and annotation
- Fix remaining type-check diagnostics in LLM managers, OpenAI provider kwargs, image subtitles, and tests
- Keep the public CUHK `--cache-dir` flag while aligning internal path naming
- Add a targeted ruff exemption for the numba SUP parser complexity

## Verification
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check scinoephile test scripts skills`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check .`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto`