### PR TITLE
Add sync timing modes and eliminate overlap

### DIFF
--- a/scinoephile/cli/multi/multi_sync_cli.py
+++ b/scinoephile/cli/multi/multi_sync_cli.py
@@ -8,6 +8,7 @@ from argparse import ArgumentParser
 from pathlib import Path
 
 from scinoephile.common.argument_parsing import (
+    enum_arg,
     float_arg,
     get_arg_groups_by_name,
     input_file_arg,
@@ -15,7 +16,7 @@ from scinoephile.common.argument_parsing import (
     output_file_arg,
 )
 from scinoephile.core.cli import ScinoephileCliBase, read_series, write_series
-from scinoephile.core.synchronization import get_synced_series
+from scinoephile.core.synchronization import SyncTimingMode, get_synced_series
 
 __all__ = ["MultiSyncCli"]
 
@@ -31,6 +32,10 @@ MULTI_SYNC_LOCALIZATIONS: dict[str, dict[str, str]] = {
         "pause length in milliseconds used to split subtitle blocks (default: 3000)": (
             "用于分割字幕块的停顿时长，单位为毫秒（默认：3000）"
         ),
+        (
+            "timing mode for generated subtitles (options: top, bottom, outer; "
+            "default: outer)"
+        ): ("生成字幕的时间轴模式（选项：top、bottom、outer；默认：outer）"),
         'subtitle infile for bottom line or "-" for stdin': (
             '底行字幕输入文件，或使用 "-" 表示标准输入'
         ),
@@ -52,6 +57,10 @@ MULTI_SYNC_LOCALIZATIONS: dict[str, dict[str, str]] = {
         "pause length in milliseconds used to split subtitle blocks (default: 3000)": (
             "用於分割字幕區塊的停頓時長，單位為毫秒（預設：3000）"
         ),
+        (
+            "timing mode for generated subtitles (options: top, bottom, outer; "
+            "default: outer)"
+        ): ("生成字幕的時間軸模式（選項：top、bottom、outer；預設：outer）"),
         'subtitle infile for bottom line or "-" for stdin': (
             '底行字幕輸入檔，或使用 "-" 代表標準輸入'
         ),
@@ -123,6 +132,17 @@ class MultiSyncCli(ScinoephileCliBase):
                 "(default: 3000)"
             ),
         )
+        arg_groups["operation arguments"].add_argument(
+            "--timing",
+            default=SyncTimingMode.OUTER,
+            dest="timing_mode",
+            metavar="{top,bottom,outer}",
+            type=enum_arg(SyncTimingMode),
+            help=(
+                "timing mode for generated subtitles (options: top, bottom, outer; "
+                "default: outer)"
+            ),
+        )
 
         # Output arguments
         arg_groups["output arguments"].add_argument(
@@ -158,6 +178,7 @@ class MultiSyncCli(ScinoephileCliBase):
         bottom_infile_path: Path | str,
         sync_cutoff: float,
         pause_length: int,
+        timing_mode: SyncTimingMode,
         outfile_path: Path | None,
         overwrite: bool,
     ):
@@ -179,6 +200,7 @@ class MultiSyncCli(ScinoephileCliBase):
             bottom,
             sync_cutoff=sync_cutoff,
             pause_length=pause_length,
+            timing_mode=timing_mode,
         )
 
         # Write outputs

--- a/scinoephile/core/synchronization.py
+++ b/scinoephile/core/synchronization.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from enum import StrEnum
 from logging import getLogger
 from pprint import pformat
 
@@ -15,6 +16,7 @@ from .subtitles import Series, Subtitle, get_concatenated_series
 
 __all__ = [
     "SyncGroup",
+    "SyncTimingMode",
     "are_series_one_to_one",
     "get_overlap_string",
     "get_sync_groups",
@@ -28,6 +30,17 @@ logger = getLogger(__name__)
 
 SyncGroup = tuple[list[int], list[int]]
 """Group of subtitles; items are indexes in first and second series, respectively."""
+
+
+class SyncTimingMode(StrEnum):
+    """Timing modes for synchronized subtitles."""
+
+    TOP = "top"
+    """Use top subtitle timing where available."""
+    BOTTOM = "bottom"
+    """Use bottom subtitle timing where available."""
+    OUTER = "outer"
+    """Use the full outer timing span of paired subtitles."""
 
 
 def are_series_one_to_one(one: Series, two: Series) -> bool:
@@ -204,6 +217,7 @@ def get_synced_series(
     two: Series,
     sync_cutoff: float = 0.16,
     pause_length: int = 3000,
+    timing_mode: SyncTimingMode = SyncTimingMode.OUTER,
 ) -> Series:
     """Compile synchonized subtitles from two series.
 
@@ -212,6 +226,7 @@ def get_synced_series(
         two: Second Series
         sync_cutoff: Initial overlap cutoff used to form sync groups
         pause_length: Pause length in milliseconds used to split subtitle blocks
+        timing_mode: Timing mode used for synchronized subtitles
     Returns:
         Synchonized subtitles
     """
@@ -231,18 +246,21 @@ def get_synced_series(
         groups = get_sync_groups(one_block, two_block, cutoff=sync_cutoff)
         logger.info(f"SYNC GROUPS:\n{pformat(groups, width=1000)}")
 
-        synced_block = get_synced_series_from_groups(one_block, two_block, groups)
+        synced_block = get_synced_series_from_groups(
+            one_block, two_block, groups, timing_mode=timing_mode
+        )
         logger.info(f"SYNCED SUBTITLES:\n{synced_block.to_simple_string()}")
         synced_blocks.append(synced_block)
 
     synced = get_concatenated_series(synced_blocks)
-    return synced
+    return _get_series_without_overlaps(synced)
 
 
 def get_synced_series_from_groups(
     one: Series,
     two: Series,
     groups: list[SyncGroup],
+    timing_mode: SyncTimingMode = SyncTimingMode.OUTER,
 ) -> Series:
     """Compile synchronized subtitles from two series based on sync groups.
 
@@ -250,6 +268,7 @@ def get_synced_series_from_groups(
         one: First series
         two: Second series
         groups: Sync groups including the indexes of subtitles in each series
+        timing_mode: Timing mode used for synchronized subtitles
     Returns:
         Series whose subtitles are composed of the text of the subtitles from the two
         input series as indicated by the sync groups
@@ -274,10 +293,11 @@ def get_synced_series_from_groups(
         if len(one_subs) == 1 and len(two_subs) == 1:
             one_text = one_subs[0].text
             two_text = two_subs[0].text
+            start, end = _get_sync_group_timings(one_subs, two_subs, 1, timing_mode)[0]
             synced.events.append(
                 Subtitle(
-                    start=min(one_subs[0].start, two_subs[0].start),
-                    end=max(one_subs[0].end, two_subs[0].end),
+                    start=start,
+                    end=end,
                     text=(
                         f"{one_text}\\N{two_text}"
                         if one_text and two_text
@@ -290,11 +310,11 @@ def get_synced_series_from_groups(
         # Many to one mapping
         if len(one_subs) > 1 and len(two_subs) == 1:
             two_sub = two_subs[0]
-            group_start = min(one_subs[0].start, two_sub.start)
-            group_end = max(one_subs[-1].end, two_sub.end)
-            edges = np.linspace(group_start, group_end, len(one_subs) + 1, dtype=int)
+            timings = _get_sync_group_timings(
+                one_subs, two_subs, len(one_subs), timing_mode
+            )
 
-            for one_sub, start, end in zip(one_subs, edges[:-1], edges[1:]):
+            for one_sub, (start, end) in zip(one_subs, timings):
                 one_text = one_sub.text
                 two_text = two_sub.text
                 synced.events.append(
@@ -313,11 +333,11 @@ def get_synced_series_from_groups(
         # One to many mapping
         if len(one_subs) == 1 and len(two_subs) > 1:
             one_sub = one_subs[0]
-            group_start = min(one_sub.start, two_subs[0].start)
-            group_end = max(one_sub.end, two_subs[-1].end)
-            edges = np.linspace(group_start, group_end, len(two_subs) + 1, dtype=int)
+            timings = _get_sync_group_timings(
+                one_subs, two_subs, len(two_subs), timing_mode
+            )
 
-            for two_sub, start, end in zip(two_subs, edges[:-1], edges[1:]):
+            for two_sub, (start, end) in zip(two_subs, timings):
                 one_text = one_sub.text
                 two_text = two_sub.text
                 synced.events.append(
@@ -339,7 +359,7 @@ def get_synced_series_from_groups(
             f"and {len(two_subs)} subtitles from series two."
         )
 
-    return synced
+    return _get_series_without_overlaps(synced)
 
 
 def _compare_sync_groups(  # noqa: PLR0912
@@ -389,6 +409,93 @@ def _compare_sync_groups(  # noqa: PLR0912
             return 1
         case _:
             raise ScinoephileError("Unexpected comparison result between sync groups")
+
+
+def _get_series_without_overlaps(series: Series) -> Series:
+    """Get a copy of a subtitle series with adjacent timing overlaps removed.
+
+    Arguments:
+        series: subtitle series whose events should be made non-overlapping
+    Returns:
+        Copy of the subtitle series with adjacent overlaps split at their midpoint
+    Raises:
+        ScinoephileError: if overlap removal would make a subtitle non-positive
+    """
+    output = type(series)(
+        events=[type(event)(**event.as_dict()) for event in series.events]
+    )
+
+    for previous, current in zip(output.events, output.events[1:]):
+        if current.start >= previous.end:
+            continue
+
+        minimum_boundary = previous.start + 1
+        maximum_boundary = current.end - 1
+        if minimum_boundary > maximum_boundary:
+            raise ScinoephileError(
+                "Cannot remove subtitle timing overlap without creating a "
+                "non-positive duration subtitle."
+            )
+
+        boundary = (previous.end + current.start) // 2
+        boundary = max(boundary, minimum_boundary)
+        boundary = min(boundary, maximum_boundary)
+
+        previous.end = boundary
+        current.start = boundary
+
+    return output
+
+
+def _get_sync_group_interval(
+    one_subs: list[Subtitle],
+    two_subs: list[Subtitle],
+    timing_mode: SyncTimingMode,
+) -> tuple[int, int]:
+    """Get the selected timing interval for a sync group.
+
+    Arguments:
+        one_subs: subtitles from the first series
+        two_subs: subtitles from the second series
+        timing_mode: timing mode used for synchronized subtitles
+    Returns:
+        Start and end times for the sync group
+    """
+    if timing_mode == SyncTimingMode.TOP and one_subs:
+        return one_subs[0].start, one_subs[-1].end
+    if timing_mode == SyncTimingMode.BOTTOM and two_subs:
+        return two_subs[0].start, two_subs[-1].end
+
+    starts = [sub.start for sub in one_subs + two_subs]
+    ends = [sub.end for sub in one_subs + two_subs]
+    return min(starts), max(ends)
+
+
+def _get_sync_group_timings(
+    one_subs: list[Subtitle],
+    two_subs: list[Subtitle],
+    count: int,
+    timing_mode: SyncTimingMode,
+) -> list[tuple[int, int]]:
+    """Get generated subtitle timings for a sync group.
+
+    Arguments:
+        one_subs: subtitles from the first series
+        two_subs: subtitles from the second series
+        count: number of generated subtitles
+        timing_mode: timing mode used for synchronized subtitles
+    Returns:
+        Start and end times for each generated subtitle
+    """
+    if timing_mode == SyncTimingMode.TOP and len(one_subs) == count:
+        return [(sub.start, sub.end) for sub in one_subs]
+    if timing_mode == SyncTimingMode.BOTTOM and len(two_subs) == count:
+        return [(sub.start, sub.end) for sub in two_subs]
+
+    # Split SyncTimingMode.OUTER, or top/bottom groups with mismatched output counts
+    group_start, group_end = _get_sync_group_interval(one_subs, two_subs, timing_mode)
+    edges = np.linspace(group_start, group_end, count + 1, dtype=int)
+    return [(int(start), int(end)) for start, end in zip(edges[:-1], edges[1:])]
 
 
 def _get_sync_groups(  # noqa: PLR0912, PLR0915

--- a/scinoephile/core/synchronization.py
+++ b/scinoephile/core/synchronization.py
@@ -425,7 +425,9 @@ def _get_series_without_overlaps(series: Series) -> Series:
         events=[type(event)(**event.as_dict()) for event in series.events]
     )
 
-    for previous, current in zip(output.events, output.events[1:]):
+    for idx, (previous, current) in enumerate(
+        zip(output.events, output.events[1:]), start=1
+    ):
         if current.start >= previous.end:
             continue
 
@@ -433,8 +435,10 @@ def _get_series_without_overlaps(series: Series) -> Series:
         maximum_boundary = current.end - 1
         if minimum_boundary > maximum_boundary:
             raise ScinoephileError(
-                "Cannot remove subtitle timing overlap without creating a "
-                "non-positive duration subtitle."
+                f"Cannot remove subtitle timing overlap between events {idx} "
+                f"and {idx + 1} without creating a non-positive duration "
+                f"subtitle: previous={previous.start}-{previous.end}, "
+                f"current={current.start}-{current.end}."
             )
 
         boundary = (previous.end + current.start) // 2

--- a/test/cli/multi/test_multi_sync_cli.py
+++ b/test/cli/multi/test_multi_sync_cli.py
@@ -13,20 +13,27 @@ import pytest
 from scinoephile.cli.multi.multi_sync_cli import MultiSyncCli
 from scinoephile.common.testing import run_cli_with_args
 from scinoephile.core.subtitles import Series
+from scinoephile.core.synchronization import SyncTimingMode
 from test.helpers import test_data_root
 
 
 @pytest.mark.parametrize(
-    ("args", "expected_sync_cutoff", "expected_pause_length"),
+    ("args", "expected_sync_cutoff", "expected_pause_length", "expected_timing_mode"),
     [
-        ("", 0.16, 3000),
-        ("--sync-cutoff 0.25 --pause-length 5000", 0.25, 5000),
+        ("", 0.16, 3000, SyncTimingMode.OUTER),
+        (
+            "--sync-cutoff 0.25 --pause-length 5000 --timing top",
+            0.25,
+            5000,
+            SyncTimingMode.TOP,
+        ),
     ],
 )
 def test_multi_sync_cli_passes_tuning_options(
     args: str,
     expected_sync_cutoff: float,
     expected_pause_length: int,
+    expected_timing_mode: SyncTimingMode,
 ):
     """Test multi sync CLI passes synchronization tuning options.
 
@@ -34,6 +41,7 @@ def test_multi_sync_cli_passes_tuning_options(
         args: extra command-line arguments
         expected_sync_cutoff: expected sync cutoff passed to synchronization
         expected_pause_length: expected pause length passed to synchronization
+        expected_timing_mode: expected timing mode passed to synchronization
     """
     top_path = (
         test_data_root
@@ -67,6 +75,7 @@ def test_multi_sync_cli_passes_tuning_options(
         bottom_series,
         sync_cutoff=expected_sync_cutoff,
         pause_length=expected_pause_length,
+        timing_mode=expected_timing_mode,
     )
     assert write_series.call_args.args[1:] == (synced_series, "-", False)
 
@@ -77,6 +86,10 @@ def test_multi_sync_cli_passes_tuning_options(
         ("--sync-cutoff -0.01", "-0.01 is less than minimum value of 0.0"),
         ("--sync-cutoff 1.01", "1.01 is greater than maximum value of 1.0"),
         ("--pause-length 0", "0 is less than minimum value of 1"),
+        (
+            "--timing inside",
+            "'inside' is not one of the supported values: top, bottom, outer",
+        ),
     ],
 )
 def test_multi_sync_cli_rejects_invalid_tuning_options(

--- a/test/cli/test_cli_argument_choices.py
+++ b/test/cli/test_cli_argument_choices.py
@@ -8,6 +8,7 @@ from argparse import Action
 
 import pytest
 
+from scinoephile.cli.multi.multi_sync_cli import MultiSyncCli
 from scinoephile.cli.ocr.ocr_fuse_cli import OcrFuseCli
 from scinoephile.cli.ocr.ocr_validate_cli import OcrValidateCli
 from scinoephile.cli.yue.yue_process_cli import YueProcessCli
@@ -23,6 +24,7 @@ from scinoephile.common import CommandLineInterface
     [
         (OcrFuseCli, "--language", "{eng,zho}"),
         (OcrValidateCli, "--language", "{eng,zho}"),
+        (MultiSyncCli, "--timing", "{top,bottom,outer}"),
         (YueProcessCli, "--proofread", "{simplified,traditional}"),
         (YueReviewVsZhoCli, "--mode", "{block,line}"),
         (YueReviewVsZhoCli, "--script", "{simplified,traditional}"),

--- a/test/core/synchronization/test_get_synced_series.py
+++ b/test/core/synchronization/test_get_synced_series.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import pytest
 
+from scinoephile.core.exceptions import ScinoephileError
 from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.core.synchronization import (
     SyncTimingMode,
@@ -125,6 +126,22 @@ def test_get_synced_series_splits_selected_timing_for_one_to_many_groups(
 
     assert [(event.start, event.end) for event in output.events] == expected_times
     assert [event.text for event in output.events] == ["A\\N1", "A\\N2"]
+
+
+def test_get_synced_series_overlap_error_includes_event_context():
+    """Test impossible overlap removal errors include adjacent event context."""
+    one = Series(
+        events=[
+            Subtitle(start=1000, end=3000, text="A"),
+            Subtitle(start=1000, end=1001, text="B"),
+        ]
+    )
+
+    with pytest.raises(
+        ScinoephileError,
+        match=("events 1 and 2.*previous=1000-3000.*current=1000-1001"),
+    ):
+        get_synced_series_from_groups(one, Series(), [([0], []), ([1], [])])
 
 
 def test_get_synced_series_kob(

--- a/test/core/synchronization/test_get_synced_series.py
+++ b/test/core/synchronization/test_get_synced_series.py
@@ -4,8 +4,14 @@
 
 from __future__ import annotations
 
-from scinoephile.core.subtitles import Series
-from scinoephile.core.synchronization import get_synced_series
+import pytest
+
+from scinoephile.core.subtitles import Series, Subtitle
+from scinoephile.core.synchronization import (
+    SyncTimingMode,
+    get_synced_series,
+    get_synced_series_from_groups,
+)
 from test.helpers import assert_series_equal
 
 
@@ -19,6 +25,106 @@ def _test_get_synced_series(one: Series, two: Series, expected: Series):
     """
     output = get_synced_series(one, two)
     assert_series_equal(output, expected)
+
+
+def test_get_synced_series_does_not_overlap_union_timing():
+    """Test sync never emits overlapping subtitles when inputs do not overlap."""
+    one = Series(
+        events=[
+            Subtitle(start=1000, end=2000, text="A"),
+            Subtitle(start=2100, end=3000, text="B"),
+        ]
+    )
+    two = Series(
+        events=[
+            Subtitle(start=900, end=1900, text="1"),
+            Subtitle(start=1950, end=2900, text="2"),
+        ]
+    )
+
+    output = get_synced_series(one, two)
+
+    assert output.events[0].text == "A\\N1"
+    assert output.events[1].text == "B\\N2"
+    assert output.events[1].start >= output.events[0].end
+
+
+@pytest.mark.parametrize(
+    ("timing_mode", "expected_times"),
+    [
+        (SyncTimingMode.TOP, [(1000, 2000), (2100, 3000)]),
+        (SyncTimingMode.BOTTOM, [(900, 1900), (1950, 2900)]),
+        (SyncTimingMode.OUTER, [(900, 1975), (1975, 3000)]),
+    ],
+)
+def test_get_synced_series_uses_requested_timing_mode(
+    timing_mode: SyncTimingMode,
+    expected_times: list[tuple[int, int]],
+):
+    """Test sync uses the requested timing mode for paired subtitles."""
+    one = Series(
+        events=[
+            Subtitle(start=1000, end=2000, text="A"),
+            Subtitle(start=2100, end=3000, text="B"),
+        ]
+    )
+    two = Series(
+        events=[
+            Subtitle(start=900, end=1900, text="1"),
+            Subtitle(start=1950, end=2900, text="2"),
+        ]
+    )
+
+    output = get_synced_series(one, two, timing_mode=timing_mode)
+
+    assert [(event.start, event.end) for event in output.events] == expected_times
+    assert [event.text for event in output.events] == ["A\\N1", "B\\N2"]
+
+
+def test_get_synced_series_timing_mode_uses_available_timing_for_unpaired_subtitles():
+    """Test unpaired subtitles keep their own timing in every timing mode."""
+    one = Series(events=[Subtitle(start=1000, end=2000, text="A")])
+    two = Series(events=[Subtitle(start=3000, end=4000, text="1")])
+    groups = [([0], []), ([], [0])]
+
+    for timing_mode in SyncTimingMode:
+        output = get_synced_series_from_groups(
+            one, two, groups, timing_mode=timing_mode
+        )
+        assert [(event.start, event.end) for event in output.events] == [
+            (1000, 2000),
+            (3000, 4000),
+        ]
+        assert [event.text for event in output.events] == ["A", "1"]
+
+
+@pytest.mark.parametrize(
+    ("timing_mode", "expected_times"),
+    [
+        (SyncTimingMode.TOP, [(1000, 1500), (1500, 2000)]),
+        (SyncTimingMode.BOTTOM, [(900, 1300), (1400, 1900)]),
+        (SyncTimingMode.OUTER, [(900, 1450), (1450, 2000)]),
+    ],
+)
+def test_get_synced_series_splits_selected_timing_for_one_to_many_groups(
+    timing_mode: SyncTimingMode,
+    expected_times: list[tuple[int, int]],
+):
+    """Test one-to-many sync splits the selected timing interval."""
+    one = Series(events=[Subtitle(start=1000, end=2000, text="A")])
+    two = Series(
+        events=[
+            Subtitle(start=900, end=1300, text="1"),
+            Subtitle(start=1400, end=1900, text="2"),
+        ]
+    )
+
+    output = get_synced_series_from_groups(
+        one, two, [([0], [0, 1])], timing_mode=timing_mode
+    )
+
+    assert [(event.start, event.end) for event in output.events] == expected_times
+    assert [event.text for event in output.events] == ["A\\N1", "A\\N2"]
 
 
 def test_get_synced_series_kob(


### PR DESCRIPTION
## Summary

Fixes multi-subtitle sync output so generated subtitles do not overlap, and adds explicit timing selection for bilingual sync output.

## Changes

- Add `SyncTimingMode` with `top`, `bottom`, and `outer` modes.
- Add `scinoephile multi sync --timing {top,bottom,outer}`, defaulting to `outer`.
- Preserve available timing for unpaired subtitles.
- Normalize adjacent generated subtitle timings to prevent overlaps.
- Add regression and CLI tests for overlap handling, timing modes, unpaired subtitles, and argument choice help.