### PR TITLE
Complete Chinese CLI help localization

### DIFF
--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -91,6 +91,9 @@
 * CLI modules should support localization by defining a `localizations` mapping when
   the repository's CLI base supports it, and writing `help`, `description`, and
   argument-group titles using stable English strings that can be translated.
+  * User-facing CLI help for the full command tree must have both `zh-hans`
+    (`zho-Hans`) and `zh-hant` (`zho-Hant`) translations; do not leave new
+    descriptions, argument help, or group titles to fall back to English.
 
 ## Testing
 * Test modules do **not** need `__init__.py` files. Pytest can discover tests without them.

--- a/scinoephile/cli/analysis/analysis_cer_cli.py
+++ b/scinoephile/cli/analysis/analysis_cer_cli.py
@@ -61,7 +61,11 @@ class AnalysisCerCli(ScinoephileCliBase):
             parser: nascent argument parser
         """
         super().add_arguments_to_argparser(parser)
-        arg_groups = get_arg_groups_by_name(parser, "input arguments")
+        arg_groups = get_arg_groups_by_name(
+            parser,
+            "input arguments",
+            optional_arguments_name="additional arguments",
+        )
 
         # Input arguments
         arg_groups["input arguments"].add_argument(

--- a/scinoephile/cli/cache/cache_clear_cli.py
+++ b/scinoephile/cli/cache/cache_clear_cli.py
@@ -21,6 +21,34 @@ __all__ = ["CacheClearCli"]
 class CacheClearCli(ScinoephileCliBase):
     """Clear cache entries."""
 
+    localizations = {
+        "zh-hans": {
+            "cache namespace to clear": "要清除的缓存命名空间",
+            "cache root directory to inspect (default: %(default)s)": (
+                "要检查的缓存根目录（默认：%(default)s）"
+            ),
+            "clear cache entries": "清除缓存条目",
+            "clear every discovered namespace": "清除所有发现的命名空间",
+            "confirm destructive deletion": "确认破坏性删除",
+            "show what would be deleted without deleting files": (
+                "显示将删除的内容但不删除文件"
+            ),
+        },
+        "zh-hant": {
+            "cache namespace to clear": "要清除的快取命名空間",
+            "cache root directory to inspect (default: %(default)s)": (
+                "要檢查的快取根目錄（預設：%(default)s）"
+            ),
+            "clear cache entries": "清除快取條目",
+            "clear every discovered namespace": "清除所有發現的命名空間",
+            "confirm destructive deletion": "確認破壞性刪除",
+            "show what would be deleted without deleting files": (
+                "顯示將刪除的內容但不刪除檔案"
+            ),
+        },
+    }
+    """Localized help text keyed by locale and English source text."""
+
     @classmethod
     def add_arguments_to_argparser(cls, parser: ArgumentParser):
         """Add arguments to a nascent argument parser.

--- a/scinoephile/cli/cache/cache_cli.py
+++ b/scinoephile/cli/cache/cache_cli.py
@@ -21,6 +21,12 @@ __all__ = ["CacheCli"]
 class CacheCli(ScinoephileCliBase):
     """Inspect and invalidate local caches."""
 
+    localizations = {
+        "zh-hans": {"inspect and invalidate local caches": "检查并清除本地缓存"},
+        "zh-hant": {"inspect and invalidate local caches": "檢查並清除本機快取"},
+    }
+    """Localized help text keyed by locale and English source text."""
+
     @classmethod
     def add_arguments_to_argparser(cls, parser: ArgumentParser):
         """Add arguments to a nascent argument parser.

--- a/scinoephile/cli/cache/cache_list_cli.py
+++ b/scinoephile/cli/cache/cache_list_cli.py
@@ -22,6 +22,32 @@ __all__ = ["CacheListCli"]
 class CacheListCli(ScinoephileCliBase):
     """List cache entries."""
 
+    localizations = {
+        "zh-hans": {
+            "cache namespace to inspect": "要检查的缓存命名空间",
+            "cache root directory to inspect (default: %(default)s)": (
+                "要检查的缓存根目录（默认：%(default)s）"
+            ),
+            "list cache entries": "列出缓存条目",
+            "maximum number of entries to show": "要显示的最大条目数",
+            "output format": "输出格式",
+            "reverse sort order": "反转排序顺序",
+            "sort field": "排序字段",
+        },
+        "zh-hant": {
+            "cache namespace to inspect": "要檢查的快取命名空間",
+            "cache root directory to inspect (default: %(default)s)": (
+                "要檢查的快取根目錄（預設：%(default)s）"
+            ),
+            "list cache entries": "列出快取條目",
+            "maximum number of entries to show": "要顯示的最大條目數",
+            "output format": "輸出格式",
+            "reverse sort order": "反轉排序順序",
+            "sort field": "排序欄位",
+        },
+    }
+    """Localized help text keyed by locale and English source text."""
+
     @classmethod
     def add_arguments_to_argparser(cls, parser: ArgumentParser):
         """Add arguments to a nascent argument parser.

--- a/scinoephile/cli/cache/cache_prune_cli.py
+++ b/scinoephile/cli/cache/cache_prune_cli.py
@@ -22,6 +22,38 @@ __all__ = ["CachePruneCli"]
 class CachePruneCli(ScinoephileCliBase):
     """Prune old cache entries."""
 
+    localizations = {
+        "zh-hans": {
+            "cache namespace to inspect": "要检查的缓存命名空间",
+            "cache root directory to inspect (default: %(default)s)": (
+                "要检查的缓存根目录（默认：%(default)s）"
+            ),
+            "confirm destructive deletion": "确认破坏性删除",
+            "delete entries older than a duration such as 7d, 30d, or 12h": (
+                "删除早于指定时长的条目，例如 7d、30d 或 12h"
+            ),
+            "prune old cache entries": "清理旧缓存条目",
+            "show what would be deleted without deleting files": (
+                "显示将删除的内容但不删除文件"
+            ),
+        },
+        "zh-hant": {
+            "cache namespace to inspect": "要檢查的快取命名空間",
+            "cache root directory to inspect (default: %(default)s)": (
+                "要檢查的快取根目錄（預設：%(default)s）"
+            ),
+            "confirm destructive deletion": "確認破壞性刪除",
+            "delete entries older than a duration such as 7d, 30d, or 12h": (
+                "刪除早於指定時長的條目，例如 7d、30d 或 12h"
+            ),
+            "prune old cache entries": "清理舊快取條目",
+            "show what would be deleted without deleting files": (
+                "顯示將刪除的內容但不刪除檔案"
+            ),
+        },
+    }
+    """Localized help text keyed by locale and English source text."""
+
     @classmethod
     def add_arguments_to_argparser(cls, parser: ArgumentParser):
         """Add arguments to a nascent argument parser.

--- a/scinoephile/cli/cache/cache_stats_cli.py
+++ b/scinoephile/cli/cache/cache_stats_cli.py
@@ -22,6 +22,26 @@ __all__ = ["CacheStatsCli"]
 class CacheStatsCli(ScinoephileCliBase):
     """Show cache statistics."""
 
+    localizations = {
+        "zh-hans": {
+            "cache namespace to inspect": "要检查的缓存命名空间",
+            "cache root directory to inspect (default: %(default)s)": (
+                "要检查的缓存根目录（默认：%(default)s）"
+            ),
+            "output format": "输出格式",
+            "show cache statistics": "显示缓存统计信息",
+        },
+        "zh-hant": {
+            "cache namespace to inspect": "要檢查的快取命名空間",
+            "cache root directory to inspect (default: %(default)s)": (
+                "要檢查的快取根目錄（預設：%(default)s）"
+            ),
+            "output format": "輸出格式",
+            "show cache statistics": "顯示快取統計資訊",
+        },
+    }
+    """Localized help text keyed by locale and English source text."""
+
     @classmethod
     def add_arguments_to_argparser(cls, parser: ArgumentParser):
         """Add arguments to a nascent argument parser.

--- a/scinoephile/cli/eng/eng_process_cli.py
+++ b/scinoephile/cli/eng/eng_process_cli.py
@@ -27,6 +27,9 @@ class EngProcessCli(ScinoephileCliBase):
 
     localizations = {
         "zh-hans": {
+            "clean subtitles of closed-caption annotations and other anomalies": (
+                "清理字幕中的隐藏字幕标注及其他异常"
+            ),
             'English subtitle infile path or "-" for stdin': (
                 '英文字幕输入文件路径，或使用 "-" 表示标准输入'
             ),
@@ -41,6 +44,9 @@ class EngProcessCli(ScinoephileCliBase):
             "proofread subtitles using LLM": "使用大语言模型校对字幕",
         },
         "zh-hant": {
+            "clean subtitles of closed-caption annotations and other anomalies": (
+                "清理字幕中的隱藏字幕標註及其他異常"
+            ),
             'English subtitle infile path or "-" for stdin': (
                 '英文字幕輸入檔路徑，或使用 "-" 代表標準輸入'
             ),

--- a/scinoephile/cli/eng/eng_validate_ocr_cli.py
+++ b/scinoephile/cli/eng/eng_validate_ocr_cli.py
@@ -33,6 +33,12 @@ class EngValidateOcrCli(ScinoephileCliBase):
             "directory in which to save validation image outputs": (
                 "保存校验图像输出的目录"
             ),
+            "English OCR image subtitle infile path (directory containing index.html "
+            "and png files, or a .sup file)": (
+                "英文 OCR 图像字幕输入路径（包含 index.html 和 png 文件的目录，或 "
+                ".sup 文件）"
+            ),
+            "overwrite outfile directory if it exists": "若输出目录已存在则覆盖",
             "prompt for interactive validation decisions": "提示进行交互式校验决策",
             "stop validation after this subtitle index": "在此字幕索引后停止校验",
             "validate OCR text against subtitle images": "对照字幕图像校验 OCR 文本",
@@ -44,6 +50,12 @@ class EngValidateOcrCli(ScinoephileCliBase):
             "directory in which to save validation image outputs": (
                 "儲存驗證影像輸出的目錄"
             ),
+            "English OCR image subtitle infile path (directory containing index.html "
+            "and png files, or a .sup file)": (
+                "英文 OCR 影像字幕輸入路徑（包含 index.html 和 png 檔案的目錄，或 "
+                ".sup 檔）"
+            ),
+            "overwrite outfile directory if it exists": "若輸出目錄已存在則覆寫",
             "prompt for interactive validation decisions": "提示進行互動式驗證決策",
             "stop validation after this subtitle index": "在此字幕索引後停止驗證",
             "validate OCR text against subtitle images": "對照字幕影像驗證 OCR 文字",

--- a/scinoephile/cli/extract_cli.py
+++ b/scinoephile/cli/extract_cli.py
@@ -32,14 +32,44 @@ class ExtractCli(ScinoephileCliBase):
 
     localizations = {
         "zh-hans": {
+            "convert extracted SUP subtitle streams to image directories": (
+                "将提取的 SUP 字幕流转换为图像目录"
+            ),
+            "directory to which matching subtitles will be extracted or mapped": (
+                "匹配字幕将被提取或映射到的目录"
+            ),
+            "extract matching subtitle streams": "提取匹配的字幕流",
             "extract matching subtitle streams from a video file": (
                 "从视频文件提取匹配的字幕流"
             ),
+            "include additional subtitle stream details": "包含更多字幕流详细信息",
+            "ISO 639 language codes to extract (default: chi eng zho yue)": (
+                "要提取的 ISO 639 语言代码（默认：chi eng zho yue）"
+            ),
+            "overwrite extracted subtitle files if they exist": (
+                "若提取的字幕文件已存在则覆盖"
+            ),
+            "video infile containing subtitle streams": "包含字幕流的视频输入文件",
         },
         "zh-hant": {
+            "convert extracted SUP subtitle streams to image directories": (
+                "將提取的 SUP 字幕流轉換為影像目錄"
+            ),
+            "directory to which matching subtitles will be extracted or mapped": (
+                "匹配字幕將被提取或映射到的目錄"
+            ),
+            "extract matching subtitle streams": "提取匹配的字幕流",
             "extract matching subtitle streams from a video file": (
                 "從影片檔提取匹配的字幕流"
             ),
+            "include additional subtitle stream details": "包含更多字幕流詳細資訊",
+            "ISO 639 language codes to extract (default: chi eng zho yue)": (
+                "要提取的 ISO 639 語言代碼（預設：chi eng zho yue）"
+            ),
+            "overwrite extracted subtitle files if they exist": (
+                "若提取的字幕檔已存在則覆寫"
+            ),
+            "video infile containing subtitle streams": "包含字幕流的影片輸入檔",
         },
     }
     """Localized help text keyed by locale and English source text."""

--- a/scinoephile/cli/sync_cli.py
+++ b/scinoephile/cli/sync_cli.py
@@ -29,10 +29,38 @@ class SyncCli(ScinoephileCliBase):
             "combine two series into the top and bottom of a synchronized series": (
                 "将两个序列合并为上下行同步字幕"
             ),
+            "initial overlap cutoff used to form sync groups (default: 0.16)": (
+                "用于形成同步组的初始重叠阈值（默认：0.16）"
+            ),
+            "pause length in milliseconds used to split subtitle blocks "
+            "(default: 3000)": ("用于分割字幕块的停顿时长，单位为毫秒（默认：3000）"),
+            'subtitle infile for bottom line or "-" for stdin': (
+                '底行字幕输入文件，或使用 "-" 表示标准输入'
+            ),
+            'subtitle infile for top line or "-" for stdin': (
+                '顶行字幕输入文件，或使用 "-" 表示标准输入'
+            ),
+            "synchronized subtitle outfile path (default: stdout)": (
+                "同步字幕输出文件路径（默认：标准输出）"
+            ),
         },
         "zh-hant": {
             "combine two series into the top and bottom of a synchronized series": (
                 "將兩個序列合併為上下行同步字幕"
+            ),
+            "initial overlap cutoff used to form sync groups (default: 0.16)": (
+                "用於形成同步組的初始重疊閾值（預設：0.16）"
+            ),
+            "pause length in milliseconds used to split subtitle blocks "
+            "(default: 3000)": ("用於分割字幕區塊的停頓時長，單位為毫秒（預設：3000）"),
+            'subtitle infile for bottom line or "-" for stdin': (
+                '底行字幕輸入檔，或使用 "-" 代表標準輸入'
+            ),
+            'subtitle infile for top line or "-" for stdin': (
+                '頂行字幕輸入檔，或使用 "-" 代表標準輸入'
+            ),
+            "synchronized subtitle outfile path (default: stdout)": (
+                "同步字幕輸出檔路徑（預設：標準輸出）"
             ),
         },
     }

--- a/scinoephile/cli/timewarp_cli.py
+++ b/scinoephile/cli/timewarp_cli.py
@@ -26,13 +26,55 @@ class TimewarpCli(ScinoephileCliBase):
 
     localizations = {
         "zh-hans": {
+            "1-based end index in anchor series (default: final subtitle)": (
+                "锚定序列中的结束索引，从 1 开始（默认：最后一条字幕）"
+            ),
+            "1-based end index in moving series (default: final subtitle)": (
+                "待调整序列中的结束索引，从 1 开始（默认：最后一条字幕）"
+            ),
+            "1-based start index in anchor series (default: 1)": (
+                "锚定序列中的起始索引，从 1 开始（默认：1）"
+            ),
+            "1-based start index in moving series (default: 1)": (
+                "待调整序列中的起始索引，从 1 开始（默认：1）"
+            ),
+            'mobile subtitle infile to be timewarped or "-" for stdin': (
+                '要调整时间轴的移动字幕输入文件，或使用 "-" 表示标准输入'
+            ),
             "shift and stretch the timings of one subtitle series to match another": (
                 "平移并拉伸一个字幕序列的时间轴以匹配另一个序列"
             ),
+            'subtitle infile used as anchor timing reference or "-" for stdin': (
+                '作为锚定时间参考的字幕输入文件，或使用 "-" 表示标准输入'
+            ),
+            "timewarped subtitle outfile path (default: stdout)": (
+                "时间轴调整后字幕输出文件路径（默认：标准输出）"
+            ),
         },
         "zh-hant": {
+            "1-based end index in anchor series (default: final subtitle)": (
+                "錨定序列中的結束索引，從 1 開始（預設：最後一條字幕）"
+            ),
+            "1-based end index in moving series (default: final subtitle)": (
+                "待調整序列中的結束索引，從 1 開始（預設：最後一條字幕）"
+            ),
+            "1-based start index in anchor series (default: 1)": (
+                "錨定序列中的起始索引，從 1 開始（預設：1）"
+            ),
+            "1-based start index in moving series (default: 1)": (
+                "待調整序列中的起始索引，從 1 開始（預設：1）"
+            ),
+            'mobile subtitle infile to be timewarped or "-" for stdin': (
+                '要調整時間軸的移動字幕輸入檔，或使用 "-" 代表標準輸入'
+            ),
             "shift and stretch the timings of one subtitle series to match another": (
                 "平移並拉伸一個字幕序列的時間軸以匹配另一個序列"
+            ),
+            'subtitle infile used as anchor timing reference or "-" for stdin': (
+                '作為錨定時間參考的字幕輸入檔，或使用 "-" 代表標準輸入'
+            ),
+            "timewarped subtitle outfile path (default: stdout)": (
+                "時間軸調整後字幕輸出檔路徑（預設：標準輸出）"
             ),
         },
     }

--- a/scinoephile/cli/yue/yue_process_cli.py
+++ b/scinoephile/cli/yue/yue_process_cli.py
@@ -46,6 +46,9 @@ class YueProcessCli(ScinoephileCliBase):
         {
             "zh-hans": {
                 "append Cantonese romanization to subtitles": "为字幕追加粤语罗马字",
+                "clean subtitles of closed-caption annotations and other anomalies": (
+                    "清理字幕中的隐藏字幕标注及其他异常"
+                ),
                 "command-line interface for written Cantonese subtitle processing": (
                     "书面粤语字幕处理命令行界面"
                 ),
@@ -71,6 +74,9 @@ class YueProcessCli(ScinoephileCliBase):
             },
             "zh-hant": {
                 "append Cantonese romanization to subtitles": "為字幕附加粵語羅馬字",
+                "clean subtitles of closed-caption annotations and other anomalies": (
+                    "清理字幕中的隱藏字幕標註及其他異常"
+                ),
                 "command-line interface for written Cantonese subtitle processing": (
                     "書面粵語字幕處理命令列介面"
                 ),

--- a/scinoephile/cli/yue/yue_transcribe_vs_zho_cli.py
+++ b/scinoephile/cli/yue/yue_transcribe_vs_zho_cli.py
@@ -49,6 +49,9 @@ class YueTranscribeVsZhoCli(ScinoephileCliBase):
     localizations = merge_conversion_localizations(
         {
             "zh-hans": {
+                "audio stream index in media input (default: 0)": (
+                    "媒体输入中的音频流索引（默认：0）"
+                ),
                 "command-line interface for written Cantonese subtitle transcription": (
                     "书面粤语字幕转写命令行界面"
                 ),
@@ -71,8 +74,15 @@ class YueTranscribeVsZhoCli(ScinoephileCliBase):
                 "Written Cantonese subtitle outfile path (default: stdout)": (
                     "书面粤语字幕输出文件路径（默认：标准输出）"
                 ),
+                (
+                    "Transcribe subtitles from audio and revise using standard "
+                    "Chinese text"
+                ): "从音频转录字幕，并使用标准中文文本修订",
             },
             "zh-hant": {
+                "audio stream index in media input (default: 0)": (
+                    "媒體輸入中的音訊流索引（預設：0）"
+                ),
                 "command-line interface for written Cantonese subtitle transcription": (
                     "書面粵語字幕轉寫命令列介面"
                 ),
@@ -95,6 +105,10 @@ class YueTranscribeVsZhoCli(ScinoephileCliBase):
                 "Written Cantonese subtitle outfile path (default: stdout)": (
                     "書面粵語字幕輸出檔路徑（預設：標準輸出）"
                 ),
+                (
+                    "Transcribe subtitles from audio and revise using standard "
+                    "Chinese text"
+                ): "從音訊轉錄字幕，並使用標準中文文字修訂",
             },
         }
     )

--- a/scinoephile/cli/zho/zho_fuse_cli.py
+++ b/scinoephile/cli/zho/zho_fuse_cli.py
@@ -41,16 +41,40 @@ class ZhoFuseCli(ScinoephileCliBase):
     localizations = merge_conversion_localizations(
         {
             "zh-hans": {
+                "clean both OCR inputs before fusion (default: disabled)": (
+                    "融合前清理两个 OCR 输入（默认：禁用）"
+                ),
                 "command-line interface for standard Chinese OCR subtitle fusion": (
                     "标准中文 OCR 字幕融合命令行界面"
+                ),
+                "Fuse OCR output from Google Lens and PaddleOCR": (
+                    "融合 Google Lens 与 PaddleOCR 的 OCR 输出"
+                ),
+                'Standard Chinese subtitles OCRed using Google Lens or "-" for stdin': (
+                    '使用 Google Lens 识别的标准中文字幕，或使用 "-" 表示标准输入'
+                ),
+                'Standard Chinese subtitles OCRed using PaddleOCR or "-" for stdin': (
+                    '使用 PaddleOCR 识别的标准中文字幕，或使用 "-" 表示标准输入'
                 ),
                 "Standard Chinese subtitle outfile path (default: stdout)": (
                     "标准中文字幕输出文件路径（默认：标准输出）"
                 ),
             },
             "zh-hant": {
+                "clean both OCR inputs before fusion (default: disabled)": (
+                    "融合前清理兩個 OCR 輸入（預設：停用）"
+                ),
                 "command-line interface for standard Chinese OCR subtitle fusion": (
                     "標準中文 OCR 字幕融合命令列介面"
+                ),
+                "Fuse OCR output from Google Lens and PaddleOCR": (
+                    "融合 Google Lens 與 PaddleOCR 的 OCR 輸出"
+                ),
+                'Standard Chinese subtitles OCRed using Google Lens or "-" for stdin': (
+                    '使用 Google Lens 識別的標準中文字幕，或使用 "-" 代表標準輸入'
+                ),
+                'Standard Chinese subtitles OCRed using PaddleOCR or "-" for stdin': (
+                    '使用 PaddleOCR 識別的標準中文字幕，或使用 "-" 代表標準輸入'
                 ),
                 "Standard Chinese subtitle outfile path (default: stdout)": (
                     "標準中文字幕輸出檔路徑（預設：標準輸出）"

--- a/scinoephile/cli/zho/zho_process_cli.py
+++ b/scinoephile/cli/zho/zho_process_cli.py
@@ -46,6 +46,9 @@ class ZhoProcessCli(ScinoephileCliBase):
         {
             "zh-hans": {
                 "append Mandarin romanization to subtitles": "为字幕追加普通话罗马字",
+                "clean subtitles of closed-caption annotations and other anomalies": (
+                    "清理字幕中的隐藏字幕标注及其他异常"
+                ),
                 "command-line interface for standard Chinese subtitle processing": (
                     "标准中文字幕处理命令行界面"
                 ),
@@ -71,6 +74,9 @@ class ZhoProcessCli(ScinoephileCliBase):
             },
             "zh-hant": {
                 "append Mandarin romanization to subtitles": "為字幕附加普通話羅馬字",
+                "clean subtitles of closed-caption annotations and other anomalies": (
+                    "清理字幕中的隱藏字幕標註及其他異常"
+                ),
                 "command-line interface for standard Chinese subtitle processing": (
                     "標準中文字幕處理命令列介面"
                 ),

--- a/scinoephile/cli/zho/zho_validate_ocr_cli.py
+++ b/scinoephile/cli/zho/zho_validate_ocr_cli.py
@@ -29,11 +29,35 @@ class ZhoValidateOcrCli(ScinoephileCliBase):
             "command-line interface for standard Chinese OCR subtitle validation": (
                 "标准中文 OCR 字幕校验命令行界面"
             ),
+            "directory in which to save validation image outputs": (
+                "保存校验图像输出的目录"
+            ),
+            "overwrite outfile directory if it exists": "若输出目录已存在则覆盖",
+            "prompt for interactive validation decisions": "提示进行交互式校验决策",
+            "Standard Chinese OCR image subtitle infile path (directory containing "
+            "index.html and png files, or a .sup file)": (
+                "标准中文 OCR 图像字幕输入路径（包含 index.html 和 png 文件的目录，或 "
+                ".sup 文件）"
+            ),
+            "stop validation after this subtitle index": "校验到此字幕索引后停止",
+            "validate OCR text against subtitle images": "对照字幕图像校验 OCR 文本",
         },
         "zh-hant": {
             "command-line interface for standard Chinese OCR subtitle validation": (
                 "標準中文 OCR 字幕驗證命令列介面"
             ),
+            "directory in which to save validation image outputs": (
+                "儲存驗證影像輸出的目錄"
+            ),
+            "overwrite outfile directory if it exists": "若輸出目錄已存在則覆寫",
+            "prompt for interactive validation decisions": "提示進行互動式驗證決策",
+            "Standard Chinese OCR image subtitle infile path (directory containing "
+            "index.html and png files, or a .sup file)": (
+                "標準中文 OCR 影像字幕輸入路徑（包含 index.html 和 png 檔案的目錄，或 "
+                ".sup 檔）"
+            ),
+            "stop validation after this subtitle index": "驗證到此字幕索引後停止",
+            "validate OCR text against subtitle images": "對照字幕影像驗證 OCR 文字",
         },
     }
     """Localized help text keyed by locale and English source text."""

--- a/scinoephile/core/cli/scinoephile_cli_base.py
+++ b/scinoephile/core/cli/scinoephile_cli_base.py
@@ -74,15 +74,14 @@ class ScinoephileCliBase(CommandLineInterface):
         Returns:
             locale to source/target text mapping
         """
-        if cls is ScinoephileCliBase:
-            return cls.localizations
-        merged: dict[str, dict[str, str]] = {
-            locale_name: dict(locale_text)
-            for locale_name, locale_text in ScinoephileCliBase.localizations.items()
-        }
-        for locale_name, locale_text in cls.localizations.items():
-            merged.setdefault(locale_name, {})
-            merged[locale_name].update(locale_text)
+        merged: dict[str, dict[str, str]] = {}
+        for base_cls in reversed(cls.mro()):
+            if not issubclass(base_cls, ScinoephileCliBase):
+                continue
+            localizations = base_cls.__dict__.get("localizations", {})
+            for locale_name, locale_text in localizations.items():
+                merged.setdefault(locale_name, {})
+                merged[locale_name].update(locale_text)
         return merged
 
     @classmethod

--- a/test/cli/test_localized_cli_help.py
+++ b/test/cli/test_localized_cli_help.py
@@ -12,7 +12,41 @@ from unittest.mock import patch
 import pytest
 
 from scinoephile.cli.scinoephile_cli import ScinoephileCli
+from scinoephile.common import CommandLineInterface
 from scinoephile.common.testing import run_cli_with_args
+from scinoephile.core.cli import ScinoephileCliBase
+
+
+def test_all_cli_help_text_has_chinese_localizations():
+    """Test every CLI help path has Simplified and Traditional localizations."""
+    missing: set[tuple[str, str, str]] = set()
+    original_translate_text = ScinoephileCliBase.translate_text.__func__
+
+    def recording_translate_text(
+        cls: type[ScinoephileCliBase], text: str | None
+    ) -> str:
+        """Record untranslated help text while preserving normal localization."""
+        translated = original_translate_text(cls, text)
+        if (
+            text
+            and ScinoephileCliBase.locale_name != "en"
+            and translated == text
+            and _is_translatable_help_text(text)
+        ):
+            missing.add((cls.__name__, ScinoephileCliBase.locale_name, text))
+        return translated
+
+    with patch.object(
+        ScinoephileCliBase,
+        "translate_text",
+        classmethod(recording_translate_text),
+    ):
+        for locale_name in ("zh-hans", "zh-hant"):
+            with patch.dict(environ, {"LC_ALL": locale_name}):
+                for subcommand in _get_help_subcommands(ScinoephileCli):
+                    _run_help(f"{subcommand} --help".strip())
+
+    assert sorted(missing) == []
 
 
 @pytest.mark.parametrize(
@@ -228,3 +262,37 @@ def _run_help(args: str) -> str:
     assert excinfo.value.code == 0
     assert stderr.getvalue() == ""
     return stdout.getvalue()
+
+
+def _get_help_subcommands(
+    cli: type[CommandLineInterface], prefix: tuple[str, ...] = ()
+) -> list[str]:
+    """Get every subcommand path that exposes help text.
+
+    Arguments:
+        cli: CLI class to inspect
+        prefix: subcommand path leading to the CLI class
+    Returns:
+        CLI subcommand paths, with an empty string for the root command
+    """
+    subcommands = getattr(cli, "subcommands", None)
+    if subcommands is None:
+        return [" ".join(prefix)]
+
+    help_subcommands = [" ".join(prefix)]
+    for name, subcommand in sorted(subcommands().items()):
+        help_subcommands.extend(_get_help_subcommands(subcommand, (*prefix, name)))
+    return help_subcommands
+
+
+def _is_translatable_help_text(text: str) -> bool:
+    """Return whether help text should have a locale-specific translation.
+
+    Arguments:
+        text: help text under translation
+    Returns:
+        whether the text is user-facing prose or a help group title
+    """
+    return any(
+        character.isascii() and character.isalpha() for character in text
+    ) and not any("\u4e00" <= character <= "\u9fff" for character in text)


### PR DESCRIPTION
## Summary
- Add full-tree CLI help coverage that fails when zh-hans or zh-hant help text falls back to English.
- Fill missing Simplified and Traditional Chinese localization entries in the owning CLI modules.
- Merge localization maps through CLI inheritance so shared CLI base classes, such as dictionary build CLIs, retain ownership of common strings.
- Document the full CLI Chinese localization requirement in `docs/STYLE.md`.

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format <changed Python files>`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix <changed Python files>`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check <changed Python files>`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest test/cli/test_localized_cli_help.py -q`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto`