### PR TITLE
Add Google Lens OCR retries

### DIFF
--- a/scinoephile/cli/ocr/ocr_lens_cli.py
+++ b/scinoephile/cli/ocr/ocr_lens_cli.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from scinoephile.common.argument_parsing import (
     get_arg_groups_by_name,
     input_file_or_dir_arg,
+    int_arg,
     output_file_arg,
 )
 from scinoephile.core import ScinoephileError
@@ -24,6 +25,9 @@ OCR_LENS_LOCALIZATIONS: dict[str, dict[str, str]] = {
         "Google Lens language code such as en, zh-CN, or zh-TW (default: en)": (
             "Google Lens 语言代码，例如 en、zh-CN 或 zh-TW（默认：en）"
         ),
+        "Google Lens request attempts per uncached image (default: %(default)s)": (
+            "每张未缓存图像的 Google Lens 请求尝试次数（默认：%(default)s）"
+        ),
         "Recognize image subtitles with Google Lens.": (
             "使用 Google Lens 识别图像字幕。"
         ),
@@ -36,6 +40,9 @@ OCR_LENS_LOCALIZATIONS: dict[str, dict[str, str]] = {
     "zh-hant": {
         "Google Lens language code such as en, zh-CN, or zh-TW (default: en)": (
             "Google Lens 語言代碼，例如 en、zh-CN 或 zh-TW（預設：en）"
+        ),
+        "Google Lens request attempts per uncached image (default: %(default)s)": (
+            "每張未快取影像的 Google Lens 請求嘗試次數（預設：%(default)s）"
         ),
         "Recognize image subtitles with Google Lens.": (
             "使用 Google Lens 識別影像字幕。"
@@ -90,6 +97,14 @@ class OcrLensCli(ScinoephileCliBase):
             default="en",
             help="Google Lens language code such as en, zh-CN, or zh-TW (default: en)",
         )
+        arg_groups["operation arguments"].add_argument(
+            "--retries",
+            default=3,
+            type=int_arg(min_value=1),
+            help=(
+                "Google Lens request attempts per uncached image (default: %(default)s)"
+            ),
+        )
 
         # Output arguments
         arg_groups["output arguments"].add_argument(
@@ -124,6 +139,7 @@ class OcrLensCli(ScinoephileCliBase):
         language: str,
         outfile_path: Path,
         overwrite: bool,
+        retries: int,
     ):
         """Execute with provided keyword arguments."""
         # Validate arguments
@@ -147,6 +163,7 @@ class OcrLensCli(ScinoephileCliBase):
             text_series = ocr_image_series_with_lens(
                 image_series,
                 language=language,
+                retries=retries,
             )
         except (
             ImportError,

--- a/scinoephile/image/ocr/lens/__init__.py
+++ b/scinoephile/image/ocr/lens/__init__.py
@@ -24,12 +24,14 @@ def get_google_lens_recognizer(
     *,
     cache_dir_path: Path | None = None,
     language: str = "en",
+    retries: int = 3,
 ) -> GoogleLensRecognizer:
     """Get Google Lens recognizer with provided configuration.
 
     Arguments:
         cache_dir_path: directory in which to cache OCR results
         language: Google Lens OCR language code
+        retries: Google Lens OCR request attempts per uncached image
     Returns:
         Google Lens recognizer
     """
@@ -38,6 +40,7 @@ def get_google_lens_recognizer(
     return GoogleLensRecognizer(
         cache_dir_path=cache_dir_path,
         language=language,
+        retries=retries,
     )
 
 
@@ -45,6 +48,7 @@ def ocr_image_series_with_lens(
     image_series: ImageSeries,
     *,
     language: str = "en",
+    retries: int = 3,
     recognizer: GoogleLensRecognizer | None = None,
 ) -> Series:
     """OCR an image subtitle series with Google Lens.
@@ -52,6 +56,7 @@ def ocr_image_series_with_lens(
     Arguments:
         image_series: image subtitle series
         language: Google Lens OCR language code
+        retries: Google Lens OCR request attempts per uncached image
         recognizer: Google Lens-compatible recognizer
     Returns:
         text subtitle series
@@ -59,6 +64,7 @@ def ocr_image_series_with_lens(
     if recognizer is None:
         lens_recognizer = get_google_lens_recognizer(
             language=language,
+            retries=retries,
         )
     else:
         lens_recognizer = recognizer

--- a/scinoephile/image/ocr/lens/google_lens_recognizer.py
+++ b/scinoephile/image/ocr/lens/google_lens_recognizer.py
@@ -24,6 +24,11 @@ _OCR_EXTRA_MESSAGE = (
     "Google Lens OCR support requires optional OCR dependencies. "
     "Install scinoephile with the 'ocr' extra."
 )
+_LENS_RETRY_DELAY_SECONDS = 1.5
+
+
+class _GoogleLensRequestError(RuntimeError):
+    """Transient Google Lens request error returned as OCR text."""
 
 
 class GoogleLensRecognizer:
@@ -48,6 +53,7 @@ class GoogleLensRecognizer:
             self.cache_dir_path = val_output_dir_path(cache_dir_path)
         self.language = language
         self.retries = val_int(retries, min_value=1)
+        self._lens_api_error_class = self._get_lens_api_error_class()
         self._api = self._get_lens_api_class()()
 
     @override
@@ -101,6 +107,14 @@ class GoogleLensRecognizer:
         cache_key = f"{image_sha256}_{image.mode}_{image.size}_{self.language}"
         cache_sha256 = hashlib.sha256(cache_key.encode("utf-8")).hexdigest()
         return self.cache_dir_path / f"{cache_sha256}.json"
+
+    def _get_transient_error_classes(self) -> tuple[type[Exception], ...]:
+        """Get exception classes that should trigger a Google Lens retry.
+
+        Returns:
+            transient exception classes
+        """
+        return self._lens_api_error_class, _GoogleLensRequestError
 
     @staticmethod
     def _clean_text(text: str) -> str:
@@ -178,6 +192,33 @@ class GoogleLensRecognizer:
         except ImportError as exc:
             raise ImportError(_OCR_EXTRA_MESSAGE) from exc
         return LensAPI
+
+    @staticmethod
+    def _get_lens_api_error_class() -> type[Exception]:
+        """Import chrome-lens-py LensAPIError on demand.
+
+        Returns:
+            chrome-lens-py LensAPIError class
+        Raises:
+            ImportError: if chrome-lens-py is not installed
+        """
+        try:
+            from chrome_lens_py.exceptions import (  # ty: ignore[unresolved-import]  # noqa: PLC0415
+                LensAPIError,
+            )
+        except ImportError as module_exc:
+            try:
+                from chrome_lens_py import (  # ty: ignore[unresolved-import]  # noqa: PLC0415
+                    LensAPIError,
+                )
+            except ImportError as package_exc:
+                raise ImportError(_OCR_EXTRA_MESSAGE) from package_exc
+            if module_exc.name != "chrome_lens_py.exceptions":
+                logger.debug(
+                    f"Imported LensAPIError from chrome_lens_py package after "
+                    f"submodule import failed: {module_exc}"
+                )
+        return cast(type[Exception], LensAPIError)
 
     @staticmethod
     def _load_lens_lines(cache_path: Path) -> list[str]:
@@ -259,31 +300,36 @@ class GoogleLensRecognizer:
         Returns:
             normalized OCR lines
         Raises:
-            Exception: last error raised by Google Lens OCR after retries
+            RuntimeError: if Google Lens returns request-error text
         """
-        for attempt in range(1, self.retries + 1):
-            try:
-                result = asyncio.run(
-                    self._api.process_image(
+        transient_error_classes = self._get_transient_error_classes()
+
+        async def recognize() -> list[str]:
+            """Run Google Lens OCR retries in one event loop."""
+            for attempt in range(1, self.retries + 1):
+                try:
+                    result = await self._api.process_image(
                         image_path=image,
                         ocr_language=self.language,
                         ocr_preserve_line_breaks=True,
                         output_format="lines",
                     )
-                )
-                lines = self._normalize_lens_result(result)
-                self._raise_if_request_error(lines)
-            except Exception as exc:
-                if attempt == self.retries:
-                    raise
-                logger.warning(
-                    f"Google Lens OCR attempt {attempt} of {self.retries} failed; "
-                    f"retrying: {exc}"
-                )
-            else:
-                return lines
+                    lines = self._normalize_lens_result(result)
+                    self._raise_if_request_error(lines)
+                except transient_error_classes as exc:
+                    if attempt == self.retries:
+                        raise
+                    logger.warning(
+                        f"Google Lens OCR attempt {attempt} of {self.retries} "
+                        f"failed; retrying: {exc}"
+                    )
+                    await asyncio.sleep(_LENS_RETRY_DELAY_SECONDS)
+                else:
+                    return lines
 
-        raise RuntimeError("Google Lens OCR retry loop exhausted without an error")
+            raise RuntimeError("Google Lens OCR retry loop exhausted without an error")
+
+        return asyncio.run(recognize())
 
     @staticmethod
     def _raise_if_request_error(lines: list[str]):
@@ -296,7 +342,7 @@ class GoogleLensRecognizer:
         """
         for line in lines:
             if "Request error (possibly proxy-related)".casefold() in line.casefold():
-                raise RuntimeError(f"Google Lens request error: {line}")
+                raise _GoogleLensRequestError(f"Google Lens request error: {line}")
 
     @staticmethod
     def _save_lens_lines(lines: list[str], cache_path: Path):

--- a/scinoephile/image/ocr/lens/google_lens_recognizer.py
+++ b/scinoephile/image/ocr/lens/google_lens_recognizer.py
@@ -14,7 +14,7 @@ from typing import Any, cast, override
 
 from PIL import Image
 
-from scinoephile.common.validation import val_output_dir_path
+from scinoephile.common.validation import val_int, val_output_dir_path
 
 __all__ = ["GoogleLensRecognizer"]
 
@@ -34,17 +34,20 @@ class GoogleLensRecognizer:
         *,
         cache_dir_path: Path | None = None,
         language: str = "en",
+        retries: int = 3,
     ):
         """Initialize.
 
         Arguments:
             cache_dir_path: directory in which to cache OCR results
             language: Google Lens OCR language code
+            retries: Google Lens OCR request attempts per uncached image
         """
         self.cache_dir_path = None
         if cache_dir_path is not None:
             self.cache_dir_path = val_output_dir_path(cache_dir_path)
         self.language = language
+        self.retries = val_int(retries, min_value=1)
         self._api = self._get_lens_api_class()()
 
     @override
@@ -53,7 +56,8 @@ class GoogleLensRecognizer:
         return (
             f"{self.__class__.__name__}("
             f"cache_dir_path={self.cache_dir_path!r}, "
-            f"language={self.language!r})"
+            f"language={self.language!r}, "
+            f"retries={self.retries!r})"
         )
 
     def recognize_image(self, image: Image.Image) -> str:
@@ -72,15 +76,13 @@ class GoogleLensRecognizer:
                 return self._format_lens_lines(lines)
 
             self._raise_if_running_loop()
-            lines = asyncio.run(self._recognize_image_uncached(image))
-            self._raise_if_request_error(lines)
+            lines = self._recognize_image_with_retries(image)
             self._save_lens_lines(lines, cache_path)
             logger.info(f"Saved Google Lens OCR result to cache: {cache_path}")
             return self._format_lens_lines(lines)
 
         self._raise_if_running_loop()
-        lines = asyncio.run(self._recognize_image_uncached(image))
-        self._raise_if_request_error(lines)
+        lines = self._recognize_image_with_retries(image)
         return self._format_lens_lines(lines)
 
     def _get_cache_path(self, image: Image.Image) -> Path | None:
@@ -264,6 +266,32 @@ class GoogleLensRecognizer:
             output_format="lines",
         )
         return self._normalize_lens_result(result)
+
+    def _recognize_image_with_retries(self, image: Image.Image) -> list[str]:
+        """Recognize uncached image text, retrying transient Lens failures.
+
+        Arguments:
+            image: input image
+        Returns:
+            normalized OCR lines
+        Raises:
+            Exception: last error raised by Google Lens OCR after retries
+        """
+        for attempt in range(1, self.retries + 1):
+            try:
+                lines = asyncio.run(self._recognize_image_uncached(image))
+                self._raise_if_request_error(lines)
+            except Exception as exc:
+                if attempt == self.retries:
+                    raise
+                logger.warning(
+                    f"Google Lens OCR attempt {attempt} of {self.retries} failed; "
+                    f"retrying: {exc}"
+                )
+            else:
+                return lines
+
+        raise RuntimeError("Google Lens OCR retry loop exhausted without an error")
 
     @staticmethod
     def _raise_if_request_error(lines: list[str]):

--- a/scinoephile/image/ocr/lens/google_lens_recognizer.py
+++ b/scinoephile/image/ocr/lens/google_lens_recognizer.py
@@ -76,13 +76,13 @@ class GoogleLensRecognizer:
                 return self._format_lens_lines(lines)
 
             self._raise_if_running_loop()
-            lines = self._recognize_image_with_retries(image)
+            lines = self._recognize_image_uncached(image)
             self._save_lens_lines(lines, cache_path)
             logger.info(f"Saved Google Lens OCR result to cache: {cache_path}")
             return self._format_lens_lines(lines)
 
         self._raise_if_running_loop()
-        lines = self._recognize_image_with_retries(image)
+        lines = self._recognize_image_uncached(image)
         return self._format_lens_lines(lines)
 
     def _get_cache_path(self, image: Image.Image) -> Path | None:
@@ -251,24 +251,8 @@ class GoogleLensRecognizer:
             "active asyncio event loop."
         )
 
-    async def _recognize_image_uncached(self, image: Image.Image) -> list[str]:
+    def _recognize_image_uncached(self, image: Image.Image) -> list[str]:
         """Recognize uncached image text through chrome-lens-py.
-
-        Arguments:
-            image: input image
-        Returns:
-            normalized OCR lines
-        """
-        result = await self._api.process_image(
-            image_path=image,
-            ocr_language=self.language,
-            ocr_preserve_line_breaks=True,
-            output_format="lines",
-        )
-        return self._normalize_lens_result(result)
-
-    def _recognize_image_with_retries(self, image: Image.Image) -> list[str]:
-        """Recognize uncached image text, retrying transient Lens failures.
 
         Arguments:
             image: input image
@@ -279,7 +263,15 @@ class GoogleLensRecognizer:
         """
         for attempt in range(1, self.retries + 1):
             try:
-                lines = asyncio.run(self._recognize_image_uncached(image))
+                result = asyncio.run(
+                    self._api.process_image(
+                        image_path=image,
+                        ocr_language=self.language,
+                        ocr_preserve_line_breaks=True,
+                        output_format="lines",
+                    )
+                )
+                lines = self._normalize_lens_result(result)
                 self._raise_if_request_error(lines)
             except Exception as exc:
                 if attempt == self.retries:

--- a/test/cli/ocr/test_ocr_cli.py
+++ b/test/cli/ocr/test_ocr_cli.py
@@ -71,8 +71,8 @@ def _write_placeholder_sup_path(tmp_path: Path) -> Path:
     return infile_path
 
 
-def test_ocr_lens_cli_help_lists_language_option_only():
-    """Test Google Lens CLI help lists language but not transport options."""
+def test_ocr_lens_cli_help_lists_language_and_retry_options_only():
+    """Test Google Lens CLI help lists supported operation options."""
     stdout = StringIO()
     stderr = StringIO()
     with pytest.raises(SystemExit) as excinfo:
@@ -84,6 +84,7 @@ def test_ocr_lens_cli_help_lists_language_option_only():
     assert stderr.getvalue() == ""
     help_text = " ".join(stdout.getvalue().split())
     assert "--language" in help_text
+    assert "--retries" in help_text
     assert "--api-key" not in help_text
     assert "--client-region" not in help_text
     assert "--client-time-zone" not in help_text
@@ -110,6 +111,7 @@ def test_ocr_lens_cli_converts_image_subtitles_to_srt(
         tiny_image_series,
     )
     input_path = _write_placeholder_sup_path(tmp_path)
+    observed_kwargs = []
 
     def fake_ocr_image_series_with_lens(*args: object, **kwargs: object) -> Series:
         """Fake Google Lens image series processing.
@@ -120,6 +122,7 @@ def test_ocr_lens_cli_converts_image_subtitles_to_srt(
         Returns:
             text subtitle series
         """
+        observed_kwargs.append(kwargs)
         return Series(events=[Subtitle(start=1000, end=2000, text="recognized")])
 
     monkeypatch.setattr(
@@ -130,10 +133,11 @@ def test_ocr_lens_cli_converts_image_subtitles_to_srt(
     output_path = tmp_path / "ocr.srt"
     run_cli_with_args(
         OcrLensCli,
-        f"--infile {input_path} --outfile {output_path}",
+        f"--infile {input_path} --outfile {output_path} --language zh-CN --retries 5",
     )
 
     assert input_paths == [input_path.resolve()]
+    assert observed_kwargs == [{"language": "zh-CN", "retries": 5}]
     output = Series.load(output_path)
     assert [(event.start, event.end, event.text) for event in output] == [
         (1000, 2000, "recognized")

--- a/test/image/ocr/lens/test_lens_engine.py
+++ b/test/image/ocr/lens/test_lens_engine.py
@@ -29,6 +29,7 @@ class CountingGoogleLensRecognizer(GoogleLensRecognizer):
         """
         self.cache_dir_path = cache_dir_path
         self.language = "en"
+        self.retries = 3
         self.predict_count = 0
 
     async def _recognize_image_uncached(self, image: Image.Image) -> list[str]:
@@ -150,7 +151,72 @@ def test_google_lens_recognizer_does_not_cache_request_errors(tmp_path: Path):
     with pytest.raises(RuntimeError, match="Google Lens request error"):
         recognizer.recognize_image(image)
 
-    assert recognizer.predict_count == 1
+    assert recognizer.predict_count == 3
+    assert not list(tmp_path.glob("*.json"))
+
+
+def test_google_lens_recognizer_retries_request_errors_before_caching(tmp_path: Path):
+    """Test Google Lens retries transient request errors before caching success."""
+
+    class RetryRecognizer(CountingGoogleLensRecognizer):
+        """Google Lens recognizer that succeeds after request errors."""
+
+        async def _recognize_image_uncached(self, image: Image.Image) -> list[str]:
+            """Run fake Google Lens recognition.
+
+            Arguments:
+                image: input image
+            Returns:
+                normalized OCR lines
+            """
+            self.predict_count += 1
+            if self.predict_count < 3:
+                return ["Request error (possibly proxy-related): 502 Bad Gateway"]
+            return ["recognized"]
+
+    recognizer = RetryRecognizer(cache_dir_path=tmp_path)
+    recognizer.retries = 3
+    image = Image.new("RGBA", (10, 8), (255, 255, 255, 0))
+
+    assert recognizer.recognize_image(image) == "recognized"
+
+    assert recognizer.predict_count == 3
+    assert len(list(tmp_path.glob("*.json"))) == 1
+
+
+def test_google_lens_recognizer_raises_last_request_error_after_retries(
+    tmp_path: Path,
+):
+    """Test Google Lens raises the last request error after retry exhaustion.
+
+    Arguments:
+        tmp_path: temporary path fixture
+    """
+
+    class RequestErrorRecognizer(CountingGoogleLensRecognizer):
+        """Google Lens recognizer that always returns a request error."""
+
+        async def _recognize_image_uncached(self, image: Image.Image) -> list[str]:
+            """Run fake Google Lens recognition.
+
+            Arguments:
+                image: input image
+            Returns:
+                normalized OCR lines
+            """
+            self.predict_count += 1
+            return [
+                f"Request error (possibly proxy-related): attempt {self.predict_count}"
+            ]
+
+    recognizer = RequestErrorRecognizer(cache_dir_path=tmp_path)
+    recognizer.retries = 3
+    image = Image.new("RGBA", (10, 8), (255, 255, 255, 0))
+
+    with pytest.raises(RuntimeError, match="attempt 3"):
+        recognizer.recognize_image(image)
+
+    assert recognizer.predict_count == 3
     assert not list(tmp_path.glob("*.json"))
 
 
@@ -265,6 +331,7 @@ def test_google_lens_recognizer_reuses_lens_api_client_per_instance(
     monkeypatch.setitem(sys.modules, "chrome_lens_py", chrome_lens_py)
     recognizer = GoogleLensRecognizer()
 
+    assert recognizer.retries == 3
     assert recognizer.recognize_image(Image.new("RGBA", (10, 8))) == "recognized"
     assert recognizer.recognize_image(Image.new("RGBA", (12, 9))) == "recognized"
 

--- a/test/image/ocr/lens/test_lens_engine.py
+++ b/test/image/ocr/lens/test_lens_engine.py
@@ -18,28 +18,36 @@ from PIL import Image
 from scinoephile.image.ocr.lens.google_lens_recognizer import GoogleLensRecognizer
 
 
+class FakeLensApiError(RuntimeError):
+    """Fake chrome-lens-py LensAPIError."""
+
+
 class CountingGoogleLensRecognizer(GoogleLensRecognizer):
     """Google Lens recognizer that counts uncached predictions."""
 
     def __init__(
         self,
         cache_dir_path: Path | None = None,
+        exceptions: list[Exception | None] | None = None,
         results: list[list[str]] | None = None,
     ):
         """Initialize.
 
         Arguments:
             cache_dir_path: directory in which to cache OCR results
+            exceptions: exceptions to raise from subsequent recognitions
             results: normalized OCR lines to return from subsequent recognitions
         """
         self.cache_dir_path = cache_dir_path
         self.language = "en"
         self.retries = 3
         self.predict_count = 0
+        self.exceptions = exceptions
         if results is None:
             results = [["cached", "text"]]
         self.results = results
         self._api = self
+        self._lens_api_error_class = FakeLensApiError
 
     async def process_image(self, **kwargs: object) -> dict[str, object]:
         """Process an image.
@@ -50,8 +58,38 @@ class CountingGoogleLensRecognizer(GoogleLensRecognizer):
             fake LensAPI result
         """
         self.predict_count += 1
+        if self.exceptions is not None:
+            exception_index = min(self.predict_count - 1, len(self.exceptions) - 1)
+            exception = self.exceptions[exception_index]
+            if exception is not None:
+                raise exception
         result_index = min(self.predict_count - 1, len(self.results) - 1)
         return {"ocr_text": "\n".join(self.results[result_index])}
+
+
+def patch_google_lens_sleep(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    """Patch Google Lens retry sleeps and capture their delays.
+
+    Arguments:
+        monkeypatch: pytest monkeypatch fixture
+    Returns:
+        captured sleep delays
+    """
+    delays = []
+
+    async def fake_sleep(delay: float):
+        """Capture retry sleep delay.
+
+        Arguments:
+            delay: requested sleep delay
+        """
+        delays.append(delay)
+
+    monkeypatch.setattr(
+        "scinoephile.image.ocr.lens.google_lens_recognizer.asyncio.sleep",
+        fake_sleep,
+    )
+    return delays
 
 
 def test_clean_google_lens_text_ignores_empty_and_error_messages():
@@ -138,8 +176,17 @@ def test_google_lens_recognizer_formats_cached_results(tmp_path: Path):
     assert recognizer.predict_count == 1
 
 
-def test_google_lens_recognizer_does_not_cache_request_errors(tmp_path: Path):
-    """Test transient Google Lens request errors are not cached as empty OCR."""
+def test_google_lens_recognizer_does_not_cache_request_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    """Test transient Google Lens request errors are not cached as empty OCR.
+
+    Arguments:
+        monkeypatch: pytest monkeypatch fixture
+        tmp_path: temporary path fixture
+    """
+    patch_google_lens_sleep(monkeypatch)
     recognizer = CountingGoogleLensRecognizer(
         cache_dir_path=tmp_path,
         results=[["Request error (possibly proxy-related)"]],
@@ -153,8 +200,17 @@ def test_google_lens_recognizer_does_not_cache_request_errors(tmp_path: Path):
     assert not list(tmp_path.glob("*.json"))
 
 
-def test_google_lens_recognizer_retries_request_errors_before_caching(tmp_path: Path):
-    """Test Google Lens retries transient request errors before caching success."""
+def test_google_lens_recognizer_retries_request_errors_before_caching(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    """Test Google Lens retries transient request errors before caching success.
+
+    Arguments:
+        monkeypatch: pytest monkeypatch fixture
+        tmp_path: temporary path fixture
+    """
+    patch_google_lens_sleep(monkeypatch)
     recognizer = CountingGoogleLensRecognizer(
         cache_dir_path=tmp_path,
         results=[
@@ -173,13 +229,16 @@ def test_google_lens_recognizer_retries_request_errors_before_caching(tmp_path: 
 
 
 def test_google_lens_recognizer_raises_last_request_error_after_retries(
+    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ):
     """Test Google Lens raises the last request error after retry exhaustion.
 
     Arguments:
+        monkeypatch: pytest monkeypatch fixture
         tmp_path: temporary path fixture
     """
+    patch_google_lens_sleep(monkeypatch)
     recognizer = CountingGoogleLensRecognizer(
         cache_dir_path=tmp_path,
         results=[
@@ -196,6 +255,110 @@ def test_google_lens_recognizer_raises_last_request_error_after_retries(
 
     assert recognizer.predict_count == 3
     assert not list(tmp_path.glob("*.json"))
+
+
+def test_google_lens_recognizer_retries_in_one_asyncio_run(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test Google Lens retries within one asyncio.run call.
+
+    Arguments:
+        monkeypatch: pytest monkeypatch fixture
+    """
+    real_asyncio_run = asyncio.run
+    run_count = 0
+    patch_google_lens_sleep(monkeypatch)
+
+    def counting_run(main: Any, **kwargs: Any) -> Any:
+        """Count asyncio.run calls.
+
+        Arguments:
+            main: awaitable to run
+            **kwargs: asyncio.run keyword arguments
+        Returns:
+            asyncio.run result
+        """
+        nonlocal run_count
+        run_count += 1
+        return real_asyncio_run(main, **kwargs)
+
+    monkeypatch.setattr(
+        "scinoephile.image.ocr.lens.google_lens_recognizer.asyncio.run",
+        counting_run,
+    )
+    recognizer = CountingGoogleLensRecognizer(
+        results=[
+            ["Request error (possibly proxy-related): 502 Bad Gateway"],
+            ["Request error (possibly proxy-related): 502 Bad Gateway"],
+            ["recognized"],
+        ],
+    )
+    image = Image.new("RGBA", (10, 8), (255, 255, 255, 0))
+
+    assert recognizer.recognize_image(image) == "recognized"
+
+    assert run_count == 1
+    assert recognizer.predict_count == 3
+
+
+def test_google_lens_recognizer_waits_between_transient_retries(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test Google Lens waits before retrying transient failures.
+
+    Arguments:
+        monkeypatch: pytest monkeypatch fixture
+    """
+    delays = patch_google_lens_sleep(monkeypatch)
+    recognizer = CountingGoogleLensRecognizer(
+        results=[
+            ["Request error (possibly proxy-related): 502 Bad Gateway"],
+            ["Request error (possibly proxy-related): 502 Bad Gateway"],
+            ["recognized"],
+        ],
+    )
+    image = Image.new("RGBA", (10, 8), (255, 255, 255, 0))
+
+    assert recognizer.recognize_image(image) == "recognized"
+
+    assert delays == [1.5, 1.5]
+
+
+def test_google_lens_recognizer_retries_lens_api_errors(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test Google Lens retries transient chrome-lens-py API errors.
+
+    Arguments:
+        monkeypatch: pytest monkeypatch fixture
+    """
+    patch_google_lens_sleep(monkeypatch)
+    recognizer = CountingGoogleLensRecognizer(
+        exceptions=[
+            FakeLensApiError("502 Bad Gateway"),
+            FakeLensApiError("502 Bad Gateway"),
+            None,
+        ],
+        results=[["recognized"]],
+    )
+    image = Image.new("RGBA", (10, 8), (255, 255, 255, 0))
+
+    assert recognizer.recognize_image(image) == "recognized"
+
+    assert recognizer.predict_count == 3
+
+
+def test_google_lens_recognizer_does_not_retry_nontransient_errors():
+    """Test Google Lens does not retry deterministic API errors."""
+    recognizer = CountingGoogleLensRecognizer(
+        exceptions=[ValueError("deterministic failure")],
+    )
+    image = Image.new("RGBA", (10, 8), (255, 255, 255, 0))
+
+    with pytest.raises(ValueError, match="deterministic failure"):
+        recognizer.recognize_image(image)
+
+    assert recognizer.predict_count == 1
 
 
 def test_google_lens_recognizer_rejects_uncached_calls_in_async_loop(
@@ -306,6 +469,7 @@ def test_google_lens_recognizer_reuses_lens_api_client_per_instance(
 
     chrome_lens_py = ModuleType("chrome_lens_py")
     setattr(chrome_lens_py, "LensAPI", FakeLensApi)
+    setattr(chrome_lens_py, "LensAPIError", FakeLensApiError)
     monkeypatch.setitem(sys.modules, "chrome_lens_py", chrome_lens_py)
     recognizer = GoogleLensRecognizer()
 

--- a/test/image/ocr/lens/test_lens_engine.py
+++ b/test/image/ocr/lens/test_lens_engine.py
@@ -21,27 +21,37 @@ from scinoephile.image.ocr.lens.google_lens_recognizer import GoogleLensRecogniz
 class CountingGoogleLensRecognizer(GoogleLensRecognizer):
     """Google Lens recognizer that counts uncached predictions."""
 
-    def __init__(self, cache_dir_path: Path | None = None):
+    def __init__(
+        self,
+        cache_dir_path: Path | None = None,
+        results: list[list[str]] | None = None,
+    ):
         """Initialize.
 
         Arguments:
             cache_dir_path: directory in which to cache OCR results
+            results: normalized OCR lines to return from subsequent recognitions
         """
         self.cache_dir_path = cache_dir_path
         self.language = "en"
         self.retries = 3
         self.predict_count = 0
+        if results is None:
+            results = [["cached", "text"]]
+        self.results = results
+        self._api = self
 
-    async def _recognize_image_uncached(self, image: Image.Image) -> list[str]:
-        """Run fake Google Lens recognition.
+    async def process_image(self, **kwargs: object) -> dict[str, object]:
+        """Process an image.
 
         Arguments:
-            image: input image
+            **kwargs: process image keyword arguments
         Returns:
-            normalized OCR lines
+            fake LensAPI result
         """
         self.predict_count += 1
-        return ["cached", "text"]
+        result_index = min(self.predict_count - 1, len(self.results) - 1)
+        return {"ocr_text": "\n".join(self.results[result_index])}
 
 
 def test_clean_google_lens_text_ignores_empty_and_error_messages():
@@ -130,22 +140,10 @@ def test_google_lens_recognizer_formats_cached_results(tmp_path: Path):
 
 def test_google_lens_recognizer_does_not_cache_request_errors(tmp_path: Path):
     """Test transient Google Lens request errors are not cached as empty OCR."""
-
-    class RequestErrorRecognizer(CountingGoogleLensRecognizer):
-        """Google Lens recognizer that returns a request error."""
-
-        async def _recognize_image_uncached(self, image: Image.Image) -> list[str]:
-            """Run fake Google Lens recognition.
-
-            Arguments:
-                image: input image
-            Returns:
-                normalized OCR lines
-            """
-            self.predict_count += 1
-            return ["Request error (possibly proxy-related)"]
-
-    recognizer = RequestErrorRecognizer(cache_dir_path=tmp_path)
+    recognizer = CountingGoogleLensRecognizer(
+        cache_dir_path=tmp_path,
+        results=[["Request error (possibly proxy-related)"]],
+    )
     image = Image.new("RGBA", (10, 8), (255, 255, 255, 0))
 
     with pytest.raises(RuntimeError, match="Google Lens request error"):
@@ -157,24 +155,14 @@ def test_google_lens_recognizer_does_not_cache_request_errors(tmp_path: Path):
 
 def test_google_lens_recognizer_retries_request_errors_before_caching(tmp_path: Path):
     """Test Google Lens retries transient request errors before caching success."""
-
-    class RetryRecognizer(CountingGoogleLensRecognizer):
-        """Google Lens recognizer that succeeds after request errors."""
-
-        async def _recognize_image_uncached(self, image: Image.Image) -> list[str]:
-            """Run fake Google Lens recognition.
-
-            Arguments:
-                image: input image
-            Returns:
-                normalized OCR lines
-            """
-            self.predict_count += 1
-            if self.predict_count < 3:
-                return ["Request error (possibly proxy-related): 502 Bad Gateway"]
-            return ["recognized"]
-
-    recognizer = RetryRecognizer(cache_dir_path=tmp_path)
+    recognizer = CountingGoogleLensRecognizer(
+        cache_dir_path=tmp_path,
+        results=[
+            ["Request error (possibly proxy-related): 502 Bad Gateway"],
+            ["Request error (possibly proxy-related): 502 Bad Gateway"],
+            ["recognized"],
+        ],
+    )
     recognizer.retries = 3
     image = Image.new("RGBA", (10, 8), (255, 255, 255, 0))
 
@@ -192,24 +180,14 @@ def test_google_lens_recognizer_raises_last_request_error_after_retries(
     Arguments:
         tmp_path: temporary path fixture
     """
-
-    class RequestErrorRecognizer(CountingGoogleLensRecognizer):
-        """Google Lens recognizer that always returns a request error."""
-
-        async def _recognize_image_uncached(self, image: Image.Image) -> list[str]:
-            """Run fake Google Lens recognition.
-
-            Arguments:
-                image: input image
-            Returns:
-                normalized OCR lines
-            """
-            self.predict_count += 1
-            return [
-                f"Request error (possibly proxy-related): attempt {self.predict_count}"
-            ]
-
-    recognizer = RequestErrorRecognizer(cache_dir_path=tmp_path)
+    recognizer = CountingGoogleLensRecognizer(
+        cache_dir_path=tmp_path,
+        results=[
+            ["Request error (possibly proxy-related): attempt 1"],
+            ["Request error (possibly proxy-related): attempt 2"],
+            ["Request error (possibly proxy-related): attempt 3"],
+        ],
+    )
     recognizer.retries = 3
     image = Image.new("RGBA", (10, 8), (255, 255, 255, 0))
 

--- a/test/image/ocr/lens/test_lens_series.py
+++ b/test/image/ocr/lens/test_lens_series.py
@@ -82,6 +82,7 @@ def test_ocr_image_series_with_lens_uses_runtime_cache(
     """
     cache_dir_path = tmp_path / "cache"
     observed_cache_dir_paths = []
+    observed_retries = []
 
     class FakeDefaultRecognizer(FakeRecognizer):
         """Fake default recognizer with cache directory tracking."""
@@ -91,15 +92,18 @@ def test_ocr_image_series_with_lens_uses_runtime_cache(
             *,
             cache_dir_path: Path | None = None,
             language: str = "en",
+            retries: int = 3,
         ):
             """Initialize.
 
             Arguments:
                 cache_dir_path: directory in which to cache OCR results
                 language: Google Lens OCR language code
+                retries: Google Lens OCR request attempts per uncached image
             """
             super().__init__([language])
             observed_cache_dir_paths.append(cache_dir_path)
+            observed_retries.append(retries)
 
     monkeypatch.setattr(
         "scinoephile.image.ocr.lens.get_runtime_cache_dir_path",
@@ -122,7 +126,9 @@ def test_ocr_image_series_with_lens_uses_runtime_cache(
     text_series = ocr_image_series_with_lens(
         image_series,
         language="zh-CN",
+        retries=5,
     )
 
     assert [event.text for event in text_series] == ["zh-CN"]
     assert observed_cache_dir_paths == [cache_dir_path]
+    assert observed_retries == [5]


### PR DESCRIPTION
## Summary

- Add configurable retry attempts for uncached Google Lens OCR calls, defaulting to 3 attempts per image.
- Expose the retry count through `ocr lens --retries` with validation that the value is at least 1.
- Keep existing cache semantics: cached images are not retried, successful uncached results are saved, and exhausted request errors are not cached.

## Why

Google Lens can return transient upstream request failures such as 502 Bad Gateway. Previously a single transient failure stopped the run, requiring a manual rerun. This change retries the failing uncached image in-process while preserving the existing per-image cache resume behavior.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/image/ocr/lens/google_lens_recognizer.py scinoephile/image/ocr/lens/__init__.py scinoephile/cli/ocr/ocr_lens_cli.py test/image/ocr/lens/test_lens_engine.py test/image/ocr/lens/test_lens_series.py test/cli/ocr/test_ocr_cli.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/image/ocr/lens/google_lens_recognizer.py scinoephile/image/ocr/lens/__init__.py scinoephile/cli/ocr/ocr_lens_cli.py test/image/ocr/lens/test_lens_engine.py test/image/ocr/lens/test_lens_series.py test/cli/ocr/test_ocr_cli.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/image/ocr/lens/google_lens_recognizer.py scinoephile/image/ocr/lens/__init__.py scinoephile/cli/ocr/ocr_lens_cli.py test/image/ocr/lens/test_lens_engine.py test/image/ocr/lens/test_lens_series.py test/cli/ocr/test_ocr_cli.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest image/ocr/lens/test_lens_engine.py image/ocr/lens/test_lens_series.py cli/ocr/test_ocr_cli.py -q` (`24 passed, 4 skipped`)
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` (`986 passed, 10 skipped`)