### PR TITLE
Move shared LLM CLI options into llm arguments group

### DIFF
--- a/scinoephile/cli/eng/eng_process_cli.py
+++ b/scinoephile/cli/eng/eng_process_cli.py
@@ -90,6 +90,7 @@ class EngProcessCli(ScinoephileCliBase):
             parser,
             "input arguments",
             "operation arguments",
+            "llm arguments",
             "output arguments",
             "additional help",
             optional_arguments_name="additional arguments",
@@ -122,7 +123,7 @@ class EngProcessCli(ScinoephileCliBase):
             help="proofread subtitles using LLM",
         )
         add_llm_provider_arguments(
-            arg_groups["operation arguments"], arg_groups["additional help"]
+            arg_groups["llm arguments"], arg_groups["additional help"]
         )
         arg_groups["operation arguments"].add_argument(
             "--offset",

--- a/scinoephile/cli/eng/eng_translate_from_yue_cli.py
+++ b/scinoephile/cli/eng/eng_translate_from_yue_cli.py
@@ -117,6 +117,7 @@ class EngTranslateFromYueCli(ScinoephileCliBase):
             parser,
             "input arguments",
             "operation arguments",
+            "llm arguments",
             "output arguments",
             "additional help",
             optional_arguments_name="additional arguments",
@@ -154,7 +155,7 @@ class EngTranslateFromYueCli(ScinoephileCliBase):
 
         # Operation arguments
         add_llm_provider_arguments(
-            arg_groups["operation arguments"], arg_groups["additional help"]
+            arg_groups["llm arguments"], arg_groups["additional help"]
         )
 
         # Output arguments

--- a/scinoephile/cli/eng/eng_translate_from_zho_cli.py
+++ b/scinoephile/cli/eng/eng_translate_from_zho_cli.py
@@ -117,6 +117,7 @@ class EngTranslateFromZhoCli(ScinoephileCliBase):
             parser,
             "input arguments",
             "operation arguments",
+            "llm arguments",
             "output arguments",
             "additional help",
             optional_arguments_name="additional arguments",
@@ -154,7 +155,7 @@ class EngTranslateFromZhoCli(ScinoephileCliBase):
 
         # Operation arguments
         add_llm_provider_arguments(
-            arg_groups["operation arguments"], arg_groups["additional help"]
+            arg_groups["llm arguments"], arg_groups["additional help"]
         )
 
         # Output arguments

--- a/scinoephile/cli/llms.py
+++ b/scinoephile/cli/llms.py
@@ -40,6 +40,7 @@ LLM_LOCALIZATIONS: dict[str, dict[str, str]] = {
         "file from which to read additional context for LLM prompts": (
             "用于读取 LLM 提示词附加上下文的文件"
         ),
+        "llm arguments": "LLM 参数",
         "LLM model identifier override": "LLM 模型标识符覆盖值",
         "LLM provider to use (default: %(default)s). Use --list-llm-providers "
         "to show providers, default models, and API-key environment variables.": (
@@ -54,6 +55,7 @@ LLM_LOCALIZATIONS: dict[str, dict[str, str]] = {
         "file from which to read additional context for LLM prompts": (
             "用於讀取 LLM 提示詞附加上下文的檔案"
         ),
+        "llm arguments": "LLM 參數",
         "LLM model identifier override": "LLM 模型識別碼覆寫值",
         "LLM provider to use (default: %(default)s). Use --list-llm-providers "
         "to show providers, default models, and API-key environment variables.": (
@@ -67,16 +69,16 @@ LLM_LOCALIZATIONS: dict[str, dict[str, str]] = {
 
 
 def add_llm_provider_arguments(
-    operation_arg_group: _ArgumentGroup,
+    llm_arg_group: _ArgumentGroup,
     additional_help_arg_group: _ArgumentGroup,
 ):
     """Add standard LLM provider arguments to argument groups.
 
     Arguments:
-        operation_arg_group: group to which provider arguments are added
+        llm_arg_group: group to which provider arguments are added
         additional_help_arg_group: group to which help-only arguments are added
     """
-    operation_arg_group.add_argument(
+    llm_arg_group.add_argument(
         "--llm-provider",
         default=DEFAULT_PROVIDER_NAME,
         dest="llm_provider_name",
@@ -86,13 +88,13 @@ def add_llm_provider_arguments(
             "to show providers, default models, and API-key environment variables."
         ),
     )
-    operation_arg_group.add_argument(
+    llm_arg_group.add_argument(
         "--llm-model",
         default=None,
         dest="llm_model_name",
         help="LLM model identifier override",
     )
-    operation_arg_group.add_argument(
+    llm_arg_group.add_argument(
         "--llm-additional-content-file",
         default=None,
         dest="llm_additional_context_file_path",

--- a/scinoephile/cli/ocr/ocr_fuse_cli.py
+++ b/scinoephile/cli/ocr/ocr_fuse_cli.py
@@ -117,6 +117,7 @@ class OcrFuseCli(ScinoephileCliBase):
             parser,
             "input arguments",
             "operation arguments",
+            "llm arguments",
             "output arguments",
             "additional help",
             optional_arguments_name="additional arguments",
@@ -163,7 +164,7 @@ class OcrFuseCli(ScinoephileCliBase):
             arg_groups["operation arguments"], arg_groups["additional help"]
         )
         add_llm_provider_arguments(
-            arg_groups["operation arguments"], arg_groups["additional help"]
+            arg_groups["llm arguments"], arg_groups["additional help"]
         )
 
         # Output arguments

--- a/scinoephile/cli/ocr/ocr_process_cli.py
+++ b/scinoephile/cli/ocr/ocr_process_cli.py
@@ -111,6 +111,7 @@ class OcrProcessCli(ScinoephileCliBase):
             parser,
             "input arguments",
             "operation arguments",
+            "llm arguments",
             "output arguments",
             "additional help",
             optional_arguments_name="additional arguments",
@@ -167,7 +168,7 @@ class OcrProcessCli(ScinoephileCliBase):
             ),
         )
         add_llm_provider_arguments(
-            arg_groups["operation arguments"], arg_groups["additional help"]
+            arg_groups["llm arguments"], arg_groups["additional help"]
         )
 
         # Output arguments

--- a/scinoephile/cli/yue/yue_process_cli.py
+++ b/scinoephile/cli/yue/yue_process_cli.py
@@ -124,6 +124,7 @@ class YueProcessCli(ScinoephileCliBase):
             parser,
             "input arguments",
             "operation arguments",
+            "llm arguments",
             "output arguments",
             "additional help",
             optional_arguments_name="additional arguments",
@@ -149,7 +150,7 @@ class YueProcessCli(ScinoephileCliBase):
             arg_groups["operation arguments"], arg_groups["additional help"]
         )
         add_llm_provider_arguments(
-            arg_groups["operation arguments"], arg_groups["additional help"]
+            arg_groups["llm arguments"], arg_groups["additional help"]
         )
         arg_groups["operation arguments"].add_argument(
             "--flatten",

--- a/scinoephile/cli/yue/yue_review_vs_zho_cli.py
+++ b/scinoephile/cli/yue/yue_review_vs_zho_cli.py
@@ -112,6 +112,7 @@ class YueReviewVsZhoCli(ScinoephileCliBase):
             parser,
             "input arguments",
             "operation arguments",
+            "llm arguments",
             "output arguments",
             "additional help",
             optional_arguments_name="additional arguments",
@@ -152,7 +153,7 @@ class YueReviewVsZhoCli(ScinoephileCliBase):
             help="script for prompts and output conversion (default: simplified)",
         )
         add_llm_provider_arguments(
-            arg_groups["operation arguments"], arg_groups["additional help"]
+            arg_groups["llm arguments"], arg_groups["additional help"]
         )
 
         # Output arguments

--- a/scinoephile/cli/yue/yue_transcribe_vs_zho_cli.py
+++ b/scinoephile/cli/yue/yue_transcribe_vs_zho_cli.py
@@ -145,6 +145,7 @@ class YueTranscribeVsZhoCli(ScinoephileCliBase):
             parser,
             "input arguments",
             "operation arguments",
+            "llm arguments",
             "output arguments",
             "additional help",
             optional_arguments_name="additional arguments",
@@ -205,7 +206,7 @@ class YueTranscribeVsZhoCli(ScinoephileCliBase):
             arg_groups["operation arguments"], arg_groups["additional help"]
         )
         add_llm_provider_arguments(
-            arg_groups["operation arguments"], arg_groups["additional help"]
+            arg_groups["llm arguments"], arg_groups["additional help"]
         )
         arg_groups["operation arguments"].add_argument(
             "--script",

--- a/scinoephile/cli/yue/yue_translate_from_eng_cli.py
+++ b/scinoephile/cli/yue/yue_translate_from_eng_cli.py
@@ -134,6 +134,7 @@ class YueTranslateFromEngCli(ScinoephileCliBase):
             parser,
             "input arguments",
             "operation arguments",
+            "llm arguments",
             "output arguments",
             "additional help",
             optional_arguments_name="additional arguments",
@@ -178,7 +179,7 @@ class YueTranslateFromEngCli(ScinoephileCliBase):
             help="script for prompts and output conversion (default: simplified)",
         )
         add_llm_provider_arguments(
-            arg_groups["operation arguments"], arg_groups["additional help"]
+            arg_groups["llm arguments"], arg_groups["additional help"]
         )
 
         # Output arguments

--- a/scinoephile/cli/yue/yue_translate_from_zho_cli.py
+++ b/scinoephile/cli/yue/yue_translate_from_zho_cli.py
@@ -136,6 +136,7 @@ class YueTranslateFromZhoCli(ScinoephileCliBase):
             parser,
             "input arguments",
             "operation arguments",
+            "llm arguments",
             "output arguments",
             "additional help",
             optional_arguments_name="additional arguments",
@@ -180,7 +181,7 @@ class YueTranslateFromZhoCli(ScinoephileCliBase):
             help="script for prompts and output conversion (default: simplified)",
         )
         add_llm_provider_arguments(
-            arg_groups["operation arguments"], arg_groups["additional help"]
+            arg_groups["llm arguments"], arg_groups["additional help"]
         )
 
         # Output arguments

--- a/scinoephile/cli/zho/zho_process_cli.py
+++ b/scinoephile/cli/zho/zho_process_cli.py
@@ -124,6 +124,7 @@ class ZhoProcessCli(ScinoephileCliBase):
             parser,
             "input arguments",
             "operation arguments",
+            "llm arguments",
             "output arguments",
             "additional help",
             optional_arguments_name="additional arguments",
@@ -149,7 +150,7 @@ class ZhoProcessCli(ScinoephileCliBase):
             arg_groups["operation arguments"], arg_groups["additional help"]
         )
         add_llm_provider_arguments(
-            arg_groups["operation arguments"], arg_groups["additional help"]
+            arg_groups["llm arguments"], arg_groups["additional help"]
         )
         arg_groups["operation arguments"].add_argument(
             "--flatten",

--- a/scinoephile/cli/zho/zho_translate_from_eng_cli.py
+++ b/scinoephile/cli/zho/zho_translate_from_eng_cli.py
@@ -134,6 +134,7 @@ class ZhoTranslateFromEngCli(ScinoephileCliBase):
             parser,
             "input arguments",
             "operation arguments",
+            "llm arguments",
             "output arguments",
             "additional help",
             optional_arguments_name="additional arguments",
@@ -178,7 +179,7 @@ class ZhoTranslateFromEngCli(ScinoephileCliBase):
             help="script for prompts and output conversion (default: simplified)",
         )
         add_llm_provider_arguments(
-            arg_groups["operation arguments"], arg_groups["additional help"]
+            arg_groups["llm arguments"], arg_groups["additional help"]
         )
 
         # Output arguments

--- a/scinoephile/cli/zho/zho_translate_from_yue_cli.py
+++ b/scinoephile/cli/zho/zho_translate_from_yue_cli.py
@@ -134,6 +134,7 @@ class ZhoTranslateFromYueCli(ScinoephileCliBase):
             parser,
             "input arguments",
             "operation arguments",
+            "llm arguments",
             "output arguments",
             "additional help",
             optional_arguments_name="additional arguments",
@@ -178,7 +179,7 @@ class ZhoTranslateFromYueCli(ScinoephileCliBase):
             help="script for prompts and output conversion (default: simplified)",
         )
         add_llm_provider_arguments(
-            arg_groups["operation arguments"], arg_groups["additional help"]
+            arg_groups["llm arguments"], arg_groups["additional help"]
         )
 
         # Output arguments

--- a/test/cli/test_cli_argument_groups.py
+++ b/test/cli/test_cli_argument_groups.py
@@ -1,0 +1,94 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests for CLI argument group assignments."""
+
+from __future__ import annotations
+
+from argparse import Action, ArgumentParser
+
+import pytest
+
+from scinoephile.cli.eng.eng_process_cli import EngProcessCli
+from scinoephile.cli.eng.eng_translate_from_yue_cli import EngTranslateFromYueCli
+from scinoephile.cli.eng.eng_translate_from_zho_cli import EngTranslateFromZhoCli
+from scinoephile.cli.ocr.ocr_fuse_cli import OcrFuseCli
+from scinoephile.cli.ocr.ocr_process_cli import OcrProcessCli
+from scinoephile.cli.yue.yue_process_cli import YueProcessCli
+from scinoephile.cli.yue.yue_review_vs_zho_cli import YueReviewVsZhoCli
+from scinoephile.cli.yue.yue_transcribe_vs_zho_cli import YueTranscribeVsZhoCli
+from scinoephile.cli.yue.yue_translate_from_eng_cli import YueTranslateFromEngCli
+from scinoephile.cli.yue.yue_translate_from_zho_cli import YueTranslateFromZhoCli
+from scinoephile.cli.zho.zho_process_cli import ZhoProcessCli
+from scinoephile.cli.zho.zho_translate_from_eng_cli import ZhoTranslateFromEngCli
+from scinoephile.cli.zho.zho_translate_from_yue_cli import ZhoTranslateFromYueCli
+from scinoephile.common import CommandLineInterface
+
+LLM_CLIS: tuple[type[CommandLineInterface], ...] = (
+    EngProcessCli,
+    EngTranslateFromYueCli,
+    EngTranslateFromZhoCli,
+    OcrFuseCli,
+    OcrProcessCli,
+    YueProcessCli,
+    YueReviewVsZhoCli,
+    YueTranscribeVsZhoCli,
+    YueTranslateFromEngCli,
+    YueTranslateFromZhoCli,
+    ZhoProcessCli,
+    ZhoTranslateFromEngCli,
+    ZhoTranslateFromYueCli,
+)
+"""CLI classes that expose shared LLM arguments."""
+
+
+@pytest.mark.parametrize("cli", LLM_CLIS)
+def test_llm_options_are_in_llm_argument_group(cli: type[CommandLineInterface]):
+    """Test shared LLM options are grouped separately from operation options.
+
+    Arguments:
+        cli: CLI class to inspect
+    """
+    assert _get_action_group_title(cli, "--llm-provider") == "llm arguments"
+    assert _get_action_group_title(cli, "--llm-model") == "llm arguments"
+    assert (
+        _get_action_group_title(cli, "--llm-additional-content-file") == "llm arguments"
+    )
+    assert _get_action_group_title(cli, "--list-llm-providers") == "additional help"
+
+
+def _get_action(parser: ArgumentParser, option: str) -> Action:
+    """Get a parser action by option string.
+
+    Arguments:
+        parser: parser to inspect
+        option: option string to inspect
+    Returns:
+        matching argparse action
+    Raises:
+        AssertionError: if the option is not present
+    """
+    for action in parser._actions:  # noqa: SLF001
+        if option in action.option_strings:
+            return action
+    raise AssertionError(f"{option} not found in {parser.prog}")
+
+
+def _get_action_group_title(cli: type[CommandLineInterface], option: str) -> str:
+    """Get the group title for a parser option.
+
+    Arguments:
+        cli: CLI class to inspect
+        option: option string to inspect
+    Returns:
+        title of the argument group containing the option
+    Raises:
+        AssertionError: if the option is not assigned to a group
+    """
+    parser = cli.argparser()
+    action = _get_action(parser, option)
+    for group in parser._action_groups:  # noqa: SLF001
+        if action in group._group_actions:  # noqa: SLF001
+            if group.title is not None:
+                return group.title
+            break
+    raise AssertionError(f"{option} is not assigned to an argument group")

--- a/test/cli/test_llm_cli.py
+++ b/test/cli/test_llm_cli.py
@@ -15,6 +15,7 @@ from scinoephile.cli.eng.eng_process_cli import EngProcessCli
 from scinoephile.cli.eng.eng_translate_from_yue_cli import EngTranslateFromYueCli
 from scinoephile.cli.eng.eng_translate_from_zho_cli import EngTranslateFromZhoCli
 from scinoephile.cli.ocr.ocr_fuse_cli import OcrFuseCli
+from scinoephile.cli.ocr.ocr_process_cli import OcrProcessCli
 from scinoephile.cli.yue.yue_process_cli import YueProcessCli
 from scinoephile.cli.yue.yue_review_vs_zho_cli import YueReviewVsZhoCli
 from scinoephile.cli.yue.yue_transcribe_vs_zho_cli import YueTranscribeVsZhoCli
@@ -34,6 +35,7 @@ from scinoephile.common.testing import run_cli_with_args
         EngTranslateFromYueCli,
         EngTranslateFromZhoCli,
         OcrFuseCli,
+        OcrProcessCli,
         YueProcessCli,
         YueReviewVsZhoCli,
         YueTranscribeVsZhoCli,


### PR DESCRIPTION
## Summary
- Move shared `--llm-provider`, `--llm-model`, and `--llm-additional-content-file` options into a dedicated `llm arguments` help group.
- Add localized `llm arguments` group text and update every shared LLM CLI caller, including `OcrProcessCli`.
- Add focused argument-group coverage and include `OcrProcessCli` in shared LLM provider-listing coverage.

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format <changed Python files>`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix <changed Python files>`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check <changed Python files>`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest test/cli/test_cli_argument_groups.py test/cli/test_llm_cli.py test/cli/test_localized_cli_help.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto`