### PR TITLE
Address CI warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Determine default branch
         run: echo "DEFAULT_BRANCH=${GITHUB_BASE_REF:-${{ github.event.repository.default_branch }}}" >> $GITHUB_ENV
@@ -24,13 +24,13 @@ jobs:
         run: git fetch --depth=1 origin $DEFAULT_BRANCH
 
       - name: Define a cache dependency glob
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.13
 

--- a/scinoephile/audio/transcription/whisper_transcriber.py
+++ b/scinoephile/audio/transcription/whisper_transcriber.py
@@ -10,7 +10,6 @@ from collections.abc import Sequence
 from logging import getLogger
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
-from warnings import catch_warnings, filterwarnings
 
 from scinoephile.common.file import get_temp_file_path
 from scinoephile.common.validation import val_output_dir_path
@@ -27,10 +26,7 @@ _TRANSCRIPTION_EXTRA_MESSAGE = (
 )
 
 if TYPE_CHECKING:
-    with catch_warnings():
-        filterwarnings("ignore", category=SyntaxWarning)
-        filterwarnings("ignore", category=RuntimeWarning)
-        from pydub import AudioSegment
+    from pydub import AudioSegment
 
 logger = getLogger(__name__)
 

--- a/scinoephile/lang/yue/romanization.py
+++ b/scinoephile/lang/yue/romanization.py
@@ -10,11 +10,8 @@ from copy import deepcopy
 from functools import cache, lru_cache
 from logging import getLogger
 from typing import Any, cast
-from warnings import catch_warnings, simplefilter
 
-with catch_warnings():
-    simplefilter("ignore", UserWarning)
-    import pycantonese
+import pycantonese
 
 from scinoephile.core.subtitles import Series
 from scinoephile.core.text import RE_WESTERN, full_to_half_punc, get_char_type

--- a/test/optimization/persistence/test_cases/test_optimization_test_cases_sqlite_store.py
+++ b/test/optimization/persistence/test_cases/test_optimization_test_cases_sqlite_store.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import sqlite3
+from contextlib import closing
 from pathlib import Path
 
 from scinoephile.core.llms import OperationSpec
@@ -53,7 +54,7 @@ def test_store_upsert_and_fetch(tmp_path: Path):
     assert loaded.answer == {"a": 2}
     assert "x.json" in loaded.source_paths
 
-    with sqlite3.connect(db_path) as connection:
+    with closing(sqlite3.connect(db_path)) as connection:
         columns = {
             str(row[1])
             for row in connection.execute(f"PRAGMA table_info({table_name})")
@@ -183,7 +184,7 @@ def test_store_splits_configured_list_fields(tmp_path: Path):
     assert loaded is not None
     assert loaded.query == tc.query
 
-    with sqlite3.connect(db_path) as connection:
+    with closing(sqlite3.connect(db_path)) as connection:
         row = connection.execute(
             f"""SELECT query__yuewen_to_punctuate_01,
                        query__yuewen_to_punctuate_02,


### PR DESCRIPTION
## Summary
- Upgrade the GitHub Actions JavaScript actions to Node 24-capable releases.
- Close raw sqlite3 connections in the optimization persistence tests that were producing ResourceWarnings.
- Remove warning suppressions that CI confirmed are unnecessary (`pycantonese` import wrapper and the `pydub` `TYPE_CHECKING` wrapper), while keeping the `jieba` and pytest `pydub` suppressions that CI still needs.

## Verification
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/lang/cmn/romanization.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/lang/cmn/romanization.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/lang/cmn/romanization.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q -W error::pytest.PytestUnraisableExceptionWarning test/optimization/persistence/test_cases/test_optimization_test_cases_sqlite_store.py test/optimization/persistence/test_cases/test_optimization_test_cases_sync.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto`