### PR TITLE
Add English zho translation workflows

### DIFF
--- a/scinoephile/cli/eng/__init__.py
+++ b/scinoephile/cli/eng/__init__.py
@@ -3,7 +3,7 @@
 """English command-line interfaces.
 
 Package hierarchy (modules may import from any above):
-* eng_process_cli
+* eng_process_cli / eng_translate_vs_zho_cli
 * eng_cli
 """
 
@@ -11,8 +11,10 @@ from __future__ import annotations
 
 from .eng_cli import EngCli
 from .eng_process_cli import EngProcessCli
+from .eng_translate_vs_zho_cli import EngTranslateVsZhoCli
 
 __all__ = [
     "EngCli",
     "EngProcessCli",
+    "EngTranslateVsZhoCli",
 ]

--- a/scinoephile/cli/eng/eng_cli.py
+++ b/scinoephile/cli/eng/eng_cli.py
@@ -11,6 +11,7 @@ from scinoephile.common import CommandLineInterface
 from scinoephile.core.cli import ScinoephileCliBase
 
 from .eng_process_cli import EngProcessCli
+from .eng_translate_vs_zho_cli import EngTranslateVsZhoCli
 
 __all__ = ["EngCli"]
 
@@ -20,12 +21,18 @@ ENG_LOCALIZATIONS: dict[str, dict[str, str]] = {
             "英文字幕操作命令行界面"
         ),
         "modify English subtitles": "修改英文字幕",
+        "translate English subtitles from Chinese subtitles": (
+            "根据中文字幕翻译英文字幕"
+        ),
     },
     "zh-hant": {
         "command-line interface for English subtitle operations": (
             "英文字幕操作命令列介面"
         ),
         "modify English subtitles": "修改英文字幕",
+        "translate English subtitles from Chinese subtitles": (
+            "根據中文字幕翻譯英文字幕"
+        ),
     },
 }
 """Localized help text keyed by locale and English source text."""
@@ -64,6 +71,7 @@ class EngCli(ScinoephileCliBase):
         """
         return {
             EngProcessCli.name(): EngProcessCli,
+            EngTranslateVsZhoCli.name(): EngTranslateVsZhoCli,
         }
 
     @classmethod

--- a/scinoephile/cli/eng/eng_translate_vs_zho_cli.py
+++ b/scinoephile/cli/eng/eng_translate_vs_zho_cli.py
@@ -44,14 +44,16 @@ ENG_TRANSLATE_VS_ZHO_LOCALIZATIONS: dict[str, dict[str, str]] = {
         "filling gaps in English subtitles or using English guide subtitles.": (
             "此命令将中文字幕翻译为英文，并可选择补全英文字幕缺口或使用英文参考字幕。"
         ),
-        'aligned Chinese subtitle infile or "-" for stdin': (
-            '已对齐的中文字幕输入文件，或使用 "-" 表示标准输入'
+        'Chinese subtitle infile or "-" for stdin': (
+            '中文字幕输入文件，或使用 "-" 表示标准输入'
         ),
-        'English subtitle infile with gaps, or "-" for stdin': (
-            '含缺口的英文字幕输入文件，或使用 "-" 表示标准输入'
+        "English subtitle infile with gaps to fill with translation from Chinese, "
+        'or "-" for stdin': (
+            '含缺口、需根据中文翻译补全的英文字幕输入文件，或使用 "-" 表示标准输入'
         ),
-        'English guide subtitle infile, or "-" for stdin': (
-            '英文参考字幕输入文件，或使用 "-" 表示标准输入'
+        "English subtitle infile with which to guide translation from Chinese, "
+        'or "-" for stdin': (
+            '用于指导从中文翻译的英文字幕输入文件，或使用 "-" 表示标准输入'
         ),
         "English subtitle outfile path (default: stdout)": (
             "英文字幕输出文件路径（默认：标准输出）"
@@ -68,14 +70,16 @@ ENG_TRANSLATE_VS_ZHO_LOCALIZATIONS: dict[str, dict[str, str]] = {
         "filling gaps in English subtitles or using English guide subtitles.": (
             "此命令將中文字幕翻譯為英文，並可選擇補全英文字幕缺口或使用英文參考字幕。"
         ),
-        'aligned Chinese subtitle infile or "-" for stdin': (
-            '已對齊的中文字幕輸入檔，或使用 "-" 代表標準輸入'
+        'Chinese subtitle infile or "-" for stdin': (
+            '中文字幕輸入檔，或使用 "-" 代表標準輸入'
         ),
-        'English subtitle infile with gaps, or "-" for stdin': (
-            '含缺口的英文字幕輸入檔，或使用 "-" 代表標準輸入'
+        "English subtitle infile with gaps to fill with translation from Chinese, "
+        'or "-" for stdin': (
+            '含缺口、需根據中文翻譯補全的英文字幕輸入檔，或使用 "-" 代表標準輸入'
         ),
-        'English guide subtitle infile, or "-" for stdin': (
-            '英文參考字幕輸入檔，或使用 "-" 代表標準輸入'
+        "English subtitle infile with which to guide translation from Chinese, "
+        'or "-" for stdin': (
+            '用於指導從中文翻譯的英文字幕輸入檔，或使用 "-" 代表標準輸入'
         ),
         "English subtitle outfile path (default: stdout)": (
             "英文字幕輸出檔路徑（預設：標準輸出）"
@@ -120,7 +124,7 @@ class EngTranslateVsZhoCli(ScinoephileCliBase):
             dest="zho_infile_path",
             required=True,
             type=input_file_arg(allow_stdin=True),
-            help='aligned Chinese subtitle infile or "-" for stdin',
+            help='Chinese subtitle infile or "-" for stdin',
         )
         eng_input_group = arg_groups["input arguments"].add_mutually_exclusive_group()
         eng_input_group.add_argument(
@@ -128,14 +132,20 @@ class EngTranslateVsZhoCli(ScinoephileCliBase):
             dest="eng_gapped_infile_path",
             default=None,
             type=input_file_arg(allow_stdin=True),
-            help='English subtitle infile with gaps, or "-" for stdin',
+            help=(
+                "English subtitle infile with gaps to fill with translation from "
+                'Chinese, or "-" for stdin'
+            ),
         )
         eng_input_group.add_argument(
             "--eng-guide-infile",
             dest="eng_guide_infile_path",
             default=None,
             type=input_file_arg(allow_stdin=True),
-            help='English guide subtitle infile, or "-" for stdin',
+            help=(
+                "English subtitle infile with which to guide translation from "
+                'Chinese, or "-" for stdin'
+            ),
         )
 
         # Operation arguments

--- a/scinoephile/cli/eng/eng_translate_vs_zho_cli.py
+++ b/scinoephile/cli/eng/eng_translate_vs_zho_cli.py
@@ -1,0 +1,226 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Command-line interface for English translation from Chinese.
+
+This command translates Chinese subtitles into English, optionally filling gaps in
+English subtitles or using English guide subtitles.
+"""
+
+from __future__ import annotations
+
+from argparse import ArgumentParser
+from pathlib import Path
+
+from scinoephile.cli.llms import LLM_LOCALIZATIONS, add_llm_provider_arguments
+from scinoephile.common.argument_parsing import (
+    get_arg_groups_by_name,
+    input_file_arg,
+    output_file_arg,
+)
+from scinoephile.core.cli import ScinoephileCliBase, read_series, write_series
+from scinoephile.core.cli.localization import merge_localizations
+from scinoephile.llms.providers.registry import get_provider
+from scinoephile.multilang.eng_zho.gapped_translation import (
+    get_eng_gapped_translated_vs_zho,
+    get_eng_vs_zho_gapped_translator,
+)
+from scinoephile.multilang.eng_zho.guided_translation import (
+    get_eng_translated_from_zho_with_eng_guidance,
+    get_eng_zho_guided_translator,
+)
+from scinoephile.multilang.eng_zho.translation import (
+    get_eng_translated_from_zho,
+    get_eng_zho_translator,
+)
+
+__all__ = ["EngTranslateVsZhoCli"]
+
+ENG_TRANSLATE_VS_ZHO_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "command-line interface for English translation from Chinese": (
+            "从中文翻译英文字幕的命令行界面"
+        ),
+        "This command translates Chinese subtitles into English, optionally "
+        "filling gaps in English subtitles or using English guide subtitles.": (
+            "此命令将中文字幕翻译为英文，并可选择补全英文字幕缺口或使用英文参考字幕。"
+        ),
+        'aligned Chinese subtitle infile or "-" for stdin': (
+            '已对齐的中文字幕输入文件，或使用 "-" 表示标准输入'
+        ),
+        'English subtitle infile with gaps, or "-" for stdin': (
+            '含缺口的英文字幕输入文件，或使用 "-" 表示标准输入'
+        ),
+        'English guide subtitle infile, or "-" for stdin': (
+            '英文参考字幕输入文件，或使用 "-" 表示标准输入'
+        ),
+        "English subtitle outfile path (default: stdout)": (
+            "英文字幕输出文件路径（默认：标准输出）"
+        ),
+        "translate English subtitles from Chinese subtitles": (
+            "根据中文字幕翻译英文字幕"
+        ),
+    },
+    "zh-hant": {
+        "command-line interface for English translation from Chinese": (
+            "從中文翻譯英文字幕的命令列介面"
+        ),
+        "This command translates Chinese subtitles into English, optionally "
+        "filling gaps in English subtitles or using English guide subtitles.": (
+            "此命令將中文字幕翻譯為英文，並可選擇補全英文字幕缺口或使用英文參考字幕。"
+        ),
+        'aligned Chinese subtitle infile or "-" for stdin': (
+            '已對齊的中文字幕輸入檔，或使用 "-" 代表標準輸入'
+        ),
+        'English subtitle infile with gaps, or "-" for stdin': (
+            '含缺口的英文字幕輸入檔，或使用 "-" 代表標準輸入'
+        ),
+        'English guide subtitle infile, or "-" for stdin': (
+            '英文參考字幕輸入檔，或使用 "-" 代表標準輸入'
+        ),
+        "English subtitle outfile path (default: stdout)": (
+            "英文字幕輸出檔路徑（預設：標準輸出）"
+        ),
+        "translate English subtitles from Chinese subtitles": (
+            "根據中文字幕翻譯英文字幕"
+        ),
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
+
+class EngTranslateVsZhoCli(ScinoephileCliBase):
+    """Translate English subtitles from Chinese subtitles."""
+
+    localizations = merge_localizations(
+        LLM_LOCALIZATIONS,
+        ENG_TRANSLATE_VS_ZHO_LOCALIZATIONS,
+    )
+    """Localized help text keyed by locale and English source text."""
+
+    @classmethod
+    def add_arguments_to_argparser(cls, parser: ArgumentParser):
+        """Add arguments to a nascent argument parser.
+
+        Arguments:
+            parser: nascent argument parser
+        """
+        super().add_arguments_to_argparser(parser)
+        arg_groups = get_arg_groups_by_name(
+            parser,
+            "input arguments",
+            "operation arguments",
+            "output arguments",
+            "additional help",
+            optional_arguments_name="additional arguments",
+        )
+
+        # Input arguments
+        arg_groups["input arguments"].add_argument(
+            "--zho-infile",
+            dest="zho_infile_path",
+            required=True,
+            type=input_file_arg(allow_stdin=True),
+            help='aligned Chinese subtitle infile or "-" for stdin',
+        )
+        eng_input_group = arg_groups["input arguments"].add_mutually_exclusive_group()
+        eng_input_group.add_argument(
+            "--eng-gapped-infile",
+            dest="eng_gapped_infile_path",
+            default=None,
+            type=input_file_arg(allow_stdin=True),
+            help='English subtitle infile with gaps, or "-" for stdin',
+        )
+        eng_input_group.add_argument(
+            "--eng-guide-infile",
+            dest="eng_guide_infile_path",
+            default=None,
+            type=input_file_arg(allow_stdin=True),
+            help='English guide subtitle infile, or "-" for stdin',
+        )
+
+        # Operation arguments
+        add_llm_provider_arguments(
+            arg_groups["operation arguments"], arg_groups["additional help"]
+        )
+
+        # Output arguments
+        arg_groups["output arguments"].add_argument(
+            "-o",
+            "--outfile",
+            default=None,
+            dest="outfile_path",
+            type=output_file_arg(),
+            help="English subtitle outfile path (default: stdout)",
+        )
+        arg_groups["output arguments"].add_argument(
+            "--overwrite",
+            action="store_true",
+            help="overwrite outfile if it exists",
+        )
+        parser.set_defaults(_parser=parser)
+
+    @classmethod
+    def name(cls) -> str:
+        """Name of this tool used to define it when it is a subparser.
+
+        Returns:
+            subcommand name
+        """
+        return "translate-vs-zho"
+
+    @classmethod
+    def _main(
+        cls,
+        *,
+        _parser: ArgumentParser | None = None,
+        zho_infile_path: Path | str,
+        eng_gapped_infile_path: Path | str | None,
+        eng_guide_infile_path: Path | str | None,
+        llm_provider_name: str,
+        llm_model_name: str | None,
+        outfile_path: Path | None,
+        overwrite: bool,
+    ):
+        """Execute with provided keyword arguments."""
+        # Validate arguments
+        parser = _parser or cls.argparser()
+        if overwrite and outfile_path is None:
+            parser.error("--overwrite may only be used with --outfile")
+        if zho_infile_path == "-" and (
+            eng_gapped_infile_path == "-" or eng_guide_infile_path == "-"
+        ):
+            parser.error("--zho-infile and an English infile may not both be '-'")
+
+        # Read inputs
+        zho = read_series(parser, zho_infile_path, allow_stdin=True)
+        provider = get_provider(llm_provider_name, model=llm_model_name)
+
+        # Perform operations
+        if eng_gapped_infile_path is not None:
+            eng = read_series(parser, eng_gapped_infile_path, allow_stdin=True)
+            translator = get_eng_vs_zho_gapped_translator(provider=provider)
+            eng = get_eng_gapped_translated_vs_zho(
+                eng=eng,
+                zho=zho,
+                translator=translator,
+            )
+        elif eng_guide_infile_path is not None:
+            eng = read_series(parser, eng_guide_infile_path, allow_stdin=True)
+            translator = get_eng_zho_guided_translator(provider=provider)
+            eng = get_eng_translated_from_zho_with_eng_guidance(
+                zho=zho,
+                eng=eng,
+                translator=translator,
+            )
+        else:
+            translator = get_eng_zho_translator(provider=provider)
+            eng = get_eng_translated_from_zho(zho=zho, translator=translator)
+
+        # Write outputs
+        write_series(
+            parser, eng, outfile_path if outfile_path is not None else "-", overwrite
+        )
+
+
+if __name__ == "__main__":
+    EngTranslateVsZhoCli.main()

--- a/scinoephile/cli/yue/yue_translate_vs_zho_cli.py
+++ b/scinoephile/cli/yue/yue_translate_vs_zho_cli.py
@@ -21,11 +21,11 @@ from scinoephile.common.argument_parsing import (
 from scinoephile.core.cli import ScinoephileCliBase, read_series, write_series
 from scinoephile.core.cli.localization import merge_localizations
 from scinoephile.llms.providers.registry import get_provider
-from scinoephile.multilang.yue_zho.gap_translation import (
-    YueGapTranslationVsZhoPromptYueHans,
-    YueGapTranslationVsZhoPromptYueHant,
-    get_yue_gap_translated_vs_zho,
-    get_yue_vs_zho_gap_translator,
+from scinoephile.multilang.yue_zho.gapped_translation import (
+    YueGappedTranslationVsZhoPromptYueHans,
+    YueGappedTranslationVsZhoPromptYueHant,
+    get_yue_gapped_translated_vs_zho,
+    get_yue_vs_zho_gapped_translator,
 )
 
 __all__ = ["YueTranslateVsZhoCli"]
@@ -162,7 +162,7 @@ class YueTranslateVsZhoCli(ScinoephileCliBase):
     @classmethod
     def _get_translation_prompt_cls(
         cls, script: str
-    ) -> type[YueGapTranslationVsZhoPromptYueHans]:
+    ) -> type[YueGappedTranslationVsZhoPromptYueHans]:
         """Get the gap translation prompt class for the selected script.
 
         Arguments:
@@ -171,8 +171,8 @@ class YueTranslateVsZhoCli(ScinoephileCliBase):
             gap translation prompt class
         """
         if script == "traditional":
-            return YueGapTranslationVsZhoPromptYueHant
-        return YueGapTranslationVsZhoPromptYueHans
+            return YueGappedTranslationVsZhoPromptYueHant
+        return YueGappedTranslationVsZhoPromptYueHans
 
     @classmethod
     def _main(
@@ -202,10 +202,10 @@ class YueTranslateVsZhoCli(ScinoephileCliBase):
         # Perform operations
         prompt_cls = cls._get_translation_prompt_cls(script)
         provider = get_provider(llm_provider_name, model=llm_model_name)
-        translator = get_yue_vs_zho_gap_translator(
+        translator = get_yue_vs_zho_gapped_translator(
             prompt_cls=prompt_cls, provider=provider
         )
-        yuewen = get_yue_gap_translated_vs_zho(
+        yuewen = get_yue_gapped_translated_vs_zho(
             yuewen=yuewen,
             zhongwen=zhongwen,
             translator=translator,

--- a/scinoephile/llms/default_test_cases.py
+++ b/scinoephile/llms/default_test_cases.py
@@ -14,9 +14,11 @@ from scinoephile.core.llms.utils import load_test_cases_from_json
 
 __all__ = [
     "ENG_BLOCK_REVIEW_JSON_PATHS",
+    "ENG_ZHO_GAPPED_TRANSLATION_JSON_PATHS",
     "ENG_ZHO_GUIDED_TRANSLATION_JSON_PATHS",
+    "ENG_ZHO_TRANSLATION_JSON_PATHS",
     "ENG_OCR_FUSION_JSON_PATHS",
-    "YUE_ZHO_GAP_TRANSLATION_JSON_PATHS",
+    "YUE_ZHO_GAPPED_TRANSLATION_JSON_PATHS",
     "YUE_ZHO_LINE_REVIEW_JSON_PATHS",
     "YUE_ZHO_BLOCK_REVIEW_JSON_PATHS",
     "YUE_ZHO_TRANSCRIPTION_PUNCTUATION_JSON_PATHS",
@@ -45,7 +47,11 @@ ENG_OCR_FUSION_JSON_PATHS = (
     Path("t/output/eng_ocr/lang/eng/ocr_fusion.json"),
 )
 
+ENG_ZHO_GAPPED_TRANSLATION_JSON_PATHS: tuple[Path, ...] = ()
+
 ENG_ZHO_GUIDED_TRANSLATION_JSON_PATHS: tuple[Path, ...] = ()
+
+ENG_ZHO_TRANSLATION_JSON_PATHS: tuple[Path, ...] = ()
 
 ZHO_HANS_BLOCK_REVIEW_JSON_PATHS = (
     Path("mlamd/output/zho-Hans_ocr/lang/zho/block_review.json"),
@@ -85,7 +91,7 @@ YUE_ZHO_BLOCK_REVIEW_JSON_PATHS = (
     Path("mlamd/output/yue-Hans_transcribe/multilang/yue_zho/block_review/mps.json"),
 )
 
-YUE_ZHO_GAP_TRANSLATION_JSON_PATHS = (
+YUE_ZHO_GAPPED_TRANSLATION_JSON_PATHS = (
     Path(
         "mlamd/output/yue-Hans_transcribe/multilang/yue_zho/gap_translation/cuda.json"
     ),

--- a/scinoephile/llms/dual_n_minus_m_to_n/manager.py
+++ b/scinoephile/llms/dual_n_minus_m_to_n/manager.py
@@ -103,8 +103,8 @@ class DualNMinusMToNManager(Manager):
         )
         fields: dict[str, Any] = {}
         for idx in gaps:
-            key = prompt_cls.src_1(idx + 1)
-            description = prompt_cls.src_1_desc(idx + 1)
+            key = prompt_cls.output(idx + 1)
+            description = prompt_cls.output_desc(idx + 1)
             fields[key] = (str, Field(..., description=description))
 
         model = create_model(

--- a/scinoephile/multilang/eng_zho/__init__.py
+++ b/scinoephile/multilang/eng_zho/__init__.py
@@ -3,5 +3,5 @@
 """Code related to English/Chinese text.
 
 Package hierarchy (modules may import from any above):
-* guided_translation
+* gapped_translation / guided_translation / translation
 """

--- a/scinoephile/multilang/eng_zho/gapped_translation/__init__.py
+++ b/scinoephile/multilang/eng_zho/gapped_translation/__init__.py
@@ -1,6 +1,6 @@
 #  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
-"""Code related to written Cantonese gap translation using standard Chinese."""
+"""Code related to English gapped translation using Chinese."""
 
 from __future__ import annotations
 
@@ -10,9 +10,8 @@ from typing import TypedDict, Unpack
 from scinoephile.core.llms import OperationSpec, TestCase
 from scinoephile.core.llms.llm_provider import LLMProvider
 from scinoephile.core.subtitles import Series
-from scinoephile.dictionaries.dictionary_tools import get_dictionary_tools
 from scinoephile.llms.default_test_cases import (
-    YUE_ZHO_GAP_TRANSLATION_JSON_PATHS,
+    ENG_ZHO_GAPPED_TRANSLATION_JSON_PATHS,
     load_default_test_cases,
 )
 from scinoephile.llms.dual_n_minus_m_to_n import (
@@ -21,82 +20,76 @@ from scinoephile.llms.dual_n_minus_m_to_n import (
 )
 from scinoephile.llms.providers.registry import get_provider
 
-from .prompts import (
-    YueGapTranslationVsZhoPromptYueHans,
-    YueGapTranslationVsZhoPromptYueHant,
-)
+from .prompts import EngGappedTranslationVsZhoPrompt
 
 __all__ = [
-    "YUE_ZHO_GAP_TRANSLATION_OPERATION_SPEC",
-    "YueGapTranslationVsZhoPromptYueHans",
-    "YueGapTranslationVsZhoPromptYueHant",
-    "YueVsZhoGapTranslationProcessKwargs",
-    "YueVsZhoGapTranslationProcessorKwargs",
-    "get_yue_gap_translated_vs_zho",
-    "get_yue_vs_zho_gap_translator",
+    "ENG_ZHO_GAPPED_TRANSLATION_OPERATION_SPEC",
+    "EngGappedTranslationVsZhoPrompt",
+    "EngVsZhoGappedTranslationProcessKwargs",
+    "EngVsZhoGappedTranslationProcessorKwargs",
+    "get_eng_gapped_translated_vs_zho",
+    "get_eng_vs_zho_gapped_translator",
 ]
 
-YUE_ZHO_GAP_TRANSLATION_OPERATION_SPEC = OperationSpec(
-    operation="yue-zho-gap-translation",
-    test_case_table_name="test_cases__yue_zho__gap_translation",
+ENG_ZHO_GAPPED_TRANSLATION_OPERATION_SPEC = OperationSpec(
+    operation="eng-zho-gapped-translation",
+    test_case_table_name="test_cases__eng_zho__gapped_translation",
     manager_cls=DualNMinusMToNManager,
-    prompt_cls=YueGapTranslationVsZhoPromptYueHans,
+    prompt_cls=EngGappedTranslationVsZhoPrompt,
 )
-"""Operation specification for written Cantonese gap translation."""
+"""Operation specification for English gapped translation from Chinese."""
 
 
-class YueVsZhoGapTranslationProcessKwargs(TypedDict, total=False):
+class EngVsZhoGappedTranslationProcessKwargs(TypedDict, total=False):
     """Keyword arguments for DualNMinusMToNProcessor.process."""
 
     stop_at_idx: int | None
     """Exclusive block index at which to stop processing."""
 
 
-class YueVsZhoGapTranslationProcessorKwargs(TypedDict, total=False):
+class EngVsZhoGappedTranslationProcessorKwargs(TypedDict, total=False):
     """Keyword arguments for DualNMinusMToNProcessor initialization."""
 
     test_case_path: Path | None
     """Path where encountered test cases are persisted."""
+    additional_context: str | None
+    """Additional context to include in the system prompt."""
     auto_verify: bool
     """Whether generated test cases should be marked verified automatically."""
 
 
-def get_yue_gap_translated_vs_zho(
-    yuewen: Series,
-    zhongwen: Series,
+def get_eng_gapped_translated_vs_zho(
+    eng: Series,
+    zho: Series,
     translator: DualNMinusMToNProcessor | None = None,
-    **kwargs: Unpack[YueVsZhoGapTranslationProcessKwargs],
+    **kwargs: Unpack[EngVsZhoGappedTranslationProcessKwargs],
 ) -> Series:
-    """Get written Cantonese subtitle gaps translated using standard Chinese.
+    """Get English subtitle gaps translated using Chinese.
 
     Arguments:
-        yuewen: written Cantonese Series
-        zhongwen: standard Chinese Series
+        eng: English subtitles that may contain gaps
+        zho: Chinese subtitles to use as reference
         translator: processor to use
         **kwargs: additional arguments for DualNMinusMToNProcessor.process
     Returns:
-        written Cantonese with gaps translated using standard Chinese
+        English subtitles with gaps translated using Chinese
     """
     if translator is None:
-        translator = get_yue_vs_zho_gap_translator()
-    return translator.process(yuewen, zhongwen, **kwargs)
+        translator = get_eng_vs_zho_gapped_translator()
+    return translator.process(eng, zho, **kwargs)
 
 
-def get_yue_vs_zho_gap_translator(
-    prompt_cls: type[YueGapTranslationVsZhoPromptYueHans] = (
-        YueGapTranslationVsZhoPromptYueHans
-    ),
+def get_eng_vs_zho_gapped_translator(
+    prompt_cls: type[EngGappedTranslationVsZhoPrompt] = EngGappedTranslationVsZhoPrompt,
     test_cases: list[TestCase] | None = None,
-    use_dictionary_tool: bool = True,
     provider: LLMProvider | None = None,
-    **kwargs: Unpack[YueVsZhoGapTranslationProcessorKwargs],
+    **kwargs: Unpack[EngVsZhoGappedTranslationProcessorKwargs],
 ) -> DualNMinusMToNProcessor:
     """Get DualNMinusMToNProcessor with provided configuration.
 
     Arguments:
         prompt_cls: text for LLM correspondence
         test_cases: test cases
-        use_dictionary_tool: whether to wire the dictionary lookup tool
         provider: provider to use for queries
         **kwargs: additional arguments for DualNMinusMToNProcessor
     Returns:
@@ -107,18 +100,14 @@ def get_yue_vs_zho_gap_translator(
             load_default_test_cases(
                 DualNMinusMToNManager,
                 prompt_cls,
-                YUE_ZHO_GAP_TRANSLATION_JSON_PATHS,
+                ENG_ZHO_GAPPED_TRANSLATION_JSON_PATHS,
             )
         )
-    tool_box = None
-    if use_dictionary_tool:
-        tool_box = get_dictionary_tools(prompt_cls)
     if provider is None:
         provider = get_provider()
     return DualNMinusMToNProcessor(
         prompt_cls=prompt_cls,
         test_cases=test_cases,
         provider=provider,
-        tool_box=tool_box,
         **kwargs,
     )

--- a/scinoephile/multilang/eng_zho/gapped_translation/prompts.py
+++ b/scinoephile/multilang/eng_zho/gapped_translation/prompts.py
@@ -1,0 +1,60 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Text for English gapped translation using Chinese."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from scinoephile.core.text import dedent_and_compact
+from scinoephile.lang.eng.prompts import PromptEng
+from scinoephile.llms.dual_n_minus_m_to_n import DualNMinusMToNPrompt
+
+__all__ = ["EngGappedTranslationVsZhoPrompt"]
+
+
+class EngGappedTranslationVsZhoPrompt(DualNMinusMToNPrompt, PromptEng):
+    """Text for English gapped translation using Chinese."""
+
+    # Prompt
+    base_system_prompt: ClassVar[str] = dedent_and_compact("""
+        You are responsible for filling missing English subtitle lines using the
+        corresponding Chinese subtitles as reference.
+
+        Only provide an English translation when the existing English subtitle line is
+        missing. If a line already has English content, do not revise it; output an
+        empty string for that line. Translate missing lines into natural subtitle
+        English that matches nearby English wording, register, dramatic intent, and
+        speaker intent. Use the Chinese as the source of meaning, but keep style and
+        terminology consistent with the existing English subtitles around the gap.
+
+        Output only the generated English subtitle text in each answer field. If no
+        translation is needed for a line, output an empty string. Do not include notes,
+        explanations, labels, alternate translations, bracketed commentary, or any text
+        outside the subtitle itself.
+        """)
+    """Base system prompt."""
+
+    # Query fields
+    src_1_pfx: ClassVar[str] = "eng_"
+    """Prefix for existing English fields in query."""
+
+    src_1_desc_tpl: ClassVar[str] = (
+        "Existing English subtitle {idx}; missing entries require translation"
+    )
+    """Description template for existing English fields in query."""
+
+    src_2_pfx: ClassVar[str] = "zho_"
+    """Prefix for Chinese reference fields in query."""
+
+    src_2_desc_tpl: ClassVar[str] = "Chinese subtitle {idx} corresponding to line {idx}"
+    """Description template for Chinese reference fields in query."""
+
+    # Answer fields
+    output_pfx: ClassVar[str] = "eng_"
+    """Prefix for generated English output fields in answer."""
+
+    output_desc_tpl: ClassVar[str] = (
+        'English subtitle {idx} for a missing line, or "" if no translation is needed'
+    )
+    """Description template for generated English output fields in answer."""

--- a/scinoephile/multilang/eng_zho/guided_translation/prompts.py
+++ b/scinoephile/multilang/eng_zho/guided_translation/prompts.py
@@ -18,17 +18,17 @@ class EngGuidedTranslationVsZhoPrompt(DualNToMPrompt, PromptEng):
 
     # Prompt
     base_system_prompt: ClassVar[str] = dedent_and_compact("""
-        You are responsible for creating English subtitles from Traditional written
-        Cantonese subtitles for Cantonese/Yue audio. You will also receive original
-        English subtitles from the same scene as reference material.
+        You are responsible for creating English subtitles from Chinese subtitles. You
+        will also receive original English subtitles from the same scene as reference
+        material.
 
-        Produce one English subtitle for each Cantonese subtitle. Match the meaning,
-        timing granularity, dramatic intent, and speaker intent of the Cantonese.
+        Produce one English subtitle for each Chinese subtitle. Match the meaning,
+        timing granularity, dramatic intent, and speaker intent of the Chinese.
         Use the original English subtitles as the source of truth for character
         names, proper nouns, recurring terms, register, and canonical phrasing when
-        that wording is compatible with the Cantonese. Do not invent alternate names
-        or translate names literally. When the Cantonese differs from the original
-        English, prioritize the Cantonese meaning while preserving established names
+        that wording is compatible with the Chinese. Do not invent alternate names
+        or translate names literally. When the Chinese differs from the original
+        English, prioritize the Chinese meaning while preserving established names
         and terms from the English reference.
 
         Output only the generated English subtitle text in each answer field. Do not
@@ -42,8 +42,8 @@ class EngGuidedTranslationVsZhoPrompt(DualNToMPrompt, PromptEng):
     src_1_pfx: ClassVar[str] = "zho_"
     """Prefix for Chinese source fields in query."""
 
-    src_1_desc_tpl: ClassVar[str] = "Cantonese subtitle {idx} to translate"
-    """Description template for Cantonese source fields in query."""
+    src_1_desc_tpl: ClassVar[str] = "Chinese subtitle {idx} to translate"
+    """Description template for Chinese source fields in query."""
 
     src_2_pfx: ClassVar[str] = "eng_reference_"
     """Prefix for English reference fields in query."""
@@ -58,6 +58,6 @@ class EngGuidedTranslationVsZhoPrompt(DualNToMPrompt, PromptEng):
     """Prefix for generated English output fields in answer."""
 
     output_desc_tpl: ClassVar[str] = (
-        "Generated English subtitle {idx} corresponding to Cantonese subtitle {idx}"
+        "Generated English subtitle {idx} corresponding to Chinese subtitle {idx}"
     )
     """Description template for generated English output fields in answer."""

--- a/scinoephile/multilang/eng_zho/translation/__init__.py
+++ b/scinoephile/multilang/eng_zho/translation/__init__.py
@@ -1,0 +1,111 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Code related to English translation from Chinese."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TypedDict, Unpack
+
+from scinoephile.core.llms import OperationSpec, TestCase
+from scinoephile.core.llms.llm_provider import LLMProvider
+from scinoephile.core.subtitles import Series
+from scinoephile.llms.default_test_cases import (
+    ENG_ZHO_TRANSLATION_JSON_PATHS,
+    load_default_test_cases,
+)
+from scinoephile.llms.dual_n_to_m import (
+    DualNToMManager,
+    DualNToMProcessor,
+)
+from scinoephile.llms.providers.registry import get_provider
+
+from .prompts import EngTranslationVsZhoPrompt
+
+__all__ = [
+    "ENG_ZHO_TRANSLATION_OPERATION_SPEC",
+    "EngTranslationVsZhoPrompt",
+    "EngZhoTranslationProcessKwargs",
+    "EngZhoTranslationProcessorKwargs",
+    "get_eng_translated_from_zho",
+    "get_eng_zho_translator",
+]
+
+ENG_ZHO_TRANSLATION_OPERATION_SPEC = OperationSpec(
+    operation="eng-zho-translation",
+    test_case_table_name="test_cases__eng_zho__translation",
+    manager_cls=DualNToMManager,
+    prompt_cls=EngTranslationVsZhoPrompt,
+)
+"""Operation specification for English translation from Chinese."""
+
+
+class EngZhoTranslationProcessKwargs(TypedDict, total=False):
+    """Keyword arguments for DualNToMProcessor.process."""
+
+    stop_at_idx: int | None
+    """Exclusive block index at which to stop processing."""
+
+
+class EngZhoTranslationProcessorKwargs(TypedDict, total=False):
+    """Keyword arguments for DualNToMProcessor initialization."""
+
+    test_case_path: Path | None
+    """Path where encountered test cases are persisted."""
+    additional_context: str | None
+    """Additional context to include in the system prompt."""
+    auto_verify: bool
+    """Whether generated test cases should be marked verified automatically."""
+
+
+def get_eng_translated_from_zho(
+    zho: Series,
+    translator: DualNToMProcessor | None = None,
+    **kwargs: Unpack[EngZhoTranslationProcessKwargs],
+) -> Series:
+    """Get English subtitles translated from Chinese.
+
+    Arguments:
+        zho: Chinese subtitles to translate
+        translator: processor to use
+        **kwargs: additional arguments for DualNToMProcessor.process
+    Returns:
+        English subtitles translated from Chinese
+    """
+    if translator is None:
+        translator = get_eng_zho_translator()
+    return translator.process(zho, Series(), **kwargs)
+
+
+def get_eng_zho_translator(
+    prompt_cls: type[EngTranslationVsZhoPrompt] = EngTranslationVsZhoPrompt,
+    test_cases: list[TestCase] | None = None,
+    provider: LLMProvider | None = None,
+    **kwargs: Unpack[EngZhoTranslationProcessorKwargs],
+) -> DualNToMProcessor:
+    """Get DualNToMProcessor with provided configuration.
+
+    Arguments:
+        prompt_cls: text for LLM correspondence
+        test_cases: test cases
+        provider: provider to use for queries
+        **kwargs: additional arguments for DualNToMProcessor
+    Returns:
+        DualNToMProcessor with provided configuration
+    """
+    if test_cases is None:
+        test_cases = list(
+            load_default_test_cases(
+                DualNToMManager,
+                prompt_cls,
+                ENG_ZHO_TRANSLATION_JSON_PATHS,
+            )
+        )
+    if provider is None:
+        provider = get_provider()
+    return DualNToMProcessor(
+        prompt_cls=prompt_cls,
+        test_cases=test_cases,
+        provider=provider,
+        **kwargs,
+    )

--- a/scinoephile/multilang/eng_zho/translation/prompts.py
+++ b/scinoephile/multilang/eng_zho/translation/prompts.py
@@ -1,0 +1,55 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Text for English translation from Chinese."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from scinoephile.core.text import dedent_and_compact
+from scinoephile.lang.eng.prompts import PromptEng
+from scinoephile.llms.dual_n_to_m import DualNToMPrompt
+
+__all__ = ["EngTranslationVsZhoPrompt"]
+
+
+class EngTranslationVsZhoPrompt(DualNToMPrompt, PromptEng):
+    """Text for English translation from Chinese."""
+
+    # Prompt
+    base_system_prompt: ClassVar[str] = dedent_and_compact("""
+        You are responsible for creating English subtitles from Chinese subtitles.
+
+        Produce one English subtitle for each Chinese subtitle. Match the meaning,
+        timing granularity, dramatic intent, and speaker intent of the Chinese. Use
+        natural subtitle English rather than word-for-word phrasing. Preserve names,
+        proper nouns, recurring terms, and subtitle markup when they are present and
+        appropriate in the generated English subtitle.
+
+        Output only the generated English subtitle text in each answer field. Do not
+        include notes, explanations, labels, alternate translations, bracketed
+        commentary, or any text outside the subtitle itself.
+        """)
+    """Base system prompt."""
+
+    # Query fields
+    src_1_pfx: ClassVar[str] = "zho_"
+    """Prefix for Chinese source fields in query."""
+
+    src_1_desc_tpl: ClassVar[str] = "Chinese subtitle {idx} to translate"
+    """Description template for Chinese source fields in query."""
+
+    src_2_pfx: ClassVar[str] = "context_"
+    """Prefix for optional context fields in query."""
+
+    src_2_desc_tpl: ClassVar[str] = "Additional context subtitle {idx}"
+    """Description template for optional context fields in query."""
+
+    # Answer fields
+    output_pfx: ClassVar[str] = "eng_"
+    """Prefix for generated English output fields in answer."""
+
+    output_desc_tpl: ClassVar[str] = (
+        "Generated English subtitle {idx} corresponding to Chinese subtitle {idx}"
+    )
+    """Description template for generated English output fields in answer."""

--- a/scinoephile/multilang/yue_zho/__init__.py
+++ b/scinoephile/multilang/yue_zho/__init__.py
@@ -3,5 +3,5 @@
 """Code related to written Cantonese/standard Chinese text.
 
 Package hierarchy (modules may import from any above):
-* block_review / gap_translation / line_review / transcription
+* block_review / gapped_translation / line_review / transcription
 """

--- a/scinoephile/multilang/yue_zho/gapped_translation/__init__.py
+++ b/scinoephile/multilang/yue_zho/gapped_translation/__init__.py
@@ -1,0 +1,124 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Code related to written Cantonese gapped translation using standard Chinese."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TypedDict, Unpack
+
+from scinoephile.core.llms import OperationSpec, TestCase
+from scinoephile.core.llms.llm_provider import LLMProvider
+from scinoephile.core.subtitles import Series
+from scinoephile.dictionaries.dictionary_tools import get_dictionary_tools
+from scinoephile.llms.default_test_cases import (
+    YUE_ZHO_GAPPED_TRANSLATION_JSON_PATHS,
+    load_default_test_cases,
+)
+from scinoephile.llms.dual_n_minus_m_to_n import (
+    DualNMinusMToNManager,
+    DualNMinusMToNProcessor,
+)
+from scinoephile.llms.providers.registry import get_provider
+
+from .prompts import (
+    YueGappedTranslationVsZhoPromptYueHans,
+    YueGappedTranslationVsZhoPromptYueHant,
+)
+
+__all__ = [
+    "YUE_ZHO_GAPPED_TRANSLATION_OPERATION_SPEC",
+    "YueGappedTranslationVsZhoPromptYueHans",
+    "YueGappedTranslationVsZhoPromptYueHant",
+    "YueVsZhoGappedTranslationProcessKwargs",
+    "YueVsZhoGappedTranslationProcessorKwargs",
+    "get_yue_gapped_translated_vs_zho",
+    "get_yue_vs_zho_gapped_translator",
+]
+
+YUE_ZHO_GAPPED_TRANSLATION_OPERATION_SPEC = OperationSpec(
+    operation="yue-zho-gapped-translation",
+    test_case_table_name="test_cases__yue_zho__gapped_translation",
+    manager_cls=DualNMinusMToNManager,
+    prompt_cls=YueGappedTranslationVsZhoPromptYueHans,
+)
+"""Operation specification for written Cantonese gapped translation."""
+
+
+class YueVsZhoGappedTranslationProcessKwargs(TypedDict, total=False):
+    """Keyword arguments for DualNMinusMToNProcessor.process."""
+
+    stop_at_idx: int | None
+    """Exclusive block index at which to stop processing."""
+
+
+class YueVsZhoGappedTranslationProcessorKwargs(TypedDict, total=False):
+    """Keyword arguments for DualNMinusMToNProcessor initialization."""
+
+    test_case_path: Path | None
+    """Path where encountered test cases are persisted."""
+    auto_verify: bool
+    """Whether generated test cases should be marked verified automatically."""
+
+
+def get_yue_gapped_translated_vs_zho(
+    yuewen: Series,
+    zhongwen: Series,
+    translator: DualNMinusMToNProcessor | None = None,
+    **kwargs: Unpack[YueVsZhoGappedTranslationProcessKwargs],
+) -> Series:
+    """Get written Cantonese subtitle gaps translated using standard Chinese.
+
+    Arguments:
+        yuewen: written Cantonese Series
+        zhongwen: standard Chinese Series
+        translator: processor to use
+        **kwargs: additional arguments for DualNMinusMToNProcessor.process
+    Returns:
+        written Cantonese with gaps translated using standard Chinese
+    """
+    if translator is None:
+        translator = get_yue_vs_zho_gapped_translator()
+    return translator.process(yuewen, zhongwen, **kwargs)
+
+
+def get_yue_vs_zho_gapped_translator(
+    prompt_cls: type[YueGappedTranslationVsZhoPromptYueHans] = (
+        YueGappedTranslationVsZhoPromptYueHans
+    ),
+    test_cases: list[TestCase] | None = None,
+    use_dictionary_tool: bool = True,
+    provider: LLMProvider | None = None,
+    **kwargs: Unpack[YueVsZhoGappedTranslationProcessorKwargs],
+) -> DualNMinusMToNProcessor:
+    """Get DualNMinusMToNProcessor with provided configuration.
+
+    Arguments:
+        prompt_cls: text for LLM correspondence
+        test_cases: test cases
+        use_dictionary_tool: whether to wire the dictionary lookup tool
+        provider: provider to use for queries
+        **kwargs: additional arguments for DualNMinusMToNProcessor
+    Returns:
+        DualNMinusMToNProcessor with provided configuration
+    """
+    if test_cases is None:
+        test_cases = list(
+            load_default_test_cases(
+                DualNMinusMToNManager,
+                prompt_cls,
+                YUE_ZHO_GAPPED_TRANSLATION_JSON_PATHS,
+            )
+        )
+    tool_box = None
+    if use_dictionary_tool:
+        tool_box = get_dictionary_tools(prompt_cls)
+    if provider is None:
+        provider = get_provider()
+    return DualNMinusMToNProcessor(
+        prompt_cls=prompt_cls,
+        test_cases=test_cases,
+        provider=provider,
+        tool_box=tool_box,
+        **kwargs,
+    )

--- a/scinoephile/multilang/yue_zho/gapped_translation/prompts.py
+++ b/scinoephile/multilang/yue_zho/gapped_translation/prompts.py
@@ -1,6 +1,6 @@
 #  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
-"""Text for written Cantonese gap translation using standard Chinese."""
+"""Text for written Cantonese gapped translation using standard Chinese."""
 
 from __future__ import annotations
 
@@ -13,15 +13,15 @@ from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.llms.dual_n_minus_m_to_n import DualNMinusMToNPrompt
 
 __all__ = [
-    "YueGapTranslationVsZhoPromptYueHans",
-    "YueGapTranslationVsZhoPromptYueHant",
+    "YueGappedTranslationVsZhoPromptYueHans",
+    "YueGappedTranslationVsZhoPromptYueHant",
 ]
 
 
-class YueGapTranslationVsZhoPromptYueHans(
+class YueGappedTranslationVsZhoPromptYueHans(
     DictionaryToolPrompt, DualNMinusMToNPrompt, PromptYueHans
 ):
-    """Text for simplified written Cantonese gap translation using standard Chinese."""
+    """Text for simplified written Cantonese gapped translation using Chinese."""
 
     # Dictionary tool
     dictionary_tool_name: ClassVar[str] = "lookup_dictionary"
@@ -92,8 +92,8 @@ class YueGapTranslationVsZhoPromptYueHans(
         return cls.output_contains_note_err_tpl.format(idx=idx)
 
 
-class YueGapTranslationVsZhoPromptYueHant(YueGapTranslationVsZhoPromptYueHans):
-    """Text for traditional written Cantonese gap translation using standard Chinese."""
+class YueGappedTranslationVsZhoPromptYueHant(YueGappedTranslationVsZhoPromptYueHans):
+    """Text for traditional written Cantonese gapped translation using Chinese."""
 
     opencc_config = OpenCCConfig.s2hk
     """Config for converting simplified Chinese characters from the parent class."""

--- a/scinoephile/optimization/operations.py
+++ b/scinoephile/optimization/operations.py
@@ -13,14 +13,20 @@ from scinoephile.lang.zho.block_review import (
     ZHO_BLOCK_REVIEW_OPERATION_SPEC,
 )
 from scinoephile.lang.zho.ocr_fusion import ZHO_OCR_FUSION_OPERATION_SPEC
+from scinoephile.multilang.eng_zho.gapped_translation import (
+    ENG_ZHO_GAPPED_TRANSLATION_OPERATION_SPEC,
+)
 from scinoephile.multilang.eng_zho.guided_translation import (
     ENG_ZHO_GUIDED_TRANSLATION_OPERATION_SPEC,
+)
+from scinoephile.multilang.eng_zho.translation import (
+    ENG_ZHO_TRANSLATION_OPERATION_SPEC,
 )
 from scinoephile.multilang.yue_zho.block_review import (
     YUE_ZHO_BLOCK_REVIEW_OPERATION_SPEC,
 )
-from scinoephile.multilang.yue_zho.gap_translation import (
-    YUE_ZHO_GAP_TRANSLATION_OPERATION_SPEC,
+from scinoephile.multilang.yue_zho.gapped_translation import (
+    YUE_ZHO_GAPPED_TRANSLATION_OPERATION_SPEC,
 )
 from scinoephile.multilang.yue_zho.line_review import (
     YUE_ZHO_LINE_REVIEW_OPERATION_SPEC,
@@ -39,12 +45,14 @@ OPERATIONS: dict[str, OperationSpec] = {
         (
             ENG_BLOCK_REVIEW_OPERATION_SPEC,
             ENG_OCR_FUSION_OPERATION_SPEC,
+            ENG_ZHO_GAPPED_TRANSLATION_OPERATION_SPEC,
             ENG_ZHO_GUIDED_TRANSLATION_OPERATION_SPEC,
+            ENG_ZHO_TRANSLATION_OPERATION_SPEC,
             ZHO_BLOCK_REVIEW_OPERATION_SPEC,
             ZHO_OCR_FUSION_OPERATION_SPEC,
             YUE_ZHO_BLOCK_REVIEW_OPERATION_SPEC,
             YUE_ZHO_LINE_REVIEW_OPERATION_SPEC,
-            YUE_ZHO_GAP_TRANSLATION_OPERATION_SPEC,
+            YUE_ZHO_GAPPED_TRANSLATION_OPERATION_SPEC,
             YUE_ZHO_TRANSCRIPTION_DELINIATION_OPERATION_SPEC,
             YUE_ZHO_TRANSCRIPTION_PUNCTUATION_OPERATION_SPEC,
         ),

--- a/test/cli/eng/test_eng_translate_vs_zho_cli.py
+++ b/test/cli/eng/test_eng_translate_vs_zho_cli.py
@@ -1,0 +1,175 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests of scinoephile.cli.eng.eng_translate_vs_zho_cli."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from scinoephile.cli.eng.eng_cli import EngCli
+from scinoephile.cli.eng.eng_translate_vs_zho_cli import EngTranslateVsZhoCli
+from scinoephile.cli.scinoephile_cli import ScinoephileCli
+from scinoephile.common import CommandLineInterface
+from scinoephile.common.file import get_temp_file_path
+from scinoephile.common.testing import run_cli_with_args
+from scinoephile.core.subtitles import Series
+from test.helpers import (
+    assert_cli_help,
+    assert_cli_usage,
+    assert_series_equal,
+    test_data_root,
+)
+
+
+@pytest.mark.parametrize(
+    "cli",
+    [
+        (EngTranslateVsZhoCli,),
+        (EngCli, EngTranslateVsZhoCli),
+        (ScinoephileCli, EngCli, EngTranslateVsZhoCli),
+    ],
+)
+def test_eng_translate_vs_zho_help(cli: tuple[type[CommandLineInterface], ...]):
+    """Test English translate-vs-zho CLI help output.
+
+    Arguments:
+        cli: CLI class tuple with optional subcommands
+    """
+    assert_cli_help(cli)
+
+
+@pytest.mark.parametrize(
+    "cli",
+    [
+        (EngTranslateVsZhoCli,),
+        (EngCli, EngTranslateVsZhoCli),
+        (ScinoephileCli, EngCli, EngTranslateVsZhoCli),
+    ],
+)
+def test_eng_translate_vs_zho_usage(cli: tuple[type[CommandLineInterface], ...]):
+    """Test English translate-vs-zho CLI usage output.
+
+    Arguments:
+        cli: CLI class tuple with optional subcommands
+    """
+    assert_cli_usage(cli)
+
+
+def test_eng_translate_vs_zho_cli_regular_translation():
+    """Test English translate-vs-zho CLI routes to regular translation."""
+    zho_input_path = test_data_root / (
+        "mnt/output/zho-Hans_ocr/fuse_clean_validate_review_flatten.srt"
+    )
+    expected_path = test_data_root / "mnt/output/eng_ocr/fuse_clean_validate_review.srt"
+    expected = Series.load(expected_path)
+
+    with get_temp_file_path(".srt") as output_path:
+        with patch(
+            "scinoephile.cli.eng.eng_translate_vs_zho_cli.get_eng_zho_translator",
+            return_value="translator",
+        ) as patched_factory:
+            with patch(
+                "scinoephile.cli.eng.eng_translate_vs_zho_cli.get_eng_translated_from_zho",
+                return_value=expected,
+            ) as patched_translate:
+                run_cli_with_args(
+                    EngTranslateVsZhoCli,
+                    f"--zho-infile {zho_input_path} --outfile {output_path}",
+                )
+        output = Series.load(output_path)
+
+    assert patched_factory.call_args.kwargs["provider"] is not None
+    called_kwargs = patched_translate.call_args.kwargs
+    assert_series_equal(called_kwargs["zho"], Series.load(zho_input_path))
+    assert called_kwargs["translator"] == "translator"
+    assert_series_equal(output, expected)
+
+
+def test_eng_translate_vs_zho_cli_gapped_translation():
+    """Test English translate-vs-zho CLI routes to gapped translation."""
+    eng_input_path = test_data_root / "mnt/output/eng_ocr/fuse_clean_validate.srt"
+    zho_input_path = test_data_root / (
+        "mnt/output/zho-Hans_ocr/fuse_clean_validate_review_flatten.srt"
+    )
+    expected_path = test_data_root / "mnt/output/eng_ocr/fuse_clean_validate_review.srt"
+    expected = Series.load(expected_path)
+
+    with get_temp_file_path(".srt") as output_path:
+        with patch(
+            "scinoephile.cli.eng.eng_translate_vs_zho_cli."
+            "get_eng_vs_zho_gapped_translator",
+            return_value="translator",
+        ) as patched_factory:
+            with patch(
+                "scinoephile.cli.eng.eng_translate_vs_zho_cli."
+                "get_eng_gapped_translated_vs_zho",
+                return_value=expected,
+            ) as patched_translate:
+                run_cli_with_args(
+                    EngTranslateVsZhoCli,
+                    f"--zho-infile {zho_input_path} "
+                    f"--eng-gapped-infile {eng_input_path} "
+                    f"--outfile {output_path}",
+                )
+        output = Series.load(output_path)
+
+    assert patched_factory.call_args.kwargs["provider"] is not None
+    called_kwargs = patched_translate.call_args.kwargs
+    assert_series_equal(called_kwargs["eng"], Series.load(eng_input_path))
+    assert_series_equal(called_kwargs["zho"], Series.load(zho_input_path))
+    assert called_kwargs["translator"] == "translator"
+    assert_series_equal(output, expected)
+
+
+def test_eng_translate_vs_zho_cli_guided_translation():
+    """Test English translate-vs-zho CLI routes to guided translation."""
+    eng_input_path = test_data_root / "mnt/output/eng_ocr/fuse_clean_validate.srt"
+    zho_input_path = test_data_root / (
+        "mnt/output/zho-Hans_ocr/fuse_clean_validate_review_flatten.srt"
+    )
+    expected_path = test_data_root / "mnt/output/eng_ocr/fuse_clean_validate_review.srt"
+    expected = Series.load(expected_path)
+
+    with get_temp_file_path(".srt") as output_path:
+        with patch(
+            "scinoephile.cli.eng.eng_translate_vs_zho_cli."
+            "get_eng_zho_guided_translator",
+            return_value="translator",
+        ) as patched_factory:
+            with patch(
+                "scinoephile.cli.eng.eng_translate_vs_zho_cli."
+                "get_eng_translated_from_zho_with_eng_guidance",
+                return_value=expected,
+            ) as patched_translate:
+                run_cli_with_args(
+                    EngTranslateVsZhoCli,
+                    f"--zho-infile {zho_input_path} "
+                    f"--eng-guide-infile {eng_input_path} "
+                    f"--outfile {output_path}",
+                )
+        output = Series.load(output_path)
+
+    assert patched_factory.call_args.kwargs["provider"] is not None
+    called_kwargs = patched_translate.call_args.kwargs
+    assert_series_equal(called_kwargs["zho"], Series.load(zho_input_path))
+    assert_series_equal(called_kwargs["eng"], Series.load(eng_input_path))
+    assert called_kwargs["translator"] == "translator"
+    assert_series_equal(output, expected)
+
+
+def test_eng_translate_vs_zho_cli_rejects_gapped_and_guide_together():
+    """Test English translate-vs-zho CLI rejects mutually exclusive inputs."""
+    eng_input_path = test_data_root / "mnt/output/eng_ocr/fuse_clean_validate.srt"
+    zho_input_path = test_data_root / (
+        "mnt/output/zho-Hans_ocr/fuse_clean_validate_review_flatten.srt"
+    )
+
+    with pytest.raises(SystemExit, match="2"):
+        run_cli_with_args(
+            EngTranslateVsZhoCli,
+            f"--zho-infile {zho_input_path} "
+            f"--eng-gapped-infile {eng_input_path} "
+            f"--eng-guide-infile {eng_input_path}",
+        )

--- a/test/cli/test_llm_cli.py
+++ b/test/cli/test_llm_cli.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 import pytest
 
 from scinoephile.cli.eng.eng_process_cli import EngProcessCli
+from scinoephile.cli.eng.eng_translate_vs_zho_cli import EngTranslateVsZhoCli
 from scinoephile.cli.ocr.ocr_fuse_cli import OcrFuseCli
 from scinoephile.cli.yue.yue_process_cli import YueProcessCli
 from scinoephile.cli.yue.yue_review_vs_zho_cli import YueReviewVsZhoCli
@@ -26,6 +27,7 @@ from scinoephile.common.testing import run_cli_with_args
     "cli",
     [
         EngProcessCli,
+        EngTranslateVsZhoCli,
         OcrFuseCli,
         YueProcessCli,
         YueReviewVsZhoCli,

--- a/test/cli/test_scinoephile_cli.py
+++ b/test/cli/test_scinoephile_cli.py
@@ -74,7 +74,7 @@ def test_scinoephile_all_commands_lists_complete_hierarchy():
     assert "\neng" in output
     eng_section = output.split("\neng", maxsplit=1)[1].split("\nmedia", maxsplit=1)[0]
     assert "\n    process" in eng_section
-    assert "\n    translate-vs-zho" not in eng_section
+    assert "\n    translate-vs-zho" in eng_section
     assert "\nocr" in output
     assert "\n    fuse" in output
     assert "\n    validate" in output

--- a/test/cli/yue/test_yue_translate_vs_zho_cli.py
+++ b/test/cli/yue/test_yue_translate_vs_zho_cli.py
@@ -15,8 +15,8 @@ from scinoephile.common import CommandLineInterface
 from scinoephile.common.file import get_temp_file_path
 from scinoephile.common.testing import run_cli_with_args
 from scinoephile.core.subtitles import Series
-from scinoephile.multilang.yue_zho.gap_translation import (
-    YueGapTranslationVsZhoPromptYueHans,
+from scinoephile.multilang.yue_zho.gapped_translation import (
+    YueGappedTranslationVsZhoPromptYueHans,
 )
 from test.helpers import (
     assert_cli_help,
@@ -89,11 +89,13 @@ def test_yue_translate_vs_zho_cli(
 
     with get_temp_file_path(".srt") as output_path:
         with patch(
-            "scinoephile.cli.yue.yue_translate_vs_zho_cli.get_yue_vs_zho_gap_translator",
+            "scinoephile.cli.yue.yue_translate_vs_zho_cli."
+            "get_yue_vs_zho_gapped_translator",
             return_value="translator",
         ) as patched_factory:
             with patch(
-                "scinoephile.cli.yue.yue_translate_vs_zho_cli.get_yue_gap_translated_vs_zho",
+                "scinoephile.cli.yue.yue_translate_vs_zho_cli."
+                "get_yue_gapped_translated_vs_zho",
                 return_value=expected,
             ) as patched_translate:
                 run_cli_with_args(
@@ -106,7 +108,7 @@ def test_yue_translate_vs_zho_cli(
 
     assert (
         patched_factory.call_args.kwargs["prompt_cls"]
-        is YueGapTranslationVsZhoPromptYueHans
+        is YueGappedTranslationVsZhoPromptYueHans
     )
     called_kwargs = patched_translate.call_args.kwargs
     assert_series_equal(called_kwargs["yuewen"], Series.load(full_yue_input_path))

--- a/test/data/kob/create_output.py
+++ b/test/data/kob/create_output.py
@@ -25,9 +25,9 @@ from scinoephile.multilang.yue_zho.block_review import (
     YueBlockReviewVsZhoPromptYueHans,
     YueBlockReviewVsZhoPromptYueHant,
 )
-from scinoephile.multilang.yue_zho.gap_translation import (
-    YueGapTranslationVsZhoPromptYueHans,
-    YueGapTranslationVsZhoPromptYueHant,
+from scinoephile.multilang.yue_zho.gapped_translation import (
+    YueGappedTranslationVsZhoPromptYueHans,
+    YueGappedTranslationVsZhoPromptYueHant,
 )
 from scinoephile.multilang.yue_zho.line_review import (
     YueLineReviewVsZhoPromptYueHans,
@@ -156,7 +156,7 @@ if "简体粤文 (Transcription)" in actions:
             "punctuation_prompt_cls": YuePunctuationVsZhoPromptYueHans,
         },
         line_reviewer_kw={"prompt_cls": YueLineReviewVsZhoPromptYueHans},
-        translator_kw={"prompt_cls": YueGapTranslationVsZhoPromptYueHans},
+        translator_kw={"prompt_cls": YueGappedTranslationVsZhoPromptYueHans},
         block_reviewer_kw={"prompt_cls": YueBlockReviewVsZhoPromptYueHans},
         overwrite_srt=True,
     )
@@ -177,7 +177,7 @@ if "简体粤文 (Transcription)" in actions:
             "punctuation_prompt_cls": YuePunctuationVsZhoPromptYueHant,
         },
         line_reviewer_kw={"prompt_cls": YueLineReviewVsZhoPromptYueHant},
-        translator_kw={"prompt_cls": YueGapTranslationVsZhoPromptYueHant},
+        translator_kw={"prompt_cls": YueGappedTranslationVsZhoPromptYueHant},
         block_reviewer_kw={"prompt_cls": YueBlockReviewVsZhoPromptYueHant},
         overwrite_srt=True,
     )

--- a/test/data/mlamd/__init__.py
+++ b/test/data/mlamd/__init__.py
@@ -39,8 +39,8 @@ from scinoephile.llms.dual_n_to_1 import DualNTo1Prompt
 from scinoephile.llms.dual_n_to_n import DualNToNManager, DualNToNPrompt
 from scinoephile.llms.mono_n import MonoNManager, MonoNPrompt
 from scinoephile.multilang.yue_zho.block_review import YueBlockReviewVsZhoPromptYueHans
-from scinoephile.multilang.yue_zho.gap_translation import (
-    YueGapTranslationVsZhoPromptYueHans,
+from scinoephile.multilang.yue_zho.gapped_translation import (
+    YueGappedTranslationVsZhoPromptYueHans,
 )
 from scinoephile.multilang.yue_zho.line_review import (
     YueLineReviewVsZhoPromptYueHans,
@@ -78,7 +78,7 @@ __all__ = [
     "get_mlamd_eng_block_review_test_cases",
     "get_mlamd_eng_ocr_fusion_test_cases",
     "get_mlamd_yue_deliniation_test_cases",
-    "get_mlamd_yue_vs_zho_gap_translation_test_cases",
+    "get_mlamd_yue_vs_zho_gapped_translation_test_cases",
     "get_mlamd_yue_punctuation_test_cases",
     "get_mlamd_yue_vs_zho_block_review_test_cases",
     "get_mlamd_yue_vs_zho_line_review_test_cases",
@@ -307,11 +307,11 @@ def get_mlamd_yue_deliniation_test_cases(
 
 
 @cache
-def get_mlamd_yue_vs_zho_gap_translation_test_cases(
-    prompt_cls: type[DualNMinusMToNPrompt] = YueGapTranslationVsZhoPromptYueHans,
+def get_mlamd_yue_vs_zho_gapped_translation_test_cases(
+    prompt_cls: type[DualNMinusMToNPrompt] = YueGappedTranslationVsZhoPromptYueHans,
     **kwargs: Any,
 ) -> list[TestCase]:
-    """Get MLAMD 简体粤文 vs 简体中文 gap translation test cases.
+    """Get MLAMD 简体粤文 vs 简体中文 gapped translation test cases.
 
     Arguments:
         prompt_cls: text for LLM correspondence

--- a/test/data/mlamd/create_output.py
+++ b/test/data/mlamd/create_output.py
@@ -16,9 +16,9 @@ from scinoephile.multilang.yue_zho.block_review import (
     get_yue_block_reviewed_vs_zho,
     get_yue_vs_zho_block_reviewer,
 )
-from scinoephile.multilang.yue_zho.gap_translation import (
-    get_yue_gap_translated_vs_zho,
-    get_yue_vs_zho_gap_translator,
+from scinoephile.multilang.yue_zho.gapped_translation import (
+    get_yue_gapped_translated_vs_zho,
+    get_yue_vs_zho_gapped_translator,
 )
 from scinoephile.multilang.yue_zho.line_review import (
     get_yue_line_reviewed_vs_zho,
@@ -129,7 +129,7 @@ if "简体粤文 (Transcription)" in actions:
     yue_hans_line_reviewed.save(outfile_path)
 
     # Translate
-    translator = get_yue_vs_zho_gap_translator(
+    translator = get_yue_vs_zho_gapped_translator(
         test_case_path=yue_hans_transcribe_path
         / "multilang"
         / "yue_zho"
@@ -137,7 +137,7 @@ if "简体粤文 (Transcription)" in actions:
         / f"{get_torch_device()}.json",
         auto_verify=True,
     )
-    yue_hans_review_translate = get_yue_gap_translated_vs_zho(
+    yue_hans_review_translate = get_yue_gapped_translated_vs_zho(
         yue_hans_line_reviewed, zho_hans, translator=translator
     )
     outfile_path = yue_hans_transcribe_path / "transcribe_review_translate.srt"

--- a/test/data/mnt/__init__.py
+++ b/test/data/mnt/__init__.py
@@ -30,9 +30,7 @@ from scinoephile.llms.dual_1_to_1 import Dual1To1Prompt
 from scinoephile.llms.dual_1_to_1.ocr_fusion import OcrFusionManager
 from scinoephile.llms.dual_n_to_m import DualNToMManager, DualNToMPrompt
 from scinoephile.llms.mono_n import MonoNManager, MonoNPrompt
-from scinoephile.multilang.eng_zho.guided_translation import (
-    EngGuidedTranslationVsZhoPrompt,
-)
+from test.data.prompts import EngGuidedTranslationVsZhoOfYuePrompt
 from test.helpers import test_data_root
 
 __all__ = [
@@ -237,7 +235,7 @@ def get_mnt_eng_ocr_fusion_test_cases(
 
 @cache
 def get_mnt_eng_zho_guided_translation_test_cases(
-    prompt_cls: type[DualNToMPrompt] = EngGuidedTranslationVsZhoPrompt,
+    prompt_cls: type[DualNToMPrompt] = EngGuidedTranslationVsZhoOfYuePrompt,
     **kwargs: Any,
 ) -> list[TestCase]:
     """Get MNT English-from-Cantonese guided translation test cases.

--- a/test/data/mnt/create_output.py
+++ b/test/data/mnt/create_output.py
@@ -19,6 +19,7 @@ from scinoephile.multilang.eng_zho.guided_translation import (
     get_eng_zho_guided_translator,
 )
 from test.data.ocr import process_eng_ocr, process_zho_hans_ocr, process_zho_hant_ocr
+from test.data.prompts import EngGuidedTranslationVsZhoOfYuePrompt
 from test.data.synchronization import process_zho_hans_eng
 from test.helpers import test_data_root
 
@@ -80,6 +81,7 @@ if "Guided English from 粤语" in actions:
     yue_zho_hant = Series.load(input_path / "yue_zho-Hant.srt")
     jpn_eng = Series.load(input_path / "jpn_eng.srt")
     translator = get_eng_zho_guided_translator(
+        prompt_cls=EngGuidedTranslationVsZhoOfYuePrompt,
         test_case_path=(
             output_path / "yue_eng/multilang/eng_zho/guided_translation.json"
         ),

--- a/test/data/prompts.py
+++ b/test/data/prompts.py
@@ -1,0 +1,53 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Test-data-specific prompt classes."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from scinoephile.core.text import dedent_and_compact
+from scinoephile.multilang.eng_zho.guided_translation import (
+    EngGuidedTranslationVsZhoPrompt,
+)
+
+__all__ = ["EngGuidedTranslationVsZhoOfYuePrompt"]
+
+
+class EngGuidedTranslationVsZhoOfYuePrompt(EngGuidedTranslationVsZhoPrompt):
+    """Text for guided English translation from Chinese subtitles of Yue source."""
+
+    # Prompt
+    base_system_prompt: ClassVar[str] = dedent_and_compact("""
+        You are responsible for creating English subtitles from Chinese subtitles for
+        Cantonese/Yue audio. You will also receive original English subtitles from the
+        same scene as reference material.
+
+        Produce one English subtitle for each Chinese subtitle. Match the meaning,
+        timing granularity, dramatic intent, and speaker intent of the Cantonese
+        source. Use the original English subtitles as the source of truth for character
+        names, proper nouns, recurring terms, register, and canonical phrasing when
+        that wording is compatible with the Cantonese source. Do not invent alternate
+        names or translate names literally. When the Cantonese source differs from the
+        original English, prioritize the Cantonese source meaning while preserving
+        established names and terms from the English reference.
+
+        Output only the generated English subtitle text in each answer field. Do not
+        include notes, explanations, labels, alternate translations, bracketed
+        commentary, or any text outside the subtitle itself. Preserve subtitle markup
+        only when it is appropriate for the generated English subtitle.
+        """)
+    """Base system prompt."""
+
+    # Query fields
+    src_1_desc_tpl: ClassVar[str] = (
+        "Chinese subtitle {idx} of Cantonese/Yue source to translate"
+    )
+    """Description template for Chinese source fields in query."""
+
+    # Answer fields
+    output_desc_tpl: ClassVar[str] = (
+        "Generated English subtitle {idx} corresponding to Chinese subtitle {idx} "
+        "of Cantonese/Yue source"
+    )
+    """Description template for generated English output fields in answer."""

--- a/test/data/transcription.py
+++ b/test/data/transcription.py
@@ -22,9 +22,9 @@ from scinoephile.multilang.yue_zho.block_review import (
     get_yue_block_reviewed_vs_zho,
     get_yue_vs_zho_block_reviewer,
 )
-from scinoephile.multilang.yue_zho.gap_translation import (
-    get_yue_gap_translated_vs_zho,
-    get_yue_vs_zho_gap_translator,
+from scinoephile.multilang.yue_zho.gapped_translation import (
+    get_yue_gapped_translated_vs_zho,
+    get_yue_vs_zho_gapped_translator,
 )
 from scinoephile.multilang.yue_zho.line_review import (
     get_yue_line_reviewed_vs_zho,
@@ -80,7 +80,7 @@ def process_yue_hans_transcription(  # noqa: PLR0912, PLR0915
         overwrite_srt: whether to overwrite subtitle outputs
         transcriber_kw: additional keyword arguments for get_yue_vs_zho_transcriber
         line_reviewer_kw: additional keyword arguments for get_yue_vs_zho_line_reviewer
-        translator_kw: additional keyword arguments for get_yue_vs_zho_gap_translator
+        translator_kw: additional keyword arguments for get_yue_vs_zho_gapped_translator
         block_reviewer_kw: additional keyword arguments for
           get_yue_vs_zho_block_reviewer
     Returns:
@@ -202,8 +202,8 @@ def process_yue_hans_transcription(  # noqa: PLR0912, PLR0915
             test_case_dir_path / "gap_translation" / f"{device}.json",
         )
         translator_kw.setdefault("auto_verify", True)
-        translator = get_yue_vs_zho_gap_translator(**translator_kw)
-        translate = get_yue_gap_translated_vs_zho(
+        translator = get_yue_vs_zho_gapped_translator(**translator_kw)
+        translate = get_yue_gapped_translated_vs_zho(
             line_review, zho, translator=translator
         )
         translate.save(translate_path, exist_ok=True)

--- a/test/dictionaries/test_dictionary_tools.py
+++ b/test/dictionaries/test_dictionary_tools.py
@@ -33,9 +33,9 @@ from scinoephile.multilang.yue_zho.block_review import (
     YueBlockReviewVsZhoPromptYueHans,
     get_yue_vs_zho_block_reviewer,
 )
-from scinoephile.multilang.yue_zho.gap_translation import (
-    YueGapTranslationVsZhoPromptYueHans,
-    get_yue_vs_zho_gap_translator,
+from scinoephile.multilang.yue_zho.gapped_translation import (
+    YueGappedTranslationVsZhoPromptYueHans,
+    get_yue_vs_zho_gapped_translator,
 )
 from scinoephile.multilang.yue_zho.line_review import (
     YueLineReviewVsZhoPromptYueHans,
@@ -236,7 +236,7 @@ def test_lookup_dictionary_returns_compact_error_for_no_available_dictionaries(
 @pytest.mark.parametrize(
     ("prompt_cls", "factory"),
     [
-        (YueGapTranslationVsZhoPromptYueHans, get_yue_vs_zho_gap_translator),
+        (YueGappedTranslationVsZhoPromptYueHans, get_yue_vs_zho_gapped_translator),
         (YueBlockReviewVsZhoPromptYueHans, get_yue_vs_zho_block_reviewer),
         (YueLineReviewVsZhoPromptYueHans, get_yue_vs_zho_line_reviewer),
     ],

--- a/test/llms/test_default_test_case_loading.py
+++ b/test/llms/test_default_test_case_loading.py
@@ -24,8 +24,10 @@ from scinoephile.lang.zho.ocr_fusion import (
 from scinoephile.llms.default_test_cases import (
     ENG_BLOCK_REVIEW_JSON_PATHS,
     ENG_OCR_FUSION_JSON_PATHS,
+    ENG_ZHO_GAPPED_TRANSLATION_JSON_PATHS,
+    ENG_ZHO_TRANSLATION_JSON_PATHS,
     YUE_ZHO_BLOCK_REVIEW_JSON_PATHS,
-    YUE_ZHO_GAP_TRANSLATION_JSON_PATHS,
+    YUE_ZHO_GAPPED_TRANSLATION_JSON_PATHS,
     YUE_ZHO_LINE_REVIEW_JSON_PATHS,
     ZHO_HANS_BLOCK_REVIEW_JSON_PATHS,
     ZHO_HANS_OCR_FUSION_JSON_PATHS,
@@ -35,11 +37,16 @@ from scinoephile.llms.default_test_cases import (
 )
 from scinoephile.llms.dual_1_to_1.ocr_fusion.manager import OcrFusionManager
 from scinoephile.llms.dual_n_minus_m_to_n.manager import DualNMinusMToNManager
+from scinoephile.llms.dual_n_to_m.manager import DualNToMManager
 from scinoephile.llms.dual_n_to_n.manager import DualNToNManager
 from scinoephile.llms.mono_n.manager import MonoNManager
+from scinoephile.multilang.eng_zho.gapped_translation import (
+    EngGappedTranslationVsZhoPrompt,
+)
+from scinoephile.multilang.eng_zho.translation import EngTranslationVsZhoPrompt
 from scinoephile.multilang.yue_zho.block_review import YueBlockReviewVsZhoPromptYueHans
-from scinoephile.multilang.yue_zho.gap_translation import (
-    YueGapTranslationVsZhoPromptYueHans,
+from scinoephile.multilang.yue_zho.gapped_translation import (
+    YueGappedTranslationVsZhoPromptYueHans,
 )
 from scinoephile.multilang.yue_zho.line_review import YueLineReviewVsZhoPromptYueHans
 from scinoephile.multilang.yue_zho.line_review.manager import YueZhoLineReviewManager
@@ -91,6 +98,24 @@ def _get_expected_case_count(relative_paths: list[str]) -> int:
                 "mnt/output/eng_ocr/lang/eng/ocr_fusion.json",
                 "t/output/eng_ocr/lang/eng/ocr_fusion.json",
             ],
+        ),
+        (
+            "eng_zho_translation",
+            lambda: load_default_test_cases(
+                DualNToMManager,
+                EngTranslationVsZhoPrompt,
+                ENG_ZHO_TRANSLATION_JSON_PATHS,
+            ),
+            [],
+        ),
+        (
+            "eng_zho_gapped_translation",
+            lambda: load_default_test_cases(
+                DualNMinusMToNManager,
+                EngGappedTranslationVsZhoPrompt,
+                ENG_ZHO_GAPPED_TRANSLATION_JSON_PATHS,
+            ),
+            [],
         ),
         (
             "zho_hans_block_review",
@@ -173,11 +198,11 @@ def _get_expected_case_count(relative_paths: list[str]) -> int:
             ],
         ),
         (
-            "yue_vs_zho_gap_translation",
+            "yue_vs_zho_gapped_translation",
             lambda: load_default_test_cases(
                 DualNMinusMToNManager,
-                YueGapTranslationVsZhoPromptYueHans,
-                YUE_ZHO_GAP_TRANSLATION_JSON_PATHS,
+                YueGappedTranslationVsZhoPromptYueHans,
+                YUE_ZHO_GAPPED_TRANSLATION_JSON_PATHS,
             ),
             [
                 "mlamd/output/yue-Hans_transcribe/multilang/yue_zho/gap_translation/cuda.json",

--- a/test/multilang/eng_zho/test_gapped_translation.py
+++ b/test/multilang/eng_zho/test_gapped_translation.py
@@ -1,0 +1,62 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests for English gapped translation from Chinese."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+from scinoephile.core.llms import LLMProvider
+from scinoephile.core.subtitles import Series, Subtitle
+from scinoephile.llms.dual_n_minus_m_to_n import DualNMinusMToNProcessor
+from scinoephile.multilang.eng_zho.gapped_translation import (
+    EngGappedTranslationVsZhoPrompt,
+    get_eng_gapped_translated_vs_zho,
+    get_eng_vs_zho_gapped_translator,
+)
+
+
+def test_eng_zho_gapped_translation_prompt_field_names():
+    """Test gapped translation prompt uses domain-specific field names."""
+    assert EngGappedTranslationVsZhoPrompt.src_1(1) == "eng_1"
+    assert EngGappedTranslationVsZhoPrompt.src_2(1) == "zho_1"
+    assert EngGappedTranslationVsZhoPrompt.output(1) == "eng_1"
+
+
+def test_get_eng_vs_zho_gapped_translator_wires_processor():
+    """Test English-from-Chinese gapped translator factory wiring."""
+    provider = Mock(spec=LLMProvider)
+
+    processor = get_eng_vs_zho_gapped_translator(test_cases=[], provider=provider)
+
+    assert isinstance(processor, DualNMinusMToNProcessor)
+    assert processor.prompt_cls is EngGappedTranslationVsZhoPrompt
+    assert processor.queryer.provider is provider
+
+
+def test_get_eng_gapped_translated_vs_zho_delegates_to_processor():
+    """Test gapped translation wrapper delegates to the provided processor."""
+    eng = Series([Subtitle(start=1000, end=2000, text="Existing line")])
+    zho = Series(
+        [
+            Subtitle(start=1000, end=2000, text="已有行"),
+            Subtitle(start=2100, end=3000, text="缺失行"),
+        ]
+    )
+    expected = Series(
+        [
+            Subtitle(start=1000, end=2000, text="Existing line"),
+            Subtitle(start=2100, end=3000, text="Missing line"),
+        ]
+    )
+    translator = Mock(spec=DualNMinusMToNProcessor)
+    translator.process.return_value = expected
+
+    output = get_eng_gapped_translated_vs_zho(
+        eng,
+        zho,
+        translator=translator,
+    )
+
+    assert output == expected
+    translator.process.assert_called_once_with(eng, zho)

--- a/test/multilang/eng_zho/test_translation.py
+++ b/test/multilang/eng_zho/test_translation.py
@@ -1,0 +1,60 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests for English translation from Chinese."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+from scinoephile.core.llms import LLMProvider
+from scinoephile.core.subtitles import Series, Subtitle
+from scinoephile.llms.dual_n_to_m import DualNToMProcessor
+from scinoephile.multilang.eng_zho.translation import (
+    EngTranslationVsZhoPrompt,
+    get_eng_translated_from_zho,
+    get_eng_zho_translator,
+)
+
+
+def test_eng_zho_translation_prompt_field_names():
+    """Test translation prompt uses domain-specific field names."""
+    assert EngTranslationVsZhoPrompt.src_1(1) == "zho_1"
+    assert EngTranslationVsZhoPrompt.src_2(1) == "context_1"
+    assert EngTranslationVsZhoPrompt.output(1) == "eng_1"
+
+
+def test_get_eng_zho_translator_wires_processor():
+    """Test English-from-Chinese translator factory wiring."""
+    provider = Mock(spec=LLMProvider)
+
+    processor = get_eng_zho_translator(test_cases=[], provider=provider)
+
+    assert isinstance(processor, DualNToMProcessor)
+    assert processor.prompt_cls is EngTranslationVsZhoPrompt
+    assert processor.queryer.provider is provider
+
+
+def test_get_eng_translated_from_zho_delegates_to_processor_with_empty_context():
+    """Test regular translation wrapper delegates to the provided processor."""
+    zho = Series(
+        [
+            Subtitle(start=1000, end=2000, text="第一句"),
+            Subtitle(start=2100, end=3000, text="第二句"),
+        ]
+    )
+    expected = Series(
+        [
+            Subtitle(start=1000, end=2000, text="First translated"),
+            Subtitle(start=2100, end=3000, text="Second translated"),
+        ]
+    )
+    translator = Mock(spec=DualNToMProcessor)
+    translator.process.return_value = expected
+
+    output = get_eng_translated_from_zho(zho, translator=translator)
+
+    assert output == expected
+    call_args = translator.process.call_args.args
+    assert call_args[0] is zho
+    assert isinstance(call_args[1], Series)
+    assert len(call_args[1].events) == 0

--- a/test/multilang/yue_zho/test_get_yue_gap_translated_vs_zho.py
+++ b/test/multilang/yue_zho/test_get_yue_gap_translated_vs_zho.py
@@ -1,20 +1,22 @@
 #  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
-"""Tests of scinoephile.multilang.yue_zho.gap_translation."""
+"""Tests of scinoephile.multilang.yue_zho.gapped_translation."""
 
 from __future__ import annotations
 
 from scinoephile.core.subtitles import Series, get_series_with_subs_merged
-from scinoephile.multilang.yue_zho.gap_translation import get_yue_gap_translated_vs_zho
+from scinoephile.multilang.yue_zho.gapped_translation import (
+    get_yue_gapped_translated_vs_zho,
+)
 from test.helpers import assert_series_equal
 
 
-def test_get_yue_gap_translated_vs_zho_mlamd(
+def test_get_yue_gapped_translated_vs_zho_mlamd(
     mlamd_yue_hans_transcribe_review: Series,
     mlamd_zho_hans_fuse_clean_validate_review_flatten: Series,
     mlamd_yue_hans_transcribe_review_translate: Series,
 ):
-    """Test get_yue_gap_translated_vs_zho with MLAMD subtitles.
+    """Test get_yue_gapped_translated_vs_zho with MLAMD subtitles.
 
     Arguments:
         mlamd_yue_hans_transcribe_review: input written Cantonese subtitles
@@ -25,5 +27,7 @@ def test_get_yue_gap_translated_vs_zho_mlamd(
     zhongwen = get_series_with_subs_merged(
         mlamd_zho_hans_fuse_clean_validate_review_flatten, 539
     )
-    output = get_yue_gap_translated_vs_zho(mlamd_yue_hans_transcribe_review, zhongwen)
+    output = get_yue_gapped_translated_vs_zho(
+        mlamd_yue_hans_transcribe_review, zhongwen
+    )
     assert_series_equal(output, mlamd_yue_hans_transcribe_review_translate)


### PR DESCRIPTION
## Summary
- Add regular and gapped zho-to-eng translation modules under `eng_zho`.
- Add `eng translate-vs-zho` CLI routing for regular, gapped, and guided translation modes.
- Rename the Yue zho gap translation package to `gapped_translation` and update callers/tests.

## Tests
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format ...`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix ...`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check ...`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` (`1188 passed, 4 skipped`)