### PR TITLE
Bundle LLM CLI arguments

### DIFF
--- a/scinoephile/cli/__init__.py
+++ b/scinoephile/cli/__init__.py
@@ -3,8 +3,9 @@
 """Command-line interfaces for Scinoephile.
 
 Package hierarchy (modules may import from any above):
-* conversion / dictionary / llms / multi / utility
-* eng / media / ocr / yue / zho
+* argument_bundle_field_action / conversion / dictionary / multi / utility
+* llms / media
+* eng / ocr / yue / zho
 * scinoephile_cli
 """
 

--- a/scinoephile/cli/argument_bundle_field_action.py
+++ b/scinoephile/cli/argument_bundle_field_action.py
@@ -1,0 +1,66 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Argument actions for bundled CLI option groups."""
+
+from __future__ import annotations
+
+from argparse import Action, ArgumentParser, Namespace
+from dataclasses import replace
+from typing import Any
+
+__all__ = ["ArgumentBundleFieldAction"]
+
+
+class ArgumentBundleFieldAction(Action):
+    """Update one field on a dataclass-backed argument bundle."""
+
+    def __init__(
+        self,
+        option_strings: list[str],
+        dest: str,
+        *,
+        bundle_type: type[Any],
+        field_name: str,
+        **kwargs: Any,
+    ):
+        """Initialize.
+
+        Arguments:
+            option_strings: option strings
+            dest: namespace destination for the bundled dataclass
+            bundle_type: dataclass type stored at dest
+            field_name: dataclass field to update when this argument is used
+            **kwargs: additional argparse action keyword arguments
+        """
+        self.bundle_type = bundle_type
+        self.field_name = field_name
+        kwargs.setdefault("default", bundle_type())
+        super().__init__(option_strings=option_strings, dest=dest, **kwargs)
+
+    def __call__(
+        self,
+        parser: ArgumentParser,
+        namespace: Namespace,
+        values: Any,
+        option_string: str | None = None,
+    ):
+        """Apply an argument value to the bundle field.
+
+        Arguments:
+            parser: active argument parser
+            namespace: argparse namespace
+            values: parsed argument value
+            option_string: option string used
+        """
+        bundle = getattr(namespace, self.dest, None)
+        if not isinstance(bundle, self.bundle_type):
+            bundle = self.bundle_type()
+        try:
+            updated_bundle = replace(bundle, **{self.field_name: values})
+        except TypeError as err:
+            argument_name = option_string or self.dest
+            parser.error(
+                f"{argument_name} cannot update argument bundle field "
+                f"{self.field_name!r}: {err}"
+            )
+        setattr(namespace, self.dest, updated_bundle)

--- a/scinoephile/cli/eng/eng_process_cli.py
+++ b/scinoephile/cli/eng/eng_process_cli.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from scinoephile.cli.llms import (
     LLM_LOCALIZATIONS,
+    LlmArguments,
     add_llm_provider_arguments,
     read_llm_additional_context,
 )
@@ -167,9 +168,7 @@ class EngProcessCli(ScinoephileCliBase):
         clean: bool,
         flatten: bool,
         proofread: bool,
-        llm_provider_name: str,
-        llm_model_name: str | None,
-        llm_additional_context_file_path: Path | None,
+        llm_args: LlmArguments,
         offset: int,
         overwrite: bool,
     ):
@@ -185,7 +184,7 @@ class EngProcessCli(ScinoephileCliBase):
         # Read inputs
         series = read_series(parser, infile_path, allow_stdin=True)
         additional_context = read_llm_additional_context(
-            parser, llm_additional_context_file_path
+            parser, llm_args.additional_context_file_path
         )
 
         # Perform operations
@@ -194,7 +193,7 @@ class EngProcessCli(ScinoephileCliBase):
         if flatten:
             series = get_eng_flattened(series)
         if proofread:
-            provider = get_provider(llm_provider_name, model=llm_model_name)
+            provider = get_provider(llm_args.provider_name, model=llm_args.model_name)
             reviewer = get_eng_block_reviewer(
                 provider=provider,
                 additional_context=additional_context,

--- a/scinoephile/cli/eng/eng_translate_from_yue_cli.py
+++ b/scinoephile/cli/eng/eng_translate_from_yue_cli.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from scinoephile.cli.llms import (
     LLM_LOCALIZATIONS,
+    LlmArguments,
     add_llm_provider_arguments,
     read_llm_additional_context,
 )
@@ -191,9 +192,7 @@ class EngTranslateFromYueCli(ScinoephileCliBase):
         yue_infile_path: Path | str,
         eng_gapped_infile_path: Path | str | None,
         eng_guide_infile_path: Path | str | None,
-        llm_provider_name: str,
-        llm_model_name: str | None,
-        llm_additional_context_file_path: Path | None,
+        llm_args: LlmArguments,
         outfile_path: Path | None,
         overwrite: bool,
     ):
@@ -210,9 +209,9 @@ class EngTranslateFromYueCli(ScinoephileCliBase):
         # Read inputs
         yuewen = read_series(parser, yue_infile_path, allow_stdin=True)
         additional_context = read_llm_additional_context(
-            parser, llm_additional_context_file_path
+            parser, llm_args.additional_context_file_path
         )
-        provider = get_provider(llm_provider_name, model=llm_model_name)
+        provider = get_provider(llm_args.provider_name, model=llm_args.model_name)
 
         # Perform operations
         if eng_gapped_infile_path is not None:

--- a/scinoephile/cli/eng/eng_translate_from_zho_cli.py
+++ b/scinoephile/cli/eng/eng_translate_from_zho_cli.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from scinoephile.cli.llms import (
     LLM_LOCALIZATIONS,
+    LlmArguments,
     add_llm_provider_arguments,
     read_llm_additional_context,
 )
@@ -191,9 +192,7 @@ class EngTranslateFromZhoCli(ScinoephileCliBase):
         zho_infile_path: Path | str,
         eng_gapped_infile_path: Path | str | None,
         eng_guide_infile_path: Path | str | None,
-        llm_provider_name: str,
-        llm_model_name: str | None,
-        llm_additional_context_file_path: Path | None,
+        llm_args: LlmArguments,
         outfile_path: Path | None,
         overwrite: bool,
     ):
@@ -210,9 +209,9 @@ class EngTranslateFromZhoCli(ScinoephileCliBase):
         # Read inputs
         zho = read_series(parser, zho_infile_path, allow_stdin=True)
         additional_context = read_llm_additional_context(
-            parser, llm_additional_context_file_path
+            parser, llm_args.additional_context_file_path
         )
-        provider = get_provider(llm_provider_name, model=llm_model_name)
+        provider = get_provider(llm_args.provider_name, model=llm_args.model_name)
 
         # Perform operations
         if eng_gapped_infile_path is not None:

--- a/scinoephile/cli/llms.py
+++ b/scinoephile/cli/llms.py
@@ -13,9 +13,11 @@ from argparse import (  # noqa: PLC2701
     Namespace,
     _ArgumentGroup,
 )
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from scinoephile.cli.argument_bundle_field_action import ArgumentBundleFieldAction
 from scinoephile.common.argument_parsing import input_file_arg
 from scinoephile.core.cli import ScinoephileCliBase
 from scinoephile.llms.providers.registry import (
@@ -28,6 +30,7 @@ from scinoephile.llms.providers.registry import (
 
 __all__ = [
     "LLM_LOCALIZATIONS",
+    "LlmArguments",
     "add_llm_provider_arguments",
     "llm_provider_name_arg",
     "read_llm_additional_context",
@@ -42,9 +45,10 @@ LLM_LOCALIZATIONS: dict[str, dict[str, str]] = {
         ),
         "llm arguments": "LLM 参数",
         "LLM model identifier override": "LLM 模型标识符覆盖值",
-        "LLM provider to use (default: %(default)s). Use --list-llm-providers "
-        "to show providers, default models, and API-key environment variables.": (
-            "要使用的 LLM 提供商（默认：%(default)s）。使用 "
+        f"LLM provider to use (default: {DEFAULT_PROVIDER_NAME}). Use "
+        "--list-llm-providers to show providers, default models, and API-key "
+        "environment variables.": (
+            f"要使用的 LLM 提供商（默认：{DEFAULT_PROVIDER_NAME}）。使用 "
             "--list-llm-providers 查看提供商、默认模型和 API 密钥环境变量。"
         ),
         "list available LLM providers and exit": "列出可用 LLM 提供商并退出",
@@ -57,15 +61,28 @@ LLM_LOCALIZATIONS: dict[str, dict[str, str]] = {
         ),
         "llm arguments": "LLM 參數",
         "LLM model identifier override": "LLM 模型識別碼覆寫值",
-        "LLM provider to use (default: %(default)s). Use --list-llm-providers "
-        "to show providers, default models, and API-key environment variables.": (
-            "要使用的 LLM 提供商（預設：%(default)s）。使用 "
+        f"LLM provider to use (default: {DEFAULT_PROVIDER_NAME}). Use "
+        "--list-llm-providers to show providers, default models, and API-key "
+        "environment variables.": (
+            f"要使用的 LLM 提供商（預設：{DEFAULT_PROVIDER_NAME}）。使用 "
             "--list-llm-providers 查看提供商、預設模型和 API 金鑰環境變數。"
         ),
         "list available LLM providers and exit": "列出可用 LLM 提供商並結束",
     },
 }
 """Localized text shared by CLIs that expose LLM provider arguments."""
+
+
+@dataclass(frozen=True)
+class LlmArguments:
+    """Parsed LLM provider CLI arguments."""
+
+    provider_name: str = DEFAULT_PROVIDER_NAME
+    """LLM provider name."""
+    model_name: str | None = None
+    """Optional LLM model name override."""
+    additional_context_file_path: Path | None = None
+    """Optional path to additional LLM prompt context."""
 
 
 def add_llm_provider_arguments(
@@ -80,24 +97,32 @@ def add_llm_provider_arguments(
     """
     llm_arg_group.add_argument(
         "--llm-provider",
-        default=DEFAULT_PROVIDER_NAME,
-        dest="llm_provider_name",
+        action=ArgumentBundleFieldAction,
+        bundle_type=LlmArguments,
+        dest="llm_args",
+        field_name="provider_name",
+        metavar="LLM_PROVIDER",
         type=llm_provider_name_arg,
-        help=(
-            "LLM provider to use (default: %(default)s). Use --list-llm-providers "
-            "to show providers, default models, and API-key environment variables."
-        ),
+        help=f"LLM provider to use (default: {DEFAULT_PROVIDER_NAME}). Use "
+        "--list-llm-providers to show providers, default models, and API-key "
+        "environment variables.",
     )
     llm_arg_group.add_argument(
         "--llm-model",
-        default=None,
-        dest="llm_model_name",
+        action=ArgumentBundleFieldAction,
+        bundle_type=LlmArguments,
+        dest="llm_args",
+        field_name="model_name",
+        metavar="LLM_MODEL",
         help="LLM model identifier override",
     )
     llm_arg_group.add_argument(
         "--llm-additional-content-file",
-        default=None,
-        dest="llm_additional_context_file_path",
+        action=ArgumentBundleFieldAction,
+        bundle_type=LlmArguments,
+        dest="llm_args",
+        field_name="additional_context_file_path",
+        metavar="FILE",
         type=input_file_arg(),
         help="file from which to read additional context for LLM prompts",
     )

--- a/scinoephile/cli/ocr/ocr_fuse_cli.py
+++ b/scinoephile/cli/ocr/ocr_fuse_cli.py
@@ -14,6 +14,7 @@ from scinoephile.cli.conversion import (
 )
 from scinoephile.cli.llms import (
     LLM_LOCALIZATIONS,
+    LlmArguments,
     add_llm_provider_arguments,
     read_llm_additional_context,
 )
@@ -203,9 +204,7 @@ class OcrFuseCli(ScinoephileCliBase):
         paddle_infile_path: Path | str | None,
         clean: bool,
         convert: OpenCCConfig | None,
-        llm_provider_name: str,
-        llm_model_name: str | None,
-        llm_additional_context_file_path: Path | None,
+        llm_args: LlmArguments,
         outfile_path: Path | None,
         overwrite: bool,
     ):
@@ -215,9 +214,9 @@ class OcrFuseCli(ScinoephileCliBase):
         if overwrite and outfile_path is None:
             parser.error("--overwrite may only be used with --outfile")
         additional_context = read_llm_additional_context(
-            parser, llm_additional_context_file_path
+            parser, llm_args.additional_context_file_path
         )
-        provider = get_provider(llm_provider_name, model=llm_model_name)
+        provider = get_provider(llm_args.provider_name, model=llm_args.model_name)
 
         # Dispatch to language-specific implementation
         if language == "eng":

--- a/scinoephile/cli/ocr/ocr_process_cli.py
+++ b/scinoephile/cli/ocr/ocr_process_cli.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from scinoephile.cli.llms import (
     LLM_LOCALIZATIONS,
+    LlmArguments,
     add_llm_provider_arguments,
     read_llm_additional_context,
 )
@@ -208,9 +209,7 @@ class OcrProcessCli(ScinoephileCliBase):
         clean: bool,
         dev: bool,
         cache_dir_path: Path,
-        llm_provider_name: str,
-        llm_model_name: str | None,
-        llm_additional_context_file_path: Path | None,
+        llm_args: LlmArguments,
         output_dir_path: Path,
         overwrite: bool,
     ):
@@ -220,9 +219,9 @@ class OcrProcessCli(ScinoephileCliBase):
         if language == "eng" and script is not None:
             parser.error("--script may only be used when --language is zho")
         additional_context = read_llm_additional_context(
-            parser, llm_additional_context_file_path
+            parser, llm_args.additional_context_file_path
         )
-        provider = get_provider(llm_provider_name, model=llm_model_name)
+        provider = get_provider(llm_args.provider_name, model=llm_args.model_name)
 
         # Perform operations
         try:

--- a/scinoephile/cli/yue/yue_process_cli.py
+++ b/scinoephile/cli/yue/yue_process_cli.py
@@ -13,6 +13,7 @@ from scinoephile.cli.conversion import (
 )
 from scinoephile.cli.llms import (
     LLM_LOCALIZATIONS,
+    LlmArguments,
     add_llm_provider_arguments,
     read_llm_additional_context,
 )
@@ -214,9 +215,7 @@ class YueProcessCli(ScinoephileCliBase):
         flatten: bool,
         convert: OpenCCConfig | None,
         review_script: str | None,
-        llm_provider_name: str,
-        llm_model_name: str | None,
-        llm_additional_context_file_path: Path | None,
+        llm_args: LlmArguments,
         romanize: bool,
         offset: int,
         overwrite: bool,
@@ -237,7 +236,7 @@ class YueProcessCli(ScinoephileCliBase):
         # Read inputs
         series = read_series(parser, infile_path, allow_stdin=True)
         additional_context = read_llm_additional_context(
-            parser, llm_additional_context_file_path
+            parser, llm_args.additional_context_file_path
         )
 
         # Perform operations
@@ -249,7 +248,7 @@ class YueProcessCli(ScinoephileCliBase):
             series = get_zho_flattened(series)
         if review_script is not None:
             prompt_cls = cls._get_review_prompt_cls(review_script)
-            provider = get_provider(llm_provider_name, model=llm_model_name)
+            provider = get_provider(llm_args.provider_name, model=llm_args.model_name)
             reviewer = get_zho_reviewer(
                 prompt_cls=prompt_cls,
                 provider=provider,

--- a/scinoephile/cli/yue/yue_review_vs_zho_cli.py
+++ b/scinoephile/cli/yue/yue_review_vs_zho_cli.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from scinoephile.cli.llms import (
     LLM_LOCALIZATIONS,
+    LlmArguments,
     add_llm_provider_arguments,
     read_llm_additional_context,
 )
@@ -220,9 +221,7 @@ class YueReviewVsZhoCli(ScinoephileCliBase):
         zho_infile_path: Path | str,
         mode: str,
         script: str,
-        llm_provider_name: str,
-        llm_model_name: str | None,
-        llm_additional_context_file_path: Path | None,
+        llm_args: LlmArguments,
         outfile_path: Path | None,
         overwrite: bool,
     ):
@@ -238,9 +237,9 @@ class YueReviewVsZhoCli(ScinoephileCliBase):
         yuewen = read_series(parser, yue_infile_path, allow_stdin=True)
         zhongwen = read_series(parser, zho_infile_path, allow_stdin=True)
         additional_context = read_llm_additional_context(
-            parser, llm_additional_context_file_path
+            parser, llm_args.additional_context_file_path
         )
-        provider = get_provider(llm_provider_name, model=llm_model_name)
+        provider = get_provider(llm_args.provider_name, model=llm_args.model_name)
 
         # Perform operations
         if mode == "line":

--- a/scinoephile/cli/yue/yue_transcribe_vs_zho_cli.py
+++ b/scinoephile/cli/yue/yue_transcribe_vs_zho_cli.py
@@ -14,6 +14,7 @@ from scinoephile.cli.conversion import (
 )
 from scinoephile.cli.llms import (
     LLM_LOCALIZATIONS,
+    LlmArguments,
     add_llm_provider_arguments,
     read_llm_additional_context,
 )
@@ -268,9 +269,7 @@ class YueTranscribeVsZhoCli(ScinoephileCliBase):
         stream_index: int | None,
         script: str,
         convert: OpenCCConfig | None,
-        llm_provider_name: str,
-        llm_model_name: str | None,
-        llm_additional_context_file_path: Path | None,
+        llm_args: LlmArguments,
         demucs: DemucsMode,
         vad: VADMode,
         whisper_model_name: str,
@@ -326,9 +325,9 @@ class YueTranscribeVsZhoCli(ScinoephileCliBase):
             cls._get_transcription_prompt_classes(script)
         )
         additional_context = read_llm_additional_context(
-            parser, llm_additional_context_file_path
+            parser, llm_args.additional_context_file_path
         )
-        provider = get_provider(llm_provider_name, model=llm_model_name)
+        provider = get_provider(llm_args.provider_name, model=llm_args.model_name)
         transcriber = get_yue_vs_zho_transcriber(
             model_name=whisper_model_name,
             demucs_mode=demucs,

--- a/scinoephile/cli/yue/yue_translate_from_eng_cli.py
+++ b/scinoephile/cli/yue/yue_translate_from_eng_cli.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from scinoephile.cli.llms import (
     LLM_LOCALIZATIONS,
+    LlmArguments,
     add_llm_provider_arguments,
     read_llm_additional_context,
 )
@@ -261,9 +262,7 @@ class YueTranslateFromEngCli(ScinoephileCliBase):
         yue_gapped_infile_path: Path | str | None,
         yue_guide_infile_path: Path | str | None,
         script: str,
-        llm_provider_name: str,
-        llm_model_name: str | None,
-        llm_additional_context_file_path: Path | None,
+        llm_args: LlmArguments,
         outfile_path: Path | None,
         overwrite: bool,
     ):
@@ -282,9 +281,9 @@ class YueTranslateFromEngCli(ScinoephileCliBase):
         # Read inputs
         eng = read_series(parser, eng_infile_path, allow_stdin=True)
         additional_context = read_llm_additional_context(
-            parser, llm_additional_context_file_path
+            parser, llm_args.additional_context_file_path
         )
-        provider = get_provider(llm_provider_name, model=llm_model_name)
+        provider = get_provider(llm_args.provider_name, model=llm_args.model_name)
 
         # Perform operations
         if yue_gapped_infile_path is not None:

--- a/scinoephile/cli/yue/yue_translate_from_zho_cli.py
+++ b/scinoephile/cli/yue/yue_translate_from_zho_cli.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from scinoephile.cli.llms import (
     LLM_LOCALIZATIONS,
+    LlmArguments,
     add_llm_provider_arguments,
     read_llm_additional_context,
 )
@@ -263,9 +264,7 @@ class YueTranslateFromZhoCli(ScinoephileCliBase):
         yue_gapped_infile_path: Path | str | None,
         yue_guide_infile_path: Path | str | None,
         script: str,
-        llm_provider_name: str,
-        llm_model_name: str | None,
-        llm_additional_context_file_path: Path | None,
+        llm_args: LlmArguments,
         outfile_path: Path | None,
         overwrite: bool,
     ):
@@ -284,9 +283,9 @@ class YueTranslateFromZhoCli(ScinoephileCliBase):
         # Read inputs
         zhongwen = read_series(parser, zho_infile_path, allow_stdin=True)
         additional_context = read_llm_additional_context(
-            parser, llm_additional_context_file_path
+            parser, llm_args.additional_context_file_path
         )
-        provider = get_provider(llm_provider_name, model=llm_model_name)
+        provider = get_provider(llm_args.provider_name, model=llm_args.model_name)
 
         # Perform operations
         if yue_gapped_infile_path is not None:

--- a/scinoephile/cli/zho/zho_process_cli.py
+++ b/scinoephile/cli/zho/zho_process_cli.py
@@ -13,6 +13,7 @@ from scinoephile.cli.conversion import (
 )
 from scinoephile.cli.llms import (
     LLM_LOCALIZATIONS,
+    LlmArguments,
     add_llm_provider_arguments,
     read_llm_additional_context,
 )
@@ -214,9 +215,7 @@ class ZhoProcessCli(ScinoephileCliBase):
         flatten: bool,
         convert: OpenCCConfig | None,
         review_script: str | None,
-        llm_provider_name: str,
-        llm_model_name: str | None,
-        llm_additional_context_file_path: Path | None,
+        llm_args: LlmArguments,
         romanize: bool,
         offset: int,
         overwrite: bool,
@@ -237,7 +236,7 @@ class ZhoProcessCli(ScinoephileCliBase):
         # Read inputs
         series = read_series(parser, infile_path, allow_stdin=True)
         additional_context = read_llm_additional_context(
-            parser, llm_additional_context_file_path
+            parser, llm_args.additional_context_file_path
         )
 
         # Perform operations
@@ -249,7 +248,7 @@ class ZhoProcessCli(ScinoephileCliBase):
             series = get_zho_flattened(series)
         if review_script is not None:
             prompt_cls = cls._get_review_prompt_cls(review_script)
-            provider = get_provider(llm_provider_name, model=llm_model_name)
+            provider = get_provider(llm_args.provider_name, model=llm_args.model_name)
             reviewer = get_zho_reviewer(
                 prompt_cls=prompt_cls,
                 provider=provider,

--- a/scinoephile/cli/zho/zho_translate_from_eng_cli.py
+++ b/scinoephile/cli/zho/zho_translate_from_eng_cli.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from scinoephile.cli.llms import (
     LLM_LOCALIZATIONS,
+    LlmArguments,
     add_llm_provider_arguments,
     read_llm_additional_context,
 )
@@ -261,9 +262,7 @@ class ZhoTranslateFromEngCli(ScinoephileCliBase):
         zho_gapped_infile_path: Path | str | None,
         zho_guide_infile_path: Path | str | None,
         script: str,
-        llm_provider_name: str,
-        llm_model_name: str | None,
-        llm_additional_context_file_path: Path | None,
+        llm_args: LlmArguments,
         outfile_path: Path | None,
         overwrite: bool,
     ):
@@ -282,9 +281,9 @@ class ZhoTranslateFromEngCli(ScinoephileCliBase):
         # Read inputs
         eng = read_series(parser, eng_infile_path, allow_stdin=True)
         additional_context = read_llm_additional_context(
-            parser, llm_additional_context_file_path
+            parser, llm_args.additional_context_file_path
         )
-        provider = get_provider(llm_provider_name, model=llm_model_name)
+        provider = get_provider(llm_args.provider_name, model=llm_args.model_name)
 
         # Perform operations
         if zho_gapped_infile_path is not None:

--- a/scinoephile/cli/zho/zho_translate_from_yue_cli.py
+++ b/scinoephile/cli/zho/zho_translate_from_yue_cli.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from scinoephile.cli.llms import (
     LLM_LOCALIZATIONS,
+    LlmArguments,
     add_llm_provider_arguments,
     read_llm_additional_context,
 )
@@ -261,9 +262,7 @@ class ZhoTranslateFromYueCli(ScinoephileCliBase):
         zho_gapped_infile_path: Path | str | None,
         zho_guide_infile_path: Path | str | None,
         script: str,
-        llm_provider_name: str,
-        llm_model_name: str | None,
-        llm_additional_context_file_path: Path | None,
+        llm_args: LlmArguments,
         outfile_path: Path | None,
         overwrite: bool,
     ):
@@ -282,9 +281,9 @@ class ZhoTranslateFromYueCli(ScinoephileCliBase):
         # Read inputs
         yuewen = read_series(parser, yue_infile_path, allow_stdin=True)
         additional_context = read_llm_additional_context(
-            parser, llm_additional_context_file_path
+            parser, llm_args.additional_context_file_path
         )
-        provider = get_provider(llm_provider_name, model=llm_model_name)
+        provider = get_provider(llm_args.provider_name, model=llm_args.model_name)
 
         # Perform operations
         if zho_gapped_infile_path is not None:

--- a/test/cli/test_cli_argument_groups.py
+++ b/test/cli/test_cli_argument_groups.py
@@ -11,6 +11,7 @@ import pytest
 from scinoephile.cli.eng.eng_process_cli import EngProcessCli
 from scinoephile.cli.eng.eng_translate_from_yue_cli import EngTranslateFromYueCli
 from scinoephile.cli.eng.eng_translate_from_zho_cli import EngTranslateFromZhoCli
+from scinoephile.cli.llms import LlmArguments, add_llm_provider_arguments
 from scinoephile.cli.ocr.ocr_fuse_cli import OcrFuseCli
 from scinoephile.cli.ocr.ocr_process_cli import OcrProcessCli
 from scinoephile.cli.yue.yue_process_cli import YueProcessCli
@@ -54,6 +55,47 @@ def test_llm_options_are_in_llm_argument_group(cli: type[CommandLineInterface]):
         _get_action_group_title(cli, "--llm-additional-content-file") == "llm arguments"
     )
     assert _get_action_group_title(cli, "--list-llm-providers") == "additional help"
+
+
+def test_add_llm_provider_arguments_bundles_standard_llm_options(tmp_path):
+    """Test the shared LLM helper bundles standard LLM provider options.
+
+    Arguments:
+        tmp_path: pytest temporary path fixture
+    """
+    context_file_path = tmp_path / "context.txt"
+    context_file_path.write_text("context", encoding="utf-8")
+    parser = ArgumentParser()
+    llm_arg_group = parser.add_argument_group("llm arguments")
+    additional_help_arg_group = parser.add_argument_group("additional help")
+
+    add_llm_provider_arguments(llm_arg_group, additional_help_arg_group)
+
+    namespace = parser.parse_args(
+        [
+            "--llm-provider",
+            "openai",
+            "--llm-model",
+            "gpt-test",
+            "--llm-additional-content-file",
+            str(context_file_path),
+        ]
+    )
+    assert namespace.llm_args == LlmArguments(
+        provider_name="openai",
+        model_name="gpt-test",
+        additional_context_file_path=context_file_path.resolve(),
+    )
+    assert not hasattr(namespace, "llm")
+    assert not hasattr(namespace, "llm_provider_name")
+    assert not hasattr(namespace, "llm_model_name")
+    assert not hasattr(namespace, "llm_additional_context_file_path")
+
+    model_namespace = parser.parse_args(["--llm-model", "gpt-test"])
+    assert model_namespace.llm_args == LlmArguments(model_name="gpt-test")
+
+    default_namespace = parser.parse_args([])
+    assert default_namespace.llm_args == LlmArguments()
 
 
 def _get_action(parser: ArgumentParser, option: str) -> Action:


### PR DESCRIPTION
## Summary

- Add `ArgumentBundleFieldAction` for dataclass-backed argparse option bundles.
- Add `LlmArguments` and route shared LLM provider/model/context-file options through `dest="llm_args"`.
- Update LLM-consuming CLIs to read provider, model, and additional context path from `llm_args`.
- Extend CLI argument-group tests to assert the bundled namespace shape and absence of old flat attributes.

This intentionally excludes web server argument bundling, OCR validation web UI behavior, Flask/HTMX/package-data changes, OCR validation cleanup, fixture churn, and unrelated source-branch changes.

## Verification

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format <changed python files>`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix <changed python files>`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check <changed python files>`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest cli/test_cli_argument_groups.py -q`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest cli/test_llm_cli.py cli/eng/test_eng_process_cli.py cli/eng/test_eng_translate_from_yue_cli.py cli/eng/test_eng_translate_from_zho_cli.py cli/ocr/test_ocr_fuse_eng_cli.py cli/ocr/test_ocr_fuse_zho_cli.py cli/ocr/test_ocr_process_cli.py cli/yue/test_yue_process_cli.py cli/yue/test_yue_review_vs_zho_cli.py cli/yue/test_yue_transcribe_vs_zho_cli.py cli/yue/test_yue_translate_from_eng_cli.py cli/yue/test_yue_translate_from_zho_cli.py cli/zho/test_zho_process_cli.py cli/zho/test_zho_translate_from_eng_cli.py cli/zho/test_zho_translate_from_yue_cli.py -q`