### PR TITLE
Wrap subtitle load/save boundary errors

### DIFF
--- a/scinoephile/audio/subtitles/series.py
+++ b/scinoephile/audio/subtitles/series.py
@@ -12,6 +12,7 @@ from typing import Any, Self, TypedDict, override
 
 import ffmpeg
 from pydub import AudioSegment
+from pydub.exceptions import PydubException
 
 from scinoephile.common.file import get_temp_directory_path
 from scinoephile.common.validation import (
@@ -140,23 +141,28 @@ class AudioSeries(Series):
         """
         path = Path(path)
 
-        # Check if directory
-        if format_ == "wav" or (not format_ and path.suffix == ""):
-            validated_output_dir_path = val_output_dir_path(path)
-            self._save_wav(validated_output_dir_path)
-            logger.info(f"Saved series to {validated_output_dir_path}")
-            return
+        try:
+            # Check if directory
+            if format_ == "wav" or (not format_ and path.suffix == ""):
+                validated_output_dir_path = val_output_dir_path(path)
+                self._save_wav(validated_output_dir_path)
+                logger.info(f"Saved series to {validated_output_dir_path}")
+                return
 
-        # Otherwise, continue as superclass
-        validated_output_path = val_output_path(path, exist_ok=True)
-        super().save(
-            validated_output_path,
-            encoding=encoding,
-            format_=format_,
-            fps=fps,
-            errors=errors,
-            **kwargs,
-        )
+            # Otherwise, continue as superclass
+            validated_output_path = val_output_path(path, exist_ok=True)
+            super().save(
+                validated_output_path,
+                encoding=encoding,
+                format_=format_,
+                fps=fps,
+                errors=errors,
+                **kwargs,
+            )
+        except (OSError, PydubException, UnicodeError, ValueError) as exc:
+            raise ScinoephileError(
+                f"Unable to save {type(self).__name__} to {path}: {exc}"
+            ) from exc
         logger.info(f"Saved series to {validated_output_path}")
 
     @override
@@ -199,24 +205,29 @@ class AudioSeries(Series):
         Returns:
             loaded series
         """
-        validated_path = val_input_dir_path(path)
-        buffer = kwargs.pop("buffer", 1000)
-        validated_srt_path = val_input_path(
-            validated_path / f"{validated_path.stem}.srt"
-        )
-        text_series = Series.load(
-            validated_srt_path,
-            encoding=encoding,
-            format_=format_,
-            fps=fps,
-            errors=errors,
-            **kwargs,
-        )
+        try:
+            validated_path = val_input_dir_path(path)
+            buffer = kwargs.pop("buffer", 1000)
+            validated_srt_path = val_input_path(
+                validated_path / f"{validated_path.stem}.srt"
+            )
+            text_series = Series.load(
+                validated_srt_path,
+                encoding=encoding,
+                format_=format_,
+                fps=fps,
+                errors=errors,
+                **kwargs,
+            )
 
-        validated_audio_path = val_input_path(
-            validated_path / f"{validated_path.stem}.wav"
-        )
-        full_audio = AudioSegment.from_wav(validated_audio_path)
+            validated_audio_path = val_input_path(
+                validated_path / f"{validated_path.stem}.wav"
+            )
+            full_audio = AudioSegment.from_wav(validated_audio_path)
+        except (OSError, PydubException, UnicodeError, ValueError) as exc:
+            raise ScinoephileError(
+                f"Unable to load {cls.__name__} from {path}: {exc}"
+            ) from exc
         logger.info(f"Loaded full audio from {validated_audio_path}")
 
         return cls.build_series(text_series, full_audio, buffer)
@@ -242,21 +253,21 @@ class AudioSeries(Series):
         Returns:
             loaded series
         """
-        validated_media_path = val_input_path(media_path)
-        validated_subtitle_path = val_input_path(subtitle_path)
-        text_series = Series.load(validated_subtitle_path, **kwargs)
+        try:
+            validated_media_path = val_input_path(media_path)
+            validated_subtitle_path = val_input_path(subtitle_path)
+            text_series = Series.load(validated_subtitle_path, **kwargs)
 
-        stream = cls._get_audio_stream(validated_media_path, stream_index)
-        if stream.channels is None:
-            raise ScinoephileError(
-                f"Audio stream {stream.index} in {validated_media_path} "
-                "cannot be used for transcription."
-            )
-        channel_count = stream.channels
+            stream = cls._get_audio_stream(validated_media_path, stream_index)
+            if stream.channels is None:
+                raise ScinoephileError(
+                    f"Audio stream {stream.index} in {validated_media_path} "
+                    "cannot be used for transcription."
+                )
+            channel_count = stream.channels
 
-        with get_temp_directory_path() as temp_dir_path:
-            full_audio_path = temp_dir_path / "full_audio.wav"
-            try:
+            with get_temp_directory_path() as temp_dir_path:
+                full_audio_path = temp_dir_path / "full_audio.wav"
                 cls.extract_audio_track(
                     validated_media_path,
                     full_audio_path,
@@ -265,13 +276,12 @@ class AudioSeries(Series):
                 )
                 logger.info(f"Loading full audio from {full_audio_path}")
                 full_audio = AudioSegment.from_wav(full_audio_path)
-            except ffmpeg.Error as exc:
-                raise ScinoephileError(
-                    f"Could not extract audio stream {stream.index} from "
-                    f"{validated_media_path}"
-                ) from exc
 
-        return cls.build_series(text_series, full_audio, buffer)
+            return cls.build_series(text_series, full_audio, buffer)
+        except (ffmpeg.Error, OSError, PydubException, UnicodeError, ValueError) as exc:
+            raise ScinoephileError(
+                f"Unable to load {cls.__name__} from media {media_path}: {exc}"
+            ) from exc
 
     @classmethod
     def build_series(
@@ -346,32 +356,38 @@ class AudioSeries(Series):
             audio_track: media stream index of an audio stream
             channels: Number of channels in audio track
         """
-        if channels >= 6:
-            logger.info(
-                "Extracting center channel of audio stream "
-                f"{audio_track} from {video_input_path} to {audio_output_path}"
-            )
-            ffmpeg.input(str(video_input_path)).output(
-                str(audio_output_path),
-                format="wav",
-                ar=16000,
-                **{
-                    "filter_complex": f"[0:{audio_track}]pan=mono|c0=c2[out]",
-                    "map": "[out]",
-                },
-            ).run(quiet=False, overwrite_output=True)
-        else:
-            logger.info(
-                f"Downmixing audio stream {audio_track} from {video_input_path} to "
-                f"{audio_output_path}"
-            )
-            ffmpeg.input(str(video_input_path)).output(
-                str(audio_output_path),
-                format="wav",
-                ar=16000,
-                map=f"0:{audio_track}",
-                ac=1,
-            ).run(quiet=False, overwrite_output=True)
+        try:
+            if channels >= 6:
+                logger.info(
+                    "Extracting center channel of audio stream "
+                    f"{audio_track} from {video_input_path} to {audio_output_path}"
+                )
+                ffmpeg.input(str(video_input_path)).output(
+                    str(audio_output_path),
+                    format="wav",
+                    ar=16000,
+                    **{
+                        "filter_complex": f"[0:{audio_track}]pan=mono|c0=c2[out]",
+                        "map": "[out]",
+                    },
+                ).run(quiet=False, overwrite_output=True)
+            else:
+                logger.info(
+                    f"Downmixing audio stream {audio_track} from {video_input_path} "
+                    f"to {audio_output_path}"
+                )
+                ffmpeg.input(str(video_input_path)).output(
+                    str(audio_output_path),
+                    format="wav",
+                    ar=16000,
+                    map=f"0:{audio_track}",
+                    ac=1,
+                ).run(quiet=False, overwrite_output=True)
+        except (ffmpeg.Error, OSError) as exc:
+            raise ScinoephileError(
+                f"Could not extract audio stream {audio_track} from "
+                f"{video_input_path} to {audio_output_path}"
+            ) from exc
 
     @staticmethod
     def _get_audio_stream(media_path: Path, stream_index: int | None) -> AudioStream:

--- a/scinoephile/core/subtitles/series.py
+++ b/scinoephile/core/subtitles/series.py
@@ -10,9 +10,11 @@ from os import PathLike
 from typing import Any, Self, cast, override
 
 from pysubs2 import SSAFile
+from pysubs2.exceptions import Pysubs2Error
 from pysubs2.time import ms_to_str
 
 from scinoephile.common.validation import val_input_path, val_output_path
+from scinoephile.core.exceptions import ScinoephileError
 
 from .subtitle import Subtitle
 
@@ -151,16 +153,21 @@ class Series(SSAFile):
             errors: encoding error handling
             **kwargs: additional keyword arguments
         """
-        validated_path = val_output_path(path, exist_ok=True)
-        SSAFile.save(
-            self,
-            str(validated_path),
-            encoding=encoding,
-            format_=format_,
-            fps=fps,
-            errors=errors,
-            **kwargs,
-        )
+        try:
+            validated_path = val_output_path(path, exist_ok=True)
+            SSAFile.save(
+                self,
+                str(validated_path),
+                encoding=encoding,
+                format_=format_,
+                fps=fps,
+                errors=errors,
+                **kwargs,
+            )
+        except (OSError, Pysubs2Error, UnicodeError, ValueError) as exc:
+            raise ScinoephileError(
+                f"Unable to save {type(self).__name__} to {path}: {exc}"
+            ) from exc
         logger.info(f"Saved series to {validated_path}")
 
     def slice(self, start: int, end: int) -> Self:
@@ -208,6 +215,29 @@ class Series(SSAFile):
             )
         return string.rstrip()
 
+    @override
+    def to_string(
+        self,
+        format_: str,
+        fps: float | None = None,
+        **kwargs: Any,
+    ) -> str:
+        """Serialize series to a string.
+
+        Arguments:
+            format_: output string format
+            fps: frames per second
+            **kwargs: additional keyword arguments
+        Returns:
+            serialized subtitle series
+        """
+        try:
+            return super().to_string(format_, fps=fps, **kwargs)
+        except (Pysubs2Error, UnicodeError, ValueError) as exc:
+            raise ScinoephileError(
+                f"Unable to serialize {type(self).__name__} to string: {exc}"
+            ) from exc
+
     @classmethod
     @override
     def from_string(
@@ -227,11 +257,18 @@ class Series(SSAFile):
         Returns:
             parsed series
         """
-        series = cast(
-            Self,
-            super().from_string(string, format_=format_, fps=fps, **kwargs),
-        )
-        series.events = [cls.event_class(**ssaevent.as_dict()) for ssaevent in series]
+        try:
+            series = cast(
+                Self,
+                super().from_string(string, format_=format_, fps=fps, **kwargs),
+            )
+            series.events = [
+                cls.event_class(**ssaevent.as_dict()) for ssaevent in series
+            ]
+        except (Pysubs2Error, UnicodeError, ValueError) as exc:
+            raise ScinoephileError(
+                f"Unable to parse {cls.__name__} from string: {exc}"
+            ) from exc
 
         return series
 
@@ -258,16 +295,23 @@ class Series(SSAFile):
         Returns:
             loaded series
         """
-        validated_path = val_input_path(path)
+        try:
+            validated_path = val_input_path(path)
 
-        with open(str(validated_path), encoding=encoding, errors=errors) as input_file:
-            series = cast(
-                Self,
-                cls.from_file(input_file, format_=format_, fps=fps, **kwargs),
-            )
-            series.events = [
-                cls.event_class(**ssaevent.as_dict()) for ssaevent in series
-            ]
+            with open(
+                str(validated_path), encoding=encoding, errors=errors
+            ) as input_file:
+                series = cast(
+                    Self,
+                    cls.from_file(input_file, format_=format_, fps=fps, **kwargs),
+                )
+                series.events = [
+                    cls.event_class(**ssaevent.as_dict()) for ssaevent in series
+                ]
+        except (OSError, Pysubs2Error, UnicodeError, ValueError) as exc:
+            raise ScinoephileError(
+                f"Unable to load {cls.__name__} from {path}: {exc}"
+            ) from exc
 
         logger.info(f"Loaded series from {validated_path}")
         return series

--- a/scinoephile/image/subtitles/series.py
+++ b/scinoephile/image/subtitles/series.py
@@ -15,10 +15,8 @@ from typing import Any, Self, override
 import numpy as np
 from PIL import Image
 
-from scinoephile.common import DirectoryNotFoundError
 from scinoephile.common.validation import (
-    val_input_dir_path,
-    val_input_path,
+    val_input_file_or_dir_path,
     val_output_dir_path,
     val_output_path,
 )
@@ -150,28 +148,33 @@ class ImageSeries(Series):
         """
         path = Path(path)
 
-        # Check if directory
-        if format_ == "html" or (not format_ and path.suffix == ""):
-            validated_output_dir_path = val_output_dir_path(path)
-            self._save_html(
-                validated_output_dir_path,
-                encoding=encoding,
-                errors=errors,
-            )
-            logger.info(f"Saved series to {validated_output_dir_path}")
-            return
+        try:
+            # Check if directory
+            if format_ == "html" or (not format_ and path.suffix == ""):
+                validated_output_dir_path = val_output_dir_path(path)
+                self._save_html(
+                    validated_output_dir_path,
+                    encoding=encoding,
+                    errors=errors,
+                )
+                logger.info(f"Saved series to {validated_output_dir_path}")
+                return
 
-        # Otherwise, continue as superclass
-        exist_ok = kwargs.pop("exist_ok", False)
-        validated_output_path = val_output_path(path, exist_ok=exist_ok)
-        super().save(
-            validated_output_path,
-            encoding=encoding,
-            format_=format_,
-            fps=fps,
-            errors=errors,
-            **kwargs,
-        )
+            # Otherwise, continue as superclass
+            exist_ok = kwargs.pop("exist_ok", False)
+            validated_output_path = val_output_path(path, exist_ok=exist_ok)
+            super().save(
+                validated_output_path,
+                encoding=encoding,
+                format_=format_,
+                fps=fps,
+                errors=errors,
+                **kwargs,
+            )
+        except (OSError, UnicodeError, ValueError) as exc:
+            raise ScinoephileError(
+                f"Unable to save {type(self).__name__} to {path}: {exc}"
+            ) from exc
         logger.info(f"Saved series to {validated_output_path}")
 
     @classmethod
@@ -198,20 +201,23 @@ class ImageSeries(Series):
             loaded series
         """
         try:
-            validated_path = val_input_dir_path(path)
-            return cls._load_html(
-                validated_path,
-                encoding=encoding,
-                errors=errors,
-            )
-        except (DirectoryNotFoundError, NotADirectoryError):
-            validated_path = val_input_path(path)
+            validated_path = val_input_file_or_dir_path(path)
+            if validated_path.is_dir():
+                return cls._load_html(
+                    validated_path,
+                    encoding=encoding,
+                    errors=errors,
+                )
             if format_ == "sup" or validated_path.suffix == ".sup":
                 return cls._load_sup(validated_path)
-            raise ValueError(
-                f"{cls.__name__}'s path must be path to a directory containing one "
-                "index.html file and N png files, or a .sup file."
-            )
+        except (OSError, UnicodeError, ValueError) as exc:
+            raise ScinoephileError(
+                f"Unable to load {cls.__name__} from {path}: {exc}"
+            ) from exc
+        raise ScinoephileError(
+            f"{cls.__name__}'s path must be path to a directory containing one "
+            "index.html file and N png files, or a .sup file."
+        )
 
     @override
     def _init_blocks(self):

--- a/test/audio/subtitles/test_audio_series.py
+++ b/test/audio/subtitles/test_audio_series.py
@@ -1,0 +1,77 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests of scinoephile.audio.subtitles.series."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from pydub import AudioSegment
+from pydub.exceptions import CouldntDecodeError
+
+from scinoephile.audio.subtitles import AudioSeries
+from scinoephile.core import ScinoephileError
+
+
+def test_audio_series_load_wraps_input_path_errors(tmp_path: Path):
+    """Test audio subtitle loading path errors are user-facing.
+
+    Arguments:
+        tmp_path: pytest temporary directory path
+    """
+    input_path = tmp_path / "missing"
+
+    with pytest.raises(
+        ScinoephileError,
+        match="Unable to load AudioSeries from .*missing",
+    ) as excinfo:
+        AudioSeries.load(input_path)
+
+    assert isinstance(excinfo.value.__cause__, OSError)
+
+
+def test_audio_series_load_wraps_decode_errors(tmp_path: Path):
+    """Test audio subtitle loading decode errors are user-facing.
+
+    Arguments:
+        tmp_path: pytest temporary directory path
+    """
+    input_path = tmp_path / "input"
+    input_path.mkdir()
+    (input_path / "input.srt").write_text(
+        "1\n00:00:01,000 --> 00:00:02,000\nText\n", encoding="utf-8"
+    )
+    (input_path / "input.wav").touch()
+
+    with patch(
+        "scinoephile.audio.subtitles.series.AudioSegment.from_wav",
+        side_effect=CouldntDecodeError("invalid audio"),
+    ):
+        with pytest.raises(
+            ScinoephileError,
+            match="Unable to load AudioSeries from .*input: invalid audio",
+        ) as excinfo:
+            AudioSeries.load(input_path)
+
+    assert isinstance(excinfo.value.__cause__, CouldntDecodeError)
+
+
+def test_audio_series_save_wraps_output_path_errors(tmp_path: Path):
+    """Test audio subtitle saving path errors are user-facing.
+
+    Arguments:
+        tmp_path: pytest temporary directory path
+    """
+    output_path = tmp_path / "audio_output"
+    output_path.touch()
+    series = AudioSeries(audio=AudioSegment.silent(duration=1000))
+
+    with pytest.raises(
+        ScinoephileError,
+        match="Unable to save AudioSeries to .*audio_output",
+    ) as excinfo:
+        series.save(output_path)
+
+    assert isinstance(excinfo.value.__cause__, OSError)

--- a/test/audio/subtitles/test_audio_series_load_from_media.py
+++ b/test/audio/subtitles/test_audio_series_load_from_media.py
@@ -7,8 +7,10 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import patch
 
+import ffmpeg
 import pytest
 from pydub import AudioSegment
+from pydub.exceptions import CouldntDecodeError
 
 from scinoephile.audio.subtitles import AudioSeries
 from scinoephile.common.file import get_temp_file_path
@@ -18,11 +20,13 @@ from scinoephile.core import ScinoephileError
 class FakeFfmpegInput:
     """Fake ffmpeg input chain that records output arguments."""
 
-    def __init__(self):
+    def __init__(self, run_exception: Exception | None = None):
         """Initialize."""
         self.output_args: tuple[object, ...] | None = None
         self.output_kwargs: dict[str, object] | None = None
         self.run_kwargs: dict[str, object] | None = None
+        self.run_exception = run_exception
+        """Exception to raise when run."""
 
     def output(self, *args: object, **kwargs: object) -> FakeFfmpegInput:
         """Record ffmpeg output arguments.
@@ -44,6 +48,8 @@ class FakeFfmpegInput:
             **kwargs: ffmpeg run keyword arguments
         """
         self.run_kwargs = kwargs
+        if self.run_exception is not None:
+            raise self.run_exception
 
 
 def test_audio_series_extract_audio_track_maps_overall_stream_index():
@@ -84,6 +90,30 @@ def test_audio_series_extract_audio_track_filters_overall_stream_index():
     assert fake_ffmpeg_input.output_kwargs["filter_complex"] == (
         "[0:12]pan=mono|c0=c2[out]"
     )
+
+
+def test_audio_series_extract_audio_track_wraps_ffmpeg_errors():
+    """Test audio extraction errors are user-facing."""
+    fake_ffmpeg_input = FakeFfmpegInput(
+        ffmpeg.Error("ffmpeg", b"", b"failed"),
+    )
+
+    with patch(
+        "scinoephile.audio.subtitles.series.ffmpeg.input",
+        return_value=fake_ffmpeg_input,
+    ):
+        with pytest.raises(
+            ScinoephileError,
+            match="Could not extract audio stream 12 from video.mkv",
+        ) as excinfo:
+            AudioSeries.extract_audio_track(
+                Path("video.mkv"),
+                Path("audio.wav"),
+                12,
+                2,
+            )
+
+    assert isinstance(excinfo.value.__cause__, ffmpeg.Error)
 
 
 def test_audio_series_load_from_media_supports_stream_index():
@@ -165,6 +195,57 @@ def test_audio_series_load_from_media_defaults_to_first_audio_stream():
     extract_audio_track.assert_called_once()
     assert extract_audio_track.call_args.args[2] == 1
     assert extract_audio_track.call_args.args[3] == 2
+
+
+def test_audio_series_load_from_media_wraps_input_path_errors(tmp_path: Path):
+    """Test media loading path errors are user-facing.
+
+    Arguments:
+        tmp_path: pytest temporary directory path
+    """
+    with pytest.raises(
+        ScinoephileError,
+        match="Unable to load AudioSeries from media .*missing.mkv",
+    ) as excinfo:
+        AudioSeries.load_from_media(
+            media_path=tmp_path / "missing.mkv",
+            subtitle_path=tmp_path / "missing.srt",
+        )
+
+    assert isinstance(excinfo.value.__cause__, OSError)
+
+
+def test_audio_series_load_from_media_wraps_decode_errors():
+    """Test media loading audio decode errors are user-facing."""
+    with get_temp_file_path(".srt") as subtitle_path:
+        subtitle_path.write_text(
+            "1\n00:00:00,000 --> 00:00:01,000\n你好\n", encoding="utf-8"
+        )
+        with get_temp_file_path(".mp4") as media_path:
+            media_path.touch()
+            with patch(
+                "scinoephile.media.probe.ffmpeg.probe",
+                return_value={
+                    "streams": [{"index": 1, "codec_type": "audio", "channels": 2}]
+                },
+            ):
+                with patch(
+                    "scinoephile.audio.subtitles.series.AudioSeries.extract_audio_track"
+                ):
+                    with patch(
+                        "scinoephile.audio.subtitles.series.AudioSegment.from_wav",
+                        side_effect=CouldntDecodeError("invalid audio"),
+                    ):
+                        with pytest.raises(
+                            ScinoephileError,
+                            match="Unable to load AudioSeries from media",
+                        ) as excinfo:
+                            AudioSeries.load_from_media(
+                                media_path=media_path,
+                                subtitle_path=subtitle_path,
+                            )
+
+    assert isinstance(excinfo.value.__cause__, CouldntDecodeError)
 
 
 def test_audio_series_load_from_media_rejects_invalid_stream_index():

--- a/test/core/subtitles/test_series.py
+++ b/test/core/subtitles/test_series.py
@@ -4,8 +4,13 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
+import pytest
+
 from scinoephile.common.file import get_temp_file_path
-from scinoephile.core.subtitles import Series
+from scinoephile.core import ScinoephileError
+from scinoephile.core.subtitles import Series, Subtitle
 from test.helpers import assert_series_equal, test_data_root
 
 
@@ -19,3 +24,57 @@ def test_series_round_trips_srt():
         output = Series.load(output_path)
 
     assert_series_equal(output, series)
+
+
+def test_series_load_wraps_input_path_errors(tmp_path: Path):
+    """Test subtitle loading path errors are user-facing.
+
+    Arguments:
+        tmp_path: pytest temporary directory path
+    """
+    path = tmp_path / "missing.srt"
+
+    with pytest.raises(
+        ScinoephileError,
+        match="Unable to load Series from .*missing.srt",
+    ) as excinfo:
+        Series.load(path)
+
+    assert isinstance(excinfo.value.__cause__, FileNotFoundError)
+
+
+def test_series_from_string_wraps_parser_errors():
+    """Test subtitle parsing errors are user-facing."""
+    with pytest.raises(
+        ScinoephileError,
+        match="Unable to parse Series from string",
+    ):
+        Series.from_string("text", format_="unsupported")
+
+
+def test_series_save_wraps_output_path_errors(tmp_path: Path):
+    """Test subtitle saving path errors are user-facing.
+
+    Arguments:
+        tmp_path: pytest temporary directory path
+    """
+    series = Series(events=[Subtitle(start=1000, end=2000, text="Text")])
+
+    with pytest.raises(
+        ScinoephileError,
+        match="Unable to save Series to ",
+    ) as excinfo:
+        series.save(tmp_path)
+
+    assert isinstance(excinfo.value.__cause__, OSError)
+
+
+def test_series_to_string_wraps_serializer_errors():
+    """Test subtitle string serialization errors are user-facing."""
+    series = Series(events=[Subtitle(start=1000, end=2000, text="Text")])
+
+    with pytest.raises(
+        ScinoephileError,
+        match="Unable to serialize Series to string",
+    ):
+        series.to_string(format_="unsupported")

--- a/test/image/subtitles/test_image_series.py
+++ b/test/image/subtitles/test_image_series.py
@@ -4,10 +4,13 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 from PIL import Image
 
 from scinoephile.common.file import get_temp_directory_path
+from scinoephile.core import ScinoephileError
 from scinoephile.image.bbox import Bbox
 from scinoephile.image.subtitles import ImageSeries, ImageSubtitle
 
@@ -77,6 +80,36 @@ def test_load_html(
         assert event.img.size[1] > 0
 
 
+def test_load_rejects_unsupported_input_file(tmp_path: Path):
+    """Test unsupported image subtitle input files raise user-facing errors.
+
+    Arguments:
+        tmp_path: pytest temporary directory path
+    """
+    input_path = tmp_path / "subtitles.txt"
+    input_path.write_text("not image subtitles", encoding="utf-8")
+
+    with pytest.raises(ScinoephileError, match="directory containing one index.html"):
+        ImageSeries.load(input_path)
+
+
+def test_image_series_load_wraps_input_path_errors(tmp_path: Path):
+    """Test image subtitle loading path errors are user-facing.
+
+    Arguments:
+        tmp_path: pytest temporary directory path
+    """
+    input_path = tmp_path / "missing"
+
+    with pytest.raises(
+        ScinoephileError,
+        match="Unable to load ImageSeries from .*missing",
+    ) as excinfo:
+        ImageSeries.load(input_path)
+
+    assert isinstance(excinfo.value.__cause__, OSError)
+
+
 def test_save_html(tiny_image_series: ImageSeries):
     """Test saving HTML image subtitles.
 
@@ -95,6 +128,27 @@ def test_save_html(tiny_image_series: ImageSeries):
 
         png_files = sorted(output_path.glob("*.png"))
         assert len(png_files) == len(tiny_image_series)
+
+
+def test_image_series_save_wraps_output_path_errors(
+    tiny_image_series: ImageSeries, tmp_path: Path
+):
+    """Test image subtitle saving path errors are user-facing.
+
+    Arguments:
+        tiny_image_series: small image subtitle series
+        tmp_path: pytest temporary directory path
+    """
+    output_path = tmp_path / "image_output"
+    output_path.touch()
+
+    with pytest.raises(
+        ScinoephileError,
+        match="Unable to save ImageSeries to .*image_output",
+    ) as excinfo:
+        tiny_image_series.save(output_path)
+
+    assert isinstance(excinfo.value.__cause__, OSError)
 
 
 def test_series_fill_and_outline_colors():


### PR DESCRIPTION
## Summary
- Wrap public subtitle load/save and parse/serialize boundary failures in `ScinoephileError` with exception chaining.
- Cover core subtitle parser/serializer errors, audio directory/media extraction/decode errors, and image subtitle load/save path errors.
- Keep the branch scoped to subtitle boundary handling without OCR web, workflow, recognizer, dependency, or stream-selection changes.

## Checks
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format <changed Python files>`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix <changed Python files>`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check <changed Python files>`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto core/subtitles/test_series.py audio/subtitles/test_audio_series.py audio/subtitles/test_audio_series_load_from_media.py image/subtitles/test_image_series.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto`