### PR TITLE
Add offset fearure to CLI process tools

### DIFF
--- a/scinoephile/cli/eng/eng_process_cli.py
+++ b/scinoephile/cli/eng/eng_process_cli.py
@@ -11,6 +11,7 @@ from typing import TypedDict, Unpack
 from scinoephile.common.argument_parsing import (
     get_arg_groups_by_name,
     input_file_arg,
+    int_arg,
     output_file_arg,
 )
 from scinoephile.common.exception import ArgumentConflictError
@@ -37,6 +38,8 @@ class _EngProcessCliKwargs(TypedDict, total=False):
     """Whether to flatten multi-line subtitles."""
     proofread: bool
     """Whether to proofread subtitles."""
+    offset: int
+    """Timing offset in milliseconds."""
     overwrite: bool
     """Whether to overwrite an existing outfile."""
 
@@ -54,6 +57,9 @@ class EngProcessCli(ScinoephileCliBase):
             ),
             "flatten multi-line subtitles into single lines": "将多行字幕合并为单行",
             "modify English subtitles": "修改英文字幕",
+            "shift subtitle timings by this many milliseconds": (
+                "按指定毫秒数平移字幕时间"
+            ),
             "proofread subtitles using LLM": "使用大语言模型校对字幕",
         },
         "zh-hant": {
@@ -65,6 +71,9 @@ class EngProcessCli(ScinoephileCliBase):
             ),
             "flatten multi-line subtitles into single lines": "將多行字幕合併為單行",
             "modify English subtitles": "修改英文字幕",
+            "shift subtitle timings by this many milliseconds": (
+                "依指定毫秒數平移字幕時間"
+            ),
             "proofread subtitles using LLM": "使用大型語言模型校對字幕",
         },
     }
@@ -111,6 +120,12 @@ class EngProcessCli(ScinoephileCliBase):
             action="store_true",
             help="proofread subtitles using LLM",
         )
+        arg_groups["operation arguments"].add_argument(
+            "--offset",
+            default=0,
+            type=int_arg(),
+            help="shift subtitle timings by this many milliseconds",
+        )
 
         # Output arguments
         arg_groups["output arguments"].add_argument(
@@ -150,9 +165,10 @@ class EngProcessCli(ScinoephileCliBase):
         clean = kwargs.pop("clean")
         flatten = kwargs.pop("flatten")
         proofread = kwargs.pop("proofread")
+        offset = kwargs.pop("offset")
         overwrite = kwargs.pop("overwrite")
 
-        if not (clean or flatten or proofread):
+        if not (clean or flatten or proofread or offset):
             parser.error("At least one operation required")
         if overwrite and outfile_path is None:
             try:
@@ -172,6 +188,8 @@ class EngProcessCli(ScinoephileCliBase):
             series = get_eng_flattened(series)
         if proofread:
             series = get_eng_block_reviewed(series)
+        if offset:
+            series.shift(ms=offset)
 
         # Write output
         write_series(

--- a/scinoephile/cli/yue/yue_process_cli.py
+++ b/scinoephile/cli/yue/yue_process_cli.py
@@ -15,6 +15,7 @@ from scinoephile.cli.conversion import (
 from scinoephile.common.argument_parsing import (
     get_arg_groups_by_name,
     input_file_arg,
+    int_arg,
     output_file_arg,
     str_arg,
 )
@@ -58,6 +59,8 @@ class _YueProcessCliKwargs(TypedDict, total=False):
     """Selected proofreading script."""
     romanize: bool
     """Whether to append Cantonese romanization."""
+    offset: int
+    """Timing offset in milliseconds."""
     overwrite: bool
     """Whether to overwrite an existing outfile."""
 
@@ -82,6 +85,9 @@ class YueProcessCli(ScinoephileCliBase):
                 "script for prompts and output conversion (default: traditional)": (
                     "提示词和输出转换使用的字形（默认：繁体）"
                 ),
+                "shift subtitle timings by this many milliseconds": (
+                    "按指定毫秒数平移字幕时间"
+                ),
                 'Written Cantonese subtitle infile path or "-" for stdin': (
                     '书面粤语字幕输入文件路径，或使用 "-" 表示标准输入'
                 ),
@@ -103,6 +109,9 @@ class YueProcessCli(ScinoephileCliBase):
                 ),
                 "script for prompts and output conversion (default: traditional)": (
                     "提示詞與輸出轉換使用的字形（預設：繁體）"
+                ),
+                "shift subtitle timings by this many milliseconds": (
+                    "依指定毫秒數平移字幕時間"
                 ),
                 'Written Cantonese subtitle infile path or "-" for stdin': (
                     '書面粵語字幕輸入檔路徑，或使用 "-" 代表標準輸入'
@@ -167,6 +176,12 @@ class YueProcessCli(ScinoephileCliBase):
             action="store_true",
             help="append Cantonese romanization to subtitles",
         )
+        arg_groups["operation arguments"].add_argument(
+            "--offset",
+            default=0,
+            type=int_arg(),
+            help="shift subtitle timings by this many milliseconds",
+        )
 
         # Output arguments
         arg_groups["output arguments"].add_argument(
@@ -208,9 +223,10 @@ class YueProcessCli(ScinoephileCliBase):
         convert = kwargs.pop("convert")
         review_script = kwargs.pop("proofread")
         romanize = kwargs.pop("romanize")
+        offset = kwargs.pop("offset")
         overwrite = kwargs.pop("overwrite")
 
-        if not (clean or flatten or convert or review_script or romanize):
+        if not (clean or flatten or convert or review_script or romanize or offset):
             parser.error("At least one operation required")
         if overwrite and outfile_path is None:
             try:
@@ -237,6 +253,8 @@ class YueProcessCli(ScinoephileCliBase):
             series = get_zho_block_reviewed(series, processor=proofreader)
         if romanize:
             series = get_yue_romanized(series, append=True)
+        if offset:
+            series.shift(ms=offset)
 
         # Write output
         write_series(

--- a/scinoephile/cli/zho/zho_process_cli.py
+++ b/scinoephile/cli/zho/zho_process_cli.py
@@ -15,6 +15,7 @@ from scinoephile.cli.conversion import (
 from scinoephile.common.argument_parsing import (
     get_arg_groups_by_name,
     input_file_arg,
+    int_arg,
     output_file_arg,
     str_arg,
 )
@@ -58,6 +59,8 @@ class _ZhoProcessCliKwargs(TypedDict, total=False):
     """Selected proofreading script."""
     romanize: bool
     """Whether to append Mandarin romanization."""
+    offset: int
+    """Timing offset in milliseconds."""
     overwrite: bool
     """Whether to overwrite an existing outfile."""
 
@@ -82,6 +85,9 @@ class ZhoProcessCli(ScinoephileCliBase):
                 "script for prompts and output conversion (default: simplified)": (
                     "提示词和输出转换使用的字形（默认：简体）"
                 ),
+                "shift subtitle timings by this many milliseconds": (
+                    "按指定毫秒数平移字幕时间"
+                ),
                 'Standard Chinese subtitle infile path or "-" for stdin': (
                     '标准中文字幕输入文件路径，或使用 "-" 表示标准输入'
                 ),
@@ -103,6 +109,9 @@ class ZhoProcessCli(ScinoephileCliBase):
                 ),
                 "script for prompts and output conversion (default: simplified)": (
                     "提示詞與輸出轉換使用的字形（預設：簡體）"
+                ),
+                "shift subtitle timings by this many milliseconds": (
+                    "依指定毫秒數平移字幕時間"
                 ),
                 'Standard Chinese subtitle infile path or "-" for stdin': (
                     '標準中文字幕輸入檔路徑，或使用 "-" 代表標準輸入'
@@ -167,6 +176,12 @@ class ZhoProcessCli(ScinoephileCliBase):
             action="store_true",
             help="append Mandarin romanization to subtitles",
         )
+        arg_groups["operation arguments"].add_argument(
+            "--offset",
+            default=0,
+            type=int_arg(),
+            help="shift subtitle timings by this many milliseconds",
+        )
 
         # Output arguments
         arg_groups["output arguments"].add_argument(
@@ -208,9 +223,10 @@ class ZhoProcessCli(ScinoephileCliBase):
         convert = kwargs.pop("convert")
         review_script = kwargs.pop("proofread")
         romanize = kwargs.pop("romanize")
+        offset = kwargs.pop("offset")
         overwrite = kwargs.pop("overwrite")
 
-        if not (clean or flatten or convert or review_script or romanize):
+        if not (clean or flatten or convert or review_script or romanize or offset):
             parser.error("At least one operation required")
         if overwrite and outfile_path is None:
             try:
@@ -237,6 +253,8 @@ class ZhoProcessCli(ScinoephileCliBase):
             series = get_zho_block_reviewed(series, processor=proofreader)
         if romanize:
             series = get_cmn_romanized(series, append=True)
+        if offset:
+            series.shift(ms=offset)
 
         # Write output
         write_series(

--- a/test/cli/eng/test_eng_process_cli.py
+++ b/test/cli/eng/test_eng_process_cli.py
@@ -131,3 +131,19 @@ def test_eng_process_cli_pipe(input_path: str, args: str, expected_path: str):
     expected = Series.load(full_expected_path)
 
     assert output == expected
+
+
+def test_eng_process_cli_offsets_timing():
+    """Test English processing CLI can offset subtitle timings."""
+    full_input_path = test_data_root / "mnt/output/eng_fuse.srt"
+
+    with get_temp_file_path(".srt") as output_path:
+        run_cli_with_args(
+            EngProcessCli,
+            f"--infile {full_input_path} --offset 1250 --outfile {output_path}",
+        )
+        output = Series.load(output_path)
+
+    expected = Series.load(full_input_path)
+    expected.shift(ms=1250)
+    assert output == expected

--- a/test/cli/yue/test_yue_process_cli.py
+++ b/test/cli/yue/test_yue_process_cli.py
@@ -122,6 +122,22 @@ def test_yue_process_cli_pipe(input_path: str, args: str, expected_path: str):
     assert output == expected
 
 
+def test_yue_process_cli_offsets_timing():
+    """Test written Cantonese processing CLI can offset subtitle timings."""
+    full_input_path = test_data_root / "kob/output/yue-Hans/timewarp_clean_flatten.srt"
+
+    with get_temp_file_path(".srt") as output_path:
+        run_cli_with_args(
+            YueProcessCli,
+            f"--infile {full_input_path} --offset 1250 --outfile {output_path}",
+        )
+        output = Series.load(output_path)
+
+    expected = Series.load(full_input_path)
+    expected.shift(ms=1250)
+    assert output == expected
+
+
 def test_yue_process_cli_rejects_bare_convert_flag():
     """Test written Cantonese processing CLI requires an explicit conversion config."""
     full_input_path = test_data_root / "kob/output/yue-Hans/timewarp_clean_flatten.srt"

--- a/test/cli/zho/test_zho_process_cli.py
+++ b/test/cli/zho/test_zho_process_cli.py
@@ -143,6 +143,22 @@ def test_zho_process_cli_pipe(input_path: str, args: str, expected_path: str):
     assert output == expected
 
 
+def test_zho_process_cli_offsets_timing():
+    """Test standard Chinese processing CLI can offset subtitle timings."""
+    full_input_path = test_data_root / "mnt/output/zho-Hans_fuse.srt"
+
+    with get_temp_file_path(".srt") as output_path:
+        run_cli_with_args(
+            ZhoProcessCli,
+            f"--infile {full_input_path} --offset 1250 --outfile {output_path}",
+        )
+        output = Series.load(output_path)
+
+    expected = Series.load(full_input_path)
+    expected.shift(ms=1250)
+    assert output == expected
+
+
 def test_zho_process_cli_rejects_bare_convert_flag():
     """Test standard Chinese processing CLI requires an explicit conversion config."""
     full_input_path = (


### PR DESCRIPTION
## Summary

Adds a `--offset` operation argument to the English, standard Chinese, and written Cantonese `process` CLIs. The argument shifts subtitle timing by an integer number of milliseconds, with positive values delaying subtitles and negative values advancing them.

## Impact

Users can now combine timing shifts with existing process operations, or run `--offset` by itself when only timing needs to move.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/cli/eng/eng_process_cli.py scinoephile/cli/zho/zho_process_cli.py scinoephile/cli/yue/yue_process_cli.py test/cli/eng/test_eng_process_cli.py test/cli/zho/test_zho_process_cli.py test/cli/yue/test_yue_process_cli.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/cli/eng/eng_process_cli.py scinoephile/cli/zho/zho_process_cli.py scinoephile/cli/yue/yue_process_cli.py test/cli/eng/test_eng_process_cli.py test/cli/zho/test_zho_process_cli.py test/cli/yue/test_yue_process_cli.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/cli/eng/eng_process_cli.py scinoephile/cli/zho/zho_process_cli.py scinoephile/cli/yue/yue_process_cli.py test/cli/eng/test_eng_process_cli.py test/cli/zho/test_zho_process_cli.py test/cli/yue/test_yue_process_cli.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest cli/eng/test_eng_process_cli.py cli/zho/test_zho_process_cli.py cli/yue/test_yue_process_cli.py -q`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto`