### PR TITLE
Use pytest GitHub annotations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: 3.13
 
       - name: Install the project
-        run: uv sync --all-extras --dev
+        run: uv sync --dev --frozen
 
       - name: Run ruff
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,11 +30,6 @@ jobs:
         with:
           python-version: 3.13
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libcairo2-dev pkg-config python3-dev
-
       - name: Install the project
         run: uv sync --all-extras --dev
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,15 +49,6 @@ jobs:
 
       - name: Run pytest
         run: |
-          set -o pipefail
-          mkdir -p ${GITHUB_WORKSPACE}/.github/outputs
           export PACKAGE_ROOT=${GITHUB_WORKSPACE}/scinoephile
           cd ${GITHUB_WORKSPACE}/test
-          uv run pytest -n auto -v --cov=scinoephile --cov-report term . | tee ${GITHUB_WORKSPACE}/.github/outputs/pytest.txt
-
-      - name: Upload test results
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: test-results
-          path: .github/outputs/
+          uv run pytest -n auto -v --cov=scinoephile --cov-report term .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         run: echo "DEFAULT_BRANCH=${GITHUB_BASE_REF:-${{ github.event.repository.default_branch }}}" >> $GITHUB_ENV
 
       - name: Fetch default branch
-        run: git fetch origin $DEFAULT_BRANCH
+        run: git fetch --depth=1 origin $DEFAULT_BRANCH
 
       - name: Define a cache dependency glob
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,17 +49,11 @@ jobs:
 
       - name: Run pytest
         run: |
+          set -o pipefail
           mkdir -p ${GITHUB_WORKSPACE}/.github/outputs
           export PACKAGE_ROOT=${GITHUB_WORKSPACE}/scinoephile
           cd ${GITHUB_WORKSPACE}/test
-          uv run pytest -n auto -v --cov=scinoephile --cov-report term . | tee ${GITHUB_WORKSPACE}/.github/outputs/pytest.txt || echo
-        continue-on-error: true
-
-      - name: Annotate with pytest results
-        uses: KarlTDebiec/LinterPrinter@main
-        with:
-          tool: pytest
-          tool_infile: .github/outputs/pytest.txt
+          uv run pytest -n auto -v --cov=scinoephile --cov-report term . | tee ${GITHUB_WORKSPACE}/.github/outputs/pytest.txt
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,9 +12,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          submodules: true
 
       - name: Determine default branch
         run: echo "DEFAULT_BRANCH=${GITHUB_BASE_REF:-${{ github.event.repository.default_branch }}}" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,27 +39,13 @@ jobs:
 
       - name: Run ruff
         run: |
-          mkdir -p ${GITHUB_WORKSPACE}/.github/outputs
           cd ${GITHUB_WORKSPACE}
-          uv run ruff check --output-format json | tee ${GITHUB_WORKSPACE}/.github/outputs/ruff.json || echo
-
-      - name: Annotate with ruff results
-        uses: KarlTDebiec/LinterPrinter@main
-        with:
-          tool: ruff
-          tool_infile: .github/outputs/ruff.json
+          uv run ruff check --output-format=github
 
       - name: Run ty
         run: |
-          mkdir -p ${GITHUB_WORKSPACE}/.github/outputs
           cd ${GITHUB_WORKSPACE}
-          uv run ty check --output-format gitlab . | tee ${GITHUB_WORKSPACE}/.github/outputs/ty.json || echo
-
-      - name: Annotate with ty results
-        uses: KarlTDebiec/LinterPrinter@main
-        with:
-          tool: ty
-          tool_infile: .github/outputs/ty.json
+          uv run ty check --output-format=github .
 
       - name: Run pytest
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,6 @@ jobs:
 
       - name: Run pytest
         run: |
+          cd ${GITHUB_WORKSPACE}
           export PACKAGE_ROOT=${GITHUB_WORKSPACE}/scinoephile
-          cd ${GITHUB_WORKSPACE}/test
-          uv run pytest -n auto -v --cov=scinoephile --cov-report term .
+          uv run pytest -n auto -v --cov=scinoephile --cov-report term test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ scinoephile = "scinoephile.cli.scinoephile_cli:ScinoephileCli.main"
 dev = [
     "pytest>=9.0.3",
     "pytest-cov>=7.1.0",
+    "pytest-github-actions-annotate-failures>=0.4.0",
     "pytest-xdist>=3.8.0",
     "ruff>=0.15.12",
     "ty>=0.0.34",

--- a/uv.lock
+++ b/uv.lock
@@ -1484,6 +1484,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-github-actions-annotate-failures"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/e1/8f2c242e6d75a26a8e5ddcc23f652a411e4aac3eedc4b923808ac0582685/pytest_github_actions_annotate_failures-0.4.0.tar.gz", hash = "sha256:77d6baa29c8c61c2dacc494fa76eb95a185f0ee61666714ac43fb12ea672d217", size = 10857, upload-time = "2026-03-02T18:57:40.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/bd/11809f5c78d5d8da2d0e004845d2382768bc20798b3e0988bca61efd349f/pytest_github_actions_annotate_failures-0.4.0-py3-none-any.whl", hash = "sha256:285fed86e16b0b7a8eac6acdcde31913798fb739b15ef5b86895b4f5e32bf237", size = 6039, upload-time = "2026-03-02T18:57:39.991Z" },
+]
+
+[[package]]
 name = "pytest-xdist"
 version = "3.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1741,6 +1753,7 @@ ocr = [
 dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-github-actions-annotate-failures" },
     { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "ty" },
@@ -1785,6 +1798,7 @@ provides-extras = ["ocr"]
 dev = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "pytest-github-actions-annotate-failures", specifier = ">=0.4.0" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = ">=0.15.12" },
     { name = "ty", specifier = ">=0.0.34" },


### PR DESCRIPTION
## Summary
- Merge current `master` into the branch before applying the pytest annotation change.
- Add `pytest-github-actions-annotate-failures` to the dev dependency set.
- Remove the pytest `LinterPrinter` annotation step and let pytest emit GitHub annotations directly.
- Remove the unused test-results artifact upload and the intermediate `.github/outputs/pytest.txt` file.
- Run pytest from `${GITHUB_WORKSPACE}` with `test` as the target so annotation paths resolve from the repository root.

## Notes
- #871 is now in `master`, so this PR's diff is limited to the pytest annotation change, artifact cleanup, and root-based pytest invocation.
- Addressed Codex review feedback about invalid `test/test/...` annotation paths when pytest runs from the `test` directory.

## Validation
- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/build.yml'); puts 'workflow YAML parsed'"`
- `UV_CACHE_DIR=/tmp/uv-cache uv sync --dev --frozen`
- Verified plugin path behavior with `compute_path`: from `test` cwd -> `test/test/test_package_data.py`; from workspace cwd -> `test/test_package_data.py`
- Local root-based pytest before the final `master` merge: `export PACKAGE_ROOT=${PWD}/scinoephile && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto -v --cov=scinoephile --cov-report term test` (`1199 passed, 4 skipped, 2 warnings`)
- GitHub Actions run `25934749917`, job `76237199119`: success on final head `ca96eee9`