### PR TITLE
Fix CLI overwrite parsing

### DIFF
--- a/scinoephile/cli/eng/eng_process_cli.py
+++ b/scinoephile/cli/eng/eng_process_cli.py
@@ -137,7 +137,7 @@ class EngProcessCli(ScinoephileCliBase):
             "--outfile",
             default=None,
             dest="outfile_path",
-            type=output_file_arg(),
+            type=output_file_arg(exist_ok=True),
             help="English subtitle outfile path (default: stdout)",
         )
         arg_groups["output arguments"].add_argument(

--- a/scinoephile/cli/eng/eng_translate_vs_zho_cli.py
+++ b/scinoephile/cli/eng/eng_translate_vs_zho_cli.py
@@ -163,7 +163,7 @@ class EngTranslateVsZhoCli(ScinoephileCliBase):
             "--outfile",
             default=None,
             dest="outfile_path",
-            type=output_file_arg(),
+            type=output_file_arg(exist_ok=True),
             help="English subtitle outfile path (default: stdout)",
         )
         arg_groups["output arguments"].add_argument(

--- a/scinoephile/cli/multi/multi_timewarp_cli.py
+++ b/scinoephile/cli/multi/multi_timewarp_cli.py
@@ -146,7 +146,7 @@ class MultiTimewarpCli(ScinoephileCliBase):
             "--outfile",
             default=None,
             dest="outfile_path",
-            type=output_file_arg(),
+            type=output_file_arg(exist_ok=True),
             help="timewarped subtitle outfile path (default: stdout)",
         )
         arg_groups["output arguments"].add_argument(

--- a/scinoephile/cli/ocr/ocr_fuse_cli.py
+++ b/scinoephile/cli/ocr/ocr_fuse_cli.py
@@ -172,7 +172,7 @@ class OcrFuseCli(ScinoephileCliBase):
             "--outfile",
             default=None,
             dest="outfile_path",
-            type=output_file_arg(),
+            type=output_file_arg(exist_ok=True),
             help="fused subtitle outfile path (default: stdout)",
         )
         arg_groups["output arguments"].add_argument(

--- a/scinoephile/cli/yue/yue_process_cli.py
+++ b/scinoephile/cli/yue/yue_process_cli.py
@@ -183,7 +183,7 @@ class YueProcessCli(ScinoephileCliBase):
             "--outfile",
             default=None,
             dest="outfile_path",
-            type=output_file_arg(),
+            type=output_file_arg(exist_ok=True),
             help="Written Cantonese subtitle outfile path (default: stdout)",
         )
         arg_groups["output arguments"].add_argument(

--- a/scinoephile/cli/yue/yue_review_vs_zho_cli.py
+++ b/scinoephile/cli/yue/yue_review_vs_zho_cli.py
@@ -161,7 +161,7 @@ class YueReviewVsZhoCli(ScinoephileCliBase):
             "--outfile",
             default=None,
             dest="outfile_path",
-            type=output_file_arg(),
+            type=output_file_arg(exist_ok=True),
             help="reviewed written Cantonese subtitle outfile path (default: stdout)",
         )
         arg_groups["output arguments"].add_argument(

--- a/scinoephile/cli/yue/yue_transcribe_vs_zho_cli.py
+++ b/scinoephile/cli/yue/yue_transcribe_vs_zho_cli.py
@@ -201,7 +201,7 @@ class YueTranscribeVsZhoCli(ScinoephileCliBase):
             "--outfile",
             default=None,
             dest="outfile_path",
-            type=output_file_arg(),
+            type=output_file_arg(exist_ok=True),
             help="Written Cantonese subtitle outfile path (default: stdout)",
         )
         arg_groups["output arguments"].add_argument(

--- a/scinoephile/cli/yue/yue_translate_vs_zho_cli.py
+++ b/scinoephile/cli/yue/yue_translate_vs_zho_cli.py
@@ -189,7 +189,7 @@ class YueTranslateVsZhoCli(ScinoephileCliBase):
             "--outfile",
             default=None,
             dest="outfile_path",
-            type=output_file_arg(),
+            type=output_file_arg(exist_ok=True),
             help="written Cantonese subtitle outfile path (default: stdout)",
         )
         arg_groups["output arguments"].add_argument(

--- a/scinoephile/cli/zho/zho_process_cli.py
+++ b/scinoephile/cli/zho/zho_process_cli.py
@@ -183,7 +183,7 @@ class ZhoProcessCli(ScinoephileCliBase):
             "--outfile",
             default=None,
             dest="outfile_path",
-            type=output_file_arg(),
+            type=output_file_arg(exist_ok=True),
             help="Standard Chinese subtitle outfile path (default: stdout)",
         )
         arg_groups["output arguments"].add_argument(

--- a/scinoephile/common/argument_parsing.py
+++ b/scinoephile/common/argument_parsing.py
@@ -217,11 +217,11 @@ def get_validator[T](function: Callable[..., T], **kwargs: Any) -> Callable[[Any
         Returns:
             Validated value
         Raises:
-            ArgumentTypeError: If TypeError or ValueError is raised by wrapped function
+            ArgumentTypeError: If validation raises a user-facing error
         """
         try:
             return function(value, **kwargs)
-        except (TypeError, ValueError) as exc:
+        except (OSError, TypeError, ValueError) as exc:
             raise ArgumentTypeError(str(exc)) from exc
 
     return wrapped

--- a/test/cli/ocr/test_ocr_fuse_eng_cli.py
+++ b/test/cli/ocr/test_ocr_fuse_eng_cli.py
@@ -117,3 +117,34 @@ def test_ocr_fuse_eng_cli_writes_stdout(tmp_path: Path):
 
     output = Series.from_string(stdout_stream.getvalue(), format_="srt")
     assert_series_equal(output, fused)
+
+
+def test_ocr_fuse_eng_cli_overwrites_existing_file(tmp_path: Path):
+    """Test English OCR fuse CLI overwrites existing output files."""
+    lens_path = tmp_path / "lens.srt"
+    tesseract_path = tmp_path / "tesseract.srt"
+    output_path = tmp_path / "fused.srt"
+    _write_series(lens_path, "lens")
+    _write_series(tesseract_path, "tesseract")
+    output_path.write_text("existing\n", encoding="utf-8")
+    fused = Series.from_string(
+        "1\n00:00:00,000 --> 00:00:01,000\nfused\n",
+        format_="srt",
+    )
+
+    with (
+        patch("scinoephile.cli.ocr.ocr_fuse_cli.get_provider"),
+        patch("scinoephile.cli.ocr.ocr_fuse_cli.get_eng_ocr_fuser"),
+        patch(
+            "scinoephile.cli.ocr.ocr_fuse_cli.get_eng_ocr_fused",
+            return_value=fused,
+        ),
+    ):
+        run_cli_with_args(
+            OcrFuseCli,
+            f"--language eng --lens-infile {lens_path} "
+            f"--tesseract-infile {tesseract_path} --outfile {output_path} "
+            "--overwrite",
+        )
+
+    assert_series_equal(Series.load(output_path), fused)

--- a/test/cli/test_overwrite_argparse.py
+++ b/test/cli/test_overwrite_argparse.py
@@ -1,0 +1,150 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests of CLI overwrite argument parsing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scinoephile.cli.eng.eng_process_cli import EngProcessCli
+from scinoephile.cli.eng.eng_translate_vs_zho_cli import EngTranslateVsZhoCli
+from scinoephile.cli.multi.multi_timewarp_cli import MultiTimewarpCli
+from scinoephile.cli.ocr.ocr_fuse_cli import OcrFuseCli
+from scinoephile.cli.yue.yue_process_cli import YueProcessCli
+from scinoephile.cli.yue.yue_review_vs_zho_cli import YueReviewVsZhoCli
+from scinoephile.cli.yue.yue_transcribe_vs_zho_cli import YueTranscribeVsZhoCli
+from scinoephile.cli.yue.yue_translate_vs_zho_cli import YueTranslateVsZhoCli
+from scinoephile.cli.zho.zho_process_cli import ZhoProcessCli
+from scinoephile.common import CommandLineInterface
+
+
+@pytest.mark.parametrize(
+    ("cli_class", "args_template"),
+    [
+        (
+            EngProcessCli,
+            [
+                "--infile",
+                "{infile}",
+                "--clean",
+                "--outfile",
+                "{outfile}",
+                "--overwrite",
+            ],
+        ),
+        (
+            ZhoProcessCli,
+            [
+                "--infile",
+                "{infile}",
+                "--clean",
+                "--outfile",
+                "{outfile}",
+                "--overwrite",
+            ],
+        ),
+        (
+            YueProcessCli,
+            [
+                "--infile",
+                "{infile}",
+                "--clean",
+                "--outfile",
+                "{outfile}",
+                "--overwrite",
+            ],
+        ),
+        (
+            EngTranslateVsZhoCli,
+            ["--zho-infile", "{infile}", "--outfile", "{outfile}", "--overwrite"],
+        ),
+        (
+            YueTranslateVsZhoCli,
+            ["--zho-infile", "{infile}", "--outfile", "{outfile}", "--overwrite"],
+        ),
+        (
+            YueReviewVsZhoCli,
+            [
+                "--yue-infile",
+                "{infile}",
+                "--zho-infile",
+                "{infile}",
+                "--outfile",
+                "{outfile}",
+                "--overwrite",
+            ],
+        ),
+        (
+            YueTranscribeVsZhoCli,
+            [
+                "--media-infile",
+                "{infile}",
+                "--zho-infile",
+                "{infile}",
+                "--outfile",
+                "{outfile}",
+                "--overwrite",
+            ],
+        ),
+        (
+            MultiTimewarpCli,
+            [
+                "--anchor-infile",
+                "{infile}",
+                "--mobile-infile",
+                "{infile}",
+                "--outfile",
+                "{outfile}",
+                "--overwrite",
+            ],
+        ),
+        (
+            OcrFuseCli,
+            [
+                "--language",
+                "eng",
+                "--lens-infile",
+                "{infile}",
+                "--tesseract-infile",
+                "{infile}",
+                "--outfile",
+                "{outfile}",
+                "--overwrite",
+            ],
+        ),
+    ],
+    ids=[
+        "eng-process",
+        "zho-process",
+        "yue-process",
+        "eng-translate-vs-zho",
+        "yue-translate-vs-zho",
+        "yue-review-vs-zho",
+        "yue-transcribe-vs-zho",
+        "multi-timewarp",
+        "ocr-fuse",
+    ],
+)
+def test_overwrite_allows_existing_outfile_during_argument_parsing(
+    tmp_path: Path,
+    cli_class: type[CommandLineInterface],
+    args_template: list[str],
+):
+    """Test overwrite-capable CLIs accept existing outfiles during parsing."""
+    infile_path = tmp_path / "input.srt"
+    outfile_path = tmp_path / "output.srt"
+    infile_path.write_text(
+        "1\n00:00:00,000 --> 00:00:01,000\ninput\n", encoding="utf-8"
+    )
+    outfile_path.write_text("existing\n", encoding="utf-8")
+    args = [
+        arg.format(infile=str(infile_path), outfile=str(outfile_path))
+        for arg in args_template
+    ]
+
+    namespace = cli_class.argparser().parse_args(args)
+
+    assert namespace.outfile_path == outfile_path.resolve()
+    assert namespace.overwrite is True

--- a/test/common/argument_parsing/test_get_validator.py
+++ b/test/common/argument_parsing/test_get_validator.py
@@ -50,3 +50,24 @@ def test_get_validator_type_error():
 
     with pytest.raises(ArgumentTypeError):
         validator("test")
+
+
+def test_get_validator_os_error():
+    """Test get_validator converts OSError to ArgumentTypeError."""
+
+    def failing_func(value: str) -> str:
+        """Function that raises OSError.
+
+        Arguments:
+            value: input value
+        Returns:
+            validated value
+        Raises:
+            OSError: always
+        """
+        raise OSError("Invalid path")
+
+    validator = get_validator(failing_func)
+
+    with pytest.raises(ArgumentTypeError, match="Invalid path"):
+        validator("test")

--- a/test/common/argument_parsing/test_validators.py
+++ b/test/common/argument_parsing/test_validators.py
@@ -19,7 +19,6 @@ from scinoephile.common.argument_parsing import (
     output_file_arg,
     str_arg,
 )
-from scinoephile.common.exceptions import DirectoryNotFoundError
 
 
 def test_float_arg():
@@ -67,8 +66,7 @@ def test_input_file_arg(tmp_path: Path):
     assert isinstance(result, Path)
     assert result.exists()
 
-    # FileNotFoundError is not caught by get_validator
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(ArgumentTypeError, match="does not exist"):
         validator(str(tmp_path / "nonexistent.txt"))
 
 
@@ -84,7 +82,7 @@ def test_input_file_or_dir_arg(tmp_path: Path):
     assert validator(str(test_file)) == test_file.resolve()
     assert validator(str(test_dir)) == test_dir.resolve()
 
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(ArgumentTypeError, match="does not exist"):
         validator(str(tmp_path / "nonexistent"))
 
 
@@ -99,8 +97,7 @@ def test_input_dir_arg(tmp_path: Path):
     assert isinstance(result, Path)
     assert result.is_dir()
 
-    # DirectoryNotFoundError is not caught by get_validator
-    with pytest.raises(DirectoryNotFoundError):
+    with pytest.raises(ArgumentTypeError, match="does not exist"):
         validator(str(tmp_path / "nonexistent"))
 
 
@@ -113,6 +110,17 @@ def test_output_file_arg(tmp_path: Path):
     result = validator(str(test_file))
     assert isinstance(result, Path)
     assert result.parent.exists()
+
+
+def test_output_file_arg_rejects_existing_file_with_argparse_error(tmp_path: Path):
+    """Test output_file_arg reports existing files as argparse errors."""
+    test_file = tmp_path / "output.txt"
+    test_file.write_text("existing", encoding="utf-8")
+
+    validator = output_file_arg()
+
+    with pytest.raises(ArgumentTypeError, match="already exists"):
+        validator(str(test_file))
 
 
 def test_output_dir_arg(tmp_path: Path):
@@ -148,5 +156,5 @@ def test_output_dir_arg_without_create_rejects_file_ancestor(tmp_path: Path):
 
     validator = output_dir_arg(create=False)
 
-    with pytest.raises(NotADirectoryError):
+    with pytest.raises(ArgumentTypeError, match="is not a directory"):
         validator(str(test_dir))


### PR DESCRIPTION
## Summary
- Allow overwrite-capable CLI outfile arguments to parse existing files, then leave overwrite enforcement to command execution.
- Convert filesystem validation failures from argument validators into clean argparse errors instead of tracebacks.
- Add regression coverage for the affected overwrite CLI surface and OCR fuse overwrite behavior.

## Root Cause
`--outfile` arguments on several commands used `output_file_arg()` with the default `exist_ok=False`, so argparse rejected existing paths before `_main` could inspect `--overwrite`.

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format ...`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix ...`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check ...`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` (`996 passed, 10 skipped`)