### PR TITLE
Remove unused CI system dependency install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,11 +30,6 @@ jobs:
         with:
           python-version: 3.13
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libcairo2-dev pkg-config python3-dev
-
       - name: Install the project
         run: uv sync --all-extras --dev
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         run: echo "DEFAULT_BRANCH=${GITHUB_BASE_REF:-${{ github.event.repository.default_branch }}}" >> $GITHUB_ENV
 
       - name: Fetch default branch
-        run: git fetch origin $DEFAULT_BRANCH
+        run: git fetch --depth=1 origin $DEFAULT_BRANCH
 
       - name: Define a cache dependency glob
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,9 +12,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          submodules: true
 
       - name: Determine default branch
         run: echo "DEFAULT_BRANCH=${GITHUB_BASE_REF:-${{ github.event.repository.default_branch }}}" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary

- Remove the `apt-get update` and `apt-get install` step from CI.
- Builds on #865 and #866, which made checkout and default-branch fetching shallow.

## Validation

- `git diff --check`
- Parsed `.github/workflows/build.yml` with Ruby YAML

This is the third CI speedup change only. It is kept in a separate dependent PR so CI can validate the change before the next update.