### PR TITLE
Add yue zho translation variants

### DIFF
--- a/scinoephile/cli/yue/yue_translate_vs_zho_cli.py
+++ b/scinoephile/cli/yue/yue_translate_vs_zho_cli.py
@@ -1,9 +1,9 @@
 #  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
-"""Command-line interface for written Cantonese gap translation.
+"""Command-line interface for written Cantonese translation from Chinese.
 
-This command fills empty written Cantonese subtitle lines using the
-corresponding standard Chinese subtitle lines as reference.
+This command translates standard Chinese subtitles into written Cantonese, optionally
+filling gaps in written Cantonese subtitles or using written Cantonese guide subtitles.
 """
 
 from __future__ import annotations
@@ -27,62 +27,92 @@ from scinoephile.multilang.yue_zho.gapped_translation import (
     get_yue_gapped_translated_vs_zho,
     get_yue_vs_zho_gapped_translator,
 )
+from scinoephile.multilang.yue_zho.guided_translation import (
+    YueGuidedTranslationVsZhoPromptYueHans,
+    YueGuidedTranslationVsZhoPromptYueHant,
+    get_yue_translated_from_zho_with_yue_guidance,
+    get_yue_zho_guided_translator,
+)
+from scinoephile.multilang.yue_zho.translation import (
+    YueTranslationVsZhoPromptYueHans,
+    YueTranslationVsZhoPromptYueHant,
+    get_yue_translated_from_zho,
+    get_yue_zho_translator,
+)
 
 __all__ = ["YueTranslateVsZhoCli"]
 
 YUE_TRANSLATE_VS_ZHO_LOCALIZATIONS: dict[str, dict[str, str]] = {
     "zh-hans": {
-        "command-line interface for written Cantonese gap translation": (
-            "书面粤语缺口翻译命令行界面"
+        "command-line interface for written Cantonese translation from Chinese": (
+            "从中文翻译书面粤语字幕的命令行界面"
         ),
-        "This command fills empty written Cantonese subtitle lines using the "
-        "corresponding standard Chinese subtitle lines as reference.": (
-            "此命令使用对应的标准中文字幕作为参考，补全空白的书面粤语字幕行。"
+        "This command translates standard Chinese subtitles into written Cantonese, "
+        "optionally filling gaps in written Cantonese subtitles or using written "
+        "Cantonese guide subtitles.": (
+            "此命令将标准中文字幕翻译为书面粤语，并可选择补全书面粤语字幕缺口"
+            "或使用书面粤语参考字幕。"
         ),
-        'aligned standard Chinese subtitle infile or "-" for stdin': (
-            '已对齐的标准中文字幕输入文件，或使用 "-" 表示标准输入'
+        'standard Chinese subtitle infile or "-" for stdin': (
+            '标准中文字幕输入文件，或使用 "-" 表示标准输入'
         ),
         "script for prompts and output conversion (default: simplified)": (
             "提示词和输出转换使用的字形（默认：简体）"
         ),
-        'written Cantonese subtitle infile with gaps, or "-" for stdin': (
-            '含缺口的书面粤语字幕输入文件，或使用 "-" 表示标准输入'
+        "written Cantonese subtitle infile with gaps to fill with translation from "
+        'standard Chinese, or "-" for stdin': (
+            "含缺口、需根据标准中文翻译补全的书面粤语字幕输入文件，或使用 "
+            '"-" 表示标准输入'
         ),
-        (
-            "gap-filled written Cantonese subtitle outfile path (default: stdout)"
-        ): "补全缺口后的书面粤语字幕输出文件路径（默认：标准输出）",
-        "fill missing written Cantonese subtitles using standard Chinese "
-        "subtitles": "使用标准中文字幕补全缺失的书面粤语字幕",
+        "written Cantonese subtitle infile with which to guide translation from "
+        'standard Chinese, or "-" for stdin': (
+            '用于指导从标准中文翻译的书面粤语字幕输入文件，或使用 "-" 表示标准输入'
+        ),
+        "written Cantonese subtitle outfile path (default: stdout)": (
+            "书面粤语字幕输出文件路径（默认：标准输出）"
+        ),
+        "translate written Cantonese subtitles from standard Chinese subtitles": (
+            "根据标准中文字幕翻译书面粤语字幕"
+        ),
     },
     "zh-hant": {
-        "command-line interface for written Cantonese gap translation": (
-            "書面粵語缺口翻譯命令列介面"
+        "command-line interface for written Cantonese translation from Chinese": (
+            "從中文翻譯書面粵語字幕的命令列介面"
         ),
-        "This command fills empty written Cantonese subtitle lines using the "
-        "corresponding standard Chinese subtitle lines as reference.": (
-            "此命令使用對應的標準中文字幕作為參考，補全空白的書面粵語字幕行。"
+        "This command translates standard Chinese subtitles into written Cantonese, "
+        "optionally filling gaps in written Cantonese subtitles or using written "
+        "Cantonese guide subtitles.": (
+            "此命令將標準中文字幕翻譯為書面粵語，並可選擇補全書面粵語字幕缺口"
+            "或使用書面粵語參考字幕。"
         ),
-        'aligned standard Chinese subtitle infile or "-" for stdin': (
-            '已對齊的標準中文字幕輸入檔，或使用 "-" 代表標準輸入'
+        'standard Chinese subtitle infile or "-" for stdin': (
+            '標準中文字幕輸入檔，或使用 "-" 代表標準輸入'
         ),
         "script for prompts and output conversion (default: simplified)": (
             "提示詞與輸出轉換使用的字形（預設：簡體）"
         ),
-        'written Cantonese subtitle infile with gaps, or "-" for stdin': (
-            '含缺口的書面粵語字幕輸入檔，或使用 "-" 代表標準輸入'
+        "written Cantonese subtitle infile with gaps to fill with translation from "
+        'standard Chinese, or "-" for stdin': (
+            "含缺口、需根據標準中文翻譯補全的書面粵語字幕輸入檔，或使用 "
+            '"-" 代表標準輸入'
         ),
-        (
-            "gap-filled written Cantonese subtitle outfile path (default: stdout)"
-        ): "補全缺口後的書面粵語字幕輸出檔路徑（預設：標準輸出）",
-        "fill missing written Cantonese subtitles using standard Chinese "
-        "subtitles": "使用標準中文字幕補全缺失的書面粵語字幕",
+        "written Cantonese subtitle infile with which to guide translation from "
+        'standard Chinese, or "-" for stdin': (
+            '用於指導從標準中文翻譯的書面粵語字幕輸入檔，或使用 "-" 代表標準輸入'
+        ),
+        "written Cantonese subtitle outfile path (default: stdout)": (
+            "書面粵語字幕輸出檔路徑（預設：標準輸出）"
+        ),
+        "translate written Cantonese subtitles from standard Chinese subtitles": (
+            "根據標準中文字幕翻譯書面粵語字幕"
+        ),
     },
 }
 """Localized help text keyed by locale and English source text."""
 
 
 class YueTranslateVsZhoCli(ScinoephileCliBase):
-    """Fill missing written Cantonese subtitles using standard Chinese subtitles."""
+    """Translate written Cantonese subtitles from standard Chinese subtitles."""
 
     localizations = merge_localizations(
         LLM_LOCALIZATIONS,
@@ -109,18 +139,32 @@ class YueTranslateVsZhoCli(ScinoephileCliBase):
 
         # Input arguments
         arg_groups["input arguments"].add_argument(
-            "--yue-infile",
-            dest="yue_infile_path",
-            required=True,
-            type=input_file_arg(allow_stdin=True),
-            help='written Cantonese subtitle infile with gaps, or "-" for stdin',
-        )
-        arg_groups["input arguments"].add_argument(
             "--zho-infile",
             dest="zho_infile_path",
             required=True,
             type=input_file_arg(allow_stdin=True),
-            help='aligned standard Chinese subtitle infile or "-" for stdin',
+            help='standard Chinese subtitle infile or "-" for stdin',
+        )
+        yue_input_group = arg_groups["input arguments"].add_mutually_exclusive_group()
+        yue_input_group.add_argument(
+            "--yue-gapped-infile",
+            dest="yue_gapped_infile_path",
+            default=None,
+            type=input_file_arg(allow_stdin=True),
+            help=(
+                "written Cantonese subtitle infile with gaps to fill with translation "
+                'from standard Chinese, or "-" for stdin'
+            ),
+        )
+        yue_input_group.add_argument(
+            "--yue-guide-infile",
+            dest="yue_guide_infile_path",
+            default=None,
+            type=input_file_arg(allow_stdin=True),
+            help=(
+                "written Cantonese subtitle infile with which to guide translation "
+                'from standard Chinese, or "-" for stdin'
+            ),
         )
 
         # Operation arguments
@@ -141,7 +185,7 @@ class YueTranslateVsZhoCli(ScinoephileCliBase):
             default=None,
             dest="outfile_path",
             type=output_file_arg(),
-            help="gap-filled written Cantonese subtitle outfile path (default: stdout)",
+            help="written Cantonese subtitle outfile path (default: stdout)",
         )
         arg_groups["output arguments"].add_argument(
             "--overwrite",
@@ -160,27 +204,58 @@ class YueTranslateVsZhoCli(ScinoephileCliBase):
         return "translate-vs-zho"
 
     @classmethod
-    def _get_translation_prompt_cls(
+    def _get_gapped_translation_prompt_cls(
         cls, script: str
     ) -> type[YueGappedTranslationVsZhoPromptYueHans]:
-        """Get the gap translation prompt class for the selected script.
+        """Get the gapped translation prompt class for the selected script.
 
         Arguments:
             script: selected script identifier
         Returns:
-            gap translation prompt class
+            gapped translation prompt class
         """
         if script == "traditional":
             return YueGappedTranslationVsZhoPromptYueHant
         return YueGappedTranslationVsZhoPromptYueHans
 
     @classmethod
+    def _get_guided_translation_prompt_cls(
+        cls, script: str
+    ) -> type[YueGuidedTranslationVsZhoPromptYueHans]:
+        """Get the guided translation prompt class for the selected script.
+
+        Arguments:
+            script: selected script identifier
+        Returns:
+            guided translation prompt class
+        """
+        if script == "traditional":
+            return YueGuidedTranslationVsZhoPromptYueHant
+        return YueGuidedTranslationVsZhoPromptYueHans
+
+    @classmethod
+    def _get_translation_prompt_cls(
+        cls, script: str
+    ) -> type[YueTranslationVsZhoPromptYueHans]:
+        """Get the regular translation prompt class for the selected script.
+
+        Arguments:
+            script: selected script identifier
+        Returns:
+            regular translation prompt class
+        """
+        if script == "traditional":
+            return YueTranslationVsZhoPromptYueHant
+        return YueTranslationVsZhoPromptYueHans
+
+    @classmethod
     def _main(
         cls,
         *,
         _parser: ArgumentParser | None = None,
-        yue_infile_path: Path | str,
         zho_infile_path: Path | str,
+        yue_gapped_infile_path: Path | str | None,
+        yue_guide_infile_path: Path | str | None,
         script: str,
         llm_provider_name: str,
         llm_model_name: str | None,
@@ -190,26 +265,54 @@ class YueTranslateVsZhoCli(ScinoephileCliBase):
         """Execute with provided keyword arguments."""
         # Validate arguments
         parser = _parser or cls.argparser()
-        if yue_infile_path == "-" and zho_infile_path == "-":
-            parser.error("--yue-infile and --zho-infile may not both be '-'")
         if overwrite and outfile_path is None:
             parser.error("--overwrite may only be used with --outfile")
+        if zho_infile_path == "-" and (
+            yue_gapped_infile_path == "-" or yue_guide_infile_path == "-"
+        ):
+            parser.error(
+                "--zho-infile and a written Cantonese infile may not both be '-'"
+            )
 
         # Read inputs
-        yuewen = read_series(parser, yue_infile_path, allow_stdin=True)
         zhongwen = read_series(parser, zho_infile_path, allow_stdin=True)
+        provider = get_provider(llm_provider_name, model=llm_model_name)
 
         # Perform operations
-        prompt_cls = cls._get_translation_prompt_cls(script)
-        provider = get_provider(llm_provider_name, model=llm_model_name)
-        translator = get_yue_vs_zho_gapped_translator(
-            prompt_cls=prompt_cls, provider=provider
-        )
-        yuewen = get_yue_gapped_translated_vs_zho(
-            yuewen=yuewen,
-            zhongwen=zhongwen,
-            translator=translator,
-        )
+        if yue_gapped_infile_path is not None:
+            yuewen = read_series(parser, yue_gapped_infile_path, allow_stdin=True)
+            prompt_cls = cls._get_gapped_translation_prompt_cls(script)
+            translator = get_yue_vs_zho_gapped_translator(
+                prompt_cls=prompt_cls,
+                provider=provider,
+            )
+            yuewen = get_yue_gapped_translated_vs_zho(
+                yuewen=yuewen,
+                zhongwen=zhongwen,
+                translator=translator,
+            )
+        elif yue_guide_infile_path is not None:
+            yuewen = read_series(parser, yue_guide_infile_path, allow_stdin=True)
+            prompt_cls = cls._get_guided_translation_prompt_cls(script)
+            translator = get_yue_zho_guided_translator(
+                prompt_cls=prompt_cls,
+                provider=provider,
+            )
+            yuewen = get_yue_translated_from_zho_with_yue_guidance(
+                zhongwen=zhongwen,
+                yuewen=yuewen,
+                translator=translator,
+            )
+        else:
+            prompt_cls = cls._get_translation_prompt_cls(script)
+            translator = get_yue_zho_translator(
+                prompt_cls=prompt_cls,
+                provider=provider,
+            )
+            yuewen = get_yue_translated_from_zho(
+                zhongwen=zhongwen,
+                translator=translator,
+            )
 
         # Write outputs
         write_series(

--- a/scinoephile/llms/default_test_cases.py
+++ b/scinoephile/llms/default_test_cases.py
@@ -19,8 +19,10 @@ __all__ = [
     "ENG_ZHO_TRANSLATION_JSON_PATHS",
     "ENG_OCR_FUSION_JSON_PATHS",
     "YUE_ZHO_GAPPED_TRANSLATION_JSON_PATHS",
+    "YUE_ZHO_GUIDED_TRANSLATION_JSON_PATHS",
     "YUE_ZHO_LINE_REVIEW_JSON_PATHS",
     "YUE_ZHO_BLOCK_REVIEW_JSON_PATHS",
+    "YUE_ZHO_TRANSLATION_JSON_PATHS",
     "YUE_ZHO_TRANSCRIPTION_PUNCTUATION_JSON_PATHS",
     "YUE_ZHO_TRANSCRIPTION_DELINIATION_JSON_PATHS",
     "ZHO_HANS_BLOCK_REVIEW_JSON_PATHS",
@@ -98,6 +100,10 @@ YUE_ZHO_GAPPED_TRANSLATION_JSON_PATHS = (
     Path("mlamd/output/yue-Hans_transcribe/multilang/yue_zho/gap_translation/cpu.json"),
     Path("mlamd/output/yue-Hans_transcribe/multilang/yue_zho/gap_translation/mps.json"),
 )
+
+YUE_ZHO_GUIDED_TRANSLATION_JSON_PATHS: tuple[Path, ...] = ()
+
+YUE_ZHO_TRANSLATION_JSON_PATHS: tuple[Path, ...] = ()
 
 YUE_ZHO_TRANSCRIPTION_DELINIATION_JSON_PATHS = (
     Path(

--- a/scinoephile/multilang/yue_zho/__init__.py
+++ b/scinoephile/multilang/yue_zho/__init__.py
@@ -3,5 +3,6 @@
 """Code related to written Cantonese/standard Chinese text.
 
 Package hierarchy (modules may import from any above):
-* block_review / gapped_translation / line_review / transcription
+* block_review / gapped_translation / guided_translation / line_review / transcription
+  / translation
 """

--- a/scinoephile/multilang/yue_zho/guided_translation/__init__.py
+++ b/scinoephile/multilang/yue_zho/guided_translation/__init__.py
@@ -1,0 +1,126 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Code related to guided written Cantonese translation from standard Chinese."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TypedDict, Unpack
+
+from scinoephile.core.llms import OperationSpec, TestCase
+from scinoephile.core.llms.llm_provider import LLMProvider
+from scinoephile.core.subtitles import Series
+from scinoephile.dictionaries.dictionary_tools import get_dictionary_tools
+from scinoephile.llms.default_test_cases import (
+    YUE_ZHO_GUIDED_TRANSLATION_JSON_PATHS,
+    load_default_test_cases,
+)
+from scinoephile.llms.dual_n_to_m import (
+    DualNToMManager,
+    DualNToMProcessor,
+)
+from scinoephile.llms.providers.registry import get_provider
+
+from .prompts import (
+    YueGuidedTranslationVsZhoPromptYueHans,
+    YueGuidedTranslationVsZhoPromptYueHant,
+)
+
+__all__ = [
+    "YUE_ZHO_GUIDED_TRANSLATION_OPERATION_SPEC",
+    "YueGuidedTranslationVsZhoPromptYueHans",
+    "YueGuidedTranslationVsZhoPromptYueHant",
+    "YueVsZhoGuidedTranslationProcessKwargs",
+    "YueVsZhoGuidedTranslationProcessorKwargs",
+    "get_yue_translated_from_zho_with_yue_guidance",
+    "get_yue_zho_guided_translator",
+]
+
+YUE_ZHO_GUIDED_TRANSLATION_OPERATION_SPEC = OperationSpec(
+    operation="yue-zho-guided-translation",
+    test_case_table_name="test_cases__yue_zho__guided_translation",
+    manager_cls=DualNToMManager,
+    prompt_cls=YueGuidedTranslationVsZhoPromptYueHans,
+)
+"""Operation specification for guided written Cantonese translation from Chinese."""
+
+
+class YueVsZhoGuidedTranslationProcessKwargs(TypedDict, total=False):
+    """Keyword arguments for DualNToMProcessor.process."""
+
+    stop_at_idx: int | None
+    """Exclusive block index at which to stop processing."""
+
+
+class YueVsZhoGuidedTranslationProcessorKwargs(TypedDict, total=False):
+    """Keyword arguments for DualNToMProcessor initialization."""
+
+    test_case_path: Path | None
+    """Path where encountered test cases are persisted."""
+    additional_context: str | None
+    """Additional context to include in the system prompt."""
+    auto_verify: bool
+    """Whether generated test cases should be marked verified automatically."""
+
+
+def get_yue_translated_from_zho_with_yue_guidance(
+    zhongwen: Series,
+    yuewen: Series,
+    translator: DualNToMProcessor | None = None,
+    **kwargs: Unpack[YueVsZhoGuidedTranslationProcessKwargs],
+) -> Series:
+    """Get written Cantonese subtitles guided-translated from Chinese.
+
+    Arguments:
+        zhongwen: standard Chinese subtitles to translate
+        yuewen: written Cantonese subtitles to use as reference
+        translator: processor to use
+        **kwargs: additional arguments for DualNToMProcessor.process
+    Returns:
+        written Cantonese subtitles guided-translated from Chinese
+    """
+    if translator is None:
+        translator = get_yue_zho_guided_translator()
+    return translator.process(zhongwen, yuewen, **kwargs)
+
+
+def get_yue_zho_guided_translator(
+    prompt_cls: type[YueGuidedTranslationVsZhoPromptYueHans] = (
+        YueGuidedTranslationVsZhoPromptYueHans
+    ),
+    test_cases: list[TestCase] | None = None,
+    use_dictionary_tool: bool = True,
+    provider: LLMProvider | None = None,
+    **kwargs: Unpack[YueVsZhoGuidedTranslationProcessorKwargs],
+) -> DualNToMProcessor:
+    """Get DualNToMProcessor with provided configuration.
+
+    Arguments:
+        prompt_cls: text for LLM correspondence
+        test_cases: test cases
+        use_dictionary_tool: whether to wire the dictionary lookup tool
+        provider: provider to use for queries
+        **kwargs: additional arguments for DualNToMProcessor
+    Returns:
+        DualNToMProcessor with provided configuration
+    """
+    if test_cases is None:
+        test_cases = list(
+            load_default_test_cases(
+                DualNToMManager,
+                prompt_cls,
+                YUE_ZHO_GUIDED_TRANSLATION_JSON_PATHS,
+            )
+        )
+    tool_box = None
+    if use_dictionary_tool:
+        tool_box = get_dictionary_tools(prompt_cls)
+    if provider is None:
+        provider = get_provider()
+    return DualNToMProcessor(
+        prompt_cls=prompt_cls,
+        test_cases=test_cases,
+        provider=provider,
+        tool_box=tool_box,
+        **kwargs,
+    )

--- a/scinoephile/multilang/yue_zho/guided_translation/prompts.py
+++ b/scinoephile/multilang/yue_zho/guided_translation/prompts.py
@@ -1,0 +1,81 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Text for guided written Cantonese translation from standard Chinese."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from scinoephile.core.dictionaries import DictionaryToolPrompt
+from scinoephile.core.text import dedent_and_compact
+from scinoephile.lang.yue.prompts import PromptYueHans
+from scinoephile.lang.zho.script.conversion import OpenCCConfig
+from scinoephile.llms.dual_n_to_m import DualNToMPrompt
+
+__all__ = [
+    "YueGuidedTranslationVsZhoPromptYueHans",
+    "YueGuidedTranslationVsZhoPromptYueHant",
+]
+
+
+class YueGuidedTranslationVsZhoPromptYueHans(
+    DictionaryToolPrompt, DualNToMPrompt, PromptYueHans
+):
+    """Text for simplified guided written Cantonese translation from Chinese."""
+
+    # Dictionary tool
+    dictionary_tool_name: ClassVar[str] = "lookup_dictionary"
+    """Name of the dictionary lookup tool."""
+
+    dictionary_tool_description: ClassVar[str] = (
+        "查本地词典入面嘅粤语同普通话词条。工具会自动判断查询系汉字、拼音定粤拼。"
+    )
+    """Description of the dictionary lookup tool."""
+
+    dictionary_tool_query_description: ClassVar[str] = (
+        "要查嘅普通话或者粤语词语，可以系汉字、拼音或者粤拼。"
+    )
+    """Description of the dictionary lookup query parameter."""
+
+    # Prompt
+    base_system_prompt: ClassVar[str] = dedent_and_compact("""
+        你负责根据中文字幕，创作对应嘅粤文字幕。你亦会收到同一段场景嘅
+        既有粤文字幕，作为参考材料。
+
+        每条中文字幕都要输出一条粤文字幕。译文要准确表达中文字幕嘅意思、
+        语气、戏剧意图同说话人意图。既有粤文字幕系角色名、专名、重复术语、
+        语域同固定讲法嘅参考；当佢同中文字幕意思兼容时，尽量沿用。
+        如果中文字幕同既有粤文字幕有分别，要优先按中文字幕意思翻译，同时保留
+        已经建立好嘅名词同称呼。
+
+        输出内容只可以系生成嘅粤文字幕正文。绝对唔好附加英文、备注、解释、标签、
+        替代译文、方括号内容、括号内容，或者任何字幕以外嘅说明。
+        """)
+    """Base system prompt."""
+
+    # Query fields
+    src_1_pfx: ClassVar[str] = "zhongwen_"
+    """Prefix for Chinese source fields in query."""
+
+    src_1_desc_tpl: ClassVar[str] = "要翻译成粤文嘅中文字幕 {idx}"
+    """Description template for Chinese source fields in query."""
+
+    src_2_pfx: ClassVar[str] = "yuewen_reference_"
+    """Prefix for written Cantonese reference fields in query."""
+
+    src_2_desc_tpl: ClassVar[str] = "同一段场景嘅既有粤文参考字幕 {idx}"
+    """Description template for written Cantonese reference fields in query."""
+
+    # Answer fields
+    output_pfx: ClassVar[str] = "yuewen_"
+    """Prefix for generated written Cantonese output fields in answer."""
+
+    output_desc_tpl: ClassVar[str] = "字幕 {idx} 对应嘅粤文译文"
+    """Description template for generated written Cantonese output fields."""
+
+
+class YueGuidedTranslationVsZhoPromptYueHant(YueGuidedTranslationVsZhoPromptYueHans):
+    """Text for traditional guided written Cantonese translation from Chinese."""
+
+    opencc_config = OpenCCConfig.s2hk
+    """Config for converting simplified Chinese characters from the parent class."""

--- a/scinoephile/multilang/yue_zho/translation/__init__.py
+++ b/scinoephile/multilang/yue_zho/translation/__init__.py
@@ -1,0 +1,121 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Code related to written Cantonese translation from standard Chinese."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TypedDict, Unpack
+
+from scinoephile.core.llms import OperationSpec, TestCase
+from scinoephile.core.llms.llm_provider import LLMProvider
+from scinoephile.core.subtitles import Series
+from scinoephile.dictionaries.dictionary_tools import get_dictionary_tools
+from scinoephile.llms.default_test_cases import (
+    YUE_ZHO_TRANSLATION_JSON_PATHS,
+    load_default_test_cases,
+)
+from scinoephile.llms.dual_n_to_m import (
+    DualNToMManager,
+    DualNToMProcessor,
+)
+from scinoephile.llms.providers.registry import get_provider
+
+from .prompts import YueTranslationVsZhoPromptYueHans, YueTranslationVsZhoPromptYueHant
+
+__all__ = [
+    "YUE_ZHO_TRANSLATION_OPERATION_SPEC",
+    "YueTranslationVsZhoPromptYueHans",
+    "YueTranslationVsZhoPromptYueHant",
+    "YueVsZhoTranslationProcessKwargs",
+    "YueVsZhoTranslationProcessorKwargs",
+    "get_yue_translated_from_zho",
+    "get_yue_zho_translator",
+]
+
+YUE_ZHO_TRANSLATION_OPERATION_SPEC = OperationSpec(
+    operation="yue-zho-translation",
+    test_case_table_name="test_cases__yue_zho__translation",
+    manager_cls=DualNToMManager,
+    prompt_cls=YueTranslationVsZhoPromptYueHans,
+)
+"""Operation specification for written Cantonese translation from Chinese."""
+
+
+class YueVsZhoTranslationProcessKwargs(TypedDict, total=False):
+    """Keyword arguments for DualNToMProcessor.process."""
+
+    stop_at_idx: int | None
+    """Exclusive block index at which to stop processing."""
+
+
+class YueVsZhoTranslationProcessorKwargs(TypedDict, total=False):
+    """Keyword arguments for DualNToMProcessor initialization."""
+
+    test_case_path: Path | None
+    """Path where encountered test cases are persisted."""
+    additional_context: str | None
+    """Additional context to include in the system prompt."""
+    auto_verify: bool
+    """Whether generated test cases should be marked verified automatically."""
+
+
+def get_yue_translated_from_zho(
+    zhongwen: Series,
+    translator: DualNToMProcessor | None = None,
+    **kwargs: Unpack[YueVsZhoTranslationProcessKwargs],
+) -> Series:
+    """Get written Cantonese subtitles translated from Chinese.
+
+    Arguments:
+        zhongwen: standard Chinese subtitles to translate
+        translator: processor to use
+        **kwargs: additional arguments for DualNToMProcessor.process
+    Returns:
+        written Cantonese subtitles translated from Chinese
+    """
+    if translator is None:
+        translator = get_yue_zho_translator()
+    return translator.process(zhongwen, Series(), **kwargs)
+
+
+def get_yue_zho_translator(
+    prompt_cls: type[YueTranslationVsZhoPromptYueHans] = (
+        YueTranslationVsZhoPromptYueHans
+    ),
+    test_cases: list[TestCase] | None = None,
+    use_dictionary_tool: bool = True,
+    provider: LLMProvider | None = None,
+    **kwargs: Unpack[YueVsZhoTranslationProcessorKwargs],
+) -> DualNToMProcessor:
+    """Get DualNToMProcessor with provided configuration.
+
+    Arguments:
+        prompt_cls: text for LLM correspondence
+        test_cases: test cases
+        use_dictionary_tool: whether to wire the dictionary lookup tool
+        provider: provider to use for queries
+        **kwargs: additional arguments for DualNToMProcessor
+    Returns:
+        DualNToMProcessor with provided configuration
+    """
+    if test_cases is None:
+        test_cases = list(
+            load_default_test_cases(
+                DualNToMManager,
+                prompt_cls,
+                YUE_ZHO_TRANSLATION_JSON_PATHS,
+            )
+        )
+    tool_box = None
+    if use_dictionary_tool:
+        tool_box = get_dictionary_tools(prompt_cls)
+    if provider is None:
+        provider = get_provider()
+    return DualNToMProcessor(
+        prompt_cls=prompt_cls,
+        test_cases=test_cases,
+        provider=provider,
+        tool_box=tool_box,
+        **kwargs,
+    )

--- a/scinoephile/multilang/yue_zho/translation/prompts.py
+++ b/scinoephile/multilang/yue_zho/translation/prompts.py
@@ -1,0 +1,79 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Text for written Cantonese translation from standard Chinese."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from scinoephile.core.dictionaries import DictionaryToolPrompt
+from scinoephile.core.text import dedent_and_compact
+from scinoephile.lang.yue.prompts import PromptYueHans
+from scinoephile.lang.zho.script.conversion import OpenCCConfig
+from scinoephile.llms.dual_n_to_m import DualNToMPrompt
+
+__all__ = [
+    "YueTranslationVsZhoPromptYueHans",
+    "YueTranslationVsZhoPromptYueHant",
+]
+
+
+class YueTranslationVsZhoPromptYueHans(
+    DictionaryToolPrompt, DualNToMPrompt, PromptYueHans
+):
+    """Text for simplified written Cantonese translation from Chinese."""
+
+    # Dictionary tool
+    dictionary_tool_name: ClassVar[str] = "lookup_dictionary"
+    """Name of the dictionary lookup tool."""
+
+    dictionary_tool_description: ClassVar[str] = (
+        "查本地词典入面嘅粤语同普通话词条。工具会自动判断查询系汉字、拼音定粤拼。"
+    )
+    """Description of the dictionary lookup tool."""
+
+    dictionary_tool_query_description: ClassVar[str] = (
+        "要查嘅普通话或者粤语词语，可以系汉字、拼音或者粤拼。"
+    )
+    """Description of the dictionary lookup query parameter."""
+
+    # Prompt
+    base_system_prompt: ClassVar[str] = dedent_and_compact("""
+        你负责根据中文字幕，创作对应嘅粤文字幕。
+
+        每条中文字幕都要输出一条粤文字幕。译文要用自然、通顺嘅书面粤语，
+        准确表达中文字幕嘅意思、语气、戏剧意图同说话人意图。唔好逐字硬译；
+        可以调整措辞令佢更似自然粤文字幕。专名、固定称呼、重复术语同字幕标记
+        要喺适合时保留或者按粤语习惯处理。
+
+        输出内容只可以系生成嘅粤文字幕正文。绝对唔好附加英文、备注、解释、标签、
+        替代译文、方括号内容、括号内容，或者任何字幕以外嘅说明。
+        """)
+    """Base system prompt."""
+
+    # Query fields
+    src_1_pfx: ClassVar[str] = "zhongwen_"
+    """Prefix for Chinese source fields in query."""
+
+    src_1_desc_tpl: ClassVar[str] = "要翻译成粤文嘅中文字幕 {idx}"
+    """Description template for Chinese source fields in query."""
+
+    src_2_pfx: ClassVar[str] = "context_"
+    """Prefix for optional context fields in query."""
+
+    src_2_desc_tpl: ClassVar[str] = "额外上下文字幕 {idx}"
+    """Description template for optional context fields in query."""
+
+    # Answer fields
+    output_pfx: ClassVar[str] = "yuewen_"
+    """Prefix for generated written Cantonese output fields in answer."""
+
+    output_desc_tpl: ClassVar[str] = "字幕 {idx} 对应嘅粤文译文"
+    """Description template for generated written Cantonese output fields."""
+
+
+class YueTranslationVsZhoPromptYueHant(YueTranslationVsZhoPromptYueHans):
+    """Text for traditional written Cantonese translation from Chinese."""
+
+    opencc_config = OpenCCConfig.s2hk
+    """Config for converting simplified Chinese characters from the parent class."""

--- a/scinoephile/optimization/operations.py
+++ b/scinoephile/optimization/operations.py
@@ -28,12 +28,18 @@ from scinoephile.multilang.yue_zho.block_review import (
 from scinoephile.multilang.yue_zho.gapped_translation import (
     YUE_ZHO_GAPPED_TRANSLATION_OPERATION_SPEC,
 )
+from scinoephile.multilang.yue_zho.guided_translation import (
+    YUE_ZHO_GUIDED_TRANSLATION_OPERATION_SPEC,
+)
 from scinoephile.multilang.yue_zho.line_review import (
     YUE_ZHO_LINE_REVIEW_OPERATION_SPEC,
 )
 from scinoephile.multilang.yue_zho.transcription import (
     YUE_ZHO_TRANSCRIPTION_DELINIATION_OPERATION_SPEC,
     YUE_ZHO_TRANSCRIPTION_PUNCTUATION_OPERATION_SPEC,
+)
+from scinoephile.multilang.yue_zho.translation import (
+    YUE_ZHO_TRANSLATION_OPERATION_SPEC,
 )
 
 __all__ = ["OPERATIONS"]
@@ -53,6 +59,8 @@ OPERATIONS: dict[str, OperationSpec] = {
             YUE_ZHO_BLOCK_REVIEW_OPERATION_SPEC,
             YUE_ZHO_LINE_REVIEW_OPERATION_SPEC,
             YUE_ZHO_GAPPED_TRANSLATION_OPERATION_SPEC,
+            YUE_ZHO_GUIDED_TRANSLATION_OPERATION_SPEC,
+            YUE_ZHO_TRANSLATION_OPERATION_SPEC,
             YUE_ZHO_TRANSCRIPTION_DELINIATION_OPERATION_SPEC,
             YUE_ZHO_TRANSCRIPTION_PUNCTUATION_OPERATION_SPEC,
         ),

--- a/test/cli/yue/test_yue_translate_vs_zho_cli.py
+++ b/test/cli/yue/test_yue_translate_vs_zho_cli.py
@@ -18,6 +18,12 @@ from scinoephile.core.subtitles import Series
 from scinoephile.multilang.yue_zho.gapped_translation import (
     YueGappedTranslationVsZhoPromptYueHans,
 )
+from scinoephile.multilang.yue_zho.guided_translation import (
+    YueGuidedTranslationVsZhoPromptYueHans,
+)
+from scinoephile.multilang.yue_zho.translation import (
+    YueTranslationVsZhoPromptYueHans,
+)
 from test.helpers import (
     assert_cli_help,
     assert_cli_usage,
@@ -60,32 +66,55 @@ def test_yue_translate_vs_zho_usage(cli: tuple[type[CommandLineInterface], ...])
     assert_cli_usage(cli)
 
 
-@pytest.mark.parametrize(
-    ("yue_input_path", "zho_input_path", "expected_path"),
-    [
-        (
-            "mlamd/output/yue-Hans_transcribe/transcribe_review.srt",
-            "mlamd/output/zho-Hans_ocr/fuse_clean_validate_review_flatten.srt",
-            "mlamd/output/yue-Hans_transcribe/transcribe_review_translate.srt",
-        ),
-    ],
-)
-def test_yue_translate_vs_zho_cli(
-    yue_input_path: str,
-    zho_input_path: str,
-    expected_path: str,
-):
-    """Test written Cantonese translate-vs-zho CLI with file arguments.
+def test_yue_translate_vs_zho_cli_regular_translation():
+    """Test written Cantonese translate-vs-zho CLI routes to regular translation."""
+    zho_input_path = test_data_root / (
+        "mlamd/output/zho-Hans_ocr/fuse_clean_validate_review_flatten.srt"
+    )
+    expected_path = test_data_root / (
+        "mlamd/output/yue-Hans_transcribe/transcribe_review_translate.srt"
+    )
+    expected = Series.load(expected_path)
 
-    Arguments:
-        yue_input_path: path to input written Cantonese subtitle fixture
-        zho_input_path: path to input standard Chinese subtitle fixture
-        expected_path: path to expected output subtitle fixture
-    """
-    full_yue_input_path = test_data_root / yue_input_path
-    full_zho_input_path = test_data_root / zho_input_path
-    full_expected_path = test_data_root / expected_path
-    expected = Series.load(full_expected_path)
+    with get_temp_file_path(".srt") as output_path:
+        with patch(
+            "scinoephile.cli.yue.yue_translate_vs_zho_cli.get_yue_zho_translator",
+            return_value="translator",
+        ) as patched_factory:
+            with patch(
+                "scinoephile.cli.yue.yue_translate_vs_zho_cli."
+                "get_yue_translated_from_zho",
+                return_value=expected,
+            ) as patched_translate:
+                run_cli_with_args(
+                    YueTranslateVsZhoCli,
+                    f"--zho-infile {zho_input_path} --outfile {output_path}",
+                )
+        output = Series.load(output_path)
+
+    assert (
+        patched_factory.call_args.kwargs["prompt_cls"]
+        is YueTranslationVsZhoPromptYueHans
+    )
+    assert patched_factory.call_args.kwargs["provider"] is not None
+    called_kwargs = patched_translate.call_args.kwargs
+    assert_series_equal(called_kwargs["zhongwen"], Series.load(zho_input_path))
+    assert called_kwargs["translator"] == "translator"
+    assert_series_equal(output, expected)
+
+
+def test_yue_translate_vs_zho_cli_gapped_translation():
+    """Test written Cantonese translate-vs-zho CLI routes to gapped translation."""
+    yue_input_path = (
+        test_data_root / "mlamd/output/yue-Hans_transcribe/transcribe_review.srt"
+    )
+    zho_input_path = test_data_root / (
+        "mlamd/output/zho-Hans_ocr/fuse_clean_validate_review_flatten.srt"
+    )
+    expected_path = test_data_root / (
+        "mlamd/output/yue-Hans_transcribe/transcribe_review_translate.srt"
+    )
+    expected = Series.load(expected_path)
 
     with get_temp_file_path(".srt") as output_path:
         with patch(
@@ -100,8 +129,8 @@ def test_yue_translate_vs_zho_cli(
             ) as patched_translate:
                 run_cli_with_args(
                     YueTranslateVsZhoCli,
-                    f"--yue-infile {full_yue_input_path} "
-                    f"--zho-infile {full_zho_input_path} "
+                    f"--zho-infile {zho_input_path} "
+                    f"--yue-gapped-infile {yue_input_path} "
                     f"--outfile {output_path}",
                 )
         output = Series.load(output_path)
@@ -110,8 +139,71 @@ def test_yue_translate_vs_zho_cli(
         patched_factory.call_args.kwargs["prompt_cls"]
         is YueGappedTranslationVsZhoPromptYueHans
     )
+    assert patched_factory.call_args.kwargs["provider"] is not None
     called_kwargs = patched_translate.call_args.kwargs
-    assert_series_equal(called_kwargs["yuewen"], Series.load(full_yue_input_path))
-    assert_series_equal(called_kwargs["zhongwen"], Series.load(full_zho_input_path))
+    assert_series_equal(called_kwargs["yuewen"], Series.load(yue_input_path))
+    assert_series_equal(called_kwargs["zhongwen"], Series.load(zho_input_path))
     assert called_kwargs["translator"] == "translator"
     assert_series_equal(output, expected)
+
+
+def test_yue_translate_vs_zho_cli_guided_translation():
+    """Test written Cantonese translate-vs-zho CLI routes to guided translation."""
+    yue_input_path = (
+        test_data_root / "mlamd/output/yue-Hans_transcribe/transcribe_review.srt"
+    )
+    zho_input_path = test_data_root / (
+        "mlamd/output/zho-Hans_ocr/fuse_clean_validate_review_flatten.srt"
+    )
+    expected_path = test_data_root / (
+        "mlamd/output/yue-Hans_transcribe/transcribe_review_translate.srt"
+    )
+    expected = Series.load(expected_path)
+
+    with get_temp_file_path(".srt") as output_path:
+        with patch(
+            "scinoephile.cli.yue.yue_translate_vs_zho_cli."
+            "get_yue_zho_guided_translator",
+            return_value="translator",
+        ) as patched_factory:
+            with patch(
+                "scinoephile.cli.yue.yue_translate_vs_zho_cli."
+                "get_yue_translated_from_zho_with_yue_guidance",
+                return_value=expected,
+            ) as patched_translate:
+                run_cli_with_args(
+                    YueTranslateVsZhoCli,
+                    f"--zho-infile {zho_input_path} "
+                    f"--yue-guide-infile {yue_input_path} "
+                    f"--outfile {output_path}",
+                )
+        output = Series.load(output_path)
+
+    assert (
+        patched_factory.call_args.kwargs["prompt_cls"]
+        is YueGuidedTranslationVsZhoPromptYueHans
+    )
+    assert patched_factory.call_args.kwargs["provider"] is not None
+    called_kwargs = patched_translate.call_args.kwargs
+    assert_series_equal(called_kwargs["zhongwen"], Series.load(zho_input_path))
+    assert_series_equal(called_kwargs["yuewen"], Series.load(yue_input_path))
+    assert called_kwargs["translator"] == "translator"
+    assert_series_equal(output, expected)
+
+
+def test_yue_translate_vs_zho_cli_rejects_gapped_and_guide_together():
+    """Test written Cantonese translate-vs-zho CLI rejects mutually exclusive inputs."""
+    yue_input_path = (
+        test_data_root / "mlamd/output/yue-Hans_transcribe/transcribe_review.srt"
+    )
+    zho_input_path = test_data_root / (
+        "mlamd/output/zho-Hans_ocr/fuse_clean_validate_review_flatten.srt"
+    )
+
+    with pytest.raises(SystemExit, match="2"):
+        run_cli_with_args(
+            YueTranslateVsZhoCli,
+            f"--zho-infile {zho_input_path} "
+            f"--yue-gapped-infile {yue_input_path} "
+            f"--yue-guide-infile {yue_input_path}",
+        )

--- a/test/llms/test_default_test_case_loading.py
+++ b/test/llms/test_default_test_case_loading.py
@@ -28,7 +28,9 @@ from scinoephile.llms.default_test_cases import (
     ENG_ZHO_TRANSLATION_JSON_PATHS,
     YUE_ZHO_BLOCK_REVIEW_JSON_PATHS,
     YUE_ZHO_GAPPED_TRANSLATION_JSON_PATHS,
+    YUE_ZHO_GUIDED_TRANSLATION_JSON_PATHS,
     YUE_ZHO_LINE_REVIEW_JSON_PATHS,
+    YUE_ZHO_TRANSLATION_JSON_PATHS,
     ZHO_HANS_BLOCK_REVIEW_JSON_PATHS,
     ZHO_HANS_OCR_FUSION_JSON_PATHS,
     ZHO_HANT_BLOCK_REVIEW_JSON_PATHS,
@@ -48,8 +50,12 @@ from scinoephile.multilang.yue_zho.block_review import YueBlockReviewVsZhoPrompt
 from scinoephile.multilang.yue_zho.gapped_translation import (
     YueGappedTranslationVsZhoPromptYueHans,
 )
+from scinoephile.multilang.yue_zho.guided_translation import (
+    YueGuidedTranslationVsZhoPromptYueHans,
+)
 from scinoephile.multilang.yue_zho.line_review import YueLineReviewVsZhoPromptYueHans
 from scinoephile.multilang.yue_zho.line_review.manager import YueZhoLineReviewManager
+from scinoephile.multilang.yue_zho.translation import YueTranslationVsZhoPromptYueHans
 
 
 def _get_expected_case_count(relative_paths: list[str]) -> int:
@@ -209,6 +215,24 @@ def _get_expected_case_count(relative_paths: list[str]) -> int:
                 "mlamd/output/yue-Hans_transcribe/multilang/yue_zho/gap_translation/cpu.json",
                 "mlamd/output/yue-Hans_transcribe/multilang/yue_zho/gap_translation/mps.json",
             ],
+        ),
+        (
+            "yue_zho_translation",
+            lambda: load_default_test_cases(
+                DualNToMManager,
+                YueTranslationVsZhoPromptYueHans,
+                YUE_ZHO_TRANSLATION_JSON_PATHS,
+            ),
+            [],
+        ),
+        (
+            "yue_zho_guided_translation",
+            lambda: load_default_test_cases(
+                DualNToMManager,
+                YueGuidedTranslationVsZhoPromptYueHans,
+                YUE_ZHO_GUIDED_TRANSLATION_JSON_PATHS,
+            ),
+            [],
         ),
     ],
 )

--- a/test/multilang/yue_zho/test_get_yue_guided_translated_vs_zho.py
+++ b/test/multilang/yue_zho/test_get_yue_guided_translated_vs_zho.py
@@ -1,0 +1,66 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests for written Cantonese guided translation from Chinese."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+from scinoephile.core.llms import LLMProvider
+from scinoephile.core.subtitles import Series, Subtitle
+from scinoephile.llms.dual_n_to_m import DualNToMProcessor
+from scinoephile.multilang.yue_zho.guided_translation import (
+    YueGuidedTranslationVsZhoPromptYueHans,
+    get_yue_translated_from_zho_with_yue_guidance,
+    get_yue_zho_guided_translator,
+)
+
+
+def test_yue_zho_guided_translation_prompt_field_names():
+    """Test guided translation prompt uses domain-specific field names."""
+    assert YueGuidedTranslationVsZhoPromptYueHans.src_1(1) == "zhongwen_1"
+    assert YueGuidedTranslationVsZhoPromptYueHans.src_2(1) == "yuewen_reference_1"
+    assert YueGuidedTranslationVsZhoPromptYueHans.output(1) == "yuewen_1"
+
+
+def test_get_yue_zho_guided_translator_wires_processor():
+    """Test written Cantonese-from-Chinese guided translator factory wiring."""
+    provider = Mock(spec=LLMProvider)
+
+    processor = get_yue_zho_guided_translator(
+        test_cases=[],
+        use_dictionary_tool=False,
+        provider=provider,
+    )
+
+    assert isinstance(processor, DualNToMProcessor)
+    assert processor.prompt_cls is YueGuidedTranslationVsZhoPromptYueHans
+    assert processor.queryer.provider is provider
+
+
+def test_get_yue_translated_from_zho_with_yue_guidance_delegates_to_processor():
+    """Test guided translation wrapper delegates to provided processor."""
+    zhongwen = Series(
+        [
+            Subtitle(start=1000, end=2000, text="第一句"),
+            Subtitle(start=2100, end=3000, text="第二句"),
+        ]
+    )
+    yuewen = Series([Subtitle(start=900, end=3100, text="参考粤文")])
+    expected = Series(
+        [
+            Subtitle(start=1000, end=2000, text="第一句粤文"),
+            Subtitle(start=2100, end=3000, text="第二句粤文"),
+        ]
+    )
+    translator = Mock(spec=DualNToMProcessor)
+    translator.process.return_value = expected
+
+    output = get_yue_translated_from_zho_with_yue_guidance(
+        zhongwen,
+        yuewen,
+        translator=translator,
+    )
+
+    assert output == expected
+    translator.process.assert_called_once_with(zhongwen, yuewen)

--- a/test/multilang/yue_zho/test_get_yue_translated_vs_zho.py
+++ b/test/multilang/yue_zho/test_get_yue_translated_vs_zho.py
@@ -1,0 +1,64 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests for written Cantonese translation from Chinese."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+from scinoephile.core.llms import LLMProvider
+from scinoephile.core.subtitles import Series, Subtitle
+from scinoephile.llms.dual_n_to_m import DualNToMProcessor
+from scinoephile.multilang.yue_zho.translation import (
+    YueTranslationVsZhoPromptYueHans,
+    get_yue_translated_from_zho,
+    get_yue_zho_translator,
+)
+
+
+def test_yue_zho_translation_prompt_field_names():
+    """Test translation prompt uses domain-specific field names."""
+    assert YueTranslationVsZhoPromptYueHans.src_1(1) == "zhongwen_1"
+    assert YueTranslationVsZhoPromptYueHans.src_2(1) == "context_1"
+    assert YueTranslationVsZhoPromptYueHans.output(1) == "yuewen_1"
+
+
+def test_get_yue_zho_translator_wires_processor():
+    """Test written Cantonese-from-Chinese translator factory wiring."""
+    provider = Mock(spec=LLMProvider)
+
+    processor = get_yue_zho_translator(
+        test_cases=[],
+        use_dictionary_tool=False,
+        provider=provider,
+    )
+
+    assert isinstance(processor, DualNToMProcessor)
+    assert processor.prompt_cls is YueTranslationVsZhoPromptYueHans
+    assert processor.queryer.provider is provider
+
+
+def test_get_yue_translated_from_zho_delegates_to_processor_with_empty_context():
+    """Test regular translation wrapper delegates to the provided processor."""
+    zhongwen = Series(
+        [
+            Subtitle(start=1000, end=2000, text="第一句"),
+            Subtitle(start=2100, end=3000, text="第二句"),
+        ]
+    )
+    expected = Series(
+        [
+            Subtitle(start=1000, end=2000, text="第一句粤文"),
+            Subtitle(start=2100, end=3000, text="第二句粤文"),
+        ]
+    )
+    translator = Mock(spec=DualNToMProcessor)
+    translator.process.return_value = expected
+
+    output = get_yue_translated_from_zho(zhongwen, translator=translator)
+
+    assert output == expected
+    call_args = translator.process.call_args.args
+    assert call_args[0] is zhongwen
+    assert isinstance(call_args[1], Series)
+    assert len(call_args[1].events) == 0


### PR DESCRIPTION
## Summary
- Add regular and guided written Cantonese translation modules for zho -> yue, matching the English translation variant shape.
- Update `yue translate-vs-zho` to route regular, gapped, or guided translation based on mutually exclusive Yue input arguments.
- Register the new operations/default test-case loaders and add CLI/module coverage.

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format` on changed Python files
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix` on changed Python files
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check` on changed Python files
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` (`1199 passed, 4 skipped`)