### PR TITLE
Support fragmented SUP images

### DIFF
--- a/scinoephile/image/subtitles/sup.py
+++ b/scinoephile/image/subtitles/sup.py
@@ -155,6 +155,13 @@ def read_sup_series(  # noqa: PLR0912, PLR0915
     current_image = np.zeros((0, 0), np.uint8)
     has_current_image = False
 
+    pending_image_data = np.zeros(0, np.uint8)
+    pending_image_data_length = -1
+    pending_image_height = 0
+    pending_image_object_id = -1
+    pending_image_version = -1
+    pending_image_width = 0
+
     active_start = -1.0
     active_image = np.zeros((0, 0, 4), np.uint8)
     has_active_image = False
@@ -192,12 +199,74 @@ def read_sup_series(  # noqa: PLR0912, PLR0915
                 raise ValueError("SUP palette segment is truncated.")
             palette = read_sup_palette(segment_bytes[2:])
         elif segment_kind == 0x15:  # Image
-            if size < 11:
+            if size < 4:
                 raise ValueError("SUP image segment is truncated.")
-            width = int(segment_bytes[7]) * 256 + int(segment_bytes[8])
-            height = int(segment_bytes[9]) * 256 + int(segment_bytes[10])
-            current_image = read_sup_image_array(segment_bytes[11:], height, width)
-            has_current_image = True
+            object_id = int(segment_bytes[0]) * 256 + int(segment_bytes[1])
+            object_version = int(segment_bytes[2])
+            sequence_descriptor = int(segment_bytes[3])
+            if (sequence_descriptor & 0x3F) != 0:
+                raise ValueError("SUP image segment has invalid sequence descriptor.")
+
+            if (sequence_descriptor & 0x80) != 0:
+                if pending_image_object_id >= 0:
+                    raise ValueError(
+                        "SUP image segment started before previous image completed."
+                    )
+                if size < 11:
+                    raise ValueError("SUP image segment is truncated.")
+                object_data_length = (
+                    int(segment_bytes[4]) * 65536
+                    + int(segment_bytes[5]) * 256
+                    + int(segment_bytes[6])
+                )
+                if object_data_length < 4:
+                    raise ValueError("SUP image segment is truncated.")
+                pending_image_data = segment_bytes[11:]
+                pending_image_data_length = object_data_length - 4
+                pending_image_height = int(segment_bytes[9]) * 256 + int(
+                    segment_bytes[10]
+                )
+                pending_image_object_id = object_id
+                pending_image_version = object_version
+                pending_image_width = int(segment_bytes[7]) * 256 + int(
+                    segment_bytes[8]
+                )
+            else:
+                if pending_image_object_id < 0:
+                    raise ValueError(
+                        "Encountered SUP image continuation without initial image "
+                        "segment."
+                    )
+                if (
+                    object_id != pending_image_object_id
+                    or object_version != pending_image_version
+                ):
+                    raise ValueError(
+                        "SUP image continuation does not match initial image segment."
+                    )
+                pending_image_data = np.concatenate(
+                    (pending_image_data, segment_bytes[4:])
+                )
+
+            if len(pending_image_data) > pending_image_data_length:
+                raise ValueError(
+                    "SUP image data extends past declared object data length."
+                )
+            if (sequence_descriptor & 0x40) != 0:
+                if len(pending_image_data) != pending_image_data_length:
+                    raise ValueError("SUP image segment data is truncated.")
+                current_image = read_sup_image_array(
+                    pending_image_data,
+                    pending_image_height,
+                    pending_image_width,
+                )
+                has_current_image = True
+                pending_image_data = np.zeros(0, np.uint8)
+                pending_image_data_length = -1
+                pending_image_height = 0
+                pending_image_object_id = -1
+                pending_image_version = -1
+                pending_image_width = 0
         elif segment_kind == 0x16:  # Presentation Composition
             if size < 11:
                 raise ValueError("SUP presentation composition segment is truncated.")
@@ -240,6 +309,9 @@ def read_sup_series(  # noqa: PLR0912, PLR0915
             set_has_object = False
 
         byte_i += size
+
+    if pending_image_object_id >= 0:
+        raise ValueError("SUP image segment data is truncated.")
 
     if has_active_image:
         starts.append(active_start)

--- a/test/image/subtitles/test_sup.py
+++ b/test/image/subtitles/test_sup.py
@@ -76,7 +76,8 @@ def test_read_sup_series_supports_fragmented_image_segments():
     """Test SUP image objects split across multiple segments are assembled."""
     rle_data = b"\x01\x01\x01\x00\x00\x01\x01\x01"
     object_data_length = 4 + len(rle_data)
-    first_fragment = rle_data[:5]
+    first_fragment = rle_data[:3]
+    middle_fragment = rle_data[3:5]
     last_fragment = rle_data[5:]
     data = np.frombuffer(
         b"".join(
@@ -97,6 +98,7 @@ def test_read_sup_series_supports_fragmented_image_segments():
                         + first_fragment
                     ),
                 ),
+                _sup_segment(90000, 0x15, b"\x00\x00\x00\x00" + middle_fragment),
                 _sup_segment(90000, 0x15, b"\x00\x00\x00\x40" + last_fragment),
                 _sup_segment(90000, 0x80, b""),
                 _sup_segment(

--- a/test/image/subtitles/test_sup.py
+++ b/test/image/subtitles/test_sup.py
@@ -10,6 +10,35 @@ import pytest
 from scinoephile.image.subtitles.sup import read_sup_image_array, read_sup_series
 
 
+def _sup_segment(timestamp: int, kind: int, payload: bytes) -> bytes:
+    """Build one SUP segment for parser tests.
+
+    Arguments:
+        timestamp: 90 kHz timestamp
+        kind: segment kind
+        payload: segment payload bytes
+    Returns:
+        complete segment bytes
+    """
+    pts = timestamp.to_bytes(4, "big")
+    return b"PG" + pts + pts + bytes([kind]) + len(payload).to_bytes(2, "big") + payload
+
+
+def _presentation_segment(composition_number: int, object_count: int) -> bytes:
+    """Build a minimal presentation composition segment.
+
+    Arguments:
+        composition_number: presentation composition number
+        object_count: number of referenced objects
+    Returns:
+        presentation composition payload bytes
+    """
+    payload = bytearray(11)
+    payload[5:7] = composition_number.to_bytes(2, "big")
+    payload[10] = object_count
+    return bytes(payload)
+
+
 def test_read_sup_image_array_rejects_row_overflow():
     """Test SUP image RLE data cannot exceed the declared row width."""
     data = np.array([0x00, 0x02], dtype=np.uint8)
@@ -41,6 +70,53 @@ def test_read_sup_series_rejects_truncated_segment_data():
 
     with pytest.raises(ValueError, match="segment data is truncated"):
         read_sup_series(data)
+
+
+def test_read_sup_series_supports_fragmented_image_segments():
+    """Test SUP image objects split across multiple segments are assembled."""
+    rle_data = b"\x01\x01\x01\x00\x00\x01\x01\x01"
+    object_data_length = 4 + len(rle_data)
+    first_fragment = rle_data[:5]
+    last_fragment = rle_data[5:]
+    data = np.frombuffer(
+        b"".join(
+            [
+                _sup_segment(
+                    90000,
+                    0x16,
+                    _presentation_segment(composition_number=1, object_count=1),
+                ),
+                _sup_segment(90000, 0x14, b"\x00\x00\x01\x80\x80\x80\xff"),
+                _sup_segment(
+                    90000,
+                    0x15,
+                    (
+                        b"\x00\x00\x00\x80"
+                        + object_data_length.to_bytes(3, "big")
+                        + b"\x00\x03\x00\x02"
+                        + first_fragment
+                    ),
+                ),
+                _sup_segment(90000, 0x15, b"\x00\x00\x00\x40" + last_fragment),
+                _sup_segment(90000, 0x80, b""),
+                _sup_segment(
+                    180000,
+                    0x16,
+                    _presentation_segment(composition_number=2, object_count=0),
+                ),
+                _sup_segment(180000, 0x80, b""),
+            ]
+        ),
+        dtype=np.uint8,
+    )
+
+    starts, ends, images = read_sup_series(data)
+
+    assert starts == [1.0]
+    assert ends == [2.0]
+    assert len(images) == 1
+    assert images[0].shape == (2, 3, 4)
+    assert np.all(images[0][:, :, 3] == 255)
 
 
 def test_read_sup_series_rejects_truncated_palette_entry():


### PR DESCRIPTION
## Summary

- Assemble fragmented PGS Object Definition Segments before decoding SUP image RLE data.
- Keep strict validation for orphaned, mismatched, overlong, or truncated image fragment chains.
- Add a synthetic fragmented SUP regression test.

## Root Cause

The Cinderella SUP file is valid PGS data with image objects split across multiple Object Definition Segments. The parser treated every image segment as a complete standalone object, so it misread a continuation fragment as width and height data and raised a row-width overflow.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/image/subtitles/sup.py test/image/subtitles/test_sup.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/image/subtitles/sup.py test/image/subtitles/test_sup.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/image/subtitles/sup.py test/image/subtitles/test_sup.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest test/image/subtitles/test_sup.py test/image/subtitles/test_image_series.py::test_load_sup`
- Direct load of `/Users/karldebiec/Code/ScinoephileProjects/scinoephile_projects/data/Cinderella (1950)/input/localization/zho-Hans-8.sup`: 945 events
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto`