### PR TITLE
Add OCR process input cleaning

### DIFF
--- a/scinoephile/cli/ocr/ocr_process_cli.py
+++ b/scinoephile/cli/ocr/ocr_process_cli.py
@@ -37,6 +37,7 @@ OCR_PROCESS_LOCALIZATIONS: dict[str, dict[str, str]] = {
     "zh-hans": {
         "cache directory for extracted media subtitle artifacts (default: "
         "%(default)s)": "提取媒体字幕产物的缓存目录（默认：%(default)s）",
+        "clean OCR subtitle outputs before fusing": "在融合前清理 OCR 字幕输出",
         "directory where OCR processing outputs will be written": (
             "写入 OCR 处理输出的目录"
         ),
@@ -62,6 +63,7 @@ OCR_PROCESS_LOCALIZATIONS: dict[str, dict[str, str]] = {
     "zh-hant": {
         "cache directory for extracted media subtitle artifacts (default: "
         "%(default)s)": "提取媒體字幕產物的快取目錄（預設：%(default)s）",
+        "clean OCR subtitle outputs before fusing": "在融合前清理 OCR 字幕輸出",
         "directory where OCR processing outputs will be written": (
             "寫入 OCR 處理輸出的目錄"
         ),
@@ -145,6 +147,11 @@ class OcrProcessCli(ScinoephileCliBase):
             help="script for standard Chinese OCR (default: simplified)",
         )
         arg_groups["operation arguments"].add_argument(
+            "--clean",
+            action="store_true",
+            help="clean OCR subtitle outputs before fusing",
+        )
+        arg_groups["operation arguments"].add_argument(
             "--cache-dir",
             default=cache_dir_path_arg("media", "subtitles"),
             dest="cache_dir_path",
@@ -197,6 +204,7 @@ class OcrProcessCli(ScinoephileCliBase):
         stream_index: int | None,
         language: str,
         script: ChineseScript | None,
+        clean: bool,
         cache_dir_path: Path,
         llm_provider_name: str,
         llm_model_name: str | None,
@@ -223,6 +231,7 @@ class OcrProcessCli(ScinoephileCliBase):
                     output_dir_path=output_dir_path,
                     stream_index=stream_index,
                     cache_dir_path=cache_dir_path,
+                    clean=clean,
                     export_images=export_images,
                     overwrite=overwrite,
                     provider=provider,
@@ -235,6 +244,7 @@ class OcrProcessCli(ScinoephileCliBase):
                     stream_index=stream_index,
                     cache_dir_path=cache_dir_path,
                     script=script or "simplified",
+                    clean=clean,
                     export_images=export_images,
                     overwrite=overwrite,
                     provider=provider,

--- a/scinoephile/cli/ocr/ocr_process_cli.py
+++ b/scinoephile/cli/ocr/ocr_process_cli.py
@@ -23,9 +23,9 @@ from scinoephile.common.argument_parsing import (
 from scinoephile.core import ScinoephileError
 from scinoephile.core.cli import ScinoephileCliBase
 from scinoephile.core.cli.localization import merge_localizations
+from scinoephile.core.text import ChineseScript
 from scinoephile.llms.providers.registry import get_provider
 from scinoephile.workflows.ocr_processing import (
-    ChineseScript,
     OcrProcessingResult,
     process_eng_ocr,
     process_zho_ocr,

--- a/scinoephile/core/text.py
+++ b/scinoephile/core/text.py
@@ -9,10 +9,12 @@ import unicodedata
 from enum import Enum
 from functools import cache
 from textwrap import dedent
+from typing import Literal
 
 from .exceptions import ScinoephileError
 
 __all__ = [
+    "ChineseScript",
     "half_punc",
     "full_punc",
     "whitespace",
@@ -32,6 +34,10 @@ __all__ = [
     "remove_non_punc_and_whitespace",
     "remove_punc_and_whitespace",
 ]
+
+
+type ChineseScript = Literal["simplified", "traditional"]
+"""Chinese script supported by text processing helpers."""
 
 
 class AnsiColor(Enum):

--- a/scinoephile/image/ocr/lens/__init__.py
+++ b/scinoephile/image/ocr/lens/__init__.py
@@ -9,6 +9,7 @@ from typing import cast
 
 from scinoephile.core.paths import get_runtime_cache_dir_path
 from scinoephile.core.subtitles import Series, Subtitle
+from scinoephile.core.text import ChineseScript
 from scinoephile.image.subtitles import ImageSeries, ImageSubtitle
 
 from .google_lens_recognizer import GoogleLensRecognizer
@@ -16,6 +17,7 @@ from .google_lens_recognizer import GoogleLensRecognizer
 __all__ = [
     "GoogleLensRecognizer",
     "get_google_lens_recognizer",
+    "get_lens_zho_code",
     "ocr_image_series_with_lens",
 ]
 
@@ -41,6 +43,24 @@ def get_google_lens_recognizer(
         cache_dir_path=cache_dir_path,
         language=language,
         retries=retries,
+    )
+
+
+def get_lens_zho_code(script: ChineseScript) -> str:
+    """Get the Google Lens language code for a Chinese script.
+
+    Arguments:
+        script: Chinese script
+    Returns:
+        Google Lens language code
+    """
+    if script == "simplified":
+        return "zh-CN"
+    if script == "traditional":
+        return "zh-TW"
+    raise ValueError(
+        f"{script!r} is not one of the supported Chinese scripts: "
+        "simplified, traditional"
     )
 
 

--- a/scinoephile/image/ocr/paddle/__init__.py
+++ b/scinoephile/image/ocr/paddle/__init__.py
@@ -15,6 +15,7 @@ from typing import TypedDict, Unpack, cast
 
 from scinoephile.core.paths import get_runtime_cache_dir_path
 from scinoephile.core.subtitles import Series, Subtitle
+from scinoephile.core.text import ChineseScript
 from scinoephile.image.subtitles import ImageSeries, ImageSubtitle
 
 from .paddle_ocr_recognizer import PaddleOcrRecognizer
@@ -24,6 +25,7 @@ __all__ = [
     "PaddleOcrRecognizer",
     "PaddleOcrRecognizerKwargs",
     "get_paddle_ocr_recognizer",
+    "get_paddle_zho_code",
     "ocr_image_series_with_paddle",
 ]
 
@@ -54,6 +56,24 @@ def get_paddle_ocr_recognizer(
     if cache_dir_path is None:
         cache_dir_path = get_runtime_cache_dir_path("paddleocr")
     return PaddleOcrRecognizer(cache_dir_path=cache_dir_path, **kwargs)
+
+
+def get_paddle_zho_code(script: ChineseScript) -> str:
+    """Get the PaddleOCR language code for a Chinese script.
+
+    Arguments:
+        script: Chinese script
+    Returns:
+        PaddleOCR language code
+    """
+    if script == "simplified":
+        return "ch"
+    if script == "traditional":
+        return "chinese_cht"
+    raise ValueError(
+        f"{script!r} is not one of the supported Chinese scripts: "
+        "simplified, traditional"
+    )
 
 
 def ocr_image_series_with_paddle(

--- a/scinoephile/workflows/ocr_processing.py
+++ b/scinoephile/workflows/ocr_processing.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from logging import getLogger, info
 from pathlib import Path
@@ -17,7 +18,9 @@ from scinoephile.image.ocr.lens import ocr_image_series_with_lens
 from scinoephile.image.ocr.paddle import ocr_image_series_with_paddle
 from scinoephile.image.ocr.tesseract import ocr_image_series_with_tesseract
 from scinoephile.image.subtitles import ImageSeries
+from scinoephile.lang.eng.cleaning import get_eng_cleaned
 from scinoephile.lang.eng.ocr_fusion import get_eng_ocr_fused, get_eng_ocr_fuser
+from scinoephile.lang.zho.cleaning import get_zho_cleaned
 from scinoephile.lang.zho.ocr_fusion import get_zho_ocr_fused, get_zho_ocr_fuser
 from scinoephile.media.probe import get_subtitle_streams
 from scinoephile.media.subtitles.cache import (
@@ -57,6 +60,7 @@ def process_eng_ocr(  # noqa: PLR0912
     stream_index: int | None = None,
     cache_dir_path: Path | None = None,
     export_images: bool = False,
+    clean: bool = False,
     overwrite: bool = False,
     provider: LLMProvider | None = None,
     additional_context: str | None = None,
@@ -69,6 +73,7 @@ def process_eng_ocr(  # noqa: PLR0912
         stream_index: media subtitle stream index when infile is media
         cache_dir_path: media subtitle cache directory path
         export_images: whether to export OCR outputs as image subtitle directories
+        clean: whether to clean OCR subtitle outputs before fusing
         overwrite: whether to overwrite existing workflow outputs
         provider: provider to use for OCR fusion queries
         additional_context: additional context to include in OCR fusion prompts
@@ -113,6 +118,30 @@ def process_eng_ocr(  # noqa: PLR0912
         tesseract.save(tesseract_path, format_="srt")
     output_paths["tesseract"] = tesseract_path
 
+    # Clean provider outputs
+    fusion_lens = lens
+    fusion_tesseract = tesseract
+    if clean:
+        lens_clean_path = output_dir_path / "lens_clean.srt"
+        fusion_lens = _get_cleaned_ocr_output(
+            lens,
+            lens_clean_path,
+            "Lens",
+            overwrite=overwrite,
+            cleaner=lambda series: get_eng_cleaned(series, remove_empty=False),
+        )
+        output_paths["lens_clean"] = lens_clean_path
+
+        tesseract_clean_path = output_dir_path / "tesseract_clean.srt"
+        fusion_tesseract = _get_cleaned_ocr_output(
+            tesseract,
+            tesseract_clean_path,
+            "Tesseract",
+            overwrite=overwrite,
+            cleaner=lambda series: get_eng_cleaned(series, remove_empty=False),
+        )
+        output_paths["tesseract_clean"] = tesseract_clean_path
+
     # Fusion
     fuse_path = output_dir_path / "fuse.srt"
     if fuse_path.exists() and not overwrite:
@@ -122,7 +151,7 @@ def process_eng_ocr(  # noqa: PLR0912
             provider=provider,
             additional_context=additional_context,
         )
-        fuse = get_eng_ocr_fused(lens, tesseract, processor=fuser)
+        fuse = get_eng_ocr_fused(fusion_lens, fusion_tesseract, processor=fuser)
         fuse.save(fuse_path, format_="srt")
     output_paths["fuse"] = fuse_path
 
@@ -141,6 +170,7 @@ def process_zho_ocr(  # noqa: PLR0912
     cache_dir_path: Path | None = None,
     script: ChineseScript = "simplified",
     export_images: bool = False,
+    clean: bool = False,
     overwrite: bool = False,
     provider: LLMProvider | None = None,
     additional_context: str | None = None,
@@ -154,23 +184,14 @@ def process_zho_ocr(  # noqa: PLR0912
         cache_dir_path: media subtitle cache directory path
         script: Chinese script to OCR, either simplified or traditional
         export_images: whether to export OCR outputs as image subtitle directories
+        clean: whether to clean OCR subtitle outputs before fusing
         overwrite: whether to overwrite existing workflow outputs
         provider: provider to use for OCR fusion queries
         additional_context: additional context to include in OCR fusion prompts
     Returns:
         OCR processing result
     """
-    if script == "simplified":
-        lens_language = "zh-CN"
-        paddle_language = "ch"
-    elif script == "traditional":
-        lens_language = "zh-TW"
-        paddle_language = "chinese_cht"
-    else:
-        raise ValueError(
-            f"{script!r} is not one of the supported Chinese scripts: "
-            "simplified, traditional"
-        )
+    lens_language, paddle_language = _get_zho_ocr_language_codes(script)
 
     # Read inputs
     image_series = _load_image_series(infile_path, stream_index, cache_dir_path)
@@ -210,6 +231,30 @@ def process_zho_ocr(  # noqa: PLR0912
         paddle.save(paddle_path, format_="srt")
     output_paths["paddle"] = paddle_path
 
+    # Clean provider outputs
+    fusion_lens = lens
+    fusion_paddle = paddle
+    if clean:
+        lens_clean_path = output_dir_path / "lens_clean.srt"
+        fusion_lens = _get_cleaned_ocr_output(
+            lens,
+            lens_clean_path,
+            "Lens",
+            overwrite=overwrite,
+            cleaner=lambda series: get_zho_cleaned(series, remove_empty=False),
+        )
+        output_paths["lens_clean"] = lens_clean_path
+
+        paddle_clean_path = output_dir_path / "paddle_clean.srt"
+        fusion_paddle = _get_cleaned_ocr_output(
+            paddle,
+            paddle_clean_path,
+            "PaddleOCR",
+            overwrite=overwrite,
+            cleaner=lambda series: get_zho_cleaned(series, remove_empty=False),
+        )
+        output_paths["paddle_clean"] = paddle_clean_path
+
     # Fusion
     fuse_path = output_dir_path / "fuse.srt"
     if fuse_path.exists() and not overwrite:
@@ -219,7 +264,7 @@ def process_zho_ocr(  # noqa: PLR0912
             provider=provider,
             additional_context=additional_context,
         )
-        fuse = get_zho_ocr_fused(lens, paddle, processor=fuser)
+        fuse = get_zho_ocr_fused(fusion_lens, fusion_paddle, processor=fuser)
         fuse.save(fuse_path, format_="srt")
     output_paths["fuse"] = fuse_path
 
@@ -228,6 +273,34 @@ def process_zho_ocr(  # noqa: PLR0912
         output_dir_path=output_dir_path,
         output_paths=output_paths,
     )
+
+
+def _get_cleaned_ocr_output(
+    series: Series,
+    outfile_path: Path,
+    output_name: str,
+    *,
+    overwrite: bool,
+    cleaner: Callable[[Series], Series],
+) -> Series:
+    """Get cleaned OCR output from an existing file or a source series.
+
+    Arguments:
+        series: source OCR subtitle series
+        outfile_path: cleaned OCR output file path
+        output_name: name of the OCR output for log messages
+        overwrite: whether to overwrite existing cleaned output
+        cleaner: function used to clean the source series
+    Returns:
+        cleaned OCR subtitle series
+    """
+    if outfile_path.exists() and not overwrite:
+        logger.info(f"Cleaned {output_name} OCR output exists: {outfile_path}")
+        return Series.load(outfile_path)
+
+    cleaned = cleaner(series)
+    cleaned.save(outfile_path, format_="srt")
+    return cleaned
 
 
 def _get_media_subtitle_stream(
@@ -253,6 +326,24 @@ def _get_media_subtitle_stream(
                 )
             return stream
     raise ScinoephileError(f"No subtitle stream {stream_index} found in {infile_path}")
+
+
+def _get_zho_ocr_language_codes(script: ChineseScript) -> tuple[str, str]:
+    """Get Google Lens and PaddleOCR language codes for a Chinese script.
+
+    Arguments:
+        script: Chinese script to OCR
+    Returns:
+        Google Lens and PaddleOCR language codes
+    """
+    if script == "simplified":
+        return "zh-CN", "ch"
+    if script == "traditional":
+        return "zh-TW", "chinese_cht"
+    raise ValueError(
+        f"{script!r} is not one of the supported Chinese scripts: "
+        "simplified, traditional"
+    )
 
 
 def _load_image_series(

--- a/scinoephile/workflows/ocr_processing.py
+++ b/scinoephile/workflows/ocr_processing.py
@@ -8,14 +8,17 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from logging import getLogger, info
 from pathlib import Path
-from typing import Literal
 
 from scinoephile.core import ScinoephileError
 from scinoephile.core.llms import LLMProvider
 from scinoephile.core.media import SubtitleStream
 from scinoephile.core.subtitles import Series
-from scinoephile.image.ocr.lens import ocr_image_series_with_lens
-from scinoephile.image.ocr.paddle import ocr_image_series_with_paddle
+from scinoephile.core.text import ChineseScript
+from scinoephile.image.ocr.lens import get_lens_zho_code, ocr_image_series_with_lens
+from scinoephile.image.ocr.paddle import (
+    get_paddle_zho_code,
+    ocr_image_series_with_paddle,
+)
 from scinoephile.image.ocr.tesseract import ocr_image_series_with_tesseract
 from scinoephile.image.subtitles import ImageSeries
 from scinoephile.lang.eng.cleaning import get_eng_cleaned
@@ -29,16 +32,12 @@ from scinoephile.media.subtitles.cache import (
 )
 
 __all__ = [
-    "ChineseScript",
     "OcrProcessingResult",
     "process_eng_ocr",
     "process_zho_ocr",
 ]
 
 logger = getLogger(__name__)
-
-type ChineseScript = Literal["simplified", "traditional"]
-"""Chinese script supported by standard Chinese OCR processing."""
 
 
 @dataclass(frozen=True)
@@ -191,7 +190,8 @@ def process_zho_ocr(  # noqa: PLR0912
     Returns:
         OCR processing result
     """
-    lens_language, paddle_language = _get_zho_ocr_language_codes(script)
+    lens_language = get_lens_zho_code(script)
+    paddle_language = get_paddle_zho_code(script)
 
     # Read inputs
     image_series = _load_image_series(infile_path, stream_index, cache_dir_path)
@@ -326,24 +326,6 @@ def _get_media_subtitle_stream(
                 )
             return stream
     raise ScinoephileError(f"No subtitle stream {stream_index} found in {infile_path}")
-
-
-def _get_zho_ocr_language_codes(script: ChineseScript) -> tuple[str, str]:
-    """Get Google Lens and PaddleOCR language codes for a Chinese script.
-
-    Arguments:
-        script: Chinese script to OCR
-    Returns:
-        Google Lens and PaddleOCR language codes
-    """
-    if script == "simplified":
-        return "zh-CN", "ch"
-    if script == "traditional":
-        return "zh-TW", "chinese_cht"
-    raise ValueError(
-        f"{script!r} is not one of the supported Chinese scripts: "
-        "simplified, traditional"
-    )
 
 
 def _load_image_series(

--- a/scinoephile/workflows/ocr_processing.py
+++ b/scinoephile/workflows/ocr_processing.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from dataclasses import dataclass
 from logging import getLogger, info
 from pathlib import Path
@@ -52,7 +51,7 @@ class OcrProcessingResult:
     """Output paths keyed by output name."""
 
 
-def process_eng_ocr(  # noqa: PLR0912
+def process_eng_ocr(  # noqa: PLR0912, PLR0915
     infile_path: Path,
     output_dir_path: Path,
     *,
@@ -122,23 +121,21 @@ def process_eng_ocr(  # noqa: PLR0912
     fusion_tesseract = tesseract
     if clean:
         lens_clean_path = output_dir_path / "lens_clean.srt"
-        fusion_lens = _get_cleaned_ocr_output(
-            lens,
-            lens_clean_path,
-            "Lens",
-            overwrite=overwrite,
-            cleaner=lambda series: get_eng_cleaned(series, remove_empty=False),
-        )
+        if lens_clean_path.exists() and not overwrite:
+            logger.info(f"Cleaned Lens OCR output exists: {lens_clean_path}")
+            fusion_lens = Series.load(lens_clean_path)
+        else:
+            fusion_lens = get_eng_cleaned(lens, remove_empty=False)
+            fusion_lens.save(lens_clean_path, format_="srt")
         output_paths["lens_clean"] = lens_clean_path
 
         tesseract_clean_path = output_dir_path / "tesseract_clean.srt"
-        fusion_tesseract = _get_cleaned_ocr_output(
-            tesseract,
-            tesseract_clean_path,
-            "Tesseract",
-            overwrite=overwrite,
-            cleaner=lambda series: get_eng_cleaned(series, remove_empty=False),
-        )
+        if tesseract_clean_path.exists() and not overwrite:
+            logger.info(f"Cleaned Tesseract OCR output exists: {tesseract_clean_path}")
+            fusion_tesseract = Series.load(tesseract_clean_path)
+        else:
+            fusion_tesseract = get_eng_cleaned(tesseract, remove_empty=False)
+            fusion_tesseract.save(tesseract_clean_path, format_="srt")
         output_paths["tesseract_clean"] = tesseract_clean_path
 
     # Fusion
@@ -161,7 +158,7 @@ def process_eng_ocr(  # noqa: PLR0912
     )
 
 
-def process_zho_ocr(  # noqa: PLR0912
+def process_zho_ocr(  # noqa: PLR0912, PLR0915
     infile_path: Path,
     output_dir_path: Path,
     *,
@@ -236,23 +233,21 @@ def process_zho_ocr(  # noqa: PLR0912
     fusion_paddle = paddle
     if clean:
         lens_clean_path = output_dir_path / "lens_clean.srt"
-        fusion_lens = _get_cleaned_ocr_output(
-            lens,
-            lens_clean_path,
-            "Lens",
-            overwrite=overwrite,
-            cleaner=lambda series: get_zho_cleaned(series, remove_empty=False),
-        )
+        if lens_clean_path.exists() and not overwrite:
+            logger.info(f"Cleaned Lens OCR output exists: {lens_clean_path}")
+            fusion_lens = Series.load(lens_clean_path)
+        else:
+            fusion_lens = get_zho_cleaned(lens, remove_empty=False)
+            fusion_lens.save(lens_clean_path, format_="srt")
         output_paths["lens_clean"] = lens_clean_path
 
         paddle_clean_path = output_dir_path / "paddle_clean.srt"
-        fusion_paddle = _get_cleaned_ocr_output(
-            paddle,
-            paddle_clean_path,
-            "PaddleOCR",
-            overwrite=overwrite,
-            cleaner=lambda series: get_zho_cleaned(series, remove_empty=False),
-        )
+        if paddle_clean_path.exists() and not overwrite:
+            logger.info(f"Cleaned PaddleOCR output exists: {paddle_clean_path}")
+            fusion_paddle = Series.load(paddle_clean_path)
+        else:
+            fusion_paddle = get_zho_cleaned(paddle, remove_empty=False)
+            fusion_paddle.save(paddle_clean_path, format_="srt")
         output_paths["paddle_clean"] = paddle_clean_path
 
     # Fusion
@@ -273,34 +268,6 @@ def process_zho_ocr(  # noqa: PLR0912
         output_dir_path=output_dir_path,
         output_paths=output_paths,
     )
-
-
-def _get_cleaned_ocr_output(
-    series: Series,
-    outfile_path: Path,
-    output_name: str,
-    *,
-    overwrite: bool,
-    cleaner: Callable[[Series], Series],
-) -> Series:
-    """Get cleaned OCR output from an existing file or a source series.
-
-    Arguments:
-        series: source OCR subtitle series
-        outfile_path: cleaned OCR output file path
-        output_name: name of the OCR output for log messages
-        overwrite: whether to overwrite existing cleaned output
-        cleaner: function used to clean the source series
-    Returns:
-        cleaned OCR subtitle series
-    """
-    if outfile_path.exists() and not overwrite:
-        logger.info(f"Cleaned {output_name} OCR output exists: {outfile_path}")
-        return Series.load(outfile_path)
-
-    cleaned = cleaner(series)
-    cleaned.save(outfile_path, format_="srt")
-    return cleaned
 
 
 def _get_media_subtitle_stream(

--- a/test/cli/ocr/test_ocr_process_cli.py
+++ b/test/cli/ocr/test_ocr_process_cli.py
@@ -48,7 +48,7 @@ def test_ocr_process_cli_passes_eng_arguments_to_workflow(tmp_path: Path):
             OcrProcessCli,
             f"--infile {infile_path} --stream-index 3 --language eng "
             f"-o {output_dir_path} --cache-dir {cache_dir_path} "
-            "--export-images --overwrite",
+            "--clean --export-images --overwrite",
         )
 
     get_provider.assert_called_once_with("openai", model=None)
@@ -57,6 +57,7 @@ def test_ocr_process_cli_passes_eng_arguments_to_workflow(tmp_path: Path):
         output_dir_path=output_dir_path.resolve(),
         stream_index=3,
         cache_dir_path=cache_dir_path.resolve(),
+        clean=True,
         export_images=True,
         overwrite=True,
         provider=provider,
@@ -93,7 +94,7 @@ def test_ocr_process_cli_passes_zho_arguments_to_workflow(tmp_path: Path):
         run_cli_with_args(
             OcrProcessCli,
             f"--infile {infile_path} --stream-index 3 --language zho "
-            f"-o {output_dir_path}",
+            f"--clean -o {output_dir_path}",
         )
 
     process.assert_called_once_with(
@@ -102,6 +103,7 @@ def test_ocr_process_cli_passes_zho_arguments_to_workflow(tmp_path: Path):
         stream_index=3,
         cache_dir_path=cache_dir_path_arg("media", "subtitles"),
         script="simplified",
+        clean=True,
         export_images=False,
         overwrite=False,
         provider=provider,
@@ -147,6 +149,7 @@ def test_ocr_process_cli_passes_traditional_script_to_zho_workflow(tmp_path: Pat
         stream_index=3,
         cache_dir_path=cache_dir_path_arg("media", "subtitles"),
         script="traditional",
+        clean=False,
         export_images=False,
         overwrite=False,
         provider=provider,

--- a/test/image/ocr/lens/test_lens_series.py
+++ b/test/image/ocr/lens/test_lens_series.py
@@ -9,8 +9,10 @@ from pathlib import Path
 import pytest
 from PIL import Image
 
+from scinoephile.core.text import ChineseScript
 from scinoephile.image.ocr.lens import (
     GoogleLensRecognizer,
+    get_lens_zho_code,
     ocr_image_series_with_lens,
 )
 from scinoephile.image.subtitles import ImageSeries, ImageSubtitle
@@ -132,3 +134,20 @@ def test_ocr_image_series_with_lens_uses_runtime_cache(
     assert [event.text for event in text_series] == ["zh-CN"]
     assert observed_cache_dir_paths == [cache_dir_path]
     assert observed_retries == [5]
+
+
+@pytest.mark.parametrize(
+    ("script", "expected"),
+    [
+        ("simplified", "zh-CN"),
+        ("traditional", "zh-TW"),
+    ],
+)
+def test_get_lens_zho_code(script: ChineseScript, expected: str):
+    """Test Google Lens language code selection for Chinese scripts.
+
+    Arguments:
+        script: Chinese script
+        expected: expected Google Lens language code
+    """
+    assert get_lens_zho_code(script) == expected

--- a/test/image/ocr/paddle/test_paddle_series.py
+++ b/test/image/ocr/paddle/test_paddle_series.py
@@ -9,8 +9,10 @@ from pathlib import Path
 import pytest
 from PIL import Image
 
+from scinoephile.core.text import ChineseScript
 from scinoephile.image.ocr.paddle import (
     PaddleOcrRecognizer,
+    get_paddle_zho_code,
     ocr_image_series_with_paddle,
 )
 from scinoephile.image.subtitles import ImageSeries, ImageSubtitle
@@ -125,3 +127,20 @@ def test_ocr_image_series_with_paddle_uses_runtime_cache(
 
     assert [event.text for event in text_series] == ["en"]
     assert observed_cache_dir_paths == [cache_dir_path]
+
+
+@pytest.mark.parametrize(
+    ("script", "expected"),
+    [
+        ("simplified", "ch"),
+        ("traditional", "chinese_cht"),
+    ],
+)
+def test_get_paddle_zho_code(script: ChineseScript, expected: str):
+    """Test PaddleOCR language code selection for Chinese scripts.
+
+    Arguments:
+        script: Chinese script
+        expected: expected PaddleOCR language code
+    """
+    assert get_paddle_zho_code(script) == expected

--- a/test/workflows/test_ocr_processing.py
+++ b/test/workflows/test_ocr_processing.py
@@ -131,6 +131,79 @@ def test_process_eng_ocr_runs_lens_tesseract_and_fusion(
     ] == ["fused"]
 
 
+def test_process_eng_ocr_can_clean_provider_outputs_before_fusion(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    tiny_image_series: ImageSeries,
+):
+    """Test English OCR processing can clean provider outputs before fusion.
+
+    Arguments:
+        monkeypatch: pytest monkeypatch fixture
+        tmp_path: pytest temporary path fixture
+        tiny_image_series: small image subtitle series
+    """
+    source_path = tmp_path / "source.sup"
+    source_path.write_bytes(b"unused")
+    output_dir_path = tmp_path / "output"
+
+    def fake_fuse(lens: Series, tesseract: Series, **kwargs: object) -> Series:
+        """Fake English OCR fusion."""
+        assert [subtitle.text for subtitle in lens] == ["lens…"]
+        assert [subtitle.text for subtitle in tesseract] == ["tesseract"]
+        assert kwargs == {"processor": fuser}
+        return _series("fused")
+
+    fuser = object()
+    monkeypatch.setattr(
+        "scinoephile.workflows.ocr_processing.ImageSeries.load",
+        lambda path: tiny_image_series,
+    )
+    monkeypatch.setattr(
+        "scinoephile.workflows.ocr_processing.ocr_image_series_with_lens",
+        lambda image_series, *, language: _series("lens..."),
+    )
+    monkeypatch.setattr(
+        "scinoephile.workflows.ocr_processing.ocr_image_series_with_tesseract",
+        lambda image_series, *, language: _series("[MUSIC] tesseract"),
+    )
+    monkeypatch.setattr(
+        "scinoephile.workflows.ocr_processing.get_eng_ocr_fuser",
+        lambda provider, additional_context: fuser,
+    )
+    monkeypatch.setattr(
+        "scinoephile.workflows.ocr_processing.get_eng_ocr_fused",
+        fake_fuse,
+    )
+
+    result = process_eng_ocr(
+        infile_path=source_path,
+        output_dir_path=output_dir_path,
+        clean=True,
+    )
+
+    assert result.output_paths == {
+        "lens": output_dir_path / "lens.srt",
+        "tesseract": output_dir_path / "tesseract.srt",
+        "lens_clean": output_dir_path / "lens_clean.srt",
+        "tesseract_clean": output_dir_path / "tesseract_clean.srt",
+        "fuse": output_dir_path / "fuse.srt",
+    }
+    assert [
+        subtitle.text for subtitle in Series.load(output_dir_path / "lens.srt")
+    ] == ["lens..."]
+    assert [
+        subtitle.text for subtitle in Series.load(output_dir_path / "tesseract.srt")
+    ] == ["[MUSIC] tesseract"]
+    assert [
+        subtitle.text for subtitle in Series.load(output_dir_path / "lens_clean.srt")
+    ] == ["lens…"]
+    assert [
+        subtitle.text
+        for subtitle in Series.load(output_dir_path / "tesseract_clean.srt")
+    ] == ["tesseract"]
+
+
 def test_process_zho_ocr_runs_lens_paddle_and_fusion(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -207,6 +280,78 @@ def test_process_zho_ocr_runs_lens_paddle_and_fusion(
     assert [
         subtitle.text for subtitle in Series.load(output_dir_path / "fuse.srt")
     ] == ["fused"]
+
+
+def test_process_zho_ocr_can_clean_provider_outputs_before_fusion(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    tiny_image_series: ImageSeries,
+):
+    """Test Chinese OCR processing can clean provider outputs before fusion.
+
+    Arguments:
+        monkeypatch: pytest monkeypatch fixture
+        tmp_path: pytest temporary path fixture
+        tiny_image_series: small image subtitle series
+    """
+    source_path = tmp_path / "source.sup"
+    source_path.write_bytes(b"unused")
+    output_dir_path = tmp_path / "output"
+
+    def fake_fuse(lens: Series, paddle: Series, **kwargs: object) -> Series:
+        """Fake Chinese OCR fusion."""
+        assert [subtitle.text for subtitle in lens] == ["镜头⋯"]
+        assert [subtitle.text for subtitle in paddle] == ["字幕，好？"]
+        assert kwargs == {"processor": fuser}
+        return _series("fused")
+
+    fuser = object()
+    monkeypatch.setattr(
+        "scinoephile.workflows.ocr_processing.ImageSeries.load",
+        lambda path: tiny_image_series,
+    )
+    monkeypatch.setattr(
+        "scinoephile.workflows.ocr_processing.ocr_image_series_with_lens",
+        lambda image_series, *, language: _series("镜头..."),
+    )
+    monkeypatch.setattr(
+        "scinoephile.workflows.ocr_processing.ocr_image_series_with_paddle",
+        lambda image_series, *, language: _series("字幕, 好?"),
+    )
+    monkeypatch.setattr(
+        "scinoephile.workflows.ocr_processing.get_zho_ocr_fuser",
+        lambda provider, additional_context: fuser,
+    )
+    monkeypatch.setattr(
+        "scinoephile.workflows.ocr_processing.get_zho_ocr_fused",
+        fake_fuse,
+    )
+
+    result = process_zho_ocr(
+        infile_path=source_path,
+        output_dir_path=output_dir_path,
+        clean=True,
+    )
+
+    assert result.output_paths == {
+        "lens": output_dir_path / "lens.srt",
+        "paddle": output_dir_path / "paddle.srt",
+        "lens_clean": output_dir_path / "lens_clean.srt",
+        "paddle_clean": output_dir_path / "paddle_clean.srt",
+        "fuse": output_dir_path / "fuse.srt",
+    }
+    assert [
+        subtitle.text for subtitle in Series.load(output_dir_path / "lens.srt")
+    ] == ["镜头..."]
+    assert [
+        subtitle.text for subtitle in Series.load(output_dir_path / "paddle.srt")
+    ] == ["字幕, 好?"]
+    assert [
+        subtitle.text for subtitle in Series.load(output_dir_path / "lens_clean.srt")
+    ] == ["镜头⋯"]
+    assert [
+        subtitle.text for subtitle in Series.load(output_dir_path / "paddle_clean.srt")
+    ] == ["字幕，好？"]
 
 
 def test_process_zho_ocr_passes_traditional_languages_to_ocr_engines(


### PR DESCRIPTION
## Summary
- Add `--clean` to `ocr process` and pass it through to the OCR workflow.
- Preserve raw Lens/Tesseract/Paddle outputs while writing `*_clean.srt` intermediates when cleaning is enabled.
- Fuse from cleaned provider subtitles for English and Chinese OCR processing.

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/workflows/ocr_processing.py scinoephile/cli/ocr/ocr_process_cli.py test/workflows/test_ocr_processing.py test/cli/ocr/test_ocr_process_cli.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/workflows/ocr_processing.py scinoephile/cli/ocr/ocr_process_cli.py test/workflows/test_ocr_processing.py test/cli/ocr/test_ocr_process_cli.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/workflows/ocr_processing.py scinoephile/cli/ocr/ocr_process_cli.py test/workflows/test_ocr_processing.py test/cli/ocr/test_ocr_process_cli.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest test/workflows/test_ocr_processing.py test/cli/ocr/test_ocr_process_cli.py -q`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto`