### PR TITLE
Expose sync tuning options

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,31 +9,6 @@ Scinoephile is a package for working with Chinese/English bilingual subtitles, w
 focus on combining separate Chinese and English subtitles into synchronized bilingual
 subtitles.
 
-## Synchronization
-
-Use `scinoephile sync` to combine two subtitle files into synchronized bilingual
-subtitles:
-
-```shell
-scinoephile sync \
-  --top-infile top.srt \
-  --bottom-infile bottom.srt \
-  --outfile synced.srt
-```
-
-For difficult subtitle sets, `--sync-cutoff` adjusts the initial overlap threshold
-used when grouping subtitles, and `--pause-length` adjusts the pause in milliseconds
-used to split long subtitle streams into blocks:
-
-```shell
-scinoephile sync \
-  --top-infile top.srt \
-  --bottom-infile bottom.srt \
-  --outfile synced.srt \
-  --sync-cutoff 0.16 \
-  --pause-length 3000
-```
-
 ## Notices
 
 Third-party license and data-source acknowledgements are listed in

--- a/README.md
+++ b/README.md
@@ -9,6 +9,31 @@ Scinoephile is a package for working with Chinese/English bilingual subtitles, w
 focus on combining separate Chinese and English subtitles into synchronized bilingual
 subtitles.
 
+## Synchronization
+
+Use `scinoephile sync` to combine two subtitle files into synchronized bilingual
+subtitles:
+
+```shell
+scinoephile sync \
+  --top-infile top.srt \
+  --bottom-infile bottom.srt \
+  --outfile synced.srt
+```
+
+For difficult subtitle sets, `--sync-cutoff` adjusts the initial overlap threshold
+used when grouping subtitles, and `--pause-length` adjusts the pause in milliseconds
+used to split long subtitle streams into blocks:
+
+```shell
+scinoephile sync \
+  --top-infile top.srt \
+  --bottom-infile bottom.srt \
+  --outfile synced.srt \
+  --sync-cutoff 0.16 \
+  --pause-length 3000
+```
+
 ## Notices
 
 Third-party license and data-source acknowledgements are listed in

--- a/scinoephile/cli/sync_cli.py
+++ b/scinoephile/cli/sync_cli.py
@@ -9,8 +9,10 @@ from pathlib import Path
 from typing import TypedDict, Unpack
 
 from scinoephile.common.argument_parsing import (
+    float_arg,
     get_arg_groups_by_name,
     input_file_arg,
+    int_arg,
     output_file_arg,
 )
 from scinoephile.common.exception import ArgumentConflictError
@@ -29,6 +31,10 @@ class _SyncCliKwargs(TypedDict, total=False):
     """Subtitle infile for top line or stdin sentinel."""
     bottom_infile: Path | str
     """Subtitle infile for bottom line or stdin sentinel."""
+    sync_cutoff: float
+    """Initial overlap cutoff used to form sync groups."""
+    pause_length: int
+    """Pause length in milliseconds used to split subtitle blocks."""
     outfile: Path | None
     """Synchronized subtitle outfile path."""
     overwrite: bool
@@ -63,6 +69,7 @@ class SyncCli(ScinoephileCliBase):
         arg_groups = get_arg_groups_by_name(
             parser,
             "input arguments",
+            "operation arguments",
             "output arguments",
             optional_arguments_name="additional arguments",
         )
@@ -79,6 +86,23 @@ class SyncCli(ScinoephileCliBase):
             required=True,
             type=input_file_arg(allow_stdin=True),
             help='subtitle infile for bottom line or "-" for stdin',
+        )
+
+        # Operation arguments
+        arg_groups["operation arguments"].add_argument(
+            "--sync-cutoff",
+            default=0.16,
+            type=float_arg(min_value=0.0, max_value=1.0),
+            help="initial overlap cutoff used to form sync groups (default: 0.16)",
+        )
+        arg_groups["operation arguments"].add_argument(
+            "--pause-length",
+            default=3000,
+            type=int_arg(min_value=1),
+            help=(
+                "pause length in milliseconds used to split subtitle blocks "
+                "(default: 3000)"
+            ),
         )
 
         # Output arguments
@@ -107,6 +131,8 @@ class SyncCli(ScinoephileCliBase):
         parser = kwargs.pop("_parser", cls.argparser())
         top_infile_path = kwargs.pop("top_infile")
         bottom_infile_path = kwargs.pop("bottom_infile")
+        sync_cutoff = kwargs.pop("sync_cutoff")
+        pause_length = kwargs.pop("pause_length")
         outfile_path: Path | None = kwargs.pop("outfile")
         overwrite = kwargs.pop("overwrite")
         if top_infile_path == "-" and bottom_infile_path == "-":
@@ -129,7 +155,12 @@ class SyncCli(ScinoephileCliBase):
         bottom = read_series(parser, bottom_infile_path, allow_stdin=True)
 
         # Perform operations
-        synced = get_synced_series(top, bottom)
+        synced = get_synced_series(
+            top,
+            bottom,
+            sync_cutoff=sync_cutoff,
+            pause_length=pause_length,
+        )
 
         # Write outputs
         write_series(

--- a/scinoephile/common/argument_parsing.py
+++ b/scinoephile/common/argument_parsing.py
@@ -193,12 +193,12 @@ def get_validator[T](function: Callable[..., T], **kwargs: Any) -> Callable[[Any
         Returns:
             Validated value
         Raises:
-            ArgumentTypeError: If TypeError is raised by wrapped function
+            ArgumentTypeError: If TypeError or ValueError is raised by wrapped function
         """
         try:
             return function(value, **kwargs)
-        except TypeError as exc:
-            raise ArgumentTypeError from exc
+        except (TypeError, ValueError) as exc:
+            raise ArgumentTypeError(str(exc)) from exc
 
     return wrapped
 

--- a/scinoephile/core/synchronization.py
+++ b/scinoephile/core/synchronization.py
@@ -199,24 +199,36 @@ def get_sync_overlap_matrix(one: Series, two: Series) -> np.ndarray:
     return overlap
 
 
-def get_synced_series(one: Series, two: Series) -> Series:
+def get_synced_series(
+    one: Series,
+    two: Series,
+    sync_cutoff: float = 0.16,
+    pause_length: int = 3000,
+) -> Series:
     """Compile synchonized subtitles from two series.
 
     Arguments:
         one: First Series
         two: Second Series
+        sync_cutoff: Initial overlap cutoff used to form sync groups
+        pause_length: Pause length in milliseconds used to split subtitle blocks
     Returns:
         Synchonized subtitles
     """
     synced_blocks = []
 
-    block_pairs = get_block_pairs_by_pause(one, two)
+    logger.info(
+        f"Synchronizing series with sync_cutoff={sync_cutoff} "
+        f"and pause_length={pause_length}"
+    )
+
+    block_pairs = get_block_pairs_by_pause(one, two, pause_length=pause_length)
     for one_block, two_block in block_pairs:
         one_str, two_str = get_pair_strings(one_block, two_block)
         logger.debug(f"ONE:\n{one_str}")
         logger.debug(f"TWO:\n{two_str}")
 
-        groups = get_sync_groups(one_block, two_block)
+        groups = get_sync_groups(one_block, two_block, cutoff=sync_cutoff)
         logger.info(f"SYNC GROUPS:\n{pformat(groups, width=1000)}")
 
         synced_block = get_synced_series_from_groups(one_block, two_block, groups)

--- a/test/cli/test_sync_cli.py
+++ b/test/cli/test_sync_cli.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from contextlib import redirect_stderr
 from io import StringIO
 from unittest.mock import patch
 
@@ -124,3 +125,91 @@ def test_sync_cli_pipe(top_path: str, bottom_path: str, expected_path: str):
     expected = Series.load(full_expected_path)
 
     assert output == expected
+
+
+@pytest.mark.parametrize(
+    ("args", "expected_sync_cutoff", "expected_pause_length"),
+    [
+        ("", 0.16, 3000),
+        ("--sync-cutoff 0.25 --pause-length 5000", 0.25, 5000),
+    ],
+)
+def test_sync_cli_passes_tuning_options(
+    args: str,
+    expected_sync_cutoff: float,
+    expected_pause_length: int,
+):
+    """Test sync CLI passes synchronization tuning options.
+
+    Arguments:
+        args: extra command-line arguments
+        expected_sync_cutoff: expected sync cutoff passed to synchronization
+        expected_pause_length: expected pause length passed to synchronization
+    """
+    top_path = (
+        test_data_root / "mlamd/output/zho-Hans_fuse_clean_validate_review_flatten.srt"
+    )
+    bottom_path = (
+        test_data_root / "mlamd/output/eng_fuse_clean_validate_review_flatten.srt"
+    )
+    top_series = Series()
+    bottom_series = Series()
+    synced_series = Series()
+
+    with patch(
+        "scinoephile.cli.sync_cli.read_series",
+        side_effect=[top_series, bottom_series],
+    ):
+        with patch("scinoephile.cli.sync_cli.write_series"):
+            with patch(
+                "scinoephile.cli.sync_cli.get_synced_series",
+                return_value=synced_series,
+            ) as get_synced_series:
+                run_cli_with_args(
+                    SyncCli,
+                    f"--top-infile {top_path} --bottom-infile {bottom_path} {args}",
+                )
+
+    get_synced_series.assert_called_once_with(
+        top_series,
+        bottom_series,
+        sync_cutoff=expected_sync_cutoff,
+        pause_length=expected_pause_length,
+    )
+
+
+@pytest.mark.parametrize(
+    ("args", "expected_error"),
+    [
+        ("--sync-cutoff -0.01", "-0.01 is less than minimum value of 0.0"),
+        ("--sync-cutoff 1.01", "1.01 is greater than maximum value of 1.0"),
+        ("--pause-length 0", "0 is less than minimum value of 1"),
+    ],
+)
+def test_sync_cli_rejects_invalid_tuning_options(
+    args: str,
+    expected_error: str,
+):
+    """Test sync CLI rejects invalid synchronization tuning options.
+
+    Arguments:
+        args: extra command-line arguments
+        expected_error: expected error message
+    """
+    top_path = (
+        test_data_root / "mlamd/output/zho-Hans_fuse_clean_validate_review_flatten.srt"
+    )
+    bottom_path = (
+        test_data_root / "mlamd/output/eng_fuse_clean_validate_review_flatten.srt"
+    )
+
+    stderr = StringIO()
+    with pytest.raises(SystemExit) as excinfo:
+        with redirect_stderr(stderr):
+            run_cli_with_args(
+                SyncCli,
+                f"--top-infile {top_path} --bottom-infile {bottom_path} {args}",
+            )
+
+    assert excinfo.value.code == 2
+    assert expected_error in stderr.getvalue()

--- a/test/common/argument_parsing/test_validators.py
+++ b/test/common/argument_parsing/test_validators.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from argparse import ArgumentTypeError
 from pathlib import Path
 
 import pytest
@@ -26,8 +27,7 @@ def test_float_arg():
 
     assert validator("5.5") == 5.5
 
-    # ValueError is not caught by get_validator, only TypeError
-    with pytest.raises(ValueError):
+    with pytest.raises(ArgumentTypeError, match="less than minimum value"):
         validator("-1.0")
 
 
@@ -37,8 +37,7 @@ def test_int_arg():
 
     assert validator("5") == 5
 
-    # ValueError is not caught by get_validator, only TypeError
-    with pytest.raises(ValueError):
+    with pytest.raises(ArgumentTypeError, match="less than minimum value"):
         validator("-1")
 
 
@@ -49,8 +48,7 @@ def test_str_arg():
     assert validator("option1") == "option1"
     assert validator("OPTION1") == "option1"
 
-    # ValueError is not caught by get_validator, only TypeError
-    with pytest.raises(ValueError):
+    with pytest.raises(ArgumentTypeError, match="is not one of options"):
         validator("invalid")
 
 


### PR DESCRIPTION
## Summary

- Add `--sync-cutoff` and `--pause-length` options to `scinoephile sync` and pass them through synchronization logic.
- Log the tuning values used for synchronization runs.
- Preserve defaults while improving argparse validation messages for ranged validators.
- Document sync tuning flags in the README.

Closes #763

## Tests

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/common/argument_parsing.py scinoephile/cli/sync_cli.py scinoephile/core/synchronization.py test/cli/test_sync_cli.py test/common/argument_parsing/test_validators.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/common/argument_parsing.py scinoephile/cli/sync_cli.py scinoephile/core/synchronization.py test/cli/test_sync_cli.py test/common/argument_parsing/test_validators.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/common/argument_parsing.py scinoephile/cli/sync_cli.py scinoephile/core/synchronization.py test/cli/test_sync_cli.py test/common/argument_parsing/test_validators.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest cli/test_sync_cli.py common/argument_parsing/test_validators.py core/synchronization/test_get_synced_series.py core/pairs/test_get_block_pairs_by_pause.py -q`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto`