### PR TITLE
Preserve LLM test case metadata flags

### DIFF
--- a/scinoephile/core/llms/queryer.py
+++ b/scinoephile/core/llms/queryer.py
@@ -241,8 +241,8 @@ class Queryer[
             test_case: test case to log
         """
         key = test_case.query.key
-        test_case.prompt = key in self.prompt_test_cases
-        test_case.verified = key in self.verified_test_cases
+        test_case.prompt = test_case.prompt or key in self.prompt_test_cases
+        test_case.verified = test_case.verified or key in self.verified_test_cases
         self.encountered_test_cases[key] = test_case
         logger.debug(f"Logged test case: {test_case.query.key_str}")
 

--- a/scinoephile/core/llms/queryer.py
+++ b/scinoephile/core/llms/queryer.py
@@ -168,7 +168,7 @@ class Queryer[
             # Validate test case
             try:
                 test_case = type(test_case).model_validate(
-                    {**test_case.model_dump(), "answer": answer}
+                    {**test_case.model_dump(), "answer": answer, "verified": False}
                 )
                 if self.auto_verify and test_case.get_auto_verified():
                     test_case.verified = True

--- a/test/llms/test_provider_injection.py
+++ b/test/llms/test_provider_injection.py
@@ -167,6 +167,27 @@ def test_queryer_preserves_existing_encountered_test_case_metadata():
     assert encountered_test_case.verified is True
 
 
+def test_queryer_clears_stale_verified_metadata_after_generating_answer():
+    """Test queryer clears stale verified metadata after generating an answer."""
+    provider = Mock(spec=LLMProvider)
+    provider.chat_completion.return_value = '{"output":"new"}'
+    queryer_cls = Queryer.get_queryer_cls(_Prompt)
+    queryer = queryer_cls(provider=provider, max_attempts=1)
+    test_case = _TestCase(
+        query=_Query(text="input"),
+        answer=_Answer(output="old"),
+        prompt=True,
+        verified=True,
+    )
+
+    output_test_case = queryer(test_case)
+
+    assert output_test_case.answer is not None
+    assert output_test_case.answer.output == "new"
+    assert output_test_case.prompt is True
+    assert output_test_case.verified is False
+
+
 def test_processor_passes_injected_provider_to_queryer():
     """Test processor wires injected providers into its queryer."""
     provider = Mock(spec=LLMProvider)

--- a/test/llms/test_provider_injection.py
+++ b/test/llms/test_provider_injection.py
@@ -148,6 +148,25 @@ def test_queryer_includes_additional_context_before_few_shot_prompt():
     )
 
 
+def test_queryer_preserves_existing_encountered_test_case_metadata():
+    """Test queryer preserves existing prompt and verified metadata."""
+    provider = Mock(spec=LLMProvider)
+    queryer_cls = Queryer.get_queryer_cls(_Prompt)
+    queryer = queryer_cls(provider=provider)
+    test_case = _TestCase(
+        query=_Query(text="input"),
+        answer=_Answer(output="done"),
+        prompt=True,
+        verified=True,
+    )
+
+    queryer.log_encountered_test_case(test_case)
+
+    encountered_test_case = queryer.encountered_test_cases[test_case.query.key]
+    assert encountered_test_case.prompt is True
+    assert encountered_test_case.verified is True
+
+
 def test_processor_passes_injected_provider_to_queryer():
     """Test processor wires injected providers into its queryer."""
     provider = Mock(spec=LLMProvider)


### PR DESCRIPTION
## Summary

- Preserve existing `TestCase.prompt` and `TestCase.verified` values when logging encountered LLM test cases.
- Add focused regression coverage for preserving both metadata flags.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest test/llms/test_provider_injection.py::test_queryer_preserves_existing_encountered_test_case_metadata` (red before fix, then passed after fix)
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/core/llms/queryer.py test/llms/test_provider_injection.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/core/llms/queryer.py test/llms/test_provider_injection.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/core/llms/queryer.py test/llms/test_provider_injection.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest test/llms/test_provider_injection.py`