### PR TITLE
Make live subprocess timeout idle-based

### DIFF
--- a/scinoephile/common/subprocess.py
+++ b/scinoephile/common/subprocess.py
@@ -6,26 +6,14 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from logging import getLogger
+from os import read
+from queue import Empty, Queue
 from subprocess import PIPE, Popen, TimeoutExpired
 from threading import Thread
 from time import monotonic
 from typing import IO
 
 logger = getLogger(__name__)
-
-
-def _decode_output(content: bytes) -> str:
-    """Decode subprocess output bytes with UTF-8 fallback.
-
-    Arguments:
-        content: bytes to decode
-    Returns:
-        decoded text
-    """
-    try:
-        return content.decode("utf-8")
-    except UnicodeDecodeError:
-        return content.decode("ISO-8859-1")
 
 
 def run_command(
@@ -100,21 +88,8 @@ def run_command_live(
     if acceptable_exitcodes is None:
         acceptable_exitcodes = [0]
 
-    stdout_lines = []
-    stderr_lines = []
-
-    def read_stream(stream: IO[bytes], lines: list[str]):
-        """Read subprocess stream line-by-line and mirror to logs.
-
-        Arguments:
-            stream: stream to read from
-            lines: list that collects the stream content
-        """
-        for line in iter(stream.readline, b""):
-            decoded_line = _decode_output(line)
-            logger.info(decoded_line.rstrip())
-            lines.append(decoded_line)
-        stream.close()
+    chunks: dict[str, list[bytes]] = {"stdout": [], "stderr": []}
+    output_queue: Queue[tuple[str, bytes | None]] = Queue()
 
     with Popen(
         command,
@@ -124,53 +99,32 @@ def run_command_live(
     ) as child:
         assert child.stdout is not None
         assert child.stderr is not None
-        stdout_thread = Thread(target=read_stream, args=(child.stdout, stdout_lines))
-        stderr_thread = Thread(target=read_stream, args=(child.stderr, stderr_lines))
+
+        stdout_thread = Thread(
+            target=_read_stream, args=(child.stdout, "stdout", output_queue)
+        )
+        stderr_thread = Thread(
+            target=_read_stream, args=(child.stderr, "stderr", output_queue)
+        )
         stdout_thread.start()
         stderr_thread.start()
 
-        if timeout is None:
-            exitcode = child.wait()
-        else:
-            deadline = monotonic() + timeout
-            try:
-                exitcode = child.wait(timeout=max(0.0, deadline - monotonic()))
-            except TimeoutExpired as exception:
-                child.kill()
-                child.wait()
-                stdout_thread.join()
-                stderr_thread.join()
-                stdout_str = "".join(stdout_lines)
-                stderr_str = "".join(stderr_lines)
-                raise TimeoutExpired(
-                    command,
-                    timeout,
-                    output=stdout_str,
-                    stderr=stderr_str,
-                ) from exception
+        timed_out = _monitor_live_output(child, timeout, output_queue, chunks)
+        stdout_thread.join()
+        stderr_thread.join()
 
-            stdout_thread.join(timeout=max(0.0, deadline - monotonic()))
-            stderr_thread.join(timeout=max(0.0, deadline - monotonic()))
-            if stdout_thread.is_alive() or stderr_thread.is_alive():
-                child.kill()
-                child.wait()
-                stdout_thread.join()
-                stderr_thread.join()
-                stdout_str = "".join(stdout_lines)
-                stderr_str = "".join(stderr_lines)
-                raise TimeoutExpired(
-                    command,
-                    timeout,
-                    output=stdout_str,
-                    stderr=stderr_str,
-                )
+        stdout_str = _decode_output(b"".join(chunks["stdout"]))
+        stderr_str = _decode_output(b"".join(chunks["stderr"]))
 
-        if timeout is None:
-            stdout_thread.join()
-            stderr_thread.join()
-
-        stdout_str = "".join(stdout_lines)
-        stderr_str = "".join(stderr_lines)
+        exitcode = child.returncode
+        assert exitcode is not None
+        if timed_out and timeout is not None:
+            raise TimeoutExpired(
+                command,
+                timeout,
+                output=stdout_str,
+                stderr=stderr_str,
+            )
 
         if exitcode not in acceptable_exitcodes:
             command_str = " ".join(command)
@@ -185,6 +139,94 @@ def run_command_live(
             )
 
     return exitcode, stdout_str, stderr_str
+
+
+def _decode_output(content: bytes) -> str:
+    """Decode subprocess output bytes with UTF-8 fallback.
+
+    Arguments:
+        content: bytes to decode
+    Returns:
+        decoded text
+    """
+    try:
+        return content.decode("utf-8")
+    except UnicodeDecodeError:
+        return content.decode("ISO-8859-1")
+
+
+def _monitor_live_output(
+    child: Popen[bytes],
+    timeout: int | None,
+    output_queue: Queue[tuple[str, bytes | None]],
+    chunks: dict[str, list[bytes]],
+) -> bool:
+    """Monitor subprocess output and return whether it timed out.
+
+    Arguments:
+        child: child process to monitor
+        timeout: maximum idle time since the last output
+        output_queue: queue containing stream output chunks
+        chunks: collected output chunks by stream name
+    Returns:
+        whether the process timed out
+    """
+    last_output_time = monotonic()
+    open_stream_names = {"stdout", "stderr"}
+    timed_out = False
+
+    while open_stream_names or child.poll() is None:
+        if timeout is None or child.poll() is not None:
+            queue_timeout = 0.1
+        else:
+            queue_timeout = max(0.0, timeout - (monotonic() - last_output_time))
+
+        try:
+            stream_name, chunk = output_queue.get(timeout=queue_timeout)
+        except Empty:
+            if timeout is not None and child.poll() is None:
+                timed_out = True
+                child.kill()
+                child.wait()
+            continue
+
+        if chunk is None:
+            open_stream_names.discard(stream_name)
+            continue
+
+        chunks[stream_name].append(chunk)
+        for line in _decode_output(chunk).replace("\r", "\n").splitlines():
+            logger.info(line.rstrip())
+        last_output_time = monotonic()
+
+    while not output_queue.empty():
+        stream_name, chunk = output_queue.get_nowait()
+        if chunk is not None:
+            chunks[stream_name].append(chunk)
+            for line in _decode_output(chunk).replace("\r", "\n").splitlines():
+                logger.info(line.rstrip())
+
+    child.wait()
+    return timed_out
+
+
+def _read_stream(
+    stream: IO[bytes],
+    stream_name: str,
+    output_queue: Queue[tuple[str, bytes | None]],
+):
+    """Read subprocess stream chunks into the output queue.
+
+    Arguments:
+        stream: stream to read from
+        stream_name: name of stream being read
+        output_queue: queue that receives stream output chunks
+    """
+    try:
+        while chunk := read(stream.fileno(), 4096):
+            output_queue.put((stream_name, chunk))
+    finally:
+        output_queue.put((stream_name, None))
 
 
 __all__ = [

--- a/test/common/subprocess/test_run_command_live.py
+++ b/test/common/subprocess/test_run_command_live.py
@@ -155,6 +155,89 @@ def test_run_command_live_timeout():
     assert elapsed < 1.5
 
 
+def test_run_command_live_timeout_starts_after_last_output():
+    """Test that command timeout is measured since the most recent output."""
+    exitcode, stdout, stderr = run_command_live(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import time\n"
+                "for index in range(3):\n"
+                "    print(index, flush=True)\n"
+                "    time.sleep(0.4)\n"
+            ),
+        ],
+        timeout=1,
+    )
+
+    assert exitcode == 0
+    assert stdout == "0\n1\n2\n"
+    assert stderr == ""
+
+
+def test_run_command_live_timeout_starts_after_carriage_return_output():
+    """Test that carriage-return progress output resets the timeout."""
+    exitcode, stdout, stderr = run_command_live(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys, time\n"
+                "for index in range(3):\n"
+                "    sys.stderr.write(f'frame={index}\\r')\n"
+                "    sys.stderr.flush()\n"
+                "    time.sleep(0.4)\n"
+            ),
+        ],
+        timeout=1,
+    )
+
+    assert exitcode == 0
+    assert stdout == ""
+    assert stderr == "frame=0\rframe=1\rframe=2\r"
+
+
+def test_run_command_live_timeout_after_output_stops():
+    """Test that command times out after output stops."""
+    start_time = monotonic()
+    with pytest.raises(TimeoutExpired) as exception_info:
+        run_command_live(
+            [
+                sys.executable,
+                "-c",
+                "import time; print('starting', flush=True); time.sleep(2)",
+            ],
+            timeout=1,
+        )
+    elapsed = monotonic() - start_time
+
+    assert elapsed < 1.5
+    assert exception_info.value.output == "starting\n"
+
+
+def test_run_command_live_timeout_after_streams_close():
+    """Test that command times out if streams close before process exit."""
+    start_time = monotonic()
+    with pytest.raises(TimeoutExpired):
+        run_command_live(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import sys, time\n"
+                    "sys.stdout.close()\n"
+                    "sys.stderr.close()\n"
+                    "time.sleep(2)\n"
+                ),
+            ],
+            timeout=1,
+        )
+    elapsed = monotonic() - start_time
+
+    assert elapsed < 1.5
+
+
 def test_run_command_live_non_utf8_output():
     """Test handling of non-UTF-8 output."""
     exitcode, stdout, stderr = run_command_live(


### PR DESCRIPTION
## Summary

- Change `run_command_live` so `timeout` measures idle time since the last stdout/stderr output instead of total process runtime.
- Replace reader threads and process-start deadline logic with a selector-based stream loop.
- Add regression tests for long-running commands that continue outputting, ffmpeg-style carriage-return progress output, and timeout after output stops.

## Root Cause

`run_command_live` previously computed one deadline from process start and passed the remaining time to `Popen.wait()`. Long-running commands such as ffmpeg could therefore be killed after the timeout even while actively producing progress output. The threaded stream readers could also race with process cleanup and attempt to read from closed streams.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/common/subprocess.py test/common/subprocess/test_run_command_live.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/common/subprocess.py test/common/subprocess/test_run_command_live.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/common/subprocess.py test/common/subprocess/test_run_command_live.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest test/common/subprocess/test_run_command_live.py -q` (`17 passed`)
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` (`940 passed, 3 skipped`)