### PR TITLE
Rename prompt classes by prompt language

### DIFF
--- a/scinoephile/cli/yue/yue_process_cli.py
+++ b/scinoephile/cli/yue/yue_process_cli.py
@@ -22,8 +22,8 @@ from scinoephile.common.exceptions import ArgumentConflictError
 from scinoephile.core.cli import ScinoephileCliBase, read_series, write_series
 from scinoephile.lang.yue.romanization import get_yue_romanized
 from scinoephile.lang.zho.block_review import (
-    ZhoHansBlockReviewPrompt,
-    ZhoHantBlockReviewPrompt,
+    BlockReviewPromptZhoHans,
+    BlockReviewPromptZhoHant,
     get_zho_block_reviewed,
     get_zho_reviewer,
 )
@@ -247,7 +247,7 @@ class YueProcessCli(ScinoephileCliBase):
     @classmethod
     def _get_review_prompt_cls(
         cls, review_script: str
-    ) -> type[ZhoHansBlockReviewPrompt]:
+    ) -> type[BlockReviewPromptZhoHans]:
         """Get the block-review prompt class for the selected script.
 
         Arguments:
@@ -256,8 +256,8 @@ class YueProcessCli(ScinoephileCliBase):
             block-review prompt class
         """
         if review_script == "traditional":
-            return ZhoHantBlockReviewPrompt
-        return ZhoHansBlockReviewPrompt
+            return BlockReviewPromptZhoHant
+        return BlockReviewPromptZhoHans
 
     @classmethod
     def _get_script_for_conversion(cls, convert: OpenCCConfig) -> str | None:

--- a/scinoephile/cli/yue/yue_review_vs_zho_cli.py
+++ b/scinoephile/cli/yue/yue_review_vs_zho_cli.py
@@ -16,14 +16,14 @@ from scinoephile.common.argument_parsing import (
 from scinoephile.common.exceptions import ArgumentConflictError
 from scinoephile.core.cli import ScinoephileCliBase, read_series, write_series
 from scinoephile.multilang.yue_zho.block_review import (
-    YueVsZhoYueHansBlockReviewPrompt,
-    YueVsZhoYueHantBlockReviewPrompt,
+    YueVsZhoBlockReviewPromptYueHans,
+    YueVsZhoBlockReviewPromptYueHant,
     get_yue_block_reviewed_vs_zho,
     get_yue_vs_zho_block_reviewer,
 )
 from scinoephile.multilang.yue_zho.line_review import (
-    YueVsZhoYueHansLineReviewPrompt,
-    YueVsZhoYueHantLineReviewPrompt,
+    YueVsZhoLineReviewPromptYueHans,
+    YueVsZhoLineReviewPromptYueHant,
     get_yue_line_reviewed_vs_zho,
     get_yue_vs_zho_line_reviewer,
 )
@@ -165,7 +165,7 @@ class YueReviewVsZhoCli(ScinoephileCliBase):
     @classmethod
     def _get_line_review_prompt_cls(
         cls, script: str
-    ) -> type[YueVsZhoYueHansLineReviewPrompt]:
+    ) -> type[YueVsZhoLineReviewPromptYueHans]:
         """Get the line-review prompt class for the selected script.
 
         Arguments:
@@ -174,13 +174,13 @@ class YueReviewVsZhoCli(ScinoephileCliBase):
             line-review prompt class
         """
         if script == "traditional":
-            return YueVsZhoYueHantLineReviewPrompt
-        return YueVsZhoYueHansLineReviewPrompt
+            return YueVsZhoLineReviewPromptYueHant
+        return YueVsZhoLineReviewPromptYueHans
 
     @classmethod
     def _get_block_review_prompt_cls(
         cls, script: str
-    ) -> type[YueVsZhoYueHansBlockReviewPrompt]:
+    ) -> type[YueVsZhoBlockReviewPromptYueHans]:
         """Get the block review prompt class for the selected script.
 
         Arguments:
@@ -189,8 +189,8 @@ class YueReviewVsZhoCli(ScinoephileCliBase):
             block review prompt class
         """
         if script == "traditional":
-            return YueVsZhoYueHantBlockReviewPrompt
-        return YueVsZhoYueHansBlockReviewPrompt
+            return YueVsZhoBlockReviewPromptYueHant
+        return YueVsZhoBlockReviewPromptYueHans
 
     @classmethod
     def _main(

--- a/scinoephile/cli/yue/yue_transcribe_vs_zho_cli.py
+++ b/scinoephile/cli/yue/yue_transcribe_vs_zho_cli.py
@@ -32,12 +32,12 @@ from scinoephile.multilang.yue_zho.transcription import (
     get_yue_vs_zho_transcriber,
 )
 from scinoephile.multilang.yue_zho.transcription.deliniation import (
-    YueVsZhoYueHansDeliniationPrompt,
-    YueVsZhoYueHantDeliniationPrompt,
+    YueVsZhoDeliniationPromptYueHans,
+    YueVsZhoDeliniationPromptYueHant,
 )
 from scinoephile.multilang.yue_zho.transcription.punctuation import (
-    YueVsZhoYueHansPunctuationPrompt,
-    YueVsZhoYueHantPunctuationPrompt,
+    YueVsZhoPunctuationPromptYueHans,
+    YueVsZhoPunctuationPromptYueHant,
 )
 
 __all__ = ["YueTranscribeVsZhoCli"]
@@ -208,7 +208,7 @@ class YueTranscribeVsZhoCli(ScinoephileCliBase):
     def _get_transcription_prompt_classes(
         cls, script: str
     ) -> tuple[
-        type[YueVsZhoYueHansDeliniationPrompt], type[YueVsZhoYueHansPunctuationPrompt]
+        type[YueVsZhoDeliniationPromptYueHans], type[YueVsZhoPunctuationPromptYueHans]
     ]:
         """Get transcription prompt classes for the selected script.
 
@@ -218,8 +218,8 @@ class YueTranscribeVsZhoCli(ScinoephileCliBase):
             deliniation and punctuation prompt classes
         """
         if script == "traditional":
-            return YueVsZhoYueHantDeliniationPrompt, YueVsZhoYueHantPunctuationPrompt
-        return YueVsZhoYueHansDeliniationPrompt, YueVsZhoYueHansPunctuationPrompt
+            return YueVsZhoDeliniationPromptYueHant, YueVsZhoPunctuationPromptYueHant
+        return YueVsZhoDeliniationPromptYueHans, YueVsZhoPunctuationPromptYueHans
 
     @classmethod
     def _main(

--- a/scinoephile/cli/yue/yue_translate_vs_zho_cli.py
+++ b/scinoephile/cli/yue/yue_translate_vs_zho_cli.py
@@ -19,8 +19,8 @@ from scinoephile.common.argument_parsing import (
 from scinoephile.common.exceptions import ArgumentConflictError
 from scinoephile.core.cli import ScinoephileCliBase, read_series, write_series
 from scinoephile.multilang.yue_zho.translation import (
-    YueVsZhoYueHansTranslationPrompt,
-    YueVsZhoYueHantTranslationPrompt,
+    YueVsZhoTranslationPromptYueHans,
+    YueVsZhoTranslationPromptYueHant,
     get_yue_translated_vs_zho,
     get_yue_vs_zho_translator,
 )
@@ -149,7 +149,7 @@ class YueTranslateVsZhoCli(ScinoephileCliBase):
     @classmethod
     def _get_translation_prompt_cls(
         cls, script: str
-    ) -> type[YueVsZhoYueHansTranslationPrompt]:
+    ) -> type[YueVsZhoTranslationPromptYueHans]:
         """Get the translation prompt class for the selected script.
 
         Arguments:
@@ -158,8 +158,8 @@ class YueTranslateVsZhoCli(ScinoephileCliBase):
             translation prompt class
         """
         if script == "traditional":
-            return YueVsZhoYueHantTranslationPrompt
-        return YueVsZhoYueHansTranslationPrompt
+            return YueVsZhoTranslationPromptYueHant
+        return YueVsZhoTranslationPromptYueHans
 
     @classmethod
     def _main(

--- a/scinoephile/cli/zho/zho_fuse_cli.py
+++ b/scinoephile/cli/zho/zho_fuse_cli.py
@@ -26,7 +26,7 @@ from scinoephile.lang.zho.conversion import (
     get_zho_converted,
 )
 from scinoephile.lang.zho.ocr_fusion import (
-    ZhoHantOcrFusionPrompt,
+    OcrFusionPromptZhoHant,
     get_zho_ocr_fused,
     get_zho_ocr_fuser,
 )
@@ -213,7 +213,7 @@ class ZhoFuseCli(ScinoephileCliBase):
         """
         script = cls._get_script_for_conversion(convert)
         if script == "traditional":
-            return get_zho_ocr_fuser(prompt_cls=ZhoHantOcrFusionPrompt)
+            return get_zho_ocr_fuser(prompt_cls=OcrFusionPromptZhoHant)
         return get_zho_ocr_fuser()
 
     @classmethod

--- a/scinoephile/cli/zho/zho_process_cli.py
+++ b/scinoephile/cli/zho/zho_process_cli.py
@@ -22,8 +22,8 @@ from scinoephile.common.exceptions import ArgumentConflictError
 from scinoephile.core.cli import ScinoephileCliBase, read_series, write_series
 from scinoephile.lang.cmn.romanization import get_cmn_romanized
 from scinoephile.lang.zho.block_review import (
-    ZhoHansBlockReviewPrompt,
-    ZhoHantBlockReviewPrompt,
+    BlockReviewPromptZhoHans,
+    BlockReviewPromptZhoHant,
     get_zho_block_reviewed,
     get_zho_reviewer,
 )
@@ -247,7 +247,7 @@ class ZhoProcessCli(ScinoephileCliBase):
     @classmethod
     def _get_review_prompt_cls(
         cls, review_script: str
-    ) -> type[ZhoHansBlockReviewPrompt]:
+    ) -> type[BlockReviewPromptZhoHans]:
         """Get the block-review prompt class for the selected script.
 
         Arguments:
@@ -256,8 +256,8 @@ class ZhoProcessCli(ScinoephileCliBase):
             block-review prompt class
         """
         if review_script == "traditional":
-            return ZhoHantBlockReviewPrompt
-        return ZhoHansBlockReviewPrompt
+            return BlockReviewPromptZhoHant
+        return BlockReviewPromptZhoHans
 
     @classmethod
     def _get_script_for_conversion(cls, convert: OpenCCConfig) -> str | None:

--- a/scinoephile/lang/eng/block_review/__init__.py
+++ b/scinoephile/lang/eng/block_review/__init__.py
@@ -17,13 +17,13 @@ from scinoephile.llms.default_test_cases import (
 from scinoephile.llms.mono_block import MonoBlockManager, MonoBlockProcessor
 from scinoephile.llms.providers.registry import get_default_provider
 
-from .prompts import EngBlockReviewPrompt
+from .prompts import BlockReviewPromptEng
 
 __all__ = [
     "ENG_BLOCK_REVIEW_OPERATION_SPEC",
     "EngBlockReviewProcessKwargs",
     "EngBlockReviewProcessorKwargs",
-    "EngBlockReviewPrompt",
+    "BlockReviewPromptEng",
     "get_eng_block_reviewed",
     "get_eng_block_reviewer",
 ]
@@ -32,7 +32,7 @@ ENG_BLOCK_REVIEW_OPERATION_SPEC = OperationSpec(
     operation="eng-block-review",
     test_case_table_name="test_cases__eng__block_review",
     manager_cls=MonoBlockManager,
-    prompt_cls=EngBlockReviewPrompt,
+    prompt_cls=BlockReviewPromptEng,
 )
 """Operation specification for English block review."""
 
@@ -73,7 +73,7 @@ def get_eng_block_reviewed(
 
 
 def get_eng_block_reviewer(
-    prompt_cls: type[EngBlockReviewPrompt] = EngBlockReviewPrompt,
+    prompt_cls: type[BlockReviewPromptEng] = BlockReviewPromptEng,
     test_cases: list[TestCase] | None = None,
     provider: LLMProvider | None = None,
     **kwargs: Unpack[EngBlockReviewProcessorKwargs],

--- a/scinoephile/lang/eng/block_review/prompts.py
+++ b/scinoephile/lang/eng/block_review/prompts.py
@@ -7,13 +7,13 @@ from __future__ import annotations
 from typing import ClassVar
 
 from scinoephile.core.text import dedent_and_compact
-from scinoephile.lang.eng.prompts import EngPrompt
+from scinoephile.lang.eng.prompts import PromptEng
 from scinoephile.llms.mono_block import MonoBlockPrompt
 
-__all__ = ["EngBlockReviewPrompt"]
+__all__ = ["BlockReviewPromptEng"]
 
 
-class EngBlockReviewPrompt(MonoBlockPrompt, EngPrompt):
+class BlockReviewPromptEng(MonoBlockPrompt, PromptEng):
     """LLM correspondence text for English block review."""
 
     # Prompt

--- a/scinoephile/lang/eng/ocr_fusion/__init__.py
+++ b/scinoephile/lang/eng/ocr_fusion/__init__.py
@@ -17,11 +17,11 @@ from scinoephile.llms.default_test_cases import (
 from scinoephile.llms.dual_single.ocr_fusion import OcrFusionManager, OcrFusionProcessor
 from scinoephile.llms.providers.registry import get_default_provider
 
-from .prompts import EngOcrFusionPrompt
+from .prompts import OcrFusionPromptEng
 
 __all__ = [
     "ENG_OCR_FUSION_OPERATION_SPEC",
-    "EngOcrFusionPrompt",
+    "OcrFusionPromptEng",
     "EngOcrFusionProcessKwargs",
     "EngOcrFusionProcessorKwargs",
     "get_eng_ocr_fuser",
@@ -32,7 +32,7 @@ ENG_OCR_FUSION_OPERATION_SPEC = OperationSpec(
     operation="eng-ocr-fusion",
     test_case_table_name="test_cases__eng__ocr_fusion",
     manager_cls=OcrFusionManager,
-    prompt_cls=EngOcrFusionPrompt,
+    prompt_cls=OcrFusionPromptEng,
 )
 """Operation specification for English OCR fusion."""
 
@@ -75,7 +75,7 @@ def get_eng_ocr_fused(
 
 
 def get_eng_ocr_fuser(
-    prompt_cls: type[EngOcrFusionPrompt] = EngOcrFusionPrompt,
+    prompt_cls: type[OcrFusionPromptEng] = OcrFusionPromptEng,
     test_cases: list[TestCase] | None = None,
     provider: LLMProvider | None = None,
     **kwargs: Unpack[EngOcrFusionProcessorKwargs],

--- a/scinoephile/lang/eng/ocr_fusion/prompts.py
+++ b/scinoephile/lang/eng/ocr_fusion/prompts.py
@@ -7,13 +7,13 @@ from __future__ import annotations
 from typing import ClassVar
 
 from scinoephile.core.text import dedent_and_compact
-from scinoephile.lang.eng.prompts import EngPrompt
+from scinoephile.lang.eng.prompts import PromptEng
 from scinoephile.llms.dual_single.ocr_fusion import OcrFusionPrompt
 
-__all__ = ["EngOcrFusionPrompt"]
+__all__ = ["OcrFusionPromptEng"]
 
 
-class EngOcrFusionPrompt(OcrFusionPrompt, EngPrompt):
+class OcrFusionPromptEng(OcrFusionPrompt, PromptEng):
     """Text for LLM correspondence for English OCR fusion."""
 
     # Prompt

--- a/scinoephile/lang/eng/prompts.py
+++ b/scinoephile/lang/eng/prompts.py
@@ -9,10 +9,10 @@ from typing import ClassVar
 
 from scinoephile.core.llms import Prompt
 
-__all__ = ["EngPrompt"]
+__all__ = ["PromptEng"]
 
 
-class EngPrompt(Prompt, ABC):
+class PromptEng(Prompt, ABC):
     """LLM correspondence text for English."""
 
     # Prompt

--- a/scinoephile/lang/yue/prompts.py
+++ b/scinoephile/lang/yue/prompts.py
@@ -7,12 +7,12 @@ from __future__ import annotations
 from abc import ABC
 from typing import ClassVar
 
-from scinoephile.lang.zho.prompts import ZhoHansPrompt
+from scinoephile.lang.zho.prompts import PromptZhoHans
 
-__all__ = ["YueHansPrompt"]
+__all__ = ["PromptYueHans"]
 
 
-class YueHansPrompt(ZhoHansPrompt, ABC):
+class PromptYueHans(PromptZhoHans, ABC):
     """LLM correspondence text for written Cantonese."""
 
     # Prompt

--- a/scinoephile/lang/zho/block_review/__init__.py
+++ b/scinoephile/lang/zho/block_review/__init__.py
@@ -18,14 +18,14 @@ from scinoephile.llms.default_test_cases import (
 from scinoephile.llms.mono_block import MonoBlockManager, MonoBlockProcessor
 from scinoephile.llms.providers.registry import get_default_provider
 
-from .prompts import ZhoHansBlockReviewPrompt, ZhoHantBlockReviewPrompt
+from .prompts import BlockReviewPromptZhoHans, BlockReviewPromptZhoHant
 
 __all__ = [
     "ZHO_BLOCK_REVIEW_OPERATION_SPEC",
     "ZhoBlockReviewProcessKwargs",
     "ZhoBlockReviewProcessorKwargs",
-    "ZhoHansBlockReviewPrompt",
-    "ZhoHantBlockReviewPrompt",
+    "BlockReviewPromptZhoHans",
+    "BlockReviewPromptZhoHant",
     "get_zho_block_reviewed",
     "get_zho_reviewer",
 ]
@@ -34,7 +34,7 @@ ZHO_BLOCK_REVIEW_OPERATION_SPEC = OperationSpec(
     operation="zho-block-review",
     test_case_table_name="test_cases__zho__block_review",
     manager_cls=MonoBlockManager,
-    prompt_cls=ZhoHansBlockReviewPrompt,
+    prompt_cls=BlockReviewPromptZhoHans,
 )
 """Operation specification for standard Chinese block review."""
 
@@ -75,7 +75,7 @@ def get_zho_block_reviewed(
 
 
 def get_zho_reviewer(
-    prompt_cls: type[ZhoHansBlockReviewPrompt] = ZhoHansBlockReviewPrompt,
+    prompt_cls: type[BlockReviewPromptZhoHans] = BlockReviewPromptZhoHans,
     test_cases: list[TestCase] | None = None,
     provider: LLMProvider | None = None,
     **kwargs: Unpack[ZhoBlockReviewProcessorKwargs],
@@ -91,7 +91,7 @@ def get_zho_reviewer(
         MonoBlockProcessor with provided configuration
     """
     if test_cases is None:
-        if prompt_cls is ZhoHantBlockReviewPrompt:
+        if prompt_cls is BlockReviewPromptZhoHant:
             test_cases = list(
                 load_default_test_cases(
                     MonoBlockManager,

--- a/scinoephile/lang/zho/block_review/prompts.py
+++ b/scinoephile/lang/zho/block_review/prompts.py
@@ -8,16 +8,16 @@ from typing import ClassVar
 
 from scinoephile.core.text import dedent_and_compact
 from scinoephile.lang.zho.conversion import OpenCCConfig
-from scinoephile.lang.zho.prompts import ZhoHansPrompt
+from scinoephile.lang.zho.prompts import PromptZhoHans
 from scinoephile.llms.mono_block import MonoBlockPrompt
 
 __all__ = [
-    "ZhoHansBlockReviewPrompt",
-    "ZhoHantBlockReviewPrompt",
+    "BlockReviewPromptZhoHans",
+    "BlockReviewPromptZhoHant",
 ]
 
 
-class ZhoHansBlockReviewPrompt(MonoBlockPrompt, ZhoHansPrompt):
+class BlockReviewPromptZhoHans(MonoBlockPrompt, PromptZhoHans):
     """LLM correspondence text for simplified standard Chinese block review."""
 
     # Prompt
@@ -68,7 +68,7 @@ class ZhoHansBlockReviewPrompt(MonoBlockPrompt, ZhoHansPrompt):
     """Error template when output is missing for a note."""
 
 
-class ZhoHantBlockReviewPrompt(ZhoHansBlockReviewPrompt):
+class BlockReviewPromptZhoHant(BlockReviewPromptZhoHans):
     """LLM correspondence text for traditional standard Chinese block review."""
 
     opencc_config = OpenCCConfig.s2t

--- a/scinoephile/lang/zho/ocr_fusion/__init__.py
+++ b/scinoephile/lang/zho/ocr_fusion/__init__.py
@@ -21,12 +21,12 @@ from scinoephile.llms.dual_single.ocr_fusion import (
 )
 from scinoephile.llms.providers.registry import get_default_provider
 
-from .prompts import ZhoHansOcrFusionPrompt, ZhoHantOcrFusionPrompt
+from .prompts import OcrFusionPromptZhoHans, OcrFusionPromptZhoHant
 
 __all__ = [
     "ZHO_OCR_FUSION_OPERATION_SPEC",
-    "ZhoHansOcrFusionPrompt",
-    "ZhoHantOcrFusionPrompt",
+    "OcrFusionPromptZhoHans",
+    "OcrFusionPromptZhoHant",
     "ZhoOcrFusionProcessKwargs",
     "ZhoOcrFusionProcessorKwargs",
     "get_zho_ocr_fuser",
@@ -37,7 +37,7 @@ ZHO_OCR_FUSION_OPERATION_SPEC = OperationSpec(
     operation="zho-ocr-fusion",
     test_case_table_name="test_cases__zho__ocr_fusion",
     manager_cls=OcrFusionManager,
-    prompt_cls=ZhoHansOcrFusionPrompt,
+    prompt_cls=OcrFusionPromptZhoHans,
 )
 """Operation specification for standard Chinese OCR fusion."""
 
@@ -80,7 +80,7 @@ def get_zho_ocr_fused(
 
 
 def get_zho_ocr_fuser(
-    prompt_cls: type[ZhoHansOcrFusionPrompt] = ZhoHansOcrFusionPrompt,
+    prompt_cls: type[OcrFusionPromptZhoHans] = OcrFusionPromptZhoHans,
     test_cases: list[TestCase] | None = None,
     provider: LLMProvider | None = None,
     **kwargs: Unpack[ZhoOcrFusionProcessorKwargs],
@@ -96,7 +96,7 @@ def get_zho_ocr_fuser(
         OcrFusionProcessor with provided configuration
     """
     if test_cases is None:
-        if prompt_cls is ZhoHantOcrFusionPrompt:
+        if prompt_cls is OcrFusionPromptZhoHant:
             test_cases = list(
                 load_default_test_cases(
                     OcrFusionManager,

--- a/scinoephile/lang/zho/ocr_fusion/prompts.py
+++ b/scinoephile/lang/zho/ocr_fusion/prompts.py
@@ -8,16 +8,16 @@ from typing import ClassVar
 
 from scinoephile.core.text import dedent_and_compact
 from scinoephile.lang.zho.conversion import OpenCCConfig
-from scinoephile.lang.zho.prompts import ZhoHansPrompt
+from scinoephile.lang.zho.prompts import PromptZhoHans
 from scinoephile.llms.dual_single.ocr_fusion import OcrFusionPrompt
 
 __all__ = [
-    "ZhoHansOcrFusionPrompt",
-    "ZhoHantOcrFusionPrompt",
+    "OcrFusionPromptZhoHans",
+    "OcrFusionPromptZhoHant",
 ]
 
 
-class ZhoHansOcrFusionPrompt(OcrFusionPrompt, ZhoHansPrompt):
+class OcrFusionPromptZhoHans(OcrFusionPrompt, PromptZhoHans):
     """Text for LLM correspondence for simplified standard Chinese OCR fusion."""
 
     # Prompt
@@ -75,7 +75,7 @@ class ZhoHansOcrFusionPrompt(OcrFusionPrompt, ZhoHansPrompt):
     """Error when note field is missing from answer."""
 
 
-class ZhoHantOcrFusionPrompt(ZhoHansOcrFusionPrompt):
+class OcrFusionPromptZhoHant(OcrFusionPromptZhoHans):
     """Text for LLM correspondence for traditional standard Chinese OCR fusion."""
 
     opencc_config = OpenCCConfig.s2t

--- a/scinoephile/lang/zho/prompts.py
+++ b/scinoephile/lang/zho/prompts.py
@@ -12,10 +12,10 @@ from scinoephile.core.llms import Prompt
 
 from .conversion import OpenCCConfig, get_zho_text_converted
 
-__all__ = ["ZhoHansPrompt"]
+__all__ = ["PromptZhoHans"]
 
 
-class ZhoHansPrompt(Prompt, ABC):
+class PromptZhoHans(Prompt, ABC):
     """LLM correspondence text for simplified standard Chinese."""
 
     opencc_config: ClassVar[OpenCCConfig | None] = None

--- a/scinoephile/multilang/yue_zho/block_review/__init__.py
+++ b/scinoephile/multilang/yue_zho/block_review/__init__.py
@@ -19,14 +19,14 @@ from scinoephile.llms.dual_block import DualBlockManager, DualBlockProcessor
 from scinoephile.llms.providers.registry import get_default_provider
 
 from .prompts import (
-    YueVsZhoYueHansBlockReviewPrompt,
-    YueVsZhoYueHantBlockReviewPrompt,
+    YueVsZhoBlockReviewPromptYueHans,
+    YueVsZhoBlockReviewPromptYueHant,
 )
 
 __all__ = [
     "YUE_ZHO_BLOCK_REVIEW_OPERATION_SPEC",
-    "YueVsZhoYueHansBlockReviewPrompt",
-    "YueVsZhoYueHantBlockReviewPrompt",
+    "YueVsZhoBlockReviewPromptYueHans",
+    "YueVsZhoBlockReviewPromptYueHant",
     "YueZhoBlockReviewProcessKwargs",
     "YueZhoBlockReviewProcessorKwargs",
     "get_yue_block_reviewed_vs_zho",
@@ -37,7 +37,7 @@ YUE_ZHO_BLOCK_REVIEW_OPERATION_SPEC = OperationSpec(
     operation="yue-zho-block-review",
     test_case_table_name="test_cases__yue_zho__block_review",
     manager_cls=DualBlockManager,
-    prompt_cls=YueVsZhoYueHansBlockReviewPrompt,
+    prompt_cls=YueVsZhoBlockReviewPromptYueHans,
 )
 """Operation specification for written Cantonese block review."""
 
@@ -80,8 +80,8 @@ def get_yue_block_reviewed_vs_zho(
 
 
 def get_yue_vs_zho_block_reviewer(
-    prompt_cls: type[YueVsZhoYueHansBlockReviewPrompt] = (
-        YueVsZhoYueHansBlockReviewPrompt
+    prompt_cls: type[YueVsZhoBlockReviewPromptYueHans] = (
+        YueVsZhoBlockReviewPromptYueHans
     ),
     test_cases: list[TestCase] | None = None,
     use_dictionary_tool: bool = True,

--- a/scinoephile/multilang/yue_zho/block_review/prompts.py
+++ b/scinoephile/multilang/yue_zho/block_review/prompts.py
@@ -8,18 +8,18 @@ from typing import ClassVar
 
 from scinoephile.core.dictionaries import DictionaryToolPrompt
 from scinoephile.core.text import dedent_and_compact
-from scinoephile.lang.yue.prompts import YueHansPrompt
+from scinoephile.lang.yue.prompts import PromptYueHans
 from scinoephile.lang.zho.conversion import OpenCCConfig
 from scinoephile.llms.dual_block import DualBlockPrompt
 
 __all__ = [
-    "YueVsZhoYueHansBlockReviewPrompt",
-    "YueVsZhoYueHantBlockReviewPrompt",
+    "YueVsZhoBlockReviewPromptYueHans",
+    "YueVsZhoBlockReviewPromptYueHant",
 ]
 
 
-class YueVsZhoYueHansBlockReviewPrompt(
-    DictionaryToolPrompt, DualBlockPrompt, YueHansPrompt
+class YueVsZhoBlockReviewPromptYueHans(
+    DictionaryToolPrompt, DualBlockPrompt, PromptYueHans
 ):
     """Text for simplified written Cantonese block review against standard Chinese."""
 
@@ -101,7 +101,7 @@ class YueVsZhoYueHansBlockReviewPrompt(
     """Error template when output is present but note is missing."""
 
 
-class YueVsZhoYueHantBlockReviewPrompt(YueVsZhoYueHansBlockReviewPrompt):
+class YueVsZhoBlockReviewPromptYueHant(YueVsZhoBlockReviewPromptYueHans):
     """Text for traditional written Cantonese block review against standard Chinese."""
 
     opencc_config = OpenCCConfig.s2hk

--- a/scinoephile/multilang/yue_zho/line_review/__init__.py
+++ b/scinoephile/multilang/yue_zho/line_review/__init__.py
@@ -20,14 +20,14 @@ from scinoephile.llms.providers.registry import get_default_provider
 from .manager import YueZhoLineReviewManager
 from .processor import YueZhoLineReviewProcessor
 from .prompts import (
-    YueVsZhoYueHansLineReviewPrompt,
-    YueVsZhoYueHantLineReviewPrompt,
+    YueVsZhoLineReviewPromptYueHans,
+    YueVsZhoLineReviewPromptYueHant,
 )
 
 __all__ = [
     "YUE_ZHO_LINE_REVIEW_OPERATION_SPEC",
-    "YueVsZhoYueHansLineReviewPrompt",
-    "YueVsZhoYueHantLineReviewPrompt",
+    "YueVsZhoLineReviewPromptYueHans",
+    "YueVsZhoLineReviewPromptYueHant",
     "YueZhoLineReviewManager",
     "YueZhoLineReviewProcessKwargs",
     "YueZhoLineReviewProcessor",
@@ -40,7 +40,7 @@ YUE_ZHO_LINE_REVIEW_OPERATION_SPEC = OperationSpec(
     operation="yue-zho-line-review",
     test_case_table_name="test_cases__yue_zho__line_review",
     manager_cls=YueZhoLineReviewManager,
-    prompt_cls=YueVsZhoYueHansLineReviewPrompt,
+    prompt_cls=YueVsZhoLineReviewPromptYueHans,
 )
 """Operation specification for written Cantonese line review."""
 
@@ -83,7 +83,7 @@ def get_yue_line_reviewed_vs_zho(
 
 
 def get_yue_vs_zho_line_reviewer(
-    prompt_cls: type[YueVsZhoYueHansLineReviewPrompt] = YueVsZhoYueHansLineReviewPrompt,
+    prompt_cls: type[YueVsZhoLineReviewPromptYueHans] = YueVsZhoLineReviewPromptYueHans,
     test_cases: list[TestCase] | None = None,
     use_dictionary_tool: bool = True,
     provider: LLMProvider | None = None,

--- a/scinoephile/multilang/yue_zho/line_review/manager.py
+++ b/scinoephile/multilang/yue_zho/line_review/manager.py
@@ -9,7 +9,7 @@ from typing import ClassVar
 from scinoephile.core.llms import Answer, TestCase
 from scinoephile.llms.dual_single import DualSingleManager
 
-from .prompts import YueVsZhoYueHansLineReviewPrompt
+from .prompts import YueVsZhoLineReviewPromptYueHans
 
 __all__ = ["YueZhoLineReviewManager"]
 
@@ -17,8 +17,8 @@ __all__ = ["YueZhoLineReviewManager"]
 class YueZhoLineReviewManager(DualSingleManager):
     """Factories for written Cantonese vs. standard Chinese line-review LLM classes."""
 
-    prompt_cls: ClassVar[type[YueVsZhoYueHansLineReviewPrompt]] = (
-        YueVsZhoYueHansLineReviewPrompt
+    prompt_cls: ClassVar[type[YueVsZhoLineReviewPromptYueHans]] = (
+        YueVsZhoLineReviewPromptYueHans
     )
     """Default prompt class."""
 
@@ -31,7 +31,7 @@ class YueZhoLineReviewManager(DualSingleManager):
         Returns:
             validated answer
         """
-        prompt_cls: type[YueVsZhoYueHansLineReviewPrompt] = getattr(model, "prompt_cls")
+        prompt_cls: type[YueVsZhoLineReviewPromptYueHans] = getattr(model, "prompt_cls")
         output = getattr(model, prompt_cls.output, None)
         note = getattr(model, prompt_cls.note, None)
         if not output and not note:
@@ -47,7 +47,7 @@ class YueZhoLineReviewManager(DualSingleManager):
         Returns:
             validated test case
         """
-        prompt_cls: type[YueVsZhoYueHansLineReviewPrompt] = getattr(model, "prompt_cls")
+        prompt_cls: type[YueVsZhoLineReviewPromptYueHans] = getattr(model, "prompt_cls")
         if model.answer is None:
             return model
 

--- a/scinoephile/multilang/yue_zho/line_review/processor.py
+++ b/scinoephile/multilang/yue_zho/line_review/processor.py
@@ -15,7 +15,7 @@ from scinoephile.core.subtitles import Series, Subtitle, get_concatenated_series
 from scinoephile.core.synchronization import get_sync_overlap_matrix
 
 from .manager import YueZhoLineReviewManager
-from .prompts import YueVsZhoYueHansLineReviewPrompt
+from .prompts import YueVsZhoLineReviewPromptYueHans
 
 __all__ = ["YueZhoLineReviewProcessor"]
 
@@ -26,7 +26,7 @@ logger = getLogger(__name__)
 class YueZhoLineReviewProcessor(Processor):
     """Processes written Cantonese vs. standard Chinese line review."""
 
-    prompt_cls: type[YueVsZhoYueHansLineReviewPrompt]
+    prompt_cls: type[YueVsZhoLineReviewPromptYueHans]
     """Text for LLM correspondence."""
 
     manager_cls = YueZhoLineReviewManager

--- a/scinoephile/multilang/yue_zho/line_review/prompts.py
+++ b/scinoephile/multilang/yue_zho/line_review/prompts.py
@@ -8,18 +8,18 @@ from typing import ClassVar
 
 from scinoephile.core.dictionaries import DictionaryToolPrompt
 from scinoephile.core.text import dedent_and_compact
-from scinoephile.lang.yue.prompts import YueHansPrompt
+from scinoephile.lang.yue.prompts import PromptYueHans
 from scinoephile.lang.zho.conversion import OpenCCConfig
 from scinoephile.llms.dual_single import DualSinglePrompt
 
 __all__ = [
-    "YueVsZhoYueHansLineReviewPrompt",
-    "YueVsZhoYueHantLineReviewPrompt",
+    "YueVsZhoLineReviewPromptYueHans",
+    "YueVsZhoLineReviewPromptYueHant",
 ]
 
 
-class YueVsZhoYueHansLineReviewPrompt(
-    DictionaryToolPrompt, DualSinglePrompt, YueHansPrompt
+class YueVsZhoLineReviewPromptYueHans(
+    DictionaryToolPrompt, DualSinglePrompt, PromptYueHans
 ):
     """Text for simplified written Cantonese line review against standard Chinese."""
 
@@ -102,7 +102,7 @@ class YueVsZhoYueHansLineReviewPrompt(
     """Error when output and note fields are both missing from answer."""
 
 
-class YueVsZhoYueHantLineReviewPrompt(YueVsZhoYueHansLineReviewPrompt):
+class YueVsZhoLineReviewPromptYueHant(YueVsZhoLineReviewPromptYueHans):
     """Text for traditional written Cantonese line review against standard Chinese."""
 
     opencc_config = OpenCCConfig.s2hk

--- a/scinoephile/multilang/yue_zho/transcription/__init__.py
+++ b/scinoephile/multilang/yue_zho/transcription/__init__.py
@@ -20,8 +20,8 @@ from scinoephile.llms.default_test_cases import (
 from scinoephile.llms.dual_pair import DualPairManager
 from scinoephile.llms.providers.registry import get_default_provider
 
-from .deliniation import YueVsZhoYueHansDeliniationPrompt
-from .punctuation import YueVsZhoYueHansPunctuationPrompt, YueZhoPunctuationManager
+from .deliniation import YueVsZhoDeliniationPromptYueHans
+from .punctuation import YueVsZhoPunctuationPromptYueHans, YueZhoPunctuationManager
 from .transcriber import DemucsMode, VADMode, YueTranscriber
 
 __all__ = [
@@ -40,7 +40,7 @@ YUE_ZHO_TRANSCRIPTION_DELINIATION_OPERATION_SPEC = OperationSpec(
     operation="yue-zho-transcription-deliniation",
     test_case_table_name="test_cases__yue_zho__transcription_deliniation",
     manager_cls=DualPairManager,
-    prompt_cls=YueVsZhoYueHansDeliniationPrompt,
+    prompt_cls=YueVsZhoDeliniationPromptYueHans,
 )
 """Operation specification for written Cantonese transcription deliniation."""
 
@@ -48,7 +48,7 @@ YUE_ZHO_TRANSCRIPTION_PUNCTUATION_OPERATION_SPEC = OperationSpec(
     operation="yue-zho-transcription-punctuation",
     test_case_table_name="test_cases__yue_zho__transcription_punctuation",
     manager_cls=YueZhoPunctuationManager,
-    prompt_cls=YueVsZhoYueHansPunctuationPrompt,
+    prompt_cls=YueVsZhoPunctuationPromptYueHans,
     list_fields={"query.yuewen_to_punctuate": 10},
 )
 """Operation specification for written Cantonese transcription punctuation."""
@@ -74,9 +74,9 @@ class YueZhoTranscriberKwargs(TypedDict, total=False):
     """provider to use for queries."""
     convert: OpenCCConfig | None
     """OpenCC configuration used for transcribed text conversion."""
-    deliniation_prompt_cls: type[YueVsZhoYueHansDeliniationPrompt]
+    deliniation_prompt_cls: type[YueVsZhoDeliniationPromptYueHans]
     """prompt class used for alignment deliniation."""
-    punctuation_prompt_cls: type[YueVsZhoYueHansPunctuationPrompt]
+    punctuation_prompt_cls: type[YueVsZhoPunctuationPromptYueHans]
     """prompt class used for transcription punctuation."""
     test_case_directory_path: Path | None
     """directory where encountered transcription test cases are persisted."""
@@ -115,11 +115,11 @@ def get_yue_vs_zho_transcriber(
     vad_mode: VADMode = VADMode.AUTO,
     provider: LLMProvider | None = None,
     convert: OpenCCConfig | None = None,
-    deliniation_prompt_cls: type[YueVsZhoYueHansDeliniationPrompt] = (
-        YueVsZhoYueHansDeliniationPrompt
+    deliniation_prompt_cls: type[YueVsZhoDeliniationPromptYueHans] = (
+        YueVsZhoDeliniationPromptYueHans
     ),
-    punctuation_prompt_cls: type[YueVsZhoYueHansPunctuationPrompt] = (
-        YueVsZhoYueHansPunctuationPrompt
+    punctuation_prompt_cls: type[YueVsZhoPunctuationPromptYueHans] = (
+        YueVsZhoPunctuationPromptYueHans
     ),
     test_case_directory_path: Path | None = None,
     deliniation_test_cases: list[TestCase] | None = None,

--- a/scinoephile/multilang/yue_zho/transcription/aligner.py
+++ b/scinoephile/multilang/yue_zho/transcription/aligner.py
@@ -32,9 +32,9 @@ from scinoephile.core.text import remove_punc_and_whitespace
 
 from .alignment import Alignment
 from .deliniation import (
-    YueVsZhoYueHansDeliniationPrompt as YueZhoHansDelineationPrompt,
+    YueVsZhoDeliniationPromptYueHans as YueZhoHansDelineationPrompt,
 )
-from .punctuation import YueVsZhoYueHansPunctuationPrompt
+from .punctuation import YueVsZhoPunctuationPromptYueHans
 
 __all__ = ["Aligner"]
 
@@ -330,7 +330,7 @@ class Aligner:
                     f"{test_case}\n"
                     f"Exception:\n{exc}"
                 )
-            prompt_cls: type[YueVsZhoYueHansPunctuationPrompt] = getattr(
+            prompt_cls: type[YueVsZhoPunctuationPromptYueHans] = getattr(
                 test_case, "prompt_cls"
             )
             yuewen_punctuated = getattr(test_case.answer, prompt_cls.output, None)

--- a/scinoephile/multilang/yue_zho/transcription/alignment.py
+++ b/scinoephile/multilang/yue_zho/transcription/alignment.py
@@ -21,8 +21,8 @@ from scinoephile.core.synchronization import (
 )
 from scinoephile.llms.dual_pair import DualPairManager
 
-from .deliniation import YueVsZhoYueHansDeliniationPrompt
-from .punctuation import YueVsZhoYueHansPunctuationPrompt, YueZhoPunctuationManager
+from .deliniation import YueVsZhoDeliniationPromptYueHans
+from .punctuation import YueVsZhoPunctuationPromptYueHans, YueZhoPunctuationManager
 
 __all__ = ["Alignment"]
 
@@ -200,7 +200,7 @@ class Alignment:
         if len(yw_1) == 0 and len(yw_2) == 0:
             return None
         test_case_cls = DualPairManager.get_test_case_cls(
-            prompt_cls=YueVsZhoYueHansDeliniationPrompt
+            prompt_cls=YueVsZhoDeliniationPromptYueHans
         )
         query_kwargs = {
             test_case_cls.prompt_cls.src_1_sub_1: zw_1,
@@ -246,7 +246,7 @@ class Alignment:
 
         # Return punctuate query
         test_case_cls = YueZhoPunctuationManager.get_test_case_cls(
-            prompt_cls=YueVsZhoYueHansPunctuationPrompt
+            prompt_cls=YueVsZhoPunctuationPromptYueHans
         )
         query_kwargs = {
             test_case_cls.prompt_cls.src_2: zw,

--- a/scinoephile/multilang/yue_zho/transcription/deliniation/__init__.py
+++ b/scinoephile/multilang/yue_zho/transcription/deliniation/__init__.py
@@ -5,11 +5,11 @@
 from __future__ import annotations
 
 from .prompt import (
-    YueVsZhoYueHansDeliniationPrompt,
-    YueVsZhoYueHantDeliniationPrompt,
+    YueVsZhoDeliniationPromptYueHans,
+    YueVsZhoDeliniationPromptYueHant,
 )
 
 __all__ = [
-    "YueVsZhoYueHansDeliniationPrompt",
-    "YueVsZhoYueHantDeliniationPrompt",
+    "YueVsZhoDeliniationPromptYueHans",
+    "YueVsZhoDeliniationPromptYueHant",
 ]

--- a/scinoephile/multilang/yue_zho/transcription/deliniation/prompt.py
+++ b/scinoephile/multilang/yue_zho/transcription/deliniation/prompt.py
@@ -7,17 +7,17 @@ from __future__ import annotations
 from typing import ClassVar
 
 from scinoephile.core.text import dedent_and_compact
-from scinoephile.lang.eng.prompts import EngPrompt
+from scinoephile.lang.eng.prompts import PromptEng
 from scinoephile.lang.zho.conversion import OpenCCConfig
 from scinoephile.llms.dual_pair import DualPairPrompt
 
 __all__ = [
-    "YueVsZhoYueHansDeliniationPrompt",
-    "YueVsZhoYueHantDeliniationPrompt",
+    "YueVsZhoDeliniationPromptYueHans",
+    "YueVsZhoDeliniationPromptYueHant",
 ]
 
 
-class YueVsZhoYueHansDeliniationPrompt(DualPairPrompt, EngPrompt):
+class YueVsZhoDeliniationPromptYueHans(DualPairPrompt, PromptEng):
     """Text for LLM correspondence for simplified written Cantonese deliniation."""
 
     # Prompt
@@ -107,7 +107,7 @@ class YueVsZhoYueHansDeliniationPrompt(DualPairPrompt, EngPrompt):
         )
 
 
-class YueVsZhoYueHantDeliniationPrompt(YueVsZhoYueHansDeliniationPrompt):
+class YueVsZhoDeliniationPromptYueHant(YueVsZhoDeliniationPromptYueHans):
     """Text for LLM correspondence for traditional written Cantonese deliniation."""
 
     opencc_config = OpenCCConfig.s2hk

--- a/scinoephile/multilang/yue_zho/transcription/punctuation/__init__.py
+++ b/scinoephile/multilang/yue_zho/transcription/punctuation/__init__.py
@@ -6,12 +6,12 @@ from __future__ import annotations
 
 from .manager import YueZhoPunctuationManager
 from .prompt import (
-    YueVsZhoYueHansPunctuationPrompt,
-    YueVsZhoYueHantPunctuationPrompt,
+    YueVsZhoPunctuationPromptYueHans,
+    YueVsZhoPunctuationPromptYueHant,
 )
 
 __all__ = [
-    "YueVsZhoYueHansPunctuationPrompt",
-    "YueVsZhoYueHantPunctuationPrompt",
+    "YueVsZhoPunctuationPromptYueHans",
+    "YueVsZhoPunctuationPromptYueHant",
     "YueZhoPunctuationManager",
 ]

--- a/scinoephile/multilang/yue_zho/transcription/punctuation/manager.py
+++ b/scinoephile/multilang/yue_zho/transcription/punctuation/manager.py
@@ -13,7 +13,7 @@ from scinoephile.core.text import (
 )
 from scinoephile.llms.dual_multi_single import DualMultiSingleManager
 
-from .prompt import YueVsZhoYueHansPunctuationPrompt
+from .prompt import YueVsZhoPunctuationPromptYueHans
 
 __all__ = ["YueZhoPunctuationManager"]
 
@@ -21,8 +21,8 @@ __all__ = ["YueZhoPunctuationManager"]
 class YueZhoPunctuationManager(DualMultiSingleManager):
     """Factories for written Cantonese/standard Chinese punctuation LLM classes."""
 
-    prompt_cls: ClassVar[type[YueVsZhoYueHansPunctuationPrompt]] = (
-        YueVsZhoYueHansPunctuationPrompt
+    prompt_cls: ClassVar[type[YueVsZhoPunctuationPromptYueHans]] = (
+        YueVsZhoPunctuationPromptYueHans
     )
     """Default prompt class."""
 
@@ -35,7 +35,7 @@ class YueZhoPunctuationManager(DualMultiSingleManager):
         Returns:
             minimum difficulty
         """
-        prompt_cls: type[YueVsZhoYueHansPunctuationPrompt] = getattr(
+        prompt_cls: type[YueVsZhoPunctuationPromptYueHans] = getattr(
             model, "prompt_cls"
         )
         min_difficulty = DualMultiSingleManager.get_min_difficulty(model)
@@ -61,7 +61,7 @@ class YueZhoPunctuationManager(DualMultiSingleManager):
         Returns:
             validated test case
         """
-        prompt_cls: type[YueVsZhoYueHansPunctuationPrompt] = getattr(
+        prompt_cls: type[YueVsZhoPunctuationPromptYueHans] = getattr(
             model, "prompt_cls"
         )
         if model.answer is None:

--- a/scinoephile/multilang/yue_zho/transcription/punctuation/prompt.py
+++ b/scinoephile/multilang/yue_zho/transcription/punctuation/prompt.py
@@ -7,17 +7,17 @@ from __future__ import annotations
 from typing import ClassVar
 
 from scinoephile.core.text import dedent_and_compact
-from scinoephile.lang.yue.prompts import YueHansPrompt
+from scinoephile.lang.yue.prompts import PromptYueHans
 from scinoephile.lang.zho.conversion import OpenCCConfig
 from scinoephile.llms.dual_multi_single import DualMultiSinglePrompt
 
 __all__ = [
-    "YueVsZhoYueHansPunctuationPrompt",
-    "YueVsZhoYueHantPunctuationPrompt",
+    "YueVsZhoPunctuationPromptYueHans",
+    "YueVsZhoPunctuationPromptYueHant",
 ]
 
 
-class YueVsZhoYueHansPunctuationPrompt(DualMultiSinglePrompt, YueHansPrompt):
+class YueVsZhoPunctuationPromptYueHans(DualMultiSinglePrompt, PromptYueHans):
     """Text for simplified written Cantonese/standard Chinese punctuation."""
 
     # Prompt
@@ -88,7 +88,7 @@ class YueVsZhoYueHansPunctuationPrompt(DualMultiSinglePrompt, YueHansPrompt):
         )
 
 
-class YueVsZhoYueHantPunctuationPrompt(YueVsZhoYueHansPunctuationPrompt):
+class YueVsZhoPunctuationPromptYueHant(YueVsZhoPunctuationPromptYueHans):
     """Text for traditional written Cantonese/standard Chinese punctuation."""
 
     opencc_config = OpenCCConfig.s2hk

--- a/scinoephile/multilang/yue_zho/transcription/transcriber.py
+++ b/scinoephile/multilang/yue_zho/transcription/transcriber.py
@@ -29,8 +29,8 @@ from scinoephile.lang.zho.conversion import OpenCCConfig
 from scinoephile.llms.providers.registry import get_default_provider
 
 from .aligner import Aligner
-from .deliniation import YueVsZhoYueHansDeliniationPrompt
-from .punctuation import YueVsZhoYueHansPunctuationPrompt
+from .deliniation import YueVsZhoDeliniationPromptYueHans
+from .punctuation import YueVsZhoPunctuationPromptYueHans
 
 __all__ = [
     "DemucsMode",
@@ -72,8 +72,8 @@ class YueTranscriber:
         vad_mode: VADMode = VADMode.AUTO,
         provider: LLMProvider | None = None,
         convert: OpenCCConfig | None = None,
-        deliniation_prompt_cls: type[YueVsZhoYueHansDeliniationPrompt],
-        punctuation_prompt_cls: type[YueVsZhoYueHansPunctuationPrompt],
+        deliniation_prompt_cls: type[YueVsZhoDeliniationPromptYueHans],
+        punctuation_prompt_cls: type[YueVsZhoPunctuationPromptYueHans],
         test_case_directory_path: Path,
         deliniation_test_cases: list[TestCase],
         punctuation_test_cases: list[TestCase],

--- a/scinoephile/multilang/yue_zho/translation/__init__.py
+++ b/scinoephile/multilang/yue_zho/translation/__init__.py
@@ -22,14 +22,14 @@ from scinoephile.llms.dual_block_gapped import (
 from scinoephile.llms.providers.registry import get_default_provider
 
 from .prompts import (
-    YueVsZhoYueHansTranslationPrompt,
-    YueVsZhoYueHantTranslationPrompt,
+    YueVsZhoTranslationPromptYueHans,
+    YueVsZhoTranslationPromptYueHant,
 )
 
 __all__ = [
     "YUE_ZHO_TRANSLATION_OPERATION_SPEC",
-    "YueVsZhoYueHansTranslationPrompt",
-    "YueVsZhoYueHantTranslationPrompt",
+    "YueVsZhoTranslationPromptYueHans",
+    "YueVsZhoTranslationPromptYueHant",
     "YueFromZhoTranslationProcessKwargs",
     "YueFromZhoTranslationProcessorKwargs",
     "get_yue_translated_vs_zho",
@@ -40,7 +40,7 @@ YUE_ZHO_TRANSLATION_OPERATION_SPEC = OperationSpec(
     operation="yue-zho-translation",
     test_case_table_name="test_cases__yue_zho__translation",
     manager_cls=DualBlockGappedManager,
-    prompt_cls=YueVsZhoYueHansTranslationPrompt,
+    prompt_cls=YueVsZhoTranslationPromptYueHans,
 )
 """Operation specification for written Cantonese translation."""
 
@@ -83,8 +83,8 @@ def get_yue_translated_vs_zho(
 
 
 def get_yue_vs_zho_translator(
-    prompt_cls: type[YueVsZhoYueHansTranslationPrompt] = (
-        YueVsZhoYueHansTranslationPrompt
+    prompt_cls: type[YueVsZhoTranslationPromptYueHans] = (
+        YueVsZhoTranslationPromptYueHans
     ),
     test_cases: list[TestCase] | None = None,
     use_dictionary_tool: bool = True,

--- a/scinoephile/multilang/yue_zho/translation/prompts.py
+++ b/scinoephile/multilang/yue_zho/translation/prompts.py
@@ -8,18 +8,18 @@ from typing import ClassVar
 
 from scinoephile.core.dictionaries import DictionaryToolPrompt
 from scinoephile.core.text import dedent_and_compact
-from scinoephile.lang.yue.prompts import YueHansPrompt
+from scinoephile.lang.yue.prompts import PromptYueHans
 from scinoephile.lang.zho.conversion import OpenCCConfig
 from scinoephile.llms.dual_block_gapped import DualBlockGappedPrompt
 
 __all__ = [
-    "YueVsZhoYueHansTranslationPrompt",
-    "YueVsZhoYueHantTranslationPrompt",
+    "YueVsZhoTranslationPromptYueHans",
+    "YueVsZhoTranslationPromptYueHant",
 ]
 
 
-class YueVsZhoYueHansTranslationPrompt(
-    DictionaryToolPrompt, DualBlockGappedPrompt, YueHansPrompt
+class YueVsZhoTranslationPromptYueHans(
+    DictionaryToolPrompt, DualBlockGappedPrompt, PromptYueHans
 ):
     """Text for translating simplified written Cantonese from standard Chinese."""
 
@@ -92,7 +92,7 @@ class YueVsZhoYueHansTranslationPrompt(
         return cls.output_contains_note_err_tpl.format(idx=idx)
 
 
-class YueVsZhoYueHantTranslationPrompt(YueVsZhoYueHansTranslationPrompt):
+class YueVsZhoTranslationPromptYueHant(YueVsZhoTranslationPromptYueHans):
     """Text for translating traditional written Cantonese from standard Chinese."""
 
     opencc_config = OpenCCConfig.s2hk

--- a/test/cli/yue/test_yue_review_vs_zho_cli.py
+++ b/test/cli/yue/test_yue_review_vs_zho_cli.py
@@ -15,7 +15,7 @@ from scinoephile.common import CommandLineInterface
 from scinoephile.common.file import get_temp_file_path
 from scinoephile.common.testing import run_cli_with_args
 from scinoephile.core.subtitles import Series
-from scinoephile.multilang.yue_zho.block_review import YueVsZhoYueHansBlockReviewPrompt
+from scinoephile.multilang.yue_zho.block_review import YueVsZhoBlockReviewPromptYueHans
 from test.helpers import (
     assert_cli_help,
     assert_cli_usage,
@@ -118,7 +118,7 @@ def test_yue_review_vs_zho_cli(
     else:
         assert (
             patched_factory.call_args.kwargs["prompt_cls"]
-            is YueVsZhoYueHansBlockReviewPrompt
+            is YueVsZhoBlockReviewPromptYueHans
         )
         called_kwargs = patched_review.call_args.kwargs
         assert_series_equal(called_kwargs["yuewen"], Series.load(full_yue_input_path))

--- a/test/cli/yue/test_yue_transcribe_vs_zho_cli.py
+++ b/test/cli/yue/test_yue_transcribe_vs_zho_cli.py
@@ -22,12 +22,12 @@ from scinoephile.core.subtitles import Series
 from scinoephile.lang.zho.conversion import OpenCCConfig
 from scinoephile.multilang.yue_zho.transcription import DemucsMode, VADMode
 from scinoephile.multilang.yue_zho.transcription.deliniation import (
-    YueVsZhoYueHansDeliniationPrompt,
-    YueVsZhoYueHantDeliniationPrompt,
+    YueVsZhoDeliniationPromptYueHans,
+    YueVsZhoDeliniationPromptYueHant,
 )
 from scinoephile.multilang.yue_zho.transcription.punctuation import (
-    YueVsZhoYueHansPunctuationPrompt,
-    YueVsZhoYueHantPunctuationPrompt,
+    YueVsZhoPunctuationPromptYueHans,
+    YueVsZhoPunctuationPromptYueHant,
 )
 from test.helpers import (
     assert_cli_help,
@@ -136,11 +136,11 @@ def test_yue_transcribe_vs_zho_cli_writes_file():
 
     assert (
         patched_factory.call_args.kwargs["deliniation_prompt_cls"]
-        is YueVsZhoYueHansDeliniationPrompt
+        is YueVsZhoDeliniationPromptYueHans
     )
     assert (
         patched_factory.call_args.kwargs["punctuation_prompt_cls"]
-        is YueVsZhoYueHansPunctuationPrompt
+        is YueVsZhoPunctuationPromptYueHans
     )
     assert patched_factory.call_args.kwargs["convert"] is None
     assert patched_factory.call_args.kwargs["demucs_mode"] == DemucsMode.OFF
@@ -327,11 +327,11 @@ def test_yue_transcribe_vs_zho_cli_keeps_script_and_convert_independent():
 
     assert (
         patched_factory.call_args.kwargs["deliniation_prompt_cls"]
-        is YueVsZhoYueHantDeliniationPrompt
+        is YueVsZhoDeliniationPromptYueHant
     )
     assert (
         patched_factory.call_args.kwargs["punctuation_prompt_cls"]
-        is YueVsZhoYueHantPunctuationPrompt
+        is YueVsZhoPunctuationPromptYueHant
     )
     assert patched_factory.call_args.kwargs["convert"] == OpenCCConfig.hk2s
 

--- a/test/cli/yue/test_yue_translate_vs_zho_cli.py
+++ b/test/cli/yue/test_yue_translate_vs_zho_cli.py
@@ -16,7 +16,7 @@ from scinoephile.common.file import get_temp_file_path
 from scinoephile.common.testing import run_cli_with_args
 from scinoephile.core.subtitles import Series
 from scinoephile.multilang.yue_zho.translation import (
-    YueVsZhoYueHansTranslationPrompt,
+    YueVsZhoTranslationPromptYueHans,
 )
 from test.helpers import (
     assert_cli_help,
@@ -106,7 +106,7 @@ def test_yue_translate_vs_zho_cli(
 
     assert (
         patched_factory.call_args.kwargs["prompt_cls"]
-        is YueVsZhoYueHansTranslationPrompt
+        is YueVsZhoTranslationPromptYueHans
     )
     called_kwargs = patched_translate.call_args.kwargs
     assert_series_equal(called_kwargs["yuewen"], Series.load(full_yue_input_path))

--- a/test/data/kob/__init__.py
+++ b/test/data/kob/__init__.py
@@ -18,27 +18,27 @@ from scinoephile.core.llms.utils import load_test_cases_from_json
 from scinoephile.core.ml import get_torch_device
 from scinoephile.core.subtitles import Series
 from scinoephile.image.subtitles import ImageSeries
-from scinoephile.lang.eng.block_review import EngBlockReviewPrompt
-from scinoephile.lang.eng.ocr_fusion import EngOcrFusionPrompt
+from scinoephile.lang.eng.block_review import BlockReviewPromptEng
+from scinoephile.lang.eng.ocr_fusion import OcrFusionPromptEng
 from scinoephile.lang.zho.block_review import (
-    ZhoHansBlockReviewPrompt,
-    ZhoHantBlockReviewPrompt,
+    BlockReviewPromptZhoHans,
+    BlockReviewPromptZhoHant,
 )
-from scinoephile.lang.zho.ocr_fusion import ZhoHantOcrFusionPrompt
+from scinoephile.lang.zho.ocr_fusion import OcrFusionPromptZhoHant
 from scinoephile.llms.dual_multi_single import DualMultiSinglePrompt
 from scinoephile.llms.dual_pair import DualPairManager, DualPairPrompt
 from scinoephile.llms.dual_single import DualSinglePrompt
 from scinoephile.llms.dual_single.ocr_fusion import OcrFusionManager
 from scinoephile.llms.mono_block import MonoBlockManager, MonoBlockPrompt
 from scinoephile.multilang.yue_zho.line_review import (
-    YueVsZhoYueHansLineReviewPrompt,
+    YueVsZhoLineReviewPromptYueHans,
     YueZhoLineReviewManager,
 )
 from scinoephile.multilang.yue_zho.transcription.deliniation import (
-    YueVsZhoYueHansDeliniationPrompt,
+    YueVsZhoDeliniationPromptYueHans,
 )
 from scinoephile.multilang.yue_zho.transcription.punctuation import (
-    YueVsZhoYueHansPunctuationPrompt,
+    YueVsZhoPunctuationPromptYueHans,
     YueZhoPunctuationManager,
 )
 from test.helpers import SeriesCERResult, test_data_root
@@ -163,7 +163,7 @@ def kob_zho_hant_ocr_paddle_new() -> Series:
 
 @cache
 def get_kob_eng_block_review_test_cases(
-    prompt_cls: type[MonoBlockPrompt] = EngBlockReviewPrompt,
+    prompt_cls: type[MonoBlockPrompt] = BlockReviewPromptEng,
     **kwargs: Unpack[_KobTestCaseKwargs],
 ) -> list[TestCase]:
     """Get KOB English block review test cases.
@@ -187,7 +187,7 @@ def get_kob_eng_block_review_test_cases(
 
 @cache
 def get_kob_eng_ocr_fusion_test_cases(
-    prompt_cls: type[DualSinglePrompt] = EngOcrFusionPrompt,
+    prompt_cls: type[DualSinglePrompt] = OcrFusionPromptEng,
     **kwargs: Unpack[_KobTestCaseKwargs],
 ) -> list[TestCase]:
     """Get KOB English OCR fusion test cases.
@@ -206,7 +206,7 @@ def get_kob_eng_ocr_fusion_test_cases(
 
 @cache
 def get_kob_yue_deliniation_test_cases(
-    prompt_cls: type[DualPairPrompt] = YueVsZhoYueHansDeliniationPrompt,
+    prompt_cls: type[DualPairPrompt] = YueVsZhoDeliniationPromptYueHans,
     **kwargs: Unpack[_KobTestCaseKwargs],
 ) -> list[TestCase]:
     """Get KOB 简体粤文 deliniation test cases.
@@ -233,7 +233,7 @@ def get_kob_yue_deliniation_test_cases(
 
 @cache
 def get_kob_yue_punctuation_test_cases(
-    prompt_cls: type[DualMultiSinglePrompt] = YueVsZhoYueHansPunctuationPrompt,
+    prompt_cls: type[DualMultiSinglePrompt] = YueVsZhoPunctuationPromptYueHans,
     **kwargs: Unpack[_KobTestCaseKwargs],
 ) -> list[TestCase]:
     """Get KOB 简体粤文 punctuation test cases.
@@ -260,7 +260,7 @@ def get_kob_yue_punctuation_test_cases(
 
 @cache
 def get_kob_yue_vs_zho_line_review_test_cases(
-    prompt_cls: type[DualSinglePrompt] = YueVsZhoYueHansLineReviewPrompt,
+    prompt_cls: type[DualSinglePrompt] = YueVsZhoLineReviewPromptYueHans,
     **kwargs: Unpack[_KobTestCaseKwargs],
 ) -> list[TestCase]:
     """Get KOB 简体粤文 vs 简体中文 line-review test cases.
@@ -286,7 +286,7 @@ def get_kob_yue_vs_zho_line_review_test_cases(
 
 @cache
 def get_kob_zho_hant_block_review_test_cases(
-    prompt_cls: type[MonoBlockPrompt] = ZhoHantBlockReviewPrompt,
+    prompt_cls: type[MonoBlockPrompt] = BlockReviewPromptZhoHant,
     **kwargs: Unpack[_KobTestCaseKwargs],
 ) -> list[TestCase]:
     """Get KOB 繁体中文 block review test cases.
@@ -305,7 +305,7 @@ def get_kob_zho_hant_block_review_test_cases(
 
 @cache
 def get_kob_zho_hant_ocr_fusion_test_cases(
-    prompt_cls: type[DualSinglePrompt] = ZhoHantOcrFusionPrompt,
+    prompt_cls: type[DualSinglePrompt] = OcrFusionPromptZhoHant,
     **kwargs: Unpack[_KobTestCaseKwargs],
 ) -> list[TestCase]:
     """Get KOB 繁体中文 OCR fusion test cases.
@@ -324,7 +324,7 @@ def get_kob_zho_hant_ocr_fusion_test_cases(
 
 @cache
 def get_kob_zho_hant_simplify_block_review_test_cases(
-    prompt_cls: type[MonoBlockPrompt] = ZhoHansBlockReviewPrompt,
+    prompt_cls: type[MonoBlockPrompt] = BlockReviewPromptZhoHans,
     **kwargs: Unpack[_KobTestCaseKwargs],
 ) -> list[TestCase]:
     """Get KOB 繁体中文 simplification block review test cases.

--- a/test/data/kob/create_output.py
+++ b/test/data/kob/create_output.py
@@ -22,25 +22,25 @@ from scinoephile.lang.zho.cleaning import get_zho_cleaned
 from scinoephile.lang.zho.conversion import OpenCCConfig
 from scinoephile.lang.zho.flattening import get_zho_flattened
 from scinoephile.multilang.yue_zho.block_review import (
-    YueVsZhoYueHansBlockReviewPrompt,
-    YueVsZhoYueHantBlockReviewPrompt,
+    YueVsZhoBlockReviewPromptYueHans,
+    YueVsZhoBlockReviewPromptYueHant,
 )
 from scinoephile.multilang.yue_zho.line_review import (
-    YueVsZhoYueHansLineReviewPrompt,
-    YueVsZhoYueHantLineReviewPrompt,
+    YueVsZhoLineReviewPromptYueHans,
+    YueVsZhoLineReviewPromptYueHant,
 )
 from scinoephile.multilang.yue_zho.transcription import DemucsMode, VADMode
 from scinoephile.multilang.yue_zho.transcription.deliniation import (
-    YueVsZhoYueHansDeliniationPrompt,
-    YueVsZhoYueHantDeliniationPrompt,
+    YueVsZhoDeliniationPromptYueHans,
+    YueVsZhoDeliniationPromptYueHant,
 )
 from scinoephile.multilang.yue_zho.transcription.punctuation import (
-    YueVsZhoYueHansPunctuationPrompt,
-    YueVsZhoYueHantPunctuationPrompt,
+    YueVsZhoPunctuationPromptYueHans,
+    YueVsZhoPunctuationPromptYueHant,
 )
 from scinoephile.multilang.yue_zho.translation import (
-    YueVsZhoYueHansTranslationPrompt,
-    YueVsZhoYueHantTranslationPrompt,
+    YueVsZhoTranslationPromptYueHans,
+    YueVsZhoTranslationPromptYueHant,
 )
 from test.data.ocr import process_eng_ocr, process_zho_hant_ocr
 from test.data.synchronization import process_yue_hans_eng, process_zho_hans_eng
@@ -152,12 +152,12 @@ if "简体粤文 (Transcription)" in actions:
             "demucs_mode": DemucsMode.ON,
             "vad_mode": VADMode.AUTO,
             "convert": OpenCCConfig.hk2s,
-            "deliniation_prompt_cls": YueVsZhoYueHansDeliniationPrompt,
-            "punctuation_prompt_cls": YueVsZhoYueHansPunctuationPrompt,
+            "deliniation_prompt_cls": YueVsZhoDeliniationPromptYueHans,
+            "punctuation_prompt_cls": YueVsZhoPunctuationPromptYueHans,
         },
-        line_reviewer_kw={"prompt_cls": YueVsZhoYueHansLineReviewPrompt},
-        translator_kw={"prompt_cls": YueVsZhoYueHansTranslationPrompt},
-        block_reviewer_kw={"prompt_cls": YueVsZhoYueHansBlockReviewPrompt},
+        line_reviewer_kw={"prompt_cls": YueVsZhoLineReviewPromptYueHans},
+        translator_kw={"prompt_cls": YueVsZhoTranslationPromptYueHans},
+        block_reviewer_kw={"prompt_cls": YueVsZhoBlockReviewPromptYueHans},
         overwrite_srt=True,
     )
 
@@ -173,12 +173,12 @@ if "简体粤文 (Transcription)" in actions:
             "demucs_mode": DemucsMode.ON,
             "vad_mode": VADMode.AUTO,
             "convert": OpenCCConfig.s2hk,
-            "deliniation_prompt_cls": YueVsZhoYueHantDeliniationPrompt,
-            "punctuation_prompt_cls": YueVsZhoYueHantPunctuationPrompt,
+            "deliniation_prompt_cls": YueVsZhoDeliniationPromptYueHant,
+            "punctuation_prompt_cls": YueVsZhoPunctuationPromptYueHant,
         },
-        line_reviewer_kw={"prompt_cls": YueVsZhoYueHantLineReviewPrompt},
-        translator_kw={"prompt_cls": YueVsZhoYueHantTranslationPrompt},
-        block_reviewer_kw={"prompt_cls": YueVsZhoYueHantBlockReviewPrompt},
+        line_reviewer_kw={"prompt_cls": YueVsZhoLineReviewPromptYueHant},
+        translator_kw={"prompt_cls": YueVsZhoTranslationPromptYueHant},
+        block_reviewer_kw={"prompt_cls": YueVsZhoBlockReviewPromptYueHant},
         overwrite_srt=True,
     )
 if "简体粤文 (Diff)" in actions:

--- a/test/data/mlamd/__init__.py
+++ b/test/data/mlamd/__init__.py
@@ -18,15 +18,15 @@ from scinoephile.core.llms.utils import load_test_cases_from_json
 from scinoephile.core.ml import get_torch_device
 from scinoephile.core.subtitles import Series
 from scinoephile.image.subtitles import ImageSeries
-from scinoephile.lang.eng.block_review import EngBlockReviewPrompt
-from scinoephile.lang.eng.ocr_fusion import EngOcrFusionPrompt
+from scinoephile.lang.eng.block_review import BlockReviewPromptEng
+from scinoephile.lang.eng.ocr_fusion import OcrFusionPromptEng
 from scinoephile.lang.zho.block_review import (
-    ZhoHansBlockReviewPrompt,
-    ZhoHantBlockReviewPrompt,
+    BlockReviewPromptZhoHans,
+    BlockReviewPromptZhoHant,
 )
 from scinoephile.lang.zho.ocr_fusion import (
-    ZhoHansOcrFusionPrompt,
-    ZhoHantOcrFusionPrompt,
+    OcrFusionPromptZhoHans,
+    OcrFusionPromptZhoHant,
 )
 from scinoephile.llms.dual_block import DualBlockManager, DualBlockPrompt
 from scinoephile.llms.dual_block_gapped import (
@@ -38,19 +38,19 @@ from scinoephile.llms.dual_pair import DualPairManager, DualPairPrompt
 from scinoephile.llms.dual_single import DualSinglePrompt
 from scinoephile.llms.dual_single.ocr_fusion import OcrFusionManager
 from scinoephile.llms.mono_block import MonoBlockManager, MonoBlockPrompt
-from scinoephile.multilang.yue_zho.block_review import YueVsZhoYueHansBlockReviewPrompt
+from scinoephile.multilang.yue_zho.block_review import YueVsZhoBlockReviewPromptYueHans
 from scinoephile.multilang.yue_zho.line_review import (
-    YueVsZhoYueHansLineReviewPrompt,
+    YueVsZhoLineReviewPromptYueHans,
     YueZhoLineReviewManager,
 )
 from scinoephile.multilang.yue_zho.transcription.deliniation import (
-    YueVsZhoYueHansDeliniationPrompt,
+    YueVsZhoDeliniationPromptYueHans,
 )
 from scinoephile.multilang.yue_zho.transcription.punctuation import (
-    YueVsZhoYueHansPunctuationPrompt,
+    YueVsZhoPunctuationPromptYueHans,
     YueZhoPunctuationManager,
 )
-from scinoephile.multilang.yue_zho.translation import YueVsZhoYueHansTranslationPrompt
+from scinoephile.multilang.yue_zho.translation import YueVsZhoTranslationPromptYueHans
 from test.helpers import test_data_root
 
 __all__ = [
@@ -199,7 +199,7 @@ def mlamd_zho_hant_ocr_sup_path() -> Path:
 
 @cache
 def get_mlamd_eng_block_review_test_cases(
-    prompt_cls: type[MonoBlockPrompt] = EngBlockReviewPrompt,
+    prompt_cls: type[MonoBlockPrompt] = BlockReviewPromptEng,
     **kwargs: Any,
 ) -> list[TestCase]:
     """Get MLAMD English block review test cases.
@@ -218,7 +218,7 @@ def get_mlamd_eng_block_review_test_cases(
 
 @cache
 def get_mlamd_eng_ocr_fusion_test_cases(
-    prompt_cls: type[DualSinglePrompt] = EngOcrFusionPrompt,
+    prompt_cls: type[DualSinglePrompt] = OcrFusionPromptEng,
     **kwargs: Any,
 ) -> list[TestCase]:
     """Get MLAMD English OCR fusion test cases.
@@ -237,7 +237,7 @@ def get_mlamd_eng_ocr_fusion_test_cases(
 
 @cache
 def get_mlamd_yue_deliniation_test_cases(
-    prompt_cls: type[DualPairPrompt] = YueVsZhoYueHansDeliniationPrompt,
+    prompt_cls: type[DualPairPrompt] = YueVsZhoDeliniationPromptYueHans,
     **kwargs: Any,
 ) -> list[TestCase]:
     """Get MLAMD 简体粤文 deliniation test cases.
@@ -264,7 +264,7 @@ def get_mlamd_yue_deliniation_test_cases(
 
 @cache
 def get_mlamd_yue_from_zho_translation_test_cases(
-    prompt_cls: type[DualBlockGappedPrompt] = YueVsZhoYueHansTranslationPrompt,
+    prompt_cls: type[DualBlockGappedPrompt] = YueVsZhoTranslationPromptYueHans,
     **kwargs: Any,
 ) -> list[TestCase]:
     """Get MLAMD 简体粤文 from 简体中文 translation test cases.
@@ -290,7 +290,7 @@ def get_mlamd_yue_from_zho_translation_test_cases(
 
 @cache
 def get_mlamd_yue_punctuation_test_cases(
-    prompt_cls: type[DualMultiSinglePrompt] = YueVsZhoYueHansPunctuationPrompt,
+    prompt_cls: type[DualMultiSinglePrompt] = YueVsZhoPunctuationPromptYueHans,
     **kwargs: Any,
 ) -> list[TestCase]:
     """Get MLAMD 简体粤文 punctuation test cases.
@@ -317,7 +317,7 @@ def get_mlamd_yue_punctuation_test_cases(
 
 @cache
 def get_mlamd_yue_vs_zho_block_review_test_cases(
-    prompt_cls: type[DualBlockPrompt] = YueVsZhoYueHansBlockReviewPrompt,
+    prompt_cls: type[DualBlockPrompt] = YueVsZhoBlockReviewPromptYueHans,
     **kwargs: Any,
 ) -> list[TestCase]:
     """Get MLAMD 简体粤文 vs 简体中文 review test cases.
@@ -343,7 +343,7 @@ def get_mlamd_yue_vs_zho_block_review_test_cases(
 
 @cache
 def get_mlamd_yue_vs_zho_line_review_test_cases(
-    prompt_cls: type[DualSinglePrompt] = YueVsZhoYueHansLineReviewPrompt,
+    prompt_cls: type[DualSinglePrompt] = YueVsZhoLineReviewPromptYueHans,
     **kwargs: Any,
 ) -> list[TestCase]:
     """Get MLAMD 简体粤文 vs 简体中文 line-review test cases.
@@ -369,7 +369,7 @@ def get_mlamd_yue_vs_zho_line_review_test_cases(
 
 @cache
 def get_mlamd_zho_hans_block_review_test_cases(
-    prompt_cls: type[MonoBlockPrompt] = ZhoHansBlockReviewPrompt,
+    prompt_cls: type[MonoBlockPrompt] = BlockReviewPromptZhoHans,
     **kwargs: Any,
 ) -> list[TestCase]:
     """Get MLAMD 简体中文 block review test cases.
@@ -388,7 +388,7 @@ def get_mlamd_zho_hans_block_review_test_cases(
 
 @cache
 def get_mlamd_zho_hans_ocr_fusion_test_cases(
-    prompt_cls: type[DualSinglePrompt] = ZhoHansOcrFusionPrompt,
+    prompt_cls: type[DualSinglePrompt] = OcrFusionPromptZhoHans,
     **kwargs: Any,
 ) -> list[TestCase]:
     """Get MLAMD 简体中文 OCR fusion test cases.
@@ -407,7 +407,7 @@ def get_mlamd_zho_hans_ocr_fusion_test_cases(
 
 @cache
 def get_mlamd_zho_hant_block_review_test_cases(
-    prompt_cls: type[MonoBlockPrompt] = ZhoHantBlockReviewPrompt,
+    prompt_cls: type[MonoBlockPrompt] = BlockReviewPromptZhoHant,
     **kwargs: Any,
 ) -> list[TestCase]:
     """Get MLAMD 繁体中文 block review test cases.
@@ -426,7 +426,7 @@ def get_mlamd_zho_hant_block_review_test_cases(
 
 @cache
 def get_mlamd_zho_hant_ocr_fusion_test_cases(
-    prompt_cls: type[DualSinglePrompt] = ZhoHantOcrFusionPrompt,
+    prompt_cls: type[DualSinglePrompt] = OcrFusionPromptZhoHant,
     **kwargs: Any,
 ) -> list[TestCase]:
     """Get MLAMD 繁体中文 OCR fusion test cases.
@@ -445,7 +445,7 @@ def get_mlamd_zho_hant_ocr_fusion_test_cases(
 
 @cache
 def get_mlamd_zho_hant_simplify_block_review_test_cases(
-    prompt_cls: type[MonoBlockPrompt] = ZhoHansBlockReviewPrompt,
+    prompt_cls: type[MonoBlockPrompt] = BlockReviewPromptZhoHans,
     **kwargs: Any,
 ) -> list[TestCase]:
     """Get MLAMD 繁体中文 simplification block review test cases.

--- a/test/data/mnt/__init__.py
+++ b/test/data/mnt/__init__.py
@@ -16,15 +16,15 @@ from scinoephile.core.llms import TestCase
 from scinoephile.core.llms.utils import load_test_cases_from_json
 from scinoephile.core.subtitles import Series
 from scinoephile.image.subtitles import ImageSeries
-from scinoephile.lang.eng.block_review import EngBlockReviewPrompt
-from scinoephile.lang.eng.ocr_fusion import EngOcrFusionPrompt
+from scinoephile.lang.eng.block_review import BlockReviewPromptEng
+from scinoephile.lang.eng.ocr_fusion import OcrFusionPromptEng
 from scinoephile.lang.zho.block_review import (
-    ZhoHansBlockReviewPrompt,
-    ZhoHantBlockReviewPrompt,
+    BlockReviewPromptZhoHans,
+    BlockReviewPromptZhoHant,
 )
 from scinoephile.lang.zho.ocr_fusion import (
-    ZhoHansOcrFusionPrompt,
-    ZhoHantOcrFusionPrompt,
+    OcrFusionPromptZhoHans,
+    OcrFusionPromptZhoHant,
 )
 from scinoephile.llms.dual_single import DualSinglePrompt
 from scinoephile.llms.dual_single.ocr_fusion import OcrFusionManager
@@ -136,7 +136,7 @@ def mnt_zho_hant_ocr_paddle_new() -> Series:
 
 @cache
 def get_mnt_eng_block_review_test_cases(
-    prompt_cls: type[MonoBlockPrompt] = EngBlockReviewPrompt,
+    prompt_cls: type[MonoBlockPrompt] = BlockReviewPromptEng,
     **kwargs: Any,
 ) -> list[TestCase]:
     """Get MNT English block review test cases.
@@ -155,7 +155,7 @@ def get_mnt_eng_block_review_test_cases(
 
 @cache
 def get_mnt_eng_ocr_fusion_test_cases(
-    prompt_cls: type[DualSinglePrompt] = EngOcrFusionPrompt,
+    prompt_cls: type[DualSinglePrompt] = OcrFusionPromptEng,
     **kwargs: Any,
 ) -> list[TestCase]:
     """Get MNT English OCR fusion test cases.
@@ -174,7 +174,7 @@ def get_mnt_eng_ocr_fusion_test_cases(
 
 @cache
 def get_mnt_zho_hans_block_review_test_cases(
-    prompt_cls: type[MonoBlockPrompt] = ZhoHansBlockReviewPrompt,
+    prompt_cls: type[MonoBlockPrompt] = BlockReviewPromptZhoHans,
     **kwargs: Any,
 ) -> list[TestCase]:
     """Get MNT 简体中文 block review test cases.
@@ -193,7 +193,7 @@ def get_mnt_zho_hans_block_review_test_cases(
 
 @cache
 def get_mnt_zho_hans_ocr_fusion_test_cases(
-    prompt_cls: type[DualSinglePrompt] = ZhoHansOcrFusionPrompt,
+    prompt_cls: type[DualSinglePrompt] = OcrFusionPromptZhoHans,
     **kwargs: Any,
 ) -> list[TestCase]:
     """Get MNT 简体中文 OCR fusion test cases.
@@ -212,7 +212,7 @@ def get_mnt_zho_hans_ocr_fusion_test_cases(
 
 @cache
 def get_mnt_zho_hant_block_review_test_cases(
-    prompt_cls: type[MonoBlockPrompt] = ZhoHantBlockReviewPrompt,
+    prompt_cls: type[MonoBlockPrompt] = BlockReviewPromptZhoHant,
     **kwargs: Any,
 ) -> list[TestCase]:
     """Get MNT 繁体中文 block review test cases.
@@ -231,7 +231,7 @@ def get_mnt_zho_hant_block_review_test_cases(
 
 @cache
 def get_mnt_zho_hant_ocr_fusion_test_cases(
-    prompt_cls: type[DualSinglePrompt] = ZhoHantOcrFusionPrompt,
+    prompt_cls: type[DualSinglePrompt] = OcrFusionPromptZhoHant,
     **kwargs: Any,
 ) -> list[TestCase]:
     """Get MNT 繁体中文 OCR fusion test cases.
@@ -250,7 +250,7 @@ def get_mnt_zho_hant_ocr_fusion_test_cases(
 
 @cache
 def get_mnt_zho_hant_simplify_block_review_test_cases(
-    prompt_cls: type[MonoBlockPrompt] = ZhoHansBlockReviewPrompt,
+    prompt_cls: type[MonoBlockPrompt] = BlockReviewPromptZhoHans,
     **kwargs: Any,
 ) -> list[TestCase]:
     """Get MNT 繁体中文 simplification block review test cases.

--- a/test/data/ocr.py
+++ b/test/data/ocr.py
@@ -21,8 +21,8 @@ from scinoephile.lang.eng.flattening import get_eng_flattened
 from scinoephile.lang.eng.ocr_fusion import get_eng_ocr_fused, get_eng_ocr_fuser
 from scinoephile.lang.eng.ocr_validation import validate_eng_ocr
 from scinoephile.lang.zho.block_review import (
-    ZhoHansBlockReviewPrompt,
-    ZhoHantBlockReviewPrompt,
+    BlockReviewPromptZhoHans,
+    BlockReviewPromptZhoHant,
     get_zho_block_reviewed,
     get_zho_reviewer,
 )
@@ -30,7 +30,7 @@ from scinoephile.lang.zho.cleaning import get_zho_cleaned
 from scinoephile.lang.zho.conversion import OpenCCConfig, get_zho_converted
 from scinoephile.lang.zho.flattening import get_zho_flattened
 from scinoephile.lang.zho.ocr_fusion import (
-    ZhoHantOcrFusionPrompt,
+    OcrFusionPromptZhoHant,
     get_zho_ocr_fused,
     get_zho_ocr_fuser,
 )
@@ -367,7 +367,7 @@ def process_zho_hant_ocr(  # noqa: PLR0912, PLR0915
             output_dir / f"{lang_code}_ocr/lang/zho/ocr_fusion.json",
         )
         fuser = get_zho_ocr_fuser(
-            prompt_cls=ZhoHantOcrFusionPrompt,
+            prompt_cls=OcrFusionPromptZhoHant,
             auto_verify=True,
             **fuser_kw,
         )
@@ -430,7 +430,7 @@ def process_zho_hant_ocr(  # noqa: PLR0912, PLR0915
             output_dir / f"{lang_code}_ocr/lang/zho/block_review.json",
         )
         reviewer = get_zho_reviewer(
-            prompt_cls=ZhoHantBlockReviewPrompt,
+            prompt_cls=BlockReviewPromptZhoHant,
             auto_verify=True,
             **reviewer_kw,
         )
@@ -461,7 +461,7 @@ def process_zho_hant_ocr(  # noqa: PLR0912, PLR0915
         simplify_review = Series.load(simplify_review_path)
     else:
         simplify_reviewer = get_zho_reviewer(
-            prompt_cls=ZhoHansBlockReviewPrompt,
+            prompt_cls=BlockReviewPromptZhoHans,
             test_case_path=output_dir
             / f"{lang_code}_ocr"
             / "lang"

--- a/test/data/t/__init__.py
+++ b/test/data/t/__init__.py
@@ -16,15 +16,15 @@ from scinoephile.core.llms import TestCase
 from scinoephile.core.llms.utils import load_test_cases_from_json
 from scinoephile.core.subtitles import Series
 from scinoephile.image.subtitles import ImageSeries
-from scinoephile.lang.eng.block_review import EngBlockReviewPrompt
-from scinoephile.lang.eng.ocr_fusion import EngOcrFusionPrompt
+from scinoephile.lang.eng.block_review import BlockReviewPromptEng
+from scinoephile.lang.eng.ocr_fusion import OcrFusionPromptEng
 from scinoephile.lang.zho.block_review import (
-    ZhoHansBlockReviewPrompt,
-    ZhoHantBlockReviewPrompt,
+    BlockReviewPromptZhoHans,
+    BlockReviewPromptZhoHant,
 )
 from scinoephile.lang.zho.ocr_fusion import (
-    ZhoHansOcrFusionPrompt,
-    ZhoHantOcrFusionPrompt,
+    OcrFusionPromptZhoHans,
+    OcrFusionPromptZhoHant,
 )
 from scinoephile.llms.dual_single import DualSinglePrompt
 from scinoephile.llms.dual_single.ocr_fusion import OcrFusionManager
@@ -155,7 +155,7 @@ def t_zho_hant_ocr_paddle_new() -> Series:
 
 @cache
 def get_t_eng_block_review_test_cases(
-    prompt_cls: type[MonoBlockPrompt] = EngBlockReviewPrompt,
+    prompt_cls: type[MonoBlockPrompt] = BlockReviewPromptEng,
     **kwargs: Any,
 ) -> list[TestCase]:
     """Get T English block review test cases.
@@ -174,7 +174,7 @@ def get_t_eng_block_review_test_cases(
 
 @cache
 def get_t_eng_ocr_fusion_test_cases(
-    prompt_cls: type[DualSinglePrompt] = EngOcrFusionPrompt,
+    prompt_cls: type[DualSinglePrompt] = OcrFusionPromptEng,
     **kwargs: Any,
 ) -> list[TestCase]:
     """Get T English OCR fusion test cases.
@@ -193,7 +193,7 @@ def get_t_eng_ocr_fusion_test_cases(
 
 @cache
 def get_t_zho_hans_block_review_test_cases(
-    prompt_cls: type[MonoBlockPrompt] = ZhoHansBlockReviewPrompt,
+    prompt_cls: type[MonoBlockPrompt] = BlockReviewPromptZhoHans,
     **kwargs: Any,
 ) -> list[TestCase]:
     """Get T 简体中文 block review test cases.
@@ -212,7 +212,7 @@ def get_t_zho_hans_block_review_test_cases(
 
 @cache
 def get_t_zho_hans_ocr_fusion_test_cases(
-    prompt_cls: type[DualSinglePrompt] = ZhoHansOcrFusionPrompt,
+    prompt_cls: type[DualSinglePrompt] = OcrFusionPromptZhoHans,
     **kwargs: Any,
 ) -> list[TestCase]:
     """Get T 简体中文 OCR fusion test cases.
@@ -231,7 +231,7 @@ def get_t_zho_hans_ocr_fusion_test_cases(
 
 @cache
 def get_t_zho_hant_block_review_test_cases(
-    prompt_cls: type[MonoBlockPrompt] = ZhoHantBlockReviewPrompt,
+    prompt_cls: type[MonoBlockPrompt] = BlockReviewPromptZhoHant,
     **kwargs: Any,
 ) -> list[TestCase]:
     """Get T 繁体中文 block review test cases.
@@ -250,7 +250,7 @@ def get_t_zho_hant_block_review_test_cases(
 
 @cache
 def get_t_zho_hant_ocr_fusion_test_cases(
-    prompt_cls: type[DualSinglePrompt] = ZhoHantOcrFusionPrompt,
+    prompt_cls: type[DualSinglePrompt] = OcrFusionPromptZhoHant,
     **kwargs: Any,
 ) -> list[TestCase]:
     """Get T 繁体中文 OCR fusion test cases.
@@ -269,7 +269,7 @@ def get_t_zho_hant_ocr_fusion_test_cases(
 
 @cache
 def get_t_zho_hant_simplify_block_review_test_cases(
-    prompt_cls: type[MonoBlockPrompt] = ZhoHansBlockReviewPrompt,
+    prompt_cls: type[MonoBlockPrompt] = BlockReviewPromptZhoHans,
     **kwargs: Any,
 ) -> list[TestCase]:
     """Get T 繁体中文 simplification block review test cases.

--- a/test/dictionaries/test_dictionary_tools.py
+++ b/test/dictionaries/test_dictionary_tools.py
@@ -30,15 +30,15 @@ from scinoephile.dictionaries.dictionary_tools import (
     lookup_dictionary,
 )
 from scinoephile.multilang.yue_zho.block_review import (
-    YueVsZhoYueHansBlockReviewPrompt,
+    YueVsZhoBlockReviewPromptYueHans,
     get_yue_vs_zho_block_reviewer,
 )
 from scinoephile.multilang.yue_zho.line_review import (
-    YueVsZhoYueHansLineReviewPrompt,
+    YueVsZhoLineReviewPromptYueHans,
     get_yue_vs_zho_line_reviewer,
 )
 from scinoephile.multilang.yue_zho.translation import (
-    YueVsZhoYueHansTranslationPrompt,
+    YueVsZhoTranslationPromptYueHans,
     get_yue_vs_zho_translator,
 )
 
@@ -236,9 +236,9 @@ def test_lookup_dictionary_returns_compact_error_for_no_available_dictionaries(
 @pytest.mark.parametrize(
     ("prompt_cls", "factory"),
     [
-        (YueVsZhoYueHansTranslationPrompt, get_yue_vs_zho_translator),
-        (YueVsZhoYueHansBlockReviewPrompt, get_yue_vs_zho_block_reviewer),
-        (YueVsZhoYueHansLineReviewPrompt, get_yue_vs_zho_line_reviewer),
+        (YueVsZhoTranslationPromptYueHans, get_yue_vs_zho_translator),
+        (YueVsZhoBlockReviewPromptYueHans, get_yue_vs_zho_block_reviewer),
+        (YueVsZhoLineReviewPromptYueHans, get_yue_vs_zho_line_reviewer),
     ],
 )
 def test_processors_use_prompt_dictionary_tooling(

--- a/test/lang/zho/test_get_zho_block_reviewed.py
+++ b/test/lang/zho/test_get_zho_block_reviewed.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from scinoephile.core.subtitles import Series
 from scinoephile.lang.zho.block_review import (
-    ZhoHantBlockReviewPrompt,
+    BlockReviewPromptZhoHant,
     get_zho_block_reviewed,
     get_zho_reviewer,
 )
@@ -45,7 +45,7 @@ def test_get_zho_block_reviewed_kob(
     _test_get_zho_block_reviewed(
         kob_zho_hant_ocr_fuse_clean_validate,
         kob_zho_hant_ocr_fuse_clean_validate_review,
-        get_zho_reviewer(prompt_cls=ZhoHantBlockReviewPrompt),
+        get_zho_reviewer(prompt_cls=BlockReviewPromptZhoHant),
     )
 
 

--- a/test/lang/zho/test_get_zho_ocr_fused.py
+++ b/test/lang/zho/test_get_zho_ocr_fused.py
@@ -8,7 +8,7 @@ from scinoephile.core.subtitles import Series
 from scinoephile.lang.zho.cleaning import get_zho_cleaned
 from scinoephile.lang.zho.conversion import OpenCCConfig, get_zho_converted
 from scinoephile.lang.zho.ocr_fusion import (
-    ZhoHantOcrFusionPrompt,
+    OcrFusionPromptZhoHant,
     get_zho_ocr_fused,
     get_zho_ocr_fuser,
 )
@@ -58,7 +58,7 @@ def test_get_zho_ocr_fused_kob(
         lens,
         paddle,
         kob_zho_hant_ocr_fuse,
-        get_zho_ocr_fuser(prompt_cls=ZhoHantOcrFusionPrompt),
+        get_zho_ocr_fuser(prompt_cls=OcrFusionPromptZhoHant),
     )
 
 

--- a/test/llms/test_default_test_case_loading.py
+++ b/test/llms/test_default_test_case_loading.py
@@ -11,15 +11,15 @@ import pytest
 
 from scinoephile.common import package_root
 from scinoephile.core.llms import TestCase
-from scinoephile.lang.eng.block_review import EngBlockReviewPrompt
-from scinoephile.lang.eng.ocr_fusion import EngOcrFusionPrompt
+from scinoephile.lang.eng.block_review import BlockReviewPromptEng
+from scinoephile.lang.eng.ocr_fusion import OcrFusionPromptEng
 from scinoephile.lang.zho.block_review import (
-    ZhoHansBlockReviewPrompt,
-    ZhoHantBlockReviewPrompt,
+    BlockReviewPromptZhoHans,
+    BlockReviewPromptZhoHant,
 )
 from scinoephile.lang.zho.ocr_fusion import (
-    ZhoHansOcrFusionPrompt,
-    ZhoHantOcrFusionPrompt,
+    OcrFusionPromptZhoHans,
+    OcrFusionPromptZhoHant,
 )
 from scinoephile.llms.default_test_cases import (
     ENG_BLOCK_REVIEW_JSON_PATHS,
@@ -37,10 +37,10 @@ from scinoephile.llms.dual_block.manager import DualBlockManager
 from scinoephile.llms.dual_block_gapped.manager import DualBlockGappedManager
 from scinoephile.llms.dual_single.ocr_fusion.manager import OcrFusionManager
 from scinoephile.llms.mono_block.manager import MonoBlockManager
-from scinoephile.multilang.yue_zho.block_review import YueVsZhoYueHansBlockReviewPrompt
-from scinoephile.multilang.yue_zho.line_review import YueVsZhoYueHansLineReviewPrompt
+from scinoephile.multilang.yue_zho.block_review import YueVsZhoBlockReviewPromptYueHans
+from scinoephile.multilang.yue_zho.line_review import YueVsZhoLineReviewPromptYueHans
 from scinoephile.multilang.yue_zho.line_review.manager import YueZhoLineReviewManager
-from scinoephile.multilang.yue_zho.translation import YueVsZhoYueHansTranslationPrompt
+from scinoephile.multilang.yue_zho.translation import YueVsZhoTranslationPromptYueHans
 
 
 def _get_expected_case_count(relative_paths: list[str]) -> int:
@@ -68,7 +68,7 @@ def _get_expected_case_count(relative_paths: list[str]) -> int:
         (
             "eng_block_review",
             lambda: load_default_test_cases(
-                MonoBlockManager, EngBlockReviewPrompt, ENG_BLOCK_REVIEW_JSON_PATHS
+                MonoBlockManager, BlockReviewPromptEng, ENG_BLOCK_REVIEW_JSON_PATHS
             ),
             [
                 "kob/output/eng_ocr/lang/eng/block_review.json",
@@ -81,7 +81,7 @@ def _get_expected_case_count(relative_paths: list[str]) -> int:
         (
             "eng_ocr_fusion",
             lambda: load_default_test_cases(
-                OcrFusionManager, EngOcrFusionPrompt, ENG_OCR_FUSION_JSON_PATHS
+                OcrFusionManager, OcrFusionPromptEng, ENG_OCR_FUSION_JSON_PATHS
             ),
             [
                 "kob/output/eng_ocr/lang/eng/ocr_fusion.json",
@@ -94,7 +94,7 @@ def _get_expected_case_count(relative_paths: list[str]) -> int:
             "zho_hans_block_review",
             lambda: load_default_test_cases(
                 MonoBlockManager,
-                ZhoHansBlockReviewPrompt,
+                BlockReviewPromptZhoHans,
                 ZHO_HANS_BLOCK_REVIEW_JSON_PATHS,
             ),
             [
@@ -107,7 +107,7 @@ def _get_expected_case_count(relative_paths: list[str]) -> int:
             "zho_hant_block_review",
             lambda: load_default_test_cases(
                 MonoBlockManager,
-                ZhoHantBlockReviewPrompt,
+                BlockReviewPromptZhoHant,
                 ZHO_HANT_BLOCK_REVIEW_JSON_PATHS,
             ),
             [
@@ -121,7 +121,7 @@ def _get_expected_case_count(relative_paths: list[str]) -> int:
             "zho_hans_ocr_fusion",
             lambda: load_default_test_cases(
                 OcrFusionManager,
-                ZhoHansOcrFusionPrompt,
+                OcrFusionPromptZhoHans,
                 ZHO_HANS_OCR_FUSION_JSON_PATHS,
             ),
             [
@@ -134,7 +134,7 @@ def _get_expected_case_count(relative_paths: list[str]) -> int:
             "zho_hant_ocr_fusion",
             lambda: load_default_test_cases(
                 OcrFusionManager,
-                ZhoHantOcrFusionPrompt,
+                OcrFusionPromptZhoHant,
                 ZHO_HANT_OCR_FUSION_JSON_PATHS,
             ),
             [
@@ -148,7 +148,7 @@ def _get_expected_case_count(relative_paths: list[str]) -> int:
             "yue_zho_line_review",
             lambda: load_default_test_cases(
                 YueZhoLineReviewManager,
-                YueVsZhoYueHansLineReviewPrompt,
+                YueVsZhoLineReviewPromptYueHans,
                 YUE_ZHO_LINE_REVIEW_JSON_PATHS,
             ),
             [
@@ -161,7 +161,7 @@ def _get_expected_case_count(relative_paths: list[str]) -> int:
             "yue_zho_block_review",
             lambda: load_default_test_cases(
                 DualBlockManager,
-                YueVsZhoYueHansBlockReviewPrompt,
+                YueVsZhoBlockReviewPromptYueHans,
                 YUE_ZHO_BLOCK_REVIEW_JSON_PATHS,
             ),
             [
@@ -174,7 +174,7 @@ def _get_expected_case_count(relative_paths: list[str]) -> int:
             "yue_from_zho_translation",
             lambda: load_default_test_cases(
                 DualBlockGappedManager,
-                YueVsZhoYueHansTranslationPrompt,
+                YueVsZhoTranslationPromptYueHans,
                 YUE_FROM_ZHO_TRANSLATION_JSON_PATHS,
             ),
             [

--- a/test/multilang/yue_zho/test_get_yue_transcriber_vs_zho.py
+++ b/test/multilang/yue_zho/test_get_yue_transcriber_vs_zho.py
@@ -21,10 +21,10 @@ from scinoephile.multilang.yue_zho.transcription import (
     get_yue_vs_zho_transcriber,
 )
 from scinoephile.multilang.yue_zho.transcription.deliniation import (
-    YueVsZhoYueHansDeliniationPrompt,
+    YueVsZhoDeliniationPromptYueHans,
 )
 from scinoephile.multilang.yue_zho.transcription.punctuation import (
-    YueVsZhoYueHansPunctuationPrompt,
+    YueVsZhoPunctuationPromptYueHans,
 )
 
 
@@ -54,8 +54,8 @@ def test_get_yue_vs_zho_transcriber_uses_writable_runtime_test_case_root():
             demucs_mode=DemucsMode.OFF,
             vad_mode=VADMode.AUTO,
             convert=None,
-            deliniation_prompt_cls=YueVsZhoYueHansDeliniationPrompt,
-            punctuation_prompt_cls=YueVsZhoYueHansPunctuationPrompt,
+            deliniation_prompt_cls=YueVsZhoDeliniationPromptYueHans,
+            punctuation_prompt_cls=YueVsZhoPunctuationPromptYueHans,
             provider=ANY,
         )
         assert (

--- a/test/optimization/persistence/test_cases/test_optimization_test_cases_sqlite_store.py
+++ b/test/optimization/persistence/test_cases/test_optimization_test_cases_sqlite_store.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from scinoephile.core.llms import OperationSpec
 from scinoephile.multilang.yue_zho.transcription.punctuation import (
-    YueVsZhoYueHansPunctuationPrompt,
+    YueVsZhoPunctuationPromptYueHans,
     YueZhoPunctuationManager,
 )
 from scinoephile.optimization.persistence.test_cases import (
@@ -24,7 +24,7 @@ def get_punctuation_operation_spec() -> OperationSpec:
         operation="unit-punctuation",
         test_case_table_name="test_cases__unit__punctuation",
         manager_cls=YueZhoPunctuationManager,
-        prompt_cls=YueVsZhoYueHansPunctuationPrompt,
+        prompt_cls=YueVsZhoPunctuationPromptYueHans,
         list_fields={"query.yuewen_to_punctuate": 10},
     )
 

--- a/test/optimization/persistence/test_cases/test_optimization_test_cases_sync.py
+++ b/test/optimization/persistence/test_cases/test_optimization_test_cases_sync.py
@@ -11,7 +11,7 @@ from scinoephile.core.llms import OperationSpec
 from scinoephile.llms.mono_block.manager import MonoBlockManager
 from scinoephile.llms.mono_block.prompt import MonoBlockPrompt
 from scinoephile.multilang.yue_zho.transcription.punctuation import (
-    YueVsZhoYueHansPunctuationPrompt,
+    YueVsZhoPunctuationPromptYueHans,
     YueZhoPunctuationManager,
 )
 from scinoephile.optimization.persistence.test_cases import TestCaseSqliteStore
@@ -200,7 +200,7 @@ def test_sync_uses_operation_list_fields(tmp_path: Path, monkeypatch):
         operation="unit-punctuation",
         test_case_table_name="test_cases__unit__punctuation",
         manager_cls=YueZhoPunctuationManager,
-        prompt_cls=YueVsZhoYueHansPunctuationPrompt,
+        prompt_cls=YueVsZhoPunctuationPromptYueHans,
         list_fields={"query.yuewen_to_punctuate": 10},
     )
 


### PR DESCRIPTION
## Summary

- Rename prompt language mixins to the `Prompt<LanguageCharset>` pattern.
- Rename language-specific operation prompts to the `<Operation>Prompt<LanguageCharset>` pattern.
- Update CLI code, default test case fixtures, and tests to use the new prompt class names.

Closes #802.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format` on changed Python files
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix` on changed Python files
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check` on changed Python files
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto`