### PR TITLE
Expose text romanization helpers

### DIFF
--- a/scinoephile/lang/cmn/romanization.py
+++ b/scinoephile/lang/cmn/romanization.py
@@ -21,6 +21,7 @@ from scinoephile.core.text import full_to_half_punc
 __all__ = [
     "get_cmn_pinyin_query_strings",
     "get_cmn_romanized",
+    "get_cmn_text_romanized",
     "is_accented_pinyin",
     "is_numbered_pinyin",
 ]
@@ -85,7 +86,7 @@ def get_cmn_romanized(series: Series, append: bool = True) -> Series:
     """
     series = deepcopy(series)
     for event in series:
-        romanized = _get_cmn_text_romanized(event.text)
+        romanized = get_cmn_text_romanized(event.text)
         if append:
             if romanized:
                 event.text = f"{event.text}\\N{romanized}"
@@ -155,7 +156,7 @@ def is_numbered_pinyin(text: str) -> bool:
     return all(RE_CMN_PINYIN_NUMBERED.fullmatch(token) for token in tokens)
 
 
-def _get_cmn_text_romanized(text: str) -> str:
+def get_cmn_text_romanized(text: str) -> str:
     """Get the Mandarin pinyin romanization of Hanzi text.
 
     Arguments:

--- a/scinoephile/lang/yue/romanization.py
+++ b/scinoephile/lang/yue/romanization.py
@@ -19,6 +19,7 @@ from scinoephile.lang.zho.script.conversion import get_zho_converter
 __all__ = [
     "get_yue_jyutping_query_strings",
     "get_yue_romanized",
+    "get_yue_text_romanized",
     "is_accented_yale",
     "is_numbered_jyutping",
 ]
@@ -69,7 +70,7 @@ def get_yue_romanized(series: Series, append: bool = True) -> Series:
     """
     series = deepcopy(series)
     for event in series:
-        romanized = _get_yue_text_romanized(event.text)
+        romanized = get_yue_text_romanized(event.text)
         if append:
             if romanized:
                 event.text = f"{event.text}\\N{romanized}"
@@ -110,7 +111,7 @@ def is_numbered_jyutping(text: str) -> bool:
     return bool(_parse_normalized_jyutping(normalized))
 
 
-def _get_yue_text_romanized(text: str) -> str:
+def get_yue_text_romanized(text: str) -> str:
     """Get the Yale Cantonese romanization of Chinese text.
 
     Arguments:

--- a/test/lang/cmn/test_get_cmn_romanized.py
+++ b/test/lang/cmn/test_get_cmn_romanized.py
@@ -7,9 +7,7 @@ from __future__ import annotations
 import pytest
 
 from scinoephile.core.subtitles import Series
-
-# noinspection PyProtectedMember
-from scinoephile.lang.cmn.romanization import _get_cmn_text_romanized, get_cmn_romanized
+from scinoephile.lang.cmn.romanization import get_cmn_romanized, get_cmn_text_romanized
 from test.helpers import assert_series_equal
 
 
@@ -66,10 +64,10 @@ def test_get_cmn_romanized_titles(
     ],
 )
 def test_get_mandarin_text_romanization(text: str, expected: str):
-    """Test _get_mandarin_text_romanization.
+    """Test get_cmn_text_romanized.
 
     Arguments:
         text: Text to romanize
         expected: Expected romanization
     """
-    assert _get_cmn_text_romanized(text) == expected
+    assert get_cmn_text_romanized(text) == expected

--- a/test/lang/yue/test_get_yue_romanized.py
+++ b/test/lang/yue/test_get_yue_romanized.py
@@ -7,11 +7,9 @@ from __future__ import annotations
 import pytest
 
 from scinoephile.core.subtitles import Series
-
-# noinspection PyProtectedMember
 from scinoephile.lang.yue.romanization import (
-    _get_yue_text_romanized,
     get_yue_romanized,
+    get_yue_text_romanized,
 )
 from test.helpers import assert_series_equal
 
@@ -64,10 +62,10 @@ def test_get_yue_romanized_titles(
     ],
 )
 def test_get_yue_text_romanized(text: str, expected: str):
-    """Test _get_cantonese_text_romanization.
+    """Test get_yue_text_romanized.
 
     Arguments:
         text: Text to romanize
         expected: Expected romanization
     """
-    assert _get_yue_text_romanized(text) == expected
+    assert get_yue_text_romanized(text) == expected


### PR DESCRIPTION
## Summary
- Extract the focused romanization helper changes from `feature/tmm`
- Rename the Mandarin and Cantonese text-level romanization implementations to public helper names
- Update both Mandarin and Cantonese romanization tests to exercise the public helpers instead of private functions

## Tests
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/lang/cmn/romanization.py scinoephile/lang/yue/romanization.py test/lang/cmn/test_get_cmn_romanized.py test/lang/yue/test_get_yue_romanized.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/lang/cmn/romanization.py scinoephile/lang/yue/romanization.py test/lang/cmn/test_get_cmn_romanized.py test/lang/yue/test_get_yue_romanized.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/lang/cmn/romanization.py scinoephile/lang/yue/romanization.py test/lang/cmn/test_get_cmn_romanized.py test/lang/yue/test_get_yue_romanized.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto lang/cmn/test_get_cmn_romanized.py lang/yue/test_get_yue_romanized.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto`