### PR TITLE
Change default OpenAI model to gpt-5.4-mini

### DIFF
--- a/scinoephile/llms/providers/openai_provider.py
+++ b/scinoephile/llms/providers/openai_provider.py
@@ -20,7 +20,7 @@ class OpenAIProvider(OpenAIProviderBase):
     }
     """Provider description translations keyed by locale."""
 
-    model = "gpt-5.4"
+    model = "gpt-5.4-mini"
     """OpenAI model identifier."""
 
     api_key_env_var_name = "OPENAI_API_KEY"

--- a/test/cli/test_llm_cli.py
+++ b/test/cli/test_llm_cli.py
@@ -65,7 +65,7 @@ def test_list_llm_providers(cli: type[CommandLineInterface]):
     assert "default model: deepseek-v4-flash" in listing
     assert "API key env: DEEPSEEK_API_KEY" in listing
     assert "  openai    OpenAI LLM Provider." in listing
-    assert "default model: gpt-5.4" in listing
+    assert "default model: gpt-5.4-mini" in listing
     assert "API key env: OPENAI_API_KEY" in listing
 
 
@@ -87,7 +87,7 @@ def test_list_llm_providers_uses_simplified_chinese_descriptions():
     assert "default model: deepseek-v4-flash" in listing
     assert "API key env: DEEPSEEK_API_KEY" in listing
     assert "  openai    OpenAI LLM 提供商。" in listing
-    assert "default model: gpt-5.4" in listing
+    assert "default model: gpt-5.4-mini" in listing
     assert "API key env: OPENAI_API_KEY" in listing
 
 

--- a/test/llms/test_provider_registry.py
+++ b/test/llms/test_provider_registry.py
@@ -60,7 +60,7 @@ def test_get_provider_preserves_default_model_with_none_override():
     provider = get_provider("openai", model=None)
 
     assert isinstance(provider, OpenAIProvider)
-    assert provider.model == "gpt-5.4"
+    assert provider.model == "gpt-5.4-mini"
 
 
 def test_get_provider_constructs_deepseek_provider_with_kwargs():


### PR DESCRIPTION
## Summary

- Change the default OpenAI provider model from `gpt-5.4` to `gpt-5.4-mini`.
- Update the provider registry and LLM CLI assertions that directly depend on the default model.

## Verification

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/llms/providers/openai_provider.py test/llms/test_provider_registry.py test/cli/test_llm_cli.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/llms/providers/openai_provider.py test/llms/test_provider_registry.py test/cli/test_llm_cli.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/llms/providers/openai_provider.py test/llms/test_provider_registry.py test/cli/test_llm_cli.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto llms/test_provider_injection.py llms/test_provider_registry.py cli/test_llm_cli.py`