### PR TITLE
Fix Chinese conversion exclusions

### DIFF
--- a/scinoephile/lang/zho/script/conversion.py
+++ b/scinoephile/lang/zho/script/conversion.py
@@ -157,14 +157,18 @@ def get_zho_text_converted(
     converter = get_zho_converter(config)
     converted_text = converter.convert(text)
 
+    excluded_chars: set[str] = set()
     if apply_exclusions:
         if config in SIMPLIFIED_CONFIGS:
-            for trad_char, simp_char in _conversion_exclusions.items():
-                if trad_char in text and simp_char in converted_text:
-                    converted_text = converted_text.replace(simp_char, trad_char)
+            excluded_chars = set(_conversion_exclusions)
         if config in TRADITIONAL_CONFIGS:
-            for trad_char, simp_char in _conversion_exclusions.items():
-                if simp_char in text and trad_char in converted_text:
-                    converted_text = converted_text.replace(trad_char, simp_char)
+            excluded_chars = set(_conversion_exclusions.values())
+
+    if excluded_chars and len(converted_text) == len(text):
+        converted_chars = list(converted_text)
+        for index, char in enumerate(text):
+            if char in excluded_chars:
+                converted_chars[index] = char
+        converted_text = "".join(converted_chars)
 
     return converted_text

--- a/test/lang/zho/test_get_zho_converted.py
+++ b/test/lang/zho/test_get_zho_converted.py
@@ -11,6 +11,7 @@ from scinoephile.lang.zho.script.conversion import (
     OpenCCConfig,
     get_zho_converted,
     get_zho_converter,
+    get_zho_text_converted,
 )
 from test.helpers import assert_series_equal
 
@@ -35,6 +36,29 @@ def _test_get_zho_converted(series: Series, config: OpenCCConfig, expected: Seri
     output = get_zho_converted(series, config)
     assert len(series) == len(output)
     assert_series_equal(output, expected)
+
+
+@pytest.mark.parametrize(
+    ("text", "config", "expected"),
+    [
+        ("台臺", OpenCCConfig.t2s, "台臺"),
+        ("台臺", OpenCCConfig.s2t, "台臺"),
+        ("台灣臺灣", OpenCCConfig.t2s, "台湾臺湾"),
+        ("台湾臺湾", OpenCCConfig.s2t, "台灣臺灣"),
+        ("这家伙", OpenCCConfig.s2t, "這傢伙"),
+    ],
+)
+def test_get_zho_text_converted_applies_exclusions_by_character_position(
+    text: str, config: OpenCCConfig, expected: str
+):
+    """Test conversion exclusions preserve only original excluded characters.
+
+    Arguments:
+        text: Text to convert
+        config: Conversion configuration
+        expected: Expected converted text
+    """
+    assert get_zho_text_converted(text, config) == expected
 
 
 def test_get_zho_converted_kob(


### PR DESCRIPTION
## Summary
- Convert the full text with OpenCC first, then restore excluded characters only at matching original character positions.
- Avoid global post-conversion replacements that can corrupt mixed simplified/traditional text.
- Add regression coverage for mixed excluded/non-excluded characters and for phrase context around an excluded character.

## Root Cause
`get_zho_text_converted` converted the full text first, then used `str.replace` globally whenever an excluded character appeared in the original input. In mixed strings such as `台臺`, that rewrote converted partners that came from non-excluded original positions.

## Fixture Impact
A scan comparing the previous global replacement behavior with the updated position-aware behavior across 168 checked-in `.srt` fixtures found zero old/new conversion differences, so no fixture regeneration was needed. The affected mixed-position behavior is covered by direct regression tests instead.

## Validation
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest lang/zho/test_get_zho_converted.py -q`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/lang/zho/script/conversion.py test/lang/zho/test_get_zho_converted.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/lang/zho/script/conversion.py test/lang/zho/test_get_zho_converted.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/lang/zho/script/conversion.py test/lang/zho/test_get_zho_converted.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto`