### PR TITLE
Sync common module improvements

### DIFF
--- a/scinoephile/common/csv.py
+++ b/scinoephile/common/csv.py
@@ -1,0 +1,46 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""CSV parsing utilities."""
+
+from __future__ import annotations
+
+__all__ = [
+    "parse_csv_int_list",
+    "parse_csv_str_list",
+]
+
+
+def parse_csv_int_list(values: str, *, name: str) -> list[int]:
+    """Parse a comma-separated integer list.
+
+    Arguments:
+        values: comma-separated integer values
+        name: argument name for error context
+    Returns:
+        list of parsed integers
+    """
+    parsed_values: list[int] = []
+    for item in values.split(","):
+        value = item.strip()
+        if value == "":
+            continue
+        try:
+            parsed_values.append(int(value))
+        except ValueError as exc:
+            raise ValueError(f"Invalid integer {value!r} in {name}") from exc
+    if not parsed_values:
+        raise ValueError(f"{name} must include at least one integer")
+    return parsed_values
+
+
+def parse_csv_str_list(values: str | None) -> list[str]:
+    """Parse a comma-separated string list.
+
+    Arguments:
+        values: comma-separated string values
+    Returns:
+        list of parsed strings with whitespace stripped and empty entries removed
+    """
+    if values is None or values.strip() == "":
+        return []
+    return [item.strip() for item in values.split(",") if item.strip()]

--- a/scinoephile/common/validation.py
+++ b/scinoephile/common/validation.py
@@ -11,7 +11,7 @@ from os.path import defpath, expanduser, expandvars
 from pathlib import Path
 from platform import system
 from shutil import which
-from typing import Any, overload
+from typing import Any, TypeAliasType, get_args, overload
 
 from .exception import (
     ArgumentConflictError,
@@ -27,6 +27,7 @@ __all__ = [
     "val_input_dir_path",
     "val_input_path",
     "val_int",
+    "val_literal",
     "val_output_dir_path",
     "val_output_path",
     "val_str",
@@ -68,7 +69,7 @@ def val_executable(
 
 @overload
 def val_float(
-    value: float,
+    value: float | int | str,
     *,
     n_values: int | None = None,
     min_value: float | None = None,
@@ -87,7 +88,7 @@ def val_float(
 
 
 def val_float(
-    value: float | Iterable[Any],
+    value: float | int | str | Iterable[Any],
     *,
     n_values: int | None = None,
     min_value: float | None = None,
@@ -271,7 +272,7 @@ def val_input_path(
 
 @overload
 def val_int(
-    value: int,
+    value: float | int | str,
     *,
     n_values: int | None = None,
     min_value: int | None = None,
@@ -292,7 +293,7 @@ def val_int(
 
 
 def val_int(
-    value: int | Iterable[Any],
+    value: float | int | str | Iterable[Any],
     *,
     n_values: int | None = None,
     min_value: int | None = None,
@@ -518,7 +519,34 @@ def val_output_path(
     return [_val_output_path(value_to_validate) for value_to_validate in value]
 
 
-def val_str(value: Any, options: Iterable[str]) -> str:
+def val_literal[LiteralValue](value: LiteralValue, literal_type: Any) -> LiteralValue:
+    """Validate a value against a Literal type or type alias.
+
+    Arguments:
+        value: input value to validate
+        literal_type: Literal type or type alias with Literal value options
+    Returns:
+        value if it is one of the Literal options
+    Raises:
+        ArgumentConflictError: If literal_type does not resolve to Literal options
+        ValueError: If value is not one of the provided Literal options
+    """
+    literal_value = (
+        literal_type.__value__
+        if isinstance(literal_type, TypeAliasType)
+        else literal_type
+    )
+    options = get_args(literal_value)
+    if not options:
+        raise ArgumentConflictError(
+            f"'{literal_type}' does not contain Literal options"
+        ) from None
+    if value not in options:
+        raise ValueError(f"'{value}' is not one of options '{options}'") from None
+    return value
+
+
+def val_str(value: Any, options: Iterable[Any]) -> str:
     """Validate a str.
 
     Arguments:

--- a/test/common/test_csv.py
+++ b/test/common/test_csv.py
@@ -1,0 +1,43 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests of common.csv."""
+
+from __future__ import annotations
+
+import pytest
+from common.csv import (  # ty:ignore[unresolved-import]
+    parse_csv_int_list,
+    parse_csv_str_list,
+)
+
+
+def test_parse_csv_int_list_empty():
+    """Test parsing of empty integer list values."""
+    with pytest.raises(ValueError, match="--sizes must include at least one integer"):
+        parse_csv_int_list(" , ", name="--sizes")
+
+
+def test_parse_csv_int_list_invalid_value():
+    """Test parsing of invalid integer list values."""
+    with pytest.raises(ValueError, match="Invalid integer 'x' in --sizes"):
+        parse_csv_int_list("1,x,3", name="--sizes")
+
+
+def test_parse_csv_int_list_values():
+    """Test parsing of comma-separated integer list values."""
+    assert parse_csv_int_list("1, 2, , 3", name="--sizes") == [1, 2, 3]
+
+
+def test_parse_csv_str_list_none():
+    """Test parsing of None string list."""
+    assert parse_csv_str_list(None) == []
+
+
+def test_parse_csv_str_list_values():
+    """Test parsing of comma-separated string list values."""
+    assert parse_csv_str_list("a, b ,, c  ") == ["a", "b", "c"]
+
+
+def test_parse_csv_str_list_whitespace():
+    """Test parsing of whitespace-only string list."""
+    assert parse_csv_str_list("   ") == []

--- a/test/common/validation/test_val_literal.py
+++ b/test/common/validation/test_val_literal.py
@@ -1,0 +1,41 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests of common.validation.val_literal."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import pytest
+from common.exception import ArgumentConflictError  # ty:ignore[unresolved-import]
+from common.validation import val_literal  # ty:ignore[unresolved-import]
+
+type Color = Literal["red", "green", "blue"]
+type Level = Literal[1, 2, 3]
+
+
+def test_val_literal_literal_type_valid():
+    """Test validation against a Literal type."""
+    assert val_literal("green", Literal["red", "green", "blue"]) == "green"
+
+
+def test_val_literal_non_literal():
+    """Test validation with non-Literal type."""
+    with pytest.raises(ArgumentConflictError, match="does not contain Literal options"):
+        val_literal("red", str)
+
+
+def test_val_literal_type_alias_invalid():
+    """Test validation with invalid value against a type alias."""
+    with pytest.raises(ValueError, match="not one of options"):
+        val_literal("yellow", Color)
+
+
+def test_val_literal_type_alias_valid_int():
+    """Test validation of a valid int against a type alias."""
+    assert val_literal(2, Level) == 2
+
+
+def test_val_literal_type_alias_valid_str():
+    """Test validation of a valid str against a type alias."""
+    assert val_literal("red", Color) == "red"


### PR DESCRIPTION
## Summary

- Add `scinoephile.common.csv` with CSV string and integer list parsers.
- Add `val_literal` for validating values against `Literal` types and type aliases.
- Bring over common validation type-hint improvements and tests from sibling project copies.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/common/csv.py scinoephile/common/validation.py test/common/test_csv.py test/common/validation/test_val_literal.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/common/csv.py scinoephile/common/validation.py test/common/test_csv.py test/common/validation/test_val_literal.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/common/csv.py scinoephile/common/validation.py test/common/test_csv.py test/common/validation/test_val_literal.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest test/common -q` (`207 passed`)