### PR TITLE
Use frozen dev sync in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: 3.13
 
       - name: Install the project
-        run: uv sync --all-extras --dev
+        run: uv sync --dev --frozen
 
       - name: Run ruff
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,11 +30,6 @@ jobs:
         with:
           python-version: 3.13
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libcairo2-dev pkg-config python3-dev
-
       - name: Install the project
         run: uv sync --all-extras --dev
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         run: echo "DEFAULT_BRANCH=${GITHUB_BASE_REF:-${{ github.event.repository.default_branch }}}" >> $GITHUB_ENV
 
       - name: Fetch default branch
-        run: git fetch origin $DEFAULT_BRANCH
+        run: git fetch --depth=1 origin $DEFAULT_BRANCH
 
       - name: Define a cache dependency glob
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,9 +12,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          submodules: true
 
       - name: Determine default branch
         run: echo "DEFAULT_BRANCH=${GITHUB_BASE_REF:-${{ github.event.repository.default_branch }}}" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary

- Replace `uv sync --all-extras --dev` with `uv sync --dev --frozen` in CI.
- Avoid installing optional extras that the test suite does not require for mocked/lazy optional integrations.
- Builds on #865, #866, and #867.

## Validation

- `git diff --check`
- Parsed `.github/workflows/build.yml` with Ruby YAML

This is the fourth CI speedup change only. CI will validate whether removing optional extras is safe before the next update.