### PR TITLE
Avoid cache side effects in dictionary usage

### DIFF
--- a/scinoephile/cli/cache/argument_types.py
+++ b/scinoephile/cli/cache/argument_types.py
@@ -26,7 +26,7 @@ def cache_dir_path_arg(value: str | None) -> Path:
         resolved cache directory path
     """
     if value is None:
-        return get_runtime_cache_dir_path()
+        return get_runtime_cache_dir_path(create=False)
     return Path(value).expanduser().resolve()
 
 

--- a/scinoephile/cli/dictionary/build/dictionary_build_cuhk_cli.py
+++ b/scinoephile/cli/dictionary/build/dictionary_build_cuhk_cli.py
@@ -90,7 +90,7 @@ class DictionaryBuildCuhkCli(DictionaryBuildCliBase):
         arg_groups["input arguments"].add_argument(
             "--cache-dir",
             dest="cache_dir_path",
-            default=get_runtime_cache_dir_path("dictionaries", "cuhk"),
+            default=get_runtime_cache_dir_path("dictionaries", "cuhk", create=False),
             type=output_dir_arg(),
             help=(
                 "cache directory for scraped HTML and link data (default: %(default)s)"

--- a/scinoephile/core/paths.py
+++ b/scinoephile/core/paths.py
@@ -13,11 +13,12 @@ from scinoephile.common.validation import val_output_dir_path
 __all__ = ["get_runtime_cache_dir_path"]
 
 
-def get_runtime_cache_dir_path(*parts: str) -> Path:
+def get_runtime_cache_dir_path(*parts: str, create: bool = True) -> Path:
     """Get runtime cache directory path for Scinoephile.
 
     Arguments:
         *parts: optional path components beneath the cache root
+        create: whether to create the directory if it does not exist
     Returns:
         cache directory path
     """
@@ -30,4 +31,7 @@ def get_runtime_cache_dir_path(*parts: str) -> Path:
     else:
         cache_root_path = Path(getenv("XDG_CACHE_HOME") or Path.home() / ".cache")
 
-    return val_output_dir_path(cache_root_path / "scinoephile" / Path(*parts))
+    return val_output_dir_path(
+        cache_root_path / "scinoephile" / Path(*parts),
+        create=create,
+    )

--- a/test/cli/dictionary/test_dictionary_cli.py
+++ b/test/cli/dictionary/test_dictionary_cli.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from scinoephile.cli.dictionary.dictionary_cli import DictionaryCli
@@ -42,3 +44,20 @@ def test_dictionary_usage(cli: tuple[type[CommandLineInterface], ...]):
         cli: CLI class tuple with optional subcommands
     """
     assert_cli_usage(cli)
+
+
+def test_dictionary_usage_does_not_create_default_cache_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Test dictionary usage output does not create default cache directories.
+
+    Arguments:
+        tmp_path: temporary directory provided by pytest
+        monkeypatch: pytest monkeypatch fixture
+    """
+    cache_dir_path = tmp_path / "cache"
+    monkeypatch.setenv("SCINOEPHILE_CACHE_DIR", str(cache_dir_path))
+
+    assert_cli_usage((DictionaryCli,))
+
+    assert not cache_dir_path.exists()

--- a/test/cli/test_localized_cli_help.py
+++ b/test/cli/test_localized_cli_help.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO
 from os import environ
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -47,6 +48,24 @@ def test_all_cli_help_text_has_chinese_localizations():
                     _run_help(f"{subcommand} --help".strip())
 
     assert sorted(missing) == []
+
+
+def test_all_cli_help_paths_do_not_create_default_cache_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Test CLI help construction does not create default cache directories.
+
+    Arguments:
+        tmp_path: temporary directory provided by pytest
+        monkeypatch: pytest monkeypatch fixture
+    """
+    cache_dir_path = tmp_path / "cache"
+    monkeypatch.setenv("SCINOEPHILE_CACHE_DIR", str(cache_dir_path))
+
+    for subcommand in _get_help_subcommands(ScinoephileCli):
+        _run_help(f"{subcommand} --help".strip())
+
+    assert not cache_dir_path.exists()
 
 
 @pytest.mark.parametrize(

--- a/test/cli/test_scinoephile_cli.py
+++ b/test/cli/test_scinoephile_cli.py
@@ -4,6 +4,10 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
+import pytest
+
 from scinoephile.cli.scinoephile_cli import ScinoephileCli
 from test.helpers import assert_cli_help, assert_cli_usage
 
@@ -16,3 +20,20 @@ def test_scinoephile_help():
 def test_scinoephile_usage():
     """Test root CLI usage output."""
     assert_cli_usage((ScinoephileCli,))
+
+
+def test_scinoephile_help_does_not_create_default_cache_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Test root help output does not create default cache directories.
+
+    Arguments:
+        tmp_path: temporary directory provided by pytest
+        monkeypatch: pytest monkeypatch fixture
+    """
+    cache_dir_path = tmp_path / "cache"
+    monkeypatch.setenv("SCINOEPHILE_CACHE_DIR", str(cache_dir_path))
+
+    assert_cli_help((ScinoephileCli,))
+
+    assert not cache_dir_path.exists()

--- a/test/common/test_command_line_interface.py
+++ b/test/common/test_command_line_interface.py
@@ -16,6 +16,7 @@ from scinoephile.common.command_line_interface import (
     CommandLineInterface,
 )
 from scinoephile.common.testing import run_cli_with_args
+from test import helpers
 
 
 class ArgsCaptureCli(CommandLineInterface):
@@ -42,6 +43,28 @@ class ArgsCaptureCli(CommandLineInterface):
     ):
         """Execute test CLI."""
         cls.captured["name"] = name
+
+
+class RequiredArgCli(CommandLineInterface):
+    """Test CLI that requires an argument."""
+
+    @classmethod
+    def add_arguments_to_argparser(cls, parser: ArgumentParser):
+        """Add arguments to a nascent argument parser.
+
+        Arguments:
+            parser: nascent argument parser
+        """
+        super().add_arguments_to_argparser(parser)
+        parser.add_argument("--name", required=True)
+
+    @classmethod
+    def _main(
+        cls,
+        *,
+        name: str,
+    ):
+        """Execute test CLI."""
 
 
 class TestCli(CommandLineInterface):
@@ -242,3 +265,27 @@ def test_run_cli_with_args_quoted_values():
     ArgsCaptureCli.captured.clear()
     run_cli_with_args(ArgsCaptureCli, '--name "value with spaces"')
     assert ArgsCaptureCli.captured.get("name") == "value with spaces"
+
+
+def test_assert_cli_usage_failure_reports_streams(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test CLI usage assertion failures include expected and actual streams.
+
+    Arguments:
+        monkeypatch: pytest monkeypatch fixture
+    """
+    monkeypatch.setattr(
+        helpers,
+        "get_usage_prefix",
+        lambda cli: "usage: intentionally-wrong.py",
+    )
+
+    with pytest.raises(AssertionError) as excinfo:
+        helpers.assert_cli_usage((RequiredArgCli,))
+
+    message = str(excinfo.value)
+    assert "Expected stderr to start with:" in message
+    assert "usage: intentionally-wrong.py" in message
+    assert "Actual stderr:" in message
+    assert "Actual stdout:" in message

--- a/test/helpers/__init__.py
+++ b/test/helpers/__init__.py
@@ -71,7 +71,17 @@ def assert_cli_usage(cli: tuple[type[CommandLineInterface], ...]):
                 run_cli_with_args(cli[0], subcommands)
     assert excinfo.value.code == 2
     assert stdout.getvalue() == ""
-    assert stderr.getvalue().startswith(get_usage_prefix(cli))
+    expected_usage_prefix = get_usage_prefix(cli)
+    actual_stdout = stdout.getvalue()
+    actual_stderr = stderr.getvalue()
+    assert actual_stderr.startswith(expected_usage_prefix), (
+        "Expected stderr to start with:\n"
+        f"{expected_usage_prefix!r}\n"
+        "Actual stderr:\n"
+        f"{actual_stderr!r}\n"
+        "Actual stdout:\n"
+        f"{actual_stdout!r}"
+    )
 
 
 def assert_expected_warnings(warnings: list[str], expected: list[str], label: str):


### PR DESCRIPTION
## Summary
- Add non-creating runtime cache path resolution for parser defaults
- Use non-creating CUHK cache default while preserving creation when the build command runs
- Add a regression test that dictionary usage output does not create default cache directories

## Verification
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/core/paths.py scinoephile/cli/dictionary/build/dictionary_build_cuhk_cli.py test/cli/dictionary/test_dictionary_cli.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/core/paths.py scinoephile/cli/dictionary/build/dictionary_build_cuhk_cli.py test/cli/dictionary/test_dictionary_cli.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/core/paths.py scinoephile/cli/dictionary/build/dictionary_build_cuhk_cli.py test/cli/dictionary/test_dictionary_cli.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest cli/dictionary/test_dictionary_cli.py cli/dictionary/build/test_dictionary_build_cuhk_cli.py -q`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto`