### PR TITLE
Support EIA-608 subtitle extraction

### DIFF
--- a/scinoephile/core/media/constants.py
+++ b/scinoephile/core/media/constants.py
@@ -9,6 +9,7 @@ __all__ = ["SUBTITLE_CODEC_OUTPUTS"]
 SUBTITLE_CODEC_OUTPUTS = {
     "ass": ("ass", "ass"),
     "dvd_subtitle": ("sub", "copy"),
+    "eia_608": ("srt", "subrip"),
     "hdmv_pgs_subtitle": ("sup", "copy"),
     "mov_text": ("srt", "subrip"),
     "ssa": ("ssa", "ass"),

--- a/scinoephile/lang/eng/cleaning.py
+++ b/scinoephile/lang/eng/cleaning.py
@@ -42,10 +42,14 @@ def _get_english_text_cleaned(text: str) -> str | None:
         Cleaned text, or None if no text remains
     """
     line_sep = "\\N"
-    cleaned = text.strip()
+    cleaned = text.replace("\xa0", " ").strip()
 
     # Remove ASS hard-space \h
     cleaned = re.sub(r"\\h", "", cleaned)
+
+    # Remove extraction markup from EIA-608 captions
+    cleaned = re.sub(r"</?font\b[^>]*>", "", cleaned, flags=re.IGNORECASE)
+    cleaned = re.sub(r"\{\\an\d+\}", "", cleaned)
 
     # Remove closed caption annotations ([...])
     cleaned = re.sub(r"\[.*?][^\S\n]*", "", cleaned, flags=re.DOTALL).strip()

--- a/scinoephile/lang/zho/cleaning.py
+++ b/scinoephile/lang/zho/cleaning.py
@@ -43,7 +43,11 @@ def _get_zho_text_cleaned(text: str) -> str | None:
         Cleaned text
     """
     line_sep = r"\N"
-    cleaned = text.strip()
+    cleaned = text.replace("\xa0", " ").strip()
+
+    # Remove extraction markup before punctuation normalization
+    cleaned = re.sub(r"</?font\b[^>]*>", "", cleaned, flags=re.IGNORECASE)
+    cleaned = re.sub(r"\{\\an\d+\}", "", cleaned)
 
     cleaned_lines = []
     for raw_line in cleaned.split(line_sep):

--- a/test/core/media/test_streams.py
+++ b/test/core/media/test_streams.py
@@ -84,6 +84,15 @@ def test_subtitle_stream_outfile_filename():
     assert stream.outfile_filename == "eng-2.srt"
 
 
+def test_subtitle_stream_supports_eia_608_output():
+    """Test EIA-608 subtitles are extracted as SubRip SRT files."""
+    stream = SubtitleStream(index=19, language="eng", codec_name="eia_608")
+
+    assert stream.extension == "srt"
+    assert stream.output_codec == "subrip"
+    assert stream.outfile_filename == "eng-19.srt"
+
+
 def test_subtitle_stream_outfile_filename_requires_language():
     """Test subtitle stream output filename rejects missing language."""
     stream = SubtitleStream(index=2, language=None, codec_name="subrip")

--- a/test/lang/eng/test_get_eng_cleaned.py
+++ b/test/lang/eng/test_get_eng_cleaned.py
@@ -27,6 +27,13 @@ def test_get_english_text_cleaned_removes_ass_dash_only_line():
     assert _get_english_text_cleaned("hello\\N-\\Nworld") == "hello\\Nworld"
 
 
+def test_get_english_text_cleaned_removes_eia_608_markup():
+    """Test EIA-608 extraction markup is removed from English text."""
+    text = '<font face="Monospace">{\\an7}WOODY:\xa0Look out!</font>'
+
+    assert _get_english_text_cleaned(text) == "WOODY: Look out!"
+
+
 def test_get_eng_cleaned_kob(
     kob_eng_ocr_fuse: Series,
     kob_eng_ocr_fuse_clean: Series,

--- a/test/lang/zho/test_get_zho_cleaned.py
+++ b/test/lang/zho/test_get_zho_cleaned.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from scinoephile.core.subtitles import Series
-from scinoephile.lang.zho.cleaning import get_zho_cleaned
+from scinoephile.lang.zho.cleaning import _get_zho_text_cleaned, get_zho_cleaned
 from test.helpers import assert_series_equal
 
 
@@ -18,6 +18,13 @@ def _test_get_zho_cleaned(series: Series, expected: Series):
     """
     output = get_zho_cleaned(series, remove_empty=False)
     assert_series_equal(output, expected)
+
+
+def test_get_zho_text_cleaned_removes_subtitle_markup():
+    """Test subtitle extraction markup is removed from standard Chinese text."""
+    text = '<font face="Monospace">{\\an7}中文\xa0測試</font>'
+
+    assert _get_zho_text_cleaned(text) == "中文 測試"
 
 
 def test_get_zho_cleaned_kob(


### PR DESCRIPTION
## Summary

- Add `eia_608` to the subtitle codec output map so media subtitle extraction writes SRT via ffmpeg `subrip`.
- Strip EIA-608 extraction markup from English subtitle cleaning, including font wrappers, ASS positioning tags, and NBSPs.
- Strip subtitle extraction markup from Chinese text cleaning before punctuation normalization so font wrappers and positioning tags do not become full-width text.
- Add regression coverage for the codec mapping and cleaned English and Chinese extraction markup.

## Root Cause

`SubtitleStream.output_codec` and `SubtitleStream.extension` rely on `SUBTITLE_CODEC_OUTPUTS`, but `eia_608` was not listed there, so extraction raised `Unsupported subtitle codec eia_608` even though ffmpeg can transcode it to SubRip.

While validating the Toy Story Chinese subtitle stream, the normal extract/load/clean path removed font tags, but direct Chinese text cleaning did not explicitly strip `&lt;font ...&gt;`, `&lt;/font&gt;`, and `{\an#}` markup before punctuation normalization. That meant markup could be converted into full-width visible text if it reached `_get_zho_text_cleaned` directly.

## Real-File Validation

Using `/Volumes/Backup/Video/HK iTunes/Toy Story.mp4`:

- English EIA-608 stream `0:19` extracts successfully to SRT through Scinoephile.
- Chinese stream `0:9` extracts and cleans successfully.
- The raw Chinese extraction contained 52 font opening/closing tags.
- After `Series.load(...)` plus `get_zho_cleaned(...)`, cleaned output contained 0 ASCII font tags and 0 full-width font tags.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format --check scinoephile/core/media/constants.py scinoephile/lang/eng/cleaning.py scinoephile/lang/zho/cleaning.py test/core/media/test_streams.py test/lang/eng/test_get_eng_cleaned.py test/lang/zho/test_get_zho_cleaned.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check scinoephile/core/media/constants.py scinoephile/lang/eng/cleaning.py scinoephile/lang/zho/cleaning.py test/core/media/test_streams.py test/lang/eng/test_get_eng_cleaned.py test/lang/zho/test_get_zho_cleaned.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/core/media/constants.py scinoephile/lang/eng/cleaning.py scinoephile/lang/zho/cleaning.py test/core/media/test_streams.py test/lang/eng/test_get_eng_cleaned.py test/lang/zho/test_get_zho_cleaned.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` (`1026 passed, 10 skipped`)