### PR TITLE
Split CLI localizations into constants

### DIFF
--- a/scinoephile/cli/dictionary/build/dictionary_build_cli.py
+++ b/scinoephile/cli/dictionary/build/dictionary_build_cli.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
-from typing import Any, ClassVar
+from typing import Any
 
 from scinoephile.core.cli import ScinoephileCliBase
 
@@ -17,20 +17,23 @@ from .dictionary_build_wiktionary_cli import DictionaryBuildWiktionaryCli
 
 __all__ = ["DictionaryBuildCli"]
 
+DICTIONARY_BUILD_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "build dictionary caches": "构建词典缓存",
+        "dictionary source": "词典来源",
+    },
+    "zh-hant": {
+        "build dictionary caches": "建立詞典快取",
+        "dictionary source": "詞典來源",
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class DictionaryBuildCli(ScinoephileCliBase):
     """Build dictionary caches."""
 
-    localizations: ClassVar[dict[str, dict[str, str]]] = {
-        "zh-hans": {
-            "build dictionary caches": "构建词典缓存",
-            "dictionary source": "词典来源",
-        },
-        "zh-hant": {
-            "build dictionary caches": "建立詞典快取",
-            "dictionary source": "詞典來源",
-        },
-    }
+    localizations = DICTIONARY_BUILD_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
     @classmethod

--- a/scinoephile/cli/dictionary/build/dictionary_build_cli_base.py
+++ b/scinoephile/cli/dictionary/build/dictionary_build_cli_base.py
@@ -19,6 +19,34 @@ __all__ = ["DictionaryBuildCliBase"]
 
 logger = getLogger(__name__)
 
+DICTIONARY_BUILD_BASE_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "base class for building a specific dictionary cache": (
+            "用于构建特定词典缓存的基类"
+        ),
+        "replace an existing SQLite database; without this, an existing "
+        "database is left untouched": (
+            "替换已有 SQLite 数据库；未指定时保留已有数据库"
+        ),
+        "SQLite database output path (default: source-specific runtime cache)": (
+            "SQLite 数据库输出路径（默认：对应来源的运行时缓存）"
+        ),
+    },
+    "zh-hant": {
+        "base class for building a specific dictionary cache": (
+            "用於建立特定詞典快取的基底類別"
+        ),
+        "replace an existing SQLite database; without this, an existing "
+        "database is left untouched": (
+            "替換已有 SQLite 資料庫；未指定時保留已有資料庫"
+        ),
+        "SQLite database output path (default: source-specific runtime cache)": (
+            "SQLite 資料庫輸出路徑（預設：對應來源的執行時快取）"
+        ),
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class DictionaryBuildCliBase(ScinoephileCliBase, ABC):
     """Base class for building a specific dictionary cache."""
@@ -26,32 +54,7 @@ class DictionaryBuildCliBase(ScinoephileCliBase, ABC):
     source: ClassVar[DictionarySource | None] = None
     """Dictionary source built by this CLI."""
 
-    localizations: ClassVar[dict[str, dict[str, str]]] = {
-        "zh-hans": {
-            "base class for building a specific dictionary cache": (
-                "用于构建特定词典缓存的基类"
-            ),
-            "replace an existing SQLite database; without this, an existing "
-            "database is left untouched": (
-                "替换已有 SQLite 数据库；未指定时保留已有数据库"
-            ),
-            "SQLite database output path (default: source-specific runtime cache)": (
-                "SQLite 数据库输出路径（默认：对应来源的运行时缓存）"
-            ),
-        },
-        "zh-hant": {
-            "base class for building a specific dictionary cache": (
-                "用於建立特定詞典快取的基底類別"
-            ),
-            "replace an existing SQLite database; without this, an existing "
-            "database is left untouched": (
-                "替換已有 SQLite 資料庫；未指定時保留已有資料庫"
-            ),
-            "SQLite database output path (default: source-specific runtime cache)": (
-                "SQLite 資料庫輸出路徑（預設：對應來源的執行時快取）"
-            ),
-        },
-    }
+    localizations = DICTIONARY_BUILD_BASE_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
     @classmethod

--- a/scinoephile/cli/dictionary/build/dictionary_build_cuhk_cli.py
+++ b/scinoephile/cli/dictionary/build/dictionary_build_cuhk_cli.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 from argparse import ArgumentParser
 from logging import getLogger
 from pathlib import Path
-from typing import ClassVar
 
 from scinoephile.common.argument_parsing import (
     float_arg,
@@ -25,6 +24,44 @@ __all__ = ["DictionaryBuildCuhkCli"]
 
 logger = getLogger(__name__)
 
+DICTIONARY_BUILD_CUHK_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "build CUHK dictionary cache": "构建 CUHK 词典缓存",
+        ("cache directory for scraped HTML and link data (default: %(default)s)"): (
+            "抓取 HTML 与链接数据的缓存目录（默认：%(default)s）"
+        ),
+        (
+            "Comparative Database of Modern Standard Chinese and Cantonese "
+            "(Chinese University of Hong Kong)."
+        ): "香港中文大学现代标准汉语与粤语对照数据库。",
+        "maximum delay between HTTP requests": "HTTP 请求之间的最大延迟",
+        "maximum retries per HTTP request": "每个 HTTP 请求的最大重试次数",
+        "minimum delay between HTTP requests": "HTTP 请求之间的最小延迟",
+        "per-request timeout in seconds": "每次请求的超时时间（秒）",
+        "stop after building the first N discovered words": (
+            "在构建前 N 个已发现词条后停止"
+        ),
+    },
+    "zh-hant": {
+        "build CUHK dictionary cache": "建立 CUHK 詞典快取",
+        ("cache directory for scraped HTML and link data (default: %(default)s)"): (
+            "擷取 HTML 與連結資料的快取目錄（預設：%(default)s）"
+        ),
+        (
+            "Comparative Database of Modern Standard Chinese and Cantonese "
+            "(Chinese University of Hong Kong)."
+        ): "香港中文大學現代標準漢語與粵語對照資料庫。",
+        "maximum delay between HTTP requests": "HTTP 請求之間的最大延遲",
+        "maximum retries per HTTP request": "每個 HTTP 請求的最大重試次數",
+        "minimum delay between HTTP requests": "HTTP 請求之間的最小延遲",
+        "per-request timeout in seconds": "每次請求的逾時時間（秒）",
+        "stop after building the first N discovered words": (
+            "在建立前 N 個已發現詞條後停止"
+        ),
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class DictionaryBuildCuhkCli(DictionaryBuildCliBase):
     """Build CUHK dictionary cache."""
@@ -32,42 +69,7 @@ class DictionaryBuildCuhkCli(DictionaryBuildCliBase):
     source = CUHK_SOURCE
     """Dictionary source built by this CLI."""
 
-    localizations: ClassVar[dict[str, dict[str, str]]] = {
-        "zh-hans": {
-            "build CUHK dictionary cache": "构建 CUHK 词典缓存",
-            ("cache directory for scraped HTML and link data (default: %(default)s)"): (
-                "抓取 HTML 与链接数据的缓存目录（默认：%(default)s）"
-            ),
-            (
-                "Comparative Database of Modern Standard Chinese and Cantonese "
-                "(Chinese University of Hong Kong)."
-            ): "香港中文大学现代标准汉语与粤语对照数据库。",
-            "maximum delay between HTTP requests": "HTTP 请求之间的最大延迟",
-            "maximum retries per HTTP request": "每个 HTTP 请求的最大重试次数",
-            "minimum delay between HTTP requests": "HTTP 请求之间的最小延迟",
-            "per-request timeout in seconds": "每次请求的超时时间（秒）",
-            "stop after building the first N discovered words": (
-                "在构建前 N 个已发现词条后停止"
-            ),
-        },
-        "zh-hant": {
-            "build CUHK dictionary cache": "建立 CUHK 詞典快取",
-            ("cache directory for scraped HTML and link data (default: %(default)s)"): (
-                "擷取 HTML 與連結資料的快取目錄（預設：%(default)s）"
-            ),
-            (
-                "Comparative Database of Modern Standard Chinese and Cantonese "
-                "(Chinese University of Hong Kong)."
-            ): "香港中文大學現代標準漢語與粵語對照資料庫。",
-            "maximum delay between HTTP requests": "HTTP 請求之間的最大延遲",
-            "maximum retries per HTTP request": "每個 HTTP 請求的最大重試次數",
-            "minimum delay between HTTP requests": "HTTP 請求之間的最小延遲",
-            "per-request timeout in seconds": "每次請求的逾時時間（秒）",
-            "stop after building the first N discovered words": (
-                "在建立前 N 個已發現詞條後停止"
-            ),
-        },
-    }
+    localizations = DICTIONARY_BUILD_CUHK_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
     @classmethod

--- a/scinoephile/cli/dictionary/build/dictionary_build_gzzj_cli.py
+++ b/scinoephile/cli/dictionary/build/dictionary_build_gzzj_cli.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 from argparse import ArgumentParser
 from logging import getLogger
 from pathlib import Path
-from typing import ClassVar
 
 from scinoephile.common.argument_parsing import get_arg_groups_by_name, input_file_arg
 from scinoephile.dictionaries.gzzj import GzzjDictionaryService
@@ -19,6 +18,30 @@ __all__ = ["DictionaryBuildGzzjCli"]
 
 logger = getLogger(__name__)
 
+DICTIONARY_BUILD_GZZJ_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "build GZZJ dictionary cache": "构建 GZZJ 词典缓存",
+        (
+            "Digital data derived from the 2004 second edition of 《廣州話正音字典》."
+        ): "由 2004 年第二版《广州话正音字典》整理而成的数字数据。",
+        "path to manually downloaded GZZJ source JSON; required unless bundled "
+        "local data is already available": (
+            "手动下载的 GZZJ 源 JSON 路径；除非已有随包本地数据，否则必须提供"
+        ),
+    },
+    "zh-hant": {
+        "build GZZJ dictionary cache": "建立 GZZJ 詞典快取",
+        (
+            "Digital data derived from the 2004 second edition of 《廣州話正音字典》."
+        ): "由 2004 年第二版《廣州話正音字典》整理而成的數碼資料。",
+        "path to manually downloaded GZZJ source JSON; required unless bundled "
+        "local data is already available": (
+            "手動下載的 GZZJ 來源 JSON 路徑；除非已有隨包本機資料，否則必須提供"
+        ),
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class DictionaryBuildGzzjCli(DictionaryBuildCliBase):
     """Build GZZJ dictionary cache."""
@@ -26,30 +49,7 @@ class DictionaryBuildGzzjCli(DictionaryBuildCliBase):
     source = GZZJ_SOURCE
     """Dictionary source built by this CLI."""
 
-    localizations: ClassVar[dict[str, dict[str, str]]] = {
-        "zh-hans": {
-            "build GZZJ dictionary cache": "构建 GZZJ 词典缓存",
-            (
-                "Digital data derived from the 2004 second edition of "
-                "《廣州話正音字典》."
-            ): "由 2004 年第二版《广州话正音字典》整理而成的数字数据。",
-            "path to manually downloaded GZZJ source JSON; required unless bundled "
-            "local data is already available": (
-                "手动下载的 GZZJ 源 JSON 路径；除非已有随包本地数据，否则必须提供"
-            ),
-        },
-        "zh-hant": {
-            "build GZZJ dictionary cache": "建立 GZZJ 詞典快取",
-            (
-                "Digital data derived from the 2004 second edition of "
-                "《廣州話正音字典》."
-            ): "由 2004 年第二版《廣州話正音字典》整理而成的數碼資料。",
-            "path to manually downloaded GZZJ source JSON; required unless bundled "
-            "local data is already available": (
-                "手動下載的 GZZJ 來源 JSON 路徑；除非已有隨包本機資料，否則必須提供"
-            ),
-        },
-    }
+    localizations = DICTIONARY_BUILD_GZZJ_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
     @classmethod

--- a/scinoephile/cli/dictionary/build/dictionary_build_kaifangcidian_cli.py
+++ b/scinoephile/cli/dictionary/build/dictionary_build_kaifangcidian_cli.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 from argparse import ArgumentParser
 from logging import getLogger
 from pathlib import Path
-from typing import ClassVar
 
 import requests
 
@@ -21,6 +20,40 @@ __all__ = ["DictionaryBuildKaifangcidianCli"]
 
 logger = getLogger(__name__)
 
+DICTIONARY_BUILD_KAIFANGCIDIAN_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "build Kaifangcidian dictionary cache": "构建 Kaifangcidian 词典缓存",
+        (
+            "Data derived from Kaifangcidian website dictionary JavaScript payloads."
+        ): "由 Kaifangcidian 网站词典 JavaScript 载荷整理而成的数据。",
+        "download fresh Kaifangcidian payloads before building": (
+            "在构建前下载最新 Kaifangcidian 数据"
+        ),
+        (
+            "maintainer option: update canonical CSV under "
+            "scinoephile/data/dictionaries/kaifangcidian"
+        ): (
+            "维护者选项：更新 scinoephile/data/dictionaries/kaifangcidian 下的标准 CSV"
+        ),
+    },
+    "zh-hant": {
+        "build Kaifangcidian dictionary cache": "建立 Kaifangcidian 詞典快取",
+        (
+            "Data derived from Kaifangcidian website dictionary JavaScript payloads."
+        ): "由 Kaifangcidian 網站詞典 JavaScript 載荷整理而成的資料。",
+        "download fresh Kaifangcidian payloads before building": (
+            "在建立前下載最新 Kaifangcidian 資料"
+        ),
+        (
+            "maintainer option: update canonical CSV under "
+            "scinoephile/data/dictionaries/kaifangcidian"
+        ): (
+            "維護者選項：更新 scinoephile/data/dictionaries/kaifangcidian 下的標準 CSV"
+        ),
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class DictionaryBuildKaifangcidianCli(DictionaryBuildCliBase):
     """Build Kaifangcidian dictionary cache."""
@@ -28,42 +61,7 @@ class DictionaryBuildKaifangcidianCli(DictionaryBuildCliBase):
     source = KAIFANGCIDIAN_SOURCE
     """Dictionary source built by this CLI."""
 
-    localizations: ClassVar[dict[str, dict[str, str]]] = {
-        "zh-hans": {
-            "build Kaifangcidian dictionary cache": "构建 Kaifangcidian 词典缓存",
-            (
-                "Data derived from Kaifangcidian website dictionary JavaScript "
-                "payloads."
-            ): "由 Kaifangcidian 网站词典 JavaScript 载荷整理而成的数据。",
-            "download fresh Kaifangcidian payloads before building": (
-                "在构建前下载最新 Kaifangcidian 数据"
-            ),
-            (
-                "maintainer option: update canonical CSV under "
-                "scinoephile/data/dictionaries/kaifangcidian"
-            ): (
-                "维护者选项：更新 scinoephile/data/dictionaries/kaifangcidian "
-                "下的标准 CSV"
-            ),
-        },
-        "zh-hant": {
-            "build Kaifangcidian dictionary cache": "建立 Kaifangcidian 詞典快取",
-            (
-                "Data derived from Kaifangcidian website dictionary JavaScript "
-                "payloads."
-            ): "由 Kaifangcidian 網站詞典 JavaScript 載荷整理而成的資料。",
-            "download fresh Kaifangcidian payloads before building": (
-                "在建立前下載最新 Kaifangcidian 資料"
-            ),
-            (
-                "maintainer option: update canonical CSV under "
-                "scinoephile/data/dictionaries/kaifangcidian"
-            ): (
-                "維護者選項：更新 scinoephile/data/dictionaries/kaifangcidian "
-                "下的標準 CSV"
-            ),
-        },
-    }
+    localizations = DICTIONARY_BUILD_KAIFANGCIDIAN_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
     @classmethod

--- a/scinoephile/cli/dictionary/build/dictionary_build_unihan_cli.py
+++ b/scinoephile/cli/dictionary/build/dictionary_build_unihan_cli.py
@@ -8,7 +8,6 @@ import zipfile
 from argparse import ArgumentParser
 from logging import getLogger
 from pathlib import Path
-from typing import ClassVar
 
 import requests
 
@@ -22,6 +21,52 @@ __all__ = ["DictionaryBuildUnihanCli"]
 
 logger = getLogger(__name__)
 
+DICTIONARY_BUILD_UNIHAN_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "build Unihan dictionary cache": "构建 Unihan 词典缓存",
+        (
+            "Data derived from Unicode Unihan files for variants, readings, and "
+            "dictionary-like metadata."
+        ): "由 Unicode Unihan 文件中的异体字、读音和类词典元数据整理而成的数据。",
+        "download fresh Unihan.zip before building": ("在构建前下载最新 Unihan.zip"),
+        "path to Unihan_DictionaryLikeData.txt (default: bundled local data)": (
+            "Unihan_DictionaryLikeData.txt 的路径（默认：随包本地数据）"
+        ),
+        "path to Unihan_Readings.txt (default: bundled local data)": (
+            "Unihan_Readings.txt 的路径（默认：随包本地数据）"
+        ),
+        "path to Unihan_Variants.txt (default: bundled local data)": (
+            "Unihan_Variants.txt 的路径（默认：随包本地数据）"
+        ),
+        "maintainer option: update source files under "
+        "scinoephile/data/dictionaries/unihan": (
+            "维护者选项：更新 scinoephile/data/dictionaries/unihan 下的源文件"
+        ),
+    },
+    "zh-hant": {
+        "build Unihan dictionary cache": "建立 Unihan 詞典快取",
+        (
+            "Data derived from Unicode Unihan files for variants, readings, and "
+            "dictionary-like metadata."
+        ): "由 Unicode Unihan 檔案中的異體字、讀音和類詞典後設資料整理而成的資料。",
+        "download fresh Unihan.zip before building": ("在建立前下載最新 Unihan.zip"),
+        "path to Unihan_DictionaryLikeData.txt (default: bundled local data)": (
+            "Unihan_DictionaryLikeData.txt 的路徑（預設：隨包本機資料）"
+        ),
+        "path to Unihan_Readings.txt (default: bundled local data)": (
+            "Unihan_Readings.txt 的路徑（預設：隨包本機資料）"
+        ),
+        "path to Unihan_Variants.txt (default: bundled local data)": (
+            "Unihan_Variants.txt 的路徑（預設：隨包本機資料）"
+        ),
+        "maintainer option: update source files under "
+        "scinoephile/data/dictionaries/unihan": (
+            "維護者選項：更新 scinoephile/data/dictionaries/unihan 下的來源檔案"
+        ),
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class DictionaryBuildUnihanCli(DictionaryBuildCliBase):
     """Build Unihan dictionary cache."""
@@ -29,54 +74,7 @@ class DictionaryBuildUnihanCli(DictionaryBuildCliBase):
     source = UNIHAN_SOURCE
     """Dictionary source built by this CLI."""
 
-    localizations: ClassVar[dict[str, dict[str, str]]] = {
-        "zh-hans": {
-            "build Unihan dictionary cache": "构建 Unihan 词典缓存",
-            (
-                "Data derived from Unicode Unihan files for variants, readings, and "
-                "dictionary-like metadata."
-            ): "由 Unicode Unihan 文件中的异体字、读音和类词典元数据整理而成的数据。",
-            "download fresh Unihan.zip before building": (
-                "在构建前下载最新 Unihan.zip"
-            ),
-            "path to Unihan_DictionaryLikeData.txt (default: bundled local data)": (
-                "Unihan_DictionaryLikeData.txt 的路径（默认：随包本地数据）"
-            ),
-            "path to Unihan_Readings.txt (default: bundled local data)": (
-                "Unihan_Readings.txt 的路径（默认：随包本地数据）"
-            ),
-            "path to Unihan_Variants.txt (default: bundled local data)": (
-                "Unihan_Variants.txt 的路径（默认：随包本地数据）"
-            ),
-            "maintainer option: update source files under "
-            "scinoephile/data/dictionaries/unihan": (
-                "维护者选项：更新 scinoephile/data/dictionaries/unihan 下的源文件"
-            ),
-        },
-        "zh-hant": {
-            "build Unihan dictionary cache": "建立 Unihan 詞典快取",
-            (
-                "Data derived from Unicode Unihan files for variants, readings, and "
-                "dictionary-like metadata."
-            ): "由 Unicode Unihan 檔案中的異體字、讀音和類詞典後設資料整理而成的資料。",
-            "download fresh Unihan.zip before building": (
-                "在建立前下載最新 Unihan.zip"
-            ),
-            "path to Unihan_DictionaryLikeData.txt (default: bundled local data)": (
-                "Unihan_DictionaryLikeData.txt 的路徑（預設：隨包本機資料）"
-            ),
-            "path to Unihan_Readings.txt (default: bundled local data)": (
-                "Unihan_Readings.txt 的路徑（預設：隨包本機資料）"
-            ),
-            "path to Unihan_Variants.txt (default: bundled local data)": (
-                "Unihan_Variants.txt 的路徑（預設：隨包本機資料）"
-            ),
-            "maintainer option: update source files under "
-            "scinoephile/data/dictionaries/unihan": (
-                "維護者選項：更新 scinoephile/data/dictionaries/unihan 下的來源檔案"
-            ),
-        },
-    }
+    localizations = DICTIONARY_BUILD_UNIHAN_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
     @classmethod

--- a/scinoephile/cli/dictionary/build/dictionary_build_wiktionary_cli.py
+++ b/scinoephile/cli/dictionary/build/dictionary_build_wiktionary_cli.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 from argparse import ArgumentParser
 from logging import getLogger
 from pathlib import Path
-from typing import ClassVar
 
 import requests
 
@@ -21,6 +20,46 @@ __all__ = ["DictionaryBuildWiktionaryCli"]
 
 logger = getLogger(__name__)
 
+DICTIONARY_BUILD_WIKTIONARY_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "build Wiktionary dictionary cache": "构建 Wiktionary 词典缓存",
+        (
+            "Data derived from Kaikki JSONL exports of Chinese entries from Wiktionary."
+        ): "由 Kaikki 导出的 Wiktionary 中文词条 JSONL 整理而成的数据。",
+        "download fresh Kaikki JSONL before building": (
+            "在构建前下载最新 Kaikki JSONL"
+        ),
+        "path to Kaikki Chinese Wiktionary JSONL dump (default: bundled local "
+        "data; use --force-download to fetch a fresh dump)": (
+            "Kaikki 中文 Wiktionary JSONL 转储路径（默认：随包本地数据；使用 "
+            "--force-download 获取最新转储）"
+        ),
+        "maintainer option: update source file under "
+        "scinoephile/data/dictionaries/wiktionary": (
+            "维护者选项：更新 scinoephile/data/dictionaries/wiktionary 下的源文件"
+        ),
+    },
+    "zh-hant": {
+        "build Wiktionary dictionary cache": "建立 Wiktionary 詞典快取",
+        (
+            "Data derived from Kaikki JSONL exports of Chinese entries from Wiktionary."
+        ): "由 Kaikki 匯出的 Wiktionary 中文詞條 JSONL 整理而成的資料。",
+        "download fresh Kaikki JSONL before building": (
+            "在建立前下載最新 Kaikki JSONL"
+        ),
+        "path to Kaikki Chinese Wiktionary JSONL dump (default: bundled local "
+        "data; use --force-download to fetch a fresh dump)": (
+            "Kaikki 中文 Wiktionary JSONL 傾印路徑（預設：隨包本機資料；使用 "
+            "--force-download 取得最新傾印）"
+        ),
+        "maintainer option: update source file under "
+        "scinoephile/data/dictionaries/wiktionary": (
+            "維護者選項：更新 scinoephile/data/dictionaries/wiktionary 下的來源檔案"
+        ),
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class DictionaryBuildWiktionaryCli(DictionaryBuildCliBase):
     """Build Wiktionary dictionary cache."""
@@ -28,46 +67,7 @@ class DictionaryBuildWiktionaryCli(DictionaryBuildCliBase):
     source = WIKTIONARY_SOURCE
     """Dictionary source built by this CLI."""
 
-    localizations: ClassVar[dict[str, dict[str, str]]] = {
-        "zh-hans": {
-            "build Wiktionary dictionary cache": "构建 Wiktionary 词典缓存",
-            (
-                "Data derived from Kaikki JSONL exports of Chinese entries from "
-                "Wiktionary."
-            ): "由 Kaikki 导出的 Wiktionary 中文词条 JSONL 整理而成的数据。",
-            "download fresh Kaikki JSONL before building": (
-                "在构建前下载最新 Kaikki JSONL"
-            ),
-            "path to Kaikki Chinese Wiktionary JSONL dump (default: bundled local "
-            "data; use --force-download to fetch a fresh dump)": (
-                "Kaikki 中文 Wiktionary JSONL 转储路径（默认：随包本地数据；使用 "
-                "--force-download 获取最新转储）"
-            ),
-            "maintainer option: update source file under "
-            "scinoephile/data/dictionaries/wiktionary": (
-                "维护者选项：更新 scinoephile/data/dictionaries/wiktionary 下的源文件"
-            ),
-        },
-        "zh-hant": {
-            "build Wiktionary dictionary cache": "建立 Wiktionary 詞典快取",
-            (
-                "Data derived from Kaikki JSONL exports of Chinese entries from "
-                "Wiktionary."
-            ): "由 Kaikki 匯出的 Wiktionary 中文詞條 JSONL 整理而成的資料。",
-            "download fresh Kaikki JSONL before building": (
-                "在建立前下載最新 Kaikki JSONL"
-            ),
-            "path to Kaikki Chinese Wiktionary JSONL dump (default: bundled local "
-            "data; use --force-download to fetch a fresh dump)": (
-                "Kaikki 中文 Wiktionary JSONL 傾印路徑（預設：隨包本機資料；使用 "
-                "--force-download 取得最新傾印）"
-            ),
-            "maintainer option: update source file under "
-            "scinoephile/data/dictionaries/wiktionary": (
-                "維護者選項：更新 scinoephile/data/dictionaries/wiktionary 下的來源檔案"
-            ),
-        },
-    }
+    localizations = DICTIONARY_BUILD_WIKTIONARY_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
     @classmethod

--- a/scinoephile/cli/multi/multi_cer_cli.py
+++ b/scinoephile/cli/multi/multi_cer_cli.py
@@ -6,13 +6,52 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import ClassVar
 
 from scinoephile.analysis.character_error_rate import SeriesCER
 from scinoephile.common.argument_parsing import get_arg_groups_by_name, input_file_arg
 from scinoephile.core.cli import ScinoephileCliBase, read_series
 
 __all__ = ["MultiCerCli"]
+
+MULTI_CER_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        (
+            "calculate the Character Error Rate (CER) of one series relative to another"
+        ): "计算一个序列相对于另一个序列的字符错误率（CER）",
+        (
+            "Character Error Rate is printed as edits divided by reference "
+            "character count."
+        ): "字符错误率按编辑次数除以参考字符数输出。",
+        (
+            "command-line interface for multi-series character error rate calculation"
+        ): "多序列字符错误率计算命令行界面",
+        'subtitle infile for candidate series or "-" for stdin': (
+            '候选序列的字幕输入文件，或用 "-" 表示标准输入'
+        ),
+        'subtitle infile for reference series or "-" for stdin': (
+            '参考序列的字幕输入文件，或用 "-" 表示标准输入'
+        ),
+    },
+    "zh-hant": {
+        (
+            "calculate the Character Error Rate (CER) of one series relative to another"
+        ): "計算一個序列相對於另一個序列的字元錯誤率（CER）",
+        (
+            "Character Error Rate is printed as edits divided by reference "
+            "character count."
+        ): "字元錯誤率按編輯次數除以參考字元數輸出。",
+        (
+            "command-line interface for multi-series character error rate calculation"
+        ): "多序列字元錯誤率計算命令列介面",
+        'subtitle infile for candidate series or "-" for stdin': (
+            '候選序列的字幕輸入檔，或用 "-" 表示標準輸入'
+        ),
+        'subtitle infile for reference series or "-" for stdin': (
+            '參考序列的字幕輸入檔，或用 "-" 表示標準輸入'
+        ),
+    },
+}
+"""Localized help text keyed by locale and English source text."""
 
 
 class MultiCerCli(ScinoephileCliBase):
@@ -21,48 +60,7 @@ class MultiCerCli(ScinoephileCliBase):
     Character Error Rate is printed as edits divided by reference character count.
     """
 
-    localizations: ClassVar[dict[str, dict[str, str]]] = {
-        "zh-hans": {
-            (
-                "calculate the Character Error Rate (CER) "
-                "of one series relative to another"
-            ): "计算一个序列相对于另一个序列的字符错误率（CER）",
-            (
-                "Character Error Rate is printed as edits divided by reference "
-                "character count."
-            ): "字符错误率按编辑次数除以参考字符数输出。",
-            (
-                "command-line interface for multi-series character error rate "
-                "calculation"
-            ): "多序列字符错误率计算命令行界面",
-            'subtitle infile for candidate series or "-" for stdin': (
-                '候选序列的字幕输入文件，或用 "-" 表示标准输入'
-            ),
-            'subtitle infile for reference series or "-" for stdin': (
-                '参考序列的字幕输入文件，或用 "-" 表示标准输入'
-            ),
-        },
-        "zh-hant": {
-            (
-                "calculate the Character Error Rate (CER) "
-                "of one series relative to another"
-            ): "計算一個序列相對於另一個序列的字元錯誤率（CER）",
-            (
-                "Character Error Rate is printed as edits divided by reference "
-                "character count."
-            ): "字元錯誤率按編輯次數除以參考字元數輸出。",
-            (
-                "command-line interface for multi-series character error rate "
-                "calculation"
-            ): "多序列字元錯誤率計算命令列介面",
-            'subtitle infile for candidate series or "-" for stdin': (
-                '候選序列的字幕輸入檔，或用 "-" 表示標準輸入'
-            ),
-            'subtitle infile for reference series or "-" for stdin': (
-                '參考序列的字幕輸入檔，或用 "-" 表示標準輸入'
-            ),
-        },
-    }
+    localizations = MULTI_CER_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
     @classmethod

--- a/scinoephile/cli/multi/multi_diff_cli.py
+++ b/scinoephile/cli/multi/multi_diff_cli.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import ClassVar
 
 from scinoephile.analysis.diff import SeriesDiff
 from scinoephile.common.argument_parsing import (
@@ -18,52 +17,55 @@ from scinoephile.core.cli import ScinoephileCliBase, read_series
 
 __all__ = ["MultiDiffCli"]
 
+MULTI_DIFF_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "calculate the diff between two series": "计算两个序列之间的差异",
+        "command-line interface for multi-series subtitle diffs": (
+            "多序列字幕差异命令行界面"
+        ),
+        "series label for candidate output in diff messages (default: candidate)": (
+            "差异消息中候选输出的序列标签（默认：candidate）"
+        ),
+        "series label for reference input in diff messages (default: reference)": (
+            "差异消息中参考输入的序列标签（默认：reference）"
+        ),
+        "similarity threshold used to pair replacements (default: 0.6)": (
+            "用于配对替换项的相似度阈值（默认：0.6）"
+        ),
+        'candidate subtitle infile to compare against the reference, or "-" '
+        "for stdin": ('要与参考输入比较的候选字幕输入文件，或用 "-" 表示标准输入'),
+        'reference subtitle infile or "-" for stdin': (
+            '参考字幕输入文件，或用 "-" 表示标准输入'
+        ),
+    },
+    "zh-hant": {
+        "calculate the diff between two series": "計算兩個序列之間的差異",
+        "command-line interface for multi-series subtitle diffs": (
+            "多序列字幕差異命令列介面"
+        ),
+        "series label for candidate output in diff messages (default: candidate)": (
+            "差異訊息中候選輸出的序列標籤（預設：candidate）"
+        ),
+        "series label for reference input in diff messages (default: reference)": (
+            "差異訊息中參考輸入的序列標籤（預設：reference）"
+        ),
+        "similarity threshold used to pair replacements (default: 0.6)": (
+            "用於配對替換項的相似度閾值（預設：0.6）"
+        ),
+        'candidate subtitle infile to compare against the reference, or "-" '
+        "for stdin": ('要與參考輸入比較的候選字幕輸入檔，或用 "-" 表示標準輸入'),
+        'reference subtitle infile or "-" for stdin': (
+            '參考字幕輸入檔，或用 "-" 表示標準輸入'
+        ),
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class MultiDiffCli(ScinoephileCliBase):
     """Calculate the diff between two series."""
 
-    localizations: ClassVar[dict[str, dict[str, str]]] = {
-        "zh-hans": {
-            "calculate the diff between two series": "计算两个序列之间的差异",
-            "command-line interface for multi-series subtitle diffs": (
-                "多序列字幕差异命令行界面"
-            ),
-            "series label for candidate output in diff messages (default: candidate)": (
-                "差异消息中候选输出的序列标签（默认：candidate）"
-            ),
-            "series label for reference input in diff messages (default: reference)": (
-                "差异消息中参考输入的序列标签（默认：reference）"
-            ),
-            "similarity threshold used to pair replacements (default: 0.6)": (
-                "用于配对替换项的相似度阈值（默认：0.6）"
-            ),
-            'candidate subtitle infile to compare against the reference, or "-" '
-            "for stdin": ('要与参考输入比较的候选字幕输入文件，或用 "-" 表示标准输入'),
-            'reference subtitle infile or "-" for stdin': (
-                '参考字幕输入文件，或用 "-" 表示标准输入'
-            ),
-        },
-        "zh-hant": {
-            "calculate the diff between two series": "計算兩個序列之間的差異",
-            "command-line interface for multi-series subtitle diffs": (
-                "多序列字幕差異命令列介面"
-            ),
-            "series label for candidate output in diff messages (default: candidate)": (
-                "差異訊息中候選輸出的序列標籤（預設：candidate）"
-            ),
-            "series label for reference input in diff messages (default: reference)": (
-                "差異訊息中參考輸入的序列標籤（預設：reference）"
-            ),
-            "similarity threshold used to pair replacements (default: 0.6)": (
-                "用於配對替換項的相似度閾值（預設：0.6）"
-            ),
-            'candidate subtitle infile to compare against the reference, or "-" '
-            "for stdin": ('要與參考輸入比較的候選字幕輸入檔，或用 "-" 表示標準輸入'),
-            'reference subtitle infile or "-" for stdin': (
-                '參考字幕輸入檔，或用 "-" 表示標準輸入'
-            ),
-        },
-    }
+    localizations = MULTI_DIFF_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
     @classmethod

--- a/scinoephile/cli/ocr/ocr_validate_cli.py
+++ b/scinoephile/cli/ocr/ocr_validate_cli.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import ClassVar
 
 from scinoephile.common import DirectoryNotFoundError
 from scinoephile.common.argument_parsing import (
@@ -24,57 +23,59 @@ from scinoephile.lang.zho.ocr_validation import validate_zho_ocr
 
 __all__ = ["OcrValidateCli"]
 
+OCR_VALIDATE_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "command-line interface for OCR subtitle validation": (
+            "OCR 字幕校验命令行界面"
+        ),
+        "directory in which to save validation image outputs": (
+            "保存校验图像输出的目录"
+        ),
+        "language of the OCR text to validate (eng or zho)": (
+            "要校验的 OCR 文本语言（eng 或 zho）"
+        ),
+        "OCR image subtitle infile path (directory containing index.html and png "
+        "files, or a .sup file)": (
+            "OCR 图像字幕输入路径（包含 index.html 和 png 文件的目录，或 .sup 文件）"
+        ),
+        "overwrite outfile directory if it exists": "若输出目录已存在则覆盖",
+        "prompt for interactive validation decisions": "提示进行交互式校验决策",
+        "stop validation after this subtitle index": "校验到此字幕索引后停止",
+        "validate OCR text against subtitle images": "对照字幕图像校验 OCR 文本",
+        "maintainer option: write validation data updates to repo data": (
+            "维护者选项：将校验数据更新写入仓库数据"
+        ),
+    },
+    "zh-hant": {
+        "command-line interface for OCR subtitle validation": (
+            "OCR 字幕驗證命令列介面"
+        ),
+        "directory in which to save validation image outputs": (
+            "儲存驗證影像輸出的目錄"
+        ),
+        "language of the OCR text to validate (eng or zho)": (
+            "要驗證的 OCR 文字語言（eng 或 zho）"
+        ),
+        "OCR image subtitle infile path (directory containing index.html and png "
+        "files, or a .sup file)": (
+            "OCR 影像字幕輸入路徑（包含 index.html 和 png 檔案的目錄，或 .sup 檔）"
+        ),
+        "overwrite outfile directory if it exists": "若輸出目錄已存在則覆寫",
+        "prompt for interactive validation decisions": "提示進行互動式驗證決策",
+        "stop validation after this subtitle index": "驗證到此字幕索引後停止",
+        "validate OCR text against subtitle images": "對照字幕影像驗證 OCR 文字",
+        "maintainer option: write validation data updates to repo data": (
+            "維護者選項：將驗證資料更新寫入儲存庫資料"
+        ),
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
 
 class OcrValidateCli(ScinoephileCliBase):
     """Validate OCR text against subtitle images."""
 
-    localizations: ClassVar[dict[str, dict[str, str]]] = {
-        "zh-hans": {
-            "command-line interface for OCR subtitle validation": (
-                "OCR 字幕校验命令行界面"
-            ),
-            "directory in which to save validation image outputs": (
-                "保存校验图像输出的目录"
-            ),
-            "language of the OCR text to validate (eng or zho)": (
-                "要校验的 OCR 文本语言（eng 或 zho）"
-            ),
-            "OCR image subtitle infile path (directory containing index.html and png "
-            "files, or a .sup file)": (
-                "OCR 图像字幕输入路径（包含 index.html 和 png 文件的目录，或 "
-                ".sup 文件）"
-            ),
-            "overwrite outfile directory if it exists": "若输出目录已存在则覆盖",
-            "prompt for interactive validation decisions": "提示进行交互式校验决策",
-            "stop validation after this subtitle index": "校验到此字幕索引后停止",
-            "validate OCR text against subtitle images": "对照字幕图像校验 OCR 文本",
-            "maintainer option: write validation data updates to repo data": (
-                "维护者选项：将校验数据更新写入仓库数据"
-            ),
-        },
-        "zh-hant": {
-            "command-line interface for OCR subtitle validation": (
-                "OCR 字幕驗證命令列介面"
-            ),
-            "directory in which to save validation image outputs": (
-                "儲存驗證影像輸出的目錄"
-            ),
-            "language of the OCR text to validate (eng or zho)": (
-                "要驗證的 OCR 文字語言（eng 或 zho）"
-            ),
-            "OCR image subtitle infile path (directory containing index.html and png "
-            "files, or a .sup file)": (
-                "OCR 影像字幕輸入路徑（包含 index.html 和 png 檔案的目錄，或 .sup 檔）"
-            ),
-            "overwrite outfile directory if it exists": "若輸出目錄已存在則覆寫",
-            "prompt for interactive validation decisions": "提示進行互動式驗證決策",
-            "stop validation after this subtitle index": "驗證到此字幕索引後停止",
-            "validate OCR text against subtitle images": "對照字幕影像驗證 OCR 文字",
-            "maintainer option: write validation data updates to repo data": (
-                "維護者選項：將驗證資料更新寫入儲存庫資料"
-            ),
-        },
-    }
+    localizations = OCR_VALIDATE_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
     @classmethod


### PR DESCRIPTION
## Summary
- Move remaining class-body CLI localization dictionaries into module-level constants.
- Normalize dictionary build, multi-series CER/diff, and OCR validation CLIs to match the existing `*_LOCALIZATIONS` pattern.
- Leave existing merged localization patterns unchanged.

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format` on changed Python files
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix` on changed Python files
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check` on changed Python files
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` (`1061 passed, 10 skipped`)