### PR TITLE
Add image series OCR font size detection

### DIFF
--- a/scinoephile/image/subtitles/series.py
+++ b/scinoephile/image/subtitles/series.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import re
+from collections import Counter
 from html import escape, unescape
 from logging import getLogger
 from os import PathLike
@@ -23,6 +24,7 @@ from scinoephile.common.validation import (
 )
 from scinoephile.core import ScinoephileError
 from scinoephile.core.subtitles import Series
+from scinoephile.image.bboxes import get_bboxes
 from scinoephile.image.colors import get_fill_and_outline_colors_from_hist
 from scinoephile.image.drawing import convert_rgba_img_to_la
 
@@ -33,6 +35,11 @@ __all__ = ["ImageSeries"]
 
 
 logger = getLogger(__name__)
+
+
+_DEFAULT_TEXT_FONT_SIZE = 50
+_MIN_TEXT_BBOX_HEIGHT = 20
+_MIN_TEXT_BBOX_WIDTH = 8
 
 
 class ImageSeries(Series):
@@ -55,6 +62,7 @@ class ImageSeries(Series):
             self.events = events
         self._fill_color = None
         self._outline_color = None
+        self._text_font_size = None
         self._blocks: list[ImageSeries] | None = None
 
     @property
@@ -74,6 +82,15 @@ class ImageSeries(Series):
         if self._outline_color is None:
             raise ScinoephileError("Outline color could not be determined.")
         return self._outline_color
+
+    @property
+    def text_font_size(self) -> int:
+        """Detected font size of subtitle text images."""
+        if self._text_font_size is None:
+            self._init_text_font_size()
+        if self._text_font_size is None:
+            raise ScinoephileError("Text font size could not be determined.")
+        return self._text_font_size
 
     @property
     @override
@@ -204,6 +221,30 @@ class ImageSeries(Series):
         fill, outline = get_fill_and_outline_colors_from_hist(hist)
         self._fill_color = fill
         self._outline_color = outline
+
+    def _init_text_font_size(self):
+        """Initialize the representative subtitle text font size."""
+        size_counts: Counter[int] = Counter()
+        for subtitle in self.events:
+            if subtitle.bboxes is None:
+                bboxes = get_bboxes(subtitle.img)
+            else:
+                bboxes = subtitle.bboxes
+            for bbox in bboxes:
+                if (
+                    bbox.height >= _MIN_TEXT_BBOX_HEIGHT
+                    and bbox.width >= _MIN_TEXT_BBOX_WIDTH
+                ):
+                    size_counts[bbox.height] += 1
+
+        if not size_counts:
+            self._text_font_size = _DEFAULT_TEXT_FONT_SIZE
+            return
+
+        self._text_font_size = max(
+            size_counts.items(),
+            key=lambda item: (item[1], item[0]),
+        )[0]
 
     def _save_html(
         self,

--- a/scinoephile/image/subtitles/series.py
+++ b/scinoephile/image/subtitles/series.py
@@ -65,6 +65,23 @@ class ImageSeries(Series):
         self._text_font_size = None
         self._blocks: list[ImageSeries] | None = None
 
+    @override
+    def __setattr__(self, name: str, value: object):
+        """Set attribute, invalidating cached image properties after event replacement.
+
+        Arguments:
+            name: attribute name
+            value: attribute value
+        """
+        super().__setattr__(name, value)
+        if name == "events":
+            if hasattr(self, "_fill_color"):
+                self._fill_color = None
+            if hasattr(self, "_outline_color"):
+                self._outline_color = None
+            if hasattr(self, "_text_font_size"):
+                self._text_font_size = None
+
     @property
     def fill_color(self) -> int:
         """Fill color of text images."""

--- a/test/image/subtitles/test_image_series.py
+++ b/test/image/subtitles/test_image_series.py
@@ -116,6 +116,33 @@ def test_text_font_size_defaults_when_no_useful_bboxes():
     assert series.text_font_size == 50
 
 
+def test_text_font_size_invalidates_when_events_change():
+    """Test cached text font size is invalidated when events change."""
+    series = ImageSeries(
+        events=[
+            ImageSubtitle(
+                start=0,
+                end=1000,
+                img=Image.new("LA", (2, 2), (255, 255)),
+                bboxes=[Bbox(0, 10, 0, 52)],
+            )
+        ]
+    )
+
+    assert series.text_font_size == 52
+
+    series.events = [
+        ImageSubtitle(
+            start=1000,
+            end=2000,
+            img=Image.new("LA", (3, 3), (255, 255)),
+            bboxes=[Bbox(0, 10, 0, 60)],
+        )
+    ]
+
+    assert series.text_font_size == 60
+
+
 def test_text_font_size_uses_most_common_useful_bbox_height():
     """Test text font size is detected across the image series."""
     series = ImageSeries(

--- a/test/image/subtitles/test_image_series.py
+++ b/test/image/subtitles/test_image_series.py
@@ -5,9 +5,11 @@
 from __future__ import annotations
 
 import pytest
+from PIL import Image
 
 from scinoephile.common.file import get_temp_directory_path
-from scinoephile.image.subtitles import ImageSeries
+from scinoephile.image.bbox import Bbox
+from scinoephile.image.subtitles import ImageSeries, ImageSubtitle
 
 
 @pytest.mark.parametrize(
@@ -93,3 +95,50 @@ def test_save_html(tiny_image_series: ImageSeries):
 
         png_files = sorted(output_path.glob("*.png"))
         assert len(png_files) == len(tiny_image_series)
+
+
+def test_text_font_size_defaults_when_no_useful_bboxes():
+    """Test text font size falls back when no useful bboxes are present."""
+    series = ImageSeries(
+        events=[
+            ImageSubtitle(
+                start=0,
+                end=1000,
+                img=Image.new("LA", (4, 4), (255, 255)),
+                bboxes=[
+                    Bbox(0, 4, 0, 16),
+                    Bbox(0, 6, 0, 60),
+                ],
+            )
+        ]
+    )
+
+    assert series.text_font_size == 50
+
+
+def test_text_font_size_uses_most_common_useful_bbox_height():
+    """Test text font size is detected across the image series."""
+    series = ImageSeries(
+        events=[
+            ImageSubtitle(
+                start=0,
+                end=1000,
+                img=Image.new("LA", (2, 2), (255, 255)),
+                bboxes=[
+                    Bbox(0, 10, 0, 52),
+                    Bbox(0, 4, 0, 10),
+                ],
+            ),
+            ImageSubtitle(
+                start=1000,
+                end=2000,
+                img=Image.new("LA", (3, 3), (255, 255)),
+                bboxes=[
+                    Bbox(0, 10, 0, 60),
+                    Bbox(12, 22, 0, 60),
+                ],
+            ),
+        ]
+    )
+
+    assert series.text_font_size == 60


### PR DESCRIPTION
## Summary
- Add lazy `ImageSeries.text_font_size` detection using the most common useful OCR bbox height across the series.
- Fall back to the existing web-layer default size of `50` when no useful bboxes are available.
- Add focused ImageSeries tests for representative detection and fallback behavior.

## Verification
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/image/subtitles/series.py test/image/subtitles/test_image_series.py` - 2 files left unchanged
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/image/subtitles/series.py test/image/subtitles/test_image_series.py` - All checks passed
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/image/subtitles/series.py test/image/subtitles/test_image_series.py` - All checks passed
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto image/subtitles/test_image_series.py` - 5 passed