### PR TITLE
Split CLI localization maps

### DIFF
--- a/scinoephile/cli/dictionary/dictionary_cli.py
+++ b/scinoephile/cli/dictionary/dictionary_cli.py
@@ -15,20 +15,23 @@ from .dictionary_search_cli import DictionarySearchCli
 
 __all__ = ["DictionaryCli"]
 
+DICTIONARY_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "build or search Chinese dictionaries": "构建或查询中文词典",
+        "command-line interface for dictionary operations": "词典操作命令行界面",
+    },
+    "zh-hant": {
+        "build or search Chinese dictionaries": "建置或查詢中文詞典",
+        "command-line interface for dictionary operations": "詞典操作命令列介面",
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class DictionaryCli(ScinoephileCliBase):
     """Build or search Chinese dictionaries."""
 
-    localizations = {
-        "zh-hans": {
-            "build or search Chinese dictionaries": "构建或查询中文词典",
-            "command-line interface for dictionary operations": "词典操作命令行界面",
-        },
-        "zh-hant": {
-            "build or search Chinese dictionaries": "建置或查詢中文詞典",
-            "command-line interface for dictionary operations": "詞典操作命令列介面",
-        },
-    }
+    localizations = DICTIONARY_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
     @classmethod

--- a/scinoephile/cli/dictionary/dictionary_search_cli.py
+++ b/scinoephile/cli/dictionary/dictionary_search_cli.py
@@ -22,36 +22,40 @@ from scinoephile.dictionaries.lookup import (
 
 __all__ = ["DictionarySearchCli"]
 
+DICTIONARY_SEARCH_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "dictionary to search, or all available dictionaries": (
+            "要查询的词典，或选择全部可用词典"
+        ),
+        "Mandarin or Cantonese query text": "普通话或粤语查询文本",
+        "maximum number of matches to show per dictionary": (
+            "每个词典显示的最大匹配数"
+        ),
+        "search dictionaries": "查询词典",
+        "SQLite database input path": "SQLite 数据库输入路径",
+    },
+    "zh-hant": {
+        "dictionary to search, or all available dictionaries": (
+            "要查詢的詞典，或選擇全部可用詞典"
+        ),
+        "Mandarin or Cantonese query text": "普通話或粵語查詢文字",
+        "maximum number of matches to show per dictionary": (
+            "每個詞典顯示的最大符合數"
+        ),
+        "search dictionaries": "查詢詞典",
+        "SQLite database input path": "SQLite 資料庫輸入路徑",
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
+
 logger = getLogger(__name__)
 
 
 class DictionarySearchCli(ScinoephileCliBase):
     """Search dictionaries."""
 
-    localizations = {
-        "zh-hans": {
-            "dictionary to search, or all available dictionaries": (
-                "要查询的词典，或选择全部可用词典"
-            ),
-            "Mandarin or Cantonese query text": "普通话或粤语查询文本",
-            "maximum number of matches to show per dictionary": (
-                "每个词典显示的最大匹配数"
-            ),
-            "search dictionaries": "查询词典",
-            "SQLite database input path": "SQLite 数据库输入路径",
-        },
-        "zh-hant": {
-            "dictionary to search, or all available dictionaries": (
-                "要查詢的詞典，或選擇全部可用詞典"
-            ),
-            "Mandarin or Cantonese query text": "普通話或粵語查詢文字",
-            "maximum number of matches to show per dictionary": (
-                "每個詞典顯示的最大符合數"
-            ),
-            "search dictionaries": "查詢詞典",
-            "SQLite database input path": "SQLite 資料庫輸入路徑",
-        },
-    }
+    localizations = DICTIONARY_SEARCH_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
     @classmethod

--- a/scinoephile/cli/eng/eng_cli.py
+++ b/scinoephile/cli/eng/eng_cli.py
@@ -14,24 +14,27 @@ from .eng_process_cli import EngProcessCli
 
 __all__ = ["EngCli"]
 
+ENG_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "command-line interface for English subtitle operations": (
+            "英文字幕操作命令行界面"
+        ),
+        "modify English subtitles": "修改英文字幕",
+    },
+    "zh-hant": {
+        "command-line interface for English subtitle operations": (
+            "英文字幕操作命令列介面"
+        ),
+        "modify English subtitles": "修改英文字幕",
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class EngCli(ScinoephileCliBase):
     """Modify English subtitles."""
 
-    localizations = {
-        "zh-hans": {
-            "command-line interface for English subtitle operations": (
-                "英文字幕操作命令行界面"
-            ),
-            "modify English subtitles": "修改英文字幕",
-        },
-        "zh-hant": {
-            "command-line interface for English subtitle operations": (
-                "英文字幕操作命令列介面"
-            ),
-            "modify English subtitles": "修改英文字幕",
-        },
-    }
+    localizations = ENG_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
     @classmethod

--- a/scinoephile/cli/eng/eng_process_cli.py
+++ b/scinoephile/cli/eng/eng_process_cli.py
@@ -26,52 +26,51 @@ from scinoephile.llms.providers.registry import get_provider
 
 __all__ = ["EngProcessCli"]
 
+ENG_PROCESS_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "clean subtitles of closed-caption annotations and other anomalies": (
+            "清理字幕中的隐藏字幕标注及其他异常"
+        ),
+        'English subtitle infile path or "-" for stdin': (
+            '英文字幕输入文件路径，或使用 "-" 表示标准输入'
+        ),
+        "English subtitle outfile path (default: stdout)": (
+            "英文字幕输出文件路径（默认：标准输出）"
+        ),
+        "flatten multi-line subtitles into single lines": ("将多行字幕合并为单行"),
+        "modify English subtitles": "修改英文字幕",
+        "shift subtitle timings by this many milliseconds": (
+            "按指定毫秒数平移字幕时间"
+        ),
+        "proofread subtitles using LLM": "使用大语言模型校对字幕",
+    },
+    "zh-hant": {
+        "clean subtitles of closed-caption annotations and other anomalies": (
+            "清理字幕中的隱藏字幕標註及其他異常"
+        ),
+        'English subtitle infile path or "-" for stdin': (
+            '英文字幕輸入檔路徑，或使用 "-" 代表標準輸入'
+        ),
+        "English subtitle outfile path (default: stdout)": (
+            "英文字幕輸出檔路徑（預設：標準輸出）"
+        ),
+        "flatten multi-line subtitles into single lines": ("將多行字幕合併為單行"),
+        "modify English subtitles": "修改英文字幕",
+        "shift subtitle timings by this many milliseconds": (
+            "依指定毫秒數平移字幕時間"
+        ),
+        "proofread subtitles using LLM": "使用大型語言模型校對字幕",
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class EngProcessCli(ScinoephileCliBase):
     """Modify English subtitles."""
 
     localizations = merge_localizations(
         LLM_LOCALIZATIONS,
-        {
-            "zh-hans": {
-                "clean subtitles of closed-caption annotations and other anomalies": (
-                    "清理字幕中的隐藏字幕标注及其他异常"
-                ),
-                'English subtitle infile path or "-" for stdin': (
-                    '英文字幕输入文件路径，或使用 "-" 表示标准输入'
-                ),
-                "English subtitle outfile path (default: stdout)": (
-                    "英文字幕输出文件路径（默认：标准输出）"
-                ),
-                "flatten multi-line subtitles into single lines": (
-                    "将多行字幕合并为单行"
-                ),
-                "modify English subtitles": "修改英文字幕",
-                "shift subtitle timings by this many milliseconds": (
-                    "按指定毫秒数平移字幕时间"
-                ),
-                "proofread subtitles using LLM": "使用大语言模型校对字幕",
-            },
-            "zh-hant": {
-                "clean subtitles of closed-caption annotations and other anomalies": (
-                    "清理字幕中的隱藏字幕標註及其他異常"
-                ),
-                'English subtitle infile path or "-" for stdin': (
-                    '英文字幕輸入檔路徑，或使用 "-" 代表標準輸入'
-                ),
-                "English subtitle outfile path (default: stdout)": (
-                    "英文字幕輸出檔路徑（預設：標準輸出）"
-                ),
-                "flatten multi-line subtitles into single lines": (
-                    "將多行字幕合併為單行"
-                ),
-                "modify English subtitles": "修改英文字幕",
-                "shift subtitle timings by this many milliseconds": (
-                    "依指定毫秒數平移字幕時間"
-                ),
-                "proofread subtitles using LLM": "使用大型語言模型校對字幕",
-            },
-        },
+        ENG_PROCESS_LOCALIZATIONS,
     )
     """Localized help text keyed by locale and English source text."""
 

--- a/scinoephile/cli/media/media_cli.py
+++ b/scinoephile/cli/media/media_cli.py
@@ -16,34 +16,37 @@ from .media_probe_cli import MediaProbeCli
 
 __all__ = ["MediaCli"]
 
+MEDIA_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "command-line interface for media operations": "媒体操作命令行界面",
+        "extract matching subtitle streams from a video file": (
+            "从视频文件提取匹配的字幕流"
+        ),
+        "estimate visual offset between two media files": (
+            "估计两个媒体文件之间的视觉偏移"
+        ),
+        "inspect and extract media streams": "检查并提取媒体流",
+        "list media streams in a media file": "列出媒体文件中的媒体流",
+    },
+    "zh-hant": {
+        "command-line interface for media operations": "媒體操作命令列介面",
+        "extract matching subtitle streams from a video file": (
+            "從影片檔提取匹配的字幕流"
+        ),
+        "estimate visual offset between two media files": (
+            "估計兩個媒體檔之間的視覺偏移"
+        ),
+        "inspect and extract media streams": "檢查並提取媒體流",
+        "list media streams in a media file": "列出媒體檔中的媒體流",
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class MediaCli(ScinoephileCliBase):
     """Inspect and extract media streams."""
 
-    localizations = {
-        "zh-hans": {
-            "command-line interface for media operations": "媒体操作命令行界面",
-            "extract matching subtitle streams from a video file": (
-                "从视频文件提取匹配的字幕流"
-            ),
-            "estimate visual offset between two media files": (
-                "估计两个媒体文件之间的视觉偏移"
-            ),
-            "inspect and extract media streams": "检查并提取媒体流",
-            "list media streams in a media file": "列出媒体文件中的媒体流",
-        },
-        "zh-hant": {
-            "command-line interface for media operations": "媒體操作命令列介面",
-            "extract matching subtitle streams from a video file": (
-                "從影片檔提取匹配的字幕流"
-            ),
-            "estimate visual offset between two media files": (
-                "估計兩個媒體檔之間的視覺偏移"
-            ),
-            "inspect and extract media streams": "檢查並提取媒體流",
-            "list media streams in a media file": "列出媒體檔中的媒體流",
-        },
-    }
+    localizations = MEDIA_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
     @classmethod

--- a/scinoephile/cli/media/media_extract_subs_cli.py
+++ b/scinoephile/cli/media/media_extract_subs_cli.py
@@ -25,52 +25,55 @@ from scinoephile.workflows.subtitle_extraction import (
 
 __all__ = ["MediaExtractSubsCli"]
 
+MEDIA_EXTRACT_SUBS_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "convert extracted SUP subtitle streams to image directories": (
+            "将提取的 SUP 字幕流转换为图像目录"
+        ),
+        "cache directory (default: %(default)s)": "缓存目录（默认：%(default)s）",
+        "directory to which matching subtitles will be extracted or mapped": (
+            "匹配字幕将被提取或映射到的目录"
+        ),
+        "extract matching subtitle streams from a video file": (
+            "从视频文件提取匹配的字幕流"
+        ),
+        "include additional subtitle stream details": "包含更多字幕流详细信息",
+        "ISO 639 language codes to extract (default: chi eng yue zho)": (
+            "要提取的 ISO 639 语言代码（默认：chi eng yue zho）"
+        ),
+        "overwrite extracted subtitle files if they exist": (
+            "若提取的字幕文件已存在则覆盖"
+        ),
+        "video infile containing subtitle streams": "包含字幕流的视频输入文件",
+    },
+    "zh-hant": {
+        "convert extracted SUP subtitle streams to image directories": (
+            "將提取的 SUP 字幕流轉換為影像目錄"
+        ),
+        "cache directory (default: %(default)s)": "快取目錄（預設：%(default)s）",
+        "directory to which matching subtitles will be extracted or mapped": (
+            "匹配字幕將被提取或映射到的目錄"
+        ),
+        "extract matching subtitle streams from a video file": (
+            "從影片檔提取匹配的字幕流"
+        ),
+        "include additional subtitle stream details": "包含更多字幕流詳細資訊",
+        "ISO 639 language codes to extract (default: chi eng yue zho)": (
+            "要提取的 ISO 639 語言代碼（預設：chi eng yue zho）"
+        ),
+        "overwrite extracted subtitle files if they exist": (
+            "若提取的字幕檔已存在則覆寫"
+        ),
+        "video infile containing subtitle streams": "包含字幕流的影片輸入檔",
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class MediaExtractSubsCli(ScinoephileCliBase):
     """Extract matching subtitle streams from a video file."""
 
-    localizations = {
-        "zh-hans": {
-            "convert extracted SUP subtitle streams to image directories": (
-                "将提取的 SUP 字幕流转换为图像目录"
-            ),
-            "cache directory (default: %(default)s)": "缓存目录（默认：%(default)s）",
-            "directory to which matching subtitles will be extracted or mapped": (
-                "匹配字幕将被提取或映射到的目录"
-            ),
-            "extract matching subtitle streams from a video file": (
-                "从视频文件提取匹配的字幕流"
-            ),
-            "include additional subtitle stream details": "包含更多字幕流详细信息",
-            "ISO 639 language codes to extract (default: chi eng yue zho)": (
-                "要提取的 ISO 639 语言代码（默认：chi eng yue zho）"
-            ),
-            "overwrite extracted subtitle files if they exist": (
-                "若提取的字幕文件已存在则覆盖"
-            ),
-            "video infile containing subtitle streams": "包含字幕流的视频输入文件",
-        },
-        "zh-hant": {
-            "convert extracted SUP subtitle streams to image directories": (
-                "將提取的 SUP 字幕流轉換為影像目錄"
-            ),
-            "cache directory (default: %(default)s)": "快取目錄（預設：%(default)s）",
-            "directory to which matching subtitles will be extracted or mapped": (
-                "匹配字幕將被提取或映射到的目錄"
-            ),
-            "extract matching subtitle streams from a video file": (
-                "從影片檔提取匹配的字幕流"
-            ),
-            "include additional subtitle stream details": "包含更多字幕流詳細資訊",
-            "ISO 639 language codes to extract (default: chi eng yue zho)": (
-                "要提取的 ISO 639 語言代碼（預設：chi eng yue zho）"
-            ),
-            "overwrite extracted subtitle files if they exist": (
-                "若提取的字幕檔已存在則覆寫"
-            ),
-            "video infile containing subtitle streams": "包含字幕流的影片輸入檔",
-        },
-    }
+    localizations = MEDIA_EXTRACT_SUBS_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
     @classmethod

--- a/scinoephile/cli/media/media_offset_cli.py
+++ b/scinoephile/cli/media/media_offset_cli.py
@@ -19,68 +19,71 @@ from scinoephile.media.video_offset import VideoOffsetResult, get_video_offset
 
 __all__ = ["MediaOffsetCli"]
 
+MEDIA_OFFSET_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "command-line interface for estimating visual media offset": (
+            "估计媒体视觉偏移的命令行界面"
+        ),
+        "estimate visual offset between two media files": (
+            "估计两个媒体文件之间的视觉偏移"
+        ),
+        "coarse search step in seconds (default: %(default)s)": (
+            "粗略搜索步长，单位为秒（默认：%(default)s）"
+        ),
+        "duration to sample in seconds (default: %(default)s)": (
+            "采样持续时间，单位为秒（默认：%(default)s）"
+        ),
+        "fine search step in seconds (default: %(default)s)": (
+            "精细搜索步长，单位为秒（默认：%(default)s）"
+        ),
+        "maximum absolute offset to search in seconds (default: %(default)s)": (
+            "要搜索的最大绝对偏移，单位为秒（默认：%(default)s）"
+        ),
+        "reference video infile": "参考视频输入文件",
+        "sample rate in frames per second (default: %(default)s)": (
+            "采样率，单位为每秒帧数（默认：%(default)s）"
+        ),
+        "start time for sampling in seconds (default: %(default)s)": (
+            "采样开始时间，单位为秒（默认：%(default)s）"
+        ),
+        "target video infile": "目标视频输入文件",
+    },
+    "zh-hant": {
+        "command-line interface for estimating visual media offset": (
+            "估計媒體視覺偏移的命令列介面"
+        ),
+        "estimate visual offset between two media files": (
+            "估計兩個媒體檔之間的視覺偏移"
+        ),
+        "coarse search step in seconds (default: %(default)s)": (
+            "粗略搜尋步長，單位為秒（預設：%(default)s）"
+        ),
+        "duration to sample in seconds (default: %(default)s)": (
+            "取樣持續時間，單位為秒（預設：%(default)s）"
+        ),
+        "fine search step in seconds (default: %(default)s)": (
+            "精細搜尋步長，單位為秒（預設：%(default)s）"
+        ),
+        "maximum absolute offset to search in seconds (default: %(default)s)": (
+            "要搜尋的最大絕對偏移，單位為秒（預設：%(default)s）"
+        ),
+        "reference video infile": "參考影片輸入檔",
+        "sample rate in frames per second (default: %(default)s)": (
+            "取樣率，單位為每秒影格數（預設：%(default)s）"
+        ),
+        "start time for sampling in seconds (default: %(default)s)": (
+            "取樣開始時間，單位為秒（預設：%(default)s）"
+        ),
+        "target video infile": "目標影片輸入檔",
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class MediaOffsetCli(ScinoephileCliBase):
     """Estimate visual offset between two media files."""
 
-    localizations = {
-        "zh-hans": {
-            "command-line interface for estimating visual media offset": (
-                "估计媒体视觉偏移的命令行界面"
-            ),
-            "estimate visual offset between two media files": (
-                "估计两个媒体文件之间的视觉偏移"
-            ),
-            "coarse search step in seconds (default: %(default)s)": (
-                "粗略搜索步长，单位为秒（默认：%(default)s）"
-            ),
-            "duration to sample in seconds (default: %(default)s)": (
-                "采样持续时间，单位为秒（默认：%(default)s）"
-            ),
-            "fine search step in seconds (default: %(default)s)": (
-                "精细搜索步长，单位为秒（默认：%(default)s）"
-            ),
-            "maximum absolute offset to search in seconds (default: %(default)s)": (
-                "要搜索的最大绝对偏移，单位为秒（默认：%(default)s）"
-            ),
-            "reference video infile": "参考视频输入文件",
-            "sample rate in frames per second (default: %(default)s)": (
-                "采样率，单位为每秒帧数（默认：%(default)s）"
-            ),
-            "start time for sampling in seconds (default: %(default)s)": (
-                "采样开始时间，单位为秒（默认：%(default)s）"
-            ),
-            "target video infile": "目标视频输入文件",
-        },
-        "zh-hant": {
-            "command-line interface for estimating visual media offset": (
-                "估計媒體視覺偏移的命令列介面"
-            ),
-            "estimate visual offset between two media files": (
-                "估計兩個媒體檔之間的視覺偏移"
-            ),
-            "coarse search step in seconds (default: %(default)s)": (
-                "粗略搜尋步長，單位為秒（預設：%(default)s）"
-            ),
-            "duration to sample in seconds (default: %(default)s)": (
-                "取樣持續時間，單位為秒（預設：%(default)s）"
-            ),
-            "fine search step in seconds (default: %(default)s)": (
-                "精細搜尋步長，單位為秒（預設：%(default)s）"
-            ),
-            "maximum absolute offset to search in seconds (default: %(default)s)": (
-                "要搜尋的最大絕對偏移，單位為秒（預設：%(default)s）"
-            ),
-            "reference video infile": "參考影片輸入檔",
-            "sample rate in frames per second (default: %(default)s)": (
-                "取樣率，單位為每秒影格數（預設：%(default)s）"
-            ),
-            "start time for sampling in seconds (default: %(default)s)": (
-                "取樣開始時間，單位為秒（預設：%(default)s）"
-            ),
-            "target video infile": "目標影片輸入檔",
-        },
-    }
+    localizations = MEDIA_OFFSET_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
     @classmethod

--- a/scinoephile/cli/media/media_probe_cli.py
+++ b/scinoephile/cli/media/media_probe_cli.py
@@ -20,30 +20,29 @@ from scinoephile.media.probe import get_streams
 
 __all__ = ["MediaProbeCli"]
 
+MEDIA_PROBE_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "command-line interface for probing media streams": ("探测媒体流的命令行界面"),
+        "cache directory (default: %(default)s)": ("缓存目录（默认：%(default)s）"),
+        "list media streams in a media file": "列出媒体文件中的媒体流",
+        "include additional stream details": "包含更多媒体流详细信息",
+        "video infile containing media streams": "包含媒体流的视频输入文件",
+    },
+    "zh-hant": {
+        "command-line interface for probing media streams": ("探測媒體流的命令列介面"),
+        "cache directory (default: %(default)s)": ("快取目錄（預設：%(default)s）"),
+        "list media streams in a media file": "列出媒體檔中的媒體流",
+        "include additional stream details": "包含更多媒體流詳細資訊",
+        "video infile containing media streams": "包含媒體流的影片輸入檔",
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class MediaProbeCli(ScinoephileCliBase):
     """List media streams in a media file."""
 
-    localizations = {
-        "zh-hans": {
-            "command-line interface for probing media streams": (
-                "探测媒体流的命令行界面"
-            ),
-            "cache directory (default: %(default)s)": ("缓存目录（默认：%(default)s）"),
-            "list media streams in a media file": "列出媒体文件中的媒体流",
-            "include additional stream details": "包含更多媒体流详细信息",
-            "video infile containing media streams": "包含媒体流的视频输入文件",
-        },
-        "zh-hant": {
-            "command-line interface for probing media streams": (
-                "探測媒體流的命令列介面"
-            ),
-            "cache directory (default: %(default)s)": ("快取目錄（預設：%(default)s）"),
-            "list media streams in a media file": "列出媒體檔中的媒體流",
-            "include additional stream details": "包含更多媒體流詳細資訊",
-            "video infile containing media streams": "包含媒體流的影片輸入檔",
-        },
-    }
+    localizations = MEDIA_PROBE_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
     @classmethod

--- a/scinoephile/cli/multi/multi_cli.py
+++ b/scinoephile/cli/multi/multi_cli.py
@@ -17,18 +17,21 @@ from .multi_timewarp_cli import MultiTimewarpCli
 
 __all__ = ["MultiCli"]
 
+MULTI_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "operate on multiple subtitle series": "处理多个字幕序列",
+    },
+    "zh-hant": {
+        "operate on multiple subtitle series": "處理多個字幕序列",
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class MultiCli(ScinoephileCliBase):
     """Operate on multiple subtitle series."""
 
-    localizations = {
-        "zh-hans": {
-            "operate on multiple subtitle series": "处理多个字幕序列",
-        },
-        "zh-hant": {
-            "operate on multiple subtitle series": "處理多個字幕序列",
-        },
-    }
+    localizations = MULTI_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
     @classmethod

--- a/scinoephile/cli/multi/multi_sync_cli.py
+++ b/scinoephile/cli/multi/multi_sync_cli.py
@@ -19,50 +19,55 @@ from scinoephile.core.synchronization import get_synced_series
 
 __all__ = ["MultiSyncCli"]
 
+MULTI_SYNC_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "combine two series into the top and bottom of a synchronized series": (
+            "将两个序列合并为上下行同步字幕"
+        ),
+        "initial overlap cutoff used to form sync groups (default: 0.16)": (
+            "用于形成同步组的初始重叠阈值（默认：0.16）"
+        ),
+        "pause length in milliseconds used to split subtitle blocks (default: 3000)": (
+            "用于分割字幕块的停顿时长，单位为毫秒（默认：3000）"
+        ),
+        'subtitle infile for bottom line or "-" for stdin': (
+            '底行字幕输入文件，或使用 "-" 表示标准输入'
+        ),
+        'subtitle infile for top line or "-" for stdin': (
+            '顶行字幕输入文件，或使用 "-" 表示标准输入'
+        ),
+        "synchronized subtitle outfile path (default: stdout)": (
+            "同步字幕输出文件路径（默认：标准输出）"
+        ),
+    },
+    "zh-hant": {
+        "combine two series into the top and bottom of a synchronized series": (
+            "將兩個序列合併為上下行同步字幕"
+        ),
+        "initial overlap cutoff used to form sync groups (default: 0.16)": (
+            "用於形成同步組的初始重疊閾值（預設：0.16）"
+        ),
+        "pause length in milliseconds used to split subtitle blocks (default: 3000)": (
+            "用於分割字幕區塊的停頓時長，單位為毫秒（預設：3000）"
+        ),
+        'subtitle infile for bottom line or "-" for stdin': (
+            '底行字幕輸入檔，或使用 "-" 代表標準輸入'
+        ),
+        'subtitle infile for top line or "-" for stdin': (
+            '頂行字幕輸入檔，或使用 "-" 代表標準輸入'
+        ),
+        "synchronized subtitle outfile path (default: stdout)": (
+            "同步字幕輸出檔路徑（預設：標準輸出）"
+        ),
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class MultiSyncCli(ScinoephileCliBase):
     """Combine two series into the top and bottom of a synchronized series."""
 
-    localizations = {
-        "zh-hans": {
-            "combine two series into the top and bottom of a synchronized series": (
-                "将两个序列合并为上下行同步字幕"
-            ),
-            "initial overlap cutoff used to form sync groups (default: 0.16)": (
-                "用于形成同步组的初始重叠阈值（默认：0.16）"
-            ),
-            "pause length in milliseconds used to split subtitle blocks "
-            "(default: 3000)": ("用于分割字幕块的停顿时长，单位为毫秒（默认：3000）"),
-            'subtitle infile for bottom line or "-" for stdin': (
-                '底行字幕输入文件，或使用 "-" 表示标准输入'
-            ),
-            'subtitle infile for top line or "-" for stdin': (
-                '顶行字幕输入文件，或使用 "-" 表示标准输入'
-            ),
-            "synchronized subtitle outfile path (default: stdout)": (
-                "同步字幕输出文件路径（默认：标准输出）"
-            ),
-        },
-        "zh-hant": {
-            "combine two series into the top and bottom of a synchronized series": (
-                "將兩個序列合併為上下行同步字幕"
-            ),
-            "initial overlap cutoff used to form sync groups (default: 0.16)": (
-                "用於形成同步組的初始重疊閾值（預設：0.16）"
-            ),
-            "pause length in milliseconds used to split subtitle blocks "
-            "(default: 3000)": ("用於分割字幕區塊的停頓時長，單位為毫秒（預設：3000）"),
-            'subtitle infile for bottom line or "-" for stdin': (
-                '底行字幕輸入檔，或使用 "-" 代表標準輸入'
-            ),
-            'subtitle infile for top line or "-" for stdin': (
-                '頂行字幕輸入檔，或使用 "-" 代表標準輸入'
-            ),
-            "synchronized subtitle outfile path (default: stdout)": (
-                "同步字幕輸出檔路徑（預設：標準輸出）"
-            ),
-        },
-    }
+    localizations = MULTI_SYNC_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
     @classmethod

--- a/scinoephile/cli/multi/multi_timewarp_cli.py
+++ b/scinoephile/cli/multi/multi_timewarp_cli.py
@@ -19,64 +19,67 @@ from scinoephile.core.timing import get_series_timewarped
 
 __all__ = ["MultiTimewarpCli"]
 
+MULTI_TIMEWARP_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "1-based end index in anchor series (default: final subtitle)": (
+            "锚定序列中的结束索引，从 1 开始（默认：最后一条字幕）"
+        ),
+        "1-based end index in moving series (default: final subtitle)": (
+            "待调整序列中的结束索引，从 1 开始（默认：最后一条字幕）"
+        ),
+        "1-based start index in anchor series (default: 1)": (
+            "锚定序列中的起始索引，从 1 开始（默认：1）"
+        ),
+        "1-based start index in moving series (default: 1)": (
+            "待调整序列中的起始索引，从 1 开始（默认：1）"
+        ),
+        'mobile subtitle infile to be timewarped or "-" for stdin': (
+            '要调整时间轴的移动字幕输入文件，或使用 "-" 表示标准输入'
+        ),
+        "shift and stretch the timings of one subtitle series to match another": (
+            "平移并拉伸一个字幕序列的时间轴以匹配另一个序列"
+        ),
+        'subtitle infile used as anchor timing reference or "-" for stdin': (
+            '作为锚定时间参考的字幕输入文件，或使用 "-" 表示标准输入'
+        ),
+        "timewarped subtitle outfile path (default: stdout)": (
+            "时间轴调整后字幕输出文件路径（默认：标准输出）"
+        ),
+    },
+    "zh-hant": {
+        "1-based end index in anchor series (default: final subtitle)": (
+            "錨定序列中的結束索引，從 1 開始（預設：最後一條字幕）"
+        ),
+        "1-based end index in moving series (default: final subtitle)": (
+            "待調整序列中的結束索引，從 1 開始（預設：最後一條字幕）"
+        ),
+        "1-based start index in anchor series (default: 1)": (
+            "錨定序列中的起始索引，從 1 開始（預設：1）"
+        ),
+        "1-based start index in moving series (default: 1)": (
+            "待調整序列中的起始索引，從 1 開始（預設：1）"
+        ),
+        'mobile subtitle infile to be timewarped or "-" for stdin': (
+            '要調整時間軸的移動字幕輸入檔，或使用 "-" 代表標準輸入'
+        ),
+        "shift and stretch the timings of one subtitle series to match another": (
+            "平移並拉伸一個字幕序列的時間軸以匹配另一個序列"
+        ),
+        'subtitle infile used as anchor timing reference or "-" for stdin': (
+            '作為錨定時間參考的字幕輸入檔，或使用 "-" 代表標準輸入'
+        ),
+        "timewarped subtitle outfile path (default: stdout)": (
+            "時間軸調整後字幕輸出檔路徑（預設：標準輸出）"
+        ),
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class MultiTimewarpCli(ScinoephileCliBase):
     """Shift and stretch the timings of one subtitle series to match another."""
 
-    localizations = {
-        "zh-hans": {
-            "1-based end index in anchor series (default: final subtitle)": (
-                "锚定序列中的结束索引，从 1 开始（默认：最后一条字幕）"
-            ),
-            "1-based end index in moving series (default: final subtitle)": (
-                "待调整序列中的结束索引，从 1 开始（默认：最后一条字幕）"
-            ),
-            "1-based start index in anchor series (default: 1)": (
-                "锚定序列中的起始索引，从 1 开始（默认：1）"
-            ),
-            "1-based start index in moving series (default: 1)": (
-                "待调整序列中的起始索引，从 1 开始（默认：1）"
-            ),
-            'mobile subtitle infile to be timewarped or "-" for stdin': (
-                '要调整时间轴的移动字幕输入文件，或使用 "-" 表示标准输入'
-            ),
-            "shift and stretch the timings of one subtitle series to match another": (
-                "平移并拉伸一个字幕序列的时间轴以匹配另一个序列"
-            ),
-            'subtitle infile used as anchor timing reference or "-" for stdin': (
-                '作为锚定时间参考的字幕输入文件，或使用 "-" 表示标准输入'
-            ),
-            "timewarped subtitle outfile path (default: stdout)": (
-                "时间轴调整后字幕输出文件路径（默认：标准输出）"
-            ),
-        },
-        "zh-hant": {
-            "1-based end index in anchor series (default: final subtitle)": (
-                "錨定序列中的結束索引，從 1 開始（預設：最後一條字幕）"
-            ),
-            "1-based end index in moving series (default: final subtitle)": (
-                "待調整序列中的結束索引，從 1 開始（預設：最後一條字幕）"
-            ),
-            "1-based start index in anchor series (default: 1)": (
-                "錨定序列中的起始索引，從 1 開始（預設：1）"
-            ),
-            "1-based start index in moving series (default: 1)": (
-                "待調整序列中的起始索引，從 1 開始（預設：1）"
-            ),
-            'mobile subtitle infile to be timewarped or "-" for stdin': (
-                '要調整時間軸的移動字幕輸入檔，或使用 "-" 代表標準輸入'
-            ),
-            "shift and stretch the timings of one subtitle series to match another": (
-                "平移並拉伸一個字幕序列的時間軸以匹配另一個序列"
-            ),
-            'subtitle infile used as anchor timing reference or "-" for stdin': (
-                '作為錨定時間參考的字幕輸入檔，或使用 "-" 代表標準輸入'
-            ),
-            "timewarped subtitle outfile path (default: stdout)": (
-                "時間軸調整後字幕輸出檔路徑（預設：標準輸出）"
-            ),
-        },
-    }
+    localizations = MULTI_TIMEWARP_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
     @classmethod

--- a/scinoephile/cli/ocr/ocr_cli.py
+++ b/scinoephile/cli/ocr/ocr_cli.py
@@ -12,18 +12,21 @@ from scinoephile.core.cli import ScinoephileCliBase
 
 __all__ = ["OcrCli"]
 
+OCR_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "Recognize text from image-based subtitles.": "识别图像字幕中的文本。",
+    },
+    "zh-hant": {
+        "Recognize text from image-based subtitles.": "識別影像字幕中的文字。",
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class OcrCli(ScinoephileCliBase):
     """Recognize text from image-based subtitles."""
 
-    localizations = {
-        "zh-hans": {
-            "Recognize text from image-based subtitles.": "识别图像字幕中的文本。",
-        },
-        "zh-hant": {
-            "Recognize text from image-based subtitles.": "識別影像字幕中的文字。",
-        },
-    }
+    localizations = OCR_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
     @classmethod

--- a/scinoephile/cli/ocr/ocr_lens_cli.py
+++ b/scinoephile/cli/ocr/ocr_lens_cli.py
@@ -19,34 +19,37 @@ from scinoephile.image.subtitles import ImageSeries
 
 __all__ = ["OcrLensCli"]
 
+OCR_LENS_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "Google Lens language code": "Google Lens 语言代码",
+        "Recognize image subtitles with Google Lens.": (
+            "使用 Google Lens 识别图像字幕。"
+        ),
+        (
+            "image subtitle infile path (directory containing index.html and "
+            "png files, or a .sup file)"
+        ): "图像字幕输入文件路径（包含 index.html 和 png 文件，或 .sup 文件）",
+        "recognized subtitle outfile path": "识别后字幕输出文件路径",
+    },
+    "zh-hant": {
+        "Google Lens language code": "Google Lens 語言代碼",
+        "Recognize image subtitles with Google Lens.": (
+            "使用 Google Lens 識別影像字幕。"
+        ),
+        (
+            "image subtitle infile path (directory containing index.html and "
+            "png files, or a .sup file)"
+        ): "影像字幕輸入檔案路徑（包含 index.html 和 png 檔案，或 .sup 檔案）",
+        "recognized subtitle outfile path": "識別後字幕輸出檔案路徑",
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class OcrLensCli(ScinoephileCliBase):
     """Recognize image subtitles with Google Lens."""
 
-    localizations = {
-        "zh-hans": {
-            "Google Lens language code": "Google Lens 语言代码",
-            "Recognize image subtitles with Google Lens.": (
-                "使用 Google Lens 识别图像字幕。"
-            ),
-            (
-                "image subtitle infile path (directory containing index.html and "
-                "png files, or a .sup file)"
-            ): "图像字幕输入文件路径（包含 index.html 和 png 文件，或 .sup 文件）",
-            "recognized subtitle outfile path": "识别后字幕输出文件路径",
-        },
-        "zh-hant": {
-            "Google Lens language code": "Google Lens 語言代碼",
-            "Recognize image subtitles with Google Lens.": (
-                "使用 Google Lens 識別影像字幕。"
-            ),
-            (
-                "image subtitle infile path (directory containing index.html and "
-                "png files, or a .sup file)"
-            ): "影像字幕輸入檔案路徑（包含 index.html 和 png 檔案，或 .sup 檔案）",
-            "recognized subtitle outfile path": "識別後字幕輸出檔案路徑",
-        },
-    }
+    localizations = OCR_LENS_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
     @classmethod

--- a/scinoephile/cli/ocr/ocr_paddle_cli.py
+++ b/scinoephile/cli/ocr/ocr_paddle_cli.py
@@ -19,52 +19,45 @@ from scinoephile.image.subtitles import ImageSeries
 
 __all__ = ["OcrPaddleCli"]
 
+OCR_PADDLE_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        (
+            "PaddleOCR language code: en (English), ch (simplified Chinese "
+            "and English), chinese_cht (traditional Chinese)"
+        ): (
+            "PaddleOCR 语言代码：en（英语），ch（简体中文和英语），"
+            "chinese_cht（繁体中文）"
+        ),
+        "Recognize image subtitles with PaddleOCR.": ("使用 PaddleOCR 识别图像字幕。"),
+        (
+            "image subtitle infile path (directory containing index.html and "
+            "png files, or a .sup file)"
+        ): ("图像字幕输入文件路径（包含 index.html 和 png 文件的目录，或 .sup 文件）"),
+        "recognized subtitle outfile path": "识别后字幕输出文件路径",
+    },
+    "zh-hant": {
+        (
+            "PaddleOCR language code: en (English), ch (simplified Chinese "
+            "and English), chinese_cht (traditional Chinese)"
+        ): (
+            "PaddleOCR 語言代碼：en（英語），ch（簡體中文和英語），"
+            "chinese_cht（繁體中文）"
+        ),
+        "Recognize image subtitles with PaddleOCR.": ("使用 PaddleOCR 識別影像字幕。"),
+        (
+            "image subtitle infile path (directory containing index.html and "
+            "png files, or a .sup file)"
+        ): ("影像字幕輸入檔案路徑（包含 index.html 和 png 檔案的目錄，或 .sup 檔案）"),
+        "recognized subtitle outfile path": "識別後字幕輸出檔案路徑",
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class OcrPaddleCli(ScinoephileCliBase):
     """Recognize image subtitles with PaddleOCR."""
 
-    localizations = {
-        "zh-hans": {
-            (
-                "PaddleOCR language code: en (English), ch (simplified Chinese "
-                "and English), chinese_cht (traditional Chinese)"
-            ): (
-                "PaddleOCR 语言代码：en（英语），ch（简体中文和英语），"
-                "chinese_cht（繁体中文）"
-            ),
-            "Recognize image subtitles with PaddleOCR.": (
-                "使用 PaddleOCR 识别图像字幕。"
-            ),
-            (
-                "image subtitle infile path (directory containing index.html and "
-                "png files, or a .sup file)"
-            ): (
-                "图像字幕输入文件路径（包含 index.html 和 png 文件的目录，"
-                "或 .sup 文件）"
-            ),
-            "recognized subtitle outfile path": "识别后字幕输出文件路径",
-        },
-        "zh-hant": {
-            (
-                "PaddleOCR language code: en (English), ch (simplified Chinese "
-                "and English), chinese_cht (traditional Chinese)"
-            ): (
-                "PaddleOCR 語言代碼：en（英語），ch（簡體中文和英語），"
-                "chinese_cht（繁體中文）"
-            ),
-            "Recognize image subtitles with PaddleOCR.": (
-                "使用 PaddleOCR 識別影像字幕。"
-            ),
-            (
-                "image subtitle infile path (directory containing index.html and "
-                "png files, or a .sup file)"
-            ): (
-                "影像字幕輸入檔案路徑（包含 index.html 和 png 檔案的目錄，"
-                "或 .sup 檔案）"
-            ),
-            "recognized subtitle outfile path": "識別後字幕輸出檔案路徑",
-        },
-    }
+    localizations = OCR_PADDLE_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
     @classmethod

--- a/scinoephile/cli/ocr/ocr_tesseract_cli.py
+++ b/scinoephile/cli/ocr/ocr_tesseract_cli.py
@@ -19,50 +19,47 @@ from scinoephile.image.subtitles import ImageSeries
 
 __all__ = ["OcrTesseractCli"]
 
+OCR_TESSERACT_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "Recognize image subtitles with Tesseract OCR.": (
+            "使用 Tesseract OCR 识别图像字幕。"
+        ),
+        "Tesseract language code (default: %(default)s)": (
+            "Tesseract 语言代码（默认：%(default)s）"
+        ),
+        "run a second legacy-engine pass to detect italic text": (
+            "运行第二次旧版引擎识别以检测斜体文本"
+        ),
+        (
+            "image subtitle infile path (directory containing index.html and "
+            "png files, or a .sup file)"
+        ): ("图像字幕输入文件路径（包含 index.html 和 png 文件的目录，或 .sup 文件）"),
+        "recognized subtitle outfile path": "识别后字幕输出文件路径",
+    },
+    "zh-hant": {
+        "Recognize image subtitles with Tesseract OCR.": (
+            "使用 Tesseract OCR 識別影像字幕。"
+        ),
+        "Tesseract language code (default: %(default)s)": (
+            "Tesseract 語言代碼（預設：%(default)s）"
+        ),
+        "run a second legacy-engine pass to detect italic text": (
+            "執行第二次舊版引擎識別以偵測斜體文字"
+        ),
+        (
+            "image subtitle infile path (directory containing index.html and "
+            "png files, or a .sup file)"
+        ): ("影像字幕輸入檔案路徑（包含 index.html 和 png 檔案的目錄，或 .sup 檔案）"),
+        "recognized subtitle outfile path": "識別後字幕輸出檔案路徑",
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class OcrTesseractCli(ScinoephileCliBase):
     """Recognize image subtitles with Tesseract OCR."""
 
-    localizations = {
-        "zh-hans": {
-            "Recognize image subtitles with Tesseract OCR.": (
-                "使用 Tesseract OCR 识别图像字幕。"
-            ),
-            "Tesseract language code (default: %(default)s)": (
-                "Tesseract 语言代码（默认：%(default)s）"
-            ),
-            "run a second legacy-engine pass to detect italic text": (
-                "运行第二次旧版引擎识别以检测斜体文本"
-            ),
-            (
-                "image subtitle infile path (directory containing index.html and "
-                "png files, or a .sup file)"
-            ): (
-                "图像字幕输入文件路径（包含 index.html 和 png 文件的目录，"
-                "或 .sup 文件）"
-            ),
-            "recognized subtitle outfile path": "识别后字幕输出文件路径",
-        },
-        "zh-hant": {
-            "Recognize image subtitles with Tesseract OCR.": (
-                "使用 Tesseract OCR 識別影像字幕。"
-            ),
-            "Tesseract language code (default: %(default)s)": (
-                "Tesseract 語言代碼（預設：%(default)s）"
-            ),
-            "run a second legacy-engine pass to detect italic text": (
-                "執行第二次舊版引擎識別以偵測斜體文字"
-            ),
-            (
-                "image subtitle infile path (directory containing index.html and "
-                "png files, or a .sup file)"
-            ): (
-                "影像字幕輸入檔案路徑（包含 index.html 和 png 檔案的目錄，"
-                "或 .sup 檔案）"
-            ),
-            "recognized subtitle outfile path": "識別後字幕輸出檔案路徑",
-        },
-    }
+    localizations = OCR_TESSERACT_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
     @classmethod

--- a/scinoephile/cli/scinoephile_cli.py
+++ b/scinoephile/cli/scinoephile_cli.py
@@ -23,6 +23,68 @@ from .zho import ZhoCli
 
 __all__ = ["ScinoephileCli"]
 
+SCINOEPHILE_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "additional help": "附加帮助",
+        "Available subcommands:": "可用子命令：",
+        "build or search Chinese dictionaries": "构建或查询中文词典",
+        "calculate the Character Error Rate (CER) of one series relative to "
+        "another": "计算一个序列相对于另一个序列的字符错误率（CER）",
+        "calculate the diff between two series": "计算两个序列之间的差异",
+        "command-line interface for Scinoephile": "Scinoephile 命令行界面",
+        "combine two series into the top and bottom of a synchronized series": (
+            "将两个序列合并为上下行同步字幕"
+        ),
+        "fuse OCR output for a selected language": "融合所选语言的 OCR 输出",
+        "inspect and extract media streams": "检查并提取媒体流",
+        "list all subcommands and exit": "列出所有子命令并退出",
+        "modify English subtitles": "修改英文字幕",
+        "modify standard Chinese subtitles": "修改标准中文字幕",
+        "modify written Cantonese subtitles": "修改书面粤语字幕",
+        "operate on multiple subtitle series": "处理多个字幕序列",
+        "recognize text from image-based subtitles": "识别图像字幕中的文本",
+        "run utility commands": "运行实用工具命令",
+        (
+            "Scinoephile is an application for working with Chinese, English, "
+            "and bilingual subtitles."
+        ): "Scinoephile 是一个用于处理中英及双语字幕的应用。",
+        "shift and stretch the timings of one subtitle series to match another": (
+            "平移并拉伸一个字幕序列的时间轴以匹配另一个序列"
+        ),
+        "validate OCR text against subtitle images": "对照字幕图像校验 OCR 文本",
+    },
+    "zh-hant": {
+        "additional help": "附加說明",
+        "Available subcommands:": "可用子命令：",
+        "build or search Chinese dictionaries": "建置或查詢中文詞典",
+        "calculate the Character Error Rate (CER) of one series relative to "
+        "another": "計算一個序列相對於另一個序列的字元錯誤率（CER）",
+        "calculate the diff between two series": "計算兩個序列之間的差異",
+        "command-line interface for Scinoephile": "Scinoephile 命令列介面",
+        "combine two series into the top and bottom of a synchronized series": (
+            "將兩個序列合併為上下行同步字幕"
+        ),
+        "fuse OCR output for a selected language": "融合所選語言的 OCR 輸出",
+        "inspect and extract media streams": "檢查並提取媒體流",
+        "list all subcommands and exit": "列出所有子命令並結束",
+        "modify English subtitles": "修改英文字幕",
+        "modify standard Chinese subtitles": "修改標準中文字幕",
+        "modify written Cantonese subtitles": "修改書面粵語字幕",
+        "operate on multiple subtitle series": "處理多個字幕序列",
+        "recognize text from image-based subtitles": "識別影像字幕中的文字",
+        "run utility commands": "執行實用工具命令",
+        (
+            "Scinoephile is an application for working with Chinese, English, "
+            "and bilingual subtitles."
+        ): "Scinoephile 是用於處理中文、英文與雙語字幕的應用程式。",
+        "shift and stretch the timings of one subtitle series to match another": (
+            "平移並拉伸一個字幕序列的時間軸以匹配另一個序列"
+        ),
+        "validate OCR text against subtitle images": "對照字幕影像驗證 OCR 文字",
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class ScinoephileCli(ScinoephileCliBase):
     """Command-line interface for Scinoephile.
@@ -31,66 +93,7 @@ class ScinoephileCli(ScinoephileCliBase):
     subtitles.
     """
 
-    localizations = {
-        "zh-hans": {
-            "additional help": "附加帮助",
-            "Available subcommands:": "可用子命令：",
-            "build or search Chinese dictionaries": "构建或查询中文词典",
-            "calculate the Character Error Rate (CER) of one series relative to "
-            "another": "计算一个序列相对于另一个序列的字符错误率（CER）",
-            "calculate the diff between two series": "计算两个序列之间的差异",
-            "command-line interface for Scinoephile": "Scinoephile 命令行界面",
-            "combine two series into the top and bottom of a synchronized series": (
-                "将两个序列合并为上下行同步字幕"
-            ),
-            "fuse OCR output for a selected language": "融合所选语言的 OCR 输出",
-            "inspect and extract media streams": "检查并提取媒体流",
-            "list all subcommands and exit": "列出所有子命令并退出",
-            "modify English subtitles": "修改英文字幕",
-            "modify standard Chinese subtitles": "修改标准中文字幕",
-            "modify written Cantonese subtitles": "修改书面粤语字幕",
-            "operate on multiple subtitle series": "处理多个字幕序列",
-            "recognize text from image-based subtitles": "识别图像字幕中的文本",
-            "run utility commands": "运行实用工具命令",
-            (
-                "Scinoephile is an application for working with Chinese, English, "
-                "and bilingual subtitles."
-            ): "Scinoephile 是一个用于处理中英及双语字幕的应用。",
-            "shift and stretch the timings of one subtitle series to match another": (
-                "平移并拉伸一个字幕序列的时间轴以匹配另一个序列"
-            ),
-            "validate OCR text against subtitle images": "对照字幕图像校验 OCR 文本",
-        },
-        "zh-hant": {
-            "additional help": "附加說明",
-            "Available subcommands:": "可用子命令：",
-            "build or search Chinese dictionaries": "建置或查詢中文詞典",
-            "calculate the Character Error Rate (CER) of one series relative to "
-            "another": "計算一個序列相對於另一個序列的字元錯誤率（CER）",
-            "calculate the diff between two series": "計算兩個序列之間的差異",
-            "command-line interface for Scinoephile": "Scinoephile 命令列介面",
-            "combine two series into the top and bottom of a synchronized series": (
-                "將兩個序列合併為上下行同步字幕"
-            ),
-            "fuse OCR output for a selected language": "融合所選語言的 OCR 輸出",
-            "inspect and extract media streams": "檢查並提取媒體流",
-            "list all subcommands and exit": "列出所有子命令並結束",
-            "modify English subtitles": "修改英文字幕",
-            "modify standard Chinese subtitles": "修改標準中文字幕",
-            "modify written Cantonese subtitles": "修改書面粵語字幕",
-            "operate on multiple subtitle series": "處理多個字幕序列",
-            "recognize text from image-based subtitles": "識別影像字幕中的文字",
-            "run utility commands": "執行實用工具命令",
-            (
-                "Scinoephile is an application for working with Chinese, English, "
-                "and bilingual subtitles."
-            ): "Scinoephile 是用於處理中文、英文與雙語字幕的應用程式。",
-            "shift and stretch the timings of one subtitle series to match another": (
-                "平移並拉伸一個字幕序列的時間軸以匹配另一個序列"
-            ),
-            "validate OCR text against subtitle images": "對照字幕影像驗證 OCR 文字",
-        },
-    }
+    localizations = SCINOEPHILE_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
     @classmethod

--- a/scinoephile/cli/utility/cache/cache_clear_cli.py
+++ b/scinoephile/cli/utility/cache/cache_clear_cli.py
@@ -17,36 +17,39 @@ from .output import print_entries
 
 __all__ = ["CacheClearCli"]
 
+CACHE_CLEAR_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "cache namespace to clear": "要清除的缓存命名空间",
+        "cache root directory to inspect (default: %(default)s)": (
+            "要检查的缓存根目录（默认：%(default)s）"
+        ),
+        "clear cache entries": "清除缓存条目",
+        "clear every discovered namespace": "清除所有发现的命名空间",
+        "confirm destructive deletion": "确认破坏性删除",
+        "show what would be deleted without deleting files": (
+            "显示将删除的内容但不删除文件"
+        ),
+    },
+    "zh-hant": {
+        "cache namespace to clear": "要清除的快取命名空間",
+        "cache root directory to inspect (default: %(default)s)": (
+            "要檢查的快取根目錄（預設：%(default)s）"
+        ),
+        "clear cache entries": "清除快取條目",
+        "clear every discovered namespace": "清除所有發現的命名空間",
+        "confirm destructive deletion": "確認破壞性刪除",
+        "show what would be deleted without deleting files": (
+            "顯示將刪除的內容但不刪除檔案"
+        ),
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class CacheClearCli(ScinoephileCliBase):
     """Clear cache entries."""
 
-    localizations = {
-        "zh-hans": {
-            "cache namespace to clear": "要清除的缓存命名空间",
-            "cache root directory to inspect (default: %(default)s)": (
-                "要检查的缓存根目录（默认：%(default)s）"
-            ),
-            "clear cache entries": "清除缓存条目",
-            "clear every discovered namespace": "清除所有发现的命名空间",
-            "confirm destructive deletion": "确认破坏性删除",
-            "show what would be deleted without deleting files": (
-                "显示将删除的内容但不删除文件"
-            ),
-        },
-        "zh-hant": {
-            "cache namespace to clear": "要清除的快取命名空間",
-            "cache root directory to inspect (default: %(default)s)": (
-                "要檢查的快取根目錄（預設：%(default)s）"
-            ),
-            "clear cache entries": "清除快取條目",
-            "clear every discovered namespace": "清除所有發現的命名空間",
-            "confirm destructive deletion": "確認破壞性刪除",
-            "show what would be deleted without deleting files": (
-                "顯示將刪除的內容但不刪除檔案"
-            ),
-        },
-    }
+    localizations = CACHE_CLEAR_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
     @classmethod

--- a/scinoephile/cli/utility/cache/cache_cli.py
+++ b/scinoephile/cli/utility/cache/cache_cli.py
@@ -17,14 +17,17 @@ from .cache_stats_cli import CacheStatsCli
 
 __all__ = ["CacheCli"]
 
+CACHE_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {"inspect and invalidate local caches": "检查并清除本地缓存"},
+    "zh-hant": {"inspect and invalidate local caches": "檢查並清除本機快取"},
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class CacheCli(ScinoephileCliBase):
     """Inspect and invalidate local caches."""
 
-    localizations = {
-        "zh-hans": {"inspect and invalidate local caches": "检查并清除本地缓存"},
-        "zh-hant": {"inspect and invalidate local caches": "檢查並清除本機快取"},
-    }
+    localizations = CACHE_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
     @classmethod

--- a/scinoephile/cli/utility/cache/cache_list_cli.py
+++ b/scinoephile/cli/utility/cache/cache_list_cli.py
@@ -18,34 +18,37 @@ from .output import print_entries, sort_entries
 
 __all__ = ["CacheListCli"]
 
+CACHE_LIST_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "cache namespace to inspect": "要检查的缓存命名空间",
+        "cache root directory to inspect (default: %(default)s)": (
+            "要检查的缓存根目录（默认：%(default)s）"
+        ),
+        "list cache entries": "列出缓存条目",
+        "maximum number of entries to show": "要显示的最大条目数",
+        "output format": "输出格式",
+        "reverse sort order": "反转排序顺序",
+        "sort field": "排序字段",
+    },
+    "zh-hant": {
+        "cache namespace to inspect": "要檢查的快取命名空間",
+        "cache root directory to inspect (default: %(default)s)": (
+            "要檢查的快取根目錄（預設：%(default)s）"
+        ),
+        "list cache entries": "列出快取條目",
+        "maximum number of entries to show": "要顯示的最大條目數",
+        "output format": "輸出格式",
+        "reverse sort order": "反轉排序順序",
+        "sort field": "排序欄位",
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class CacheListCli(ScinoephileCliBase):
     """List cache entries."""
 
-    localizations = {
-        "zh-hans": {
-            "cache namespace to inspect": "要检查的缓存命名空间",
-            "cache root directory to inspect (default: %(default)s)": (
-                "要检查的缓存根目录（默认：%(default)s）"
-            ),
-            "list cache entries": "列出缓存条目",
-            "maximum number of entries to show": "要显示的最大条目数",
-            "output format": "输出格式",
-            "reverse sort order": "反转排序顺序",
-            "sort field": "排序字段",
-        },
-        "zh-hant": {
-            "cache namespace to inspect": "要檢查的快取命名空間",
-            "cache root directory to inspect (default: %(default)s)": (
-                "要檢查的快取根目錄（預設：%(default)s）"
-            ),
-            "list cache entries": "列出快取條目",
-            "maximum number of entries to show": "要顯示的最大條目數",
-            "output format": "輸出格式",
-            "reverse sort order": "反轉排序順序",
-            "sort field": "排序欄位",
-        },
-    }
+    localizations = CACHE_LIST_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
     @classmethod

--- a/scinoephile/cli/utility/cache/cache_prune_cli.py
+++ b/scinoephile/cli/utility/cache/cache_prune_cli.py
@@ -18,40 +18,43 @@ from .output import print_entries
 
 __all__ = ["CachePruneCli"]
 
+CACHE_PRUNE_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "cache namespace to inspect": "要检查的缓存命名空间",
+        "cache root directory to inspect (default: %(default)s)": (
+            "要检查的缓存根目录（默认：%(default)s）"
+        ),
+        "confirm destructive deletion": "确认破坏性删除",
+        "delete entries older than a duration such as 7d, 30d, or 12h": (
+            "删除早于指定时长的条目，例如 7d、30d 或 12h"
+        ),
+        "prune old cache entries": "清理旧缓存条目",
+        "show what would be deleted without deleting files": (
+            "显示将删除的内容但不删除文件"
+        ),
+    },
+    "zh-hant": {
+        "cache namespace to inspect": "要檢查的快取命名空間",
+        "cache root directory to inspect (default: %(default)s)": (
+            "要檢查的快取根目錄（預設：%(default)s）"
+        ),
+        "confirm destructive deletion": "確認破壞性刪除",
+        "delete entries older than a duration such as 7d, 30d, or 12h": (
+            "刪除早於指定時長的條目，例如 7d、30d 或 12h"
+        ),
+        "prune old cache entries": "清理舊快取條目",
+        "show what would be deleted without deleting files": (
+            "顯示將刪除的內容但不刪除檔案"
+        ),
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class CachePruneCli(ScinoephileCliBase):
     """Prune old cache entries."""
 
-    localizations = {
-        "zh-hans": {
-            "cache namespace to inspect": "要检查的缓存命名空间",
-            "cache root directory to inspect (default: %(default)s)": (
-                "要检查的缓存根目录（默认：%(default)s）"
-            ),
-            "confirm destructive deletion": "确认破坏性删除",
-            "delete entries older than a duration such as 7d, 30d, or 12h": (
-                "删除早于指定时长的条目，例如 7d、30d 或 12h"
-            ),
-            "prune old cache entries": "清理旧缓存条目",
-            "show what would be deleted without deleting files": (
-                "显示将删除的内容但不删除文件"
-            ),
-        },
-        "zh-hant": {
-            "cache namespace to inspect": "要檢查的快取命名空間",
-            "cache root directory to inspect (default: %(default)s)": (
-                "要檢查的快取根目錄（預設：%(default)s）"
-            ),
-            "confirm destructive deletion": "確認破壞性刪除",
-            "delete entries older than a duration such as 7d, 30d, or 12h": (
-                "刪除早於指定時長的條目，例如 7d、30d 或 12h"
-            ),
-            "prune old cache entries": "清理舊快取條目",
-            "show what would be deleted without deleting files": (
-                "顯示將刪除的內容但不刪除檔案"
-            ),
-        },
-    }
+    localizations = CACHE_PRUNE_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
     @classmethod

--- a/scinoephile/cli/utility/cache/cache_stats_cli.py
+++ b/scinoephile/cli/utility/cache/cache_stats_cli.py
@@ -18,28 +18,31 @@ from .output import print_stats
 
 __all__ = ["CacheStatsCli"]
 
+CACHE_STATS_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "cache namespace to inspect": "要检查的缓存命名空间",
+        "cache root directory to inspect (default: %(default)s)": (
+            "要检查的缓存根目录（默认：%(default)s）"
+        ),
+        "output format": "输出格式",
+        "show cache statistics": "显示缓存统计信息",
+    },
+    "zh-hant": {
+        "cache namespace to inspect": "要檢查的快取命名空間",
+        "cache root directory to inspect (default: %(default)s)": (
+            "要檢查的快取根目錄（預設：%(default)s）"
+        ),
+        "output format": "輸出格式",
+        "show cache statistics": "顯示快取統計資訊",
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class CacheStatsCli(ScinoephileCliBase):
     """Show cache statistics."""
 
-    localizations = {
-        "zh-hans": {
-            "cache namespace to inspect": "要检查的缓存命名空间",
-            "cache root directory to inspect (default: %(default)s)": (
-                "要检查的缓存根目录（默认：%(default)s）"
-            ),
-            "output format": "输出格式",
-            "show cache statistics": "显示缓存统计信息",
-        },
-        "zh-hant": {
-            "cache namespace to inspect": "要檢查的快取命名空間",
-            "cache root directory to inspect (default: %(default)s)": (
-                "要檢查的快取根目錄（預設：%(default)s）"
-            ),
-            "output format": "輸出格式",
-            "show cache statistics": "顯示快取統計資訊",
-        },
-    }
+    localizations = CACHE_STATS_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
     @classmethod

--- a/scinoephile/cli/utility/optimization/optimization_cli.py
+++ b/scinoephile/cli/utility/optimization/optimization_cli.py
@@ -14,20 +14,23 @@ from .optimization_test_cases_cli import OptimizationSyncTestCasesCli
 
 __all__ = ["OptimizationCli"]
 
+OPTIMIZATION_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "optimization-related tools": "优化相关工具",
+        "prompt optimization utilities and persistence": "提示词优化工具与持久化",
+    },
+    "zh-hant": {
+        "optimization-related tools": "最佳化相關工具",
+        "prompt optimization utilities and persistence": "提示詞最佳化工具與持久化",
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class OptimizationCli(ScinoephileCliBase):
     """Prompt optimization utilities and persistence."""
 
-    localizations = {
-        "zh-hans": {
-            "optimization-related tools": "优化相关工具",
-            "prompt optimization utilities and persistence": "提示词优化工具与持久化",
-        },
-        "zh-hant": {
-            "optimization-related tools": "最佳化相關工具",
-            "prompt optimization utilities and persistence": "提示詞最佳化工具與持久化",
-        },
-    }
+    localizations = OPTIMIZATION_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
     @classmethod

--- a/scinoephile/cli/utility/optimization/optimization_test_cases_cli.py
+++ b/scinoephile/cli/utility/optimization/optimization_test_cases_cli.py
@@ -23,38 +23,41 @@ from .argument_types import operation_arg
 
 __all__ = ["OptimizationSyncTestCasesCli"]
 
+OPTIMIZATION_SYNC_TEST_CASES_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "SQLite database outfile path": "SQLite 数据库输出路径",
+        "operation to which test case JSON file(s) correspond": (
+            "测试用例 JSON 文件对应的操作"
+        ),
+        "list rows that would be inserted, updated, or deleted without writing": (
+            "列出将插入、更新或删除的行而不写入"
+        ),
+        "one or more input JSON paths": "一个或多个输入 JSON 路径",
+        "synchronize persisted LLM test cases from JSON into SQLite": (
+            "将 JSON 测试用例同步到 SQLite"
+        ),
+    },
+    "zh-hant": {
+        "SQLite database outfile path": "SQLite 資料庫輸出路徑",
+        "operation to which test case JSON file(s) correspond": (
+            "測試用例 JSON 檔對應的操作"
+        ),
+        "list rows that would be inserted, updated, or deleted without writing": (
+            "列出將插入、更新或刪除的列而不寫入"
+        ),
+        "one or more input JSON paths": "一個或多個輸入 JSON 路徑",
+        "synchronize persisted LLM test cases from JSON into SQLite": (
+            "將 JSON 測試用例同步到 SQLite"
+        ),
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class OptimizationSyncTestCasesCli(ScinoephileCliBase):
     """Synchronize persisted LLM test cases from JSON into SQLite."""
 
-    localizations = {
-        "zh-hans": {
-            "SQLite database outfile path": "SQLite 数据库输出路径",
-            "operation to which test case JSON file(s) correspond": (
-                "测试用例 JSON 文件对应的操作"
-            ),
-            "list rows that would be inserted, updated, or deleted without writing": (
-                "列出将插入、更新或删除的行而不写入"
-            ),
-            "one or more input JSON paths": "一个或多个输入 JSON 路径",
-            "synchronize persisted LLM test cases from JSON into SQLite": (
-                "将 JSON 测试用例同步到 SQLite"
-            ),
-        },
-        "zh-hant": {
-            "SQLite database outfile path": "SQLite 資料庫輸出路徑",
-            "operation to which test case JSON file(s) correspond": (
-                "測試用例 JSON 檔對應的操作"
-            ),
-            "list rows that would be inserted, updated, or deleted without writing": (
-                "列出將插入、更新或刪除的列而不寫入"
-            ),
-            "one or more input JSON paths": "一個或多個輸入 JSON 路徑",
-            "synchronize persisted LLM test cases from JSON into SQLite": (
-                "將 JSON 測試用例同步到 SQLite"
-            ),
-        },
-    }
+    localizations = OPTIMIZATION_SYNC_TEST_CASES_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
     @classmethod

--- a/scinoephile/cli/utility/utility_cli.py
+++ b/scinoephile/cli/utility/utility_cli.py
@@ -15,20 +15,23 @@ from .optimization import OptimizationCli
 
 __all__ = ["UtilityCli"]
 
+UTILITY_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "command-line interface for utility operations": "实用工具命令行界面",
+        "run utility commands": "运行实用工具命令",
+    },
+    "zh-hant": {
+        "command-line interface for utility operations": "實用工具命令列介面",
+        "run utility commands": "執行實用工具命令",
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class UtilityCli(ScinoephileCliBase):
     """Run utility commands."""
 
-    localizations = {
-        "zh-hans": {
-            "command-line interface for utility operations": "实用工具命令行界面",
-            "run utility commands": "运行实用工具命令",
-        },
-        "zh-hant": {
-            "command-line interface for utility operations": "實用工具命令列介面",
-            "run utility commands": "執行實用工具命令",
-        },
-    }
+    localizations = UTILITY_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
     @classmethod

--- a/scinoephile/cli/yue/yue_cli.py
+++ b/scinoephile/cli/yue/yue_cli.py
@@ -17,24 +17,27 @@ from .yue_translate_vs_zho_cli import YueTranslateVsZhoCli
 
 __all__ = ["YueCli"]
 
+YUE_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "command-line interface for written Cantonese subtitle operations": (
+            "书面粤语字幕操作命令行界面"
+        ),
+        "modify written Cantonese subtitles": "修改书面粤语字幕",
+    },
+    "zh-hant": {
+        "command-line interface for written Cantonese subtitle operations": (
+            "書面粵語字幕操作命令列介面"
+        ),
+        "modify written Cantonese subtitles": "修改書面粵語字幕",
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class YueCli(ScinoephileCliBase):
     """Modify written Cantonese subtitles."""
 
-    localizations = {
-        "zh-hans": {
-            "command-line interface for written Cantonese subtitle operations": (
-                "书面粤语字幕操作命令行界面"
-            ),
-            "modify written Cantonese subtitles": "修改书面粤语字幕",
-        },
-        "zh-hant": {
-            "command-line interface for written Cantonese subtitle operations": (
-                "書面粵語字幕操作命令列介面"
-            ),
-            "modify written Cantonese subtitles": "修改書面粵語字幕",
-        },
-    }
+    localizations = YUE_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
     @classmethod

--- a/scinoephile/cli/yue/yue_process_cli.py
+++ b/scinoephile/cli/yue/yue_process_cli.py
@@ -41,6 +41,62 @@ from scinoephile.llms.providers.registry import get_provider
 
 __all__ = ["YueProcessCli"]
 
+YUE_PROCESS_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "append Cantonese romanization to subtitles": "为字幕追加粤语罗马字",
+        "clean subtitles of closed-caption annotations and other anomalies": (
+            "清理字幕中的隐藏字幕标注及其他异常"
+        ),
+        "command-line interface for written Cantonese subtitle processing": (
+            "书面粤语字幕处理命令行界面"
+        ),
+        "flatten multi-line subtitles into single lines": ("将多行字幕合并为单行"),
+        "modify written Cantonese subtitles": "修改书面粤语字幕",
+        "proofread subtitles using LLM (default: traditional)": (
+            "使用大语言模型校对字幕（默认：繁体）"
+        ),
+        "script for prompts and output conversion (default: traditional)": (
+            "提示词和输出转换使用的字形（默认：繁体）"
+        ),
+        "shift subtitle timings by this many milliseconds": (
+            "按指定毫秒数平移字幕时间"
+        ),
+        'Written Cantonese subtitle infile path or "-" for stdin': (
+            '书面粤语字幕输入文件路径，或使用 "-" 表示标准输入'
+        ),
+        "Written Cantonese subtitle outfile path (default: stdout)": (
+            "书面粤语字幕输出文件路径（默认：标准输出）"
+        ),
+    },
+    "zh-hant": {
+        "append Cantonese romanization to subtitles": "為字幕附加粵語羅馬字",
+        "clean subtitles of closed-caption annotations and other anomalies": (
+            "清理字幕中的隱藏字幕標註及其他異常"
+        ),
+        "command-line interface for written Cantonese subtitle processing": (
+            "書面粵語字幕處理命令列介面"
+        ),
+        "flatten multi-line subtitles into single lines": ("將多行字幕合併為單行"),
+        "modify written Cantonese subtitles": "修改書面粵語字幕",
+        "proofread subtitles using LLM (default: traditional)": (
+            "使用大型語言模型校對字幕（預設：繁體）"
+        ),
+        "script for prompts and output conversion (default: traditional)": (
+            "提示詞與輸出轉換使用的字形（預設：繁體）"
+        ),
+        "shift subtitle timings by this many milliseconds": (
+            "依指定毫秒數平移字幕時間"
+        ),
+        'Written Cantonese subtitle infile path or "-" for stdin': (
+            '書面粵語字幕輸入檔路徑，或使用 "-" 代表標準輸入'
+        ),
+        "Written Cantonese subtitle outfile path (default: stdout)": (
+            "書面粵語字幕輸出檔路徑（預設：標準輸出）"
+        ),
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class YueProcessCli(ScinoephileCliBase):
     """Modify written Cantonese subtitles."""
@@ -48,64 +104,7 @@ class YueProcessCli(ScinoephileCliBase):
     localizations = merge_localizations(
         CONVERSION_LOCALIZATIONS,
         LLM_LOCALIZATIONS,
-        {
-            "zh-hans": {
-                "append Cantonese romanization to subtitles": "为字幕追加粤语罗马字",
-                "clean subtitles of closed-caption annotations and other anomalies": (
-                    "清理字幕中的隐藏字幕标注及其他异常"
-                ),
-                "command-line interface for written Cantonese subtitle processing": (
-                    "书面粤语字幕处理命令行界面"
-                ),
-                "flatten multi-line subtitles into single lines": (
-                    "将多行字幕合并为单行"
-                ),
-                "modify written Cantonese subtitles": "修改书面粤语字幕",
-                "proofread subtitles using LLM (default: traditional)": (
-                    "使用大语言模型校对字幕（默认：繁体）"
-                ),
-                "script for prompts and output conversion (default: traditional)": (
-                    "提示词和输出转换使用的字形（默认：繁体）"
-                ),
-                "shift subtitle timings by this many milliseconds": (
-                    "按指定毫秒数平移字幕时间"
-                ),
-                'Written Cantonese subtitle infile path or "-" for stdin': (
-                    '书面粤语字幕输入文件路径，或使用 "-" 表示标准输入'
-                ),
-                "Written Cantonese subtitle outfile path (default: stdout)": (
-                    "书面粤语字幕输出文件路径（默认：标准输出）"
-                ),
-            },
-            "zh-hant": {
-                "append Cantonese romanization to subtitles": "為字幕附加粵語羅馬字",
-                "clean subtitles of closed-caption annotations and other anomalies": (
-                    "清理字幕中的隱藏字幕標註及其他異常"
-                ),
-                "command-line interface for written Cantonese subtitle processing": (
-                    "書面粵語字幕處理命令列介面"
-                ),
-                "flatten multi-line subtitles into single lines": (
-                    "將多行字幕合併為單行"
-                ),
-                "modify written Cantonese subtitles": "修改書面粵語字幕",
-                "proofread subtitles using LLM (default: traditional)": (
-                    "使用大型語言模型校對字幕（預設：繁體）"
-                ),
-                "script for prompts and output conversion (default: traditional)": (
-                    "提示詞與輸出轉換使用的字形（預設：繁體）"
-                ),
-                "shift subtitle timings by this many milliseconds": (
-                    "依指定毫秒數平移字幕時間"
-                ),
-                'Written Cantonese subtitle infile path or "-" for stdin': (
-                    '書面粵語字幕輸入檔路徑，或使用 "-" 代表標準輸入'
-                ),
-                "Written Cantonese subtitle outfile path (default: stdout)": (
-                    "書面粵語字幕輸出檔路徑（預設：標準輸出）"
-                ),
-            },
-        },
+        YUE_PROCESS_LOCALIZATIONS,
     )
     """Localized help text keyed by locale and English source text."""
 

--- a/scinoephile/cli/yue/yue_review_vs_zho_cli.py
+++ b/scinoephile/cli/yue/yue_review_vs_zho_cli.py
@@ -32,66 +32,67 @@ from scinoephile.multilang.yue_zho.line_review import (
 
 __all__ = ["YueReviewVsZhoCli"]
 
+YUE_REVIEW_VS_ZHO_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        (
+            "command-line interface for written Cantonese review against "
+            "standard Chinese"
+        ): "书面粤语对照标准中文校对命令行界面",
+        (
+            "review mode (default: block): block=block-by-block review, "
+            "line=line-by-line review"
+        ): "校对模式（默认：block）：block=按区块校对，line=按行校对",
+        "reviewed written Cantonese subtitle outfile path (default: stdout)": (
+            "校对后的书面粤语字幕输出文件路径（默认：标准输出）"
+        ),
+        (
+            "review written Cantonese subtitles against standard Chinese subtitles"
+        ): "校对书面粤语字幕与标准中文字幕",
+        "script for prompts and output conversion (default: simplified)": (
+            "提示词和输出转换使用的字形（默认：简体）"
+        ),
+        'target written Cantonese subtitle infile path or "-" for stdin': (
+            '目标书面粤语字幕输入文件路径，或使用 "-" 表示标准输入'
+        ),
+        'reference standard Chinese subtitle infile path or "-" for stdin': (
+            '参考标准中文字幕输入文件路径，或使用 "-" 表示标准输入'
+        ),
+    },
+    "zh-hant": {
+        (
+            "command-line interface for written Cantonese review against "
+            "standard Chinese"
+        ): "書面粵語對照標準中文校對命令列介面",
+        (
+            "review mode (default: block): block=block-by-block review, "
+            "line=line-by-line review"
+        ): "校對模式（預設：block）：block=按區塊校對，line=按行校對",
+        "reviewed written Cantonese subtitle outfile path (default: stdout)": (
+            "校對後的書面粵語字幕輸出檔路徑（預設：標準輸出）"
+        ),
+        (
+            "review written Cantonese subtitles against standard Chinese subtitles"
+        ): "校對書面粵語字幕與標準中文字幕",
+        "script for prompts and output conversion (default: simplified)": (
+            "提示詞與輸出轉換使用的字形（預設：簡體）"
+        ),
+        'target written Cantonese subtitle infile path or "-" for stdin': (
+            '目標書面粵語字幕輸入檔路徑，或使用 "-" 代表標準輸入'
+        ),
+        'reference standard Chinese subtitle infile path or "-" for stdin': (
+            '參考標準中文字幕輸入檔路徑，或使用 "-" 代表標準輸入'
+        ),
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class YueReviewVsZhoCli(ScinoephileCliBase):
     """Review written Cantonese subtitles against standard Chinese subtitles."""
 
     localizations = merge_localizations(
         LLM_LOCALIZATIONS,
-        {
-            "zh-hans": {
-                (
-                    "command-line interface for written Cantonese review against "
-                    "standard Chinese"
-                ): "书面粤语对照标准中文校对命令行界面",
-                (
-                    "review mode (default: block): block=block-by-block review, "
-                    "line=line-by-line review"
-                ): "校对模式（默认：block）：block=按区块校对，line=按行校对",
-                "reviewed written Cantonese subtitle outfile path (default: stdout)": (
-                    "校对后的书面粤语字幕输出文件路径（默认：标准输出）"
-                ),
-                (
-                    "review written Cantonese subtitles against standard Chinese "
-                    "subtitles"
-                ): "校对书面粤语字幕与标准中文字幕",
-                "script for prompts and output conversion (default: simplified)": (
-                    "提示词和输出转换使用的字形（默认：简体）"
-                ),
-                'target written Cantonese subtitle infile path or "-" for stdin': (
-                    '目标书面粤语字幕输入文件路径，或使用 "-" 表示标准输入'
-                ),
-                'reference standard Chinese subtitle infile path or "-" for stdin': (
-                    '参考标准中文字幕输入文件路径，或使用 "-" 表示标准输入'
-                ),
-            },
-            "zh-hant": {
-                (
-                    "command-line interface for written Cantonese review against "
-                    "standard Chinese"
-                ): "書面粵語對照標準中文校對命令列介面",
-                (
-                    "review mode (default: block): block=block-by-block review, "
-                    "line=line-by-line review"
-                ): "校對模式（預設：block）：block=按區塊校對，line=按行校對",
-                "reviewed written Cantonese subtitle outfile path (default: stdout)": (
-                    "校對後的書面粵語字幕輸出檔路徑（預設：標準輸出）"
-                ),
-                (
-                    "review written Cantonese subtitles against standard Chinese "
-                    "subtitles"
-                ): "校對書面粵語字幕與標準中文字幕",
-                "script for prompts and output conversion (default: simplified)": (
-                    "提示詞與輸出轉換使用的字形（預設：簡體）"
-                ),
-                'target written Cantonese subtitle infile path or "-" for stdin': (
-                    '目標書面粵語字幕輸入檔路徑，或使用 "-" 代表標準輸入'
-                ),
-                'reference standard Chinese subtitle infile path or "-" for stdin': (
-                    '參考標準中文字幕輸入檔路徑，或使用 "-" 代表標準輸入'
-                ),
-            },
-        },
+        YUE_REVIEW_VS_ZHO_LOCALIZATIONS,
     )
     """Localized help text keyed by locale and English source text."""
 

--- a/scinoephile/cli/yue/yue_transcribe_vs_zho_cli.py
+++ b/scinoephile/cli/yue/yue_transcribe_vs_zho_cli.py
@@ -45,6 +45,70 @@ from scinoephile.multilang.yue_zho.transcription.punctuation import (
 
 __all__ = ["YueTranscribeVsZhoCli"]
 
+YUE_TRANSCRIBE_VS_ZHO_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "audio stream index in media input (default: 0)": (
+            "媒体输入中的音频流索引（默认：0）"
+        ),
+        (
+            "command-line interface for written Cantonese subtitle transcription"
+        ): "书面粤语字幕转写命令行界面",
+        "script used for transcription prompts (default: simplified)": (
+            "转写提示词使用的字形（默认：简体）"
+        ),
+        "Demucs vocal-separation mode (options: on, off; default: off)": (
+            "Demucs 人声分离模式（选项：on、off；默认：off）"
+        ),
+        (
+            "Whisper voice activity detection mode "
+            "(options: on, off, auto; default: auto)"
+        ): "Whisper 语音活动检测模式（选项：on、off、auto；默认：auto）",
+        'Standard Chinese subtitle infile or "-" for stdin': (
+            '标准中文字幕输入文件，或使用 "-" 表示标准输入'
+        ),
+        "video or audio media input path used for transcription": (
+            "用于转写的视频或音频输入路径"
+        ),
+        "Written Cantonese subtitle outfile path (default: stdout)": (
+            "书面粤语字幕输出文件路径（默认：标准输出）"
+        ),
+        (
+            "Transcribe subtitles from audio and revise using standard Chinese text"
+        ): "从音频转录字幕，并使用标准中文文本修订",
+    },
+    "zh-hant": {
+        "audio stream index in media input (default: 0)": (
+            "媒體輸入中的音訊流索引（預設：0）"
+        ),
+        (
+            "command-line interface for written Cantonese subtitle transcription"
+        ): "書面粵語字幕轉寫命令列介面",
+        "script used for transcription prompts (default: simplified)": (
+            "轉寫提示詞使用的字形（預設：簡體）"
+        ),
+        "Demucs vocal-separation mode (options: on, off; default: off)": (
+            "Demucs 人聲分離模式（選項：on、off；預設：off）"
+        ),
+        (
+            "Whisper voice activity detection mode "
+            "(options: on, off, auto; default: auto)"
+        ): "Whisper 語音活動偵測模式（選項：on、off、auto；預設：auto）",
+        'Standard Chinese subtitle infile or "-" for stdin': (
+            '標準中文字幕輸入檔，或使用 "-" 代表標準輸入'
+        ),
+        "video or audio media input path used for transcription": (
+            "用於轉寫的視訊或音訊輸入路徑"
+        ),
+        "Written Cantonese subtitle outfile path (default: stdout)": (
+            "書面粵語字幕輸出檔路徑（預設：標準輸出）"
+        ),
+        (
+            "Transcribe subtitles from audio and revise using standard Chinese text"
+        ): "從音訊轉錄字幕，並使用標準中文文字修訂",
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class YueTranscribeVsZhoCli(ScinoephileCliBase):
     """Transcribe subtitles from audio and revise using standard Chinese text."""
@@ -52,72 +116,7 @@ class YueTranscribeVsZhoCli(ScinoephileCliBase):
     localizations = merge_localizations(
         CONVERSION_LOCALIZATIONS,
         LLM_LOCALIZATIONS,
-        {
-            "zh-hans": {
-                "audio stream index in media input (default: 0)": (
-                    "媒体输入中的音频流索引（默认：0）"
-                ),
-                (
-                    "command-line interface for written Cantonese subtitle "
-                    "transcription"
-                ): "书面粤语字幕转写命令行界面",
-                "script used for transcription prompts (default: simplified)": (
-                    "转写提示词使用的字形（默认：简体）"
-                ),
-                "Demucs vocal-separation mode (options: on, off; default: off)": (
-                    "Demucs 人声分离模式（选项：on、off；默认：off）"
-                ),
-                (
-                    "Whisper voice activity detection mode "
-                    "(options: on, off, auto; default: auto)"
-                ): "Whisper 语音活动检测模式（选项：on、off、auto；默认：auto）",
-                'Standard Chinese subtitle infile or "-" for stdin': (
-                    '标准中文字幕输入文件，或使用 "-" 表示标准输入'
-                ),
-                "video or audio media input path used for transcription": (
-                    "用于转写的视频或音频输入路径"
-                ),
-                "Written Cantonese subtitle outfile path (default: stdout)": (
-                    "书面粤语字幕输出文件路径（默认：标准输出）"
-                ),
-                (
-                    "Transcribe subtitles from audio and revise using standard "
-                    "Chinese text"
-                ): "从音频转录字幕，并使用标准中文文本修订",
-            },
-            "zh-hant": {
-                "audio stream index in media input (default: 0)": (
-                    "媒體輸入中的音訊流索引（預設：0）"
-                ),
-                (
-                    "command-line interface for written Cantonese subtitle "
-                    "transcription"
-                ): "書面粵語字幕轉寫命令列介面",
-                "script used for transcription prompts (default: simplified)": (
-                    "轉寫提示詞使用的字形（預設：簡體）"
-                ),
-                "Demucs vocal-separation mode (options: on, off; default: off)": (
-                    "Demucs 人聲分離模式（選項：on、off；預設：off）"
-                ),
-                (
-                    "Whisper voice activity detection mode "
-                    "(options: on, off, auto; default: auto)"
-                ): "Whisper 語音活動偵測模式（選項：on、off、auto；預設：auto）",
-                'Standard Chinese subtitle infile or "-" for stdin': (
-                    '標準中文字幕輸入檔，或使用 "-" 代表標準輸入'
-                ),
-                "video or audio media input path used for transcription": (
-                    "用於轉寫的視訊或音訊輸入路徑"
-                ),
-                "Written Cantonese subtitle outfile path (default: stdout)": (
-                    "書面粵語字幕輸出檔路徑（預設：標準輸出）"
-                ),
-                (
-                    "Transcribe subtitles from audio and revise using standard "
-                    "Chinese text"
-                ): "從音訊轉錄字幕，並使用標準中文文字修訂",
-            },
-        },
+        YUE_TRANSCRIBE_VS_ZHO_LOCALIZATIONS,
     )
     """Localized help text keyed by locale and English source text."""
 

--- a/scinoephile/cli/yue/yue_translate_vs_zho_cli.py
+++ b/scinoephile/cli/yue/yue_translate_vs_zho_cli.py
@@ -30,62 +30,63 @@ from scinoephile.multilang.yue_zho.gap_translation import (
 
 __all__ = ["YueTranslateVsZhoCli"]
 
+YUE_TRANSLATE_VS_ZHO_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "command-line interface for written Cantonese gap translation": (
+            "书面粤语缺口翻译命令行界面"
+        ),
+        "This command fills empty written Cantonese subtitle lines using the "
+        "corresponding standard Chinese subtitle lines as reference.": (
+            "此命令使用对应的标准中文字幕作为参考，补全空白的书面粤语字幕行。"
+        ),
+        'aligned standard Chinese subtitle infile or "-" for stdin': (
+            '已对齐的标准中文字幕输入文件，或使用 "-" 表示标准输入'
+        ),
+        "script for prompts and output conversion (default: simplified)": (
+            "提示词和输出转换使用的字形（默认：简体）"
+        ),
+        'written Cantonese subtitle infile with gaps, or "-" for stdin': (
+            '含缺口的书面粤语字幕输入文件，或使用 "-" 表示标准输入'
+        ),
+        (
+            "gap-filled written Cantonese subtitle outfile path (default: stdout)"
+        ): "补全缺口后的书面粤语字幕输出文件路径（默认：标准输出）",
+        "fill missing written Cantonese subtitles using standard Chinese "
+        "subtitles": "使用标准中文字幕补全缺失的书面粤语字幕",
+    },
+    "zh-hant": {
+        "command-line interface for written Cantonese gap translation": (
+            "書面粵語缺口翻譯命令列介面"
+        ),
+        "This command fills empty written Cantonese subtitle lines using the "
+        "corresponding standard Chinese subtitle lines as reference.": (
+            "此命令使用對應的標準中文字幕作為參考，補全空白的書面粵語字幕行。"
+        ),
+        'aligned standard Chinese subtitle infile or "-" for stdin': (
+            '已對齊的標準中文字幕輸入檔，或使用 "-" 代表標準輸入'
+        ),
+        "script for prompts and output conversion (default: simplified)": (
+            "提示詞與輸出轉換使用的字形（預設：簡體）"
+        ),
+        'written Cantonese subtitle infile with gaps, or "-" for stdin': (
+            '含缺口的書面粵語字幕輸入檔，或使用 "-" 代表標準輸入'
+        ),
+        (
+            "gap-filled written Cantonese subtitle outfile path (default: stdout)"
+        ): "補全缺口後的書面粵語字幕輸出檔路徑（預設：標準輸出）",
+        "fill missing written Cantonese subtitles using standard Chinese "
+        "subtitles": "使用標準中文字幕補全缺失的書面粵語字幕",
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class YueTranslateVsZhoCli(ScinoephileCliBase):
     """Fill missing written Cantonese subtitles using standard Chinese subtitles."""
 
     localizations = merge_localizations(
         LLM_LOCALIZATIONS,
-        {
-            "zh-hans": {
-                "command-line interface for written Cantonese gap translation": (
-                    "书面粤语缺口翻译命令行界面"
-                ),
-                "This command fills empty written Cantonese subtitle lines using the "
-                "corresponding standard Chinese subtitle lines as reference.": (
-                    "此命令使用对应的标准中文字幕作为参考，补全空白的书面粤语字幕行。"
-                ),
-                'aligned standard Chinese subtitle infile or "-" for stdin': (
-                    '已对齐的标准中文字幕输入文件，或使用 "-" 表示标准输入'
-                ),
-                "script for prompts and output conversion (default: simplified)": (
-                    "提示词和输出转换使用的字形（默认：简体）"
-                ),
-                'written Cantonese subtitle infile with gaps, or "-" for stdin': (
-                    '含缺口的书面粤语字幕输入文件，或使用 "-" 表示标准输入'
-                ),
-                (
-                    "gap-filled written Cantonese subtitle outfile path "
-                    "(default: stdout)"
-                ): "补全缺口后的书面粤语字幕输出文件路径（默认：标准输出）",
-                "fill missing written Cantonese subtitles using standard Chinese "
-                "subtitles": "使用标准中文字幕补全缺失的书面粤语字幕",
-            },
-            "zh-hant": {
-                "command-line interface for written Cantonese gap translation": (
-                    "書面粵語缺口翻譯命令列介面"
-                ),
-                "This command fills empty written Cantonese subtitle lines using the "
-                "corresponding standard Chinese subtitle lines as reference.": (
-                    "此命令使用對應的標準中文字幕作為參考，補全空白的書面粵語字幕行。"
-                ),
-                'aligned standard Chinese subtitle infile or "-" for stdin': (
-                    '已對齊的標準中文字幕輸入檔，或使用 "-" 代表標準輸入'
-                ),
-                "script for prompts and output conversion (default: simplified)": (
-                    "提示詞與輸出轉換使用的字形（預設：簡體）"
-                ),
-                'written Cantonese subtitle infile with gaps, or "-" for stdin': (
-                    '含缺口的書面粵語字幕輸入檔，或使用 "-" 代表標準輸入'
-                ),
-                (
-                    "gap-filled written Cantonese subtitle outfile path "
-                    "(default: stdout)"
-                ): "補全缺口後的書面粵語字幕輸出檔路徑（預設：標準輸出）",
-                "fill missing written Cantonese subtitles using standard Chinese "
-                "subtitles": "使用標準中文字幕補全缺失的書面粵語字幕",
-            },
-        },
+        YUE_TRANSLATE_VS_ZHO_LOCALIZATIONS,
     )
     """Localized help text keyed by locale and English source text."""
 

--- a/scinoephile/cli/zho/zho_cli.py
+++ b/scinoephile/cli/zho/zho_cli.py
@@ -14,24 +14,27 @@ from .zho_process_cli import ZhoProcessCli
 
 __all__ = ["ZhoCli"]
 
+ZHO_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "command-line interface for standard Chinese subtitle operations": (
+            "标准中文字幕操作命令行界面"
+        ),
+        "modify standard Chinese subtitles": "修改标准中文字幕",
+    },
+    "zh-hant": {
+        "command-line interface for standard Chinese subtitle operations": (
+            "標準中文字幕操作命令列介面"
+        ),
+        "modify standard Chinese subtitles": "修改標準中文字幕",
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class ZhoCli(ScinoephileCliBase):
     """Modify standard Chinese subtitles."""
 
-    localizations = {
-        "zh-hans": {
-            "command-line interface for standard Chinese subtitle operations": (
-                "标准中文字幕操作命令行界面"
-            ),
-            "modify standard Chinese subtitles": "修改标准中文字幕",
-        },
-        "zh-hant": {
-            "command-line interface for standard Chinese subtitle operations": (
-                "標準中文字幕操作命令列介面"
-            ),
-            "modify standard Chinese subtitles": "修改標準中文字幕",
-        },
-    }
+    localizations = ZHO_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
     @classmethod

--- a/scinoephile/cli/zho/zho_process_cli.py
+++ b/scinoephile/cli/zho/zho_process_cli.py
@@ -41,6 +41,62 @@ from scinoephile.llms.providers.registry import get_provider
 
 __all__ = ["ZhoProcessCli"]
 
+ZHO_PROCESS_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "append Mandarin romanization to subtitles": "为字幕追加普通话罗马字",
+        "clean subtitles of closed-caption annotations and other anomalies": (
+            "清理字幕中的隐藏字幕标注及其他异常"
+        ),
+        "command-line interface for standard Chinese subtitle processing": (
+            "标准中文字幕处理命令行界面"
+        ),
+        "flatten multi-line subtitles into single lines": ("将多行字幕合并为单行"),
+        "modify standard Chinese subtitles": "修改标准中文字幕",
+        "proofread subtitles using LLM (default: simplified)": (
+            "使用大语言模型校对字幕（默认：简体）"
+        ),
+        "script for prompts and output conversion (default: simplified)": (
+            "提示词和输出转换使用的字形（默认：简体）"
+        ),
+        "shift subtitle timings by this many milliseconds": (
+            "按指定毫秒数平移字幕时间"
+        ),
+        'Standard Chinese subtitle infile path or "-" for stdin': (
+            '标准中文字幕输入文件路径，或使用 "-" 表示标准输入'
+        ),
+        "Standard Chinese subtitle outfile path (default: stdout)": (
+            "标准中文字幕输出文件路径（默认：标准输出）"
+        ),
+    },
+    "zh-hant": {
+        "append Mandarin romanization to subtitles": "為字幕附加普通話羅馬字",
+        "clean subtitles of closed-caption annotations and other anomalies": (
+            "清理字幕中的隱藏字幕標註及其他異常"
+        ),
+        "command-line interface for standard Chinese subtitle processing": (
+            "標準中文字幕處理命令列介面"
+        ),
+        "flatten multi-line subtitles into single lines": ("將多行字幕合併為單行"),
+        "modify standard Chinese subtitles": "修改標準中文字幕",
+        "proofread subtitles using LLM (default: simplified)": (
+            "使用大型語言模型校對字幕（預設：簡體）"
+        ),
+        "script for prompts and output conversion (default: simplified)": (
+            "提示詞與輸出轉換使用的字形（預設：簡體）"
+        ),
+        "shift subtitle timings by this many milliseconds": (
+            "依指定毫秒數平移字幕時間"
+        ),
+        'Standard Chinese subtitle infile path or "-" for stdin': (
+            '標準中文字幕輸入檔路徑，或使用 "-" 代表標準輸入'
+        ),
+        "Standard Chinese subtitle outfile path (default: stdout)": (
+            "標準中文字幕輸出檔路徑（預設：標準輸出）"
+        ),
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class ZhoProcessCli(ScinoephileCliBase):
     """Modify standard Chinese subtitles."""
@@ -48,64 +104,7 @@ class ZhoProcessCli(ScinoephileCliBase):
     localizations = merge_localizations(
         CONVERSION_LOCALIZATIONS,
         LLM_LOCALIZATIONS,
-        {
-            "zh-hans": {
-                "append Mandarin romanization to subtitles": "为字幕追加普通话罗马字",
-                "clean subtitles of closed-caption annotations and other anomalies": (
-                    "清理字幕中的隐藏字幕标注及其他异常"
-                ),
-                "command-line interface for standard Chinese subtitle processing": (
-                    "标准中文字幕处理命令行界面"
-                ),
-                "flatten multi-line subtitles into single lines": (
-                    "将多行字幕合并为单行"
-                ),
-                "modify standard Chinese subtitles": "修改标准中文字幕",
-                "proofread subtitles using LLM (default: simplified)": (
-                    "使用大语言模型校对字幕（默认：简体）"
-                ),
-                "script for prompts and output conversion (default: simplified)": (
-                    "提示词和输出转换使用的字形（默认：简体）"
-                ),
-                "shift subtitle timings by this many milliseconds": (
-                    "按指定毫秒数平移字幕时间"
-                ),
-                'Standard Chinese subtitle infile path or "-" for stdin': (
-                    '标准中文字幕输入文件路径，或使用 "-" 表示标准输入'
-                ),
-                "Standard Chinese subtitle outfile path (default: stdout)": (
-                    "标准中文字幕输出文件路径（默认：标准输出）"
-                ),
-            },
-            "zh-hant": {
-                "append Mandarin romanization to subtitles": "為字幕附加普通話羅馬字",
-                "clean subtitles of closed-caption annotations and other anomalies": (
-                    "清理字幕中的隱藏字幕標註及其他異常"
-                ),
-                "command-line interface for standard Chinese subtitle processing": (
-                    "標準中文字幕處理命令列介面"
-                ),
-                "flatten multi-line subtitles into single lines": (
-                    "將多行字幕合併為單行"
-                ),
-                "modify standard Chinese subtitles": "修改標準中文字幕",
-                "proofread subtitles using LLM (default: simplified)": (
-                    "使用大型語言模型校對字幕（預設：簡體）"
-                ),
-                "script for prompts and output conversion (default: simplified)": (
-                    "提示詞與輸出轉換使用的字形（預設：簡體）"
-                ),
-                "shift subtitle timings by this many milliseconds": (
-                    "依指定毫秒數平移字幕時間"
-                ),
-                'Standard Chinese subtitle infile path or "-" for stdin': (
-                    '標準中文字幕輸入檔路徑，或使用 "-" 代表標準輸入'
-                ),
-                "Standard Chinese subtitle outfile path (default: stdout)": (
-                    "標準中文字幕輸出檔路徑（預設：標準輸出）"
-                ),
-            },
-        },
+        ZHO_PROCESS_LOCALIZATIONS,
     )
     """Localized help text keyed by locale and English source text."""
 


### PR DESCRIPTION
## Summary
- Move each CLI-specific localization map into a module-level `*_LOCALIZATIONS` constant.
- Update CLI classes to reference those constants directly or pass them through `merge_localizations(...)` with shared maps.
- Leave existing localized help behavior and tests unchanged.

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format` on changed Python files
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix` on changed Python files
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check` on changed Python files
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` (1169 passed, 4 skipped)