### PR TITLE
Add Whisper model option to Yue transcription CLI

### DIFF
--- a/scinoephile/cli/yue/yue_transcribe_vs_zho_cli.py
+++ b/scinoephile/cli/yue/yue_transcribe_vs_zho_cli.py
@@ -68,6 +68,9 @@ YUE_TRANSCRIBE_VS_ZHO_LOCALIZATIONS: dict[str, dict[str, str]] = {
             "Whisper voice activity detection mode "
             "(options: on, off, auto; default: auto)"
         ): "Whisper 语音活动检测模式（选项：on、off、auto；默认：auto）",
+        "Whisper model identifier used for transcription (default: %(default)s)": (
+            "用于转写的 Whisper 模型标识符（默认：%(default)s）"
+        ),
         'standard Chinese subtitle infile, or "-" for stdin': (
             '标准中文字幕输入文件，或使用 "-" 表示标准输入'
         ),
@@ -99,6 +102,9 @@ YUE_TRANSCRIBE_VS_ZHO_LOCALIZATIONS: dict[str, dict[str, str]] = {
             "Whisper voice activity detection mode "
             "(options: on, off, auto; default: auto)"
         ): "Whisper 語音活動偵測模式（選項：on、off、auto；預設：auto）",
+        "Whisper model identifier used for transcription (default: %(default)s)": (
+            "用於轉寫的 Whisper 模型識別碼（預設：%(default)s）"
+        ),
         'standard Chinese subtitle infile, or "-" for stdin': (
             '標準中文字幕輸入檔，或使用 "-" 代表標準輸入'
         ),
@@ -186,6 +192,14 @@ class YueTranscribeVsZhoCli(ScinoephileCliBase):
                 "(options: on, off, auto; default: auto)"
             ),
         )
+        arg_groups["operation arguments"].add_argument(
+            "--whisper-model",
+            default="khleeloo/whisper-large-v3-cantonese",
+            dest="whisper_model_name",
+            help=(
+                "Whisper model identifier used for transcription (default: %(default)s)"
+            ),
+        )
         add_opencc_convert_argument(
             arg_groups["operation arguments"], arg_groups["additional help"]
         )
@@ -257,6 +271,7 @@ class YueTranscribeVsZhoCli(ScinoephileCliBase):
         llm_additional_context_file_path: Path | None,
         demucs: DemucsMode,
         vad: VADMode,
+        whisper_model_name: str,
         outfile_path: Path | None,
         overwrite: bool,
     ):
@@ -313,6 +328,7 @@ class YueTranscribeVsZhoCli(ScinoephileCliBase):
         )
         provider = get_provider(llm_provider_name, model=llm_model_name)
         transcriber = get_yue_vs_zho_transcriber(
+            model_name=whisper_model_name,
             demucs_mode=demucs,
             vad_mode=vad,
             provider=provider,

--- a/scinoephile/cli/yue/yue_transcribe_vs_zho_cli.py
+++ b/scinoephile/cli/yue/yue_transcribe_vs_zho_cli.py
@@ -33,6 +33,7 @@ from scinoephile.core.exceptions import ScinoephileError
 from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.llms.providers.registry import get_provider
 from scinoephile.multilang.yue_zho.transcription import (
+    DEFAULT_YUE_WHISPER_MODEL_NAME,
     DemucsMode,
     VADMode,
     get_yue_transcribed_vs_zho,
@@ -194,7 +195,7 @@ class YueTranscribeVsZhoCli(ScinoephileCliBase):
         )
         arg_groups["operation arguments"].add_argument(
             "--whisper-model",
-            default="khleeloo/whisper-large-v3-cantonese",
+            default=DEFAULT_YUE_WHISPER_MODEL_NAME,
             dest="whisper_model_name",
             help=(
                 "Whisper model identifier used for transcription (default: %(default)s)"

--- a/scinoephile/multilang/yue_zho/transcription/__init__.py
+++ b/scinoephile/multilang/yue_zho/transcription/__init__.py
@@ -29,9 +29,15 @@ from scinoephile.llms.providers.registry import get_provider
 
 from .deliniation import YueDeliniationVsZhoPromptYueHans
 from .punctuation import YuePunctuationVsZhoPromptYueHans, YueZhoPunctuationManager
-from .transcriber import DemucsMode, VADMode, YueTranscriber
+from .transcriber import (
+    DEFAULT_YUE_WHISPER_MODEL_NAME,
+    DemucsMode,
+    VADMode,
+    YueTranscriber,
+)
 
 __all__ = [
+    "DEFAULT_YUE_WHISPER_MODEL_NAME",
     "YUE_ZHO_TRANSCRIPTION_DELINIATION_OPERATION_SPEC",
     "YUE_ZHO_TRANSCRIPTION_PUNCTUATION_OPERATION_SPEC",
     "get_yue_transcribed_vs_zho",
@@ -117,7 +123,7 @@ def get_yue_transcribed_vs_zho(
 
 
 def get_yue_vs_zho_transcriber(
-    model_name: str = "khleeloo/whisper-large-v3-cantonese",
+    model_name: str = DEFAULT_YUE_WHISPER_MODEL_NAME,
     demucs_mode: DemucsMode = DemucsMode.OFF,
     vad_mode: VADMode = VADMode.AUTO,
     provider: LLMProvider | None = None,

--- a/scinoephile/multilang/yue_zho/transcription/transcriber.py
+++ b/scinoephile/multilang/yue_zho/transcription/transcriber.py
@@ -33,10 +33,14 @@ from .deliniation import YueDeliniationVsZhoPromptYueHans
 from .punctuation import YuePunctuationVsZhoPromptYueHans
 
 __all__ = [
+    "DEFAULT_YUE_WHISPER_MODEL_NAME",
     "DemucsMode",
     "VADMode",
     "YueTranscriber",
 ]
+
+DEFAULT_YUE_WHISPER_MODEL_NAME = "khleeloo/whisper-large-v3-cantonese"
+"""Default Whisper model name for written Cantonese transcription."""
 
 logger = getLogger(__name__)
 
@@ -67,7 +71,7 @@ class YueTranscriber:
     def __init__(
         self,
         *,
-        model_name: str = "khleeloo/whisper-large-v3-cantonese",
+        model_name: str = DEFAULT_YUE_WHISPER_MODEL_NAME,
         demucs_mode: DemucsMode = DemucsMode.OFF,
         vad_mode: VADMode = VADMode.AUTO,
         provider: LLMProvider | None = None,

--- a/test/cli/yue/test_yue_transcribe_vs_zho_cli.py
+++ b/test/cli/yue/test_yue_transcribe_vs_zho_cli.py
@@ -17,7 +17,11 @@ from scinoephile.common.testing import run_cli_with_args
 from scinoephile.core import ScinoephileError
 from scinoephile.core.subtitles import Series
 from scinoephile.lang.zho.script.conversion import OpenCCConfig
-from scinoephile.multilang.yue_zho.transcription import DemucsMode, VADMode
+from scinoephile.multilang.yue_zho.transcription import (
+    DEFAULT_YUE_WHISPER_MODEL_NAME,
+    DemucsMode,
+    VADMode,
+)
 from scinoephile.multilang.yue_zho.transcription.deliniation import (
     YueDeliniationVsZhoPromptYueHans,
     YueDeliniationVsZhoPromptYueHant,
@@ -33,7 +37,7 @@ from test.helpers import (
 
 
 def test_yue_transcribe_vs_zho_help_lists_transcription_options():
-    """Test written Cantonese CLI help lists prompt and conversion options."""
+    """Test written Cantonese CLI help lists transcription options."""
     stdout = StringIO()
     stderr = StringIO()
 
@@ -62,6 +66,18 @@ def test_yue_transcribe_vs_zho_help_lists_transcription_options():
     assert "--whisper-model WHISPER_MODEL_NAME" in help_text
     assert "Whisper model identifier used for transcription" in help_text
     assert "default: first audio stream" in help_text
+
+
+def test_yue_transcribe_vs_zho_cli_uses_default_whisper_model_constant():
+    """Test CLI default Whisper model matches the transcription default."""
+    parser = YueTranscribeVsZhoCli.argparser()
+    whisper_model_action = next(
+        action
+        for action in parser._actions  # noqa: SLF001
+        if "--whisper-model" in action.option_strings
+    )
+
+    assert whisper_model_action.default == DEFAULT_YUE_WHISPER_MODEL_NAME
 
 
 def test_yue_transcribe_vs_zho_cli_writes_file():

--- a/test/cli/yue/test_yue_transcribe_vs_zho_cli.py
+++ b/test/cli/yue/test_yue_transcribe_vs_zho_cli.py
@@ -32,7 +32,7 @@ from test.helpers import (
 )
 
 
-def test_yue_transcribe_vs_zho_help_lists_script_convert_demucs_and_vad_options():
+def test_yue_transcribe_vs_zho_help_lists_transcription_options():
     """Test written Cantonese CLI help lists prompt and conversion options."""
     stdout = StringIO()
     stderr = StringIO()
@@ -59,6 +59,8 @@ def test_yue_transcribe_vs_zho_help_lists_script_convert_demucs_and_vad_options(
     assert "--vad {auto,on,off}" in help_text
     assert "Whisper voice activity detection mode" in help_text
     assert "off, auto; default: auto" in help_text
+    assert "--whisper-model WHISPER_MODEL_NAME" in help_text
+    assert "Whisper model identifier used for transcription" in help_text
     assert "default: first audio stream" in help_text
 
 
@@ -225,6 +227,38 @@ def test_yue_transcribe_vs_zho_cli_passes_requested_demucs_mode():
                 )
 
     assert patched_factory.call_args.kwargs["demucs_mode"] == DemucsMode.ON
+
+
+def test_yue_transcribe_vs_zho_cli_passes_requested_whisper_model():
+    """Test written Cantonese CLI passes through explicit Whisper model."""
+    zhongwen_infile_path = test_data_root / "mnt/output/zho-Hans_ocr/fuse.srt"
+    media_infile_path = "/tmp/test_media.mp4"
+    expected_series = Series.from_string(
+        "1\n00:00:00,000 --> 00:00:01,000\n你好\n",
+        format_="srt",
+    )
+    yuewen_audio_series = Mock(spec=AudioSeries)
+
+    with patch(
+        "scinoephile.cli.yue.yue_transcribe_vs_zho_cli.AudioSeries.load_from_media",
+        return_value=yuewen_audio_series,
+    ):
+        with patch(
+            "scinoephile.cli.yue.yue_transcribe_vs_zho_cli.get_yue_vs_zho_transcriber",
+            return_value="transcriber",
+        ) as patched_factory:
+            with patch(
+                "scinoephile.cli.yue.yue_transcribe_vs_zho_cli.get_yue_transcribed_vs_zho",
+                return_value=expected_series,
+            ):
+                run_cli_with_args(
+                    YueTranscribeVsZhoCli,
+                    f"--media-infile {media_infile_path} "
+                    f"--zho-infile {zhongwen_infile_path} "
+                    "--whisper-model openai/whisper-large-v3",
+                )
+
+    assert patched_factory.call_args.kwargs["model_name"] == "openai/whisper-large-v3"
 
 
 def test_yue_transcribe_vs_zho_cli_passes_requested_convert():

--- a/test/multilang/yue_zho/test_get_yue_transcriber_vs_zho.py
+++ b/test/multilang/yue_zho/test_get_yue_transcriber_vs_zho.py
@@ -18,6 +18,7 @@ from scinoephile.llms.default_test_cases import (
     YUE_ZHO_TRANSCRIPTION_PUNCTUATION_JSON_PATHS,
 )
 from scinoephile.multilang.yue_zho.transcription import (
+    DEFAULT_YUE_WHISPER_MODEL_NAME,
     DemucsMode,
     VADMode,
     get_yue_vs_zho_transcriber,
@@ -52,7 +53,7 @@ def test_get_yue_vs_zho_transcriber_uses_writable_runtime_test_case_root():
             test_case_directory_path=runtime_test_case_dir_path,
             deliniation_test_cases=deliniation_test_cases,
             punctuation_test_cases=punctuation_test_cases,
-            model_name="khleeloo/whisper-large-v3-cantonese",
+            model_name=DEFAULT_YUE_WHISPER_MODEL_NAME,
             demucs_mode=DemucsMode.OFF,
             vad_mode=VADMode.AUTO,
             convert=None,


### PR DESCRIPTION
## Summary

Adds a `--whisper-model` command-line argument to the written Cantonese transcription CLI and passes it through to the existing `get_yue_vs_zho_transcriber(..., model_name=...)` path.

## Impact

Users can choose the Whisper/Hugging Face model used for Cantonese transcription without changing code. The default remains `khleeloo/whisper-large-v3-cantonese`.

## Review follow-up

- Updated the help-test docstring so it describes transcription options accurately.
- Added and reused `DEFAULT_YUE_WHISPER_MODEL_NAME` so the CLI, factory, and transcriber class share the same default model value.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/cli/yue/yue_transcribe_vs_zho_cli.py scinoephile/multilang/yue_zho/transcription/__init__.py scinoephile/multilang/yue_zho/transcription/transcriber.py test/cli/yue/test_yue_transcribe_vs_zho_cli.py test/multilang/yue_zho/test_get_yue_transcriber_vs_zho.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/cli/yue/yue_transcribe_vs_zho_cli.py scinoephile/multilang/yue_zho/transcription/__init__.py scinoephile/multilang/yue_zho/transcription/transcriber.py test/cli/yue/test_yue_transcribe_vs_zho_cli.py test/multilang/yue_zho/test_get_yue_transcriber_vs_zho.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/cli/yue/yue_transcribe_vs_zho_cli.py scinoephile/multilang/yue_zho/transcription/__init__.py scinoephile/multilang/yue_zho/transcription/transcriber.py test/cli/yue/test_yue_transcribe_vs_zho_cli.py test/multilang/yue_zho/test_get_yue_transcriber_vs_zho.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest cli/yue/test_yue_transcribe_vs_zho_cli.py multilang/yue_zho/test_get_yue_transcriber_vs_zho.py` (`23 passed`)
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` (`1068 passed, 10 skipped`)