### PR TITLE
Add CI concurrency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: 3.13
 
       - name: Install the project
-        run: uv sync --all-extras --dev
+        run: uv sync --dev --frozen
 
       - name: Run ruff
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,11 +30,6 @@ jobs:
         with:
           python-version: 3.13
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libcairo2-dev pkg-config python3-dev
-
       - name: Install the project
         run: uv sync --all-extras --dev
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         run: echo "DEFAULT_BRANCH=${GITHUB_BASE_REF:-${{ github.event.repository.default_branch }}}" >> $GITHUB_ENV
 
       - name: Fetch default branch
-        run: git fetch origin $DEFAULT_BRANCH
+        run: git fetch --depth=1 origin $DEFAULT_BRANCH
 
       - name: Define a cache dependency glob
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,9 +12,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          submodules: true
 
       - name: Determine default branch
         run: echo "DEFAULT_BRANCH=${GITHUB_BASE_REF:-${{ github.event.repository.default_branch }}}" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary

- Add workflow-level concurrency for the Build workflow.
- Cancel older in-progress runs for the same workflow/ref when newer runs start.
- Builds on #865, #866, #867, and #868.

## Validation

- `git diff --check`
- Parsed `.github/workflows/build.yml` with Ruby YAML

This is the fifth CI speedup change only. CI will validate the complete incremental workflow state.