### PR TITLE
Add LLM additional context file option

### DIFF
--- a/scinoephile/cli/eng/eng_process_cli.py
+++ b/scinoephile/cli/eng/eng_process_cli.py
@@ -7,7 +7,11 @@ from __future__ import annotations
 from argparse import ArgumentParser
 from pathlib import Path
 
-from scinoephile.cli.llms import LLM_LOCALIZATIONS, add_llm_provider_arguments
+from scinoephile.cli.llms import (
+    LLM_LOCALIZATIONS,
+    add_llm_provider_arguments,
+    read_llm_additional_context,
+)
 from scinoephile.common.argument_parsing import (
     get_arg_groups_by_name,
     input_file_arg,
@@ -164,6 +168,7 @@ class EngProcessCli(ScinoephileCliBase):
         proofread: bool,
         llm_provider_name: str,
         llm_model_name: str | None,
+        llm_additional_context_file_path: Path | None,
         offset: int,
         overwrite: bool,
     ):
@@ -178,6 +183,9 @@ class EngProcessCli(ScinoephileCliBase):
 
         # Read inputs
         series = read_series(parser, infile_path, allow_stdin=True)
+        additional_context = read_llm_additional_context(
+            parser, llm_additional_context_file_path
+        )
 
         # Perform operations
         if clean:
@@ -186,7 +194,10 @@ class EngProcessCli(ScinoephileCliBase):
             series = get_eng_flattened(series)
         if proofread:
             provider = get_provider(llm_provider_name, model=llm_model_name)
-            reviewer = get_eng_block_reviewer(provider=provider)
+            reviewer = get_eng_block_reviewer(
+                provider=provider,
+                additional_context=additional_context,
+            )
             series = get_eng_block_reviewed(series, processor=reviewer)
         if offset:
             series.shift(ms=offset)

--- a/scinoephile/cli/eng/eng_translate_vs_zho_cli.py
+++ b/scinoephile/cli/eng/eng_translate_vs_zho_cli.py
@@ -11,7 +11,11 @@ from __future__ import annotations
 from argparse import ArgumentParser
 from pathlib import Path
 
-from scinoephile.cli.llms import LLM_LOCALIZATIONS, add_llm_provider_arguments
+from scinoephile.cli.llms import (
+    LLM_LOCALIZATIONS,
+    add_llm_provider_arguments,
+    read_llm_additional_context,
+)
 from scinoephile.common.argument_parsing import (
     get_arg_groups_by_name,
     input_file_arg,
@@ -188,6 +192,7 @@ class EngTranslateVsZhoCli(ScinoephileCliBase):
         eng_guide_infile_path: Path | str | None,
         llm_provider_name: str,
         llm_model_name: str | None,
+        llm_additional_context_file_path: Path | None,
         outfile_path: Path | None,
         overwrite: bool,
     ):
@@ -203,12 +208,18 @@ class EngTranslateVsZhoCli(ScinoephileCliBase):
 
         # Read inputs
         zho = read_series(parser, zho_infile_path, allow_stdin=True)
+        additional_context = read_llm_additional_context(
+            parser, llm_additional_context_file_path
+        )
         provider = get_provider(llm_provider_name, model=llm_model_name)
 
         # Perform operations
         if eng_gapped_infile_path is not None:
             eng = read_series(parser, eng_gapped_infile_path, allow_stdin=True)
-            translator = get_eng_vs_zho_gapped_translator(provider=provider)
+            translator = get_eng_vs_zho_gapped_translator(
+                provider=provider,
+                additional_context=additional_context,
+            )
             eng = get_eng_gapped_translated_vs_zho(
                 eng=eng,
                 zho=zho,
@@ -216,14 +227,20 @@ class EngTranslateVsZhoCli(ScinoephileCliBase):
             )
         elif eng_guide_infile_path is not None:
             eng = read_series(parser, eng_guide_infile_path, allow_stdin=True)
-            translator = get_eng_zho_guided_translator(provider=provider)
+            translator = get_eng_zho_guided_translator(
+                provider=provider,
+                additional_context=additional_context,
+            )
             eng = get_eng_translated_from_zho_with_eng_guidance(
                 zho=zho,
                 eng=eng,
                 translator=translator,
             )
         else:
-            translator = get_eng_zho_translator(provider=provider)
+            translator = get_eng_zho_translator(
+                provider=provider,
+                additional_context=additional_context,
+            )
             eng = get_eng_translated_from_zho(zho=zho, translator=translator)
 
         # Write outputs

--- a/scinoephile/cli/llms.py
+++ b/scinoephile/cli/llms.py
@@ -13,8 +13,10 @@ from argparse import (  # noqa: PLC2701
     Namespace,
     _ArgumentGroup,
 )
+from pathlib import Path
 from typing import Any
 
+from scinoephile.common.argument_parsing import input_file_arg
 from scinoephile.core.cli import ScinoephileCliBase
 from scinoephile.llms.providers.registry import (
     DEFAULT_PROVIDER_NAME,
@@ -26,12 +28,16 @@ __all__ = [
     "LLM_LOCALIZATIONS",
     "add_llm_provider_arguments",
     "llm_provider_name_arg",
+    "read_llm_additional_context",
 ]
 
 LLM_LOCALIZATIONS: dict[str, dict[str, str]] = {
     "zh-hans": {
         "additional help": "附加帮助",
         "Available LLM providers:": "可用 LLM 提供商：",
+        "file from which to read additional context for LLM prompts": (
+            "用于读取 LLM 提示词附加上下文的文件"
+        ),
         "LLM model identifier override": "LLM 模型标识符覆盖值",
         "LLM provider to use (default: %(default)s). Use --list-llm-providers "
         "to show available providers.": (
@@ -43,6 +49,9 @@ LLM_LOCALIZATIONS: dict[str, dict[str, str]] = {
     "zh-hant": {
         "additional help": "附加說明",
         "Available LLM providers:": "可用 LLM 提供商：",
+        "file from which to read additional context for LLM prompts": (
+            "用於讀取 LLM 提示詞附加上下文的檔案"
+        ),
         "LLM model identifier override": "LLM 模型識別碼覆寫值",
         "LLM provider to use (default: %(default)s). Use --list-llm-providers "
         "to show available providers.": (
@@ -81,6 +90,13 @@ def add_llm_provider_arguments(
         dest="llm_model_name",
         help="LLM model identifier override",
     )
+    operation_arg_group.add_argument(
+        "--llm-additional-content-file",
+        default=None,
+        dest="llm_additional_context_file_path",
+        type=input_file_arg(),
+        help="file from which to read additional context for LLM prompts",
+    )
     additional_help_arg_group.add_argument(
         "--list-llm-providers",
         action=_ListLLMProvidersAction,
@@ -106,6 +122,26 @@ def llm_provider_name_arg(value: str) -> str:
     raise ArgumentTypeError(
         f"{value!r} is not one of the supported LLM providers: {options}"
     )
+
+
+def read_llm_additional_context(
+    parser: ArgumentParser,
+    llm_additional_context_file_path: Path | None,
+) -> str | None:
+    """Read additional context for LLM prompts.
+
+    Arguments:
+        parser: active argument parser
+        llm_additional_context_file_path: optional file from which to read context
+    Returns:
+        additional context text, if provided
+    """
+    if llm_additional_context_file_path is None:
+        return None
+    try:
+        return llm_additional_context_file_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        parser.error(str(exc))
 
 
 class _ListLLMProvidersAction(Action):

--- a/scinoephile/cli/ocr/ocr_fuse_cli.py
+++ b/scinoephile/cli/ocr/ocr_fuse_cli.py
@@ -12,7 +12,11 @@ from scinoephile.cli.conversion import (
     CONVERSION_LOCALIZATIONS,
     add_opencc_convert_argument,
 )
-from scinoephile.cli.llms import LLM_LOCALIZATIONS, add_llm_provider_arguments
+from scinoephile.cli.llms import (
+    LLM_LOCALIZATIONS,
+    add_llm_provider_arguments,
+    read_llm_additional_context,
+)
 from scinoephile.common.argument_parsing import (
     get_arg_groups_by_name,
     input_file_arg,
@@ -199,6 +203,7 @@ class OcrFuseCli(ScinoephileCliBase):
         convert: OpenCCConfig | None,
         llm_provider_name: str,
         llm_model_name: str | None,
+        llm_additional_context_file_path: Path | None,
         outfile_path: Path | None,
         overwrite: bool,
     ):
@@ -207,6 +212,9 @@ class OcrFuseCli(ScinoephileCliBase):
         parser = _parser or cls.argparser()
         if overwrite and outfile_path is None:
             parser.error("--overwrite may only be used with --outfile")
+        additional_context = read_llm_additional_context(
+            parser, llm_additional_context_file_path
+        )
         provider = get_provider(llm_provider_name, model=llm_model_name)
 
         # Dispatch to language-specific implementation
@@ -219,6 +227,7 @@ class OcrFuseCli(ScinoephileCliBase):
                 clean=clean,
                 convert=convert,
                 provider=provider,
+                additional_context=additional_context,
                 outfile_path=outfile_path,
                 overwrite=overwrite,
             )
@@ -231,28 +240,38 @@ class OcrFuseCli(ScinoephileCliBase):
                 clean=clean,
                 convert=convert,
                 provider=provider,
+                additional_context=additional_context,
                 outfile_path=outfile_path,
                 overwrite=overwrite,
             )
 
     @classmethod
     def _get_ocr_fuser(
-        cls, convert: OpenCCConfig | None, provider: LLMProvider
+        cls,
+        convert: OpenCCConfig | None,
+        provider: LLMProvider,
+        additional_context: str | None,
     ) -> OcrFusionProcessor:
         """Get OCR fuser for selected conversion output script.
 
         Arguments:
             convert: OpenCC conversion configuration
             provider: provider to use for queries
+            additional_context: additional context to include in LLM prompts
         Returns:
             configured OCR fuser
         """
         script = cls._get_script_for_conversion(convert)
         if script == "traditional":
             return get_zho_ocr_fuser(
-                prompt_cls=OcrFusionPromptZhoHant, provider=provider
+                prompt_cls=OcrFusionPromptZhoHant,
+                provider=provider,
+                additional_context=additional_context,
             )
-        return get_zho_ocr_fuser(provider=provider)
+        return get_zho_ocr_fuser(
+            provider=provider,
+            additional_context=additional_context,
+        )
 
     @classmethod
     def _get_script_for_conversion(cls, convert: OpenCCConfig | None) -> str:
@@ -282,6 +301,7 @@ class OcrFuseCli(ScinoephileCliBase):
         clean: bool,
         convert: OpenCCConfig | None,
         provider: LLMProvider,
+        additional_context: str | None,
         outfile_path: Path | None,
         overwrite: bool,
     ):
@@ -295,6 +315,7 @@ class OcrFuseCli(ScinoephileCliBase):
             clean: whether to clean inputs before fusion
             convert: OpenCC conversion configuration, if provided
             provider: provider to use for queries
+            additional_context: additional context to include in LLM prompts
             outfile_path: output subtitle path
             overwrite: whether to overwrite an existing output file
         """
@@ -316,7 +337,10 @@ class OcrFuseCli(ScinoephileCliBase):
         if clean:
             lens = get_eng_cleaned(lens, remove_empty=False)
             tesseract = get_eng_cleaned(tesseract, remove_empty=False)
-        fuser = get_eng_ocr_fuser(provider=provider)
+        fuser = get_eng_ocr_fuser(
+            provider=provider,
+            additional_context=additional_context,
+        )
         fused = get_eng_ocr_fused(lens, tesseract, processor=fuser)
 
         # Write outputs
@@ -335,6 +359,7 @@ class OcrFuseCli(ScinoephileCliBase):
         clean: bool,
         convert: OpenCCConfig | None,
         provider: LLMProvider,
+        additional_context: str | None,
         outfile_path: Path | None,
         overwrite: bool,
     ):
@@ -348,6 +373,7 @@ class OcrFuseCli(ScinoephileCliBase):
             clean: whether to clean inputs before fusion
             convert: OpenCC conversion configuration, if provided
             provider: provider to use for queries
+            additional_context: additional context to include in LLM prompts
             outfile_path: output subtitle path
             overwrite: whether to overwrite an existing output file
         """
@@ -371,7 +397,7 @@ class OcrFuseCli(ScinoephileCliBase):
             lens = get_zho_converted(lens, convert)
             paddle = get_zho_converted(paddle, convert)
 
-        processor = cls._get_ocr_fuser(convert, provider)
+        processor = cls._get_ocr_fuser(convert, provider, additional_context)
         fused = get_zho_ocr_fused(lens, paddle, processor=processor)
 
         # Write outputs

--- a/scinoephile/cli/yue/yue_process_cli.py
+++ b/scinoephile/cli/yue/yue_process_cli.py
@@ -11,7 +11,11 @@ from scinoephile.cli.conversion import (
     CONVERSION_LOCALIZATIONS,
     add_opencc_convert_argument,
 )
-from scinoephile.cli.llms import LLM_LOCALIZATIONS, add_llm_provider_arguments
+from scinoephile.cli.llms import (
+    LLM_LOCALIZATIONS,
+    add_llm_provider_arguments,
+    read_llm_additional_context,
+)
 from scinoephile.common.argument_parsing import (
     get_arg_groups_by_name,
     input_file_arg,
@@ -210,6 +214,7 @@ class YueProcessCli(ScinoephileCliBase):
         review_script: str | None,
         llm_provider_name: str,
         llm_model_name: str | None,
+        llm_additional_context_file_path: Path | None,
         romanize: bool,
         offset: int,
         overwrite: bool,
@@ -229,6 +234,9 @@ class YueProcessCli(ScinoephileCliBase):
 
         # Read inputs
         series = read_series(parser, infile_path, allow_stdin=True)
+        additional_context = read_llm_additional_context(
+            parser, llm_additional_context_file_path
+        )
 
         # Perform operations
         if clean:
@@ -240,7 +248,11 @@ class YueProcessCli(ScinoephileCliBase):
         if review_script is not None:
             prompt_cls = cls._get_review_prompt_cls(review_script)
             provider = get_provider(llm_provider_name, model=llm_model_name)
-            reviewer = get_zho_reviewer(prompt_cls=prompt_cls, provider=provider)
+            reviewer = get_zho_reviewer(
+                prompt_cls=prompt_cls,
+                provider=provider,
+                additional_context=additional_context,
+            )
             series = get_zho_block_reviewed(series, processor=reviewer)
         if romanize:
             series = get_yue_romanized(series, append=True)

--- a/scinoephile/cli/yue/yue_review_vs_zho_cli.py
+++ b/scinoephile/cli/yue/yue_review_vs_zho_cli.py
@@ -7,7 +7,11 @@ from __future__ import annotations
 from argparse import ArgumentParser
 from pathlib import Path
 
-from scinoephile.cli.llms import LLM_LOCALIZATIONS, add_llm_provider_arguments
+from scinoephile.cli.llms import (
+    LLM_LOCALIZATIONS,
+    add_llm_provider_arguments,
+    read_llm_additional_context,
+)
 from scinoephile.common.argument_parsing import (
     get_arg_groups_by_name,
     input_file_arg,
@@ -215,6 +219,7 @@ class YueReviewVsZhoCli(ScinoephileCliBase):
         script: str,
         llm_provider_name: str,
         llm_model_name: str | None,
+        llm_additional_context_file_path: Path | None,
         outfile_path: Path | None,
         overwrite: bool,
     ):
@@ -229,13 +234,18 @@ class YueReviewVsZhoCli(ScinoephileCliBase):
         # Read inputs
         yuewen = read_series(parser, yue_infile_path, allow_stdin=True)
         zhongwen = read_series(parser, zho_infile_path, allow_stdin=True)
+        additional_context = read_llm_additional_context(
+            parser, llm_additional_context_file_path
+        )
         provider = get_provider(llm_provider_name, model=llm_model_name)
 
         # Perform operations
         if mode == "line":
             prompt_cls = cls._get_line_review_prompt_cls(script)
             line_reviewer = get_yue_vs_zho_line_reviewer(
-                prompt_cls=prompt_cls, provider=provider
+                prompt_cls=prompt_cls,
+                provider=provider,
+                additional_context=additional_context,
             )
             reviewed = get_yue_line_reviewed_vs_zho(
                 yuewen=yuewen,
@@ -245,7 +255,9 @@ class YueReviewVsZhoCli(ScinoephileCliBase):
         else:
             prompt_cls = cls._get_block_review_prompt_cls(script)
             reviewer = get_yue_vs_zho_block_reviewer(
-                prompt_cls=prompt_cls, provider=provider
+                prompt_cls=prompt_cls,
+                provider=provider,
+                additional_context=additional_context,
             )
             reviewed = get_yue_block_reviewed_vs_zho(
                 yuewen=yuewen,

--- a/scinoephile/cli/yue/yue_transcribe_vs_zho_cli.py
+++ b/scinoephile/cli/yue/yue_transcribe_vs_zho_cli.py
@@ -12,7 +12,11 @@ from scinoephile.cli.conversion import (
     CONVERSION_LOCALIZATIONS,
     add_opencc_convert_argument,
 )
-from scinoephile.cli.llms import LLM_LOCALIZATIONS, add_llm_provider_arguments
+from scinoephile.cli.llms import (
+    LLM_LOCALIZATIONS,
+    add_llm_provider_arguments,
+    read_llm_additional_context,
+)
 from scinoephile.common.argument_parsing import (
     enum_arg,
     get_arg_groups_by_name,
@@ -242,6 +246,7 @@ class YueTranscribeVsZhoCli(ScinoephileCliBase):
         convert: OpenCCConfig | None,
         llm_provider_name: str,
         llm_model_name: str | None,
+        llm_additional_context_file_path: Path | None,
         demucs: DemucsMode,
         vad: VADMode,
         outfile_path: Path | None,
@@ -295,6 +300,9 @@ class YueTranscribeVsZhoCli(ScinoephileCliBase):
         deliniation_prompt_cls, punctuation_prompt_cls = (
             cls._get_transcription_prompt_classes(script)
         )
+        additional_context = read_llm_additional_context(
+            parser, llm_additional_context_file_path
+        )
         provider = get_provider(llm_provider_name, model=llm_model_name)
         transcriber = get_yue_vs_zho_transcriber(
             demucs_mode=demucs,
@@ -303,6 +311,7 @@ class YueTranscribeVsZhoCli(ScinoephileCliBase):
             convert=convert,
             deliniation_prompt_cls=deliniation_prompt_cls,
             punctuation_prompt_cls=punctuation_prompt_cls,
+            additional_context=additional_context,
         )
         yuewen = get_yue_transcribed_vs_zho(
             yuewen=yuewen,

--- a/scinoephile/cli/yue/yue_translate_vs_zho_cli.py
+++ b/scinoephile/cli/yue/yue_translate_vs_zho_cli.py
@@ -11,7 +11,11 @@ from __future__ import annotations
 from argparse import ArgumentParser
 from pathlib import Path
 
-from scinoephile.cli.llms import LLM_LOCALIZATIONS, add_llm_provider_arguments
+from scinoephile.cli.llms import (
+    LLM_LOCALIZATIONS,
+    add_llm_provider_arguments,
+    read_llm_additional_context,
+)
 from scinoephile.common.argument_parsing import (
     get_arg_groups_by_name,
     input_file_arg,
@@ -259,6 +263,7 @@ class YueTranslateVsZhoCli(ScinoephileCliBase):
         script: str,
         llm_provider_name: str,
         llm_model_name: str | None,
+        llm_additional_context_file_path: Path | None,
         outfile_path: Path | None,
         overwrite: bool,
     ):
@@ -276,6 +281,9 @@ class YueTranslateVsZhoCli(ScinoephileCliBase):
 
         # Read inputs
         zhongwen = read_series(parser, zho_infile_path, allow_stdin=True)
+        additional_context = read_llm_additional_context(
+            parser, llm_additional_context_file_path
+        )
         provider = get_provider(llm_provider_name, model=llm_model_name)
 
         # Perform operations
@@ -285,6 +293,7 @@ class YueTranslateVsZhoCli(ScinoephileCliBase):
             translator = get_yue_vs_zho_gapped_translator(
                 prompt_cls=prompt_cls,
                 provider=provider,
+                additional_context=additional_context,
             )
             yuewen = get_yue_gapped_translated_vs_zho(
                 yuewen=yuewen,
@@ -297,6 +306,7 @@ class YueTranslateVsZhoCli(ScinoephileCliBase):
             translator = get_yue_zho_guided_translator(
                 prompt_cls=prompt_cls,
                 provider=provider,
+                additional_context=additional_context,
             )
             yuewen = get_yue_translated_from_zho_with_yue_guidance(
                 zhongwen=zhongwen,
@@ -308,6 +318,7 @@ class YueTranslateVsZhoCli(ScinoephileCliBase):
             translator = get_yue_zho_translator(
                 prompt_cls=prompt_cls,
                 provider=provider,
+                additional_context=additional_context,
             )
             yuewen = get_yue_translated_from_zho(
                 zhongwen=zhongwen,

--- a/scinoephile/cli/zho/zho_process_cli.py
+++ b/scinoephile/cli/zho/zho_process_cli.py
@@ -11,7 +11,11 @@ from scinoephile.cli.conversion import (
     CONVERSION_LOCALIZATIONS,
     add_opencc_convert_argument,
 )
-from scinoephile.cli.llms import LLM_LOCALIZATIONS, add_llm_provider_arguments
+from scinoephile.cli.llms import (
+    LLM_LOCALIZATIONS,
+    add_llm_provider_arguments,
+    read_llm_additional_context,
+)
 from scinoephile.common.argument_parsing import (
     get_arg_groups_by_name,
     input_file_arg,
@@ -210,6 +214,7 @@ class ZhoProcessCli(ScinoephileCliBase):
         review_script: str | None,
         llm_provider_name: str,
         llm_model_name: str | None,
+        llm_additional_context_file_path: Path | None,
         romanize: bool,
         offset: int,
         overwrite: bool,
@@ -229,6 +234,9 @@ class ZhoProcessCli(ScinoephileCliBase):
 
         # Read inputs
         series = read_series(parser, infile_path, allow_stdin=True)
+        additional_context = read_llm_additional_context(
+            parser, llm_additional_context_file_path
+        )
 
         # Perform operations
         if clean:
@@ -240,7 +248,11 @@ class ZhoProcessCli(ScinoephileCliBase):
         if review_script is not None:
             prompt_cls = cls._get_review_prompt_cls(review_script)
             provider = get_provider(llm_provider_name, model=llm_model_name)
-            reviewer = get_zho_reviewer(prompt_cls=prompt_cls, provider=provider)
+            reviewer = get_zho_reviewer(
+                prompt_cls=prompt_cls,
+                provider=provider,
+                additional_context=additional_context,
+            )
             series = get_zho_block_reviewed(series, processor=reviewer)
         if romanize:
             series = get_cmn_romanized(series, append=True)

--- a/scinoephile/lang/eng/block_review/__init__.py
+++ b/scinoephile/lang/eng/block_review/__init__.py
@@ -49,6 +49,8 @@ class EngBlockReviewProcessorKwargs(TypedDict, total=False):
 
     test_case_path: Path | None
     """path where encountered or verified test cases are persisted."""
+    additional_context: str | None
+    """additional context to include in the system prompt."""
     auto_verify: bool
     """whether to automatically verify model outputs against expected cases."""
 

--- a/scinoephile/lang/eng/ocr_fusion/__init__.py
+++ b/scinoephile/lang/eng/ocr_fusion/__init__.py
@@ -49,6 +49,8 @@ class EngOcrFusionProcessorKwargs(TypedDict, total=False):
 
     test_case_path: Path | None
     """Path where encountered test cases are persisted."""
+    additional_context: str | None
+    """Additional context to include in the system prompt."""
     auto_verify: bool
     """Whether generated test cases should be marked verified automatically."""
 

--- a/scinoephile/lang/zho/block_review/__init__.py
+++ b/scinoephile/lang/zho/block_review/__init__.py
@@ -51,6 +51,8 @@ class ZhoBlockReviewProcessorKwargs(TypedDict, total=False):
 
     test_case_path: Path | None
     """Path where encountered test cases are persisted."""
+    additional_context: str | None
+    """Additional context to include in the system prompt."""
     auto_verify: bool
     """Whether generated test cases should be marked verified automatically."""
 

--- a/scinoephile/lang/zho/ocr_fusion/__init__.py
+++ b/scinoephile/lang/zho/ocr_fusion/__init__.py
@@ -54,6 +54,8 @@ class ZhoOcrFusionProcessorKwargs(TypedDict, total=False):
 
     test_case_path: Path | None
     """Path where encountered test cases are persisted."""
+    additional_context: str | None
+    """Additional context to include in the system prompt."""
     auto_verify: bool
     """Whether generated test cases should be marked verified automatically."""
 

--- a/scinoephile/multilang/yue_zho/block_review/__init__.py
+++ b/scinoephile/multilang/yue_zho/block_review/__init__.py
@@ -54,6 +54,8 @@ class YueZhoBlockReviewProcessorKwargs(TypedDict, total=False):
 
     test_case_path: Path | None
     """Path where encountered test cases are persisted."""
+    additional_context: str | None
+    """Additional context to include in the system prompt."""
     auto_verify: bool
     """Whether generated test cases should be marked verified automatically."""
 

--- a/scinoephile/multilang/yue_zho/gapped_translation/__init__.py
+++ b/scinoephile/multilang/yue_zho/gapped_translation/__init__.py
@@ -57,6 +57,8 @@ class YueVsZhoGappedTranslationProcessorKwargs(TypedDict, total=False):
 
     test_case_path: Path | None
     """Path where encountered test cases are persisted."""
+    additional_context: str | None
+    """Additional context to include in the system prompt."""
     auto_verify: bool
     """Whether generated test cases should be marked verified automatically."""
 

--- a/scinoephile/multilang/yue_zho/line_review/__init__.py
+++ b/scinoephile/multilang/yue_zho/line_review/__init__.py
@@ -63,6 +63,8 @@ class YueZhoLineReviewProcessorKwargs(TypedDict, total=False):
 
     test_case_path: Path | None
     """path where review test cases are persisted."""
+    additional_context: str | None
+    """additional context to include in the system prompt."""
     auto_verify: bool
     """whether to automatically verify updated test cases."""
 

--- a/scinoephile/multilang/yue_zho/transcription/__init__.py
+++ b/scinoephile/multilang/yue_zho/transcription/__init__.py
@@ -122,6 +122,7 @@ def get_yue_vs_zho_transcriber(
     vad_mode: VADMode = VADMode.AUTO,
     provider: LLMProvider | None = None,
     convert: OpenCCConfig | None = None,
+    additional_context: str | None = None,
     deliniation_prompt_cls: type[YueDeliniationVsZhoPromptYueHans] = (
         YueDeliniationVsZhoPromptYueHans
     ),
@@ -140,6 +141,7 @@ def get_yue_vs_zho_transcriber(
         vad_mode: Whisper VAD mode for transcription
         provider: provider to use for queries
         convert: OpenCC configuration used for transcribed text conversion
+        additional_context: additional context to include in LLM prompts
         deliniation_prompt_cls: prompt class for alignment deliniation
         punctuation_prompt_cls: prompt class for transcription punctuation
         test_case_directory_path: optional directory where test cases are updated
@@ -174,6 +176,7 @@ def get_yue_vs_zho_transcriber(
         vad_mode=vad_mode,
         provider=provider,
         convert=convert,
+        additional_context=additional_context,
         deliniation_prompt_cls=deliniation_prompt_cls,
         punctuation_prompt_cls=punctuation_prompt_cls,
         test_case_directory_path=test_case_directory_path,

--- a/scinoephile/multilang/yue_zho/transcription/transcriber.py
+++ b/scinoephile/multilang/yue_zho/transcription/transcriber.py
@@ -72,6 +72,7 @@ class YueTranscriber:
         vad_mode: VADMode = VADMode.AUTO,
         provider: LLMProvider | None = None,
         convert: OpenCCConfig | None = None,
+        additional_context: str | None = None,
         deliniation_prompt_cls: type[YueDeliniationVsZhoPromptYueHans],
         punctuation_prompt_cls: type[YuePunctuationVsZhoPromptYueHans],
         test_case_directory_path: Path,
@@ -86,6 +87,7 @@ class YueTranscriber:
             vad_mode: Whisper VAD mode for transcription
             provider: provider to use for LLM queryers
             convert: OpenCC configuration used to convert transcribed text
+            additional_context: additional context to include in LLM prompts
             deliniation_prompt_cls: prompt class for block-boundary deliniation
             punctuation_prompt_cls: prompt class for line punctuation
             test_case_directory_path: path to directory containing test cases
@@ -116,6 +118,7 @@ class YueTranscriber:
             verified_test_cases=[tc for tc in deliniation_test_cases if tc.verified],
             provider=provider,
             cache_dir_path=get_runtime_cache_dir_path("llm"),
+            additional_context=additional_context,
         )
         punctuation_queryer_cls = Queryer.get_queryer_cls(punctuation_prompt_cls)
         self.punctuation_queryer = punctuation_queryer_cls(
@@ -123,6 +126,7 @@ class YueTranscriber:
             verified_test_cases=[tc for tc in punctuation_test_cases if tc.verified],
             provider=provider,
             cache_dir_path=get_runtime_cache_dir_path("llm"),
+            additional_context=additional_context,
         )
         self.aligner = Aligner(
             deliniation_queryer=self.deliniation_queryer,

--- a/test/cli/eng/test_eng_translate_vs_zho_cli.py
+++ b/test/cli/eng/test_eng_translate_vs_zho_cli.py
@@ -87,6 +87,38 @@ def test_eng_translate_vs_zho_cli_regular_translation():
     assert_series_equal(output, expected)
 
 
+def test_eng_translate_vs_zho_cli_passes_llm_additional_context_file(tmp_path):
+    """Test English translate-vs-zho CLI passes LLM additional context."""
+    zho_input_path = test_data_root / (
+        "mnt/output/zho-Hans_ocr/fuse_clean_validate_review_flatten.srt"
+    )
+    expected_path = test_data_root / "mnt/output/eng_ocr/fuse_clean_validate_review.srt"
+    expected = Series.load(expected_path)
+    context_path = tmp_path / "context.txt"
+    context_path.write_text("Use canonical character names.\n", encoding="utf-8")
+
+    with get_temp_file_path(".srt") as output_path:
+        with patch(
+            "scinoephile.cli.eng.eng_translate_vs_zho_cli.get_eng_zho_translator",
+            return_value="translator",
+        ) as patched_factory:
+            with patch(
+                "scinoephile.cli.eng.eng_translate_vs_zho_cli.get_eng_translated_from_zho",
+                return_value=expected,
+            ):
+                run_cli_with_args(
+                    EngTranslateVsZhoCli,
+                    f"--zho-infile {zho_input_path} "
+                    f"--llm-additional-content-file {context_path} "
+                    f"--outfile {output_path}",
+                )
+
+    assert (
+        patched_factory.call_args.kwargs["additional_context"]
+        == "Use canonical character names.\n"
+    )
+
+
 def test_eng_translate_vs_zho_cli_gapped_translation():
     """Test English translate-vs-zho CLI routes to gapped translation."""
     eng_input_path = test_data_root / "mnt/output/eng_ocr/fuse_clean_validate.srt"

--- a/test/cli/yue/test_yue_transcribe_vs_zho_cli.py
+++ b/test/cli/yue/test_yue_transcribe_vs_zho_cli.py
@@ -191,7 +191,7 @@ def test_yue_transcribe_vs_zho_cli_writes_stdout():
     assert_series_equal(output_series, expected_series)
 
 
-def test_yue_transcribe_vs_zho_cli_passes_requested_vad_mode():
+def test_yue_transcribe_vs_zho_cli_passes_llm_options(tmp_path):
     """Test written Cantonese transcribe-vs-zho CLI passes through explicit VAD mode."""
     zhongwen_infile_path = test_data_root / "mnt/output/zho-Hans_ocr/fuse.srt"
     media_infile_path = "/tmp/test_media.mp4"
@@ -200,6 +200,8 @@ def test_yue_transcribe_vs_zho_cli_passes_requested_vad_mode():
         format_="srt",
     )
     yuewen_audio_series = Mock(spec=AudioSeries)
+    context_path = tmp_path / "context.txt"
+    context_path.write_text("Prefer existing subtitles.\n", encoding="utf-8")
 
     with patch(
         "scinoephile.cli.yue.yue_transcribe_vs_zho_cli.AudioSeries.load_from_media",
@@ -216,10 +218,15 @@ def test_yue_transcribe_vs_zho_cli_passes_requested_vad_mode():
                 run_cli_with_args(
                     YueTranscribeVsZhoCli,
                     f"--media-infile {media_infile_path} "
-                    f"--zhongwen-infile {zhongwen_infile_path} --vad off",
+                    f"--zhongwen-infile {zhongwen_infile_path} --vad off "
+                    f"--llm-additional-content-file {context_path}",
                 )
 
     assert patched_factory.call_args.kwargs["vad_mode"] == VADMode.OFF
+    assert (
+        patched_factory.call_args.kwargs["additional_context"]
+        == "Prefer existing subtitles.\n"
+    )
 
 
 def test_yue_transcribe_vs_zho_cli_passes_requested_demucs_mode():

--- a/test/cli/zho/test_zho_process_cli.py
+++ b/test/cli/zho/test_zho_process_cli.py
@@ -176,12 +176,14 @@ def test_zho_process_cli_rejects_bare_convert_flag():
         run_cli_with_args(ZhoProcessCli, f"--infile {full_input_path} --convert")
 
 
-def test_zho_process_cli_passes_llm_provider_and_model_to_reviewer():
+def test_zho_process_cli_passes_llm_options_to_reviewer(tmp_path):
     """Test standard Chinese CLI constructs configured LLM provider for review."""
     full_input_path = test_data_root / "mnt/output/zho-Hant_ocr/fuse_clean_validate.srt"
     expected = Series.load(
         test_data_root / "mnt/output/zho-Hant_ocr/fuse_clean_validate_review.srt"
     )
+    context_path = tmp_path / "context.txt"
+    context_path.write_text("Use glossary terms.\n", encoding="utf-8")
 
     with get_temp_file_path(".srt") as output_path:
         with patch(
@@ -196,9 +198,14 @@ def test_zho_process_cli_passes_llm_provider_and_model_to_reviewer():
                     ZhoProcessCli,
                     f"--infile {full_input_path} --proofread traditional "
                     "--llm-provider deepseek --llm-model custom-model "
+                    f"--llm-additional-content-file {context_path} "
                     f"--outfile {output_path}",
                 )
 
     provider = patched_factory.call_args.kwargs["provider"]
     assert isinstance(provider, DeepSeekProvider)
     assert provider.model == "custom-model"
+    assert (
+        patched_factory.call_args.kwargs["additional_context"]
+        == "Use glossary terms.\n"
+    )

--- a/test/multilang/yue_zho/test_get_yue_transcriber_vs_zho.py
+++ b/test/multilang/yue_zho/test_get_yue_transcriber_vs_zho.py
@@ -54,6 +54,7 @@ def test_get_yue_vs_zho_transcriber_uses_writable_runtime_test_case_root():
             demucs_mode=DemucsMode.OFF,
             vad_mode=VADMode.AUTO,
             convert=None,
+            additional_context=None,
             deliniation_prompt_cls=YueDeliniationVsZhoPromptYueHans,
             punctuation_prompt_cls=YuePunctuationVsZhoPromptYueHans,
             provider=ANY,


### PR DESCRIPTION
## Summary
- Add shared `--llm-additional-content-file` support to LLM-backed CLI argument setup.
- Read UTF-8 additional context from the provided file and pass it into LLM processors, translators, reviewers, OCR fusion, and Yue transcription paths.
- Extend focused CLI/unit coverage for the new option and default transcriber construction.

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format` on changed Python files
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix` on changed Python files
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check` on changed Python files
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` (`1200 passed, 4 skipped`)