### PR TITLE
Use media stream indexes for audio selection

### DIFF
--- a/scinoephile/audio/subtitles/series.py
+++ b/scinoephile/audio/subtitles/series.py
@@ -21,7 +21,9 @@ from scinoephile.common.validation import (
     val_output_path,
 )
 from scinoephile.core import ScinoephileError
+from scinoephile.core.media import AudioStream
 from scinoephile.core.subtitles import Series
+from scinoephile.media.probe import get_streams
 
 from .subtitle import AudioSubtitle
 
@@ -224,7 +226,7 @@ class AudioSeries(Series):
         cls,
         media_path: Path | str,
         subtitle_path: Path | str,
-        stream_index: int = 0,
+        stream_index: int | None = None,
         buffer: int = 1000,
         **kwargs: Any,
     ) -> Self:
@@ -233,7 +235,8 @@ class AudioSeries(Series):
         Arguments:
             media_path: path to media file
             subtitle_path: path to subtitle file
-            stream_index: media stream index of an audio stream
+            stream_index: media stream index of an audio stream, or None to use the
+              first audio stream
             buffer: additional buffer to include before and after subtitles (ms)
             **kwargs: additional keyword arguments passed to Series.load
         Returns:
@@ -243,45 +246,13 @@ class AudioSeries(Series):
         validated_subtitle_path = val_input_path(subtitle_path)
         text_series = Series.load(validated_subtitle_path, **kwargs)
 
-        try:
-            probe = ffmpeg.probe(str(validated_media_path))
-        except ffmpeg.Error as exc:
+        stream = cls._get_audio_stream(validated_media_path, stream_index)
+        if stream.channels is None:
             raise ScinoephileError(
-                f"Could not probe media file {validated_media_path}"
-            ) from exc
-        streams = [
-            stream for stream in probe.get("streams", []) if isinstance(stream, dict)
-        ]
-        streams_by_index: dict[int, dict[str, Any]] = {}
-        for stream in streams:
-            try:
-                probed_stream_index = int(stream.get("index", -1))
-            except (TypeError, ValueError):
-                continue
-            streams_by_index[probed_stream_index] = stream
-
-        if stream_index not in streams_by_index:
-            raise ScinoephileError(
-                f"No stream index {stream_index} found in {validated_media_path}"
-            )
-        stream = streams_by_index[stream_index]
-        if stream.get("codec_type") != "audio":
-            raise ScinoephileError(
-                f"Stream index {stream_index} is not an audio stream"
-            )
-        channels = stream.get("channels")
-        if channels is None:
-            raise ScinoephileError(
-                f"Audio stream {stream_index} in {validated_media_path} "
+                f"Audio stream {stream.index} in {validated_media_path} "
                 "cannot be used for transcription."
             )
-        try:
-            channel_count = int(channels)
-        except (TypeError, ValueError) as exc:
-            raise ScinoephileError(
-                f"Audio stream {stream_index} in {validated_media_path} "
-                "cannot be used for transcription."
-            ) from exc
+        channel_count = stream.channels
 
         with get_temp_directory_path() as temp_dir_path:
             full_audio_path = temp_dir_path / "full_audio.wav"
@@ -289,14 +260,14 @@ class AudioSeries(Series):
                 cls.extract_audio_track(
                     validated_media_path,
                     full_audio_path,
-                    stream_index,
+                    stream.index,
                     channel_count,
                 )
                 logger.info(f"Loading full audio from {full_audio_path}")
                 full_audio = AudioSegment.from_wav(full_audio_path)
             except ffmpeg.Error as exc:
                 raise ScinoephileError(
-                    f"Could not extract audio stream {stream_index} from "
+                    f"Could not extract audio stream {stream.index} from "
                     f"{validated_media_path}"
                 ) from exc
 
@@ -401,6 +372,33 @@ class AudioSeries(Series):
                 map=f"0:{audio_track}",
                 ac=1,
             ).run(quiet=False, overwrite_output=True)
+
+    @staticmethod
+    def _get_audio_stream(media_path: Path, stream_index: int | None) -> AudioStream:
+        """Get the selected audio stream from a media file.
+
+        Arguments:
+            media_path: media input path
+            stream_index: audio stream index, or None to use the first audio stream
+        Returns:
+            selected audio stream
+        """
+        streams = get_streams(media_path)
+        if stream_index is None:
+            for stream in streams:
+                if isinstance(stream, AudioStream):
+                    return stream
+            raise ScinoephileError(f"No audio streams found in {media_path}")
+
+        for stream in streams:
+            if stream.index != stream_index:
+                continue
+            if not isinstance(stream, AudioStream):
+                raise ScinoephileError(
+                    f"Stream index {stream_index} is not an audio stream"
+                )
+            return stream
+        raise ScinoephileError(f"No stream index {stream_index} found in {media_path}")
 
     @override
     def _init_blocks(self):

--- a/scinoephile/audio/subtitles/series.py
+++ b/scinoephile/audio/subtitles/series.py
@@ -233,7 +233,7 @@ class AudioSeries(Series):
         Arguments:
             media_path: path to media file
             subtitle_path: path to subtitle file
-            stream_index: audio stream index (zero-based)
+            stream_index: media stream index of an audio stream
             buffer: additional buffer to include before and after subtitles (ms)
             **kwargs: additional keyword arguments passed to Series.load
         Returns:
@@ -249,22 +249,32 @@ class AudioSeries(Series):
             raise ScinoephileError(
                 f"Could not probe media file {validated_media_path}"
             ) from exc
-        audio_streams = [
-            stream
-            for stream in probe.get("streams", [])
-            if stream.get("codec_type") == "audio"
+        streams = [
+            stream for stream in probe.get("streams", []) if isinstance(stream, dict)
         ]
-        if not audio_streams:
+        streams_by_index: dict[int, dict[str, Any]] = {}
+        for stream in streams:
+            try:
+                probed_stream_index = int(stream.get("index", -1))
+            except (TypeError, ValueError):
+                continue
+            streams_by_index[probed_stream_index] = stream
+
+        if stream_index not in streams_by_index:
             raise ScinoephileError(
-                f"No audio streams found in media file {validated_media_path}"
+                f"No stream index {stream_index} found in {validated_media_path}"
             )
-        if stream_index < 0 or stream_index >= len(audio_streams):
+        stream = streams_by_index[stream_index]
+        if stream.get("codec_type") != "audio":
             raise ScinoephileError(
-                f"Invalid audio stream index {stream_index} for "
-                f"{validated_media_path}; found {len(audio_streams)} audio stream(s)."
+                f"Stream index {stream_index} is not an audio stream"
             )
-        stream = audio_streams[stream_index]
         channels = stream.get("channels")
+        if channels is None:
+            raise ScinoephileError(
+                f"Audio stream {stream_index} in {validated_media_path} "
+                "cannot be used for transcription."
+            )
         try:
             channel_count = int(channels)
         except (TypeError, ValueError) as exc:
@@ -362,7 +372,7 @@ class AudioSeries(Series):
         Arguments:
             video_input_path: Path to input video file
             audio_output_path: Path to output audio file
-            audio_track: Audio track (zero-indexed)
+            audio_track: media stream index of an audio stream
             channels: Number of channels in audio track
         """
         if channels >= 6:
@@ -375,7 +385,7 @@ class AudioSeries(Series):
                 format="wav",
                 ar=16000,
                 **{
-                    "filter_complex": f"[0:a:{audio_track}]pan=mono|c0=c2[out]",
+                    "filter_complex": f"[0:{audio_track}]pan=mono|c0=c2[out]",
                     "map": "[out]",
                 },
             ).run(quiet=False, overwrite_output=True)
@@ -388,7 +398,7 @@ class AudioSeries(Series):
                 str(audio_output_path),
                 format="wav",
                 ar=16000,
-                map=f"0:a:{audio_track}",
+                map=f"0:{audio_track}",
                 ac=1,
             ).run(quiet=False, overwrite_output=True)
 

--- a/scinoephile/cli/yue/yue_transcribe_vs_zho_cli.py
+++ b/scinoephile/cli/yue/yue_transcribe_vs_zho_cli.py
@@ -51,9 +51,10 @@ __all__ = ["YueTranscribeVsZhoCli"]
 
 YUE_TRANSCRIBE_VS_ZHO_LOCALIZATIONS: dict[str, dict[str, str]] = {
     "zh-hans": {
-        "media stream index of audio stream in media input (default: 0)": (
-            "媒体输入中的音频媒体流索引（默认：0）"
-        ),
+        (
+            "media stream index of audio stream in media input "
+            "(default: first audio stream)"
+        ): ("媒体输入中的音频媒体流索引（默认：第一个音频流）"),
         (
             "command-line interface for written Cantonese subtitle transcription"
         ): "书面粤语字幕转写命令行界面",
@@ -81,9 +82,10 @@ YUE_TRANSCRIBE_VS_ZHO_LOCALIZATIONS: dict[str, dict[str, str]] = {
         ): "从音频转录字幕，并使用标准中文文本修订",
     },
     "zh-hant": {
-        "media stream index of audio stream in media input (default: 0)": (
-            "媒體輸入中的音訊媒體流索引（預設：0）"
-        ),
+        (
+            "media stream index of audio stream in media input "
+            "(default: first audio stream)"
+        ): ("媒體輸入中的音訊媒體流索引（預設：第一個音訊流）"),
         (
             "command-line interface for written Cantonese subtitle transcription"
         ): "書面粵語字幕轉寫命令列介面",
@@ -152,8 +154,11 @@ class YueTranscribeVsZhoCli(ScinoephileCliBase):
         arg_groups["input arguments"].add_argument(
             "--stream-index",
             type=int_arg(min_value=0),
-            default=0,
-            help="media stream index of audio stream in media input (default: 0)",
+            default=None,
+            help=(
+                "media stream index of audio stream in media input "
+                "(default: first audio stream)"
+            ),
         )
         arg_groups["input arguments"].add_argument(
             "--zho-infile",
@@ -244,7 +249,7 @@ class YueTranscribeVsZhoCli(ScinoephileCliBase):
         _parser: ArgumentParser | None = None,
         media_infile_path: str,
         zho_infile_path: Path | str,
-        stream_index: int,
+        stream_index: int | None,
         script: str,
         convert: OpenCCConfig | None,
         llm_provider_name: str,

--- a/scinoephile/cli/yue/yue_transcribe_vs_zho_cli.py
+++ b/scinoephile/cli/yue/yue_transcribe_vs_zho_cli.py
@@ -51,8 +51,8 @@ __all__ = ["YueTranscribeVsZhoCli"]
 
 YUE_TRANSCRIBE_VS_ZHO_LOCALIZATIONS: dict[str, dict[str, str]] = {
     "zh-hans": {
-        "audio stream index in media input (default: 0)": (
-            "媒体输入中的音频流索引（默认：0）"
+        "media stream index of audio stream in media input (default: 0)": (
+            "媒体输入中的音频媒体流索引（默认：0）"
         ),
         (
             "command-line interface for written Cantonese subtitle transcription"
@@ -81,8 +81,8 @@ YUE_TRANSCRIBE_VS_ZHO_LOCALIZATIONS: dict[str, dict[str, str]] = {
         ): "从音频转录字幕，并使用标准中文文本修订",
     },
     "zh-hant": {
-        "audio stream index in media input (default: 0)": (
-            "媒體輸入中的音訊流索引（預設：0）"
+        "media stream index of audio stream in media input (default: 0)": (
+            "媒體輸入中的音訊媒體流索引（預設：0）"
         ),
         (
             "command-line interface for written Cantonese subtitle transcription"
@@ -153,7 +153,7 @@ class YueTranscribeVsZhoCli(ScinoephileCliBase):
             "--stream-index",
             type=int_arg(min_value=0),
             default=0,
-            help="audio stream index in media input (default: 0)",
+            help="media stream index of audio stream in media input (default: 0)",
         )
         arg_groups["input arguments"].add_argument(
             "--zho-infile",

--- a/scinoephile/media/probe.py
+++ b/scinoephile/media/probe.py
@@ -37,7 +37,10 @@ def get_streams(infile_path: Path) -> list[Stream]:
     for stream in probe.get("streams", []):
         if not isinstance(stream, dict):
             continue
-        streams.append(_from_ffprobe_stream(stream))
+        stream_index = _get_stream_index(stream)
+        if stream_index is None:
+            continue
+        streams.append(_from_ffprobe_stream(stream, stream_index))
     return streams
 
 
@@ -58,23 +61,24 @@ def get_subtitle_streams(infile_path: Path) -> list[SubtitleStream]:
     ]
 
 
-def _from_ffprobe_stream(stream: dict[str, Any]) -> Stream:
+def _from_ffprobe_stream(stream: dict[str, Any], stream_index: int) -> Stream:
     """Parse a probed ffmpeg stream into typed stream metadata.
 
     Arguments:
         stream: ffprobe stream object
+        stream_index: absolute media stream index
     Returns:
         stream metadata
     """
     codec_type = _get_codec_type(stream)
     if codec_type == "audio":
-        return _from_ffprobe_audio_stream(stream)
+        return _from_ffprobe_audio_stream(stream, stream_index)
     if codec_type == "subtitle":
-        return _from_ffprobe_subtitle_stream(stream)
+        return _from_ffprobe_subtitle_stream(stream, stream_index)
     if codec_type == "video":
-        return _from_ffprobe_video_stream(stream)
+        return _from_ffprobe_video_stream(stream, stream_index)
     return Stream(
-        index=int(stream.get("index", 0)),
+        index=stream_index,
         codec_type=codec_type,
         codec_name=_get_codec_name(stream, codec_type),
         language=_get_language(stream),
@@ -82,11 +86,14 @@ def _from_ffprobe_stream(stream: dict[str, Any]) -> Stream:
     )
 
 
-def _from_ffprobe_audio_stream(stream: dict[str, Any]) -> AudioStream:
+def _from_ffprobe_audio_stream(
+    stream: dict[str, Any], stream_index: int
+) -> AudioStream:
     """Parse a probed ffmpeg stream into audio stream metadata.
 
     Arguments:
         stream: ffprobe stream object
+        stream_index: absolute media stream index
     Returns:
         audio stream metadata
     """
@@ -94,7 +101,7 @@ def _from_ffprobe_audio_stream(stream: dict[str, Any]) -> AudioStream:
     if not isinstance(channels, int):
         channels = None
     return AudioStream(
-        index=int(stream.get("index", 0)),
+        index=stream_index,
         codec_type="audio",
         codec_name=_get_codec_name(stream, "audio"),
         language=_get_language(stream),
@@ -103,11 +110,14 @@ def _from_ffprobe_audio_stream(stream: dict[str, Any]) -> AudioStream:
     )
 
 
-def _from_ffprobe_subtitle_stream(stream: dict[str, Any]) -> SubtitleStream:
+def _from_ffprobe_subtitle_stream(
+    stream: dict[str, Any], stream_index: int
+) -> SubtitleStream:
     """Parse a probed ffmpeg stream into subtitle metadata.
 
     Arguments:
         stream: ffprobe stream object
+        stream_index: absolute media stream index
     Returns:
         subtitle stream metadata
     """
@@ -122,7 +132,7 @@ def _from_ffprobe_subtitle_stream(stream: dict[str, Any]) -> SubtitleStream:
         subtitle_count = None
 
     return SubtitleStream(
-        index=int(stream.get("index", 0)),
+        index=stream_index,
         codec_type="subtitle",
         codec_name=_get_codec_name(stream, "subtitle"),
         language=_get_language(stream),
@@ -133,11 +143,14 @@ def _from_ffprobe_subtitle_stream(stream: dict[str, Any]) -> SubtitleStream:
     )
 
 
-def _from_ffprobe_video_stream(stream: dict[str, Any]) -> VideoStream:
+def _from_ffprobe_video_stream(
+    stream: dict[str, Any], stream_index: int
+) -> VideoStream:
     """Parse a probed ffmpeg stream into video stream metadata.
 
     Arguments:
         stream: ffprobe stream object
+        stream_index: absolute media stream index
     Returns:
         video stream metadata
     """
@@ -148,7 +161,7 @@ def _from_ffprobe_video_stream(stream: dict[str, Any]) -> VideoStream:
     if not isinstance(height, int):
         height = None
     return VideoStream(
-        index=int(stream.get("index", 0)),
+        index=stream_index,
         codec_type="video",
         codec_name=_get_codec_name(stream, "video"),
         language=_get_language(stream),
@@ -185,6 +198,26 @@ def _get_codec_type(stream: dict[str, Any]) -> str:
     if not isinstance(codec_type, str) or not codec_type:
         codec_type = "unknown"
     return codec_type
+
+
+def _get_stream_index(stream: dict[str, Any]) -> int | None:
+    """Return usable stream index from an ffprobe stream.
+
+    Arguments:
+        stream: ffprobe stream object
+    Returns:
+        absolute media stream index, if present and nonnegative
+    """
+    stream_index_value = stream.get("index")
+    if stream_index_value is None:
+        return None
+    try:
+        stream_index = int(stream_index_value)
+    except (TypeError, ValueError):
+        return None
+    if stream_index < 0:
+        return None
+    return stream_index
 
 
 def _get_language(stream: dict[str, Any]) -> str | None:

--- a/test/audio/subtitles/test_audio_series_load_from_media.py
+++ b/test/audio/subtitles/test_audio_series_load_from_media.py
@@ -97,7 +97,7 @@ def test_audio_series_load_from_media_supports_stream_index():
         with get_temp_file_path(".mp4") as media_path:
             media_path.touch()
             with patch(
-                "scinoephile.audio.subtitles.series.ffmpeg.probe",
+                "scinoephile.media.probe.ffmpeg.probe",
                 return_value={
                     "streams": [
                         {"index": 0, "codec_type": "video"},
@@ -126,6 +126,47 @@ def test_audio_series_load_from_media_supports_stream_index():
     assert extract_audio_track.call_args.args[3] == 6
 
 
+def test_audio_series_load_from_media_defaults_to_first_audio_stream():
+    """Test media loading defaults to the first probed audio stream."""
+    full_audio = AudioSegment.silent(duration=3000)
+
+    with get_temp_file_path(".srt") as subtitle_path:
+        subtitle_path.write_text(
+            "1\n00:00:01,000 --> 00:00:02,000\n你好\n", encoding="utf-8"
+        )
+        with get_temp_file_path(".mp4") as media_path:
+            media_path.touch()
+            with patch(
+                "scinoephile.media.probe.ffmpeg.probe",
+                return_value={
+                    "streams": [
+                        {"index": 0, "codec_type": "video"},
+                        {"codec_type": "audio", "channels": 2},
+                        {"index": -1, "codec_type": "audio", "channels": 2},
+                        {"index": 1, "codec_type": "audio", "channels": 2},
+                        {"index": 12, "codec_type": "audio", "channels": 6},
+                    ]
+                },
+            ):
+                with patch(
+                    "scinoephile.audio.subtitles.series.AudioSeries.extract_audio_track"
+                ) as extract_audio_track:
+                    with patch(
+                        "scinoephile.audio.subtitles.series.AudioSegment.from_wav",
+                        return_value=full_audio,
+                    ):
+                        yuewen_series = AudioSeries.load_from_media(
+                            media_path=media_path,
+                            subtitle_path=subtitle_path,
+                        )
+
+    assert isinstance(yuewen_series, AudioSeries)
+    assert [event.text for event in yuewen_series.events] == ["你好"]
+    extract_audio_track.assert_called_once()
+    assert extract_audio_track.call_args.args[2] == 1
+    assert extract_audio_track.call_args.args[3] == 2
+
+
 def test_audio_series_load_from_media_rejects_invalid_stream_index():
     """Test media loading rejects missing stream indexes."""
     with get_temp_file_path(".srt") as subtitle_path:
@@ -135,7 +176,7 @@ def test_audio_series_load_from_media_rejects_invalid_stream_index():
         with get_temp_file_path(".mp4") as media_path:
             media_path.touch()
             with patch(
-                "scinoephile.audio.subtitles.series.ffmpeg.probe",
+                "scinoephile.media.probe.ffmpeg.probe",
                 return_value={
                     "streams": [{"index": 1, "codec_type": "audio", "channels": 2}]
                 },
@@ -157,7 +198,7 @@ def test_audio_series_load_from_media_rejects_non_audio_stream_index():
         with get_temp_file_path(".mp4") as media_path:
             media_path.touch()
             with patch(
-                "scinoephile.audio.subtitles.series.ffmpeg.probe",
+                "scinoephile.media.probe.ffmpeg.probe",
                 return_value={
                     "streams": [
                         {"index": 0, "codec_type": "video"},

--- a/test/audio/subtitles/test_audio_series_load_from_media.py
+++ b/test/audio/subtitles/test_audio_series_load_from_media.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -12,6 +13,77 @@ from pydub import AudioSegment
 from scinoephile.audio.subtitles import AudioSeries
 from scinoephile.common.file import get_temp_file_path
 from scinoephile.core import ScinoephileError
+
+
+class FakeFfmpegInput:
+    """Fake ffmpeg input chain that records output arguments."""
+
+    def __init__(self):
+        """Initialize."""
+        self.output_args: tuple[object, ...] | None = None
+        self.output_kwargs: dict[str, object] | None = None
+        self.run_kwargs: dict[str, object] | None = None
+
+    def output(self, *args: object, **kwargs: object) -> FakeFfmpegInput:
+        """Record ffmpeg output arguments.
+
+        Arguments:
+            *args: ffmpeg output positional arguments
+            **kwargs: ffmpeg output keyword arguments
+        Returns:
+            fake ffmpeg input chain
+        """
+        self.output_args = args
+        self.output_kwargs = kwargs
+        return self
+
+    def run(self, **kwargs: object):
+        """Record ffmpeg run arguments.
+
+        Arguments:
+            **kwargs: ffmpeg run keyword arguments
+        """
+        self.run_kwargs = kwargs
+
+
+def test_audio_series_extract_audio_track_maps_overall_stream_index():
+    """Test audio extraction maps the absolute media stream index."""
+    fake_ffmpeg_input = FakeFfmpegInput()
+
+    with patch(
+        "scinoephile.audio.subtitles.series.ffmpeg.input",
+        return_value=fake_ffmpeg_input,
+    ):
+        AudioSeries.extract_audio_track(
+            Path("video.mkv"),
+            Path("audio.wav"),
+            12,
+            2,
+        )
+
+    assert fake_ffmpeg_input.output_kwargs is not None
+    assert fake_ffmpeg_input.output_kwargs["map"] == "0:12"
+
+
+def test_audio_series_extract_audio_track_filters_overall_stream_index():
+    """Test center-channel extraction filters the absolute media stream index."""
+    fake_ffmpeg_input = FakeFfmpegInput()
+
+    with patch(
+        "scinoephile.audio.subtitles.series.ffmpeg.input",
+        return_value=fake_ffmpeg_input,
+    ):
+        AudioSeries.extract_audio_track(
+            Path("video.mkv"),
+            Path("audio.wav"),
+            12,
+            6,
+        )
+
+    assert fake_ffmpeg_input.output_kwargs is not None
+    assert fake_ffmpeg_input.output_kwargs["filter_complex"] == (
+        "[0:12]pan=mono|c0=c2[out]"
+    )
 
 
 def test_audio_series_load_from_media_supports_stream_index():
@@ -28,9 +100,9 @@ def test_audio_series_load_from_media_supports_stream_index():
                 "scinoephile.audio.subtitles.series.ffmpeg.probe",
                 return_value={
                     "streams": [
-                        {"codec_type": "video"},
-                        {"codec_type": "audio", "channels": 2},
-                        {"codec_type": "audio", "channels": 6},
+                        {"index": 0, "codec_type": "video"},
+                        {"index": 1, "codec_type": "audio", "channels": 2},
+                        {"index": 12, "codec_type": "audio", "channels": 6},
                     ]
                 },
             ):
@@ -44,18 +116,18 @@ def test_audio_series_load_from_media_supports_stream_index():
                         yuewen_series = AudioSeries.load_from_media(
                             media_path=media_path,
                             subtitle_path=subtitle_path,
-                            stream_index=1,
+                            stream_index=12,
                         )
 
     assert isinstance(yuewen_series, AudioSeries)
     assert [event.text for event in yuewen_series.events] == ["你好"]
     extract_audio_track.assert_called_once()
-    assert extract_audio_track.call_args.args[2] == 1
+    assert extract_audio_track.call_args.args[2] == 12
     assert extract_audio_track.call_args.args[3] == 6
 
 
 def test_audio_series_load_from_media_rejects_invalid_stream_index():
-    """Test media loading rejects invalid stream indexes."""
+    """Test media loading rejects missing stream indexes."""
     with get_temp_file_path(".srt") as subtitle_path:
         subtitle_path.write_text(
             "1\n00:00:00,000 --> 00:00:01,000\n你好\n", encoding="utf-8"
@@ -64,13 +136,40 @@ def test_audio_series_load_from_media_rejects_invalid_stream_index():
             media_path.touch()
             with patch(
                 "scinoephile.audio.subtitles.series.ffmpeg.probe",
-                return_value={"streams": [{"codec_type": "audio", "channels": 2}]},
+                return_value={
+                    "streams": [{"index": 1, "codec_type": "audio", "channels": 2}]
+                },
+            ):
+                with pytest.raises(ScinoephileError, match="No stream index 2"):
+                    AudioSeries.load_from_media(
+                        media_path=media_path,
+                        subtitle_path=subtitle_path,
+                        stream_index=2,
+                    )
+
+
+def test_audio_series_load_from_media_rejects_non_audio_stream_index():
+    """Test media loading rejects overall stream indexes that are not audio."""
+    with get_temp_file_path(".srt") as subtitle_path:
+        subtitle_path.write_text(
+            "1\n00:00:00,000 --> 00:00:01,000\n你好\n", encoding="utf-8"
+        )
+        with get_temp_file_path(".mp4") as media_path:
+            media_path.touch()
+            with patch(
+                "scinoephile.audio.subtitles.series.ffmpeg.probe",
+                return_value={
+                    "streams": [
+                        {"index": 0, "codec_type": "video"},
+                        {"index": 1, "codec_type": "audio", "channels": 2},
+                    ]
+                },
             ):
                 with pytest.raises(
-                    ScinoephileError, match="Invalid audio stream index 1"
+                    ScinoephileError, match="Stream index 0 is not an audio stream"
                 ):
                     AudioSeries.load_from_media(
                         media_path=media_path,
                         subtitle_path=subtitle_path,
-                        stream_index=1,
+                        stream_index=0,
                     )

--- a/test/cli/yue/test_yue_transcribe_vs_zho_cli.py
+++ b/test/cli/yue/test_yue_transcribe_vs_zho_cli.py
@@ -59,6 +59,7 @@ def test_yue_transcribe_vs_zho_help_lists_script_convert_demucs_and_vad_options(
     assert "--vad {auto,on,off}" in help_text
     assert "Whisper voice activity detection mode" in help_text
     assert "off, auto; default: auto" in help_text
+    assert "default: first audio stream" in help_text
 
 
 def test_yue_transcribe_vs_zho_cli_writes_file():
@@ -132,7 +133,7 @@ def test_yue_transcribe_vs_zho_cli_writes_stdout():
     with patch(
         "scinoephile.cli.yue.yue_transcribe_vs_zho_cli.AudioSeries.load_from_media",
         return_value=yuewen_audio_series,
-    ):
+    ) as patched_loader:
         with patch(
             "scinoephile.cli.yue.yue_transcribe_vs_zho_cli.get_yue_vs_zho_transcriber",
             return_value="transcriber",
@@ -149,6 +150,11 @@ def test_yue_transcribe_vs_zho_cli_writes_stdout():
                     )
 
     output_series = Series.from_string(stdout_stream.getvalue(), format_="srt")
+    patched_loader.assert_called_once_with(
+        media_path=media_infile_path,
+        subtitle_path=zhongwen_infile_path,
+        stream_index=None,
+    )
     assert_series_equal(output_series, expected_series)
 
 

--- a/test/cli/yue/test_yue_transcribe_vs_zho_cli.py
+++ b/test/cli/yue/test_yue_transcribe_vs_zho_cli.py
@@ -322,7 +322,7 @@ def test_yue_transcribe_vs_zho_cli_stream_errors_are_user_facing():
     media_infile_path = "/tmp/test_media.mp4"
     with patch(
         "scinoephile.cli.yue.yue_transcribe_vs_zho_cli.AudioSeries.load_from_media",
-        side_effect=ScinoephileError("Invalid audio stream index 7"),
+        side_effect=ScinoephileError("No stream index 7 found"),
     ):
         with pytest.raises(SystemExit, match="2"):
             run_cli_with_args(

--- a/test/data/transcription.py
+++ b/test/data/transcription.py
@@ -49,7 +49,7 @@ def process_yue_hans_transcription(  # noqa: PLR0912, PLR0915
     output_dir_path: Path | None = None,
     audio_path: Path | None = None,
     media_path: Path | None = None,
-    stream_index: int = 0,
+    stream_index: int | None = None,
     overwrite_srt: bool = False,
     transcriber_kw: dict[str, Any] | None = None,
     line_reviewer_kw: dict[str, Any] | None = None,
@@ -76,7 +76,8 @@ def process_yue_hans_transcription(  # noqa: PLR0912, PLR0915
         audio_path: path to the staged audio wav file; defaults to
           `title_root_path/output/yue-Hans_transcribe/audio/audio.wav`
         media_path: optional media path used to generate `audio_path` if missing
-        stream_index: media stream index of audio stream used when generating audio
+        stream_index: media stream index of audio stream used when generating audio,
+          or None to use the first audio stream
         overwrite_srt: whether to overwrite subtitle outputs
         transcriber_kw: additional keyword arguments for get_yue_vs_zho_transcriber
         line_reviewer_kw: additional keyword arguments for get_yue_vs_zho_line_reviewer

--- a/test/data/transcription.py
+++ b/test/data/transcription.py
@@ -76,7 +76,7 @@ def process_yue_hans_transcription(  # noqa: PLR0912, PLR0915
         audio_path: path to the staged audio wav file; defaults to
           `title_root_path/output/yue-Hans_transcribe/audio/audio.wav`
         media_path: optional media path used to generate `audio_path` if missing
-        stream_index: audio stream index in media used when generating audio
+        stream_index: media stream index of audio stream used when generating audio
         overwrite_srt: whether to overwrite subtitle outputs
         transcriber_kw: additional keyword arguments for get_yue_vs_zho_transcriber
         line_reviewer_kw: additional keyword arguments for get_yue_vs_zho_line_reviewer

--- a/test/media/test_probe.py
+++ b/test/media/test_probe.py
@@ -95,6 +95,29 @@ def test_get_streams_returns_all_typed_streams(tmp_path: Path):
     assert streams[3].codec_type == "data"
 
 
+def test_get_streams_skips_streams_without_nonnegative_index(tmp_path: Path):
+    """Test media stream probing skips streams without usable indexes."""
+    infile_path = tmp_path / "video.mkv"
+    infile_path.touch()
+
+    with patch(
+        "scinoephile.media.probe.ffmpeg.probe",
+        return_value={
+            "streams": [
+                {"codec_type": "audio", "channels": 2},
+                {"index": None, "codec_type": "audio", "channels": 2},
+                {"index": -1, "codec_type": "audio", "channels": 2},
+                {"index": "bad", "codec_type": "audio", "channels": 2},
+                {"index": 1, "codec_type": "audio", "channels": 2},
+            ],
+        },
+    ):
+        streams = get_streams(infile_path)
+
+    assert len(streams) == 1
+    assert streams[0].index == 1
+
+
 def test_get_streams_normalizes_missing_codecs(tmp_path: Path):
     """Test media stream probing normalizes missing codec fields."""
     infile_path = tmp_path / "video.mkv"


### PR DESCRIPTION
## Summary
- Treat media-backed audio selection as an absolute ffprobe/container stream index.
- Extract audio with `0:<stream_index>` and reject missing or non-audio stream indexes before transcription.
- Update Yue transcription CLI help/localizations and regression tests for absolute stream indexes.

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/audio/subtitles/series.py scinoephile/cli/yue/yue_transcribe_vs_zho_cli.py test/audio/subtitles/test_audio_series_load_from_media.py test/cli/yue/test_yue_transcribe_vs_zho_cli.py test/data/transcription.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/audio/subtitles/series.py scinoephile/cli/yue/yue_transcribe_vs_zho_cli.py test/audio/subtitles/test_audio_series_load_from_media.py test/cli/yue/test_yue_transcribe_vs_zho_cli.py test/data/transcription.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/audio/subtitles/series.py scinoephile/cli/yue/yue_transcribe_vs_zho_cli.py test/audio/subtitles/test_audio_series_load_from_media.py test/cli/yue/test_yue_transcribe_vs_zho_cli.py test/data/transcription.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest test/audio/subtitles/test_audio_series_load_from_media.py test/cli/yue/test_yue_transcribe_vs_zho_cli.py -q`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto`