### PR TITLE
Rename language-pair prompt classes

### DIFF
--- a/scinoephile/cli/yue/yue_review_vs_zho_cli.py
+++ b/scinoephile/cli/yue/yue_review_vs_zho_cli.py
@@ -18,14 +18,14 @@ from scinoephile.core.cli import ScinoephileCliBase, read_series, write_series
 from scinoephile.core.cli.localization import merge_localizations
 from scinoephile.llms.providers.registry import get_provider
 from scinoephile.multilang.yue_zho.block_review import (
-    YueVsZhoBlockReviewPromptYueHans,
-    YueVsZhoBlockReviewPromptYueHant,
+    YueBlockReviewVsZhoPromptYueHans,
+    YueBlockReviewVsZhoPromptYueHant,
     get_yue_block_reviewed_vs_zho,
     get_yue_vs_zho_block_reviewer,
 )
 from scinoephile.multilang.yue_zho.line_review import (
-    YueVsZhoLineReviewPromptYueHans,
-    YueVsZhoLineReviewPromptYueHant,
+    YueLineReviewVsZhoPromptYueHans,
+    YueLineReviewVsZhoPromptYueHant,
     get_yue_line_reviewed_vs_zho,
     get_yue_vs_zho_line_reviewer,
 )
@@ -177,7 +177,7 @@ class YueReviewVsZhoCli(ScinoephileCliBase):
     @classmethod
     def _get_line_review_prompt_cls(
         cls, script: str
-    ) -> type[YueVsZhoLineReviewPromptYueHans]:
+    ) -> type[YueLineReviewVsZhoPromptYueHans]:
         """Get the line-review prompt class for the selected script.
 
         Arguments:
@@ -186,13 +186,13 @@ class YueReviewVsZhoCli(ScinoephileCliBase):
             line-review prompt class
         """
         if script == "traditional":
-            return YueVsZhoLineReviewPromptYueHant
-        return YueVsZhoLineReviewPromptYueHans
+            return YueLineReviewVsZhoPromptYueHant
+        return YueLineReviewVsZhoPromptYueHans
 
     @classmethod
     def _get_block_review_prompt_cls(
         cls, script: str
-    ) -> type[YueVsZhoBlockReviewPromptYueHans]:
+    ) -> type[YueBlockReviewVsZhoPromptYueHans]:
         """Get the block review prompt class for the selected script.
 
         Arguments:
@@ -201,8 +201,8 @@ class YueReviewVsZhoCli(ScinoephileCliBase):
             block review prompt class
         """
         if script == "traditional":
-            return YueVsZhoBlockReviewPromptYueHant
-        return YueVsZhoBlockReviewPromptYueHans
+            return YueBlockReviewVsZhoPromptYueHant
+        return YueBlockReviewVsZhoPromptYueHans
 
     @classmethod
     def _main(

--- a/scinoephile/cli/yue/yue_transcribe_vs_zho_cli.py
+++ b/scinoephile/cli/yue/yue_transcribe_vs_zho_cli.py
@@ -35,12 +35,12 @@ from scinoephile.multilang.yue_zho.transcription import (
     get_yue_vs_zho_transcriber,
 )
 from scinoephile.multilang.yue_zho.transcription.deliniation import (
-    YueVsZhoDeliniationPromptYueHans,
-    YueVsZhoDeliniationPromptYueHant,
+    YueDeliniationVsZhoPromptYueHans,
+    YueDeliniationVsZhoPromptYueHant,
 )
 from scinoephile.multilang.yue_zho.transcription.punctuation import (
-    YueVsZhoPunctuationPromptYueHans,
-    YueVsZhoPunctuationPromptYueHant,
+    YuePunctuationVsZhoPromptYueHans,
+    YuePunctuationVsZhoPromptYueHant,
 )
 
 __all__ = ["YueTranscribeVsZhoCli"]
@@ -217,7 +217,7 @@ class YueTranscribeVsZhoCli(ScinoephileCliBase):
     def _get_transcription_prompt_classes(
         cls, script: str
     ) -> tuple[
-        type[YueVsZhoDeliniationPromptYueHans], type[YueVsZhoPunctuationPromptYueHans]
+        type[YueDeliniationVsZhoPromptYueHans], type[YuePunctuationVsZhoPromptYueHans]
     ]:
         """Get transcription prompt classes for the selected script.
 
@@ -227,8 +227,8 @@ class YueTranscribeVsZhoCli(ScinoephileCliBase):
             deliniation and punctuation prompt classes
         """
         if script == "traditional":
-            return YueVsZhoDeliniationPromptYueHant, YueVsZhoPunctuationPromptYueHant
-        return YueVsZhoDeliniationPromptYueHans, YueVsZhoPunctuationPromptYueHans
+            return YueDeliniationVsZhoPromptYueHant, YuePunctuationVsZhoPromptYueHant
+        return YueDeliniationVsZhoPromptYueHans, YuePunctuationVsZhoPromptYueHans
 
     @classmethod
     def _main(

--- a/scinoephile/cli/yue/yue_translate_vs_zho_cli.py
+++ b/scinoephile/cli/yue/yue_translate_vs_zho_cli.py
@@ -22,8 +22,8 @@ from scinoephile.core.cli import ScinoephileCliBase, read_series, write_series
 from scinoephile.core.cli.localization import merge_localizations
 from scinoephile.llms.providers.registry import get_provider
 from scinoephile.multilang.yue_zho.gap_translation import (
-    YueVsZhoGapTranslationPromptYueHans,
-    YueVsZhoGapTranslationPromptYueHant,
+    YueGapTranslationVsZhoPromptYueHans,
+    YueGapTranslationVsZhoPromptYueHant,
     get_yue_gap_translated_vs_zho,
     get_yue_vs_zho_gap_translator,
 )
@@ -162,7 +162,7 @@ class YueTranslateVsZhoCli(ScinoephileCliBase):
     @classmethod
     def _get_translation_prompt_cls(
         cls, script: str
-    ) -> type[YueVsZhoGapTranslationPromptYueHans]:
+    ) -> type[YueGapTranslationVsZhoPromptYueHans]:
         """Get the gap translation prompt class for the selected script.
 
         Arguments:
@@ -171,8 +171,8 @@ class YueTranslateVsZhoCli(ScinoephileCliBase):
             gap translation prompt class
         """
         if script == "traditional":
-            return YueVsZhoGapTranslationPromptYueHant
-        return YueVsZhoGapTranslationPromptYueHans
+            return YueGapTranslationVsZhoPromptYueHant
+        return YueGapTranslationVsZhoPromptYueHans
 
     @classmethod
     def _main(

--- a/scinoephile/multilang/eng_zho/guided_translation/__init__.py
+++ b/scinoephile/multilang/eng_zho/guided_translation/__init__.py
@@ -20,13 +20,13 @@ from scinoephile.llms.dual_n_to_m import (
 )
 from scinoephile.llms.providers.registry import get_provider
 
-from .prompts import EngZhoGuidedTranslationPrompt
+from .prompts import EngGuidedTranslationVsZhoPrompt
 
 __all__ = [
     "ENG_ZHO_GUIDED_TRANSLATION_OPERATION_SPEC",
     "EngZhoGuidedTranslationProcessKwargs",
     "EngZhoGuidedTranslationProcessorKwargs",
-    "EngZhoGuidedTranslationPrompt",
+    "EngGuidedTranslationVsZhoPrompt",
     "get_eng_translated_from_zho_with_eng_guidance",
     "get_eng_zho_guided_translator",
 ]
@@ -35,7 +35,7 @@ ENG_ZHO_GUIDED_TRANSLATION_OPERATION_SPEC = OperationSpec(
     operation="eng-zho-guided-translation",
     test_case_table_name="test_cases__eng_zho__guided_translation",
     manager_cls=DualNToMManager,
-    prompt_cls=EngZhoGuidedTranslationPrompt,
+    prompt_cls=EngGuidedTranslationVsZhoPrompt,
 )
 """Operation specification for English guided translation from Chinese."""
 
@@ -80,7 +80,7 @@ def get_eng_translated_from_zho_with_eng_guidance(
 
 
 def get_eng_zho_guided_translator(
-    prompt_cls: type[EngZhoGuidedTranslationPrompt] = EngZhoGuidedTranslationPrompt,
+    prompt_cls: type[EngGuidedTranslationVsZhoPrompt] = EngGuidedTranslationVsZhoPrompt,
     test_cases: list[TestCase] | None = None,
     provider: LLMProvider | None = None,
     **kwargs: Unpack[EngZhoGuidedTranslationProcessorKwargs],

--- a/scinoephile/multilang/eng_zho/guided_translation/prompts.py
+++ b/scinoephile/multilang/eng_zho/guided_translation/prompts.py
@@ -10,10 +10,10 @@ from scinoephile.core.text import dedent_and_compact
 from scinoephile.lang.eng.prompts import PromptEng
 from scinoephile.llms.dual_n_to_m import DualNToMPrompt
 
-__all__ = ["EngZhoGuidedTranslationPrompt"]
+__all__ = ["EngGuidedTranslationVsZhoPrompt"]
 
 
-class EngZhoGuidedTranslationPrompt(DualNToMPrompt, PromptEng):
+class EngGuidedTranslationVsZhoPrompt(DualNToMPrompt, PromptEng):
     """Text for guided translation of English from Chinese with English guidance."""
 
     # Prompt

--- a/scinoephile/multilang/yue_zho/block_review/__init__.py
+++ b/scinoephile/multilang/yue_zho/block_review/__init__.py
@@ -19,14 +19,14 @@ from scinoephile.llms.dual_n_to_n import DualNToNManager, DualNToNProcessor
 from scinoephile.llms.providers.registry import get_provider
 
 from .prompts import (
-    YueVsZhoBlockReviewPromptYueHans,
-    YueVsZhoBlockReviewPromptYueHant,
+    YueBlockReviewVsZhoPromptYueHans,
+    YueBlockReviewVsZhoPromptYueHant,
 )
 
 __all__ = [
     "YUE_ZHO_BLOCK_REVIEW_OPERATION_SPEC",
-    "YueVsZhoBlockReviewPromptYueHans",
-    "YueVsZhoBlockReviewPromptYueHant",
+    "YueBlockReviewVsZhoPromptYueHans",
+    "YueBlockReviewVsZhoPromptYueHant",
     "YueZhoBlockReviewProcessKwargs",
     "YueZhoBlockReviewProcessorKwargs",
     "get_yue_block_reviewed_vs_zho",
@@ -37,7 +37,7 @@ YUE_ZHO_BLOCK_REVIEW_OPERATION_SPEC = OperationSpec(
     operation="yue-zho-block-review",
     test_case_table_name="test_cases__yue_zho__block_review",
     manager_cls=DualNToNManager,
-    prompt_cls=YueVsZhoBlockReviewPromptYueHans,
+    prompt_cls=YueBlockReviewVsZhoPromptYueHans,
 )
 """Operation specification for written Cantonese block review."""
 
@@ -80,8 +80,8 @@ def get_yue_block_reviewed_vs_zho(
 
 
 def get_yue_vs_zho_block_reviewer(
-    prompt_cls: type[YueVsZhoBlockReviewPromptYueHans] = (
-        YueVsZhoBlockReviewPromptYueHans
+    prompt_cls: type[YueBlockReviewVsZhoPromptYueHans] = (
+        YueBlockReviewVsZhoPromptYueHans
     ),
     test_cases: list[TestCase] | None = None,
     use_dictionary_tool: bool = True,

--- a/scinoephile/multilang/yue_zho/block_review/prompts.py
+++ b/scinoephile/multilang/yue_zho/block_review/prompts.py
@@ -13,12 +13,12 @@ from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.llms.dual_n_to_n import DualNToNPrompt
 
 __all__ = [
-    "YueVsZhoBlockReviewPromptYueHans",
-    "YueVsZhoBlockReviewPromptYueHant",
+    "YueBlockReviewVsZhoPromptYueHans",
+    "YueBlockReviewVsZhoPromptYueHant",
 ]
 
 
-class YueVsZhoBlockReviewPromptYueHans(
+class YueBlockReviewVsZhoPromptYueHans(
     DictionaryToolPrompt, DualNToNPrompt, PromptYueHans
 ):
     """Text for simplified written Cantonese block review against standard Chinese."""
@@ -101,7 +101,7 @@ class YueVsZhoBlockReviewPromptYueHans(
     """Error template when output is present but note is missing."""
 
 
-class YueVsZhoBlockReviewPromptYueHant(YueVsZhoBlockReviewPromptYueHans):
+class YueBlockReviewVsZhoPromptYueHant(YueBlockReviewVsZhoPromptYueHans):
     """Text for traditional written Cantonese block review against standard Chinese."""
 
     opencc_config = OpenCCConfig.s2hk

--- a/scinoephile/multilang/yue_zho/gap_translation/__init__.py
+++ b/scinoephile/multilang/yue_zho/gap_translation/__init__.py
@@ -22,14 +22,14 @@ from scinoephile.llms.dual_n_minus_m_to_n import (
 from scinoephile.llms.providers.registry import get_provider
 
 from .prompts import (
-    YueVsZhoGapTranslationPromptYueHans,
-    YueVsZhoGapTranslationPromptYueHant,
+    YueGapTranslationVsZhoPromptYueHans,
+    YueGapTranslationVsZhoPromptYueHant,
 )
 
 __all__ = [
     "YUE_ZHO_GAP_TRANSLATION_OPERATION_SPEC",
-    "YueVsZhoGapTranslationPromptYueHans",
-    "YueVsZhoGapTranslationPromptYueHant",
+    "YueGapTranslationVsZhoPromptYueHans",
+    "YueGapTranslationVsZhoPromptYueHant",
     "YueVsZhoGapTranslationProcessKwargs",
     "YueVsZhoGapTranslationProcessorKwargs",
     "get_yue_gap_translated_vs_zho",
@@ -40,7 +40,7 @@ YUE_ZHO_GAP_TRANSLATION_OPERATION_SPEC = OperationSpec(
     operation="yue-zho-gap-translation",
     test_case_table_name="test_cases__yue_zho__gap_translation",
     manager_cls=DualNMinusMToNManager,
-    prompt_cls=YueVsZhoGapTranslationPromptYueHans,
+    prompt_cls=YueGapTranslationVsZhoPromptYueHans,
 )
 """Operation specification for written Cantonese gap translation."""
 
@@ -83,8 +83,8 @@ def get_yue_gap_translated_vs_zho(
 
 
 def get_yue_vs_zho_gap_translator(
-    prompt_cls: type[YueVsZhoGapTranslationPromptYueHans] = (
-        YueVsZhoGapTranslationPromptYueHans
+    prompt_cls: type[YueGapTranslationVsZhoPromptYueHans] = (
+        YueGapTranslationVsZhoPromptYueHans
     ),
     test_cases: list[TestCase] | None = None,
     use_dictionary_tool: bool = True,

--- a/scinoephile/multilang/yue_zho/gap_translation/prompts.py
+++ b/scinoephile/multilang/yue_zho/gap_translation/prompts.py
@@ -13,12 +13,12 @@ from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.llms.dual_n_minus_m_to_n import DualNMinusMToNPrompt
 
 __all__ = [
-    "YueVsZhoGapTranslationPromptYueHans",
-    "YueVsZhoGapTranslationPromptYueHant",
+    "YueGapTranslationVsZhoPromptYueHans",
+    "YueGapTranslationVsZhoPromptYueHant",
 ]
 
 
-class YueVsZhoGapTranslationPromptYueHans(
+class YueGapTranslationVsZhoPromptYueHans(
     DictionaryToolPrompt, DualNMinusMToNPrompt, PromptYueHans
 ):
     """Text for simplified written Cantonese gap translation using standard Chinese."""
@@ -92,7 +92,7 @@ class YueVsZhoGapTranslationPromptYueHans(
         return cls.output_contains_note_err_tpl.format(idx=idx)
 
 
-class YueVsZhoGapTranslationPromptYueHant(YueVsZhoGapTranslationPromptYueHans):
+class YueGapTranslationVsZhoPromptYueHant(YueGapTranslationVsZhoPromptYueHans):
     """Text for traditional written Cantonese gap translation using standard Chinese."""
 
     opencc_config = OpenCCConfig.s2hk

--- a/scinoephile/multilang/yue_zho/line_review/__init__.py
+++ b/scinoephile/multilang/yue_zho/line_review/__init__.py
@@ -26,14 +26,14 @@ from scinoephile.llms.providers.registry import get_provider
 from .manager import YueZhoLineReviewManager
 from .processor import YueZhoLineReviewProcessor
 from .prompts import (
-    YueVsZhoLineReviewPromptYueHans,
-    YueVsZhoLineReviewPromptYueHant,
+    YueLineReviewVsZhoPromptYueHans,
+    YueLineReviewVsZhoPromptYueHant,
 )
 
 __all__ = [
     "YUE_ZHO_LINE_REVIEW_OPERATION_SPEC",
-    "YueVsZhoLineReviewPromptYueHans",
-    "YueVsZhoLineReviewPromptYueHant",
+    "YueLineReviewVsZhoPromptYueHans",
+    "YueLineReviewVsZhoPromptYueHant",
     "YueZhoLineReviewManager",
     "YueZhoLineReviewProcessKwargs",
     "YueZhoLineReviewProcessor",
@@ -46,7 +46,7 @@ YUE_ZHO_LINE_REVIEW_OPERATION_SPEC = OperationSpec(
     operation="yue-zho-line-review",
     test_case_table_name="test_cases__yue_zho__line_review",
     manager_cls=YueZhoLineReviewManager,
-    prompt_cls=YueVsZhoLineReviewPromptYueHans,
+    prompt_cls=YueLineReviewVsZhoPromptYueHans,
 )
 """Operation specification for written Cantonese line review."""
 
@@ -89,7 +89,7 @@ def get_yue_line_reviewed_vs_zho(
 
 
 def get_yue_vs_zho_line_reviewer(
-    prompt_cls: type[YueVsZhoLineReviewPromptYueHans] = YueVsZhoLineReviewPromptYueHans,
+    prompt_cls: type[YueLineReviewVsZhoPromptYueHans] = YueLineReviewVsZhoPromptYueHans,
     test_cases: list[TestCase] | None = None,
     use_dictionary_tool: bool = True,
     provider: LLMProvider | None = None,

--- a/scinoephile/multilang/yue_zho/line_review/manager.py
+++ b/scinoephile/multilang/yue_zho/line_review/manager.py
@@ -9,7 +9,7 @@ from typing import ClassVar
 from scinoephile.core.llms import Answer, TestCase
 from scinoephile.llms.dual_1_to_1 import Dual1To1Manager
 
-from .prompts import YueVsZhoLineReviewPromptYueHans
+from .prompts import YueLineReviewVsZhoPromptYueHans
 
 __all__ = ["YueZhoLineReviewManager"]
 
@@ -17,8 +17,8 @@ __all__ = ["YueZhoLineReviewManager"]
 class YueZhoLineReviewManager(Dual1To1Manager):
     """Factories for written Cantonese vs. standard Chinese line-review LLM classes."""
 
-    prompt_cls: ClassVar[type[YueVsZhoLineReviewPromptYueHans]] = (
-        YueVsZhoLineReviewPromptYueHans
+    prompt_cls: ClassVar[type[YueLineReviewVsZhoPromptYueHans]] = (
+        YueLineReviewVsZhoPromptYueHans
     )
     """Default prompt class."""
 
@@ -31,7 +31,7 @@ class YueZhoLineReviewManager(Dual1To1Manager):
         Returns:
             validated answer
         """
-        prompt_cls: type[YueVsZhoLineReviewPromptYueHans] = getattr(model, "prompt_cls")
+        prompt_cls: type[YueLineReviewVsZhoPromptYueHans] = getattr(model, "prompt_cls")
         output = getattr(model, prompt_cls.output, None)
         note = getattr(model, prompt_cls.note, None)
         if not output and not note:
@@ -47,7 +47,7 @@ class YueZhoLineReviewManager(Dual1To1Manager):
         Returns:
             validated test case
         """
-        prompt_cls: type[YueVsZhoLineReviewPromptYueHans] = getattr(model, "prompt_cls")
+        prompt_cls: type[YueLineReviewVsZhoPromptYueHans] = getattr(model, "prompt_cls")
         if model.answer is None:
             return model
 

--- a/scinoephile/multilang/yue_zho/line_review/processor.py
+++ b/scinoephile/multilang/yue_zho/line_review/processor.py
@@ -15,7 +15,7 @@ from scinoephile.core.subtitles import Series, Subtitle, get_concatenated_series
 from scinoephile.core.synchronization import get_sync_overlap_matrix
 
 from .manager import YueZhoLineReviewManager
-from .prompts import YueVsZhoLineReviewPromptYueHans
+from .prompts import YueLineReviewVsZhoPromptYueHans
 
 __all__ = ["YueZhoLineReviewProcessor"]
 
@@ -26,7 +26,7 @@ logger = getLogger(__name__)
 class YueZhoLineReviewProcessor(Processor):
     """Processes written Cantonese vs. standard Chinese line review."""
 
-    prompt_cls: type[YueVsZhoLineReviewPromptYueHans]
+    prompt_cls: type[YueLineReviewVsZhoPromptYueHans]
     """Text for LLM correspondence."""
 
     manager_cls = YueZhoLineReviewManager

--- a/scinoephile/multilang/yue_zho/line_review/prompts.py
+++ b/scinoephile/multilang/yue_zho/line_review/prompts.py
@@ -13,12 +13,12 @@ from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.llms.dual_1_to_1 import Dual1To1Prompt
 
 __all__ = [
-    "YueVsZhoLineReviewPromptYueHans",
-    "YueVsZhoLineReviewPromptYueHant",
+    "YueLineReviewVsZhoPromptYueHans",
+    "YueLineReviewVsZhoPromptYueHant",
 ]
 
 
-class YueVsZhoLineReviewPromptYueHans(
+class YueLineReviewVsZhoPromptYueHans(
     DictionaryToolPrompt, Dual1To1Prompt, PromptYueHans
 ):
     """Text for simplified written Cantonese line review against standard Chinese."""
@@ -102,7 +102,7 @@ class YueVsZhoLineReviewPromptYueHans(
     """Error when output and note fields are both missing from answer."""
 
 
-class YueVsZhoLineReviewPromptYueHant(YueVsZhoLineReviewPromptYueHans):
+class YueLineReviewVsZhoPromptYueHant(YueLineReviewVsZhoPromptYueHans):
     """Text for traditional written Cantonese line review against standard Chinese."""
 
     opencc_config = OpenCCConfig.s2hk

--- a/scinoephile/multilang/yue_zho/transcription/__init__.py
+++ b/scinoephile/multilang/yue_zho/transcription/__init__.py
@@ -27,8 +27,8 @@ from scinoephile.llms.default_test_cases import (
 from scinoephile.llms.dual_2_to_2 import Dual2To2Manager
 from scinoephile.llms.providers.registry import get_provider
 
-from .deliniation import YueVsZhoDeliniationPromptYueHans
-from .punctuation import YueVsZhoPunctuationPromptYueHans, YueZhoPunctuationManager
+from .deliniation import YueDeliniationVsZhoPromptYueHans
+from .punctuation import YuePunctuationVsZhoPromptYueHans, YueZhoPunctuationManager
 from .transcriber import DemucsMode, VADMode, YueTranscriber
 
 __all__ = [
@@ -47,7 +47,7 @@ YUE_ZHO_TRANSCRIPTION_DELINIATION_OPERATION_SPEC = OperationSpec(
     operation="yue-zho-transcription-deliniation",
     test_case_table_name="test_cases__yue_zho__transcription_deliniation",
     manager_cls=Dual2To2Manager,
-    prompt_cls=YueVsZhoDeliniationPromptYueHans,
+    prompt_cls=YueDeliniationVsZhoPromptYueHans,
 )
 """Operation specification for written Cantonese transcription deliniation."""
 
@@ -55,7 +55,7 @@ YUE_ZHO_TRANSCRIPTION_PUNCTUATION_OPERATION_SPEC = OperationSpec(
     operation="yue-zho-transcription-punctuation",
     test_case_table_name="test_cases__yue_zho__transcription_punctuation",
     manager_cls=YueZhoPunctuationManager,
-    prompt_cls=YueVsZhoPunctuationPromptYueHans,
+    prompt_cls=YuePunctuationVsZhoPromptYueHans,
     list_fields={"query.yuewen_to_punctuate": 10},
 )
 """Operation specification for written Cantonese transcription punctuation."""
@@ -81,9 +81,9 @@ class YueZhoTranscriberKwargs(TypedDict, total=False):
     """provider to use for queries."""
     convert: OpenCCConfig | None
     """OpenCC configuration used for transcribed text conversion."""
-    deliniation_prompt_cls: type[YueVsZhoDeliniationPromptYueHans]
+    deliniation_prompt_cls: type[YueDeliniationVsZhoPromptYueHans]
     """prompt class used for alignment deliniation."""
-    punctuation_prompt_cls: type[YueVsZhoPunctuationPromptYueHans]
+    punctuation_prompt_cls: type[YuePunctuationVsZhoPromptYueHans]
     """prompt class used for transcription punctuation."""
     test_case_directory_path: Path | None
     """directory where encountered transcription test cases are persisted."""
@@ -122,11 +122,11 @@ def get_yue_vs_zho_transcriber(
     vad_mode: VADMode = VADMode.AUTO,
     provider: LLMProvider | None = None,
     convert: OpenCCConfig | None = None,
-    deliniation_prompt_cls: type[YueVsZhoDeliniationPromptYueHans] = (
-        YueVsZhoDeliniationPromptYueHans
+    deliniation_prompt_cls: type[YueDeliniationVsZhoPromptYueHans] = (
+        YueDeliniationVsZhoPromptYueHans
     ),
-    punctuation_prompt_cls: type[YueVsZhoPunctuationPromptYueHans] = (
-        YueVsZhoPunctuationPromptYueHans
+    punctuation_prompt_cls: type[YuePunctuationVsZhoPromptYueHans] = (
+        YuePunctuationVsZhoPromptYueHans
     ),
     test_case_directory_path: Path | None = None,
     deliniation_test_cases: list[TestCase] | None = None,

--- a/scinoephile/multilang/yue_zho/transcription/aligner.py
+++ b/scinoephile/multilang/yue_zho/transcription/aligner.py
@@ -31,10 +31,8 @@ from scinoephile.core.synchronization import get_sync_groups_string
 from scinoephile.core.text import remove_punc_and_whitespace
 
 from .alignment import Alignment
-from .deliniation import (
-    YueVsZhoDeliniationPromptYueHans as YueZhoHansDelineationPrompt,
-)
-from .punctuation import YueVsZhoPunctuationPromptYueHans
+from .deliniation import YueDeliniationVsZhoPromptYueHans
+from .punctuation import YuePunctuationVsZhoPromptYueHans
 
 __all__ = ["Aligner"]
 
@@ -131,7 +129,7 @@ class Aligner:
                 message = "Delineation query returned no answer."
                 logger.error(message)
                 raise ScinoephileError(message)
-            prompt_cls: type[YueZhoHansDelineationPrompt] = getattr(
+            prompt_cls: type[YueDeliniationVsZhoPromptYueHans] = getattr(
                 test_case, "prompt_cls"
             )
             yuewen_1_shifted = getattr(answer, prompt_cls.src_2_sub_1_shifted, None)
@@ -177,7 +175,9 @@ class Aligner:
         sg_2 = alignment.sync_groups[sg_2_idx]
 
         # Get written Cantonese
-        prompt_cls: type[YueZhoHansDelineationPrompt] = getattr(query, "prompt_cls")
+        prompt_cls: type[YueDeliniationVsZhoPromptYueHans] = getattr(
+            query, "prompt_cls"
+        )
         yw_1_idxs = sg_1[1]
         yw_2_idxs = sg_2[1]
         yw_1 = getattr(query, prompt_cls.src_2_sub_1, "")
@@ -330,7 +330,7 @@ class Aligner:
                     f"{test_case}\n"
                     f"Exception:\n{exc}"
                 )
-            prompt_cls: type[YueVsZhoPunctuationPromptYueHans] = getattr(
+            prompt_cls: type[YuePunctuationVsZhoPromptYueHans] = getattr(
                 test_case, "prompt_cls"
             )
             yuewen_punctuated = getattr(test_case.answer, prompt_cls.output, None)

--- a/scinoephile/multilang/yue_zho/transcription/alignment.py
+++ b/scinoephile/multilang/yue_zho/transcription/alignment.py
@@ -21,8 +21,8 @@ from scinoephile.core.synchronization import (
 )
 from scinoephile.llms.dual_2_to_2 import Dual2To2Manager
 
-from .deliniation import YueVsZhoDeliniationPromptYueHans
-from .punctuation import YueVsZhoPunctuationPromptYueHans, YueZhoPunctuationManager
+from .deliniation import YueDeliniationVsZhoPromptYueHans
+from .punctuation import YuePunctuationVsZhoPromptYueHans, YueZhoPunctuationManager
 
 __all__ = ["Alignment"]
 
@@ -200,7 +200,7 @@ class Alignment:
         if len(yw_1) == 0 and len(yw_2) == 0:
             return None
         test_case_cls = Dual2To2Manager.get_test_case_cls(
-            prompt_cls=YueVsZhoDeliniationPromptYueHans
+            prompt_cls=YueDeliniationVsZhoPromptYueHans
         )
         query_kwargs = {
             test_case_cls.prompt_cls.src_1_sub_1: zw_1,
@@ -246,7 +246,7 @@ class Alignment:
 
         # Return punctuate query
         test_case_cls = YueZhoPunctuationManager.get_test_case_cls(
-            prompt_cls=YueVsZhoPunctuationPromptYueHans
+            prompt_cls=YuePunctuationVsZhoPromptYueHans
         )
         query_kwargs = {
             test_case_cls.prompt_cls.src_2: zw,

--- a/scinoephile/multilang/yue_zho/transcription/deliniation/__init__.py
+++ b/scinoephile/multilang/yue_zho/transcription/deliniation/__init__.py
@@ -5,11 +5,11 @@
 from __future__ import annotations
 
 from .prompt import (
-    YueVsZhoDeliniationPromptYueHans,
-    YueVsZhoDeliniationPromptYueHant,
+    YueDeliniationVsZhoPromptYueHans,
+    YueDeliniationVsZhoPromptYueHant,
 )
 
 __all__ = [
-    "YueVsZhoDeliniationPromptYueHans",
-    "YueVsZhoDeliniationPromptYueHant",
+    "YueDeliniationVsZhoPromptYueHans",
+    "YueDeliniationVsZhoPromptYueHant",
 ]

--- a/scinoephile/multilang/yue_zho/transcription/deliniation/prompt.py
+++ b/scinoephile/multilang/yue_zho/transcription/deliniation/prompt.py
@@ -12,12 +12,12 @@ from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.llms.dual_2_to_2 import Dual2To2Prompt
 
 __all__ = [
-    "YueVsZhoDeliniationPromptYueHans",
-    "YueVsZhoDeliniationPromptYueHant",
+    "YueDeliniationVsZhoPromptYueHans",
+    "YueDeliniationVsZhoPromptYueHant",
 ]
 
 
-class YueVsZhoDeliniationPromptYueHans(Dual2To2Prompt, PromptEng):
+class YueDeliniationVsZhoPromptYueHans(Dual2To2Prompt, PromptEng):
     """Text for LLM correspondence for simplified written Cantonese deliniation."""
 
     # Prompt
@@ -107,7 +107,7 @@ class YueVsZhoDeliniationPromptYueHans(Dual2To2Prompt, PromptEng):
         )
 
 
-class YueVsZhoDeliniationPromptYueHant(YueVsZhoDeliniationPromptYueHans):
+class YueDeliniationVsZhoPromptYueHant(YueDeliniationVsZhoPromptYueHans):
     """Text for LLM correspondence for traditional written Cantonese deliniation."""
 
     opencc_config = OpenCCConfig.s2hk

--- a/scinoephile/multilang/yue_zho/transcription/punctuation/__init__.py
+++ b/scinoephile/multilang/yue_zho/transcription/punctuation/__init__.py
@@ -11,12 +11,12 @@ from __future__ import annotations
 
 from .manager import YueZhoPunctuationManager
 from .prompt import (
-    YueVsZhoPunctuationPromptYueHans,
-    YueVsZhoPunctuationPromptYueHant,
+    YuePunctuationVsZhoPromptYueHans,
+    YuePunctuationVsZhoPromptYueHant,
 )
 
 __all__ = [
-    "YueVsZhoPunctuationPromptYueHans",
-    "YueVsZhoPunctuationPromptYueHant",
+    "YuePunctuationVsZhoPromptYueHans",
+    "YuePunctuationVsZhoPromptYueHant",
     "YueZhoPunctuationManager",
 ]

--- a/scinoephile/multilang/yue_zho/transcription/punctuation/manager.py
+++ b/scinoephile/multilang/yue_zho/transcription/punctuation/manager.py
@@ -13,7 +13,7 @@ from scinoephile.core.text import (
 )
 from scinoephile.llms.dual_n_to_1 import DualNTo1Manager
 
-from .prompt import YueVsZhoPunctuationPromptYueHans
+from .prompt import YuePunctuationVsZhoPromptYueHans
 
 __all__ = ["YueZhoPunctuationManager"]
 
@@ -21,8 +21,8 @@ __all__ = ["YueZhoPunctuationManager"]
 class YueZhoPunctuationManager(DualNTo1Manager):
     """Factories for written Cantonese/standard Chinese punctuation LLM classes."""
 
-    prompt_cls: ClassVar[type[YueVsZhoPunctuationPromptYueHans]] = (
-        YueVsZhoPunctuationPromptYueHans
+    prompt_cls: ClassVar[type[YuePunctuationVsZhoPromptYueHans]] = (
+        YuePunctuationVsZhoPromptYueHans
     )
     """Default prompt class."""
 
@@ -35,7 +35,7 @@ class YueZhoPunctuationManager(DualNTo1Manager):
         Returns:
             minimum difficulty
         """
-        prompt_cls: type[YueVsZhoPunctuationPromptYueHans] = getattr(
+        prompt_cls: type[YuePunctuationVsZhoPromptYueHans] = getattr(
             model, "prompt_cls"
         )
         min_difficulty = DualNTo1Manager.get_min_difficulty(model)
@@ -61,7 +61,7 @@ class YueZhoPunctuationManager(DualNTo1Manager):
         Returns:
             validated test case
         """
-        prompt_cls: type[YueVsZhoPunctuationPromptYueHans] = getattr(
+        prompt_cls: type[YuePunctuationVsZhoPromptYueHans] = getattr(
             model, "prompt_cls"
         )
         if model.answer is None:

--- a/scinoephile/multilang/yue_zho/transcription/punctuation/prompt.py
+++ b/scinoephile/multilang/yue_zho/transcription/punctuation/prompt.py
@@ -12,12 +12,12 @@ from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.llms.dual_n_to_1 import DualNTo1Prompt
 
 __all__ = [
-    "YueVsZhoPunctuationPromptYueHans",
-    "YueVsZhoPunctuationPromptYueHant",
+    "YuePunctuationVsZhoPromptYueHans",
+    "YuePunctuationVsZhoPromptYueHant",
 ]
 
 
-class YueVsZhoPunctuationPromptYueHans(DualNTo1Prompt, PromptYueHans):
+class YuePunctuationVsZhoPromptYueHans(DualNTo1Prompt, PromptYueHans):
     """Text for simplified written Cantonese/standard Chinese punctuation."""
 
     # Prompt
@@ -88,7 +88,7 @@ class YueVsZhoPunctuationPromptYueHans(DualNTo1Prompt, PromptYueHans):
         )
 
 
-class YueVsZhoPunctuationPromptYueHant(YueVsZhoPunctuationPromptYueHans):
+class YuePunctuationVsZhoPromptYueHant(YuePunctuationVsZhoPromptYueHans):
     """Text for traditional written Cantonese/standard Chinese punctuation."""
 
     opencc_config = OpenCCConfig.s2hk

--- a/scinoephile/multilang/yue_zho/transcription/transcriber.py
+++ b/scinoephile/multilang/yue_zho/transcription/transcriber.py
@@ -29,8 +29,8 @@ from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.llms.providers.registry import get_provider
 
 from .aligner import Aligner
-from .deliniation import YueVsZhoDeliniationPromptYueHans
-from .punctuation import YueVsZhoPunctuationPromptYueHans
+from .deliniation import YueDeliniationVsZhoPromptYueHans
+from .punctuation import YuePunctuationVsZhoPromptYueHans
 
 __all__ = [
     "DemucsMode",
@@ -72,8 +72,8 @@ class YueTranscriber:
         vad_mode: VADMode = VADMode.AUTO,
         provider: LLMProvider | None = None,
         convert: OpenCCConfig | None = None,
-        deliniation_prompt_cls: type[YueVsZhoDeliniationPromptYueHans],
-        punctuation_prompt_cls: type[YueVsZhoPunctuationPromptYueHans],
+        deliniation_prompt_cls: type[YueDeliniationVsZhoPromptYueHans],
+        punctuation_prompt_cls: type[YuePunctuationVsZhoPromptYueHans],
         test_case_directory_path: Path,
         deliniation_test_cases: list[TestCase],
         punctuation_test_cases: list[TestCase],

--- a/test/cli/yue/test_yue_review_vs_zho_cli.py
+++ b/test/cli/yue/test_yue_review_vs_zho_cli.py
@@ -15,7 +15,7 @@ from scinoephile.common import CommandLineInterface
 from scinoephile.common.file import get_temp_file_path
 from scinoephile.common.testing import run_cli_with_args
 from scinoephile.core.subtitles import Series
-from scinoephile.multilang.yue_zho.block_review import YueVsZhoBlockReviewPromptYueHans
+from scinoephile.multilang.yue_zho.block_review import YueBlockReviewVsZhoPromptYueHans
 from test.helpers import (
     assert_cli_help,
     assert_cli_usage,
@@ -118,7 +118,7 @@ def test_yue_review_vs_zho_cli(
     else:
         assert (
             patched_factory.call_args.kwargs["prompt_cls"]
-            is YueVsZhoBlockReviewPromptYueHans
+            is YueBlockReviewVsZhoPromptYueHans
         )
         called_kwargs = patched_review.call_args.kwargs
         assert_series_equal(called_kwargs["yuewen"], Series.load(full_yue_input_path))

--- a/test/cli/yue/test_yue_transcribe_vs_zho_cli.py
+++ b/test/cli/yue/test_yue_transcribe_vs_zho_cli.py
@@ -22,12 +22,12 @@ from scinoephile.core.subtitles import Series
 from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.multilang.yue_zho.transcription import DemucsMode, VADMode
 from scinoephile.multilang.yue_zho.transcription.deliniation import (
-    YueVsZhoDeliniationPromptYueHans,
-    YueVsZhoDeliniationPromptYueHant,
+    YueDeliniationVsZhoPromptYueHans,
+    YueDeliniationVsZhoPromptYueHant,
 )
 from scinoephile.multilang.yue_zho.transcription.punctuation import (
-    YueVsZhoPunctuationPromptYueHans,
-    YueVsZhoPunctuationPromptYueHant,
+    YuePunctuationVsZhoPromptYueHans,
+    YuePunctuationVsZhoPromptYueHant,
 )
 from test.helpers import (
     assert_cli_help,
@@ -136,11 +136,11 @@ def test_yue_transcribe_vs_zho_cli_writes_file():
 
     assert (
         patched_factory.call_args.kwargs["deliniation_prompt_cls"]
-        is YueVsZhoDeliniationPromptYueHans
+        is YueDeliniationVsZhoPromptYueHans
     )
     assert (
         patched_factory.call_args.kwargs["punctuation_prompt_cls"]
-        is YueVsZhoPunctuationPromptYueHans
+        is YuePunctuationVsZhoPromptYueHans
     )
     assert patched_factory.call_args.kwargs["convert"] is None
     assert patched_factory.call_args.kwargs["demucs_mode"] == DemucsMode.OFF
@@ -327,11 +327,11 @@ def test_yue_transcribe_vs_zho_cli_keeps_script_and_convert_independent():
 
     assert (
         patched_factory.call_args.kwargs["deliniation_prompt_cls"]
-        is YueVsZhoDeliniationPromptYueHant
+        is YueDeliniationVsZhoPromptYueHant
     )
     assert (
         patched_factory.call_args.kwargs["punctuation_prompt_cls"]
-        is YueVsZhoPunctuationPromptYueHant
+        is YuePunctuationVsZhoPromptYueHant
     )
     assert patched_factory.call_args.kwargs["convert"] == OpenCCConfig.hk2s
 

--- a/test/cli/yue/test_yue_translate_vs_zho_cli.py
+++ b/test/cli/yue/test_yue_translate_vs_zho_cli.py
@@ -16,7 +16,7 @@ from scinoephile.common.file import get_temp_file_path
 from scinoephile.common.testing import run_cli_with_args
 from scinoephile.core.subtitles import Series
 from scinoephile.multilang.yue_zho.gap_translation import (
-    YueVsZhoGapTranslationPromptYueHans,
+    YueGapTranslationVsZhoPromptYueHans,
 )
 from test.helpers import (
     assert_cli_help,
@@ -106,7 +106,7 @@ def test_yue_translate_vs_zho_cli(
 
     assert (
         patched_factory.call_args.kwargs["prompt_cls"]
-        is YueVsZhoGapTranslationPromptYueHans
+        is YueGapTranslationVsZhoPromptYueHans
     )
     called_kwargs = patched_translate.call_args.kwargs
     assert_series_equal(called_kwargs["yuewen"], Series.load(full_yue_input_path))

--- a/test/data/kob/__init__.py
+++ b/test/data/kob/__init__.py
@@ -31,14 +31,14 @@ from scinoephile.llms.dual_2_to_2 import Dual2To2Manager, Dual2To2Prompt
 from scinoephile.llms.dual_n_to_1 import DualNTo1Prompt
 from scinoephile.llms.mono_n import MonoNManager, MonoNPrompt
 from scinoephile.multilang.yue_zho.line_review import (
-    YueVsZhoLineReviewPromptYueHans,
+    YueLineReviewVsZhoPromptYueHans,
     YueZhoLineReviewManager,
 )
 from scinoephile.multilang.yue_zho.transcription.deliniation import (
-    YueVsZhoDeliniationPromptYueHans,
+    YueDeliniationVsZhoPromptYueHans,
 )
 from scinoephile.multilang.yue_zho.transcription.punctuation import (
-    YueVsZhoPunctuationPromptYueHans,
+    YuePunctuationVsZhoPromptYueHans,
     YueZhoPunctuationManager,
 )
 from test.helpers import SeriesCERResult, test_data_root
@@ -234,7 +234,7 @@ def get_kob_eng_ocr_fusion_test_cases(
 
 @cache
 def get_kob_yue_deliniation_test_cases(
-    prompt_cls: type[Dual2To2Prompt] = YueVsZhoDeliniationPromptYueHans,
+    prompt_cls: type[Dual2To2Prompt] = YueDeliniationVsZhoPromptYueHans,
     **kwargs: Unpack[_KobTestCaseKwargs],
 ) -> list[TestCase]:
     """Get KOB 简体粤文 deliniation test cases.
@@ -261,7 +261,7 @@ def get_kob_yue_deliniation_test_cases(
 
 @cache
 def get_kob_yue_punctuation_test_cases(
-    prompt_cls: type[DualNTo1Prompt] = YueVsZhoPunctuationPromptYueHans,
+    prompt_cls: type[DualNTo1Prompt] = YuePunctuationVsZhoPromptYueHans,
     **kwargs: Unpack[_KobTestCaseKwargs],
 ) -> list[TestCase]:
     """Get KOB 简体粤文 punctuation test cases.
@@ -288,7 +288,7 @@ def get_kob_yue_punctuation_test_cases(
 
 @cache
 def get_kob_yue_vs_zho_line_review_test_cases(
-    prompt_cls: type[Dual1To1Prompt] = YueVsZhoLineReviewPromptYueHans,
+    prompt_cls: type[Dual1To1Prompt] = YueLineReviewVsZhoPromptYueHans,
     **kwargs: Unpack[_KobTestCaseKwargs],
 ) -> list[TestCase]:
     """Get KOB 简体粤文 vs 简体中文 line-review test cases.

--- a/test/data/kob/create_output.py
+++ b/test/data/kob/create_output.py
@@ -22,25 +22,25 @@ from scinoephile.lang.zho.cleaning import get_zho_cleaned
 from scinoephile.lang.zho.flattening import get_zho_flattened
 from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.multilang.yue_zho.block_review import (
-    YueVsZhoBlockReviewPromptYueHans,
-    YueVsZhoBlockReviewPromptYueHant,
+    YueBlockReviewVsZhoPromptYueHans,
+    YueBlockReviewVsZhoPromptYueHant,
 )
 from scinoephile.multilang.yue_zho.gap_translation import (
-    YueVsZhoGapTranslationPromptYueHans,
-    YueVsZhoGapTranslationPromptYueHant,
+    YueGapTranslationVsZhoPromptYueHans,
+    YueGapTranslationVsZhoPromptYueHant,
 )
 from scinoephile.multilang.yue_zho.line_review import (
-    YueVsZhoLineReviewPromptYueHans,
-    YueVsZhoLineReviewPromptYueHant,
+    YueLineReviewVsZhoPromptYueHans,
+    YueLineReviewVsZhoPromptYueHant,
 )
 from scinoephile.multilang.yue_zho.transcription import DemucsMode, VADMode
 from scinoephile.multilang.yue_zho.transcription.deliniation import (
-    YueVsZhoDeliniationPromptYueHans,
-    YueVsZhoDeliniationPromptYueHant,
+    YueDeliniationVsZhoPromptYueHans,
+    YueDeliniationVsZhoPromptYueHant,
 )
 from scinoephile.multilang.yue_zho.transcription.punctuation import (
-    YueVsZhoPunctuationPromptYueHans,
-    YueVsZhoPunctuationPromptYueHant,
+    YuePunctuationVsZhoPromptYueHans,
+    YuePunctuationVsZhoPromptYueHant,
 )
 from test.data.ocr import process_eng_ocr, process_zho_hant_ocr
 from test.data.synchronization import process_yue_hans_eng, process_zho_hans_eng
@@ -152,12 +152,12 @@ if "简体粤文 (Transcription)" in actions:
             "demucs_mode": DemucsMode.ON,
             "vad_mode": VADMode.AUTO,
             "convert": OpenCCConfig.hk2s,
-            "deliniation_prompt_cls": YueVsZhoDeliniationPromptYueHans,
-            "punctuation_prompt_cls": YueVsZhoPunctuationPromptYueHans,
+            "deliniation_prompt_cls": YueDeliniationVsZhoPromptYueHans,
+            "punctuation_prompt_cls": YuePunctuationVsZhoPromptYueHans,
         },
-        line_reviewer_kw={"prompt_cls": YueVsZhoLineReviewPromptYueHans},
-        translator_kw={"prompt_cls": YueVsZhoGapTranslationPromptYueHans},
-        block_reviewer_kw={"prompt_cls": YueVsZhoBlockReviewPromptYueHans},
+        line_reviewer_kw={"prompt_cls": YueLineReviewVsZhoPromptYueHans},
+        translator_kw={"prompt_cls": YueGapTranslationVsZhoPromptYueHans},
+        block_reviewer_kw={"prompt_cls": YueBlockReviewVsZhoPromptYueHans},
         overwrite_srt=True,
     )
 
@@ -173,12 +173,12 @@ if "简体粤文 (Transcription)" in actions:
             "demucs_mode": DemucsMode.ON,
             "vad_mode": VADMode.AUTO,
             "convert": OpenCCConfig.s2hk,
-            "deliniation_prompt_cls": YueVsZhoDeliniationPromptYueHant,
-            "punctuation_prompt_cls": YueVsZhoPunctuationPromptYueHant,
+            "deliniation_prompt_cls": YueDeliniationVsZhoPromptYueHant,
+            "punctuation_prompt_cls": YuePunctuationVsZhoPromptYueHant,
         },
-        line_reviewer_kw={"prompt_cls": YueVsZhoLineReviewPromptYueHant},
-        translator_kw={"prompt_cls": YueVsZhoGapTranslationPromptYueHant},
-        block_reviewer_kw={"prompt_cls": YueVsZhoBlockReviewPromptYueHant},
+        line_reviewer_kw={"prompt_cls": YueLineReviewVsZhoPromptYueHant},
+        translator_kw={"prompt_cls": YueGapTranslationVsZhoPromptYueHant},
+        block_reviewer_kw={"prompt_cls": YueBlockReviewVsZhoPromptYueHant},
         overwrite_srt=True,
     )
 if "简体粤文 (Diff)" in actions:

--- a/test/data/mlamd/__init__.py
+++ b/test/data/mlamd/__init__.py
@@ -38,19 +38,19 @@ from scinoephile.llms.dual_n_minus_m_to_n import (
 from scinoephile.llms.dual_n_to_1 import DualNTo1Prompt
 from scinoephile.llms.dual_n_to_n import DualNToNManager, DualNToNPrompt
 from scinoephile.llms.mono_n import MonoNManager, MonoNPrompt
-from scinoephile.multilang.yue_zho.block_review import YueVsZhoBlockReviewPromptYueHans
+from scinoephile.multilang.yue_zho.block_review import YueBlockReviewVsZhoPromptYueHans
 from scinoephile.multilang.yue_zho.gap_translation import (
-    YueVsZhoGapTranslationPromptYueHans,
+    YueGapTranslationVsZhoPromptYueHans,
 )
 from scinoephile.multilang.yue_zho.line_review import (
-    YueVsZhoLineReviewPromptYueHans,
+    YueLineReviewVsZhoPromptYueHans,
     YueZhoLineReviewManager,
 )
 from scinoephile.multilang.yue_zho.transcription.deliniation import (
-    YueVsZhoDeliniationPromptYueHans,
+    YueDeliniationVsZhoPromptYueHans,
 )
 from scinoephile.multilang.yue_zho.transcription.punctuation import (
-    YueVsZhoPunctuationPromptYueHans,
+    YuePunctuationVsZhoPromptYueHans,
     YueZhoPunctuationManager,
 )
 from test.helpers import test_data_root
@@ -281,7 +281,7 @@ def get_mlamd_eng_ocr_fusion_test_cases(
 
 @cache
 def get_mlamd_yue_deliniation_test_cases(
-    prompt_cls: type[Dual2To2Prompt] = YueVsZhoDeliniationPromptYueHans,
+    prompt_cls: type[Dual2To2Prompt] = YueDeliniationVsZhoPromptYueHans,
     **kwargs: Any,
 ) -> list[TestCase]:
     """Get MLAMD 简体粤文 deliniation test cases.
@@ -308,7 +308,7 @@ def get_mlamd_yue_deliniation_test_cases(
 
 @cache
 def get_mlamd_yue_vs_zho_gap_translation_test_cases(
-    prompt_cls: type[DualNMinusMToNPrompt] = YueVsZhoGapTranslationPromptYueHans,
+    prompt_cls: type[DualNMinusMToNPrompt] = YueGapTranslationVsZhoPromptYueHans,
     **kwargs: Any,
 ) -> list[TestCase]:
     """Get MLAMD 简体粤文 vs 简体中文 gap translation test cases.
@@ -334,7 +334,7 @@ def get_mlamd_yue_vs_zho_gap_translation_test_cases(
 
 @cache
 def get_mlamd_yue_punctuation_test_cases(
-    prompt_cls: type[DualNTo1Prompt] = YueVsZhoPunctuationPromptYueHans,
+    prompt_cls: type[DualNTo1Prompt] = YuePunctuationVsZhoPromptYueHans,
     **kwargs: Any,
 ) -> list[TestCase]:
     """Get MLAMD 简体粤文 punctuation test cases.
@@ -361,7 +361,7 @@ def get_mlamd_yue_punctuation_test_cases(
 
 @cache
 def get_mlamd_yue_vs_zho_block_review_test_cases(
-    prompt_cls: type[DualNToNPrompt] = YueVsZhoBlockReviewPromptYueHans,
+    prompt_cls: type[DualNToNPrompt] = YueBlockReviewVsZhoPromptYueHans,
     **kwargs: Any,
 ) -> list[TestCase]:
     """Get MLAMD 简体粤文 vs 简体中文 review test cases.
@@ -387,7 +387,7 @@ def get_mlamd_yue_vs_zho_block_review_test_cases(
 
 @cache
 def get_mlamd_yue_vs_zho_line_review_test_cases(
-    prompt_cls: type[Dual1To1Prompt] = YueVsZhoLineReviewPromptYueHans,
+    prompt_cls: type[Dual1To1Prompt] = YueLineReviewVsZhoPromptYueHans,
     **kwargs: Any,
 ) -> list[TestCase]:
     """Get MLAMD 简体粤文 vs 简体中文 line-review test cases.

--- a/test/data/mnt/__init__.py
+++ b/test/data/mnt/__init__.py
@@ -31,7 +31,7 @@ from scinoephile.llms.dual_1_to_1.ocr_fusion import OcrFusionManager
 from scinoephile.llms.dual_n_to_m import DualNToMManager, DualNToMPrompt
 from scinoephile.llms.mono_n import MonoNManager, MonoNPrompt
 from scinoephile.multilang.eng_zho.guided_translation import (
-    EngZhoGuidedTranslationPrompt,
+    EngGuidedTranslationVsZhoPrompt,
 )
 from test.helpers import test_data_root
 
@@ -237,7 +237,7 @@ def get_mnt_eng_ocr_fusion_test_cases(
 
 @cache
 def get_mnt_eng_zho_guided_translation_test_cases(
-    prompt_cls: type[DualNToMPrompt] = EngZhoGuidedTranslationPrompt,
+    prompt_cls: type[DualNToMPrompt] = EngGuidedTranslationVsZhoPrompt,
     **kwargs: Any,
 ) -> list[TestCase]:
     """Get MNT English-from-Cantonese guided translation test cases.

--- a/test/dictionaries/test_dictionary_tools.py
+++ b/test/dictionaries/test_dictionary_tools.py
@@ -30,15 +30,15 @@ from scinoephile.dictionaries.dictionary_tools import (
     lookup_dictionary,
 )
 from scinoephile.multilang.yue_zho.block_review import (
-    YueVsZhoBlockReviewPromptYueHans,
+    YueBlockReviewVsZhoPromptYueHans,
     get_yue_vs_zho_block_reviewer,
 )
 from scinoephile.multilang.yue_zho.gap_translation import (
-    YueVsZhoGapTranslationPromptYueHans,
+    YueGapTranslationVsZhoPromptYueHans,
     get_yue_vs_zho_gap_translator,
 )
 from scinoephile.multilang.yue_zho.line_review import (
-    YueVsZhoLineReviewPromptYueHans,
+    YueLineReviewVsZhoPromptYueHans,
     get_yue_vs_zho_line_reviewer,
 )
 
@@ -236,9 +236,9 @@ def test_lookup_dictionary_returns_compact_error_for_no_available_dictionaries(
 @pytest.mark.parametrize(
     ("prompt_cls", "factory"),
     [
-        (YueVsZhoGapTranslationPromptYueHans, get_yue_vs_zho_gap_translator),
-        (YueVsZhoBlockReviewPromptYueHans, get_yue_vs_zho_block_reviewer),
-        (YueVsZhoLineReviewPromptYueHans, get_yue_vs_zho_line_reviewer),
+        (YueGapTranslationVsZhoPromptYueHans, get_yue_vs_zho_gap_translator),
+        (YueBlockReviewVsZhoPromptYueHans, get_yue_vs_zho_block_reviewer),
+        (YueLineReviewVsZhoPromptYueHans, get_yue_vs_zho_line_reviewer),
     ],
 )
 def test_processors_use_prompt_dictionary_tooling(

--- a/test/llms/test_default_test_case_loading.py
+++ b/test/llms/test_default_test_case_loading.py
@@ -37,11 +37,11 @@ from scinoephile.llms.dual_1_to_1.ocr_fusion.manager import OcrFusionManager
 from scinoephile.llms.dual_n_minus_m_to_n.manager import DualNMinusMToNManager
 from scinoephile.llms.dual_n_to_n.manager import DualNToNManager
 from scinoephile.llms.mono_n.manager import MonoNManager
-from scinoephile.multilang.yue_zho.block_review import YueVsZhoBlockReviewPromptYueHans
+from scinoephile.multilang.yue_zho.block_review import YueBlockReviewVsZhoPromptYueHans
 from scinoephile.multilang.yue_zho.gap_translation import (
-    YueVsZhoGapTranslationPromptYueHans,
+    YueGapTranslationVsZhoPromptYueHans,
 )
-from scinoephile.multilang.yue_zho.line_review import YueVsZhoLineReviewPromptYueHans
+from scinoephile.multilang.yue_zho.line_review import YueLineReviewVsZhoPromptYueHans
 from scinoephile.multilang.yue_zho.line_review.manager import YueZhoLineReviewManager
 
 
@@ -150,7 +150,7 @@ def _get_expected_case_count(relative_paths: list[str]) -> int:
             "yue_zho_line_review",
             lambda: load_default_test_cases(
                 YueZhoLineReviewManager,
-                YueVsZhoLineReviewPromptYueHans,
+                YueLineReviewVsZhoPromptYueHans,
                 YUE_ZHO_LINE_REVIEW_JSON_PATHS,
             ),
             [
@@ -163,7 +163,7 @@ def _get_expected_case_count(relative_paths: list[str]) -> int:
             "yue_zho_block_review",
             lambda: load_default_test_cases(
                 DualNToNManager,
-                YueVsZhoBlockReviewPromptYueHans,
+                YueBlockReviewVsZhoPromptYueHans,
                 YUE_ZHO_BLOCK_REVIEW_JSON_PATHS,
             ),
             [
@@ -176,7 +176,7 @@ def _get_expected_case_count(relative_paths: list[str]) -> int:
             "yue_vs_zho_gap_translation",
             lambda: load_default_test_cases(
                 DualNMinusMToNManager,
-                YueVsZhoGapTranslationPromptYueHans,
+                YueGapTranslationVsZhoPromptYueHans,
                 YUE_ZHO_GAP_TRANSLATION_JSON_PATHS,
             ),
             [

--- a/test/multilang/eng_zho/test_guided_translation.py
+++ b/test/multilang/eng_zho/test_guided_translation.py
@@ -10,7 +10,7 @@ from scinoephile.core.llms import LLMProvider
 from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.llms.dual_n_to_m import DualNToMProcessor
 from scinoephile.multilang.eng_zho.guided_translation import (
-    EngZhoGuidedTranslationPrompt,
+    EngGuidedTranslationVsZhoPrompt,
     get_eng_translated_from_zho_with_eng_guidance,
     get_eng_zho_guided_translator,
 )
@@ -18,9 +18,9 @@ from scinoephile.multilang.eng_zho.guided_translation import (
 
 def test_eng_zho_guided_translation_prompt_field_names():
     """Test guided translation prompt uses domain-specific field names."""
-    assert EngZhoGuidedTranslationPrompt.src_1(1) == "zho_1"
-    assert EngZhoGuidedTranslationPrompt.src_2(1) == "eng_reference_1"
-    assert EngZhoGuidedTranslationPrompt.output(1) == "eng_1"
+    assert EngGuidedTranslationVsZhoPrompt.src_1(1) == "zho_1"
+    assert EngGuidedTranslationVsZhoPrompt.src_2(1) == "eng_reference_1"
+    assert EngGuidedTranslationVsZhoPrompt.output(1) == "eng_1"
 
 
 def test_get_eng_zho_guided_translator_wires_processor():
@@ -30,7 +30,7 @@ def test_get_eng_zho_guided_translator_wires_processor():
     processor = get_eng_zho_guided_translator(test_cases=[], provider=provider)
 
     assert isinstance(processor, DualNToMProcessor)
-    assert processor.prompt_cls is EngZhoGuidedTranslationPrompt
+    assert processor.prompt_cls is EngGuidedTranslationVsZhoPrompt
     assert processor.queryer.provider is provider
 
 

--- a/test/multilang/yue_zho/test_get_yue_transcriber_vs_zho.py
+++ b/test/multilang/yue_zho/test_get_yue_transcriber_vs_zho.py
@@ -21,10 +21,10 @@ from scinoephile.multilang.yue_zho.transcription import (
     get_yue_vs_zho_transcriber,
 )
 from scinoephile.multilang.yue_zho.transcription.deliniation import (
-    YueVsZhoDeliniationPromptYueHans,
+    YueDeliniationVsZhoPromptYueHans,
 )
 from scinoephile.multilang.yue_zho.transcription.punctuation import (
-    YueVsZhoPunctuationPromptYueHans,
+    YuePunctuationVsZhoPromptYueHans,
 )
 
 
@@ -54,8 +54,8 @@ def test_get_yue_vs_zho_transcriber_uses_writable_runtime_test_case_root():
             demucs_mode=DemucsMode.OFF,
             vad_mode=VADMode.AUTO,
             convert=None,
-            deliniation_prompt_cls=YueVsZhoDeliniationPromptYueHans,
-            punctuation_prompt_cls=YueVsZhoPunctuationPromptYueHans,
+            deliniation_prompt_cls=YueDeliniationVsZhoPromptYueHans,
+            punctuation_prompt_cls=YuePunctuationVsZhoPromptYueHans,
             provider=ANY,
         )
         assert (

--- a/test/optimization/persistence/test_cases/test_optimization_test_cases_sqlite_store.py
+++ b/test/optimization/persistence/test_cases/test_optimization_test_cases_sqlite_store.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from scinoephile.core.llms import OperationSpec
 from scinoephile.multilang.yue_zho.transcription.punctuation import (
-    YueVsZhoPunctuationPromptYueHans,
+    YuePunctuationVsZhoPromptYueHans,
     YueZhoPunctuationManager,
 )
 from scinoephile.optimization.persistence.test_cases import (
@@ -24,7 +24,7 @@ def get_punctuation_operation_spec() -> OperationSpec:
         operation="unit-punctuation",
         test_case_table_name="test_cases__unit__punctuation",
         manager_cls=YueZhoPunctuationManager,
-        prompt_cls=YueVsZhoPunctuationPromptYueHans,
+        prompt_cls=YuePunctuationVsZhoPromptYueHans,
         list_fields={"query.yuewen_to_punctuate": 10},
     )
 

--- a/test/optimization/persistence/test_cases/test_optimization_test_cases_sync.py
+++ b/test/optimization/persistence/test_cases/test_optimization_test_cases_sync.py
@@ -11,7 +11,7 @@ from scinoephile.core.llms import OperationSpec
 from scinoephile.llms.mono_n.manager import MonoNManager
 from scinoephile.llms.mono_n.prompt import MonoNPrompt
 from scinoephile.multilang.yue_zho.transcription.punctuation import (
-    YueVsZhoPunctuationPromptYueHans,
+    YuePunctuationVsZhoPromptYueHans,
     YueZhoPunctuationManager,
 )
 from scinoephile.optimization.persistence.test_cases import TestCaseSqliteStore
@@ -200,7 +200,7 @@ def test_sync_uses_operation_list_fields(tmp_path: Path, monkeypatch):
         operation="unit-punctuation",
         test_case_table_name="test_cases__unit__punctuation",
         manager_cls=YueZhoPunctuationManager,
-        prompt_cls=YueVsZhoPunctuationPromptYueHans,
+        prompt_cls=YuePunctuationVsZhoPromptYueHans,
         list_fields={"query.yuewen_to_punctuate": 10},
     )
 


### PR DESCRIPTION
## Summary

- Rename Yue/Zho prompt classes to put the operation before `VsZho`, preserving the script suffix.
- Rename `EngZhoGuidedTranslationPrompt` to `EngGuidedTranslationVsZhoPrompt`.
- Remove the local `YueZhoHansDelineationPrompt` alias in `aligner.py` and use the renamed prompt class directly.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format $(git diff --name-only -- '*.py')`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix $(git diff --name-only -- '*.py')`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check $(git diff --name-only -- '*.py')`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` (`1169 passed, 4 skipped`)