### PR TITLE
Centralize series comparison assertions

### DIFF
--- a/test/cli/eng/test_eng_fuse_cli.py
+++ b/test/cli/eng/test_eng_fuse_cli.py
@@ -16,7 +16,12 @@ from scinoephile.common import CommandLineInterface
 from scinoephile.common.file import get_temp_file_path
 from scinoephile.common.testing import run_cli_with_args
 from scinoephile.core.subtitles import Series
-from test.helpers import assert_cli_help, assert_cli_usage, test_data_root
+from test.helpers import (
+    assert_cli_help,
+    assert_cli_usage,
+    assert_series_equal,
+    test_data_root,
+)
 
 
 @pytest.mark.parametrize(
@@ -110,7 +115,7 @@ def test_eng_fuse_cli(
         output = Series.load(output_path)
         expected = Series.load(full_expected_path)
 
-    assert output == expected
+    assert_series_equal(output, expected)
 
 
 @pytest.mark.parametrize(
@@ -153,4 +158,4 @@ def test_eng_fuse_cli_pipe(
     output = Series.from_string(stdout_stream.getvalue(), format_="srt")
     expected = Series.load(full_expected_path)
 
-    assert output == expected
+    assert_series_equal(output, expected)

--- a/test/cli/eng/test_eng_process_cli.py
+++ b/test/cli/eng/test_eng_process_cli.py
@@ -16,7 +16,12 @@ from scinoephile.common import CommandLineInterface
 from scinoephile.common.file import get_temp_file_path
 from scinoephile.common.testing import run_cli_with_args
 from scinoephile.core.subtitles import Series
-from test.helpers import assert_cli_help, assert_cli_usage, test_data_root
+from test.helpers import (
+    assert_cli_help,
+    assert_cli_usage,
+    assert_series_equal,
+    test_data_root,
+)
 
 
 @pytest.mark.parametrize(
@@ -96,7 +101,7 @@ def test_eng_process_cli(
         output = Series.load(output_path)
         expected = Series.load(full_expected_path)
 
-    assert output == expected
+    assert_series_equal(output, expected)
 
 
 @pytest.mark.parametrize(
@@ -130,7 +135,7 @@ def test_eng_process_cli_pipe(input_path: str, args: str, expected_path: str):
     output = Series.from_string(stdout_stream.getvalue(), format_="srt")
     expected = Series.load(full_expected_path)
 
-    assert output == expected
+    assert_series_equal(output, expected)
 
 
 def test_eng_process_cli_offsets_timing():
@@ -146,4 +151,4 @@ def test_eng_process_cli_offsets_timing():
 
     expected = Series.load(full_input_path)
     expected.shift(ms=1250)
-    assert output == expected
+    assert_series_equal(output, expected)

--- a/test/cli/eng/test_eng_validate_ocr_cli.py
+++ b/test/cli/eng/test_eng_validate_ocr_cli.py
@@ -14,7 +14,12 @@ from scinoephile.common.file import get_temp_directory_path
 from scinoephile.common.testing import run_cli_with_args
 from scinoephile.image.subtitles import ImageSeries
 from scinoephile.lang.eng.ocr_validation import validate_eng_ocr
-from test.helpers import assert_cli_help, assert_cli_usage, test_data_root
+from test.helpers import (
+    assert_cli_help,
+    assert_cli_usage,
+    assert_series_equal,
+    test_data_root,
+)
 
 
 @pytest.mark.parametrize(
@@ -79,6 +84,6 @@ def test_eng_validate_ocr_cli(input_path: str):
         )
 
         output = ImageSeries.load(outfile_path)
-        assert output == expected
+        assert_series_equal(output, expected)
         assert (outfile_path / "index.html").exists()
         assert any(outfile_path.glob("*.png"))

--- a/test/cli/test_sync_cli.py
+++ b/test/cli/test_sync_cli.py
@@ -16,7 +16,12 @@ from scinoephile.common import CommandLineInterface
 from scinoephile.common.file import get_temp_file_path
 from scinoephile.common.testing import run_cli_with_args
 from scinoephile.core.subtitles import Series
-from test.helpers import assert_cli_help, assert_cli_usage, test_data_root
+from test.helpers import (
+    assert_cli_help,
+    assert_cli_usage,
+    assert_series_equal,
+    test_data_root,
+)
 
 
 @pytest.mark.parametrize(
@@ -89,7 +94,7 @@ def test_sync_cli(
         output = Series.load(output_path)
         expected = Series.load(full_expected_path)
 
-    assert output == expected
+    assert_series_equal(output, expected)
 
 
 @pytest.mark.parametrize(
@@ -124,7 +129,7 @@ def test_sync_cli_pipe(top_path: str, bottom_path: str, expected_path: str):
     output = Series.from_string(stdout_stream.getvalue(), format_="srt")
     expected = Series.load(full_expected_path)
 
-    assert output == expected
+    assert_series_equal(output, expected)
 
 
 @pytest.mark.parametrize(

--- a/test/cli/test_timewarp_cli.py
+++ b/test/cli/test_timewarp_cli.py
@@ -15,7 +15,12 @@ from scinoephile.common import CommandLineInterface
 from scinoephile.common.file import get_temp_file_path
 from scinoephile.common.testing import run_cli_with_args
 from scinoephile.core.subtitles import Series
-from test.helpers import assert_cli_help, assert_cli_usage, test_data_root
+from test.helpers import (
+    assert_cli_help,
+    assert_cli_usage,
+    assert_series_equal,
+    test_data_root,
+)
 
 
 @pytest.mark.parametrize(
@@ -88,7 +93,7 @@ def test_timewarp_cli(
         output = Series.load(output_path)
         expected = Series.load(full_expected_path)
 
-    assert output == expected
+    assert_series_equal(output, expected)
 
 
 @pytest.mark.parametrize(
@@ -128,4 +133,4 @@ def test_timewarp_cli_pipe(
     output = Series.from_string(stdout_stream.getvalue(), format_="srt")
     expected = Series.load(full_expected_path)
 
-    assert output == expected
+    assert_series_equal(output, expected)

--- a/test/cli/yue/test_yue_process_cli.py
+++ b/test/cli/yue/test_yue_process_cli.py
@@ -16,7 +16,12 @@ from scinoephile.common import CommandLineInterface
 from scinoephile.common.file import get_temp_file_path
 from scinoephile.common.testing import run_cli_with_args
 from scinoephile.core.subtitles import Series
-from test.helpers import assert_cli_help, assert_cli_usage, test_data_root
+from test.helpers import (
+    assert_cli_help,
+    assert_cli_usage,
+    assert_series_equal,
+    test_data_root,
+)
 
 
 @pytest.mark.parametrize(
@@ -86,7 +91,7 @@ def test_yue_process_cli(
         output = Series.load(output_path)
 
     expected = Series.load(full_expected_path)
-    assert output == expected
+    assert_series_equal(output, expected)
 
 
 @pytest.mark.parametrize(
@@ -119,7 +124,7 @@ def test_yue_process_cli_pipe(input_path: str, args: str, expected_path: str):
 
     output = Series.from_string(stdout_stream.getvalue(), format_="srt")
     expected = Series.load(full_expected_path)
-    assert output == expected
+    assert_series_equal(output, expected)
 
 
 def test_yue_process_cli_offsets_timing():
@@ -135,7 +140,7 @@ def test_yue_process_cli_offsets_timing():
 
     expected = Series.load(full_input_path)
     expected.shift(ms=1250)
-    assert output == expected
+    assert_series_equal(output, expected)
 
 
 def test_yue_process_cli_rejects_bare_convert_flag():

--- a/test/cli/yue/test_yue_review_vs_zho_cli.py
+++ b/test/cli/yue/test_yue_review_vs_zho_cli.py
@@ -16,7 +16,12 @@ from scinoephile.common.file import get_temp_file_path
 from scinoephile.common.testing import run_cli_with_args
 from scinoephile.core.subtitles import Series
 from scinoephile.multilang.yue_zho.block_review import YueVsZhoYueHansBlockReviewPrompt
-from test.helpers import assert_cli_help, assert_cli_usage, test_data_root
+from test.helpers import (
+    assert_cli_help,
+    assert_cli_usage,
+    assert_series_equal,
+    test_data_root,
+)
 
 
 @pytest.mark.parametrize(
@@ -106,8 +111,8 @@ def test_yue_review_vs_zho_cli(
 
     if args == "--mode line":
         called_kwargs = patched_line.call_args.kwargs
-        assert called_kwargs["yuewen"] == Series.load(full_yue_input_path)
-        assert called_kwargs["zhongwen"] == Series.load(full_zho_input_path)
+        assert_series_equal(called_kwargs["yuewen"], Series.load(full_yue_input_path))
+        assert_series_equal(called_kwargs["zhongwen"], Series.load(full_zho_input_path))
         patched_review.assert_not_called()
         patched_factory.assert_not_called()
     else:
@@ -116,8 +121,8 @@ def test_yue_review_vs_zho_cli(
             is YueVsZhoYueHansBlockReviewPrompt
         )
         called_kwargs = patched_review.call_args.kwargs
-        assert called_kwargs["yuewen"] == Series.load(full_yue_input_path)
-        assert called_kwargs["zhongwen"] == Series.load(full_zho_input_path)
+        assert_series_equal(called_kwargs["yuewen"], Series.load(full_yue_input_path))
+        assert_series_equal(called_kwargs["zhongwen"], Series.load(full_zho_input_path))
         assert called_kwargs["reviewer"] == "reviewer"
         patched_line.assert_not_called()
-    assert output == expected
+    assert_series_equal(output, expected)

--- a/test/cli/yue/test_yue_transcribe_vs_zho_cli.py
+++ b/test/cli/yue/test_yue_transcribe_vs_zho_cli.py
@@ -29,7 +29,12 @@ from scinoephile.multilang.yue_zho.transcription.punctuation import (
     YueVsZhoYueHansPunctuationPrompt,
     YueVsZhoYueHantPunctuationPrompt,
 )
-from test.helpers import assert_cli_help, assert_cli_usage, test_data_root
+from test.helpers import (
+    assert_cli_help,
+    assert_cli_usage,
+    assert_series_equal,
+    test_data_root,
+)
 
 
 @pytest.mark.parametrize(
@@ -142,14 +147,14 @@ def test_yue_transcribe_vs_zho_cli_writes_file():
     assert patched_factory.call_args.kwargs["vad_mode"] == VADMode.AUTO
     called_kwargs = patched_transcribe.call_args.kwargs
     assert called_kwargs["yuewen"] == yuewen_audio_series
-    assert called_kwargs["zhongwen"] == Series.load(zhongwen_infile_path)
+    assert_series_equal(called_kwargs["zhongwen"], Series.load(zhongwen_infile_path))
     assert called_kwargs["transcriber"] == "transcriber"
     patched_loader.assert_called_once_with(
         media_path=media_infile_path,
         subtitle_path=zhongwen_infile_path,
         stream_index=1,
     )
-    assert output_series == expected_series
+    assert_series_equal(output_series, expected_series)
 
 
 def test_yue_transcribe_vs_zho_cli_writes_stdout():
@@ -183,7 +188,7 @@ def test_yue_transcribe_vs_zho_cli_writes_stdout():
                     )
 
     output_series = Series.from_string(stdout_stream.getvalue(), format_="srt")
-    assert output_series == expected_series
+    assert_series_equal(output_series, expected_series)
 
 
 def test_yue_transcribe_vs_zho_cli_passes_requested_vad_mode():
@@ -418,12 +423,12 @@ def test_yue_transcribe_vs_zho_cli_allows_stdin_subtitle_infile():
 
     called_kwargs = patched_transcribe.call_args.kwargs
     assert called_kwargs["yuewen"] == yuewen_audio_series
-    assert called_kwargs["zhongwen"] == Series.load(zhongwen_infile_path)
+    assert_series_equal(called_kwargs["zhongwen"], Series.load(zhongwen_infile_path))
     patched_loader.assert_called_once()
     assert patched_loader.call_args.kwargs["media_path"] == media_infile_path
     assert patched_loader.call_args.kwargs["subtitle_path"] != "-"
     output_series = Series.from_string(stdout_stream.getvalue(), format_="srt")
-    assert output_series == expected_series
+    assert_series_equal(output_series, expected_series)
 
 
 def test_yue_transcribe_vs_zho_cli_rejects_two_stdin_infiles():

--- a/test/cli/yue/test_yue_translate_vs_zho_cli.py
+++ b/test/cli/yue/test_yue_translate_vs_zho_cli.py
@@ -18,7 +18,12 @@ from scinoephile.core.subtitles import Series
 from scinoephile.multilang.yue_zho.translation import (
     YueVsZhoYueHansTranslationPrompt,
 )
-from test.helpers import assert_cli_help, assert_cli_usage, test_data_root
+from test.helpers import (
+    assert_cli_help,
+    assert_cli_usage,
+    assert_series_equal,
+    test_data_root,
+)
 
 
 @pytest.mark.parametrize(
@@ -104,7 +109,7 @@ def test_yue_translate_vs_zho_cli(
         is YueVsZhoYueHansTranslationPrompt
     )
     called_kwargs = patched_translate.call_args.kwargs
-    assert called_kwargs["yuewen"] == Series.load(full_yue_input_path)
-    assert called_kwargs["zhongwen"] == Series.load(full_zho_input_path)
+    assert_series_equal(called_kwargs["yuewen"], Series.load(full_yue_input_path))
+    assert_series_equal(called_kwargs["zhongwen"], Series.load(full_zho_input_path))
     assert called_kwargs["translator"] == "translator"
-    assert output == expected
+    assert_series_equal(output, expected)

--- a/test/cli/zho/test_zho_fuse_cli.py
+++ b/test/cli/zho/test_zho_fuse_cli.py
@@ -16,7 +16,12 @@ from scinoephile.common import CommandLineInterface
 from scinoephile.common.file import get_temp_file_path
 from scinoephile.common.testing import run_cli_with_args
 from scinoephile.core.subtitles import Series
-from test.helpers import assert_cli_help, assert_cli_usage, test_data_root
+from test.helpers import (
+    assert_cli_help,
+    assert_cli_usage,
+    assert_series_equal,
+    test_data_root,
+)
 
 
 @pytest.mark.parametrize(
@@ -110,7 +115,7 @@ def test_zho_fuse_cli(
         output = Series.load(output_path)
         expected = Series.load(full_expected_path)
 
-    assert output == expected
+    assert_series_equal(output, expected)
 
 
 @pytest.mark.parametrize(
@@ -152,7 +157,7 @@ def test_zho_fuse_cli_pipe(
     output = Series.from_string(stdout_stream.getvalue(), format_="srt")
     expected = Series.load(full_expected_path)
 
-    assert output == expected
+    assert_series_equal(output, expected)
 
 
 def test_zho_fuse_cli_rejects_bare_convert_flag():

--- a/test/cli/zho/test_zho_process_cli.py
+++ b/test/cli/zho/test_zho_process_cli.py
@@ -16,7 +16,12 @@ from scinoephile.common import CommandLineInterface
 from scinoephile.common.file import get_temp_file_path
 from scinoephile.common.testing import run_cli_with_args
 from scinoephile.core.subtitles import Series
-from test.helpers import assert_cli_help, assert_cli_usage, test_data_root
+from test.helpers import (
+    assert_cli_help,
+    assert_cli_usage,
+    assert_series_equal,
+    test_data_root,
+)
 
 
 @pytest.mark.parametrize(
@@ -106,7 +111,7 @@ def test_zho_process_cli(
         output = Series.load(output_path)
         expected = Series.load(full_expected_path)
 
-    assert output == expected
+    assert_series_equal(output, expected)
 
 
 @pytest.mark.parametrize(
@@ -140,7 +145,7 @@ def test_zho_process_cli_pipe(input_path: str, args: str, expected_path: str):
     output = Series.from_string(stdout_stream.getvalue(), format_="srt")
     expected = Series.load(full_expected_path)
 
-    assert output == expected
+    assert_series_equal(output, expected)
 
 
 def test_zho_process_cli_offsets_timing():
@@ -156,7 +161,7 @@ def test_zho_process_cli_offsets_timing():
 
     expected = Series.load(full_input_path)
     expected.shift(ms=1250)
-    assert output == expected
+    assert_series_equal(output, expected)
 
 
 def test_zho_process_cli_rejects_bare_convert_flag():

--- a/test/cli/zho/test_zho_validate_ocr_cli.py
+++ b/test/cli/zho/test_zho_validate_ocr_cli.py
@@ -14,7 +14,12 @@ from scinoephile.common.file import get_temp_directory_path
 from scinoephile.common.testing import run_cli_with_args
 from scinoephile.image.subtitles import ImageSeries
 from scinoephile.lang.zho.ocr_validation import validate_zho_ocr
-from test.helpers import assert_cli_help, assert_cli_usage, test_data_root
+from test.helpers import (
+    assert_cli_help,
+    assert_cli_usage,
+    assert_series_equal,
+    test_data_root,
+)
 
 
 @pytest.mark.parametrize(
@@ -79,6 +84,6 @@ def test_zho_validate_ocr_cli(input_path: str):
         )
 
         output = ImageSeries.load(outfile_path)
-        assert output == expected
+        assert_series_equal(output, expected)
         assert (outfile_path / "index.html").exists()
         assert any(outfile_path.glob("*.png"))

--- a/test/core/synchronization/test_get_synced_series.py
+++ b/test/core/synchronization/test_get_synced_series.py
@@ -4,10 +4,9 @@
 
 from __future__ import annotations
 
-import pytest
-
 from scinoephile.core.subtitles import Series
 from scinoephile.core.synchronization import get_synced_series
+from test.helpers import assert_series_equal
 
 
 def _test_get_synced_series(one: Series, two: Series, expected: Series):
@@ -19,26 +18,7 @@ def _test_get_synced_series(one: Series, two: Series, expected: Series):
         expected: expected output series
     """
     output = get_synced_series(one, two)
-
-    errors = []
-    for i, (event, expected_event) in enumerate(zip(output, expected), 1):
-        if event != expected_event:
-            errors.append(f"Subtitle {i} does not match: {event} != {expected_event}")
-
-    if errors:
-        for error in errors:
-            print(error)
-        pytest.fail(f"Found {len(errors)} discrepancies")
-
-    errors = []
-    for i, (event, expected_event) in enumerate(zip(output, expected), 1):
-        if event != expected_event:
-            errors.append(f"Subtitle {i} does not match: {event} != {expected_event}")
-
-    if errors:
-        for error in errors:
-            print(error)
-        pytest.fail(f"Found {len(errors)} discrepancies")
+    assert_series_equal(output, expected)
 
 
 def test_get_synced_series_kob(

--- a/test/core/timing/test_get_series_timewarped.py
+++ b/test/core/timing/test_get_series_timewarped.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from scinoephile.core.subtitles import Series
 from scinoephile.core.timing import get_series_timewarped
+from test.helpers import assert_series_equal
 
 
 def _test_get_series_timewarped(anchor: Series, source: Series, expected: Series):
@@ -25,7 +26,7 @@ def _test_get_series_timewarped(anchor: Series, source: Series, expected: Series
         two_end_idx=1461,
     )
 
-    assert output == expected
+    assert_series_equal(output, expected)
 
 
 def test_get_series_timewarped_kob(

--- a/test/helpers/__init__.py
+++ b/test/helpers/__init__.py
@@ -18,6 +18,7 @@ from pytest import fixture, mark
 from scinoephile.common import CommandLineInterface, package_root
 from scinoephile.common.testing import run_cli_with_args
 
+from .series_assertions import assert_series_equal
 from .series_cer_result import SeriesCERResult
 
 __all__ = [
@@ -25,6 +26,7 @@ __all__ = [
     "assert_cli_help",
     "assert_cli_usage",
     "assert_expected_warnings",
+    "assert_series_equal",
     "build_subcommands",
     "get_warning_messages",
     "get_usage_prefix",

--- a/test/helpers/series_assertions.py
+++ b/test/helpers/series_assertions.py
@@ -1,0 +1,44 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Assertions for subtitle series tests."""
+
+from __future__ import annotations
+
+from scinoephile.core.subtitles import Series
+
+__all__ = ["assert_series_equal"]
+
+
+def assert_series_equal(actual: Series, expected: Series):
+    """Assert that subtitle series match, with mismatch details.
+
+    Arguments:
+        actual: actual subtitle series
+        expected: expected subtitle series
+    """
+    if len(actual) != len(expected):
+        raise AssertionError(
+            "Subtitle series length mismatch.\n"
+            f"Actual length: {len(actual)}\n"
+            f"Expected length: {len(expected)}"
+        )
+
+    for event_idx, (actual_event, expected_event) in enumerate(
+        zip(actual, expected), start=1
+    ):
+        actual_text = actual_event.text.replace("\n", "\\N")
+        expected_text = expected_event.text.replace("\n", "\\N")
+        if (
+            actual_event.start == expected_event.start
+            and actual_event.end == expected_event.end
+            and actual_text == expected_text
+        ):
+            continue
+
+        raise AssertionError(
+            f"Subtitle event {event_idx} mismatch.\n"
+            f"Actual: start={actual_event.start}, end={actual_event.end}, "
+            f"text={actual_text!r}\n"
+            f"Expected: start={expected_event.start}, end={expected_event.end}, "
+            f"text={expected_text!r}"
+        )

--- a/test/helpers/series_assertions.py
+++ b/test/helpers/series_assertions.py
@@ -4,18 +4,21 @@
 
 from __future__ import annotations
 
-from scinoephile.core.subtitles import Series
+from pysubs2 import SSAFile
 
 __all__ = ["assert_series_equal"]
 
 
-def assert_series_equal(actual: Series, expected: Series):
+def assert_series_equal(actual: SSAFile, expected: SSAFile):
     """Assert that subtitle series match, with mismatch details.
 
     Arguments:
         actual: actual subtitle series
         expected: expected subtitle series
     """
+    _assert_subtitle_series(actual, "actual")
+    _assert_subtitle_series(expected, "expected")
+
     if len(actual) != len(expected):
         raise AssertionError(
             "Subtitle series length mismatch.\n"
@@ -41,4 +44,17 @@ def assert_series_equal(actual: Series, expected: Series):
             f"text={actual_text!r}\n"
             f"Expected: start={expected_event.start}, end={expected_event.end}, "
             f"text={expected_text!r}"
+        )
+
+
+def _assert_subtitle_series(value: object, label: str):
+    """Assert that a value is a subtitle series.
+
+    Arguments:
+        value: value to validate
+        label: name of the validated value
+    """
+    if not isinstance(value, SSAFile):
+        raise AssertionError(
+            f"{label} is not a subtitle series: {type(value).__name__}"
         )

--- a/test/helpers/test_series_assertions.py
+++ b/test/helpers/test_series_assertions.py
@@ -4,7 +4,10 @@
 
 from __future__ import annotations
 
+from typing import cast
+
 import pytest
+from pysubs2 import SSAFile
 
 from scinoephile.core.subtitles import Series, Subtitle
 from test.helpers import assert_series_equal
@@ -40,3 +43,25 @@ def test_assert_series_equal_reports_mismatching_subtitle():
     assert "Subtitle event 2 mismatch" in message
     assert "Actual: start=3000, end=4000, text='actual'" in message
     assert "Expected: start=3000, end=4500, text='expected'" in message
+
+
+def test_assert_series_equal_rejects_non_series_actual():
+    """Test subtitle series assertion rejects non-series actual values."""
+    actual = [Subtitle(start=1000, end=2000, text="same")]
+    expected = Series(events=[Subtitle(start=1000, end=2000, text="same")])
+
+    with pytest.raises(AssertionError) as excinfo:
+        assert_series_equal(cast(SSAFile, actual), expected)
+
+    assert str(excinfo.value) == "actual is not a subtitle series: list"
+
+
+def test_assert_series_equal_rejects_non_series_expected():
+    """Test subtitle series assertion rejects non-series expected values."""
+    actual = Series(events=[Subtitle(start=1000, end=2000, text="same")])
+    expected = [Subtitle(start=1000, end=2000, text="same")]
+
+    with pytest.raises(AssertionError) as excinfo:
+        assert_series_equal(actual, cast(SSAFile, expected))
+
+    assert str(excinfo.value) == "expected is not a subtitle series: list"

--- a/test/helpers/test_series_assertions.py
+++ b/test/helpers/test_series_assertions.py
@@ -1,0 +1,42 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests of subtitle series assertions."""
+
+from __future__ import annotations
+
+import pytest
+
+from scinoephile.core.subtitles import Series, Subtitle
+from test.helpers import assert_series_equal
+
+
+def test_assert_series_equal_passes_for_matching_series():
+    """Test subtitle series assertion passes for matching series."""
+    actual = Series(events=[Subtitle(start=1000, end=2000, text="same")])
+    expected = Series(events=[Subtitle(start=1000, end=2000, text="same")])
+
+    assert_series_equal(actual, expected)
+
+
+def test_assert_series_equal_reports_mismatching_subtitle():
+    """Test subtitle series assertion reports mismatching subtitle details."""
+    actual = Series(
+        events=[
+            Subtitle(start=1000, end=2000, text="same"),
+            Subtitle(start=3000, end=4000, text="actual"),
+        ]
+    )
+    expected = Series(
+        events=[
+            Subtitle(start=1000, end=2000, text="same"),
+            Subtitle(start=3000, end=4500, text="expected"),
+        ]
+    )
+
+    with pytest.raises(AssertionError) as excinfo:
+        assert_series_equal(actual, expected)
+
+    message = str(excinfo.value)
+    assert "Subtitle event 2 mismatch" in message
+    assert "Actual: start=3000, end=4000, text='actual'" in message
+    assert "Expected: start=3000, end=4500, text='expected'" in message

--- a/test/lang/cmn/test_get_cmn_romanized.py
+++ b/test/lang/cmn/test_get_cmn_romanized.py
@@ -10,6 +10,7 @@ from scinoephile.core.subtitles import Series
 
 # noinspection PyProtectedMember
 from scinoephile.lang.cmn.romanization import _get_cmn_text_romanized, get_cmn_romanized
+from test.helpers import assert_series_equal
 
 
 def _test_get_cmn_romanized(series: Series, expected: Series):
@@ -20,7 +21,7 @@ def _test_get_cmn_romanized(series: Series, expected: Series):
         expected: Expected output series
     """
     output = get_cmn_romanized(series, append=True)
-    assert output == expected
+    assert_series_equal(output, expected)
 
 
 @pytest.mark.parametrize(

--- a/test/lang/eng/test_get_eng_cleaned.py
+++ b/test/lang/eng/test_get_eng_cleaned.py
@@ -4,10 +4,9 @@
 
 from __future__ import annotations
 
-import pytest
-
 from scinoephile.core.subtitles import Series
 from scinoephile.lang.eng.cleaning import get_eng_cleaned
+from test.helpers import assert_series_equal
 
 # noinspection PyProtectedMember
 
@@ -20,16 +19,7 @@ def _test_get_eng_cleaned(series: Series, expected: Series):
         expected: Expected output series
     """
     output = get_eng_cleaned(series, remove_empty=False)
-
-    errors = []
-    for i, (event, expected_event) in enumerate(zip(output, expected), 1):
-        if event != expected_event:
-            errors.append(f"Subtitle {i} does not match: {event} != {expected_event}")
-
-    if errors:
-        for error in errors:
-            print(error)
-        pytest.fail(f"Found {len(errors)} discrepancies")
+    assert_series_equal(output, expected)
 
 
 def test_get_eng_cleaned_kob(

--- a/test/lang/eng/test_get_eng_flattened.py
+++ b/test/lang/eng/test_get_eng_flattened.py
@@ -10,6 +10,7 @@ from scinoephile.core.subtitles import Series
 
 # noinspection PyProtectedMember
 from scinoephile.lang.eng.flattening import _get_eng_text_flattened, get_eng_flattened
+from test.helpers import assert_series_equal
 
 
 def _test_get_eng_flattened(series: Series, expected: Series):
@@ -24,16 +25,15 @@ def _test_get_eng_flattened(series: Series, expected: Series):
     assert len(series) == len(output)
 
     errors = []
-    for i, (event, expected_event) in enumerate(zip(output, expected), 1):
+    for i, event in enumerate(output, 1):
         if event.text.count("\n") != 0:
             errors.append(f"Subtitle {i} contains newline")
-        if event != expected_event:
-            errors.append(f"Subtitle {i} does not match: {event} != {expected_event}")
 
     if errors:
         for error in errors:
             print(error)
         pytest.fail(f"Found {len(errors)} discrepancies")
+    assert_series_equal(output, expected)
 
 
 def test_get_eng_flattened_kob(

--- a/test/lang/eng/test_get_eng_ocr_fused.py
+++ b/test/lang/eng/test_get_eng_ocr_fused.py
@@ -4,11 +4,10 @@
 
 from __future__ import annotations
 
-import pytest
-
 from scinoephile.core.subtitles import Series
 from scinoephile.lang.eng.cleaning import get_eng_cleaned
 from scinoephile.lang.eng.ocr_fusion import get_eng_ocr_fused
+from test.helpers import assert_series_equal
 
 
 def _test_get_eng_ocr_fused(lens: Series, tesseract: Series, expected: Series):
@@ -22,16 +21,7 @@ def _test_get_eng_ocr_fused(lens: Series, tesseract: Series, expected: Series):
     output = get_eng_ocr_fused(lens, tesseract)
 
     assert len(lens) == len(output)
-
-    errors = []
-    for i, (event, expected_event) in enumerate(zip(output, expected), 1):
-        if event != expected_event:
-            errors.append(f"Subtitle {i} does not match: {event} != {expected_event}")
-
-    if errors:
-        for error in errors:
-            print(error)
-        pytest.fail(f"Found {len(errors)} discrepancies:\n" + "\n".join(errors))
+    assert_series_equal(output, expected)
 
 
 def test_get_eng_ocr_fused_kob(

--- a/test/lang/yue/test_get_yue_romanized.py
+++ b/test/lang/yue/test_get_yue_romanized.py
@@ -13,6 +13,7 @@ from scinoephile.lang.yue.romanization import (
     _get_yue_text_romanized,
     get_yue_romanized,
 )
+from test.helpers import assert_series_equal
 
 
 def _test_get_yue_romanized(series: Series, expected: Series):
@@ -23,7 +24,7 @@ def _test_get_yue_romanized(series: Series, expected: Series):
         expected: Expected output series
     """
     output = get_yue_romanized(series, append=True)
-    assert output == expected
+    assert_series_equal(output, expected)
 
 
 @pytest.mark.parametrize(

--- a/test/lang/zho/test_get_zho_block_reviewed.py
+++ b/test/lang/zho/test_get_zho_block_reviewed.py
@@ -4,8 +4,6 @@
 
 from __future__ import annotations
 
-import pytest
-
 from scinoephile.core.subtitles import Series
 from scinoephile.lang.zho.block_review import (
     ZhoHantBlockReviewPrompt,
@@ -13,6 +11,7 @@ from scinoephile.lang.zho.block_review import (
     get_zho_reviewer,
 )
 from scinoephile.llms.mono_block import MonoBlockProcessor
+from test.helpers import assert_series_equal
 
 
 def _test_get_zho_block_reviewed(
@@ -28,16 +27,7 @@ def _test_get_zho_block_reviewed(
     output = get_zho_block_reviewed(series, processor=processor)
 
     assert len(output) == len(expected)
-
-    errors = []
-    for i, (event, expected_event) in enumerate(zip(output, expected), 1):
-        if event != expected_event:
-            errors.append(f"Subtitle {i} does not match: {event} != {expected_event}")
-
-    if errors:
-        for error in errors:
-            print(error)
-        pytest.fail(f"Found {len(errors)} discrepancies:\n" + "\n".join(errors))
+    assert_series_equal(output, expected)
 
 
 def test_get_zho_block_reviewed_kob(

--- a/test/lang/zho/test_get_zho_cleaned.py
+++ b/test/lang/zho/test_get_zho_cleaned.py
@@ -4,10 +4,9 @@
 
 from __future__ import annotations
 
-import pytest
-
 from scinoephile.core.subtitles import Series
 from scinoephile.lang.zho.cleaning import get_zho_cleaned
+from test.helpers import assert_series_equal
 
 
 def _test_get_zho_cleaned(series: Series, expected: Series):
@@ -18,16 +17,7 @@ def _test_get_zho_cleaned(series: Series, expected: Series):
         expected: Expected output series
     """
     output = get_zho_cleaned(series, remove_empty=False)
-
-    errors = []
-    for i, (event, expected_event) in enumerate(zip(output, expected), 1):
-        if event != expected_event:
-            errors.append(f"Subtitle {i} does not match: {event} != {expected_event}")
-
-    if errors:
-        for error in errors:
-            print(error)
-        pytest.fail(f"Found {len(errors)} discrepancies")
+    assert_series_equal(output, expected)
 
 
 def test_get_zho_cleaned_kob(

--- a/test/lang/zho/test_get_zho_converted.py
+++ b/test/lang/zho/test_get_zho_converted.py
@@ -12,6 +12,7 @@ from scinoephile.lang.zho.conversion import (
     get_zho_converted,
     get_zho_converter,
 )
+from test.helpers import assert_series_equal
 
 
 def _test_get_zho_converted(series: Series, config: OpenCCConfig, expected: Series):
@@ -24,16 +25,7 @@ def _test_get_zho_converted(series: Series, config: OpenCCConfig, expected: Seri
     """
     output = get_zho_converted(series, config)
     assert len(series) == len(output)
-
-    errors = []
-    for i, (event, expected_event) in enumerate(zip(output, expected), 1):
-        if event != expected_event:
-            errors.append(f"Subtitle {i} does not match: {event} != {expected_event}")
-
-    if errors:
-        for error in errors:
-            print(error)
-        pytest.fail(f"Found {len(errors)} discrepancies")
+    assert_series_equal(output, expected)
 
 
 def test_get_zho_converted_kob(

--- a/test/lang/zho/test_get_zho_flattened.py
+++ b/test/lang/zho/test_get_zho_flattened.py
@@ -8,6 +8,7 @@ import pytest
 
 from scinoephile.core.subtitles import Series
 from scinoephile.lang.zho.flattening import get_zho_flattened
+from test.helpers import assert_series_equal
 
 # noinspection PyProtectedMember
 
@@ -23,16 +24,15 @@ def _test_get_zho_flattened(series: Series, expected: Series):
     assert len(series) == len(output)
 
     errors = []
-    for i, (event, expected_event) in enumerate(zip(output, expected), 1):
+    for i, event in enumerate(output, 1):
         if event.text.count("\n") != 0:
             errors.append(f"Subtitle {i} contains newline")
-        if event != expected_event:
-            errors.append(f"Subtitle {i} does not match: {event} != {expected_event}")
 
     if errors:
         for error in errors:
             print(error)
         pytest.fail(f"Found {len(errors)} discrepancies")
+    assert_series_equal(output, expected)
 
 
 def test_get_zho_flattened_kob(

--- a/test/lang/zho/test_get_zho_ocr_fused.py
+++ b/test/lang/zho/test_get_zho_ocr_fused.py
@@ -4,8 +4,6 @@
 
 from __future__ import annotations
 
-import pytest
-
 from scinoephile.core.subtitles import Series
 from scinoephile.lang.zho.cleaning import get_zho_cleaned
 from scinoephile.lang.zho.conversion import OpenCCConfig, get_zho_converted
@@ -15,6 +13,7 @@ from scinoephile.lang.zho.ocr_fusion import (
     get_zho_ocr_fuser,
 )
 from scinoephile.llms.dual_single.ocr_fusion import OcrFusionProcessor
+from test.helpers import assert_series_equal
 
 
 def _test_get_zho_ocr_fused(
@@ -34,16 +33,7 @@ def _test_get_zho_ocr_fused(
     output = get_zho_ocr_fused(lens, paddle, processor=processor)
 
     assert len(output) == len(expected)
-
-    errors = []
-    for i, (event, expected_event) in enumerate(zip(output, expected), 1):
-        if event != expected_event:
-            errors.append(f"Subtitle {i} does not match: {event} != {expected_event}")
-
-    if errors:
-        for error in errors:
-            print(error)
-        pytest.fail(f"Found {len(errors)} discrepancies:\n" + "\n".join(errors))
+    assert_series_equal(output, expected)
 
 
 def test_get_zho_ocr_fused_kob(

--- a/test/multilang/yue_zho/test_get_yue_line_reviewed_vs_zho.py
+++ b/test/multilang/yue_zho/test_get_yue_line_reviewed_vs_zho.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from scinoephile.core.subtitles import Series, get_series_with_subs_merged
 from scinoephile.multilang.yue_zho.line_review import get_yue_line_reviewed_vs_zho
+from test.helpers import assert_series_equal
 
 
 def test_get_yue_line_reviewed_vs_zho_mlamd(
@@ -25,4 +26,4 @@ def test_get_yue_line_reviewed_vs_zho_mlamd(
         mlamd_zho_hans_fuse_clean_validate_review_flatten, 539
     )
     output = get_yue_line_reviewed_vs_zho(mlamd_yue_hans_transcribe, zhongwen)
-    assert output == mlamd_yue_hans_transcribe_review
+    assert_series_equal(output, mlamd_yue_hans_transcribe_review)

--- a/test/multilang/yue_zho/test_get_yue_reviewed_vs_zho.py
+++ b/test/multilang/yue_zho/test_get_yue_reviewed_vs_zho.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from scinoephile.core.subtitles import Series, get_series_with_subs_merged
 from scinoephile.multilang.yue_zho.block_review import get_yue_block_reviewed_vs_zho
+from test.helpers import assert_series_equal
 
 
 def test_get_yue_block_reviewed_vs_zho_mlamd(
@@ -28,4 +29,4 @@ def test_get_yue_block_reviewed_vs_zho_mlamd(
     output = get_yue_block_reviewed_vs_zho(
         mlamd_yue_hans_transcribe_review_translate, zhongwen
     )
-    assert output == mlamd_yue_hans_transcribe_review_translate_block_review
+    assert_series_equal(output, mlamd_yue_hans_transcribe_review_translate_block_review)

--- a/test/multilang/yue_zho/test_get_yue_translated_vs_zho.py
+++ b/test/multilang/yue_zho/test_get_yue_translated_vs_zho.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from scinoephile.core.subtitles import Series, get_series_with_subs_merged
 from scinoephile.multilang.yue_zho.translation import get_yue_translated_vs_zho
+from test.helpers import assert_series_equal
 
 
 def test_get_yue_translated_vs_zho_mlamd(
@@ -25,4 +26,4 @@ def test_get_yue_translated_vs_zho_mlamd(
         mlamd_zho_hans_fuse_clean_validate_review_flatten, 539
     )
     output = get_yue_translated_vs_zho(mlamd_yue_hans_transcribe_review, zhongwen)
-    assert output == mlamd_yue_hans_transcribe_review_translate
+    assert_series_equal(output, mlamd_yue_hans_transcribe_review_translate)


### PR DESCRIPTION
Closes #798

## Summary
- Add a shared `assert_series_equal` test helper that reports the mismatching subtitle event.
- Replace direct `Series` equality checks and hand-rolled comparison loops in test code with the helper.

## Verification
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format ...`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix ...`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check ...`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest ... -q` (`177 passed`)