### PR TITLE
Fix English ASS newline cleaning

### DIFF
--- a/scinoephile/lang/eng/cleaning.py
+++ b/scinoephile/lang/eng/cleaning.py
@@ -41,7 +41,7 @@ def _get_english_text_cleaned(text: str) -> str | None:
     Returns:
         Cleaned text, or None if no text remains
     """
-    line_sep = r"\\N"
+    line_sep = "\\N"
     cleaned = text.strip()
 
     # Remove ASS hard-space \h

--- a/test/lang/eng/test_get_eng_cleaned.py
+++ b/test/lang/eng/test_get_eng_cleaned.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from scinoephile.core.subtitles import Series
-from scinoephile.lang.eng.cleaning import get_eng_cleaned
+from scinoephile.lang.eng.cleaning import _get_english_text_cleaned, get_eng_cleaned
 from test.helpers import assert_series_equal
 
 # noinspection PyProtectedMember
@@ -20,6 +20,11 @@ def _test_get_eng_cleaned(series: Series, expected: Series):
     """
     output = get_eng_cleaned(series, remove_empty=False)
     assert_series_equal(output, expected)
+
+
+def test_get_english_text_cleaned_removes_ass_dash_only_line():
+    """Test ASS multiline dash-only line removal."""
+    assert _get_english_text_cleaned("hello\\N-\\Nworld") == "hello\\Nworld"
 
 
 def test_get_eng_cleaned_kob(


### PR DESCRIPTION
## Summary

- Use the actual ASS newline literal (`\N`) when splitting English subtitle text during cleaning.
- Add a focused regression test for a dash-only middle line in ASS multiline text.
- Merge current `master` into the branch and keep the new cached-block cleaning regression from master alongside this PR's regression test.

## Root Cause

English cleaning used `r"\\N"`, which matches a doubled backslash sequence rather than the `\N` separator stored by the subtitle layer. As a result, dash-only lines inside ASS multiline text were not removed.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format test/lang/eng/test_get_eng_cleaned.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix test/lang/eng/test_get_eng_cleaned.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check test/lang/eng/test_get_eng_cleaned.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest test/lang/eng/test_get_eng_cleaned.py::test_get_english_text_cleaned_removes_ass_dash_only_line test/lang/eng/test_get_eng_cleaned.py::test_get_eng_cleaned_invalidates_cached_blocks`
- From `test/`: `UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` (`1099 passed, 4 skipped`)
