### PR TITLE
Use native ruff and ty annotations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: 3.13
 
       - name: Install the project
-        run: uv sync --all-extras --dev
+        run: uv sync --dev --frozen
 
       - name: Run ruff
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,11 +30,6 @@ jobs:
         with:
           python-version: 3.13
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libcairo2-dev pkg-config python3-dev
-
       - name: Install the project
         run: uv sync --all-extras --dev
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         run: echo "DEFAULT_BRANCH=${GITHUB_BASE_REF:-${{ github.event.repository.default_branch }}}" >> $GITHUB_ENV
 
       - name: Fetch default branch
-        run: git fetch origin $DEFAULT_BRANCH
+        run: git fetch --depth=1 origin $DEFAULT_BRANCH
 
       - name: Define a cache dependency glob
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,9 +12,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          submodules: true
 
       - name: Determine default branch
         run: echo "DEFAULT_BRANCH=${GITHUB_BASE_REF:-${{ github.event.repository.default_branch }}}" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,27 +39,13 @@ jobs:
 
       - name: Run ruff
         run: |
-          mkdir -p ${GITHUB_WORKSPACE}/.github/outputs
           cd ${GITHUB_WORKSPACE}
-          uv run ruff check --output-format json | tee ${GITHUB_WORKSPACE}/.github/outputs/ruff.json || echo
-
-      - name: Annotate with ruff results
-        uses: KarlTDebiec/LinterPrinter@main
-        with:
-          tool: ruff
-          tool_infile: .github/outputs/ruff.json
+          uv run ruff check --output-format=github
 
       - name: Run ty
         run: |
-          mkdir -p ${GITHUB_WORKSPACE}/.github/outputs
           cd ${GITHUB_WORKSPACE}
-          uv run ty check --output-format gitlab . | tee ${GITHUB_WORKSPACE}/.github/outputs/ty.json || echo
-
-      - name: Annotate with ty results
-        uses: KarlTDebiec/LinterPrinter@main
-        with:
-          tool: ty
-          tool_infile: .github/outputs/ty.json
+          uv run ty check --output-format=github .
 
       - name: Run pytest
         run: |


### PR DESCRIPTION
## Summary

- Replace `LinterPrinter` ruff and ty annotation steps with native GitHub Actions output from each tool.
- Let `ruff` and `ty` fail their own steps on diagnostics instead of piping through `tee ... || echo`.
- Keep pytest annotation handling unchanged for this PR.

## Validation

- `git diff --check`
- Parsed `.github/workflows/build.yml` with Ruby YAML

This PR intentionally builds on the existing CI speedup stack so each annotation change can be validated separately.