### PR TITLE
Preserve OCR fusion newlines

### DIFF
--- a/scinoephile/llms/dual_1_to_1/ocr_fusion/processor.py
+++ b/scinoephile/llms/dual_1_to_1/ocr_fusion/processor.py
@@ -56,8 +56,8 @@ class OcrFusionProcessor(Processor):
         ):
             if sub_idx >= stop_at_idx:
                 break
-            text_one = sub_one.text
-            text_two = sub_two.text
+            text_one = sub_one.text_with_newline
+            text_two = sub_two.text_with_newline
 
             # Handle missing data
             if not text_one and not text_two:
@@ -92,8 +92,8 @@ class OcrFusionProcessor(Processor):
             test_case_cls = OcrFusionManager.get_test_case_cls(prompt_cls)
             query_cls = test_case_cls.query_cls
             query_kwargs = {
-                prompt_cls.src_1: sub_one.text_with_newline,
-                prompt_cls.src_2: sub_two.text_with_newline,
+                prompt_cls.src_1: text_one,
+                prompt_cls.src_2: text_two,
             }
             query = query_cls(**query_kwargs)
             test_case = test_case_cls(query=query)

--- a/test/lang/zho/test_get_zho_ocr_fused.py
+++ b/test/lang/zho/test_get_zho_ocr_fused.py
@@ -4,7 +4,10 @@
 
 from __future__ import annotations
 
-from scinoephile.core.subtitles import Series
+from unittest.mock import Mock
+
+from scinoephile.core.llms import LLMProvider
+from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.lang.zho.cleaning import get_zho_cleaned
 from scinoephile.lang.zho.ocr_fusion import (
     OcrFusionPromptZhoHant,
@@ -34,6 +37,35 @@ def _test_get_zho_ocr_fused(
 
     assert len(output) == len(expected)
     assert_series_equal(output, expected)
+
+
+def test_get_zho_ocr_fused_treats_newline_forms_as_identical():
+    """Test OCR fusion skips queries when texts only differ by newline form."""
+    lens = Series(
+        [
+            Subtitle(
+                start=0,
+                end=1000,
+                text="嗯达摩\n达摩祖师果然厉害",
+            )
+        ]
+    )
+    paddle = Series(
+        [
+            Subtitle(
+                start=0,
+                end=1000,
+                text="嗯达摩\\N达摩祖师果然厉害",
+            )
+        ]
+    )
+    provider = Mock(spec=LLMProvider)
+    processor = get_zho_ocr_fuser(provider=provider)
+
+    output = get_zho_ocr_fused(lens, paddle, processor=processor)
+
+    assert output.events[0].text == "嗯达摩\n达摩祖师果然厉害"
+    provider.chat_completion.assert_not_called()
 
 
 def test_get_zho_ocr_fused_kob(


### PR DESCRIPTION
## Summary

- Preserve `text_with_newline` when OCR fusion reads source subtitle text.
- Reuse the preserved newline-aware text when constructing OCR fusion LLM queries.
- Add a focused regression test for OCR inputs that differ only by newline encoding.

## Verification

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/llms/dual_1_to_1/ocr_fusion/processor.py test/lang/zho/test_get_zho_ocr_fused.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/llms/dual_1_to_1/ocr_fusion/processor.py test/lang/zho/test_get_zho_ocr_fused.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/llms/dual_1_to_1/ocr_fusion/processor.py test/lang/zho/test_get_zho_ocr_fused.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q -o log_cli=false lang/zho/test_get_zho_ocr_fused.py`