### PR TITLE
Invalidate subtitle block cache on event replacement

### DIFF
--- a/scinoephile/core/subtitles/series.py
+++ b/scinoephile/core/subtitles/series.py
@@ -102,6 +102,18 @@ class Series(SSAFile):
             f"<{self.__class__.__name__} with 0 events and {len(self.styles)} styles>"
         )
 
+    @override
+    def __setattr__(self, name: str, value: object):
+        """Set attribute, invalidating cached blocks after event replacement.
+
+        Arguments:
+            name: attribute name
+            value: attribute value
+        """
+        super().__setattr__(name, value)
+        if name == "events" and hasattr(self, "_blocks"):
+            self._blocks = None
+
     @property
     def blocks(self) -> list[Series]:
         """List of blocks in the series."""

--- a/test/lang/eng/test_get_eng_cleaned.py
+++ b/test/lang/eng/test_get_eng_cleaned.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from scinoephile.core.subtitles import Series
+from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.lang.eng.cleaning import get_eng_cleaned
 from test.helpers import assert_series_equal
 
@@ -33,6 +33,19 @@ def test_get_eng_cleaned_kob(
         kob_eng_ocr_fuse_clean: Expected cleaned KOB English series fixture
     """
     _test_get_eng_cleaned(kob_eng_ocr_fuse, kob_eng_ocr_fuse_clean)
+
+
+def test_get_eng_cleaned_invalidates_cached_blocks():
+    """Test get_eng_cleaned invalidates cached blocks when events are removed."""
+    series = Series(events=[Subtitle(start=0, end=1000, text="-")])
+    assert [[event.text for event in block.events] for block in series.blocks] == [
+        ["-"]
+    ]
+
+    output = get_eng_cleaned(series)
+
+    assert output.events == []
+    assert output.blocks == []
 
 
 def test_get_eng_cleaned_mlamd(


### PR DESCRIPTION
## Summary
- Invalidate `Series._blocks` whenever `events` is replaced, so transforms that deepcopy and filter events rebuild blocks from current subtitles.
- Add a regression test for English cleaning where a cached one-event `"-"` series becomes empty and must also have no blocks.

## Root Cause
`Series.blocks` is cached in `_blocks`. `get_eng_cleaned()` deep-copies the input series, including a populated `_blocks`, then replaces `series.events` after removing empty subtitles. That event replacement did not invalidate the copied cache, so `.blocks` could still expose removed subtitles.

## Testing
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/core/subtitles/series.py test/lang/eng/test_get_eng_cleaned.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/core/subtitles/series.py test/lang/eng/test_get_eng_cleaned.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/core/subtitles/series.py test/lang/eng/test_get_eng_cleaned.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` (`1098 passed, 4 skipped`)