### PR TITLE
Move transcription dependencies to optional extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,14 +12,11 @@ dependencies = [
     "aiofiles>=25.1.0",
     "audioop-lts>=0.2.2",
     "beautifulsoup4>=4.14.3",
-    "demucs-infer>=4.1.2",
     "ffmpeg-python>=0.2.0",
-    "huggingface-hub>=1.14.0",
     "hkscs-unicode-converter>=1.1.0",
     "jieba>=0.42.1",
     "numba>=0.65.1",
     "numpy>=2.4.3",
-    "onnxruntime>=1.26.0",
     "openai>=2.36.0",
     "opencc>=1.3.0",
     "pillow>=12.1.1",
@@ -31,11 +28,7 @@ dependencies = [
     "requests>=2.33.1",
     "setuptools>=82.0.1",
     "sqlalchemy>=2.0.49",
-    "torch>=2.10.0",
-    "torchaudio>=2.10.0,<2.11.0",
-    "transformers>=5.8.0",
     "typing-extensions>=4.15.0",
-    "whisper-timestamped>=1.15.9",
 ]
 
 [project.optional-dependencies]
@@ -43,6 +36,15 @@ ocr = [
     "chrome-lens-py>=3.4.2",
     "paddleocr>=3.1.0",
     "paddlepaddle>=3.3.1; (platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')",
+]
+transcription = [
+    "demucs-infer>=4.1.2",
+    "huggingface-hub>=1.14.0",
+    "onnxruntime>=1.26.0",
+    "torch>=2.10.0",
+    "torchaudio>=2.10.0,<2.11.0",
+    "transformers>=5.8.0",
+    "whisper-timestamped>=1.15.9",
 ]
 
 [project.scripts]

--- a/scinoephile/audio/transcription/demucs_separator.py
+++ b/scinoephile/audio/transcription/demucs_separator.py
@@ -10,10 +10,6 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
-import torch
-import torchaudio.functional
-from demucs_infer.apply import apply_model
-from demucs_infer.pretrained import get_model
 from pydub import AudioSegment
 
 from scinoephile.common.validation import val_output_dir_path
@@ -23,6 +19,11 @@ from scinoephile.core.ml import get_torch_device
 __all__ = ["DemucsSeparator"]
 
 logger = getLogger(__name__)
+
+_TRANSCRIPTION_EXTRA_MESSAGE = (
+    "Demucs separation support requires optional transcription dependencies. "
+    "Install scinoephile with the 'transcription' extra."
+)
 
 
 class DemucsSeparator:
@@ -43,7 +44,7 @@ class DemucsSeparator:
         self.model_name = model_name
         """Demucs model name used for source separation."""
 
-        self.device = get_torch_device()
+        self._device: str | None = None
         """Torch device identifier used for inference."""
 
         self._model: Any | None = None
@@ -64,6 +65,30 @@ class DemucsSeparator:
         """
         return self.separate_vocals(audio)
 
+    @property
+    def device(self) -> str:
+        """Get torch device identifier."""
+        if self._device is None:
+            self._device = get_torch_device()
+        return self._device
+
+    @property
+    def model(self) -> Any:
+        """Get the cached Demucs model, loading it if needed.
+
+        Returns:
+            loaded Demucs model
+        """
+        if self._model is None:
+            model_loader = self._get_model_loader()
+            try:
+                self._model = model_loader(self.model_name).to(self.device).eval()
+            except Exception as exc:
+                raise ScinoephileError(
+                    f"Unable to load Demucs model '{self.model_name}'."
+                ) from exc
+        return self._model
+
     def get_cached_vocals(self, cache_audio: AudioSegment) -> AudioSegment | None:
         """Get cached vocals separation for audio if available.
 
@@ -79,22 +104,6 @@ class DemucsSeparator:
         vocals = AudioSegment.from_file(cache_path)
         cache_path.touch()
         return vocals
-
-    @property
-    def model(self) -> Any:
-        """Get the cached Demucs model, loading it if needed.
-
-        Returns:
-            loaded Demucs model
-        """
-        if self._model is None:
-            try:
-                self._model = get_model(self.model_name).to(self.device).eval()
-            except Exception as exc:
-                raise ScinoephileError(
-                    f"Unable to load Demucs model '{self.model_name}'."
-                ) from exc
-        return self._model
 
     def _separate_vocals_uncached(self, audio: AudioSegment) -> AudioSegment:
         """Separate vocals without consulting or updating the cache.
@@ -113,10 +122,13 @@ class DemucsSeparator:
             self.model, "samplerate", normalized_audio.frame_rate
         )
         if normalized_audio.frame_rate != target_frame_rate:
-            waveform = torchaudio.functional.resample(
+            torchaudio_functional = self._get_torchaudio_functional_module()
+            waveform = torchaudio_functional.resample(
                 waveform, normalized_audio.frame_rate, target_frame_rate
             )
 
+        torch = self._get_torch_module()
+        apply_model = self._get_apply_model()
         with torch.no_grad():
             try:
                 sources = apply_model(
@@ -137,7 +149,8 @@ class DemucsSeparator:
 
         vocals = sources[0, vocals_idx].cpu()
         if target_frame_rate != normalized_audio.frame_rate:
-            vocals = torchaudio.functional.resample(
+            torchaudio_functional = self._get_torchaudio_functional_module()
+            vocals = torchaudio_functional.resample(
                 vocals, target_frame_rate, normalized_audio.frame_rate
             )
 
@@ -189,7 +202,7 @@ class DemucsSeparator:
     @staticmethod
     def _get_audio_segment(
         *,
-        vocals: torch.Tensor,
+        vocals: Any,
         frame_rate: int,
         channels: int,
     ) -> AudioSegment:
@@ -226,7 +239,49 @@ class DemucsSeparator:
         )
 
     @staticmethod
-    def _get_waveform(audio: AudioSegment) -> torch.Tensor:
+    def _get_apply_model() -> Any:
+        """Import Demucs apply_model on demand."""
+        try:
+            from demucs_infer.apply import (  # ty: ignore[unresolved-import]  # noqa: E501, PLC0415
+                apply_model,
+            )
+        except ImportError as exc:
+            raise ImportError(_TRANSCRIPTION_EXTRA_MESSAGE) from exc
+        return apply_model
+
+    @staticmethod
+    def _get_model_loader() -> Any:
+        """Import Demucs model loader on demand."""
+        try:
+            from demucs_infer.pretrained import (  # ty: ignore[unresolved-import]  # noqa: E501, PLC0415
+                get_model,
+            )
+        except ImportError as exc:
+            raise ImportError(_TRANSCRIPTION_EXTRA_MESSAGE) from exc
+        return get_model
+
+    @staticmethod
+    def _get_torch_module() -> Any:
+        """Import torch on demand."""
+        try:
+            import torch  # ty: ignore[unresolved-import]  # noqa: PLC0415
+        except ImportError as exc:
+            raise ImportError(_TRANSCRIPTION_EXTRA_MESSAGE) from exc
+        return torch
+
+    @staticmethod
+    def _get_torchaudio_functional_module() -> Any:
+        """Import torchaudio.functional on demand."""
+        try:
+            from torchaudio import (  # ty: ignore[unresolved-import]  # noqa: PLC0415
+                functional,
+            )
+        except ImportError as exc:
+            raise ImportError(_TRANSCRIPTION_EXTRA_MESSAGE) from exc
+        return functional
+
+    @staticmethod
+    def _get_waveform(audio: AudioSegment) -> Any:
         """Convert a pydub AudioSegment into a waveform tensor.
 
         Arguments:
@@ -235,6 +290,7 @@ class DemucsSeparator:
             waveform tensor as [channels, time]
         """
         array = np.array(audio.get_array_of_samples(), dtype=np.int16)
+        torch = DemucsSeparator._get_torch_module()
         waveform = torch.from_numpy(
             array.reshape((-1, audio.channels)).T.astype(np.float32)
             / np.iinfo(np.int16).max

--- a/scinoephile/audio/transcription/whisper_transcriber.py
+++ b/scinoephile/audio/transcription/whisper_transcriber.py
@@ -12,10 +12,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from warnings import catch_warnings, filterwarnings
 
-import whisper_timestamped as whisper
-from huggingface_hub import snapshot_download
-from huggingface_hub.utils import HFValidationError, validate_repo_id
-
 from scinoephile.common.file import get_temp_file_path
 from scinoephile.common.validation import val_output_dir_path
 from scinoephile.core.ml import get_torch_device
@@ -25,6 +21,10 @@ from .transcribed_segment import TranscribedSegment
 __all__ = ["WhisperTranscriber"]
 
 _LOCAL_MODEL_PATH_PREFIXES = {"checkpoint", "checkpoints", "model", "models"}
+_TRANSCRIPTION_EXTRA_MESSAGE = (
+    "Whisper transcription support requires optional transcription dependencies. "
+    "Install scinoephile with the 'transcription' extra."
+)
 
 if TYPE_CHECKING:
     with catch_warnings():
@@ -85,6 +85,7 @@ class WhisperTranscriber:
             loaded Whisper model
         """
         if self._model is None:
+            whisper = self._get_whisper_module()
             try:
                 self._model = whisper.load_model(
                     self.model_name, device=get_torch_device()
@@ -96,6 +97,7 @@ class WhisperTranscriber:
                     "Whisper model load failed due to missing cache file; "
                     "re-downloading HuggingFace snapshot and retrying."
                 )
+                snapshot_download = self._get_snapshot_download()
                 snapshot_download(repo_id=self.model_name)
                 self._model = whisper.load_model(
                     self.model_name, device=get_torch_device()
@@ -144,6 +146,7 @@ class WhisperTranscriber:
 
         # Transcribe using Whisper
         cache_path = self._get_cache_path(cache_audio)
+        whisper = self._get_whisper_module()
         with get_temp_file_path(suffix=".wav") as temp_audio_path:
             audio.export(temp_audio_path, format="wav")
             result = whisper.transcribe(
@@ -186,9 +189,12 @@ class WhisperTranscriber:
             )
         ):
             return False
+        hf_validation_error_cls, validate_repo_id = (
+            self._get_huggingface_repo_validation()
+        )
         try:
             validate_repo_id(self.model_name)
-        except HFValidationError:
+        except hf_validation_error_cls:
             return False
         return "/" in self.model_name
 
@@ -304,6 +310,38 @@ class WhisperTranscriber:
             return None
 
         return segment_text_from_words
+
+    @staticmethod
+    def _get_huggingface_repo_validation() -> tuple[type[Exception], Any]:
+        """Import HuggingFace repo validation helpers on demand."""
+        try:
+            from huggingface_hub.utils import (  # ty: ignore[unresolved-import]  # noqa: E501, PLC0415
+                HFValidationError,
+                validate_repo_id,
+            )
+        except ImportError as exc:
+            raise ImportError(_TRANSCRIPTION_EXTRA_MESSAGE) from exc
+        return HFValidationError, validate_repo_id
+
+    @staticmethod
+    def _get_snapshot_download() -> Any:
+        """Import HuggingFace snapshot downloader on demand."""
+        try:
+            from huggingface_hub import (  # ty: ignore[unresolved-import]  # noqa: PLC0415
+                snapshot_download,
+            )
+        except ImportError as exc:
+            raise ImportError(_TRANSCRIPTION_EXTRA_MESSAGE) from exc
+        return snapshot_download
+
+    @staticmethod
+    def _get_whisper_module() -> Any:
+        """Import whisper-timestamped on demand."""
+        try:
+            import whisper_timestamped as whisper  # ty: ignore[unresolved-import]  # noqa: E501, PLC0415
+        except ImportError as exc:
+            raise ImportError(_TRANSCRIPTION_EXTRA_MESSAGE) from exc
+        return whisper
 
     def _get_cache_path(self, audio: AudioSegment) -> Path | None:
         """Get cache path based on hash of audio data.

--- a/scinoephile/core/ml.py
+++ b/scinoephile/core/ml.py
@@ -5,8 +5,7 @@
 from __future__ import annotations
 
 from functools import cache
-
-import torch
+from typing import Any
 
 __all__ = ["get_torch_device"]
 
@@ -18,8 +17,22 @@ def get_torch_device() -> str:
     Returns:
         torch device identifier
     """
+    torch = _get_torch_module()
     if torch.mps.is_available():
         return "mps"
     if torch.cuda.is_available():
         return "cuda"
     return "cpu"
+
+
+@cache
+def _get_torch_module() -> Any:
+    """Import torch on demand."""
+    try:
+        import torch  # ty: ignore[unresolved-import]  # noqa: PLC0415
+    except ImportError as exc:
+        raise ImportError(
+            "Torch support requires optional transcription dependencies. "
+            "Install scinoephile with the 'transcription' extra."
+        ) from exc
+    return torch

--- a/scinoephile/image/ocr/lens/google_lens_recognizer.py
+++ b/scinoephile/image/ocr/lens/google_lens_recognizer.py
@@ -20,6 +20,11 @@ __all__ = ["GoogleLensRecognizer"]
 
 logger = getLogger(__name__)
 
+_OCR_EXTRA_MESSAGE = (
+    "Google Lens OCR support requires optional OCR dependencies. "
+    "Install scinoephile with the 'ocr' extra."
+)
+
 
 class GoogleLensRecognizer:
     """Google Lens recognizer for image subtitles."""
@@ -169,10 +174,7 @@ class GoogleLensRecognizer:
                 LensAPI,
             )
         except ImportError as exc:
-            raise ImportError(
-                "Google Lens OCR support requires chrome-lens-py. Install "
-                "scinoephile with the 'ocr' extra."
-            ) from exc
+            raise ImportError(_OCR_EXTRA_MESSAGE) from exc
         return LensAPI
 
     @staticmethod

--- a/scinoephile/image/ocr/paddle/paddle_ocr_recognizer.py
+++ b/scinoephile/image/ocr/paddle/paddle_ocr_recognizer.py
@@ -28,6 +28,10 @@ _SUPPORTED_LANGUAGES = {"ch", "chinese_cht", "en"}
 _TEXT_DETECTION_MODEL_NAME = "PP-OCRv5_server_det"
 _TEXT_RECOGNITION_MODEL_NAME = "PP-OCRv5_server_rec"
 _TEXTLINE_ORIENTATION_MODEL_NAME = "PP-LCNet_x1_0_textline_ori"
+_OCR_EXTRA_MESSAGE = (
+    "PaddleOCR support requires optional OCR dependencies. "
+    "Install scinoephile with the 'ocr' extra."
+)
 
 
 class PaddleOcrRecognizer:
@@ -143,10 +147,7 @@ class PaddleOcrRecognizer:
                 PaddleOCR,
             )
         except ImportError as exc:
-            raise ImportError(
-                "PaddleOCR support requires optional OCR dependencies. "
-                "Install scinoephile with the 'ocr' extra."
-            ) from exc
+            raise ImportError(_OCR_EXTRA_MESSAGE) from exc
         return PaddleOCR
 
     @staticmethod

--- a/test/audio/transcription/test_demucs_separator.py
+++ b/test/audio/transcription/test_demucs_separator.py
@@ -4,17 +4,38 @@
 
 from __future__ import annotations
 
+import builtins
+from collections.abc import Mapping, Sequence
 from unittest.mock import Mock, patch
 
-import torch
+import numpy as np
+import pytest
 from pydub import AudioSegment
 
 from scinoephile.audio.transcription.demucs_separator import DemucsSeparator
 
 
+class _NumpyBackedTensor:
+    """Minimal tensor-shaped object for audio conversion tests."""
+
+    def __init__(self, array: np.ndarray):
+        """Initialize.
+
+        Arguments:
+            array: array returned by the numpy method
+        """
+        self._array = array
+
+    def numpy(self) -> np.ndarray:
+        """Return the wrapped numpy array."""
+        return self._array
+
+
 def test_get_audio_segment_restores_mono_output():
     """Test separated stereo vocals can be restored to mono output."""
-    vocals = torch.tensor([[0.25, -0.25], [0.25, -0.25]], dtype=torch.float32)
+    vocals = _NumpyBackedTensor(
+        np.array([[0.25, -0.25], [0.25, -0.25]], dtype=np.float32)
+    )
 
     audio = DemucsSeparator._get_audio_segment(
         vocals=vocals,
@@ -26,22 +47,44 @@ def test_get_audio_segment_restores_mono_output():
     assert audio.channels == 1
 
 
+def test_demucs_model_loader_requires_transcription_extra(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test Demucs import errors mention the transcription extra."""
+    original_import = builtins.__import__
+
+    def import_without_demucs(
+        name: str,
+        globals: Mapping[str, object] | None = None,
+        locals: Mapping[str, object] | None = None,
+        fromlist: Sequence[str] | None = (),
+        level: int = 0,
+    ) -> object:
+        if name.split(".", 1)[0] == "demucs_infer":
+            raise ImportError("blocked optional dependency")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_demucs)
+
+    with pytest.raises(ImportError, match="'transcription' extra"):
+        DemucsSeparator._get_model_loader()
+
+
 def test_separate_vocals_uses_default_demucs_shifts():
     """Test Demucs separation relies on library-default shift behavior."""
+    torch = pytest.importorskip("torch")
     separator = DemucsSeparator()
     separator._model = Mock(samplerate=16000, sources=["vocals"])
     separator._model.to.return_value = separator._model
     separator._model.eval.return_value = separator._model
     input_audio = AudioSegment.silent(duration=1000, frame_rate=16000).set_channels(1)
     separated_sources = torch.zeros((1, 1, 2, 16000), dtype=torch.float32)
+    apply_model = Mock(return_value=separated_sources)
 
-    with patch(
-        "scinoephile.audio.transcription.demucs_separator.apply_model",
-        return_value=separated_sources,
-    ) as patched_apply_model:
+    with patch.object(DemucsSeparator, "_get_apply_model", return_value=apply_model):
         output_audio = separator.separate_vocals(input_audio)
 
     assert isinstance(output_audio, AudioSegment)
     assert output_audio.frame_rate == input_audio.frame_rate
-    patched_apply_model.assert_called_once()
-    assert "shifts" not in patched_apply_model.call_args.kwargs
+    apply_model.assert_called_once()
+    assert "shifts" not in apply_model.call_args.kwargs

--- a/test/audio/transcription/test_whisper_transcriber.py
+++ b/test/audio/transcription/test_whisper_transcriber.py
@@ -4,13 +4,32 @@
 
 from __future__ import annotations
 
+import builtins
+import os
+import subprocess
+import sys
+from collections.abc import Mapping, Sequence
 from pathlib import Path
+from textwrap import dedent
 from unittest.mock import Mock
+
+import pytest
 
 from scinoephile.audio.transcription import get_segment_split_at_idx
 from scinoephile.audio.transcription.transcribed_segment import TranscribedSegment
 from scinoephile.audio.transcription.transcribed_word import TranscribedWord
 from scinoephile.audio.transcription.whisper_transcriber import WhisperTranscriber
+
+_OPTIONAL_TRANSCRIPTION_MODULES = (
+    "demucs_infer",
+    "huggingface_hub",
+    "onnxruntime",
+    "torch",
+    "torchaudio",
+    "transformers",
+    "whisper_timestamped",
+)
+_REPO_ROOT_PATH = Path(__file__).parents[3]
 
 
 def test_get_cache_path_separates_vad_modes_with_shared_cache_dir():
@@ -111,6 +130,7 @@ def test_get_cache_path_separates_demucs_modes():
 
 def test_model_name_is_huggingface_repo_id_rejects_local_paths():
     """Test HuggingFace retry is skipped for local filesystem paths."""
+    pytest.importorskip("huggingface_hub")
     transcriber = object.__new__(WhisperTranscriber)
     transcriber.model_name = "khleeloo/whisper-large-v3-cantonese"
 
@@ -127,6 +147,75 @@ def test_model_name_is_huggingface_repo_id_rejects_local_paths():
 
     transcriber.model_name = "large-v3"
     assert not transcriber._model_name_is_huggingface_repo_id()
+
+
+def test_transcription_imports_without_optional_runtime_dependencies():
+    """Test importing transcription APIs does not require runtime extras."""
+    script = dedent(
+        f"""
+        import importlib.abc
+        import sys
+
+        blocked_roots = {set(_OPTIONAL_TRANSCRIPTION_MODULES)!r}
+
+        class Blocker(importlib.abc.MetaPathFinder):
+            def find_spec(self, fullname, path, target=None):
+                if fullname.split(".", 1)[0] in blocked_roots:
+                    raise ImportError(f"blocked optional dependency: {{fullname}}")
+                return None
+
+        sys.meta_path.insert(0, Blocker())
+
+        from scinoephile.audio.transcription import (
+            DemucsSeparator,
+            TranscribedSegment,
+            WhisperTranscriber,
+            get_segment_split_at_idx,
+        )
+        from scinoephile.cli.yue.yue_cli import YueCli
+
+        WhisperTranscriber()
+        assert DemucsSeparator.__name__ == "DemucsSeparator"
+        assert TranscribedSegment.__name__ == "TranscribedSegment"
+        assert get_segment_split_at_idx.__name__ == "get_segment_split_at_idx"
+        assert "transcribe-vs-zho" in YueCli.subcommands()
+        """
+    )
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(_REPO_ROOT_PATH), env.get("PYTHONPATH", "")]
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=_REPO_ROOT_PATH,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_whisper_module_requires_transcription_extra(monkeypatch: pytest.MonkeyPatch):
+    """Test Whisper import errors mention the transcription extra."""
+    original_import = builtins.__import__
+
+    def import_without_whisper(
+        name: str,
+        globals: Mapping[str, object] | None = None,
+        locals: Mapping[str, object] | None = None,
+        fromlist: Sequence[str] | None = (),
+        level: int = 0,
+    ) -> object:
+        if name == "whisper_timestamped":
+            raise ImportError("blocked optional dependency")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_whisper)
+
+    with pytest.raises(ImportError, match="'transcription' extra"):
+        WhisperTranscriber._get_whisper_module()
 
 
 def test_normalize_transcription_segments_coalesces_malformed_duplicate_pair():

--- a/test/image/ocr/lens/test_lens_engine.py
+++ b/test/image/ocr/lens/test_lens_engine.py
@@ -208,7 +208,7 @@ def test_google_lens_recognizer_import_error_is_actionable(
 
     monkeypatch.setattr("builtins.__import__", fake_import)
 
-    with pytest.raises(ImportError, match="chrome-lens-py"):
+    with pytest.raises(ImportError, match="'ocr' extra"):
         GoogleLensRecognizer._get_lens_api_class()
 
 

--- a/test/image/ocr/paddle/test_engine.py
+++ b/test/image/ocr/paddle/test_engine.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import subprocess
 import sys
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from types import ModuleType
 from typing import Any
@@ -113,6 +114,40 @@ def test_paddle_ocr_recognizer_imports_paddleocr_only_when_needed():
     )
 
     assert result.returncode == 0, result.stderr
+
+
+def test_paddle_ocr_class_requires_ocr_extra(monkeypatch: pytest.MonkeyPatch):
+    """Test PaddleOCR import errors mention the OCR extra."""
+    real_import = __import__
+
+    def fake_import(
+        name: str,
+        globals_: Mapping[str, object] | None = None,
+        locals_: Mapping[str, object] | None = None,
+        fromlist: Sequence[str] | None = (),
+        level: int = 0,
+    ) -> object:
+        """Fake import that treats paddleocr as missing.
+
+        Arguments:
+            name: module name
+            globals_: global namespace
+            locals_: local namespace
+            fromlist: names to import
+            level: import level
+        Returns:
+            imported module
+        Raises:
+            ImportError: if importing paddleocr
+        """
+        if name == "paddleocr":
+            raise ImportError("missing paddleocr")
+        return real_import(name, globals_, locals_, fromlist, level)
+
+    monkeypatch.setattr("builtins.__import__", fake_import)
+
+    with pytest.raises(ImportError, match="'ocr' extra"):
+        PaddleOcrRecognizer._get_paddle_ocr_class()
 
 
 def test_paddle_ocr_recognizer_rejects_unsupported_languages():

--- a/uv.lock
+++ b/uv.lock
@@ -1716,14 +1716,11 @@ dependencies = [
     { name = "aiofiles" },
     { name = "audioop-lts" },
     { name = "beautifulsoup4" },
-    { name = "demucs-infer" },
     { name = "ffmpeg-python" },
     { name = "hkscs-unicode-converter" },
-    { name = "huggingface-hub" },
     { name = "jieba" },
     { name = "numba" },
     { name = "numpy" },
-    { name = "onnxruntime" },
     { name = "openai" },
     { name = "opencc" },
     { name = "pillow" },
@@ -1735,11 +1732,7 @@ dependencies = [
     { name = "requests" },
     { name = "setuptools" },
     { name = "sqlalchemy" },
-    { name = "torch" },
-    { name = "torchaudio" },
-    { name = "transformers" },
     { name = "typing-extensions" },
-    { name = "whisper-timestamped" },
 ]
 
 [package.optional-dependencies]
@@ -1747,6 +1740,15 @@ ocr = [
     { name = "chrome-lens-py" },
     { name = "paddleocr" },
     { name = "paddlepaddle", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+transcription = [
+    { name = "demucs-infer" },
+    { name = "huggingface-hub" },
+    { name = "onnxruntime" },
+    { name = "torch" },
+    { name = "torchaudio" },
+    { name = "transformers" },
+    { name = "whisper-timestamped" },
 ]
 
 [package.dev-dependencies]
@@ -1765,14 +1767,14 @@ requires-dist = [
     { name = "audioop-lts", specifier = ">=0.2.2" },
     { name = "beautifulsoup4", specifier = ">=4.14.3" },
     { name = "chrome-lens-py", marker = "extra == 'ocr'", specifier = ">=3.4.2" },
-    { name = "demucs-infer", specifier = ">=4.1.2" },
+    { name = "demucs-infer", marker = "extra == 'transcription'", specifier = ">=4.1.2" },
     { name = "ffmpeg-python", specifier = ">=0.2.0" },
     { name = "hkscs-unicode-converter", specifier = ">=1.1.0" },
-    { name = "huggingface-hub", specifier = ">=1.14.0" },
+    { name = "huggingface-hub", marker = "extra == 'transcription'", specifier = ">=1.14.0" },
     { name = "jieba", specifier = ">=0.42.1" },
     { name = "numba", specifier = ">=0.65.1" },
     { name = "numpy", specifier = ">=2.4.3" },
-    { name = "onnxruntime", specifier = ">=1.26.0" },
+    { name = "onnxruntime", marker = "extra == 'transcription'", specifier = ">=1.26.0" },
     { name = "openai", specifier = ">=2.36.0" },
     { name = "opencc", specifier = ">=1.3.0" },
     { name = "paddleocr", marker = "extra == 'ocr'", specifier = ">=3.1.0" },
@@ -1786,13 +1788,13 @@ requires-dist = [
     { name = "requests", specifier = ">=2.33.1" },
     { name = "setuptools", specifier = ">=82.0.1" },
     { name = "sqlalchemy", specifier = ">=2.0.49" },
-    { name = "torch", specifier = ">=2.10.0" },
-    { name = "torchaudio", specifier = ">=2.10.0,<2.11.0" },
-    { name = "transformers", specifier = ">=5.8.0" },
+    { name = "torch", marker = "extra == 'transcription'", specifier = ">=2.10.0" },
+    { name = "torchaudio", marker = "extra == 'transcription'", specifier = ">=2.10.0,<2.11.0" },
+    { name = "transformers", marker = "extra == 'transcription'", specifier = ">=5.8.0" },
     { name = "typing-extensions", specifier = ">=4.15.0" },
-    { name = "whisper-timestamped", specifier = ">=1.15.9" },
+    { name = "whisper-timestamped", marker = "extra == 'transcription'", specifier = ">=1.15.9" },
 ]
-provides-extras = ["ocr"]
+provides-extras = ["ocr", "transcription"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
- Move Demucs, Whisper, Hugging Face, Torch, Torchaudio, ONNX Runtime, and Transformers dependencies from base install into a new `transcription` optional extra.
- Replace top-level transcription runtime imports with OCR-style direct local import helpers that raise install guidance for the `transcription` extra.
- Keep transcription/Yue CLI imports cheap without the optional runtime modules, while skipping only tests that require the optional runtime stack.

## Verification
- `UV_CACHE_DIR=/tmp/uv-cache uv sync --dev --frozen`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/audio/transcription/demucs_separator.py scinoephile/audio/transcription/whisper_transcriber.py scinoephile/core/ml.py test/audio/transcription/test_demucs_separator.py test/audio/transcription/test_whisper_transcriber.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/audio/transcription/demucs_separator.py scinoephile/audio/transcription/whisper_transcriber.py scinoephile/core/ml.py test/audio/transcription/test_demucs_separator.py test/audio/transcription/test_whisper_transcriber.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/audio/transcription/demucs_separator.py scinoephile/audio/transcription/whisper_transcriber.py scinoephile/core/ml.py test/audio/transcription/test_demucs_separator.py test/audio/transcription/test_whisper_transcriber.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto`