### PR TITLE
Speed up line alignment with numba

### DIFF
--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -48,6 +48,7 @@
 * Exclusively use f-strings for string interpolation.
 * Where possible, classes should implement `__repr__` methods such that they may be reconstructed from its `repr` output.
 * Avoid ternary expressions; prefer explicit `if`/`else` statements for readability.
+* Use one-line block comments above continuous blocks of code when they help separate the steps of nontrivial logic; do not end these comments with periods.
 
 ## Type Annotations
 * Include type annotations for all function and method signatures, with the following exception:

--- a/scinoephile/analysis/line_alignment/line_alignment.py
+++ b/scinoephile/analysis/line_alignment/line_alignment.py
@@ -4,6 +4,9 @@
 
 from __future__ import annotations
 
+import numba as nb
+import numpy as np
+
 from .line_alignment_operation import LineAlignmentOperation
 from .line_alignment_pair import LineAlignmentPair
 
@@ -16,7 +19,176 @@ _OPERATION_DELETE = LineAlignmentOperation.DELETE.value
 _OPERATION_INSERT = LineAlignmentOperation.INSERT.value
 _GAP_NONE = -1
 
-type _MetricKey = tuple[int, int, int, int, int]
+
+@nb.jit(nopython=True, nogil=True, cache=True)
+def _get_alignment_operation_table(  # noqa: PLR0915
+    one: np.ndarray,
+    two: np.ndarray,
+) -> np.ndarray:
+    """Get the compact dynamic-programming operation table.
+
+    Arguments:
+        one: first string as Unicode code points
+        two: second string as Unicode code points
+    Returns:
+        operation table used to backtrace the best alignment
+    """
+    one_length = len(one)
+    two_length = len(two)
+    operation_table = np.full(
+        (one_length + 1, two_length + 1),
+        _OPERATION_NONE,
+        dtype=np.uint8,
+    )
+    if two_length > 0:
+        operation_table[0, 1:] = _OPERATION_INSERT
+
+    previous_metrics = np.zeros((two_length + 1, 5), dtype=np.int32)
+    current_metrics = np.empty((two_length + 1, 5), dtype=np.int32)
+    previous_gaps = np.empty(two_length + 1, dtype=np.int16)
+    current_gaps = np.empty(two_length + 1, dtype=np.int16)
+
+    previous_gaps[0] = _GAP_NONE
+    for two_idx in range(1, two_length + 1):
+        previous_metrics[two_idx, 0] = two_idx
+        previous_metrics[two_idx, 1] = 1
+        previous_metrics[two_idx, 2] = 0
+        previous_metrics[two_idx, 3] = 0
+        previous_metrics[two_idx, 4] = two_idx
+        previous_gaps[two_idx] = _OPERATION_INSERT
+
+    for one_idx in range(1, one_length + 1):
+        operation_table[one_idx, 0] = _OPERATION_DELETE
+        current_metrics[0, 0] = one_idx
+        current_metrics[0, 1] = 1
+        current_metrics[0, 2] = 0
+        current_metrics[0, 3] = one_idx
+        current_metrics[0, 4] = 0
+        current_gaps[0] = _OPERATION_DELETE
+        one_char = one[one_idx - 1]
+
+        for two_idx in range(1, two_length + 1):
+            two_char = two[two_idx - 1]
+            previous_diagonal_idx = two_idx - 1
+            if one_char == two_char:
+                best_0 = previous_metrics[previous_diagonal_idx, 0]
+                best_1 = previous_metrics[previous_diagonal_idx, 1]
+                best_2 = previous_metrics[previous_diagonal_idx, 2]
+                best_3 = previous_metrics[previous_diagonal_idx, 3]
+                best_4 = previous_metrics[previous_diagonal_idx, 4]
+                best_operation = _OPERATION_MATCH
+                best_gap = _GAP_NONE
+            else:
+                best_0 = previous_metrics[previous_diagonal_idx, 0] + 1
+                best_1 = previous_metrics[previous_diagonal_idx, 1]
+                best_2 = previous_metrics[previous_diagonal_idx, 2] + 1
+                best_3 = previous_metrics[previous_diagonal_idx, 3]
+                best_4 = previous_metrics[previous_diagonal_idx, 4]
+                best_operation = _OPERATION_SUBSTITUTE
+                best_gap = _GAP_NONE
+
+            previous_insert_idx = two_idx - 1
+            insert_1 = current_metrics[previous_insert_idx, 1]
+            if current_gaps[previous_insert_idx] != _OPERATION_INSERT:
+                insert_1 += 1
+            insert_0 = current_metrics[previous_insert_idx, 0] + 1
+            insert_2 = current_metrics[previous_insert_idx, 2]
+            insert_3 = current_metrics[previous_insert_idx, 3]
+            insert_4 = current_metrics[previous_insert_idx, 4] + 1
+            if insert_0 < best_0 or (
+                insert_0 == best_0
+                and (
+                    insert_1 < best_1
+                    or (
+                        insert_1 == best_1
+                        and (
+                            insert_2 < best_2
+                            or (
+                                insert_2 == best_2
+                                and (
+                                    insert_3 < best_3
+                                    or (insert_3 == best_3 and insert_4 < best_4)
+                                )
+                            )
+                        )
+                    )
+                )
+            ):
+                best_0 = insert_0
+                best_1 = insert_1
+                best_2 = insert_2
+                best_3 = insert_3
+                best_4 = insert_4
+                best_operation = _OPERATION_INSERT
+                best_gap = _OPERATION_INSERT
+
+            delete_1 = previous_metrics[two_idx, 1]
+            if previous_gaps[two_idx] != _OPERATION_DELETE:
+                delete_1 += 1
+            delete_0 = previous_metrics[two_idx, 0] + 1
+            delete_2 = previous_metrics[two_idx, 2]
+            delete_3 = previous_metrics[two_idx, 3] + 1
+            delete_4 = previous_metrics[two_idx, 4]
+            delete_is_less = delete_0 < best_0 or (
+                delete_0 == best_0
+                and (
+                    delete_1 < best_1
+                    or (
+                        delete_1 == best_1
+                        and (
+                            delete_2 < best_2
+                            or (
+                                delete_2 == best_2
+                                and (
+                                    delete_3 < best_3
+                                    or (delete_3 == best_3 and delete_4 < best_4)
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+            delete_is_equal = (
+                delete_0 == best_0
+                and delete_1 == best_1
+                and delete_2 == best_2
+                and delete_3 == best_3
+                and delete_4 == best_4
+            )
+            if delete_is_less or (
+                delete_is_equal and _OPERATION_DELETE < best_operation
+            ):
+                best_0 = delete_0
+                best_1 = delete_1
+                best_2 = delete_2
+                best_3 = delete_3
+                best_4 = delete_4
+                best_operation = _OPERATION_DELETE
+                best_gap = _OPERATION_DELETE
+
+            current_metrics[two_idx, 0] = best_0
+            current_metrics[two_idx, 1] = best_1
+            current_metrics[two_idx, 2] = best_2
+            current_metrics[two_idx, 3] = best_3
+            current_metrics[two_idx, 4] = best_4
+            current_gaps[two_idx] = best_gap
+            operation_table[one_idx, two_idx] = best_operation
+
+        previous_metrics, current_metrics = current_metrics, previous_metrics
+        previous_gaps, current_gaps = current_gaps, previous_gaps
+
+    return operation_table
+
+
+def _get_codepoints(text: str) -> np.ndarray:
+    """Convert text to Unicode code points.
+
+    Arguments:
+        text: text to convert
+    Returns:
+        integer code points
+    """
+    return np.fromiter((ord(char) for char in text), dtype=np.int32, count=len(text))
 
 
 class LineAlignment:
@@ -55,141 +227,19 @@ class LineAlignment:
         """
         return f"{type(self).__name__}({self.one!r}, {self.two!r})"
 
-    def _get_operation_table(  # noqa: PLR0915
-        self,
-    ) -> list[bytearray]:
+    def _get_operation_table(self) -> np.ndarray:
         """Get the compact dynamic-programming operation table.
 
         Returns:
             operation table used to backtrace the best alignment
         """
-        one_length = len(self.one)
-        two_length = len(self.two)
-
-        # Initialize the backtrace-only table. Metrics are kept only for the
-        # previous and current rows, but every chosen operation must be retained
-        # so the final alignment can be reconstructed from bottom-right to top-left.
-        operation_table = [
-            bytearray([_OPERATION_NONE]) * (two_length + 1)
-            for _ in range(one_length + 1)
-        ]
-        if two_length > 0:
-            operation_table[0][1:] = bytearray([_OPERATION_INSERT]) * two_length
-
-        # The top edge aligns an empty first string with prefixes of `two`, so
-        # every non-origin cell is reached by one contiguous insert run.
-        previous_metrics = [
-            self._get_insert_metric(two_idx) for two_idx in range(two_length + 1)
-        ]
-        previous_gaps = [_GAP_NONE]
-        previous_gaps.extend(_OPERATION_INSERT for _ in range(two_length))
-
-        for one_idx in range(1, one_length + 1):
-            # The left edge aligns prefixes of `one` with an empty second string,
-            # so each row starts with one contiguous delete run.
-            operation_table[one_idx][0] = _OPERATION_DELETE
-            current_metrics = [self._get_delete_metric(one_idx)]
-            current_gaps = [_OPERATION_DELETE]
-            one_char = self.one[one_idx - 1]
-            operation_row = operation_table[one_idx]
-
-            for two_idx in range(1, two_length + 1):
-                two_char = self.two[two_idx - 1]
-
-                # The diagonal candidate consumes one character from both sides.
-                # It is free for a match and costs one substitution otherwise.
-                previous_diagonal = previous_metrics[two_idx - 1]
-                if one_char == two_char:
-                    best_key = previous_diagonal
-                    best_operation = _OPERATION_MATCH
-                    best_gap = _GAP_NONE
-                else:
-                    best_key = (
-                        previous_diagonal[0] + 1,
-                        previous_diagonal[1],
-                        previous_diagonal[2] + 1,
-                        previous_diagonal[3],
-                        previous_diagonal[4],
-                    )
-                    best_operation = _OPERATION_SUBSTITUTE
-                    best_gap = _GAP_NONE
-
-                # The left candidate consumes the next character from `two`.
-                # Starting a new insert run is worse than extending an existing one.
-                previous_insert = current_metrics[two_idx - 1]
-                insert_gap_runs = previous_insert[1]
-                if current_gaps[two_idx - 1] != _OPERATION_INSERT:
-                    insert_gap_runs += 1
-                insert_key = (
-                    previous_insert[0] + 1,
-                    insert_gap_runs,
-                    previous_insert[2],
-                    previous_insert[3],
-                    previous_insert[4] + 1,
-                )
-                if insert_key < best_key:
-                    best_key = insert_key
-                    best_operation = _OPERATION_INSERT
-                    best_gap = _OPERATION_INSERT
-
-                # The upper candidate consumes the next character from `one`.
-                # Ties are resolved by operation enum order to match prior behavior.
-                previous_delete = previous_metrics[two_idx]
-                delete_gap_runs = previous_delete[1]
-                if previous_gaps[two_idx] != _OPERATION_DELETE:
-                    delete_gap_runs += 1
-                delete_key = (
-                    previous_delete[0] + 1,
-                    delete_gap_runs,
-                    previous_delete[2],
-                    previous_delete[3] + 1,
-                    previous_delete[4],
-                )
-                if delete_key < best_key or (
-                    delete_key == best_key and _OPERATION_DELETE < best_operation
-                ):
-                    best_key = delete_key
-                    best_operation = _OPERATION_DELETE
-                    best_gap = _OPERATION_DELETE
-
-                current_metrics.append(best_key)
-                current_gaps.append(best_gap)
-                operation_row[two_idx] = best_operation
-
-            previous_metrics = current_metrics
-            previous_gaps = current_gaps
-
-        return operation_table
-
-    @staticmethod
-    def _get_delete_metric(count: int) -> _MetricKey:
-        """Build an edge metric for forced deletes.
-
-        Arguments:
-            count: number of deleted characters
-        Returns:
-            metric for a prefix aligned only by deletes
-        """
-        if count == 0:
-            return (0, 0, 0, 0, 0)
-        return (count, 1, 0, count, 0)
-
-    @staticmethod
-    def _get_insert_metric(count: int) -> _MetricKey:
-        """Build an edge metric for forced inserts.
-
-        Arguments:
-            count: number of inserted characters
-        Returns:
-            metric for a prefix aligned only by inserts
-        """
-        if count == 0:
-            return (0, 0, 0, 0, 0)
-        return (count, 1, 0, 0, count)
+        one = _get_codepoints(self.one)
+        two = _get_codepoints(self.two)
+        return _get_alignment_operation_table(one, two)
 
     def _populate_alignment_pairs(
         self,
-        operation_table: list[bytearray],
+        operation_table: np.ndarray,
     ):
         """Populate alignment pairs by backtracing DP operations.
 
@@ -200,7 +250,7 @@ class LineAlignment:
         two_idx = len(self.two)
         self.alignment_pairs = []
         while one_idx != 0 or two_idx != 0:
-            operation_value = operation_table[one_idx][two_idx]
+            operation_value = int(operation_table[one_idx, two_idx])
             if operation_value == _OPERATION_NONE:
                 break
             operation = LineAlignmentOperation(operation_value)

--- a/scinoephile/analysis/line_alignment/line_alignment.py
+++ b/scinoephile/analysis/line_alignment/line_alignment.py
@@ -50,20 +50,12 @@ def _get_alignment_operation_table(  # noqa: PLR0915
 
     previous_gaps[0] = _GAP_NONE
     for two_idx in range(1, two_length + 1):
-        previous_metrics[two_idx, 0] = two_idx
-        previous_metrics[two_idx, 1] = 1
-        previous_metrics[two_idx, 2] = 0
-        previous_metrics[two_idx, 3] = 0
-        previous_metrics[two_idx, 4] = two_idx
+        _set_metric(previous_metrics, two_idx, two_idx, 1, 0, 0, two_idx)
         previous_gaps[two_idx] = _OPERATION_INSERT
 
     for one_idx in range(1, one_length + 1):
         operation_table[one_idx, 0] = _OPERATION_DELETE
-        current_metrics[0, 0] = one_idx
-        current_metrics[0, 1] = 1
-        current_metrics[0, 2] = 0
-        current_metrics[0, 3] = one_idx
-        current_metrics[0, 4] = 0
+        _set_metric(current_metrics, 0, one_idx, 1, 0, one_idx, 0)
         current_gaps[0] = _OPERATION_DELETE
         one_char = one[one_idx - 1]
 
@@ -95,24 +87,17 @@ def _get_alignment_operation_table(  # noqa: PLR0915
             insert_2 = current_metrics[previous_insert_idx, 2]
             insert_3 = current_metrics[previous_insert_idx, 3]
             insert_4 = current_metrics[previous_insert_idx, 4] + 1
-            if insert_0 < best_0 or (
-                insert_0 == best_0
-                and (
-                    insert_1 < best_1
-                    or (
-                        insert_1 == best_1
-                        and (
-                            insert_2 < best_2
-                            or (
-                                insert_2 == best_2
-                                and (
-                                    insert_3 < best_3
-                                    or (insert_3 == best_3 and insert_4 < best_4)
-                                )
-                            )
-                        )
-                    )
-                )
+            if _is_metric_less(
+                insert_0,
+                insert_1,
+                insert_2,
+                insert_3,
+                insert_4,
+                best_0,
+                best_1,
+                best_2,
+                best_3,
+                best_4,
             ):
                 best_0 = insert_0
                 best_1 = insert_1
@@ -129,31 +114,29 @@ def _get_alignment_operation_table(  # noqa: PLR0915
             delete_2 = previous_metrics[two_idx, 2]
             delete_3 = previous_metrics[two_idx, 3] + 1
             delete_4 = previous_metrics[two_idx, 4]
-            delete_is_less = delete_0 < best_0 or (
-                delete_0 == best_0
-                and (
-                    delete_1 < best_1
-                    or (
-                        delete_1 == best_1
-                        and (
-                            delete_2 < best_2
-                            or (
-                                delete_2 == best_2
-                                and (
-                                    delete_3 < best_3
-                                    or (delete_3 == best_3 and delete_4 < best_4)
-                                )
-                            )
-                        )
-                    )
-                )
+            delete_is_less = _is_metric_less(
+                delete_0,
+                delete_1,
+                delete_2,
+                delete_3,
+                delete_4,
+                best_0,
+                best_1,
+                best_2,
+                best_3,
+                best_4,
             )
-            delete_is_equal = (
-                delete_0 == best_0
-                and delete_1 == best_1
-                and delete_2 == best_2
-                and delete_3 == best_3
-                and delete_4 == best_4
+            delete_is_equal = _is_metric_equal(
+                delete_0,
+                delete_1,
+                delete_2,
+                delete_3,
+                delete_4,
+                best_0,
+                best_1,
+                best_2,
+                best_3,
+                best_4,
             )
             if delete_is_less or (
                 delete_is_equal and _OPERATION_DELETE < best_operation
@@ -166,11 +149,15 @@ def _get_alignment_operation_table(  # noqa: PLR0915
                 best_operation = _OPERATION_DELETE
                 best_gap = _OPERATION_DELETE
 
-            current_metrics[two_idx, 0] = best_0
-            current_metrics[two_idx, 1] = best_1
-            current_metrics[two_idx, 2] = best_2
-            current_metrics[two_idx, 3] = best_3
-            current_metrics[two_idx, 4] = best_4
+            _set_metric(
+                current_metrics,
+                two_idx,
+                best_0,
+                best_1,
+                best_2,
+                best_3,
+                best_4,
+            )
             current_gaps[two_idx] = best_gap
             operation_table[one_idx, two_idx] = best_operation
 
@@ -189,6 +176,112 @@ def _get_codepoints(text: str) -> np.ndarray:
         integer code points
     """
     return np.fromiter((ord(char) for char in text), dtype=np.int32, count=len(text))
+
+
+@nb.jit(nopython=True, nogil=True, inline="always")
+def _is_metric_equal(
+    left_0: int,
+    left_1: int,
+    left_2: int,
+    left_3: int,
+    left_4: int,
+    right_0: int,
+    right_1: int,
+    right_2: int,
+    right_3: int,
+    right_4: int,
+) -> bool:
+    """Check whether two alignment metrics are equal.
+
+    Arguments:
+        left_0: first element of the left metric
+        left_1: second element of the left metric
+        left_2: third element of the left metric
+        left_3: fourth element of the left metric
+        left_4: fifth element of the left metric
+        right_0: first element of the right metric
+        right_1: second element of the right metric
+        right_2: third element of the right metric
+        right_3: fourth element of the right metric
+        right_4: fifth element of the right metric
+    Returns:
+        whether the two metrics are equal
+    """
+    return (
+        left_0 == right_0
+        and left_1 == right_1
+        and left_2 == right_2
+        and left_3 == right_3
+        and left_4 == right_4
+    )
+
+
+@nb.jit(nopython=True, nogil=True, inline="always")
+def _is_metric_less(
+    left_0: int,
+    left_1: int,
+    left_2: int,
+    left_3: int,
+    left_4: int,
+    right_0: int,
+    right_1: int,
+    right_2: int,
+    right_3: int,
+    right_4: int,
+) -> bool:
+    """Check whether one alignment metric sorts before another.
+
+    Arguments:
+        left_0: first element of the left metric
+        left_1: second element of the left metric
+        left_2: third element of the left metric
+        left_3: fourth element of the left metric
+        left_4: fifth element of the left metric
+        right_0: first element of the right metric
+        right_1: second element of the right metric
+        right_2: third element of the right metric
+        right_3: fourth element of the right metric
+        right_4: fifth element of the right metric
+    Returns:
+        whether the left metric sorts before the right metric
+    """
+    if left_0 != right_0:
+        return left_0 < right_0
+    if left_1 != right_1:
+        return left_1 < right_1
+    if left_2 != right_2:
+        return left_2 < right_2
+    if left_3 != right_3:
+        return left_3 < right_3
+    return left_4 < right_4
+
+
+@nb.jit(nopython=True, nogil=True, inline="always")
+def _set_metric(
+    metrics: np.ndarray,
+    idx: int,
+    value_0: int,
+    value_1: int,
+    value_2: int,
+    value_3: int,
+    value_4: int,
+):
+    """Set one row of the alignment metric table.
+
+    Arguments:
+        metrics: metric table to update
+        idx: row index to update
+        value_0: first metric value
+        value_1: second metric value
+        value_2: third metric value
+        value_3: fourth metric value
+        value_4: fifth metric value
+    """
+    metrics[idx, 0] = value_0
+    metrics[idx, 1] = value_1
+    metrics[idx, 2] = value_2
+    metrics[idx, 3] = value_3
+    metrics[idx, 4] = value_4
 
 
 class LineAlignment:

--- a/scinoephile/analysis/line_alignment/line_alignment.py
+++ b/scinoephile/analysis/line_alignment/line_alignment.py
@@ -20,6 +20,108 @@ _OPERATION_INSERT = LineAlignmentOperation.INSERT.value
 _GAP_NONE = -1
 
 
+class LineAlignment:
+    """Character-level alignment between two strings.
+
+    Uses Levenshtein-style dynamic programming with backtrace. The fill step
+    keeps only the previous and current metric rows, plus one compact operation
+    table for backtrace, to avoid allocating Python objects for every candidate
+    in large subtitle blocks.
+    """
+
+    def __init__(self, one: str, two: str):
+        """Initialize and fill dynamic-programming tables.
+
+        Arguments:
+            one: first string
+            two: second string
+        """
+        self.one = one
+        """First string."""
+
+        self.two = two
+        """Second string."""
+
+        self.alignment_pairs: list[LineAlignmentPair] = []
+        """Aligned character pairs."""
+
+        # Fill the alignment from the compact operation table
+        operation_table = self._get_operation_table()
+        self._populate_alignment_pairs(operation_table)
+
+    def __repr__(self) -> str:
+        """Return a reconstructable representation of this alignment.
+
+        Returns:
+            reconstructable representation
+        """
+        return f"{type(self).__name__}({self.one!r}, {self.two!r})"
+
+    def _get_operation_table(self) -> np.ndarray:
+        """Get the compact dynamic-programming operation table.
+
+        Returns:
+            operation table used to backtrace the best alignment
+        """
+        one = _get_codepoints(self.one)
+        two = _get_codepoints(self.two)
+        return _get_alignment_operation_table(one, two)
+
+    def _populate_alignment_pairs(
+        self,
+        operation_table: np.ndarray,
+    ):
+        """Populate alignment pairs by backtracing DP operations.
+
+        Arguments:
+            operation_table: operation table produced by dynamic programming
+        """
+        # Start from the bottom-right table cell
+        one_idx = len(self.one)
+        two_idx = len(self.two)
+        self.alignment_pairs = []
+
+        # Walk backward through chosen edit operations
+        while one_idx != 0 or two_idx != 0:
+            operation_value = int(operation_table[one_idx, two_idx])
+            if operation_value == _OPERATION_NONE:
+                break
+            operation = LineAlignmentOperation(operation_value)
+
+            # Resolve matches and substitutions diagonally
+            if operation in (
+                LineAlignmentOperation.MATCH,
+                LineAlignmentOperation.SUBSTITUTE,
+            ):
+                pair = LineAlignmentPair(
+                    self.one[one_idx - 1],
+                    self.two[two_idx - 1],
+                    operation,
+                )
+                one_idx -= 1
+                two_idx -= 1
+            # Resolve insertions horizontally
+            elif operation == LineAlignmentOperation.INSERT:
+                pair = LineAlignmentPair(
+                    None,
+                    self.two[two_idx - 1],
+                    operation,
+                )
+                two_idx -= 1
+            # Resolve deletions vertically
+            else:
+                pair = LineAlignmentPair(
+                    self.one[one_idx - 1],
+                    None,
+                    operation,
+                )
+                one_idx -= 1
+            self.alignment_pairs.append(pair)
+
+        # Store pairs in forward order
+        self.alignment_pairs.reverse()
+
+
 @nb.jit(nopython=True, nogil=True, cache=True)
 def _get_alignment_operation_table(  # noqa: PLR0915
     one: np.ndarray,
@@ -33,6 +135,7 @@ def _get_alignment_operation_table(  # noqa: PLR0915
     Returns:
         operation table used to backtrace the best alignment
     """
+    # Allocate backtrace table and rolling metric state
     one_length = len(one)
     two_length = len(two)
     operation_table = np.full(
@@ -48,18 +151,22 @@ def _get_alignment_operation_table(  # noqa: PLR0915
     previous_gaps = np.empty(two_length + 1, dtype=np.int16)
     current_gaps = np.empty(two_length + 1, dtype=np.int16)
 
+    # Seed the first row with insertions
     previous_gaps[0] = _GAP_NONE
     for two_idx in range(1, two_length + 1):
         _set_metric(previous_metrics, two_idx, two_idx, 1, 0, 0, two_idx)
         previous_gaps[two_idx] = _OPERATION_INSERT
 
+    # Fill each dynamic-programming row
     for one_idx in range(1, one_length + 1):
+        # Seed the first column with deletions
         operation_table[one_idx, 0] = _OPERATION_DELETE
         _set_metric(current_metrics, 0, one_idx, 1, 0, one_idx, 0)
         current_gaps[0] = _OPERATION_DELETE
         one_char = one[one_idx - 1]
 
         for two_idx in range(1, two_length + 1):
+            # Choose the diagonal match or substitution candidate
             two_char = two[two_idx - 1]
             previous_diagonal_idx = two_idx - 1
             if one_char == two_char:
@@ -79,6 +186,7 @@ def _get_alignment_operation_table(  # noqa: PLR0915
                 best_operation = _OPERATION_SUBSTITUTE
                 best_gap = _GAP_NONE
 
+            # Compare the insertion candidate
             previous_insert_idx = two_idx - 1
             insert_1 = current_metrics[previous_insert_idx, 1]
             if current_gaps[previous_insert_idx] != _OPERATION_INSERT:
@@ -107,6 +215,7 @@ def _get_alignment_operation_table(  # noqa: PLR0915
                 best_operation = _OPERATION_INSERT
                 best_gap = _OPERATION_INSERT
 
+            # Compare the deletion candidate
             delete_1 = previous_metrics[two_idx, 1]
             if previous_gaps[two_idx] != _OPERATION_DELETE:
                 delete_1 += 1
@@ -149,6 +258,7 @@ def _get_alignment_operation_table(  # noqa: PLR0915
                 best_operation = _OPERATION_DELETE
                 best_gap = _OPERATION_DELETE
 
+            # Store the chosen candidate and operation
             _set_metric(
                 current_metrics,
                 two_idx,
@@ -161,6 +271,7 @@ def _get_alignment_operation_table(  # noqa: PLR0915
             current_gaps[two_idx] = best_gap
             operation_table[one_idx, two_idx] = best_operation
 
+        # Roll current state forward
         previous_metrics, current_metrics = current_metrics, previous_metrics
         previous_gaps, current_gaps = current_gaps, previous_gaps
 
@@ -282,97 +393,3 @@ def _set_metric(
     metrics[idx, 2] = value_2
     metrics[idx, 3] = value_3
     metrics[idx, 4] = value_4
-
-
-class LineAlignment:
-    """Character-level alignment between two strings.
-
-    Uses Levenshtein-style dynamic programming with backtrace. The fill step
-    keeps only the previous and current metric rows, plus one compact operation
-    table for backtrace, to avoid allocating Python objects for every candidate
-    in large subtitle blocks.
-    """
-
-    def __init__(self, one: str, two: str):
-        """Initialize and fill dynamic-programming tables.
-
-        Arguments:
-            one: first string
-            two: second string
-        """
-        self.one = one
-        """First string."""
-
-        self.two = two
-        """Second string."""
-
-        self.alignment_pairs: list[LineAlignmentPair] = []
-        """Aligned character pairs."""
-
-        operation_table = self._get_operation_table()
-        self._populate_alignment_pairs(operation_table)
-
-    def __repr__(self) -> str:
-        """Return a reconstructable representation of this alignment.
-
-        Returns:
-            reconstructable representation
-        """
-        return f"{type(self).__name__}({self.one!r}, {self.two!r})"
-
-    def _get_operation_table(self) -> np.ndarray:
-        """Get the compact dynamic-programming operation table.
-
-        Returns:
-            operation table used to backtrace the best alignment
-        """
-        one = _get_codepoints(self.one)
-        two = _get_codepoints(self.two)
-        return _get_alignment_operation_table(one, two)
-
-    def _populate_alignment_pairs(
-        self,
-        operation_table: np.ndarray,
-    ):
-        """Populate alignment pairs by backtracing DP operations.
-
-        Arguments:
-            operation_table: operation table produced by dynamic programming
-        """
-        one_idx = len(self.one)
-        two_idx = len(self.two)
-        self.alignment_pairs = []
-        while one_idx != 0 or two_idx != 0:
-            operation_value = int(operation_table[one_idx, two_idx])
-            if operation_value == _OPERATION_NONE:
-                break
-            operation = LineAlignmentOperation(operation_value)
-
-            if operation in (
-                LineAlignmentOperation.MATCH,
-                LineAlignmentOperation.SUBSTITUTE,
-            ):
-                pair = LineAlignmentPair(
-                    self.one[one_idx - 1],
-                    self.two[two_idx - 1],
-                    operation,
-                )
-                one_idx -= 1
-                two_idx -= 1
-            elif operation == LineAlignmentOperation.INSERT:
-                pair = LineAlignmentPair(
-                    None,
-                    self.two[two_idx - 1],
-                    operation,
-                )
-                two_idx -= 1
-            else:
-                pair = LineAlignmentPair(
-                    self.one[one_idx - 1],
-                    None,
-                    operation,
-                )
-                one_idx -= 1
-            self.alignment_pairs.append(pair)
-
-        self.alignment_pairs.reverse()

--- a/test/analysis/line_alignment/test_line_alignment.py
+++ b/test/analysis/line_alignment/test_line_alignment.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import numpy as np
 import pytest
 
 from scinoephile.analysis.line_alignment import (
@@ -59,3 +60,15 @@ def test_line_alignment_operations(
     assert len(ops) == sum(expected_counts.values())
     for operation, expected_count in expected_counts.items():
         assert ops.count(operation) == expected_count
+
+
+def test_line_alignment_operation_table_uses_numeric_array():
+    """Test alignment operation table uses a compact numeric array."""
+    alignment = object.__new__(LineAlignment)
+    alignment.one = "廣東話"
+    alignment.two = "广东话"
+
+    operation_table = alignment._get_operation_table()
+
+    assert isinstance(operation_table, np.ndarray)
+    assert operation_table.dtype == np.uint8


### PR DESCRIPTION
## Summary

- Move the `LineAlignment` dynamic-programming table fill into a cached Numba helper over NumPy codepoint arrays.
- Preserve the existing public `LineAlignment.alignment_pairs` API and diff/CER behavior.
- Add a regression test that keeps the operation table on a compact numeric array path.

## Why

The CI timing investigation showed full-fixture diff and CER tests dominated runtime. The KOB English diff path spent most of its time in pure-Python dynamic programming, with tens of millions of list appends while building alignment operation tables. This mirrors the existing SUP parsing acceleration pattern, where tight numeric loops are isolated behind a Python-facing API and compiled with Numba.

## Impact

The comparable CI-shaped pytest run with coverage and durations improved from `72.81s` pytest time before the refactor to `21.06s` after it. The formerly slow KOB diff cases dropped from tens of seconds to sub-second durations.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/analysis/line_alignment/line_alignment.py test/analysis/line_alignment/test_line_alignment.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/analysis/line_alignment/line_alignment.py test/analysis/line_alignment/test_line_alignment.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/analysis/line_alignment/line_alignment.py test/analysis/line_alignment/test_line_alignment.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest test/analysis/line_alignment/test_line_alignment.py test/analysis/diff/test_series_diff.py test/analysis/character_error_rate/test_character_error_rate.py test/cli/multi/test_multi_diff_cli.py::test_multi_diff_cli_matches_expected_fixture test/cli/multi/test_multi_cer_cli.py::test_multi_cer_cli -q --durations=20 --durations-min=0`
- `CI=true PACKAGE_ROOT=/Users/karldebiec/.codex/worktrees/4865/Scinoephile/scinoephile UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto -q --cov=scinoephile --cov-report term --durations=100 --durations-min=0 .`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto`