### PR TITLE
Speed up CI test suite

### DIFF
--- a/test/cli/ocr/test_ocr_cli.py
+++ b/test/cli/ocr/test_ocr_cli.py
@@ -22,9 +22,10 @@ from scinoephile.cli.ocr import (
 )
 from scinoephile.cli.scinoephile_cli import ScinoephileCli
 from scinoephile.common import CommandLineInterface
-from scinoephile.common.file import get_temp_directory_path, get_temp_file_path
+from scinoephile.common.file import get_temp_file_path
 from scinoephile.common.testing import run_cli_with_args
 from scinoephile.core.subtitles import Series, Subtitle
+from scinoephile.image.subtitles import ImageSeries
 from test.helpers import (
     assert_cli_help,
     assert_cli_usage,
@@ -32,6 +33,50 @@ from test.helpers import (
     skip_if_ci,
     test_data_root,
 )
+
+
+def _patch_image_series_load(
+    monkeypatch: pytest.MonkeyPatch,
+    target: str,
+    image_series: ImageSeries,
+) -> list[Path]:
+    """Patch image subtitle loading and return captured input paths.
+
+    Arguments:
+        monkeypatch: pytest monkeypatch fixture
+        target: monkeypatch target for ImageSeries.load
+        image_series: image subtitle series to return
+    Returns:
+        paths passed to ImageSeries.load
+    """
+    input_paths: list[Path] = []
+
+    def fake_load(path: Path) -> ImageSeries:
+        """Fake image subtitle loading.
+
+        Arguments:
+            path: image subtitle input path
+        Returns:
+            configured image subtitle series
+        """
+        input_paths.append(path)
+        return image_series
+
+    monkeypatch.setattr(target, fake_load)
+    return input_paths
+
+
+def _write_placeholder_sup_path(tmp_path: Path) -> Path:
+    """Write a placeholder SUP file for CLI path validation.
+
+    Arguments:
+        tmp_path: pytest temporary path fixture
+    Returns:
+        placeholder SUP file path
+    """
+    infile_path = tmp_path / "source.sup"
+    infile_path.write_bytes(b"unused")
+    return infile_path
 
 
 def test_ocr_tesseract_cli_imports_ocr_function_at_module_load():
@@ -112,13 +157,22 @@ def test_ocr_lens_cli_help_lists_language_option_only():
 
 def test_ocr_lens_cli_converts_image_subtitles_to_srt(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    tiny_image_series: ImageSeries,
 ):
     """Test Google Lens CLI writes OCR output to SRT.
 
     Arguments:
         monkeypatch: pytest monkeypatch fixture
+        tmp_path: pytest temporary path fixture
+        tiny_image_series: small image subtitle series
     """
-    input_path = test_data_root / "mlamd/input/eng_ocr/source.sup"
+    input_paths = _patch_image_series_load(
+        monkeypatch,
+        "scinoephile.cli.ocr.ocr_lens_cli.ImageSeries.load",
+        tiny_image_series,
+    )
+    input_path = _write_placeholder_sup_path(tmp_path)
 
     def fake_ocr_image_series_with_lens(*args: object, **kwargs: object) -> Series:
         """Fake Google Lens image series processing.
@@ -136,17 +190,17 @@ def test_ocr_lens_cli_converts_image_subtitles_to_srt(
         fake_ocr_image_series_with_lens,
     )
 
-    with get_temp_directory_path() as output_dir_path:
-        output_path = output_dir_path / "ocr.srt"
-        run_cli_with_args(
-            OcrLensCli,
-            f"--infile {input_path} --outfile {output_path}",
-        )
+    output_path = tmp_path / "ocr.srt"
+    run_cli_with_args(
+        OcrLensCli,
+        f"--infile {input_path} --outfile {output_path}",
+    )
 
-        output = Series.load(output_path)
-        assert [(event.start, event.end, event.text) for event in output] == [
-            (1000, 2000, "recognized")
-        ]
+    assert input_paths == [input_path.resolve()]
+    output = Series.load(output_path)
+    assert [(event.start, event.end, event.text) for event in output] == [
+        (1000, 2000, "recognized")
+    ]
 
 
 def test_ocr_paddle_cli_help_lists_language_codes():
@@ -184,13 +238,22 @@ def test_ocr_tesseract_cli_help_lists_default_language():
 
 def test_ocr_paddle_cli_converts_image_subtitles_to_srt(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    tiny_image_series: ImageSeries,
 ):
     """Test PaddleOCR CLI writes OCR output to SRT.
 
     Arguments:
         monkeypatch: pytest monkeypatch fixture
+        tmp_path: pytest temporary path fixture
+        tiny_image_series: small image subtitle series
     """
-    input_path = test_data_root / "mlamd/input/eng_ocr/source.sup"
+    input_paths = _patch_image_series_load(
+        monkeypatch,
+        "scinoephile.cli.ocr.ocr_paddle_cli.ImageSeries.load",
+        tiny_image_series,
+    )
+    input_path = _write_placeholder_sup_path(tmp_path)
 
     def fake_ocr_image_series_with_paddle(*args: object, **kwargs: object) -> Series:
         """Fake PaddleOCR image series processing.
@@ -208,28 +271,37 @@ def test_ocr_paddle_cli_converts_image_subtitles_to_srt(
         fake_ocr_image_series_with_paddle,
     )
 
-    with get_temp_directory_path() as output_dir_path:
-        output_path = output_dir_path / "ocr.srt"
-        run_cli_with_args(
-            OcrPaddleCli,
-            f"--infile {input_path} --outfile {output_path}",
-        )
+    output_path = tmp_path / "ocr.srt"
+    run_cli_with_args(
+        OcrPaddleCli,
+        f"--infile {input_path} --outfile {output_path}",
+    )
 
-        output = Series.load(output_path)
-        assert [(event.start, event.end, event.text) for event in output] == [
-            (1000, 2000, "recognized")
-        ]
+    assert input_paths == [input_path.resolve()]
+    output = Series.load(output_path)
+    assert [(event.start, event.end, event.text) for event in output] == [
+        (1000, 2000, "recognized")
+    ]
 
 
 def test_ocr_tesseract_cli_converts_image_subtitles_to_srt(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    tiny_image_series: ImageSeries,
 ):
     """Test Tesseract OCR CLI writes OCR output to SRT.
 
     Arguments:
         monkeypatch: pytest monkeypatch fixture
+        tmp_path: pytest temporary path fixture
+        tiny_image_series: small image subtitle series
     """
-    input_path = test_data_root / "mlamd/input/eng_ocr/source.sup"
+    input_paths = _patch_image_series_load(
+        monkeypatch,
+        "scinoephile.cli.ocr.ocr_tesseract_cli.ImageSeries.load",
+        tiny_image_series,
+    )
+    input_path = _write_placeholder_sup_path(tmp_path)
 
     def fake_ocr_image_series_with_tesseract(*args: object, **kwargs: object) -> Series:
         """Fake Tesseract OCR image series processing.
@@ -251,28 +323,37 @@ def test_ocr_tesseract_cli_converts_image_subtitles_to_srt(
         fake_ocr_image_series_with_tesseract,
     )
 
-    with get_temp_directory_path() as output_dir_path:
-        output_path = output_dir_path / "ocr.srt"
-        run_cli_with_args(
-            OcrTesseractCli,
-            f"--infile {input_path} --outfile {output_path}",
-        )
+    output_path = tmp_path / "ocr.srt"
+    run_cli_with_args(
+        OcrTesseractCli,
+        f"--infile {input_path} --outfile {output_path}",
+    )
 
-        output = Series.load(output_path)
-        assert [(event.start, event.end, event.text) for event in output] == [
-            (1000, 2000, "recognized")
-        ]
+    assert input_paths == [input_path.resolve()]
+    output = Series.load(output_path)
+    assert [(event.start, event.end, event.text) for event in output] == [
+        (1000, 2000, "recognized")
+    ]
 
 
 def test_ocr_tesseract_cli_passes_italic_detection_options(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    tiny_image_series: ImageSeries,
 ):
     """Test Tesseract OCR CLI passes italic detection options.
 
     Arguments:
         monkeypatch: pytest monkeypatch fixture
+        tmp_path: pytest temporary path fixture
+        tiny_image_series: small image subtitle series
     """
-    input_path = test_data_root / "mlamd/input/eng_ocr/source.sup"
+    input_paths = _patch_image_series_load(
+        monkeypatch,
+        "scinoephile.cli.ocr.ocr_tesseract_cli.ImageSeries.load",
+        tiny_image_series,
+    )
+    input_path = _write_placeholder_sup_path(tmp_path)
 
     def fake_ocr_image_series_with_tesseract(*args: object, **kwargs: object) -> Series:
         """Fake Tesseract OCR image series processing.
@@ -294,17 +375,17 @@ def test_ocr_tesseract_cli_passes_italic_detection_options(
         fake_ocr_image_series_with_tesseract,
     )
 
-    with get_temp_directory_path() as output_dir_path:
-        output_path = output_dir_path / "ocr.srt"
-        run_cli_with_args(
-            OcrTesseractCli,
-            f"--infile {input_path} --detect-italics --outfile {output_path}",
-        )
+    output_path = tmp_path / "ocr.srt"
+    run_cli_with_args(
+        OcrTesseractCli,
+        f"--infile {input_path} --detect-italics --outfile {output_path}",
+    )
 
-        output = Series.load(output_path)
-        assert [(event.start, event.end, event.text) for event in output] == [
-            (1000, 2000, "recognized")
-        ]
+    assert input_paths == [input_path.resolve()]
+    output = Series.load(output_path)
+    assert [(event.start, event.end, event.text) for event in output] == [
+        (1000, 2000, "recognized")
+    ]
 
 
 def test_ocr_tesseract_cli_rejects_italic_detection_for_non_english(

--- a/test/cli/ocr/test_ocr_validate_eng_cli.py
+++ b/test/cli/ocr/test_ocr_validate_eng_cli.py
@@ -12,15 +12,11 @@ from scinoephile.cli.ocr.ocr_cli import OcrCli
 from scinoephile.cli.ocr.ocr_validate_cli import OcrValidateCli
 from scinoephile.cli.scinoephile_cli import ScinoephileCli
 from scinoephile.common import CommandLineInterface
-from scinoephile.common.file import get_temp_directory_path
 from scinoephile.common.testing import run_cli_with_args
 from scinoephile.image.subtitles import ImageSeries
-from scinoephile.lang.eng.ocr_validation import validate_eng_ocr
 from test.helpers import (
     assert_cli_help,
     assert_cli_usage,
-    assert_series_equal,
-    test_data_root,
 )
 
 
@@ -65,41 +61,109 @@ def test_ocr_validate_eng_usage(cli: tuple[type[CommandLineInterface], ...]):
         ("mlamd/input/eng_ocr/source.sup",),
     ],
 )
-def test_ocr_validate_eng_cli(input_path: str):
+def test_ocr_validate_eng_cli(
+    input_path: str,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    tiny_image_series: ImageSeries,
+):
     """Test OCR validate CLI processing for English subtitles with directory output.
 
     Arguments:
         input_path: path to input image subtitle fixture
+        monkeypatch: pytest monkeypatch fixture
+        tmp_path: pytest temporary path fixture
+        tiny_image_series: small image subtitle series
     """
-    full_input_path = test_data_root / input_path
-    expected = validate_eng_ocr(
-        ImageSeries.load(full_input_path),
-        stop_at_idx=1,
-        interactive=False,
+    original_load = ImageSeries.load
+    infile_path = tmp_path / input_path
+    infile_path.parent.mkdir(parents=True, exist_ok=True)
+    if infile_path.suffix:
+        infile_path.write_bytes(b"unused")
+    else:
+        infile_path.mkdir()
+
+    load_paths: list[Path] = []
+    validate_calls: list[tuple[ImageSeries, int | None, bool, bool]] = []
+
+    def fake_load(path: Path) -> ImageSeries:
+        """Fake image subtitle loading.
+
+        Arguments:
+            path: image subtitle input path
+        Returns:
+            configured image subtitle series
+        """
+        load_paths.append(path)
+        return tiny_image_series
+
+    def fake_validate_eng_ocr(
+        series: ImageSeries,
+        stop_at_idx: int | None = None,
+        interactive: bool = False,
+        dev: bool = False,
+    ) -> ImageSeries:
+        """Fake English OCR validation.
+
+        Arguments:
+            series: ImageSeries to validate
+            stop_at_idx: stop processing at this index
+            interactive: whether to prompt user for confirmations
+            dev: whether to write validation data updates to the repo
+        Returns:
+            configured validated image series
+        """
+        validate_calls.append((series, stop_at_idx, interactive, dev))
+        return tiny_image_series
+
+    monkeypatch.setattr(
+        "scinoephile.cli.ocr.ocr_validate_cli.ImageSeries.load",
+        fake_load,
+    )
+    monkeypatch.setattr(
+        "scinoephile.cli.ocr.ocr_validate_cli.validate_eng_ocr",
+        fake_validate_eng_ocr,
     )
 
-    with get_temp_directory_path() as output_dir_path:
-        outfile_path = output_dir_path / "validated"
-        run_cli_with_args(
-            OcrValidateCli,
-            f"--language eng --infile {full_input_path} --stop-at-idx 1 "
-            f"--outfile {outfile_path}",
-        )
+    outfile_path = tmp_path / "validated"
+    run_cli_with_args(
+        OcrValidateCli,
+        f"--language eng --infile {infile_path} --stop-at-idx 1 "
+        f"--outfile {outfile_path}",
+    )
 
-        output = ImageSeries.load(outfile_path)
-        assert_series_equal(output, expected)
-        assert (outfile_path / "index.html").exists()
-        assert any(outfile_path.glob("*.png"))
+    assert load_paths == [infile_path]
+    assert validate_calls == [(tiny_image_series, 1, False, False)]
+    output = original_load(outfile_path)
+    assert len(output) == len(tiny_image_series)
+    assert (outfile_path / "index.html").exists()
+    assert len(list(outfile_path.glob("*.png"))) == len(tiny_image_series)
 
 
-def test_ocr_validate_eng_cli_dev(monkeypatch, tmp_path):
+def test_ocr_validate_eng_cli_dev(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    tiny_image_series: ImageSeries,
+):
     """Test OCR validate CLI forwards dev mode for English subtitles.
 
     Arguments:
         monkeypatch: pytest monkeypatch fixture
         tmp_path: pytest temporary path fixture
+        tiny_image_series: small image subtitle series
     """
     captured_dev = None
+
+    def fake_load(path: Path) -> ImageSeries:
+        """Fake image subtitle loading.
+
+        Arguments:
+            path: image subtitle input path
+        Returns:
+            configured image subtitle series
+        """
+        _ = path
+        return tiny_image_series
 
     def mock_validate_eng_ocr(
         series: ImageSeries,
@@ -125,7 +189,12 @@ def test_ocr_validate_eng_cli_dev(monkeypatch, tmp_path):
         "scinoephile.cli.ocr.ocr_validate_cli.validate_eng_ocr",
         mock_validate_eng_ocr,
     )
-    full_input_path = test_data_root / "mlamd/output/eng_ocr/image"
+    monkeypatch.setattr(
+        "scinoephile.cli.ocr.ocr_validate_cli.ImageSeries.load",
+        fake_load,
+    )
+    full_input_path = tmp_path / "image"
+    full_input_path.mkdir()
     outfile_path = Path(tmp_path) / "validated"
 
     run_cli_with_args(

--- a/test/cli/ocr/test_ocr_validate_zho_cli.py
+++ b/test/cli/ocr/test_ocr_validate_zho_cli.py
@@ -4,21 +4,19 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from scinoephile.cli.ocr.ocr_cli import OcrCli
 from scinoephile.cli.ocr.ocr_validate_cli import OcrValidateCli
 from scinoephile.cli.scinoephile_cli import ScinoephileCli
 from scinoephile.common import CommandLineInterface
-from scinoephile.common.file import get_temp_directory_path
 from scinoephile.common.testing import run_cli_with_args
 from scinoephile.image.subtitles import ImageSeries
-from scinoephile.lang.zho.ocr_validation import validate_zho_ocr
 from test.helpers import (
     assert_cli_help,
     assert_cli_usage,
-    assert_series_equal,
-    test_data_root,
 )
 
 
@@ -63,28 +61,80 @@ def test_ocr_validate_zho_usage(cli: tuple[type[CommandLineInterface], ...]):
         ("mlamd/input/zho-Hans_ocr/source.sup",),
     ],
 )
-def test_ocr_validate_zho_cli(input_path: str):
+def test_ocr_validate_zho_cli(
+    input_path: str,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    tiny_image_series: ImageSeries,
+):
     """Test OCR validate CLI processing for standard Chinese subtitles.
 
     Arguments:
         input_path: path to input image subtitle fixture
+        monkeypatch: pytest monkeypatch fixture
+        tmp_path: pytest temporary path fixture
+        tiny_image_series: small image subtitle series
     """
-    full_input_path = test_data_root / input_path
-    expected = validate_zho_ocr(
-        ImageSeries.load(full_input_path),
-        stop_at_idx=1,
-        interactive=False,
+    original_load = ImageSeries.load
+    infile_path = tmp_path / input_path
+    infile_path.parent.mkdir(parents=True, exist_ok=True)
+    if infile_path.suffix:
+        infile_path.write_bytes(b"unused")
+    else:
+        infile_path.mkdir()
+
+    load_paths: list[Path] = []
+    validate_calls: list[tuple[ImageSeries, int | None, bool, bool]] = []
+
+    def fake_load(path: Path) -> ImageSeries:
+        """Fake image subtitle loading.
+
+        Arguments:
+            path: image subtitle input path
+        Returns:
+            configured image subtitle series
+        """
+        load_paths.append(path)
+        return tiny_image_series
+
+    def fake_validate_zho_ocr(
+        series: ImageSeries,
+        stop_at_idx: int | None = None,
+        interactive: bool = False,
+        dev: bool = False,
+    ) -> ImageSeries:
+        """Fake standard Chinese OCR validation.
+
+        Arguments:
+            series: ImageSeries to validate
+            stop_at_idx: stop processing at this index
+            interactive: whether to prompt user for confirmations
+            dev: whether to write validation data updates to the repo
+        Returns:
+            configured validated image series
+        """
+        validate_calls.append((series, stop_at_idx, interactive, dev))
+        return tiny_image_series
+
+    monkeypatch.setattr(
+        "scinoephile.cli.ocr.ocr_validate_cli.ImageSeries.load",
+        fake_load,
+    )
+    monkeypatch.setattr(
+        "scinoephile.cli.ocr.ocr_validate_cli.validate_zho_ocr",
+        fake_validate_zho_ocr,
     )
 
-    with get_temp_directory_path() as output_dir_path:
-        outfile_path = output_dir_path / "validated"
-        run_cli_with_args(
-            OcrValidateCli,
-            f"--language zho --infile {full_input_path} --stop-at-idx 1 "
-            f"--outfile {outfile_path}",
-        )
+    outfile_path = tmp_path / "validated"
+    run_cli_with_args(
+        OcrValidateCli,
+        f"--language zho --infile {infile_path} --stop-at-idx 1 "
+        f"--outfile {outfile_path}",
+    )
 
-        output = ImageSeries.load(outfile_path)
-        assert_series_equal(output, expected)
-        assert (outfile_path / "index.html").exists()
-        assert any(outfile_path.glob("*.png"))
+    assert load_paths == [infile_path]
+    assert validate_calls == [(tiny_image_series, 1, False, False)]
+    output = original_load(outfile_path)
+    assert len(output) == len(tiny_image_series)
+    assert (outfile_path / "index.html").exists()
+    assert len(list(outfile_path.glob("*.png"))) == len(tiny_image_series)

--- a/test/common/subprocess/test_run_command.py
+++ b/test/common/subprocess/test_run_command.py
@@ -120,13 +120,13 @@ def test_run_command_timeout():
     start_time = monotonic()
     exitcode, stdout, stderr = run_command(
         [sys.executable, "-c", "import time; time.sleep(10)"],
-        timeout=1,
+        timeout=0,
         acceptable_exitcodes=[-9, -15, 1],
     )
     elapsed = monotonic() - start_time
 
     assert exitcode != 0
-    assert elapsed < 2.0
+    assert elapsed < 1.0
 
 
 def test_run_command_unicode_output():

--- a/test/common/subprocess/test_run_command_live.py
+++ b/test/common/subprocess/test_run_command_live.py
@@ -148,11 +148,11 @@ def test_run_command_live_timeout():
     start_time = monotonic()
     with pytest.raises(TimeoutExpired):
         run_command_live(
-            [sys.executable, "-c", "import time; time.sleep(2)"], timeout=1
+            [sys.executable, "-c", "import time; time.sleep(2)"], timeout=0
         )
     elapsed = monotonic() - start_time
 
-    assert elapsed < 1.5
+    assert elapsed < 1.0
 
 
 def test_run_command_live_non_utf8_output():

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,8 +4,34 @@
 
 from __future__ import annotations
 
+import pytest
+from PIL import Image
+
+from scinoephile.image.subtitles import ImageSeries, ImageSubtitle
+
 # ruff: noqa: F401 F403
 from test.data.kob import *
 from test.data.mlamd import *
 from test.data.mnt import *
 from test.data.t import *
+
+
+@pytest.fixture
+def tiny_image_series() -> ImageSeries:
+    """Small image subtitle series for tests that do not need full fixtures."""
+    return ImageSeries(
+        events=[
+            ImageSubtitle(
+                start=1000,
+                end=2000,
+                img=Image.new("LA", (4, 3), (255, 255)),
+                text="recognized",
+            ),
+            ImageSubtitle(
+                start=3000,
+                end=4000,
+                img=Image.new("LA", (2, 5), (255, 255)),
+                text="validated",
+            ),
+        ]
+    )

--- a/test/image/subtitles/test_image_series.py
+++ b/test/image/subtitles/test_image_series.py
@@ -78,30 +78,15 @@ def test_load_html(
         assert event.img.size[1] > 0
 
 
-@pytest.mark.parametrize(
-    "input_path_fixture, expected_event_count",
-    [
-        ("mlamd_eng_image_path", 942),
-        ("mlamd_zho_hans_image_path", 932),
-    ],
-)
-def test_save_html(
-    input_path_fixture: str,
-    expected_event_count: int,
-    request: pytest.FixtureRequest,
-):
+def test_save_html(tiny_image_series: ImageSeries):
     """Test saving HTML image subtitles.
 
     Arguments:
-        input_path_fixture: html input path fixture name
-        expected_event_count: expected number of subtitles
-        request: pytest fixture request
+        tiny_image_series: small image subtitle series
     """
-    source_path = request.getfixturevalue(input_path_fixture)
-    series = ImageSeries.load(source_path, encoding="utf-8")
     with get_temp_directory_path() as output_dir:
         output_path = output_dir / "image_subtitles"
-        series.save(output_path)
+        tiny_image_series.save(output_path)
 
         html_path = output_path / "index.html"
         assert html_path.exists()
@@ -110,4 +95,4 @@ def test_save_html(
         assert "<img src='0001.png' />" in html_text
 
         png_files = sorted(output_path.glob("*.png"))
-        assert len(png_files) == expected_event_count
+        assert len(png_files) == len(tiny_image_series)


### PR DESCRIPTION
## Summary

- Replace full MLAMD image subtitle fixture loading in mocked OCR CLI tests with a small synthetic image series fixture.
- Use the small image series for generic HTML save coverage instead of writing hundreds of PNGs.
- Tighten subprocess timeout tests to exercise timeout handling without waiting one second per test.

## Why

The CI-style pytest profile showed several unit-level tests paying integration-level fixture costs. The slowest mocked OCR CLI tests loaded full SUP/image subtitle fixtures even though OCR and validation behavior were patched, and the HTML save unit test wrote roughly 900 PNGs per parameterized case.

## Impact

Local CI-style timing improved from `1149 passed, 4 skipped in 19.39s` to `1148 passed, 4 skipped in 12.49s` with `pytest -n auto`, while preserving full fixture coverage in the loader and OCR validation tests.

## Verification

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format test/conftest.py test/image/subtitles/test_image_series.py test/cli/ocr/test_ocr_cli.py test/cli/ocr/test_ocr_validate_eng_cli.py test/cli/ocr/test_ocr_validate_zho_cli.py test/common/subprocess/test_run_command.py test/common/subprocess/test_run_command_live.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix test/conftest.py test/image/subtitles/test_image_series.py test/cli/ocr/test_ocr_cli.py test/cli/ocr/test_ocr_validate_eng_cli.py test/cli/ocr/test_ocr_validate_zho_cli.py test/common/subprocess/test_run_command.py test/common/subprocess/test_run_command_live.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check test/conftest.py test/image/subtitles/test_image_series.py test/cli/ocr/test_ocr_cli.py test/cli/ocr/test_ocr_validate_eng_cli.py test/cli/ocr/test_ocr_validate_zho_cli.py test/common/subprocess/test_run_command.py test/common/subprocess/test_run_command_live.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto --durations=50 --durations-min=0.01`