### PR TITLE
Ignore OCR SUP fixture sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ scinoephile.egg-info
 /test/data/*/input/*_ocr/source.sup
 /test/data/*/output/**/*.html
 /test/data/*/output/**/*.json
-!/test/data/*/output/*_ocr/lang/*/*.json
 /test/data/*/output/**/*.png
 /test/data/*/output/**/*.wav
 /test/data/cache/**

--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,10 @@ __pycache__
 scinoephile.egg-info
 /local/
 /test/.coverage
+/test/data/*/input/*_ocr/source.sup
 /test/data/*/output/**/*.html
 /test/data/*/output/**/*.json
+!/test/data/*/output/*_ocr/lang/*/*.json
 /test/data/*/output/**/*.png
 /test/data/*/output/**/*.wav
 /test/data/cache/**


### PR DESCRIPTION
## Summary
- Ignore local OCR SUP source files under test data input directories.

## Validation
- Confirmed `git diff master...HEAD -- .gitignore` contains only `/test/data/*/input/*_ocr/source.sup`.
- Confirmed `git diff master...HEAD --name-only` reports only `.gitignore`.
- Python checks were not run because the change only touches `.gitignore`.