### PR TITLE
Add tracked-file note to sync fixture skill

### DIFF
--- a/skills/sync-test-fixtures/SKILL.md
+++ b/skills/sync-test-fixtures/SKILL.md
@@ -79,6 +79,7 @@ cd test && uv run pytest
 ## Notes
 
 - Keep changes minimal and consistent with existing naming patterns.
+- Do not add fixtures for files that are not tracked by git.
 - Ensure files/directories of interest (all extensions and formats, including `_image`)
   are actually under version control before adding fixtures for them.
 - Keep the grouping/order in `__all__` aligned with fixture grouping (input/action/output).


### PR DESCRIPTION
## Summary

- Add a Notes-section reminder that sync-test-fixtures should not add fixtures for files that are not tracked by git.

## Verification

- `git diff --name-only github/master..HEAD` showed only `skills/sync-test-fixtures/SKILL.md`.
- `git diff --check github/master..HEAD` completed with no whitespace errors.
- Python checks were not run because this changes only a Markdown skill file.