### PR TITLE
Harden style audit checks

### DIFF
--- a/skills/audit-style/scripts/audit_style.py
+++ b/skills/audit-style/scripts/audit_style.py
@@ -38,6 +38,12 @@ COPYRIGHT_LINE_TWO_RE = re.compile(
 RST_DOUBLE_BACKTICK_RE = re.compile(r"``[^`]+``")
 """Regex matching reStructuredText-style double backticks."""
 
+PERCENT_INTERPOLATION_RE = re.compile(
+    r"(?<!%)%(?!%)(?:\([^)]+\))?[#0\- +]*(?:\d+|\*)?"
+    r"(?:\.(?:\d+|\*))?[hlL]?[diouxXeEfFgGcrsa]"
+)
+"""Regex matching percent-style string interpolation placeholders."""
+
 EXEMPT_RETURN_NONE_NAMES = {"__init__"}
 """Function names allowed to omit a return annotation despite no returned value."""
 
@@ -51,6 +57,7 @@ EXCLUDED_DIR_NAMES = {
     "__pycache__",
     "build",
     "dist",
+    "local",
 }
 """Directory names excluded from recursive source scans."""
 
@@ -560,6 +567,14 @@ def _audit_string_interpolation(
             node.lineno,
             "uses `%` interpolation; prefer f-strings",
         )
+    if isinstance(node, ast.Call) and _is_percent_interpolation_call(node):
+        _add_note(
+            notes,
+            file_path,
+            "Strings",
+            node.lineno,
+            "uses `%` interpolation arguments; prefer f-strings",
+        )
 
 
 def _audit_print_call(
@@ -973,6 +988,24 @@ def _is_overload(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
     return "overload" in _decorator_names(node)
 
 
+def _is_percent_interpolation_call(node: ast.Call) -> bool:
+    """Check whether a call uses percent-style string interpolation arguments.
+
+    Arguments:
+        node: call node
+    Returns:
+        whether the call has a percent-format template followed by values
+    """
+    if len(node.args) < 2:
+        return False
+    template_node = node.args[0]
+    if not isinstance(template_node, ast.Constant):
+        return False
+    if not isinstance(template_node.value, str):
+        return False
+    return PERCENT_INTERPOLATION_RE.search(template_node.value) is not None
+
+
 def _is_cli_module(file_path: Path) -> bool:
     """Check whether a file belongs to the CLI package.
 
@@ -1212,7 +1245,7 @@ def audit_file(file_path: Path, notes: dict[str, list[StyleNote]]):
         file_path: source file path
         notes: notes keyed by POSIX path
     """
-    text = file_path.read_text()
+    text = file_path.read_text(encoding="utf-8")
     lines = text.splitlines()
     stripped = text.strip()
     package_name = _package_name_for(file_path)

--- a/test/test_audit_style.py
+++ b/test/test_audit_style.py
@@ -1,0 +1,170 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests of the style audit helper script."""
+
+from __future__ import annotations
+
+import importlib.util
+from collections import defaultdict
+from collections.abc import Callable
+from pathlib import Path
+from types import ModuleType
+from typing import Protocol, cast
+
+import pytest
+
+REPO_DIR_PATH = Path(__file__).resolve().parents[1]
+AUDIT_STYLE_PATH = REPO_DIR_PATH / "skills/audit-style/scripts/audit_style.py"
+COPYRIGHT_LINE_ONE = (
+    "#  Copyright 2017-2026 Karl T Debiec. All rights reserved. "
+    "This software may be modified"
+)
+COPYRIGHT_LINE_TWO = (
+    "#  and distributed under the terms of the BSD license. "
+    "See the LICENSE file for details."
+)
+
+
+class StyleNoteLike(Protocol):
+    """Protocol for style audit notes loaded from the audit script."""
+
+    category: str
+    """Style category."""
+
+    line_number: int
+    """Source line number."""
+
+    message: str
+    """Note text."""
+
+
+AuditFile = Callable[[Path, dict[str, list[StyleNoteLike]]], None]
+GetPythonFiles = Callable[[Path], list[Path]]
+
+
+def test_get_python_files_excludes_local_directory(tmp_path: Path):
+    """Test local scratch files are excluded from recursive style audits."""
+    source_path = tmp_path / "scinoephile/source.py"
+    local_path = tmp_path / "local/scratch.py"
+    source_path.parent.mkdir()
+    local_path.parent.mkdir()
+    source_path.write_text("", encoding="utf-8")
+    local_path.write_text("", encoding="utf-8")
+
+    file_paths = get_python_files()(tmp_path)
+
+    assert file_paths == [source_path]
+
+
+def test_audit_file_reads_source_as_utf8(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Test source files are read with explicit UTF-8 encoding."""
+    source_path = write_source(tmp_path / "sample.py", '"""Café."""')
+    original_read_text = Path.read_text
+
+    def read_text(
+        path: Path, encoding: str | None = None, errors: str | None = None
+    ) -> str:
+        """Require audit source reads to pass explicit UTF-8 encoding."""
+        if path == source_path and encoding != "utf-8":
+            raise AssertionError("expected explicit UTF-8 source read")
+        return original_read_text(path, encoding=encoding, errors=errors)
+
+    monkeypatch.setattr(Path, "read_text", read_text)
+    notes: dict[str, list[StyleNoteLike]] = defaultdict(list)
+
+    audit_file()(source_path, notes)
+
+
+def test_audit_file_flags_percent_interpolation_arguments(tmp_path: Path):
+    """Test audit flags logging-style percent interpolation arguments."""
+    source_path = write_source(
+        tmp_path / "sample.py",
+        "\n".join(
+            [
+                '"""Sample module."""',
+                "",
+                "from __future__ import annotations",
+                "",
+                "",
+                "def render(name: str) -> str:",
+                '    """Render a name."""',
+                '    logger.warning("hello %s", name)',
+                '    return f"hello {name}"',
+            ]
+        ),
+    )
+    notes: dict[str, list[StyleNoteLike]] = defaultdict(list)
+
+    audit_file()(source_path, notes)
+
+    assert get_string_note_messages(notes) == [
+        "uses `%` interpolation arguments; prefer f-strings"
+    ]
+
+
+def audit_file() -> AuditFile:
+    """Get the audit-file function from the audit script.
+
+    Returns:
+        audit-file function
+    """
+    return cast(AuditFile, getattr(get_audit_style_module(), "audit_file"))
+
+
+def get_audit_style_module() -> ModuleType:
+    """Load the audit-style helper module.
+
+    Returns:
+        loaded audit-style module
+    """
+    spec = importlib.util.spec_from_file_location("audit_style", AUDIT_STYLE_PATH)
+    if spec is None or spec.loader is None:
+        pytest.fail(f"Could not load audit script at {AUDIT_STYLE_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def get_python_files() -> GetPythonFiles:
+    """Get the get-python-files function from the audit script.
+
+    Returns:
+        get-python-files function
+    """
+    return cast(GetPythonFiles, getattr(get_audit_style_module(), "get_python_files"))
+
+
+def get_string_note_messages(
+    notes: dict[str, list[StyleNoteLike]],
+) -> list[str]:
+    """Get string style note messages from audit notes.
+
+    Arguments:
+        notes: style notes by file
+    Returns:
+        string style note messages
+    """
+    return [
+        note.message
+        for file_notes in notes.values()
+        for note in file_notes
+        if note.category == "Strings"
+    ]
+
+
+def write_source(source_path: Path, body: str) -> Path:
+    """Write a Python source file with the repository copyright header.
+
+    Arguments:
+        source_path: path to write
+        body: source body after the copyright header
+    Returns:
+        written source path
+    """
+    source_path.write_text(
+        "\n".join([COPYRIGHT_LINE_ONE, COPYRIGHT_LINE_TWO, body]) + "\n",
+        encoding="utf-8",
+    )
+    return source_path


### PR DESCRIPTION
## Summary
- Add focused pytest coverage for the style audit script behavior
- Exclude `local` from recursive audit scans
- Read audited source files as UTF-8 explicitly
- Flag logging-style percent interpolation arguments in the audit script

## Validation
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` — 1031 passed, 10 skipped