### PR TITLE
Migrate optimization test case persistence to SQLAlchemy Core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "pysubs2>=1.8.1",
     "requests>=2.33.1",
     "setuptools>=82.0.1",
+    "sqlalchemy>=2.0.49",
     "torch>=2.10.0",
     "torchaudio>=2.10.0,<2.11.0",
     "transformers>=5.7.0",

--- a/scinoephile/core/optimization.py
+++ b/scinoephile/core/optimization.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-import sqlite3
+from collections.abc import Mapping
 
 __all__ = [
     "get_prefixed_payload",
@@ -25,11 +25,11 @@ def get_prefixed_payload(prefix: str, payload: dict) -> dict[str, object]:
     return {f"{prefix}__{key}": value for key, value in sorted(payload.items())}
 
 
-def get_unprefixed_payload(row: sqlite3.Row, prefix: str) -> dict:
+def get_unprefixed_payload(row: Mapping[str, object], prefix: str) -> dict:
     """Get a nested payload from row columns matching a prefix.
 
     Arguments:
-        row: SQLite row
+        row: database row mapping
         prefix: column prefix
     Returns:
         nested payload

--- a/scinoephile/core/optimization.py
+++ b/scinoephile/core/optimization.py
@@ -6,6 +6,9 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 
+_DatabaseValue = str | int | float | bytes | None
+"""Scalar value loaded from a SQL database row."""
+
 __all__ = [
     "get_prefixed_payload",
     "get_unprefixed_payload",
@@ -25,7 +28,7 @@ def get_prefixed_payload(prefix: str, payload: dict) -> dict[str, object]:
     return {f"{prefix}__{key}": value for key, value in sorted(payload.items())}
 
 
-def get_unprefixed_payload(row: Mapping[str, object], prefix: str) -> dict:
+def get_unprefixed_payload(row: Mapping[str, _DatabaseValue], prefix: str) -> dict:
     """Get a nested payload from row columns matching a prefix.
 
     Arguments:

--- a/scinoephile/optimization/persistence/test_cases/sqlite_store.py
+++ b/scinoephile/optimization/persistence/test_cases/sqlite_store.py
@@ -29,37 +29,13 @@ from sqlalchemy.exc import OperationalError
 
 from scinoephile.common.validation import val_output_path
 from scinoephile.core.llms.operation_spec import OperationSpec
-from scinoephile.core.optimization import (
-    get_prefixed_payload,
-    get_unprefixed_payload,
-)
+from scinoephile.core.optimization import get_prefixed_payload, get_unprefixed_payload
 
 from .persisted_test_case import PersistedTestCase
 
 __all__ = ["TestCaseSqliteStore"]
 
 logger = getLogger(__name__)
-
-
-_metadata = MetaData()
-"""SQLAlchemy Core metadata for optimization test case persistence."""
-
-_test_case_sources = Table(
-    "test_case_sources",
-    _metadata,
-    Column("table_name", Text, nullable=False),
-    Column("test_case_id", Text, nullable=False),
-    Column("source_path", Text, nullable=False),
-    UniqueConstraint(
-        "table_name",
-        "test_case_id",
-        "source_path",
-        sqlite_on_conflict="IGNORE",
-    ),
-    Index("test_case_sources_source_path", "source_path"),
-    Index("test_case_sources_table_name", "table_name"),
-)
-"""SQLAlchemy Core table for test case source links."""
 
 
 class TestCaseSqliteStore:
@@ -70,6 +46,26 @@ class TestCaseSqliteStore:
 
     schema_version = 2
     """SQLite schema version."""
+
+    _metadata = MetaData()
+    """SQLAlchemy Core metadata for this store's fixed schema objects."""
+
+    _test_case_sources = Table(
+        "test_case_sources",
+        _metadata,
+        Column("table_name", Text, nullable=False),
+        Column("test_case_id", Text, nullable=False),
+        Column("source_path", Text, nullable=False),
+        UniqueConstraint(
+            "table_name",
+            "test_case_id",
+            "source_path",
+            sqlite_on_conflict="IGNORE",
+        ),
+        Index("test_case_sources_source_path", "source_path"),
+        Index("test_case_sources_table_name", "table_name"),
+    )
+    """Source-link table shared by all dynamic test case tables."""
 
     def __init__(
         self,
@@ -100,7 +96,7 @@ class TestCaseSqliteStore:
         self.database_path = val_output_path(self.database_path, exist_ok=True)
         with self.engine.begin() as connection:
             connection.execute(text(f"PRAGMA user_version={self.schema_version}"))
-            _test_case_sources.create(connection, checkfirst=True)
+            self._test_case_sources.create(connection, checkfirst=True)
 
     def ensure_table(self, table_name: str):
         """Ensure a test case table exists.
@@ -165,14 +161,14 @@ class TestCaseSqliteStore:
                     connection.execute(
                         select(table)
                         .join(
-                            _test_case_sources,
-                            (_test_case_sources.c.table_name == table_name)
+                            self._test_case_sources,
+                            (self._test_case_sources.c.table_name == table_name)
                             & (
-                                _test_case_sources.c.test_case_id
+                                self._test_case_sources.c.test_case_id
                                 == table.c.test_case_id
                             ),
                         )
-                        .where(_test_case_sources.c.source_path == source_path)
+                        .where(self._test_case_sources.c.source_path == source_path)
                         .order_by(table.c.test_case_id)
                     )
                     .mappings()
@@ -196,10 +192,10 @@ class TestCaseSqliteStore:
             try:
                 rows = (
                     connection.execute(
-                        select(_test_case_sources.c.source_path)
+                        select(self._test_case_sources.c.source_path)
                         .distinct()
-                        .where(_test_case_sources.c.table_name == table_name)
-                        .order_by(_test_case_sources.c.source_path)
+                        .where(self._test_case_sources.c.table_name == table_name)
+                        .order_by(self._test_case_sources.c.source_path)
                     )
                     .scalars()
                     .all()
@@ -273,10 +269,10 @@ class TestCaseSqliteStore:
             table = self._get_test_case_table(table_name)
             with self.engine.begin() as connection:
                 connection.execute(
-                    _test_case_sources.delete().where(
-                        (_test_case_sources.c.table_name == table_name)
-                        & (_test_case_sources.c.source_path == source_path)
-                        & (_test_case_sources.c.test_case_id.in_(to_delete_ids))
+                    self._test_case_sources.delete().where(
+                        (self._test_case_sources.c.table_name == table_name)
+                        & (self._test_case_sources.c.source_path == source_path)
+                        & (self._test_case_sources.c.test_case_id.in_(to_delete_ids))
                     )
                 )
                 orphaned_ids = self._get_orphaned_test_case_ids(
@@ -342,7 +338,7 @@ class TestCaseSqliteStore:
 
                 for sp in merged_sources:
                     connection.execute(
-                        sqlite_insert(_test_case_sources)
+                        sqlite_insert(self._test_case_sources)
                         .values(
                             table_name=table_name,
                             test_case_id=tc.test_case_id,
@@ -372,9 +368,9 @@ class TestCaseSqliteStore:
             try:
                 rows = (
                     connection.execute(
-                        select(_test_case_sources.c.test_case_id).where(
-                            (_test_case_sources.c.table_name == table_name)
-                            & (_test_case_sources.c.source_path == source_path)
+                        select(self._test_case_sources.c.test_case_id).where(
+                            (self._test_case_sources.c.table_name == table_name)
+                            & (self._test_case_sources.c.source_path == source_path)
                         )
                     )
                     .scalars()
@@ -494,11 +490,11 @@ class TestCaseSqliteStore:
             return []
         rows = (
             connection.execute(
-                select(_test_case_sources.c.test_case_id)
+                select(TestCaseSqliteStore._test_case_sources.c.test_case_id)
                 .distinct()
                 .where(
-                    (_test_case_sources.c.table_name == table_name)
-                    & (_test_case_sources.c.test_case_id.in_(ids))
+                    (TestCaseSqliteStore._test_case_sources.c.table_name == table_name)
+                    & (TestCaseSqliteStore._test_case_sources.c.test_case_id.in_(ids))
                 )
             )
             .scalars()
@@ -638,12 +634,18 @@ class TestCaseSqliteStore:
         try:
             rows = (
                 connection.execute(
-                    select(_test_case_sources.c.source_path)
+                    select(TestCaseSqliteStore._test_case_sources.c.source_path)
                     .where(
-                        (_test_case_sources.c.table_name == table_name)
-                        & (_test_case_sources.c.test_case_id == test_case_id)
+                        (
+                            TestCaseSqliteStore._test_case_sources.c.table_name
+                            == table_name
+                        )
+                        & (
+                            TestCaseSqliteStore._test_case_sources.c.test_case_id
+                            == test_case_id
+                        )
                     )
-                    .order_by(_test_case_sources.c.source_path)
+                    .order_by(TestCaseSqliteStore._test_case_sources.c.source_path)
                 )
                 .scalars()
                 .all()

--- a/scinoephile/optimization/persistence/test_cases/sqlite_store.py
+++ b/scinoephile/optimization/persistence/test_cases/sqlite_store.py
@@ -4,17 +4,34 @@
 
 from __future__ import annotations
 
-import sqlite3
 from collections.abc import Iterable
 from logging import getLogger
 from pathlib import Path
+
+from sqlalchemy import (
+    Column,
+    Index,
+    Integer,
+    MetaData,
+    Table,
+    Text,
+    UniqueConstraint,
+    create_engine,
+    func,
+    inspect,
+    select,
+    text,
+)
+from sqlalchemy.dialects.sqlite import Insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.engine import Connection, RowMapping
+from sqlalchemy.exc import OperationalError
 
 from scinoephile.common.validation import val_output_path
 from scinoephile.core.llms.operation_spec import OperationSpec
 from scinoephile.core.optimization import (
     get_prefixed_payload,
     get_unprefixed_payload,
-    quote_identifier,
 )
 
 from .persisted_test_case import PersistedTestCase
@@ -22,6 +39,27 @@ from .persisted_test_case import PersistedTestCase
 __all__ = ["TestCaseSqliteStore"]
 
 logger = getLogger(__name__)
+
+
+_metadata = MetaData()
+"""SQLAlchemy Core metadata for optimization test case persistence."""
+
+_test_case_sources = Table(
+    "test_case_sources",
+    _metadata,
+    Column("table_name", Text, nullable=False),
+    Column("test_case_id", Text, nullable=False),
+    Column("source_path", Text, nullable=False),
+    UniqueConstraint(
+        "table_name",
+        "test_case_id",
+        "source_path",
+        sqlite_on_conflict="IGNORE",
+    ),
+    Index("test_case_sources_source_path", "source_path"),
+    Index("test_case_sources_table_name", "table_name"),
+)
+"""SQLAlchemy Core table for test case source links."""
 
 
 class TestCaseSqliteStore:
@@ -51,31 +89,18 @@ class TestCaseSqliteStore:
             create=False,
         )
         self.operation_spec = operation_spec
-        self.list_fields = dict(operation_spec.list_fields if operation_spec else {})
+        if operation_spec:
+            self.list_fields = dict(operation_spec.list_fields)
+        else:
+            self.list_fields = {}
+        self.engine = create_engine(f"sqlite:///{self.database_path}", future=True)
 
     def create_schema(self):
         """Create SQLite schema if needed."""
         self.database_path = val_output_path(self.database_path, exist_ok=True)
-        with sqlite3.connect(self.database_path) as connection:
-            cursor = connection.cursor()
-            cursor.execute(f"PRAGMA user_version={self.schema_version}")
-            cursor.execute(
-                """CREATE TABLE IF NOT EXISTS test_case_sources(
-                       table_name TEXT NOT NULL,
-                       test_case_id TEXT NOT NULL,
-                       source_path TEXT NOT NULL,
-                       UNIQUE(table_name, test_case_id, source_path) ON CONFLICT IGNORE
-                   )"""
-            )
-            cursor.execute(
-                "CREATE INDEX IF NOT EXISTS test_case_sources_source_path "
-                "ON test_case_sources(source_path)"
-            )
-            cursor.execute(
-                "CREATE INDEX IF NOT EXISTS test_case_sources_table_name "
-                "ON test_case_sources(table_name)"
-            )
-            connection.commit()
+        with self.engine.begin() as connection:
+            connection.execute(text(f"PRAGMA user_version={self.schema_version}"))
+            _test_case_sources.create(connection, checkfirst=True)
 
     def ensure_table(self, table_name: str):
         """Ensure a test case table exists.
@@ -84,10 +109,8 @@ class TestCaseSqliteStore:
             table_name: SQLite table name
         """
         self.create_schema()
-        with sqlite3.connect(self.database_path) as connection:
-            cursor = connection.cursor()
-            self._create_test_case_table(cursor, table_name)
-            connection.commit()
+        with self.engine.begin() as connection:
+            self._create_test_case_table(connection, table_name)
 
     def get_test_case(
         self,
@@ -104,16 +127,17 @@ class TestCaseSqliteStore:
         """
         if not self.database_path.exists():
             return None
-        with sqlite3.connect(self.database_path) as connection:
-            connection.row_factory = sqlite3.Row
+        with self.engine.connect() as connection:
+            table = self._get_test_case_table(table_name, connection=connection)
             try:
-                row = connection.execute(
-                    f"""SELECT *
-                        FROM {quote_identifier(table_name)}
-                        WHERE test_case_id = ?""",
-                    (test_case_id,),
-                ).fetchone()
-            except sqlite3.OperationalError:
+                row = (
+                    connection.execute(
+                        select(table).where(table.c.test_case_id == test_case_id)
+                    )
+                    .mappings()
+                    .first()
+                )
+            except OperationalError:
                 return None
             if row is None:
                 return None
@@ -134,20 +158,27 @@ class TestCaseSqliteStore:
         """
         if not self.database_path.exists():
             return []
-        with sqlite3.connect(self.database_path) as connection:
-            connection.row_factory = sqlite3.Row
+        with self.engine.connect() as connection:
+            table = self._get_test_case_table(table_name, connection=connection)
             try:
-                rows = connection.execute(
-                    f"""SELECT t.*
-                        FROM {quote_identifier(table_name)} AS t
-                        JOIN test_case_sources AS s
-                          ON s.table_name = ?
-                         AND s.test_case_id = t.test_case_id
-                       WHERE s.source_path = ?
-                       ORDER BY t.test_case_id""",
-                    (table_name, source_path),
-                ).fetchall()
-            except sqlite3.OperationalError:
+                rows = (
+                    connection.execute(
+                        select(table)
+                        .join(
+                            _test_case_sources,
+                            (_test_case_sources.c.table_name == table_name)
+                            & (
+                                _test_case_sources.c.test_case_id
+                                == table.c.test_case_id
+                            ),
+                        )
+                        .where(_test_case_sources.c.source_path == source_path)
+                        .order_by(table.c.test_case_id)
+                    )
+                    .mappings()
+                    .all()
+                )
+            except OperationalError:
                 return []
             return [self._row_to_test_case(connection, table_name, r) for r in rows]
 
@@ -161,15 +192,21 @@ class TestCaseSqliteStore:
         """
         if not self.database_path.exists():
             return []
-        with sqlite3.connect(self.database_path) as connection:
-            rows = connection.execute(
-                """SELECT DISTINCT source_path
-                   FROM test_case_sources
-                   WHERE table_name = ?
-                   ORDER BY source_path""",
-                (table_name,),
-            ).fetchall()
-        return [str(row[0]) for row in rows]
+        with self.engine.connect() as connection:
+            try:
+                rows = (
+                    connection.execute(
+                        select(_test_case_sources.c.source_path)
+                        .distinct()
+                        .where(_test_case_sources.c.table_name == table_name)
+                        .order_by(_test_case_sources.c.source_path)
+                    )
+                    .scalars()
+                    .all()
+                )
+            except OperationalError:
+                return []
+        return [str(row) for row in rows]
 
     def list_tables(self) -> list[str]:
         """List tables currently present in the database.
@@ -179,11 +216,7 @@ class TestCaseSqliteStore:
         """
         if not self.database_path.exists():
             return []
-        with sqlite3.connect(self.database_path) as connection:
-            rows = connection.execute(
-                "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
-            ).fetchall()
-        return [str(row[0]) for row in rows]
+        return sorted(inspect(self.engine).get_table_names())
 
     def sync_table_source_path(
         self,
@@ -237,30 +270,23 @@ class TestCaseSqliteStore:
             )
 
         if to_delete_ids:
-            with sqlite3.connect(self.database_path) as connection:
-                cursor = connection.cursor()
-                cursor.executemany(
-                    """DELETE FROM test_case_sources
-                       WHERE table_name = ?
-                         AND source_path = ?
-                         AND test_case_id = ?""",
-                    [
-                        (table_name, source_path, test_case_id)
-                        for test_case_id in to_delete_ids
-                    ],
+            table = self._get_test_case_table(table_name)
+            with self.engine.begin() as connection:
+                connection.execute(
+                    _test_case_sources.delete().where(
+                        (_test_case_sources.c.table_name == table_name)
+                        & (_test_case_sources.c.source_path == source_path)
+                        & (_test_case_sources.c.test_case_id.in_(to_delete_ids))
+                    )
                 )
-
                 orphaned_ids = self._get_orphaned_test_case_ids(
-                    cursor,
+                    connection,
                     table_name,
                     to_delete_ids,
                 )
-                cursor.executemany(
-                    f"DELETE FROM {quote_identifier(table_name)} "
-                    "WHERE test_case_id = ?",
-                    [(test_case_id,) for test_case_id in orphaned_ids],
+                connection.execute(
+                    table.delete().where(table.c.test_case_id.in_(orphaned_ids))
                 )
-                connection.commit()
 
         return (to_insert, to_update, to_delete_ids)
 
@@ -283,13 +309,15 @@ class TestCaseSqliteStore:
         self.create_schema()
         test_cases = list(test_cases)
         touched = 0
-        with sqlite3.connect(self.database_path) as connection:
-            cursor = connection.cursor()
-            self._create_test_case_table(cursor, table_name)
-            self._ensure_test_case_columns(cursor, table_name, test_cases)
+        with self.engine.begin() as connection:
+            self._create_test_case_table(connection, table_name)
+            self._ensure_test_case_columns(connection, table_name, test_cases)
+            table = self._get_test_case_table(table_name, connection=connection)
 
             for tc in test_cases:
-                existing = self._get_source_paths(cursor, table_name, tc.test_case_id)
+                existing = self._get_source_paths(
+                    connection, table_name, tc.test_case_id
+                )
                 merged_sources = self._merge_source_paths(existing, tc.source_paths)
                 if source_path not in merged_sources:
                     merged_sources.append(source_path)
@@ -298,40 +326,30 @@ class TestCaseSqliteStore:
                 payload: dict[str, object] = {
                     "test_case_id": tc.test_case_id,
                     "difficulty": int(tc.difficulty),
-                    "prompt": 1 if tc.prompt else 0,
-                    "verified": 1 if tc.verified else 0,
+                    "prompt": int(tc.prompt),
+                    "verified": int(tc.verified),
                 }
                 payload.update(self._get_prefixed_payload("query", tc.query))
                 payload.update(self._get_prefixed_payload("answer", tc.answer))
-                columns = tuple(payload)
-                placeholders = ", ".join("?" for _ in columns)
-                quoted_columns = ", ".join(quote_identifier(c) for c in columns)
-                updates = ", ".join(
-                    self._get_upsert_update_clause(c)
-                    for c in columns
-                    if c != "test_case_id"
-                )
-                cursor.execute(
-                    f"""INSERT INTO {quote_identifier(table_name)}(
-                           {quoted_columns}
-                       ) VALUES ({placeholders})
-                       ON CONFLICT(test_case_id) DO UPDATE SET
-                           {updates}""",
-                    tuple(payload.values()),
+                insert_statement = sqlite_insert(table).values(payload)
+                connection.execute(
+                    insert_statement.on_conflict_do_update(
+                        index_elements=[table.c.test_case_id],
+                        set_=self._get_upsert_update_values(table, insert_statement),
+                    )
                 )
                 touched += 1
 
                 for sp in merged_sources:
-                    cursor.execute(
-                        """INSERT INTO test_case_sources(
-                               table_name,
-                               test_case_id,
-                               source_path
-                           ) VALUES (?, ?, ?)""",
-                        (table_name, tc.test_case_id, sp),
+                    connection.execute(
+                        sqlite_insert(_test_case_sources)
+                        .values(
+                            table_name=table_name,
+                            test_case_id=tc.test_case_id,
+                            source_path=sp,
+                        )
+                        .on_conflict_do_nothing()
                     )
-
-            connection.commit()
         logger.info(f"Upserted {touched} rows into {table_name}")
         return touched
 
@@ -350,19 +368,21 @@ class TestCaseSqliteStore:
         """
         if not self.database_path.exists():
             return set()
-        with sqlite3.connect(self.database_path) as connection:
-            connection.row_factory = sqlite3.Row
+        with self.engine.connect() as connection:
             try:
-                rows = connection.execute(
-                    """SELECT test_case_id
-                       FROM test_case_sources
-                       WHERE table_name = ?
-                         AND source_path = ?""",
-                    (table_name, source_path),
-                ).fetchall()
-            except sqlite3.OperationalError:
+                rows = (
+                    connection.execute(
+                        select(_test_case_sources.c.test_case_id).where(
+                            (_test_case_sources.c.table_name == table_name)
+                            & (_test_case_sources.c.source_path == source_path)
+                        )
+                    )
+                    .scalars()
+                    .all()
+                )
+            except OperationalError:
                 return set()
-        return {str(row["test_case_id"]) for row in rows}
+        return {str(row) for row in rows}
 
     def _get_test_cases_by_ids(
         self,
@@ -380,58 +400,39 @@ class TestCaseSqliteStore:
         ids = tuple(sorted(set(test_case_ids)))
         if not ids or not self.database_path.exists():
             return {}
-        placeholders = ", ".join("?" for _ in ids)
-        with sqlite3.connect(self.database_path) as connection:
-            connection.row_factory = sqlite3.Row
+        with self.engine.connect() as connection:
+            table = self._get_test_case_table(table_name, connection=connection)
             try:
-                rows = connection.execute(
-                    f"""SELECT *
-                        FROM {quote_identifier(table_name)}
-                        WHERE test_case_id IN ({placeholders})""",
-                    ids,
-                ).fetchall()
-            except sqlite3.OperationalError:
+                rows = (
+                    connection.execute(
+                        select(table).where(table.c.test_case_id.in_(ids))
+                    )
+                    .mappings()
+                    .all()
+                )
+            except OperationalError:
                 return {}
             test_cases = [
                 self._row_to_test_case(connection, table_name, r) for r in rows
             ]
         return {tc.test_case_id: tc for tc in test_cases}
 
-    @staticmethod
-    def _create_test_case_table(cursor: sqlite3.Cursor, table_name: str):
-        """Create a test-case table if it does not exist.
-
-        Arguments:
-            cursor: SQLite cursor
-            table_name: SQLite table name
-        """
-        cursor.execute(
-            f"""CREATE TABLE IF NOT EXISTS {quote_identifier(table_name)}(
-                    test_case_id TEXT PRIMARY KEY,
-                    difficulty INTEGER NOT NULL,
-                    prompt INTEGER NOT NULL,
-                    verified INTEGER NOT NULL
-                )"""
-        )
-
     def _ensure_test_case_columns(
         self,
-        cursor: sqlite3.Cursor,
+        connection: Connection,
         table_name: str,
         test_cases: Iterable[PersistedTestCase],
     ):
         """Ensure query and answer payload columns exist.
 
         Arguments:
-            cursor: SQLite cursor
+            connection: SQLAlchemy connection
             table_name: SQLite table name
             test_cases: test cases whose payload fields should be represented
         """
         existing_columns = {
-            str(row[1])
-            for row in cursor.execute(
-                f"PRAGMA table_info({quote_identifier(table_name)})"
-            ).fetchall()
+            str(column["name"])
+            for column in inspect(connection).get_columns(table_name)
         }
         desired_columns = set[str]()
         for test_case in test_cases:
@@ -440,9 +441,12 @@ class TestCaseSqliteStore:
                 self._get_prefixed_payload("answer", test_case.answer)
             )
         for column in sorted(desired_columns - existing_columns):
-            cursor.execute(
-                f"ALTER TABLE {quote_identifier(table_name)} "
-                f"ADD COLUMN {quote_identifier(column)}"
+            preparer = connection.dialect.identifier_preparer
+            connection.execute(
+                text(
+                    f"ALTER TABLE {preparer.quote(table_name)} "
+                    f"ADD COLUMN {preparer.quote(column)}"
+                )
             )
 
     @staticmethod
@@ -472,14 +476,14 @@ class TestCaseSqliteStore:
 
     @staticmethod
     def _get_orphaned_test_case_ids(
-        cursor: sqlite3.Cursor,
+        connection: Connection,
         table_name: str,
         test_case_ids: Iterable[str],
     ) -> list[str]:
         """Get test case IDs that no longer have source path links.
 
         Arguments:
-            cursor: SQLite cursor
+            connection: SQLAlchemy connection
             table_name: SQLite table name
             test_case_ids: candidate test case identifiers
         Returns:
@@ -488,15 +492,19 @@ class TestCaseSqliteStore:
         ids = tuple(sorted(set(test_case_ids)))
         if not ids:
             return []
-        placeholders = ", ".join("?" for _ in ids)
-        rows = cursor.execute(
-            f"""SELECT DISTINCT test_case_id
-                FROM test_case_sources
-                WHERE table_name = ?
-                  AND test_case_id IN ({placeholders})""",
-            (table_name, *ids),
-        ).fetchall()
-        remaining_ids = {str(row[0]) for row in rows}
+        rows = (
+            connection.execute(
+                select(_test_case_sources.c.test_case_id)
+                .distinct()
+                .where(
+                    (_test_case_sources.c.table_name == table_name)
+                    & (_test_case_sources.c.test_case_id.in_(ids))
+                )
+            )
+            .scalars()
+            .all()
+        )
+        remaining_ids = {str(row) for row in rows}
         return [
             test_case_id for test_case_id in ids if test_case_id not in remaining_ids
         ]
@@ -536,99 +544,16 @@ class TestCaseSqliteStore:
                     flattened[column] = None
         return flattened
 
-    @staticmethod
-    def _get_source_paths(
-        cursor: sqlite3.Cursor,
-        table_name: str,
-        test_case_id: str,
-    ) -> list[str]:
-        """Get source paths associated with a test case.
-
-        Arguments:
-            cursor: SQLite cursor
-            table_name: SQLite table name
-            test_case_id: test case identifier
-        Returns:
-            source paths associated with the test case
-        """
-        try:
-            row = cursor.execute(
-                """SELECT source_path
-                   FROM test_case_sources
-                   WHERE table_name = ?
-                     AND test_case_id = ?
-                   ORDER BY source_path""",
-                (table_name, test_case_id),
-            ).fetchall()
-        except sqlite3.OperationalError:
-            return []
-        return [str(r[0]) for r in row]
-
-    @staticmethod
-    def _get_source_paths_for_row(
-        connection: sqlite3.Connection,
-        table_name: str,
-        test_case_id: str,
-    ) -> list[str]:
-        """Get source paths associated with a row.
-
-        Arguments:
-            connection: SQLite connection
-            table_name: SQLite table name
-            test_case_id: test case identifier
-        Returns:
-            source paths associated with the row
-        """
-        try:
-            rows = connection.execute(
-                """SELECT source_path
-                   FROM test_case_sources
-                   WHERE table_name = ?
-                     AND test_case_id = ?
-                   ORDER BY source_path""",
-                (table_name, test_case_id),
-            ).fetchall()
-        except sqlite3.OperationalError:
-            return []
-        return [str(row["source_path"]) for row in rows]
-
-    @staticmethod
-    def _get_upsert_update_clause(column: str) -> str:
-        """Get an update clause for a SQLite upsert column.
-
-        Arguments:
-            column: SQLite column name
-        Returns:
-            update clause for a SQLite upsert
-        """
-        quoted_column = quote_identifier(column)
-        if column in {"difficulty", "prompt", "verified"}:
-            return f"{quoted_column}=max({quoted_column}, excluded.{quoted_column})"
-        return f"{quoted_column}=excluded.{quoted_column}"
-
-    @staticmethod
-    def _get_split_column_name(prefix: str, field_name: str, idx: int) -> str:
-        """Get a column name for a split list item.
-
-        Arguments:
-            prefix: column prefix
-            field_name: list field name
-            idx: zero-based list item index
-        Returns:
-            split column name
-        """
-        return f"{prefix}__{field_name}_{idx + 1:02d}"
-
-    def _get_unprefixed_payload(self, row: sqlite3.Row, prefix: str) -> dict:
+    def _get_unprefixed_payload(self, row: RowMapping, prefix: str) -> dict:
         """Get a nested payload from row columns matching a prefix.
 
         Arguments:
-            row: SQLite row
+            row: SQLAlchemy row mapping
             prefix: column prefix
         Returns:
             nested payload
         """
-        payload = get_unprefixed_payload(row, prefix)
+        payload = get_unprefixed_payload(dict(row), prefix)
         row_keys = set(row.keys())
         for list_field, max_items in sorted(self.list_fields.items()):
             list_prefix, field_name = self._parse_list_field(list_field)
@@ -651,32 +576,18 @@ class TestCaseSqliteStore:
             payload[field_name] = values
         return payload
 
-    @staticmethod
-    def _merge_source_paths(existing: list[str], incoming: list[str]) -> list[str]:
-        """Merge two source path lists.
-
-        Arguments:
-            existing: source paths already recorded
-            incoming: source paths to add
-        Returns:
-            sorted merged source paths
-        """
-        merged = set(existing)
-        merged.update(incoming)
-        return sorted(merged)
-
     def _row_to_test_case(
         self,
-        connection: sqlite3.Connection,
+        connection: Connection,
         table_name: str,
-        row: sqlite3.Row,
+        row: RowMapping,
     ) -> PersistedTestCase:
-        """Convert a SQLite row to a persisted test case.
+        """Convert a SQLAlchemy row mapping to a persisted test case.
 
         Arguments:
-            connection: SQLite connection
+            connection: SQLAlchemy connection
             table_name: SQLite table name
-            row: SQLite row
+            row: SQLAlchemy row mapping
         Returns:
             persisted test case
         """
@@ -696,6 +607,146 @@ class TestCaseSqliteStore:
             answer=answer,
             source_paths=source_paths,
         )
+
+    @staticmethod
+    def _create_test_case_table(connection: Connection, table_name: str):
+        """Create a test-case table if it does not exist.
+
+        Arguments:
+            connection: SQLAlchemy connection
+            table_name: SQLite table name
+        """
+        TestCaseSqliteStore._get_test_case_table(table_name).create(
+            connection, checkfirst=True
+        )
+
+    @staticmethod
+    def _get_source_paths(
+        connection: Connection,
+        table_name: str,
+        test_case_id: str,
+    ) -> list[str]:
+        """Get source paths associated with a test case.
+
+        Arguments:
+            connection: SQLAlchemy connection
+            table_name: SQLite table name
+            test_case_id: test case identifier
+        Returns:
+            source paths associated with the test case
+        """
+        try:
+            rows = (
+                connection.execute(
+                    select(_test_case_sources.c.source_path)
+                    .where(
+                        (_test_case_sources.c.table_name == table_name)
+                        & (_test_case_sources.c.test_case_id == test_case_id)
+                    )
+                    .order_by(_test_case_sources.c.source_path)
+                )
+                .scalars()
+                .all()
+            )
+        except OperationalError:
+            return []
+        return [str(row) for row in rows]
+
+    @staticmethod
+    def _get_source_paths_for_row(
+        connection: Connection,
+        table_name: str,
+        test_case_id: str,
+    ) -> list[str]:
+        """Get source paths associated with a row.
+
+        Arguments:
+            connection: SQLAlchemy connection
+            table_name: SQLite table name
+            test_case_id: test case identifier
+        Returns:
+            source paths associated with the row
+        """
+        return TestCaseSqliteStore._get_source_paths(
+            connection, table_name, test_case_id
+        )
+
+    @staticmethod
+    def _get_test_case_table(
+        table_name: str,
+        *,
+        connection: Connection | None = None,
+    ) -> Table:
+        """Get SQLAlchemy Core table metadata for a test case table.
+
+        Arguments:
+            table_name: SQLite table name
+            connection: optional connection used to reflect existing columns
+        Returns:
+            test case table
+        """
+        table_metadata = MetaData()
+        if connection is not None and inspect(connection).has_table(table_name):
+            return Table(table_name, table_metadata, autoload_with=connection)
+
+        table = Table(
+            table_name,
+            table_metadata,
+            Column("test_case_id", Text, primary_key=True),
+            Column("difficulty", Integer, nullable=False),
+            Column("prompt", Integer, nullable=False),
+            Column("verified", Integer, nullable=False),
+        )
+        return table
+
+    @staticmethod
+    def _get_upsert_update_values(table: Table, insert_statement: Insert) -> dict:
+        """Get update values for a SQLite upsert.
+
+        Arguments:
+            table: SQLAlchemy Core table
+            insert_statement: SQLite insert statement
+        Returns:
+            update value mapping
+        """
+        update_values = {}
+        for column in table.c:
+            if column.name == "test_case_id":
+                continue
+            if column.name in {"difficulty", "prompt", "verified"}:
+                update_values[column.name] = func.max(
+                    column, insert_statement.excluded[column.name]
+                )
+            else:
+                update_values[column.name] = insert_statement.excluded[column.name]
+        return update_values
+
+    @staticmethod
+    def _get_split_column_name(prefix: str, field_name: str, idx: int) -> str:
+        """Get a column name for a split list item.
+
+        Arguments:
+            prefix: column prefix
+            field_name: list field name
+            idx: zero-based list item index
+        Returns:
+            split column name
+        """
+        return f"{prefix}__{field_name}_{idx + 1:02d}"
+
+    @staticmethod
+    def _merge_source_paths(existing: list[str], incoming: list[str]) -> list[str]:
+        """Merge two source path lists.
+
+        Arguments:
+            existing: source paths already recorded
+            incoming: source paths to add
+        Returns:
+            sorted merged source paths
+        """
+        merged = set(existing)
+        merged.update(incoming)
+        return sorted(merged)
 
     @staticmethod
     def _parse_list_field(list_field: str) -> tuple[str, str]:

--- a/scinoephile/optimization/persistence/test_cases/sqlite_store.py
+++ b/scinoephile/optimization/persistence/test_cases/sqlite_store.py
@@ -24,8 +24,9 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.sqlite import Insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
-from sqlalchemy.engine import Connection, RowMapping
+from sqlalchemy.engine import URL, Connection, RowMapping
 from sqlalchemy.exc import OperationalError
+from sqlalchemy.pool import NullPool
 
 from scinoephile.common.validation import val_output_path
 from scinoephile.core.llms.operation_spec import OperationSpec
@@ -89,7 +90,11 @@ class TestCaseSqliteStore:
             self.list_fields = dict(operation_spec.list_fields)
         else:
             self.list_fields = {}
-        self.engine = create_engine(f"sqlite:///{self.database_path}", future=True)
+        self.engine = create_engine(
+            URL.create("sqlite", database=str(self.database_path)),
+            future=True,
+            poolclass=NullPool,
+        )
 
     def create_schema(self):
         """Create SQLite schema if needed."""
@@ -331,7 +336,9 @@ class TestCaseSqliteStore:
                 connection.execute(
                     insert_statement.on_conflict_do_update(
                         index_elements=[table.c.test_case_id],
-                        set_=self._get_upsert_update_values(table, insert_statement),
+                        set_=self._get_upsert_update_values(
+                            table, insert_statement, payload
+                        ),
                     )
                 )
                 touched += 1
@@ -702,19 +709,25 @@ class TestCaseSqliteStore:
         return table
 
     @staticmethod
-    def _get_upsert_update_values(table: Table, insert_statement: Insert) -> dict:
+    def _get_upsert_update_values(
+        table: Table,
+        insert_statement: Insert,
+        payload: dict[str, object],
+    ) -> dict:
         """Get update values for a SQLite upsert.
 
         Arguments:
             table: SQLAlchemy Core table
             insert_statement: SQLite insert statement
+            payload: payload being inserted
         Returns:
             update value mapping
         """
         update_values = {}
-        for column in table.c:
-            if column.name == "test_case_id":
+        for column_name in payload:
+            if column_name == "test_case_id":
                 continue
+            column = table.c[column_name]
             if column.name in {"difficulty", "prompt", "verified"}:
                 update_values[column.name] = func.max(
                     column, insert_statement.excluded[column.name]

--- a/uv.lock
+++ b/uv.lock
@@ -340,6 +340,22 @@ wheels = [
 ]
 
 [[package]]
+name = "greenlet"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/3f/dbf99fb14bfeb88c28f16729215478c0e265cacd6dc22270c8f31bb6892f/greenlet-3.5.0.tar.gz", hash = "sha256:d419647372241bc68e957bf38d5c1f98852155e4146bd1e4121adea81f4f01e4", size = 196995, upload-time = "2026-04-27T13:37:15.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/58/fc576f99037ce19c5aa16628e4c3226b6d1419f72a62c79f5f40576e6eb3/greenlet-3.5.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:5a5ed18de6a0f6cc7087f1563f6bd93fc7df1c19165ca01e9bde5a5dc281d106", size = 285066, upload-time = "2026-04-27T12:23:05.033Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/ba/b28ddbe6bfad6a8ac196ef0e8cff37bc65b79735995b9e410923fffeeb70/greenlet-3.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a717fbc46d8a354fa675f7c1e813485b6ba3885f9bef0cd56e5ba27d758ff5b", size = 604414, upload-time = "2026-04-27T12:52:42.358Z" },
+    { url = "https://files.pythonhosted.org/packages/09/06/4b69f8f0b67603a8be2790e55107a190b376f2627fe0eaf5695d85ffb3cd/greenlet-3.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ddc090c5c1792b10246a78e8c2163ebbe04cf877f9d785c230a7b27b39ad038e", size = 617349, upload-time = "2026-04-27T12:59:43.32Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/17/a3918541fd0ddefe024a69de6d16aa7b46d36ac19562adaa63c7fa180eff/greenlet-3.5.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2094acd54b272cb6eae8c03dd87b3fa1820a4cef18d6889c378d503500a1dc13", size = 613927, upload-time = "2026-04-27T12:25:30.28Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/e1/bd0af6213c7dd33175d8a462d4c1fe1175124ebed4855bc1475a5b5242c2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5e05ba267789ea87b5a155cf0e810b1ab88bf18e9e8740813945ceb8ee4350ba", size = 1570893, upload-time = "2026-04-27T12:53:29.483Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/2a/0789702f864f5382cb476b93d7a9c823c10472658102ccd65f415747d2e2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0ecec963079cd58cbd14723582384f11f166fd58883c15dcbfb342e0bc9b5846", size = 1636060, upload-time = "2026-04-27T12:25:28.845Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/8f/22bf9df92bbff0eb07842b60f7e63bf7675a9742df628437a9f02d09137f/greenlet-3.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:728d9667d8f2f586644b748dbd9bb67e50d6a9381767d1357714ea6825bb3bf5", size = 238740, upload-time = "2026-04-27T12:24:01.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/b7/9c5c3d653bd4ff614277c049ac676422e2c557db47b4fe43e6313fc005dc/greenlet-3.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:47422135b1d308c14b2c6e758beedb1acd33bb91679f5670edf77bf46244722b", size = 235525, upload-time = "2026-04-27T12:23:12.308Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1221,6 +1237,7 @@ dependencies = [
     { name = "pysubs2" },
     { name = "requests" },
     { name = "setuptools" },
+    { name = "sqlalchemy" },
     { name = "torch" },
     { name = "torchaudio" },
     { name = "transformers" },
@@ -1259,6 +1276,7 @@ requires-dist = [
     { name = "pysubs2", specifier = ">=1.8.1" },
     { name = "requests", specifier = ">=2.33.1" },
     { name = "setuptools", specifier = ">=82.0.1" },
+    { name = "sqlalchemy", specifier = ">=2.0.49" },
     { name = "torch", specifier = ">=2.10.0" },
     { name = "torchaudio", specifier = ">=2.10.0,<2.11.0" },
     { name = "transformers", specifier = ">=5.7.0" },
@@ -1340,6 +1358,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+]
+
+[[package]]
+name = "sqlalchemy"
+version = "2.0.49"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/45/461788f35e0364a8da7bda51a1fe1b09762d0c32f12f63727998d85a873b/sqlalchemy-2.0.49.tar.gz", hash = "sha256:d15950a57a210e36dd4cec1aac22787e2a4d57ba9318233e2ef8b2daf9ff2d5f", size = 9898221, upload-time = "2026-04-03T16:38:11.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/81/81755f50eb2478eaf2049728491d4ea4f416c1eb013338682173259efa09/sqlalchemy-2.0.49-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:df2d441bacf97022e81ad047e1597552eb3f83ca8a8f1a1fdd43cd7fe3898120", size = 2154547, upload-time = "2026-04-03T16:53:08.64Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/bc/3494270da80811d08bcfa247404292428c4fe16294932bce5593f215cad9/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8e20e511dc15265fb433571391ba313e10dd8ea7e509d51686a51313b4ac01a2", size = 3280782, upload-time = "2026-04-03T17:07:43.508Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/f5/038741f5e747a5f6ea3e72487211579d8cbea5eb9827a9cbd61d0108c4bd/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47604cb2159f8bbd5a1ab48a714557156320f20871ee64d550d8bf2683d980d3", size = 3297156, upload-time = "2026-04-03T17:12:27.697Z" },
+    { url = "https://files.pythonhosted.org/packages/88/50/a6af0ff9dc954b43a65ca9b5367334e45d99684c90a3d3413fc19a02d43c/sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:22d8798819f86720bc646ab015baff5ea4c971d68121cb36e2ebc2ee43ead2b7", size = 3228832, upload-time = "2026-04-03T17:07:45.38Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/d1/5f6bdad8de0bf546fc74370939621396515e0cdb9067402d6ba1b8afbe9a/sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9b1c058c171b739e7c330760044803099c7fff11511e3ab3573e5327116a9c33", size = 3267000, upload-time = "2026-04-03T17:12:29.657Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/30/ad62227b4a9819a5e1c6abff77c0f614fa7c9326e5a3bdbee90f7139382b/sqlalchemy-2.0.49-cp313-cp313-win32.whl", hash = "sha256:a143af2ea6672f2af3f44ed8f9cd020e9cc34c56f0e8db12019d5d9ecf41cb3b", size = 2115641, upload-time = "2026-04-03T17:05:43.989Z" },
+    { url = "https://files.pythonhosted.org/packages/17/3a/7215b1b7d6d49dc9a87211be44562077f5f04f9bb5a59552c1c8e2d98173/sqlalchemy-2.0.49-cp313-cp313-win_amd64.whl", hash = "sha256:12b04d1db2663b421fe072d638a138460a51d5a862403295671c4f3987fb9148", size = 2141498, upload-time = "2026-04-03T17:05:45.7Z" },
+    { url = "https://files.pythonhosted.org/packages/28/4b/52a0cb2687a9cd1648252bb257be5a1ba2c2ded20ba695c65756a55a15a4/sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:24bd94bb301ec672d8f0623eba9226cc90d775d25a0c92b5f8e4965d7f3a1518", size = 3560807, upload-time = "2026-04-03T16:58:31.666Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d8/fda95459204877eed0458550d6c7c64c98cc50c2d8d618026737de9ed41a/sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a51d3db74ba489266ef55c7a4534eb0b8db9a326553df481c11e5d7660c8364d", size = 3527481, upload-time = "2026-04-03T17:06:00.155Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0a/2aac8b78ac6487240cf7afef8f203ca783e8796002dc0cf65c4ee99ff8bb/sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:55250fe61d6ebfd6934a272ee16ef1244e0f16b7af6cd18ab5b1fc9f08631db0", size = 3468565, upload-time = "2026-04-03T16:58:33.414Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/3d/ce71cfa82c50a373fd2148b3c870be05027155ce791dc9a5dcf439790b8b/sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:46796877b47034b559a593d7e4b549aba151dae73f9e78212a3478161c12ab08", size = 3477769, upload-time = "2026-04-03T17:06:02.787Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e8/0a9f5c1f7c6f9ca480319bf57c2d7423f08d31445974167a27d14483c948/sqlalchemy-2.0.49-cp313-cp313t-win32.whl", hash = "sha256:9c4969a86e41454f2858256c39bdfb966a20961e9b58bf8749b65abf447e9a8d", size = 2143319, upload-time = "2026-04-03T17:02:04.328Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/51/fb5240729fbec73006e137c4f7a7918ffd583ab08921e6ff81a999d6517a/sqlalchemy-2.0.49-cp313-cp313t-win_amd64.whl", hash = "sha256:b9870d15ef00e4d0559ae10ee5bc71b654d1f20076dbe8bc7ed19b4c0625ceba", size = 2175104, upload-time = "2026-04-03T17:02:05.989Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/30/8519fdde58a7bdf155b714359791ad1dc018b47d60269d5d160d311fdc36/sqlalchemy-2.0.49-py3-none-any.whl", hash = "sha256:ec44cfa7ef1a728e88ad41674de50f6db8cfdb3e2af84af86e0041aaf02d43d0", size = 1942158, upload-time = "2026-04-03T16:53:44.135Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Migrate optimization test case persistence from direct `sqlite3` calls to SQLAlchemy Core tables, statements, reflection, and SQLite dialect upserts.
- Add SQLAlchemy as a project dependency and update the lockfile.
- Generalize optimization row payload extraction to accept mapping-style database rows.

## Impact

This preserves the existing SQLite schema and behavior while moving the optimization test case store onto SQLAlchemy Core. Existing dynamic payload columns, source-path links, upserts, dry-run sync reporting, and orphan cleanup continue to work.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/core/optimization.py scinoephile/optimization/persistence/test_cases/sqlite_store.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/core/optimization.py scinoephile/optimization/persistence/test_cases/sqlite_store.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/core/optimization.py scinoephile/optimization/persistence/test_cases/sqlite_store.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest optimization/persistence/test_cases cli/optimization -q`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto`