### PR TITLE
Rename dual_pair LLM shape to dual_2_to_2

### DIFF
--- a/scinoephile/llms/__init__.py
+++ b/scinoephile/llms/__init__.py
@@ -6,6 +6,6 @@ This module may import from: common, core
 
 Hierarchy within module (lower may import from higher)::
 * providers / default_test_cases
-* dual_block / dual_block_gapped / dual_n_to_1 / dual_pair / dual_1_to_1
+* dual_block / dual_block_gapped / dual_n_to_1 / dual_2_to_2 / dual_1_to_1
   / mono_n
 """

--- a/scinoephile/llms/dual_2_to_2/__init__.py
+++ b/scinoephile/llms/dual_2_to_2/__init__.py
@@ -1,13 +1,13 @@
 #  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
-"""Code related to dual pair matters using LLMs."""
+"""Code related to dual 2 to 2 matters using LLMs."""
 
 from __future__ import annotations
 
-from .manager import DualPairManager
-from .prompt import DualPairPrompt
+from .manager import Dual2To2Manager
+from .prompt import Dual2To2Prompt
 
 __all__ = [
-    "DualPairManager",
-    "DualPairPrompt",
+    "Dual2To2Manager",
+    "Dual2To2Prompt",
 ]

--- a/scinoephile/llms/dual_2_to_2/manager.py
+++ b/scinoephile/llms/dual_2_to_2/manager.py
@@ -1,6 +1,6 @@
 #  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
-"""Factories for dual track / subtitle pair LLM classes."""
+"""Factories for dual 2 to 2 LLM classes."""
 
 from __future__ import annotations
 
@@ -13,22 +13,22 @@ from scinoephile.core import ScinoephileError
 from scinoephile.core.llms import Answer, Manager, Query, TestCase, TestCaseClsKwargs
 from scinoephile.core.llms.models import get_model_name
 
-from .prompt import DualPairPrompt
+from .prompt import Dual2To2Prompt
 
-__all__ = ["DualPairManager"]
+__all__ = ["Dual2To2Manager"]
 
 
-class DualPairManager(Manager):
-    """Factories for dual track / subtitle pair LLM classes."""
+class Dual2To2Manager(Manager):
+    """Factories for dual 2 to 2 LLM classes."""
 
-    prompt_cls: ClassVar[type[DualPairPrompt]] = DualPairPrompt
+    prompt_cls: ClassVar[type[Dual2To2Prompt]] = Dual2To2Prompt
     """Default prompt class."""
 
     @classmethod
     @cache
     def get_query_cls(
         cls,
-        prompt_cls: type[DualPairPrompt] = DualPairPrompt,
+        prompt_cls: type[Dual2To2Prompt] = Dual2To2Prompt,
     ) -> type[Query]:
         """Get concrete query class with provided configuration.
 
@@ -37,7 +37,7 @@ class DualPairManager(Manager):
         Returns:
             query model class
         """
-        name = get_model_name("DualPairQuery", prompt_cls.__name__)
+        name = get_model_name("Dual2To2Query", prompt_cls.__name__)
         fields: dict[str, Any] = {
             prompt_cls.src_1_sub_1: (
                 str,
@@ -75,7 +75,7 @@ class DualPairManager(Manager):
     @cache
     def get_answer_cls(
         cls,
-        prompt_cls: type[DualPairPrompt] = DualPairPrompt,
+        prompt_cls: type[Dual2To2Prompt] = Dual2To2Prompt,
     ) -> type[Answer]:
         """Get concrete answer class with provided configuration.
 
@@ -84,7 +84,7 @@ class DualPairManager(Manager):
         Returns:
             answer model class
         """
-        name = get_model_name("DualPairAnswer", prompt_cls.__name__)
+        name = get_model_name("Dual2To2Answer", prompt_cls.__name__)
         fields: dict[str, Any] = {
             prompt_cls.src_2_sub_1_shifted: (
                 str,
@@ -132,7 +132,7 @@ class DualPairManager(Manager):
         Returns:
             minimum difficulty
         """
-        prompt_cls: type[DualPairPrompt] = getattr(model, "prompt_cls")
+        prompt_cls: type[Dual2To2Prompt] = getattr(model, "prompt_cls")
         min_difficulty = 0
         if model.answer is None:
             return min_difficulty
@@ -152,7 +152,7 @@ class DualPairManager(Manager):
         Returns:
             validated query
         """
-        prompt_cls: type[DualPairPrompt] = getattr(model, "prompt_cls")
+        prompt_cls: type[Dual2To2Prompt] = getattr(model, "prompt_cls")
         src_2_sub_1 = getattr(model, prompt_cls.src_2_sub_1, None)
         src_2_sub_2 = getattr(model, prompt_cls.src_2_sub_2, None)
         if not src_2_sub_1 and not src_2_sub_2:
@@ -168,7 +168,7 @@ class DualPairManager(Manager):
         Returns:
             validated test case
         """
-        prompt_cls: type[DualPairPrompt] = getattr(model, "prompt_cls")
+        prompt_cls: type[Dual2To2Prompt] = getattr(model, "prompt_cls")
         if model.answer is None:
             return model
 

--- a/scinoephile/llms/dual_2_to_2/prompt.py
+++ b/scinoephile/llms/dual_2_to_2/prompt.py
@@ -1,6 +1,6 @@
 #  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
-"""Text for LLM correspondence for dual track / subtitle pair matters."""
+"""Text for LLM correspondence for dual 2 to 2 matters."""
 
 from __future__ import annotations
 
@@ -9,11 +9,11 @@ from typing import ClassVar
 
 from scinoephile.core.llms import Prompt
 
-__all__ = ["DualPairPrompt"]
+__all__ = ["Dual2To2Prompt"]
 
 
-class DualPairPrompt(Prompt, ABC):
-    """Text for LLM correspondence for dual track / subtitle pair matters."""
+class Dual2To2Prompt(Prompt, ABC):
+    """Text for LLM correspondence for dual 2 to 2 matters."""
 
     # Query fields
     src_1_sub_1: ClassVar[str] = "src_1_sub_1"

--- a/scinoephile/multilang/yue_zho/transcription/__init__.py
+++ b/scinoephile/multilang/yue_zho/transcription/__init__.py
@@ -17,7 +17,7 @@ from scinoephile.llms.default_test_cases import (
     YUE_ZHO_TRANSCRIPTION_PUNCTUATION_JSON_PATHS,
     load_default_test_cases,
 )
-from scinoephile.llms.dual_pair import DualPairManager
+from scinoephile.llms.dual_2_to_2 import Dual2To2Manager
 from scinoephile.llms.providers.registry import get_default_provider
 
 from .deliniation import YueVsZhoDeliniationPromptYueHans
@@ -39,7 +39,7 @@ __all__ = [
 YUE_ZHO_TRANSCRIPTION_DELINIATION_OPERATION_SPEC = OperationSpec(
     operation="yue-zho-transcription-deliniation",
     test_case_table_name="test_cases__yue_zho__transcription_deliniation",
-    manager_cls=DualPairManager,
+    manager_cls=Dual2To2Manager,
     prompt_cls=YueVsZhoDeliniationPromptYueHans,
 )
 """Operation specification for written Cantonese transcription deliniation."""
@@ -148,7 +148,7 @@ def get_yue_vs_zho_transcriber(
     if deliniation_test_cases is None:
         deliniation_test_cases = list(
             load_default_test_cases(
-                DualPairManager,
+                Dual2To2Manager,
                 deliniation_prompt_cls,
                 YUE_ZHO_TRANSCRIPTION_DELINIATION_JSON_PATHS,
             )

--- a/scinoephile/multilang/yue_zho/transcription/alignment.py
+++ b/scinoephile/multilang/yue_zho/transcription/alignment.py
@@ -19,7 +19,7 @@ from scinoephile.core.synchronization import (
     get_sync_groups_string,
     get_sync_overlap_matrix,
 )
-from scinoephile.llms.dual_pair import DualPairManager
+from scinoephile.llms.dual_2_to_2 import Dual2To2Manager
 
 from .deliniation import YueVsZhoDeliniationPromptYueHans
 from .punctuation import YueVsZhoPunctuationPromptYueHans, YueZhoPunctuationManager
@@ -199,7 +199,7 @@ class Alignment:
         # Return
         if len(yw_1) == 0 and len(yw_2) == 0:
             return None
-        test_case_cls = DualPairManager.get_test_case_cls(
+        test_case_cls = Dual2To2Manager.get_test_case_cls(
             prompt_cls=YueVsZhoDeliniationPromptYueHans
         )
         query_kwargs = {

--- a/scinoephile/multilang/yue_zho/transcription/deliniation/prompt.py
+++ b/scinoephile/multilang/yue_zho/transcription/deliniation/prompt.py
@@ -9,7 +9,7 @@ from typing import ClassVar
 from scinoephile.core.text import dedent_and_compact
 from scinoephile.lang.eng.prompts import PromptEng
 from scinoephile.lang.zho.conversion import OpenCCConfig
-from scinoephile.llms.dual_pair import DualPairPrompt
+from scinoephile.llms.dual_2_to_2 import Dual2To2Prompt
 
 __all__ = [
     "YueVsZhoDeliniationPromptYueHans",
@@ -17,7 +17,7 @@ __all__ = [
 ]
 
 
-class YueVsZhoDeliniationPromptYueHans(DualPairPrompt, PromptEng):
+class YueVsZhoDeliniationPromptYueHans(Dual2To2Prompt, PromptEng):
     """Text for LLM correspondence for simplified written Cantonese deliniation."""
 
     # Prompt

--- a/test/data/kob/__init__.py
+++ b/test/data/kob/__init__.py
@@ -27,8 +27,8 @@ from scinoephile.lang.zho.block_review import (
 from scinoephile.lang.zho.ocr_fusion import OcrFusionPromptZhoHant
 from scinoephile.llms.dual_1_to_1 import Dual1To1Prompt
 from scinoephile.llms.dual_1_to_1.ocr_fusion import OcrFusionManager
+from scinoephile.llms.dual_2_to_2 import Dual2To2Manager, Dual2To2Prompt
 from scinoephile.llms.dual_n_to_1 import DualNTo1Prompt
-from scinoephile.llms.dual_pair import DualPairManager, DualPairPrompt
 from scinoephile.llms.mono_n import MonoNManager, MonoNPrompt
 from scinoephile.multilang.yue_zho.line_review import (
     YueVsZhoLineReviewPromptYueHans,
@@ -206,7 +206,7 @@ def get_kob_eng_ocr_fusion_test_cases(
 
 @cache
 def get_kob_yue_deliniation_test_cases(
-    prompt_cls: type[DualPairPrompt] = YueVsZhoDeliniationPromptYueHans,
+    prompt_cls: type[Dual2To2Prompt] = YueVsZhoDeliniationPromptYueHans,
     **kwargs: Unpack[_KobTestCaseKwargs],
 ) -> list[TestCase]:
     """Get KOB 简体粤文 deliniation test cases.
@@ -227,7 +227,7 @@ def get_kob_yue_deliniation_test_cases(
         / f"{get_torch_device()}.json"
     )
     return load_test_cases_from_json(
-        path, DualPairManager, prompt_cls=prompt_cls, **kwargs
+        path, Dual2To2Manager, prompt_cls=prompt_cls, **kwargs
     )
 
 

--- a/test/data/mlamd/__init__.py
+++ b/test/data/mlamd/__init__.py
@@ -30,13 +30,13 @@ from scinoephile.lang.zho.ocr_fusion import (
 )
 from scinoephile.llms.dual_1_to_1 import Dual1To1Prompt
 from scinoephile.llms.dual_1_to_1.ocr_fusion import OcrFusionManager
+from scinoephile.llms.dual_2_to_2 import Dual2To2Manager, Dual2To2Prompt
 from scinoephile.llms.dual_block import DualBlockManager, DualBlockPrompt
 from scinoephile.llms.dual_block_gapped import (
     DualBlockGappedManager,
     DualBlockGappedPrompt,
 )
 from scinoephile.llms.dual_n_to_1 import DualNTo1Prompt
-from scinoephile.llms.dual_pair import DualPairManager, DualPairPrompt
 from scinoephile.llms.mono_n import MonoNManager, MonoNPrompt
 from scinoephile.multilang.yue_zho.block_review import YueVsZhoBlockReviewPromptYueHans
 from scinoephile.multilang.yue_zho.gap_translation import (
@@ -239,7 +239,7 @@ def get_mlamd_eng_ocr_fusion_test_cases(
 
 @cache
 def get_mlamd_yue_deliniation_test_cases(
-    prompt_cls: type[DualPairPrompt] = YueVsZhoDeliniationPromptYueHans,
+    prompt_cls: type[Dual2To2Prompt] = YueVsZhoDeliniationPromptYueHans,
     **kwargs: Any,
 ) -> list[TestCase]:
     """Get MLAMD 简体粤文 deliniation test cases.
@@ -260,7 +260,7 @@ def get_mlamd_yue_deliniation_test_cases(
         / f"{get_torch_device()}.json"
     )
     return load_test_cases_from_json(
-        path, DualPairManager, prompt_cls=prompt_cls, **kwargs
+        path, Dual2To2Manager, prompt_cls=prompt_cls, **kwargs
     )
 
 


### PR DESCRIPTION
## Summary
- Rename the `scinoephile.llms.dual_pair` module to `scinoephile.llms.dual_2_to_2`.
- Rename the public shape class prefix from `DualPair` to `Dual2To2`.
- Update Yue/Zho transcription alignment/delineation and test-data imports to use the new shape terminology without compatibility shims.

## Verification
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format <changed Python files>`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix <changed Python files>`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check <changed Python files>`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest test/llms/test_default_test_case_loading.py test/optimization/persistence/test_cases/test_optimization_test_cases_sync.py test/multilang/yue_zho/test_get_yue_transcriber_vs_zho.py test/multilang/yue_zho/test_get_yue_transcribed_vs_zho.py -q`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto`