### PR TITLE
Collapse adjacent Tesseract italic spans

### DIFF
--- a/scinoephile/image/ocr/tesseract/hocr.py
+++ b/scinoephile/image/ocr/tesseract/hocr.py
@@ -216,6 +216,7 @@ def _apply_italic_mask(text: str, italic_mask: list[bool]) -> str:
     Returns:
         text with italic tags
     """
+    italic_mask = _include_between_word_italic_separators(text, italic_mask)
     parts: list[str] = []
     italic_open = False
     for character, italic in zip(text, italic_mask, strict=True):
@@ -246,13 +247,11 @@ def _format_tesseract_hocr_words(
     """
     formatted_lines = []
     for line in lines:
-        formatted_words = []
-        for word in line:
-            if word.italic:
-                formatted_words.append(f"<i>{word.text}</i>")
-            else:
-                formatted_words.append(word.text)
-        line_text = word_separator.join(formatted_words).strip()
+        line_text, word_spans = _get_text_and_word_spans(
+            [line], word_separator=word_separator
+        )
+        italic_mask = _get_italic_mask(line_text, word_spans)
+        line_text = _apply_italic_mask(line_text, italic_mask).strip()
         if line_text:
             formatted_lines.append(line_text)
     return "\\N".join(formatted_lines)
@@ -260,11 +259,14 @@ def _format_tesseract_hocr_words(
 
 def _get_text_and_word_spans(
     lines: list[list[TesseractHocrWord]],
+    *,
+    word_separator: str = " ",
 ) -> tuple[str, list[_TesseractHocrWordSpan]]:
     """Get formatted plain text and word spans.
 
     Arguments:
         lines: line-grouped recognized words
+        word_separator: text with which to join hOCR word spans
     Returns:
         plain text and word spans
     """
@@ -277,8 +279,8 @@ def _get_text_and_word_spans(
             text_length += 2
         for word_index, word in enumerate(line):
             if word_index > 0:
-                text_parts.append(" ")
-                text_length += 1
+                text_parts.append(word_separator)
+                text_length += len(word_separator)
             start = text_length
             text_parts.append(word.text)
             text_length += len(word.text)
@@ -291,6 +293,54 @@ def _get_text_and_word_spans(
                 )
             )
     return "".join(text_parts), word_spans
+
+
+def _get_italic_mask(text: str, word_spans: list[_TesseractHocrWordSpan]) -> list[bool]:
+    """Get italic mask from word spans.
+
+    Arguments:
+        text: plain text
+        word_spans: word spans within text
+    Returns:
+        character-level italic mask
+    """
+    italic_mask = [False] * len(text)
+    for word_span in word_spans:
+        if not word_span.italic:
+            continue
+        italic_mask[word_span.start : word_span.end] = [True] * (
+            word_span.end - word_span.start
+        )
+    return italic_mask
+
+
+def _include_between_word_italic_separators(
+    text: str, italic_mask: list[bool]
+) -> list[bool]:
+    """Include spaces between adjacent italic words in italic runs.
+
+    Arguments:
+        text: plain text
+        italic_mask: character-level italic mask
+    Returns:
+        italic mask with word separators between italic words included
+    """
+    collapsed_mask = italic_mask.copy()
+    index = 0
+    while index < len(text):
+        if italic_mask[index] or not text[index].isspace():
+            index += 1
+            continue
+
+        start = index
+        while index < len(text) and not italic_mask[index] and text[index].isspace():
+            index += 1
+        end = index
+        if start == 0 or end == len(text):
+            continue
+        if italic_mask[start - 1] and italic_mask[end]:
+            collapsed_mask[start:end] = [True] * (end - start)
+    return collapsed_mask
 
 
 def _title_indicates_italic(title: str | None) -> bool:

--- a/test/image/ocr/tesseract/test_hocr.py
+++ b/test/image/ocr/tesseract/test_hocr.py
@@ -51,6 +51,23 @@ def test_parse_tesseract_hocr_decodes_entities_and_keeps_italics():
     assert parse_tesseract_hocr(hocr) == "<i>Tom</i> & Jerry's"
 
 
+def test_parse_tesseract_hocr_collapses_adjacent_italic_words():
+    """Test hOCR parser includes separators between adjacent italic words."""
+    hocr = """
+    <span class='ocr_line' id='line_1'>
+      <span class='ocrx_word' id='word_1'><em>Gusteau's</em></span>
+      <span class='ocrx_word' id='word_2'><em>restaurant</em></span>
+      <span class='ocrx_word' id='word_3'>is</span>
+      <span class='ocrx_word' id='word_4'><em>booked</em></span>
+      <span class='ocrx_word' id='word_5'><em>solid.</em></span>
+    </span>
+    """
+
+    assert parse_tesseract_hocr(hocr) == (
+        "<i>Gusteau's restaurant</i> is <i>booked solid.</i>"
+    )
+
+
 def test_parse_tesseract_hocr_detects_italic_font_metadata():
     """Test hOCR parser detects Tesseract italic font metadata."""
     hocr = """
@@ -95,6 +112,32 @@ def test_transfer_tesseract_hocr_italics_applies_legacy_emphasis():
 
     assert transfer_tesseract_hocr_italics(primary_hocr, legacy_hocr) == (
         "<i>Hey,</i> let's go"
+    )
+
+
+def test_transfer_tesseract_hocr_italics_collapses_adjacent_words():
+    """Test transferred italics include spaces between adjacent italic words."""
+    primary_hocr = """
+    <span class='ocr_line' id='line_1'>
+      <span class='ocrx_word' id='word_1'>booked</span>
+      <span class='ocrx_word' id='word_2'>five</span>
+      <span class='ocrx_word' id='word_3'>months</span>
+      <span class='ocrx_word' id='word_4'>in</span>
+      <span class='ocrx_word' id='word_5'>advance.</span>
+    </span>
+    """
+    legacy_hocr = """
+    <span class='ocr_line' id='line_1'>
+      <span class='ocrx_word' id='word_1'><em>booked</em></span>
+      <span class='ocrx_word' id='word_2'>five</span>
+      <span class='ocrx_word' id='word_3'><em>months</em></span>
+      <span class='ocrx_word' id='word_4'><em>in</em></span>
+      <span class='ocrx_word' id='word_5'><em>advance.</em></span>
+    </span>
+    """
+
+    assert transfer_tesseract_hocr_italics(primary_hocr, legacy_hocr) == (
+        "<i>booked</i> five <i>months in advance.</i>"
     )
 
 


### PR DESCRIPTION
## Summary

- Collapse adjacent Tesseract italic words into a single italic span that includes the intervening word separator.
- Reuse the character-mask formatting path for parsed hOCR words so direct hOCR italics and transferred legacy italics behave consistently.
- Add regression tests for adjacent italic words in both direct parse and legacy italic-transfer flows.

## Root Cause

Tesseract hOCR parsing preserved italic state per word, but `_format_tesseract_hocr_words` wrapped each italic word before joining words with spaces. That left separators outside the italic run and produced output like `<i>months</i> <i>in</i> <i>advance.</i>`.

The transfer path also applied italics word-by-word at the character-mask level, so adjacent italic words still closed and reopened around spaces.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/image/ocr/tesseract/hocr.py test/image/ocr/tesseract/test_hocr.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/image/ocr/tesseract/hocr.py test/image/ocr/tesseract/test_hocr.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/image/ocr/tesseract/hocr.py test/image/ocr/tesseract/test_hocr.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest test/image/ocr/tesseract/test_hocr.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` from the implementation run: `1094 passed, 4 skipped`

## Manual Check

Regenerated Ratatouille OCR output uncached against `eng-10.sup`; the cited cue now renders as:

```srt
<i>Gusteau's restaurant</i>
<i>is the toast of Paris,</i>

<i>booked</i> five <i>months in advance.</i>
```

The old file had 637 `</i> <i>` boundaries; the regenerated output had 0.