### PR TITLE
Use shallow CI checkout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,9 +12,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          submodules: true
 
       - name: Determine default branch
         run: echo "DEFAULT_BRANCH=${GITHUB_BASE_REF:-${{ github.event.repository.default_branch }}}" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary

- Remove the explicit full-history checkout from CI.
- Stop asking `actions/checkout` to initialize submodules, since this repository currently has none.

## Validation

- `git diff --check`
- Parsed `.github/workflows/build.yml` with Ruby YAML

This is the first CI speedup change only; later changes will be handled in separate PRs after this PR's CI passes.