### PR TITLE
OCR engine API cleanup

### DIFF
--- a/scinoephile/image/ocr/lens/__init__.py
+++ b/scinoephile/image/ocr/lens/__init__.py
@@ -4,100 +4,66 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-from typing import cast
+from logging import getLogger
+from typing import Unpack, cast
 
+from scinoephile.core import ScinoephileError
 from scinoephile.core.paths import get_runtime_cache_dir_path
 from scinoephile.core.subtitles import Series, Subtitle
-from scinoephile.core.text import ChineseScript
 from scinoephile.image.subtitles import ImageSeries, ImageSubtitle
 
-from .google_lens_recognizer import GoogleLensRecognizer
+from .lens_recognizer import LensRecognizer, LensRecognizerKwargs
 
 __all__ = [
-    "GoogleLensRecognizer",
-    "get_google_lens_recognizer",
-    "get_lens_zho_code",
+    "LensRecognizer",
+    "LensRecognizerKwargs",
     "ocr_image_series_with_lens",
 ]
 
-
-def get_google_lens_recognizer(
-    *,
-    cache_dir_path: Path | None = None,
-    language: str = "en",
-    retries: int = 3,
-) -> GoogleLensRecognizer:
-    """Get Google Lens recognizer with provided configuration.
-
-    Arguments:
-        cache_dir_path: directory in which to cache OCR results
-        language: Google Lens OCR language code
-        retries: Google Lens OCR request attempts per uncached image
-    Returns:
-        Google Lens recognizer
-    """
-    if cache_dir_path is None:
-        cache_dir_path = get_runtime_cache_dir_path("google-lens")
-    return GoogleLensRecognizer(
-        cache_dir_path=cache_dir_path,
-        language=language,
-        retries=retries,
-    )
-
-
-def get_lens_zho_code(script: ChineseScript) -> str:
-    """Get the Google Lens language code for a Chinese script.
-
-    Arguments:
-        script: Chinese script
-    Returns:
-        Google Lens language code
-    """
-    if script == "simplified":
-        return "zh-CN"
-    if script == "traditional":
-        return "zh-TW"
-    raise ValueError(
-        f"{script!r} is not one of the supported Chinese scripts: "
-        "simplified, traditional"
-    )
+logger = getLogger(__name__)
 
 
 def ocr_image_series_with_lens(
     image_series: ImageSeries,
-    *,
-    language: str = "en",
-    retries: int = 3,
-    recognizer: GoogleLensRecognizer | None = None,
+    **kwargs: Unpack[LensRecognizerKwargs],
 ) -> Series:
     """OCR an image subtitle series with Google Lens.
 
     Arguments:
         image_series: image subtitle series
-        language: Google Lens OCR language code
-        retries: Google Lens OCR request attempts per uncached image
-        recognizer: Google Lens-compatible recognizer
+        **kwargs: additional keyword arguments for LensRecognizer
     Returns:
         text subtitle series
     """
-    if recognizer is None:
-        lens_recognizer = get_google_lens_recognizer(
-            language=language,
-            retries=retries,
-        )
-    else:
-        lens_recognizer = recognizer
+    try:
+        if "cache_dir_path" not in kwargs:
+            kwargs["cache_dir_path"] = get_runtime_cache_dir_path("google-lens")
+        lens_recognizer = LensRecognizer(**kwargs)
 
-    events = []
-    for subtitle in image_series:
-        image_subtitle = cast(ImageSubtitle, subtitle)
-        text = lens_recognizer.recognize_image(image_subtitle.img)
-        events.append(
-            Subtitle(
-                start=image_subtitle.start,
-                end=image_subtitle.end,
-                text=text,
+        events = []
+        subtitle_count = len(image_series.events)
+        for subtitle_idx, subtitle in enumerate(image_series, 1):
+            logger.info(
+                f"OCRing subtitle {subtitle_idx}/{subtitle_count} with Google Lens"
             )
-        )
-    return Series(events=events)
+            image_subtitle = cast(ImageSubtitle, subtitle)
+            text = lens_recognizer.recognize_image(image_subtitle.img)
+            events.append(
+                Subtitle(
+                    start=image_subtitle.start,
+                    end=image_subtitle.end,
+                    text=text,
+                )
+            )
+        return Series(events=events)
+    except ScinoephileError:
+        raise
+    except (
+        ImportError,
+        OSError,
+        RuntimeError,
+        ValueError,
+    ) as exc:
+        raise ScinoephileError(
+            f"Unable to OCR image series with Google Lens: {exc}"
+        ) from exc

--- a/scinoephile/image/ocr/lens/lens_recognizer.py
+++ b/scinoephile/image/ocr/lens/lens_recognizer.py
@@ -10,13 +10,17 @@ import json
 from collections.abc import Mapping
 from logging import getLogger
 from pathlib import Path
-from typing import Any, cast, override
+from typing import Any, TypedDict, cast, override
 
 from PIL import Image
 
 from scinoephile.common.validation import val_int, val_output_dir_path
+from scinoephile.core import Language
 
-__all__ = ["GoogleLensRecognizer"]
+__all__ = [
+    "LensRecognizer",
+    "LensRecognizerKwargs",
+]
 
 logger = getLogger(__name__)
 
@@ -25,33 +29,67 @@ _OCR_EXTRA_MESSAGE = (
     "Install scinoephile with the 'ocr' extra."
 )
 _LENS_RETRY_DELAY_SECONDS = 1.5
+_LENS_LANGUAGE_CODES = {
+    Language.eng: "en",
+    Language.zho_hans: "zh-CN",
+    Language.zho_hant: "zh-TW",
+}
+_LENS_LANGUAGE_ALIASES = {
+    "en": Language.eng,
+    "eng": Language.eng,
+    "zh-cn": Language.zho_hans,
+    "zh-hans": Language.zho_hans,
+    "zh-tw": Language.zho_hant,
+    "zh-hant": Language.zho_hant,
+    "zho-hans": Language.zho_hans,
+    "zho-hant": Language.zho_hant,
+}
+
+
+class LensRecognizerKwargs(TypedDict, total=False):
+    """Additional keyword arguments forwarded to LensRecognizer."""
+
+    cache_dir_path: Path | None
+    """Directory in which to cache OCR results."""
+
+    language: Language | str
+    """Scinoephile language."""
+
+    retries: int
+    """Google Lens OCR request attempts per uncached image."""
 
 
 class _GoogleLensRequestError(RuntimeError):
     """Transient Google Lens request error returned as OCR text."""
 
 
-class GoogleLensRecognizer:
+class LensRecognizer:
     """Google Lens recognizer for image subtitles."""
 
     def __init__(
         self,
         *,
         cache_dir_path: Path | None = None,
-        language: str = "en",
+        language: Language | str = Language.eng,
         retries: int = 3,
     ):
         """Initialize.
 
         Arguments:
             cache_dir_path: directory in which to cache OCR results
-            language: Google Lens OCR language code
+            language: Scinoephile language
             retries: Google Lens OCR request attempts per uncached image
         """
         self.cache_dir_path = None
         if cache_dir_path is not None:
             self.cache_dir_path = val_output_dir_path(cache_dir_path)
-        self.language = language
+        self.language = _coerce_lens_language(language)
+        try:
+            self.lens_language_code = _LENS_LANGUAGE_CODES[self.language]
+        except KeyError as exc:
+            raise ValueError(
+                f"{self.language} is not supported by Google Lens OCR"
+            ) from exc
         self.retries = val_int(retries, min_value=1)
         self._lens_api_error_class = self._get_lens_api_error_class()
         self._api = self._get_lens_api_class()()
@@ -104,7 +142,9 @@ class GoogleLensRecognizer:
 
         image_bytes = image.tobytes()
         image_sha256 = hashlib.sha256(image_bytes).hexdigest()
-        cache_key = f"{image_sha256}_{image.mode}_{image.size}_{self.language}"
+        cache_key = (
+            f"{image_sha256}_{image.mode}_{image.size}_{self.lens_language_code}"
+        )
         cache_sha256 = hashlib.sha256(cache_key.encode("utf-8")).hexdigest()
         return self.cache_dir_path / f"{cache_sha256}.json"
 
@@ -174,7 +214,7 @@ class GoogleLensRecognizer:
         Returns:
             subtitle text
         """
-        return GoogleLensRecognizer._clean_text("\n".join(lines))
+        return LensRecognizer._clean_text("\n".join(lines))
 
     @staticmethod
     def _get_lens_api_class() -> Any:
@@ -247,17 +287,17 @@ class GoogleLensRecognizer:
         Returns:
             normalized OCR lines
         """
-        line_blocks = GoogleLensRecognizer._get_result_value(result, "line_blocks")
+        line_blocks = LensRecognizer._get_result_value(result, "line_blocks")
         if isinstance(line_blocks, list | tuple):
             lines = []
             for block in line_blocks:
-                text = GoogleLensRecognizer._get_result_value(block, "text")
+                text = LensRecognizer._get_result_value(block, "text")
                 if isinstance(text, str):
                     lines.append(text)
             if lines:
                 return lines
 
-        ocr_text = GoogleLensRecognizer._get_result_value(result, "ocr_text")
+        ocr_text = LensRecognizer._get_result_value(result, "ocr_text")
         if isinstance(ocr_text, str):
             return ocr_text.splitlines()
         return []
@@ -288,7 +328,7 @@ class GoogleLensRecognizer:
         except RuntimeError:
             return
         raise RuntimeError(
-            "GoogleLensRecognizer cannot run uncached Google Lens OCR from an "
+            "LensRecognizer cannot run uncached Google Lens OCR from an "
             "active asyncio event loop."
         )
 
@@ -310,7 +350,7 @@ class GoogleLensRecognizer:
                 try:
                     result = await self._api.process_image(
                         image_path=image,
-                        ocr_language=self.language,
+                        ocr_language=self.lens_language_code,
                         ocr_preserve_line_breaks=True,
                         output_format="lines",
                     )
@@ -356,3 +396,21 @@ class GoogleLensRecognizer:
         data = {"lines": lines}
         with cache_path.open("w", encoding="utf-8") as file:
             json.dump(data, file, ensure_ascii=False)
+
+
+def _coerce_lens_language(language: Language | str) -> Language:
+    """Coerce a language value into a supported Google Lens language.
+
+    Arguments:
+        language: Scinoephile language or legacy Google Lens language code
+    Returns:
+        Scinoephile language
+    Raises:
+        ValueError: if the language is unsupported
+    """
+    if isinstance(language, Language):
+        return language
+    if language_key := language.strip().casefold():
+        if language_key in _LENS_LANGUAGE_ALIASES:
+            return _LENS_LANGUAGE_ALIASES[language_key]
+    raise ValueError(f"{language} is not supported by Google Lens OCR")

--- a/scinoephile/image/ocr/paddle/__init__.py
+++ b/scinoephile/image/ocr/paddle/__init__.py
@@ -5,107 +5,69 @@
 Package hierarchy (modules may import from any above):
 * bounding_box / preprocessing
 * text_result
-* paddle_ocr_recognizer
+* paddle_recognizer
 """
 
 from __future__ import annotations
 
-from pathlib import Path
-from typing import TypedDict, Unpack, cast
+from logging import getLogger
+from typing import Unpack, cast
 
+from scinoephile.core import ScinoephileError
 from scinoephile.core.paths import get_runtime_cache_dir_path
 from scinoephile.core.subtitles import Series, Subtitle
-from scinoephile.core.text import ChineseScript
 from scinoephile.image.subtitles import ImageSeries, ImageSubtitle
 
-from .paddle_ocr_recognizer import PaddleOcrRecognizer
-from .preprocessing import preprocess_paddle_ocr_image
+from .paddle_recognizer import PaddleRecognizer, PaddleRecognizerKwargs
 
 __all__ = [
-    "PaddleOcrRecognizer",
-    "PaddleOcrRecognizerKwargs",
-    "get_paddle_ocr_recognizer",
-    "get_paddle_zho_code",
+    "PaddleRecognizer",
+    "PaddleRecognizerKwargs",
     "ocr_image_series_with_paddle",
 ]
 
-
-class PaddleOcrRecognizerKwargs(TypedDict, total=False):
-    """Additional keyword arguments forwarded to PaddleOcrRecognizer."""
-
-    language: str
-    """PaddleOCR language code."""
-
-    min_confidence: float
-    """Minimum confidence to include."""
-
-
-def get_paddle_ocr_recognizer(
-    *,
-    cache_dir_path: Path | None = None,
-    **kwargs: Unpack[PaddleOcrRecognizerKwargs],
-) -> PaddleOcrRecognizer:
-    """Get PaddleOCR recognizer with provided configuration.
-
-    Arguments:
-        cache_dir_path: directory in which to cache OCR results
-        **kwargs: additional keyword arguments for PaddleOcrRecognizer
-    Returns:
-        PaddleOCR recognizer
-    """
-    if cache_dir_path is None:
-        cache_dir_path = get_runtime_cache_dir_path("paddleocr")
-    return PaddleOcrRecognizer(cache_dir_path=cache_dir_path, **kwargs)
-
-
-def get_paddle_zho_code(script: ChineseScript) -> str:
-    """Get the PaddleOCR language code for a Chinese script.
-
-    Arguments:
-        script: Chinese script
-    Returns:
-        PaddleOCR language code
-    """
-    if script == "simplified":
-        return "ch"
-    if script == "traditional":
-        return "chinese_cht"
-    raise ValueError(
-        f"{script!r} is not one of the supported Chinese scripts: "
-        "simplified, traditional"
-    )
+logger = getLogger(__name__)
 
 
 def ocr_image_series_with_paddle(
     image_series: ImageSeries,
-    *,
-    recognizer: PaddleOcrRecognizer | None = None,
-    language: str = "en",
+    **kwargs: Unpack[PaddleRecognizerKwargs],
 ) -> Series:
     """OCR an image subtitle series with PaddleOCR.
 
     Arguments:
         image_series: image subtitle series
-        recognizer: PaddleOCR-compatible recognizer
-        language: PaddleOCR language code
+        **kwargs: additional keyword arguments for PaddleRecognizer
     Returns:
         text subtitle series
     """
-    if recognizer is None:
-        paddle_recognizer = get_paddle_ocr_recognizer(language=language)
-    else:
-        paddle_recognizer = recognizer
+    try:
+        from .preprocessing import preprocess_paddle_ocr_image  # noqa: PLC0415
 
-    events = []
-    for subtitle in image_series:
-        image_subtitle = cast(ImageSubtitle, subtitle)
-        preprocessed_image = preprocess_paddle_ocr_image(image_subtitle.img)
-        text = paddle_recognizer.recognize_image(preprocessed_image)
-        events.append(
-            Subtitle(
-                start=image_subtitle.start,
-                end=image_subtitle.end,
-                text=text,
+        if "cache_dir_path" not in kwargs:
+            kwargs["cache_dir_path"] = get_runtime_cache_dir_path("paddleocr")
+        paddle_recognizer = PaddleRecognizer(**kwargs)
+
+        events = []
+        subtitle_count = len(image_series.events)
+        for subtitle_idx, subtitle in enumerate(image_series, 1):
+            logger.info(
+                f"OCRing subtitle {subtitle_idx}/{subtitle_count} with PaddleOCR"
             )
-        )
-    return Series(events=events)
+            image_subtitle = cast(ImageSubtitle, subtitle)
+            preprocessed_image = preprocess_paddle_ocr_image(image_subtitle.img)
+            text = paddle_recognizer.recognize_image(preprocessed_image)
+            events.append(
+                Subtitle(
+                    start=image_subtitle.start,
+                    end=image_subtitle.end,
+                    text=text,
+                )
+            )
+        return Series(events=events)
+    except ScinoephileError:
+        raise
+    except (ImportError, OSError, RuntimeError, ValueError) as exc:
+        raise ScinoephileError(
+            f"Unable to OCR image series with PaddleOCR: {exc}"
+        ) from exc

--- a/scinoephile/image/ocr/paddle/paddle_recognizer.py
+++ b/scinoephile/image/ocr/paddle/paddle_recognizer.py
@@ -10,21 +10,24 @@ import os
 from dataclasses import asdict
 from logging import getLogger
 from pathlib import Path
-from typing import Any, override
+from typing import Any, TypedDict, override
 
 import numpy as np
 from PIL import Image
 
 from scinoephile.common.validation import val_output_dir_path
+from scinoephile.core import Language
 
 from .bounding_box import PaddleOcrBoundingBox
 from .text_result import PaddleOcrTextResult
 
-__all__ = ["PaddleOcrRecognizer"]
+__all__ = [
+    "PaddleRecognizer",
+    "PaddleRecognizerKwargs",
+]
 
 logger = getLogger(__name__)
 
-_SUPPORTED_LANGUAGES = {"ch", "chinese_cht", "en"}
 _TEXT_DETECTION_MODEL_NAME = "PP-OCRv5_server_det"
 _TEXT_RECOGNITION_MODEL_NAME = "PP-OCRv5_server_rec"
 _TEXTLINE_ORIENTATION_MODEL_NAME = "PP-LCNet_x1_0_textline_ori"
@@ -32,35 +35,65 @@ _OCR_EXTRA_MESSAGE = (
     "PaddleOCR support requires optional OCR dependencies. "
     "Install scinoephile with the 'ocr' extra."
 )
+_PADDLE_LANGUAGE_CODES = {
+    Language.eng: "en",
+    Language.zho_hans: "ch",
+    Language.zho_hant: "chinese_cht",
+}
+_PADDLE_LANGUAGE_ALIASES = {
+    "ch": Language.zho_hans,
+    "chi_sim": Language.zho_hans,
+    "chinese_cht": Language.zho_hant,
+    "en": Language.eng,
+    "eng": Language.eng,
+    "zh-cn": Language.zho_hans,
+    "zh-hans": Language.zho_hans,
+    "zh-tw": Language.zho_hant,
+    "zh-hant": Language.zho_hant,
+    "zho-hans": Language.zho_hans,
+    "zho-hant": Language.zho_hant,
+}
 
 
-class PaddleOcrRecognizer:
+class PaddleRecognizerKwargs(TypedDict, total=False):
+    """Additional keyword arguments forwarded to PaddleRecognizer."""
+
+    cache_dir_path: Path | None
+    """Directory in which to cache OCR results."""
+
+    language: Language | str
+    """Scinoephile language."""
+
+    min_confidence: float
+    """Minimum confidence to include."""
+
+
+class PaddleRecognizer:
     """PaddleOCR recognizer for image subtitles."""
 
     def __init__(
         self,
         *,
         cache_dir_path: Path | None = None,
-        language: str = "en",
+        language: Language | str = Language.eng,
         min_confidence: float = 0.0,
     ):
         """Initialize.
 
         Arguments:
             cache_dir_path: directory in which to cache OCR results
-            language: PaddleOCR language code
+            language: Scinoephile language
             min_confidence: minimum confidence to include
         Raises:
             ValueError: if language is unsupported
         """
-        if language not in _SUPPORTED_LANGUAGES:
-            raise ValueError(
-                "PaddleOCR language must be one of: "
-                f"{', '.join(sorted(_SUPPORTED_LANGUAGES))}"
-            )
+        self.language = _coerce_paddle_language(language)
+        try:
+            self.paddle_language_code = _PADDLE_LANGUAGE_CODES[self.language]
+        except KeyError as exc:
+            raise ValueError(f"{self.language} is not supported by PaddleOCR") from exc
         os.environ.setdefault("PADDLE_PDX_DISABLE_MODEL_SOURCE_CHECK", "True")
 
-        self.language = language
         self.min_confidence = min_confidence
         self.cache_dir_path = None
         if cache_dir_path is not None:
@@ -68,7 +101,7 @@ class PaddleOcrRecognizer:
 
         paddle_ocr_cls = self._get_paddle_ocr_class()
         self._ocr = paddle_ocr_cls(
-            lang=language,
+            lang=self.paddle_language_code,
             use_doc_orientation_classify=False,
             use_doc_unwarping=False,
             use_textline_orientation=True,
@@ -131,7 +164,7 @@ class PaddleOcrRecognizer:
         image_bytes = image.tobytes()
         image_sha256 = hashlib.sha256(image_bytes).hexdigest()
         cache_key = (
-            f"{image_sha256}_{image.mode}_{image.size}_{self.language}_"
+            f"{image_sha256}_{image.mode}_{image.size}_{self.paddle_language_code}_"
             f"{_TEXT_DETECTION_MODEL_NAME}_"
             f"{_TEXT_RECOGNITION_MODEL_NAME}_"
             f"{_TEXTLINE_ORIENTATION_MODEL_NAME}"
@@ -311,3 +344,21 @@ class PaddleOcrRecognizer:
         cache_path.parent.mkdir(parents=True, exist_ok=True)
         with cache_path.open("w", encoding="utf-8") as file:
             json.dump([asdict(result) for result in results], file, ensure_ascii=False)
+
+
+def _coerce_paddle_language(language: Language | str) -> Language:
+    """Coerce a language value into a supported PaddleOCR language.
+
+    Arguments:
+        language: Scinoephile language or legacy PaddleOCR language code
+    Returns:
+        Scinoephile language
+    Raises:
+        ValueError: if the language is unsupported
+    """
+    if isinstance(language, Language):
+        return language
+    if language_key := language.strip().casefold():
+        if language_key in _PADDLE_LANGUAGE_ALIASES:
+            return _PADDLE_LANGUAGE_ALIASES[language_key]
+    raise ValueError(f"{language} is not supported by PaddleOCR")

--- a/scinoephile/image/ocr/tesseract/__init__.py
+++ b/scinoephile/image/ocr/tesseract/__init__.py
@@ -4,112 +4,66 @@
 
 Package hierarchy (modules may import from any above):
 * hocr / preprocessing
-* tesseract_ocr_recognizer
+* tesseract_recognizer
 """
 
 from __future__ import annotations
 
 from logging import getLogger
-from pathlib import Path
-from typing import TypedDict, Unpack, cast
+from typing import Unpack, cast
 
+from scinoephile.core import ScinoephileError
 from scinoephile.core.paths import get_runtime_cache_dir_path
 from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.image.subtitles import ImageSeries, ImageSubtitle
 
-from .tesseract_ocr_recognizer import TesseractOcrRecognizer
+from .tesseract_recognizer import TesseractRecognizer, TesseractRecognizerKwargs
 
 __all__ = [
-    "TesseractOcrRecognizer",
-    "TesseractOcrRecognizerKwargs",
-    "get_tesseract_ocr_recognizer",
+    "TesseractRecognizer",
+    "TesseractRecognizerKwargs",
     "ocr_image_series_with_tesseract",
 ]
 
 logger = getLogger(__name__)
 
 
-class TesseractOcrRecognizerKwargs(TypedDict, total=False):
-    """Additional keyword arguments forwarded to TesseractOcrRecognizer."""
-
-    detect_italics: bool
-    """Whether to run a legacy-engine pass for italics."""
-
-    executable_path: Path | str
-    """Tesseract executable path or command name."""
-
-    language: str
-    """Tesseract language code."""
-
-    oem: int | None
-    """Tesseract OCR engine mode, or None to omit --oem."""
-
-    psm: int
-    """Tesseract page segmentation mode."""
-
-    scale: int
-    """Image preprocessing scale."""
-
-    skip_executable_validation: bool
-    """Whether to skip executable validation."""
-
-    tessdata_dir_path: Path | None
-    """Optional tessdata directory."""
-
-
-def get_tesseract_ocr_recognizer(
-    *,
-    cache_dir_path: Path | None = None,
-    **kwargs: Unpack[TesseractOcrRecognizerKwargs],
-) -> TesseractOcrRecognizer:
-    """Get Tesseract recognizer with provided configuration.
-
-    Arguments:
-        cache_dir_path: directory in which to cache OCR results
-        **kwargs: additional keyword arguments for TesseractOcrRecognizer
-    Returns:
-        Tesseract recognizer
-    """
-    if cache_dir_path is None:
-        cache_dir_path = get_runtime_cache_dir_path("tesseract")
-    return TesseractOcrRecognizer(cache_dir_path=cache_dir_path, **kwargs)
-
-
 def ocr_image_series_with_tesseract(
     image_series: ImageSeries,
-    *,
-    recognizer: TesseractOcrRecognizer | None = None,
-    detect_italics: bool = False,
-    language: str = "eng",
+    **kwargs: Unpack[TesseractRecognizerKwargs],
 ) -> Series:
     """OCR an image subtitle series with Tesseract.
 
     Arguments:
         image_series: image subtitle series
-        recognizer: Tesseract-compatible recognizer
-        detect_italics: whether to run a legacy-engine pass for italics
-        language: Tesseract language code
+        **kwargs: additional keyword arguments for TesseractRecognizer
     Returns:
         text subtitle series
     """
-    if recognizer is None:
-        tesseract_recognizer = get_tesseract_ocr_recognizer(
-            detect_italics=detect_italics, language=language
-        )
-    else:
-        tesseract_recognizer = recognizer
+    try:
+        if "cache_dir_path" not in kwargs:
+            kwargs["cache_dir_path"] = get_runtime_cache_dir_path("tesseract")
+        tesseract_recognizer = TesseractRecognizer(**kwargs)
 
-    events = []
-    subtitle_count = len(image_series.events)
-    for subtitle_idx, subtitle in enumerate(image_series, 1):
-        logger.info(f"OCRing subtitle {subtitle_idx}/{subtitle_count} with Tesseract")
-        image_subtitle = cast(ImageSubtitle, subtitle)
-        text = tesseract_recognizer.recognize_image(image_subtitle.img)
-        events.append(
-            Subtitle(
-                start=image_subtitle.start,
-                end=image_subtitle.end,
-                text=text,
+        events = []
+        subtitle_count = len(image_series.events)
+        for subtitle_idx, subtitle in enumerate(image_series, 1):
+            logger.info(
+                f"OCRing subtitle {subtitle_idx}/{subtitle_count} with Tesseract"
             )
-        )
-    return Series(events=events)
+            image_subtitle = cast(ImageSubtitle, subtitle)
+            text = tesseract_recognizer.recognize_image(image_subtitle.img)
+            events.append(
+                Subtitle(
+                    start=image_subtitle.start,
+                    end=image_subtitle.end,
+                    text=text,
+                )
+            )
+        return Series(events=events)
+    except ScinoephileError:
+        raise
+    except (ImportError, OSError, RuntimeError, ValueError) as exc:
+        raise ScinoephileError(
+            f"Unable to OCR image series with Tesseract: {exc}"
+        ) from exc

--- a/scinoephile/image/ocr/tesseract/tesseract_recognizer.py
+++ b/scinoephile/image/ocr/tesseract/tesseract_recognizer.py
@@ -9,7 +9,7 @@ import json
 from logging import getLogger
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import override
+from typing import TypedDict, override
 
 import requests
 from PIL import Image
@@ -20,13 +20,16 @@ from scinoephile.common.validation import (
     val_input_dir_path,
     val_output_dir_path,
 )
-from scinoephile.core import ScinoephileError
+from scinoephile.core import Language, ScinoephileError
 from scinoephile.core.paths import get_runtime_cache_dir_path
 
 from .hocr import parse_tesseract_hocr, transfer_tesseract_hocr_italics
 from .preprocessing import preprocess_tesseract_ocr_image
 
-__all__ = ["TesseractOcrRecognizer"]
+__all__ = [
+    "TesseractRecognizer",
+    "TesseractRecognizerKwargs",
+]
 
 logger = getLogger(__name__)
 
@@ -35,9 +38,57 @@ TESSERACT_LEGACY_TESSDATA_URL_TEMPLATE = (
     "{language}.traineddata"
 )
 """URL template for legacy-capable Tesseract traineddata."""
+_TESSERACT_LANGUAGE_CODES = {
+    Language.eng: "eng",
+    Language.zho_hans: "chi_sim",
+    Language.zho_hant: "chi_tra",
+}
+_TESSERACT_LANGUAGE_ALIASES = {
+    "chi_sim": Language.zho_hans,
+    "chi_tra": Language.zho_hant,
+    "en": Language.eng,
+    "eng": Language.eng,
+    "zh-cn": Language.zho_hans,
+    "zh-hans": Language.zho_hans,
+    "zh-tw": Language.zho_hant,
+    "zh-hant": Language.zho_hant,
+    "zho-hans": Language.zho_hans,
+    "zho-hant": Language.zho_hant,
+}
 
 
-class TesseractOcrRecognizer:
+class TesseractRecognizerKwargs(TypedDict, total=False):
+    """Additional keyword arguments forwarded to TesseractRecognizer."""
+
+    cache_dir_path: Path | None
+    """Directory in which to cache OCR results."""
+
+    detect_italics: bool
+    """Whether to run a legacy-engine pass for italics."""
+
+    executable_path: Path | str
+    """Tesseract executable path or command name."""
+
+    language: Language | str
+    """Scinoephile language."""
+
+    oem: int | None
+    """Tesseract OCR engine mode, or None to omit --oem."""
+
+    psm: int
+    """Tesseract page segmentation mode."""
+
+    scale: int
+    """Image preprocessing scale."""
+
+    skip_executable_validation: bool
+    """Whether to skip executable validation."""
+
+    tessdata_dir_path: Path | None
+    """Optional tessdata directory."""
+
+
+class TesseractRecognizer:
     """Tesseract recognizer for image subtitles."""
 
     def __init__(
@@ -46,7 +97,7 @@ class TesseractOcrRecognizer:
         cache_dir_path: Path | None = None,
         executable_path: Path | str = "tesseract",
         detect_italics: bool = False,
-        language: str = "eng",
+        language: Language | str = Language.eng,
         oem: int | None = 3,
         psm: int = 6,
         scale: int = 2,
@@ -59,19 +110,25 @@ class TesseractOcrRecognizer:
             cache_dir_path: directory in which to cache OCR results
             executable_path: Tesseract executable path or command name
             detect_italics: whether to run a legacy-engine pass for italics
-            language: Tesseract language code
+            language: Scinoephile language
             oem: Tesseract OCR engine mode, or None to omit --oem
             psm: Tesseract page segmentation mode
             scale: image preprocessing scale
             skip_executable_validation: whether to skip executable validation
             tessdata_dir_path: optional tessdata directory
         """
-        if detect_italics and language != "eng":
+        self.language = _coerce_tesseract_language(language)
+        if detect_italics and self.language is not Language.eng:
             raise ValueError(
                 "Tesseract italic detection is only supported with language eng"
             )
+        try:
+            self.tesseract_language_code = _TESSERACT_LANGUAGE_CODES[self.language]
+        except KeyError as exc:
+            raise ValueError(
+                f"{self.language} is not supported by Tesseract OCR"
+            ) from exc
 
-        self.language = language
         self.detect_italics = detect_italics
         self.oem = oem
         self.psm = psm
@@ -130,7 +187,7 @@ class TesseractOcrRecognizer:
     @property
     def _hocr_word_separator(self) -> str:
         """Text with which to join hOCR word spans."""
-        if self.language.startswith("chi_"):
+        if self.tesseract_language_code.startswith("chi_"):
             return ""
         return " "
 
@@ -148,7 +205,7 @@ class TesseractOcrRecognizer:
             str(image_path),
             str(output_base_path),
             "-l",
-            self.language,
+            self.tesseract_language_code,
             "--psm",
             str(self.psm),
             "hocr",
@@ -182,7 +239,7 @@ class TesseractOcrRecognizer:
             str(image_path),
             str(output_base_path),
             "-l",
-            self.language,
+            self.tesseract_language_code,
             "--psm",
             str(psm),
             "--oem",
@@ -244,7 +301,8 @@ class TesseractOcrRecognizer:
         image_sha256 = hashlib.sha256(image.tobytes()).hexdigest()
         cache_key = (
             f"{image_sha256}_{image.mode}_{image.size}_{self.executable_path}_"
-            f"{self.detect_italics}_{self.language}_{self.oem}_{self.psm}_"
+            f"{self.detect_italics}_{self.tesseract_language_code}_{self.oem}_"
+            f"{self.psm}_"
             f"{self.scale}_{self.tessdata_dir_path}"
         )
         cache_sha256 = hashlib.sha256(cache_key.encode("utf-8")).hexdigest()
@@ -258,7 +316,9 @@ class TesseractOcrRecognizer:
         Raises:
             ScinoephileError: if the download fails
         """
-        url = TESSERACT_LEGACY_TESSDATA_URL_TEMPLATE.format(language=self.language)
+        url = TESSERACT_LEGACY_TESSDATA_URL_TEMPLATE.format(
+            language=self.tesseract_language_code
+        )
         temp_traineddata_path = traineddata_path.with_suffix(".traineddata.tmp")
         logger.info(f"Downloading Tesseract legacy traineddata: {url}")
         try:
@@ -270,7 +330,8 @@ class TesseractOcrRecognizer:
             temp_traineddata_path.unlink(missing_ok=True)
             raise ScinoephileError(
                 "Tesseract legacy OCR requires legacy-capable traineddata. "
-                f"Failed to download {self.language}.traineddata from {url}."
+                "Failed to download "
+                f"{self.tesseract_language_code}.traineddata from {url}."
             ) from exc
         logger.info(f"Downloaded Tesseract legacy traineddata: {traineddata_path}")
 
@@ -289,7 +350,9 @@ class TesseractOcrRecognizer:
                 self.cache_dir_path / "legacy-tessdata"
             )
 
-        traineddata_path = legacy_tessdata_dir_path / f"{self.language}.traineddata"
+        traineddata_path = (
+            legacy_tessdata_dir_path / f"{self.tesseract_language_code}.traineddata"
+        )
         if traineddata_path.exists():
             logger.info(
                 f"Using cached Tesseract legacy traineddata: {traineddata_path}"
@@ -327,7 +390,7 @@ class TesseractOcrRecognizer:
             if self._is_usable_legacy_blank_fallback_text(fallback_text):
                 logger.info(
                     "Using Tesseract legacy fallback for blank OCR result "
-                    f"with language {self.language}"
+                    f"with language {self.tesseract_language_code}"
                 )
                 return fallback_text
             return text
@@ -457,3 +520,21 @@ class TesseractOcrRecognizer:
         cache_path.parent.mkdir(parents=True, exist_ok=True)
         with cache_path.open("w", encoding="utf-8") as file:
             json.dump({"text": text}, file, ensure_ascii=False)
+
+
+def _coerce_tesseract_language(language: Language | str) -> Language:
+    """Coerce a language value into a supported Tesseract language.
+
+    Arguments:
+        language: Scinoephile language or legacy Tesseract language code
+    Returns:
+        Scinoephile language
+    Raises:
+        ValueError: if the language is unsupported
+    """
+    if isinstance(language, Language):
+        return language
+    if language_key := language.strip().casefold():
+        if language_key in _TESSERACT_LANGUAGE_ALIASES:
+            return _TESSERACT_LANGUAGE_ALIASES[language_key]
+    raise ValueError(f"{language} is not supported by Tesseract OCR")

--- a/scinoephile/workflows/ocr_processing.py
+++ b/scinoephile/workflows/ocr_processing.py
@@ -15,11 +15,8 @@ from scinoephile.core.llms import LLMProvider
 from scinoephile.core.media import SubtitleStream
 from scinoephile.core.subtitles import Series
 from scinoephile.core.text import ChineseScript
-from scinoephile.image.ocr.lens import get_lens_zho_code, ocr_image_series_with_lens
-from scinoephile.image.ocr.paddle import (
-    get_paddle_zho_code,
-    ocr_image_series_with_paddle,
-)
+from scinoephile.image.ocr.lens import ocr_image_series_with_lens
+from scinoephile.image.ocr.paddle import ocr_image_series_with_paddle
 from scinoephile.image.ocr.tesseract import ocr_image_series_with_tesseract
 from scinoephile.image.subtitles import ImageSeries, ImageSubtitle
 from scinoephile.lang.eng.cleaning import get_eng_cleaned
@@ -199,8 +196,17 @@ def process_zho_ocr(
     Returns:
         OCR processing result
     """
-    lens_language = get_lens_zho_code(script)
-    paddle_language = get_paddle_zho_code(script)
+    if script == "simplified":
+        lens_language = "zh-CN"
+        paddle_language = "ch"
+    elif script == "traditional":
+        lens_language = "zh-TW"
+        paddle_language = "chinese_cht"
+    else:
+        raise ValueError(
+            f"{script!r} is not one of the supported Chinese scripts: "
+            "simplified, traditional"
+        )
 
     # Read inputs
     image_series = _load_image_series(infile_path, stream_index, cache_dir_path)

--- a/test/image/ocr/lens/test_lens_engine.py
+++ b/test/image/ocr/lens/test_lens_engine.py
@@ -15,14 +15,18 @@ from typing import Any
 import pytest
 from PIL import Image
 
-from scinoephile.image.ocr.lens.google_lens_recognizer import GoogleLensRecognizer
+from scinoephile.core import Language
+from scinoephile.image.ocr.lens.lens_recognizer import (
+    LensRecognizer,
+    _coerce_lens_language,
+)
 
 
 class FakeLensApiError(RuntimeError):
     """Fake chrome-lens-py LensAPIError."""
 
 
-class CountingGoogleLensRecognizer(GoogleLensRecognizer):
+class CountingLensRecognizer(LensRecognizer):
     """Google Lens recognizer that counts uncached predictions."""
 
     def __init__(
@@ -39,7 +43,8 @@ class CountingGoogleLensRecognizer(GoogleLensRecognizer):
             results: normalized OCR lines to return from subsequent recognitions
         """
         self.cache_dir_path = cache_dir_path
-        self.language = "en"
+        self.language = Language.eng
+        self.lens_language_code = "en"
         self.retries = 3
         self.predict_count = 0
         self.exceptions = exceptions
@@ -86,7 +91,7 @@ def patch_google_lens_sleep(monkeypatch: pytest.MonkeyPatch) -> list[float]:
         delays.append(delay)
 
     monkeypatch.setattr(
-        "scinoephile.image.ocr.lens.google_lens_recognizer.asyncio.sleep",
+        "scinoephile.image.ocr.lens.lens_recognizer.asyncio.sleep",
         fake_sleep,
     )
     return delays
@@ -94,7 +99,7 @@ def patch_google_lens_sleep(monkeypatch: pytest.MonkeyPatch) -> list[float]:
 
 def test_clean_google_lens_text_ignores_empty_and_error_messages():
     """Test Google Lens text cleanup suppresses non-subtitle messages."""
-    text = GoogleLensRecognizer._clean_text(
+    text = LensRecognizer._clean_text(
         "No OCR text found.\nRequest error (possibly proxy-related)\n"
     )
 
@@ -103,7 +108,7 @@ def test_clean_google_lens_text_ignores_empty_and_error_messages():
 
 def test_clean_google_lens_text_joins_standalone_dash_and_ellipsis():
     """Test SubtitleEdit GoogleLensSharp line cleanup rules."""
-    text = GoogleLensRecognizer._clean_text("-\nHello\n...\nworld")
+    text = LensRecognizer._clean_text("-\nHello\n...\nworld")
 
     assert text == "- Hello ...\nworld"
 
@@ -112,7 +117,7 @@ def test_normalize_lens_result_falls_back_to_ocr_text_lines():
     """Test normalization falls back to full OCR text lines."""
     result = {"ocr_text": "full\ntext", "line_blocks": []}
 
-    lines = GoogleLensRecognizer._normalize_lens_result(result)
+    lines = LensRecognizer._normalize_lens_result(result)
 
     assert lines == ["full", "text"]
 
@@ -127,7 +132,7 @@ def test_normalize_lens_result_prefers_line_blocks():
         ],
     }
 
-    lines = GoogleLensRecognizer._normalize_lens_result(result)
+    lines = LensRecognizer._normalize_lens_result(result)
 
     assert lines == ["first", "second"]
 
@@ -142,14 +147,44 @@ def test_normalize_lens_result_supports_object_results():
         ],
     )
 
-    lines = GoogleLensRecognizer._normalize_lens_result(result)
+    lines = LensRecognizer._normalize_lens_result(result)
 
     assert lines == ["first", "second"]
 
 
-def test_google_lens_recognizer_caches_results_by_image(tmp_path: Path):
+def test_lens_recognizer_rejects_unsupported_languages():
+    """Test Google Lens recognizer only supports English and Chinese."""
+    with pytest.raises(ValueError, match="not supported by Google Lens OCR"):
+        LensRecognizer(language="korean")
+
+
+@pytest.mark.parametrize(
+    ("language", "expected"),
+    [
+        ("en", Language.eng),
+        ("eng", Language.eng),
+        ("zh-CN", Language.zho_hans),
+        ("zh-TW", Language.zho_hant),
+        ("zho-Hans", Language.zho_hans),
+        ("zho-Hant", Language.zho_hant),
+    ],
+)
+def test_coerce_lens_language_accepts_current_and_legacy_codes(
+    language: str,
+    expected: Language,
+):
+    """Test Google Lens language coercion accepts supported language codes.
+
+    Arguments:
+        language: language code to coerce
+        expected: expected Scinoephile language
+    """
+    assert _coerce_lens_language(language) is expected
+
+
+def test_lens_recognizer_caches_results_by_image(tmp_path: Path):
     """Test Google Lens recognizer caches OCR results by image content."""
-    recognizer = CountingGoogleLensRecognizer(cache_dir_path=tmp_path)
+    recognizer = CountingLensRecognizer(cache_dir_path=tmp_path)
     image = Image.new("RGBA", (10, 8), (255, 255, 255, 0))
 
     assert recognizer.recognize_image(image) == "cached\ntext"
@@ -159,9 +194,9 @@ def test_google_lens_recognizer_caches_results_by_image(tmp_path: Path):
     assert len(list(tmp_path.glob("*.json"))) == 1
 
 
-def test_google_lens_recognizer_formats_cached_results(tmp_path: Path):
+def test_lens_recognizer_formats_cached_results(tmp_path: Path):
     """Test cached Google Lens results are formatted after loading."""
-    recognizer = CountingGoogleLensRecognizer(cache_dir_path=tmp_path)
+    recognizer = CountingLensRecognizer(cache_dir_path=tmp_path)
     image = Image.new("RGBA", (10, 8), (255, 255, 255, 0))
 
     assert recognizer.recognize_image(image) == "cached\ntext"
@@ -176,7 +211,7 @@ def test_google_lens_recognizer_formats_cached_results(tmp_path: Path):
     assert recognizer.predict_count == 1
 
 
-def test_google_lens_recognizer_does_not_cache_request_errors(
+def test_lens_recognizer_does_not_cache_request_errors(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ):
@@ -187,7 +222,7 @@ def test_google_lens_recognizer_does_not_cache_request_errors(
         tmp_path: temporary path fixture
     """
     patch_google_lens_sleep(monkeypatch)
-    recognizer = CountingGoogleLensRecognizer(
+    recognizer = CountingLensRecognizer(
         cache_dir_path=tmp_path,
         results=[["Request error (possibly proxy-related)"]],
     )
@@ -200,7 +235,7 @@ def test_google_lens_recognizer_does_not_cache_request_errors(
     assert not list(tmp_path.glob("*.json"))
 
 
-def test_google_lens_recognizer_retries_request_errors_before_caching(
+def test_lens_recognizer_retries_request_errors_before_caching(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ):
@@ -211,7 +246,7 @@ def test_google_lens_recognizer_retries_request_errors_before_caching(
         tmp_path: temporary path fixture
     """
     patch_google_lens_sleep(monkeypatch)
-    recognizer = CountingGoogleLensRecognizer(
+    recognizer = CountingLensRecognizer(
         cache_dir_path=tmp_path,
         results=[
             ["Request error (possibly proxy-related): 502 Bad Gateway"],
@@ -228,7 +263,7 @@ def test_google_lens_recognizer_retries_request_errors_before_caching(
     assert len(list(tmp_path.glob("*.json"))) == 1
 
 
-def test_google_lens_recognizer_raises_last_request_error_after_retries(
+def test_lens_recognizer_raises_last_request_error_after_retries(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ):
@@ -239,7 +274,7 @@ def test_google_lens_recognizer_raises_last_request_error_after_retries(
         tmp_path: temporary path fixture
     """
     patch_google_lens_sleep(monkeypatch)
-    recognizer = CountingGoogleLensRecognizer(
+    recognizer = CountingLensRecognizer(
         cache_dir_path=tmp_path,
         results=[
             ["Request error (possibly proxy-related): attempt 1"],
@@ -257,7 +292,7 @@ def test_google_lens_recognizer_raises_last_request_error_after_retries(
     assert not list(tmp_path.glob("*.json"))
 
 
-def test_google_lens_recognizer_retries_in_one_asyncio_run(
+def test_lens_recognizer_retries_in_one_asyncio_run(
     monkeypatch: pytest.MonkeyPatch,
 ):
     """Test Google Lens retries within one asyncio.run call.
@@ -283,10 +318,10 @@ def test_google_lens_recognizer_retries_in_one_asyncio_run(
         return real_asyncio_run(main, **kwargs)
 
     monkeypatch.setattr(
-        "scinoephile.image.ocr.lens.google_lens_recognizer.asyncio.run",
+        "scinoephile.image.ocr.lens.lens_recognizer.asyncio.run",
         counting_run,
     )
-    recognizer = CountingGoogleLensRecognizer(
+    recognizer = CountingLensRecognizer(
         results=[
             ["Request error (possibly proxy-related): 502 Bad Gateway"],
             ["Request error (possibly proxy-related): 502 Bad Gateway"],
@@ -301,7 +336,7 @@ def test_google_lens_recognizer_retries_in_one_asyncio_run(
     assert recognizer.predict_count == 3
 
 
-def test_google_lens_recognizer_waits_between_transient_retries(
+def test_lens_recognizer_waits_between_transient_retries(
     monkeypatch: pytest.MonkeyPatch,
 ):
     """Test Google Lens waits before retrying transient failures.
@@ -310,7 +345,7 @@ def test_google_lens_recognizer_waits_between_transient_retries(
         monkeypatch: pytest monkeypatch fixture
     """
     delays = patch_google_lens_sleep(monkeypatch)
-    recognizer = CountingGoogleLensRecognizer(
+    recognizer = CountingLensRecognizer(
         results=[
             ["Request error (possibly proxy-related): 502 Bad Gateway"],
             ["Request error (possibly proxy-related): 502 Bad Gateway"],
@@ -324,7 +359,7 @@ def test_google_lens_recognizer_waits_between_transient_retries(
     assert delays == [1.5, 1.5]
 
 
-def test_google_lens_recognizer_retries_lens_api_errors(
+def test_lens_recognizer_retries_lens_api_errors(
     monkeypatch: pytest.MonkeyPatch,
 ):
     """Test Google Lens retries transient chrome-lens-py API errors.
@@ -333,7 +368,7 @@ def test_google_lens_recognizer_retries_lens_api_errors(
         monkeypatch: pytest monkeypatch fixture
     """
     patch_google_lens_sleep(monkeypatch)
-    recognizer = CountingGoogleLensRecognizer(
+    recognizer = CountingLensRecognizer(
         exceptions=[
             FakeLensApiError("502 Bad Gateway"),
             FakeLensApiError("502 Bad Gateway"),
@@ -348,9 +383,9 @@ def test_google_lens_recognizer_retries_lens_api_errors(
     assert recognizer.predict_count == 3
 
 
-def test_google_lens_recognizer_does_not_retry_nontransient_errors():
+def test_lens_recognizer_does_not_retry_nontransient_errors():
     """Test Google Lens does not retry deterministic API errors."""
-    recognizer = CountingGoogleLensRecognizer(
+    recognizer = CountingLensRecognizer(
         exceptions=[ValueError("deterministic failure")],
     )
     image = Image.new("RGBA", (10, 8), (255, 255, 255, 0))
@@ -361,7 +396,7 @@ def test_google_lens_recognizer_does_not_retry_nontransient_errors():
     assert recognizer.predict_count == 1
 
 
-def test_google_lens_recognizer_rejects_uncached_calls_in_async_loop(
+def test_lens_recognizer_rejects_uncached_calls_in_async_loop(
     tmp_path: Path,
 ):
     """Test uncached synchronous recognition fails clearly in an async loop.
@@ -369,7 +404,7 @@ def test_google_lens_recognizer_rejects_uncached_calls_in_async_loop(
     Arguments:
         tmp_path: temporary path fixture
     """
-    recognizer = CountingGoogleLensRecognizer(cache_dir_path=tmp_path)
+    recognizer = CountingLensRecognizer(cache_dir_path=tmp_path)
 
     async def recognize() -> None:
         """Run synchronous recognition from an async context."""
@@ -379,7 +414,7 @@ def test_google_lens_recognizer_rejects_uncached_calls_in_async_loop(
     asyncio.run(recognize())
 
 
-def test_google_lens_recognizer_import_error_is_actionable(
+def test_lens_recognizer_import_error_is_actionable(
     monkeypatch: pytest.MonkeyPatch,
 ):
     """Test missing chrome-lens-py dependency produces an actionable error.
@@ -416,10 +451,10 @@ def test_google_lens_recognizer_import_error_is_actionable(
     monkeypatch.setattr("builtins.__import__", fake_import)
 
     with pytest.raises(ImportError, match="'ocr' extra"):
-        GoogleLensRecognizer._get_lens_api_class()
+        LensRecognizer._get_lens_api_class()
 
 
-def test_google_lens_recognizer_imports_chrome_lens_py_only_when_needed():
+def test_lens_recognizer_imports_chrome_lens_py_only_when_needed():
     """Test importing Google Lens OCR does not import chrome-lens-py."""
     result = subprocess.run(
         [
@@ -427,7 +462,7 @@ def test_google_lens_recognizer_imports_chrome_lens_py_only_when_needed():
             "-c",
             (
                 "import sys;"
-                "import scinoephile.image.ocr.lens.google_lens_recognizer;"
+                "import scinoephile.image.ocr.lens.lens_recognizer;"
                 "raise SystemExit('chrome_lens_py' in sys.modules)"
             ),
         ],
@@ -439,7 +474,7 @@ def test_google_lens_recognizer_imports_chrome_lens_py_only_when_needed():
     assert result.returncode == 0, result.stderr
 
 
-def test_google_lens_recognizer_reuses_lens_api_client_per_instance(
+def test_lens_recognizer_reuses_lens_api_client_per_instance(
     monkeypatch: pytest.MonkeyPatch,
 ):
     """Test each Google Lens recognizer reuses one LensAPI client.
@@ -471,8 +506,10 @@ def test_google_lens_recognizer_reuses_lens_api_client_per_instance(
     setattr(chrome_lens_py, "LensAPI", FakeLensApi)
     setattr(chrome_lens_py, "LensAPIError", FakeLensApiError)
     monkeypatch.setitem(sys.modules, "chrome_lens_py", chrome_lens_py)
-    recognizer = GoogleLensRecognizer()
+    recognizer = LensRecognizer()
 
+    assert recognizer.language is Language.eng
+    assert recognizer.lens_language_code == "en"
     assert recognizer.retries == 3
     assert recognizer.recognize_image(Image.new("RGBA", (10, 8))) == "recognized"
     assert recognizer.recognize_image(Image.new("RGBA", (12, 9))) == "recognized"

--- a/test/image/ocr/lens/test_lens_series.py
+++ b/test/image/ocr/lens/test_lens_series.py
@@ -9,26 +9,41 @@ from pathlib import Path
 import pytest
 from PIL import Image
 
-from scinoephile.core.text import ChineseScript
-from scinoephile.image.ocr.lens import (
-    GoogleLensRecognizer,
-    get_lens_zho_code,
-    ocr_image_series_with_lens,
-)
+import scinoephile.image.ocr.lens as lens_ocr
+from scinoephile.core import Language, ScinoephileError
+from scinoephile.image.ocr.lens import lens_recognizer, ocr_image_series_with_lens
 from scinoephile.image.subtitles import ImageSeries, ImageSubtitle
 
 
-class FakeRecognizer(GoogleLensRecognizer):
+class FakeRecognizer:
     """Fake Google Lens recognizer for tests."""
 
-    def __init__(self, texts: list[str]):
+    texts: list[str] = []
+    """Texts to return from subsequent recognitions."""
+
+    instances: list[FakeRecognizer] = []
+    """Fake recognizer instances created by the OCR helper."""
+
+    def __init__(
+        self,
+        *,
+        cache_dir_path: Path | None = None,
+        language: Language = Language.eng,
+        retries: int = 3,
+    ):
         """Initialize.
 
         Arguments:
-            texts: texts to return from subsequent recognitions
+            cache_dir_path: directory in which to cache OCR results
+            language: Scinoephile language
+            retries: Google Lens OCR request attempts per uncached image
         """
-        self.texts = texts
+        self.cache_dir_path = cache_dir_path
+        self.language = language
+        self.retries = retries
+        self.texts = list(type(self).texts)
         self.images: list[Image.Image] = []
+        type(self).instances.append(self)
 
     def recognize_image(self, image: Image.Image) -> str:
         """Recognize text from an image.
@@ -42,8 +57,49 @@ class FakeRecognizer(GoogleLensRecognizer):
         return self.texts.pop(0)
 
 
-def test_ocr_image_series_with_lens_preserves_timings_and_sets_text():
-    """Test Google Lens image series processing preserves timings and text."""
+class FailingRecognizer:
+    """Fake Google Lens recognizer that raises a configured exception."""
+
+    exception: Exception | None = None
+    """Exception raised during recognition."""
+
+    def __init__(self, **kwargs: object):
+        """Initialize.
+
+        Arguments:
+            **kwargs: ignored recognizer keyword arguments
+        """
+        _ = kwargs
+
+    def recognize_image(self, image: Image.Image) -> str:
+        """Recognize text from an image.
+
+        Arguments:
+            image: input image
+        Raises:
+            Exception: configured exception
+        """
+        _ = image
+        if self.exception is None:
+            raise AssertionError("FailingRecognizer.exception must be configured")
+        raise self.exception
+
+
+def test_lens_module_exposes_only_current_public_helpers():
+    """Test Google Lens module no longer exposes removed helper functions."""
+    assert not hasattr(lens_ocr, "get_lens_recognizer")
+    assert not hasattr(lens_ocr, "get_lens_language_code")
+    assert lens_ocr.LensRecognizerKwargs is lens_recognizer.LensRecognizerKwargs
+
+
+def test_ocr_image_series_with_lens_preserves_timings_and_sets_text(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test Google Lens image series processing preserves timings and text.
+
+    Arguments:
+        monkeypatch: pytest monkeypatch fixture
+    """
     image_series = ImageSeries(
         events=[
             ImageSubtitle(
@@ -58,18 +114,59 @@ def test_ocr_image_series_with_lens_preserves_timings_and_sets_text():
             ),
         ]
     )
-    recognizer = FakeRecognizer(["first", "second"])
+    FakeRecognizer.texts = ["first", "second"]
+    FakeRecognizer.instances = []
+    monkeypatch.setattr("scinoephile.image.ocr.lens.LensRecognizer", FakeRecognizer)
 
-    text_series = ocr_image_series_with_lens(
-        image_series,
-        recognizer=recognizer,
-    )
+    text_series = ocr_image_series_with_lens(image_series)
 
     assert [(event.start, event.end, event.text) for event in text_series] == [
         (1000, 2000, "first"),
         (3000, 4000, "second"),
     ]
+    recognizer = FakeRecognizer.instances[0]
     assert [image.size for image in recognizer.images] == [(10, 8), (12, 9)]
+
+
+def test_ocr_image_series_with_lens_logs_progress(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test Google Lens image series processing logs OCR progress.
+
+    Arguments:
+        caplog: pytest log capture fixture
+        monkeypatch: pytest monkeypatch fixture
+    """
+    image_series = ImageSeries(
+        events=[
+            ImageSubtitle(
+                start=1000,
+                end=2000,
+                img=Image.new("RGBA", (10, 8), (255, 255, 255, 0)),
+            ),
+            ImageSubtitle(
+                start=3000,
+                end=4000,
+                img=Image.new("RGBA", (12, 9), (255, 255, 255, 0)),
+            ),
+        ]
+    )
+    FakeRecognizer.texts = ["first", "second"]
+    FakeRecognizer.instances = []
+    monkeypatch.setattr("scinoephile.image.ocr.lens.LensRecognizer", FakeRecognizer)
+
+    with caplog.at_level("INFO", logger="scinoephile.image.ocr.lens"):
+        ocr_image_series_with_lens(image_series)
+
+    assert [
+        record.message
+        for record in caplog.records
+        if record.name == "scinoephile.image.ocr.lens"
+    ] == [
+        "OCRing subtitle 1/2 with Google Lens",
+        "OCRing subtitle 2/2 with Google Lens",
+    ]
 
 
 def test_ocr_image_series_with_lens_uses_runtime_cache(
@@ -83,38 +180,14 @@ def test_ocr_image_series_with_lens_uses_runtime_cache(
         tmp_path: temporary path fixture
     """
     cache_dir_path = tmp_path / "cache"
-    observed_cache_dir_paths = []
-    observed_retries = []
-
-    class FakeDefaultRecognizer(FakeRecognizer):
-        """Fake default recognizer with cache directory tracking."""
-
-        def __init__(
-            self,
-            *,
-            cache_dir_path: Path | None = None,
-            language: str = "en",
-            retries: int = 3,
-        ):
-            """Initialize.
-
-            Arguments:
-                cache_dir_path: directory in which to cache OCR results
-                language: Google Lens OCR language code
-                retries: Google Lens OCR request attempts per uncached image
-            """
-            super().__init__([language])
-            observed_cache_dir_paths.append(cache_dir_path)
-            observed_retries.append(retries)
+    FakeRecognizer.texts = [Language.zho_hans.tag]
+    FakeRecognizer.instances = []
 
     monkeypatch.setattr(
         "scinoephile.image.ocr.lens.get_runtime_cache_dir_path",
         lambda *parts: cache_dir_path,
     )
-    monkeypatch.setattr(
-        "scinoephile.image.ocr.lens.GoogleLensRecognizer",
-        FakeDefaultRecognizer,
-    )
+    monkeypatch.setattr("scinoephile.image.ocr.lens.LensRecognizer", FakeRecognizer)
     image_series = ImageSeries(
         events=[
             ImageSubtitle(
@@ -127,27 +200,56 @@ def test_ocr_image_series_with_lens_uses_runtime_cache(
 
     text_series = ocr_image_series_with_lens(
         image_series,
-        language="zh-CN",
+        language=Language.zho_hans,
         retries=5,
     )
 
-    assert [event.text for event in text_series] == ["zh-CN"]
-    assert observed_cache_dir_paths == [cache_dir_path]
-    assert observed_retries == [5]
+    assert [event.text for event in text_series] == ["zho-Hans"]
+    recognizer = FakeRecognizer.instances[0]
+    assert recognizer.cache_dir_path == cache_dir_path
+    assert recognizer.language is Language.zho_hans
+    assert recognizer.retries == 5
 
 
 @pytest.mark.parametrize(
-    ("script", "expected"),
+    "exception",
     [
-        ("simplified", "zh-CN"),
-        ("traditional", "zh-TW"),
+        ImportError("missing lens dependency"),
+        NotADirectoryError("invalid cache directory"),
+        OSError("cache read failed"),
+        RuntimeError("lens request failed"),
+        ValueError("invalid lens response"),
     ],
 )
-def test_get_lens_zho_code(script: ChineseScript, expected: str):
-    """Test Google Lens language code selection for Chinese scripts.
+def test_ocr_image_series_with_lens_wraps_processing_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    exception: Exception,
+):
+    """Test Lens image series processing wraps implementation errors.
 
     Arguments:
-        script: Chinese script
-        expected: expected Google Lens language code
+        monkeypatch: pytest monkeypatch fixture
+        exception: implementation exception raised during OCR
     """
-    assert get_lens_zho_code(script) == expected
+    FailingRecognizer.exception = exception
+    monkeypatch.setattr(
+        "scinoephile.image.ocr.lens.LensRecognizer",
+        FailingRecognizer,
+    )
+    image_series = ImageSeries(
+        events=[
+            ImageSubtitle(
+                start=1000,
+                end=2000,
+                img=Image.new("RGBA", (10, 8), (255, 255, 255, 0)),
+            ),
+        ]
+    )
+
+    with pytest.raises(
+        ScinoephileError,
+        match="Unable to OCR image series with Google Lens",
+    ) as excinfo:
+        ocr_image_series_with_lens(image_series)
+
+    assert excinfo.value.__cause__ is exception

--- a/test/image/ocr/paddle/test_engine.py
+++ b/test/image/ocr/paddle/test_engine.py
@@ -15,12 +15,14 @@ import numpy as np
 import pytest
 from PIL import Image
 
-from scinoephile.image.ocr.paddle import PaddleOcrRecognizer
+from scinoephile.core import Language
+from scinoephile.image.ocr.paddle import PaddleRecognizer
 from scinoephile.image.ocr.paddle.bounding_box import PaddleOcrBoundingBox
+from scinoephile.image.ocr.paddle.paddle_recognizer import _coerce_paddle_language
 from scinoephile.image.ocr.paddle.text_result import PaddleOcrTextResult
 
 
-class CountingPaddleOcrRecognizer(PaddleOcrRecognizer):
+class CountingPaddleRecognizer(PaddleRecognizer):
     """PaddleOCR recognizer that counts uncached predictions."""
 
     def __init__(self, cache_dir_path: Path | None = None):
@@ -29,7 +31,8 @@ class CountingPaddleOcrRecognizer(PaddleOcrRecognizer):
         Arguments:
             cache_dir_path: directory in which to cache OCR results
         """
-        self.language = "en"
+        self.language = Language.eng
+        self.paddle_language_code = "en"
         self.min_confidence = 0.0
         self.cache_dir_path = cache_dir_path
         self.predict_count = 0
@@ -53,9 +56,9 @@ class CountingPaddleOcrRecognizer(PaddleOcrRecognizer):
         ]
 
 
-def test_paddle_ocr_recognizer_caches_results_by_image(tmp_path: Path):
+def test_paddle_recognizer_caches_results_by_image(tmp_path: Path):
     """Test PaddleOCR recognizer caches OCR results by image content."""
-    recognizer = CountingPaddleOcrRecognizer(cache_dir_path=tmp_path)
+    recognizer = CountingPaddleRecognizer(cache_dir_path=tmp_path)
     image = Image.new("RGBA", (10, 8), (255, 255, 255, 0))
 
     assert recognizer.recognize_image(image) == "cached text"
@@ -65,7 +68,7 @@ def test_paddle_ocr_recognizer_caches_results_by_image(tmp_path: Path):
     assert len(list(tmp_path.glob("*.json"))) == 1
 
 
-def test_paddle_ocr_recognizer_uses_server_models(
+def test_paddle_recognizer_uses_server_models(
     monkeypatch: pytest.MonkeyPatch,
 ):
     """Test PaddleOCR recognizer hardcodes PP-OCRv5 server models.
@@ -90,13 +93,14 @@ def test_paddle_ocr_recognizer_uses_server_models(
     setattr(paddleocr, "PaddleOCR", FakePaddleOCR)
     monkeypatch.setitem(sys.modules, "paddleocr", paddleocr)
 
-    PaddleOcrRecognizer(language="ch")
+    PaddleRecognizer(language=Language.zho_hans)
 
+    assert observed_kwargs["lang"] == "ch"
     assert observed_kwargs["text_detection_model_name"] == "PP-OCRv5_server_det"
     assert observed_kwargs["text_recognition_model_name"] == "PP-OCRv5_server_rec"
 
 
-def test_paddle_ocr_recognizer_imports_paddleocr_only_when_needed():
+def test_paddle_recognizer_imports_paddleocr_only_when_needed():
     """Test importing PaddleOCR recognizer does not import paddleocr."""
     result = subprocess.run(
         [
@@ -104,7 +108,7 @@ def test_paddle_ocr_recognizer_imports_paddleocr_only_when_needed():
             "-c",
             (
                 "import sys;"
-                "import scinoephile.image.ocr.paddle.paddle_ocr_recognizer;"
+                "import scinoephile.image.ocr.paddle.paddle_recognizer;"
                 "raise SystemExit('paddleocr' in sys.modules)"
             ),
         ],
@@ -147,13 +151,37 @@ def test_paddle_ocr_class_requires_ocr_extra(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr("builtins.__import__", fake_import)
 
     with pytest.raises(ImportError, match="'ocr' extra"):
-        PaddleOcrRecognizer._get_paddle_ocr_class()
+        PaddleRecognizer._get_paddle_ocr_class()
 
 
-def test_paddle_ocr_recognizer_rejects_unsupported_languages():
+def test_paddle_recognizer_rejects_unsupported_languages():
     """Test PaddleOCR recognizer only supports English and Chinese."""
-    with pytest.raises(ValueError, match="PaddleOCR language must be one of"):
-        PaddleOcrRecognizer(language="korean")
+    with pytest.raises(ValueError, match="not supported by PaddleOCR"):
+        PaddleRecognizer(language="korean")
+
+
+@pytest.mark.parametrize(
+    ("language", "expected"),
+    [
+        ("en", Language.eng),
+        ("eng", Language.eng),
+        ("ch", Language.zho_hans),
+        ("chinese_cht", Language.zho_hant),
+        ("zho-Hans", Language.zho_hans),
+        ("zho-Hant", Language.zho_hant),
+    ],
+)
+def test_coerce_paddle_language_accepts_current_and_legacy_codes(
+    language: str,
+    expected: Language,
+):
+    """Test PaddleOCR language coercion accepts supported language codes.
+
+    Arguments:
+        language: language code to coerce
+        expected: expected Scinoephile language
+    """
+    assert _coerce_paddle_language(language) is expected
 
 
 def test_format_paddle_ocr_text_orders_results_into_lines():
@@ -165,7 +193,7 @@ def test_format_paddle_ocr_text_orders_results_into_lines():
         _result("Top left", 10, 10),
     ]
 
-    text = PaddleOcrRecognizer._format_paddle_ocr_text(results)
+    text = PaddleRecognizer._format_paddle_ocr_text(results)
 
     assert text == "Top left Top right\\NBottom left Bottom right"
 
@@ -185,7 +213,7 @@ def test_normalize_paddle_ocr_results_parses_paddleocr3_result_dict():
         }
     ]
 
-    results = PaddleOcrRecognizer._normalize_paddle_ocr_results(raw_results)
+    results = PaddleRecognizer._normalize_paddle_ocr_results(raw_results)
 
     assert [(result.text, result.confidence) for result in results] == [
         ("left", 0.95),

--- a/test/image/ocr/paddle/test_paddle_series.py
+++ b/test/image/ocr/paddle/test_paddle_series.py
@@ -9,26 +9,41 @@ from pathlib import Path
 import pytest
 from PIL import Image
 
-from scinoephile.core.text import ChineseScript
-from scinoephile.image.ocr.paddle import (
-    PaddleOcrRecognizer,
-    get_paddle_zho_code,
-    ocr_image_series_with_paddle,
-)
+import scinoephile.image.ocr.paddle as paddle_ocr
+from scinoephile.core import Language, ScinoephileError
+from scinoephile.image.ocr.paddle import ocr_image_series_with_paddle, paddle_recognizer
 from scinoephile.image.subtitles import ImageSeries, ImageSubtitle
 
 
-class FakeRecognizer(PaddleOcrRecognizer):
+class FakeRecognizer:
     """Fake PaddleOCR recognizer for tests."""
 
-    def __init__(self, texts: list[str]):
+    texts: list[str] = []
+    """Texts to return from subsequent recognitions."""
+
+    instances: list[FakeRecognizer] = []
+    """Fake recognizer instances created by the OCR helper."""
+
+    def __init__(
+        self,
+        *,
+        cache_dir_path: Path | None = None,
+        language: Language = Language.eng,
+        min_confidence: float = 0.0,
+    ):
         """Initialize.
 
         Arguments:
-            texts: texts to return from subsequent recognitions
+            cache_dir_path: directory in which to cache OCR results
+            language: Scinoephile language
+            min_confidence: minimum confidence to include
         """
-        self.texts = texts
+        self.cache_dir_path = cache_dir_path
+        self.language = language
+        self.min_confidence = min_confidence
+        self.texts = list(type(self).texts)
         self.images: list[Image.Image] = []
+        type(self).instances.append(self)
 
     def recognize_image(self, image: Image.Image) -> str:
         """Recognize text from an image.
@@ -42,8 +57,49 @@ class FakeRecognizer(PaddleOcrRecognizer):
         return self.texts.pop(0)
 
 
-def test_ocr_image_series_with_paddle_preserves_timings_and_sets_text():
-    """Test PaddleOCR image series processing preserves timings and writes text."""
+class FailingRecognizer:
+    """Fake PaddleOCR recognizer that raises a configured exception."""
+
+    exception: Exception | None = None
+    """Exception raised during recognition."""
+
+    def __init__(self, **kwargs: object):
+        """Initialize.
+
+        Arguments:
+            **kwargs: ignored recognizer keyword arguments
+        """
+        _ = kwargs
+
+    def recognize_image(self, image: Image.Image) -> str:
+        """Recognize text from an image.
+
+        Arguments:
+            image: input image
+        Raises:
+            Exception: configured exception
+        """
+        _ = image
+        if self.exception is None:
+            raise AssertionError("FailingRecognizer.exception must be configured")
+        raise self.exception
+
+
+def test_paddle_module_exposes_only_current_public_helpers():
+    """Test PaddleOCR module no longer exposes removed helper functions."""
+    assert not hasattr(paddle_ocr, "get_paddle_recognizer")
+    assert not hasattr(paddle_ocr, "get_paddle_language_code")
+    assert paddle_ocr.PaddleRecognizerKwargs is paddle_recognizer.PaddleRecognizerKwargs
+
+
+def test_ocr_image_series_with_paddle_preserves_timings_and_sets_text(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test PaddleOCR image series processing preserves timings and writes text.
+
+    Arguments:
+        monkeypatch: pytest monkeypatch fixture
+    """
     image_series = ImageSeries(
         events=[
             ImageSubtitle(
@@ -58,18 +114,65 @@ def test_ocr_image_series_with_paddle_preserves_timings_and_sets_text():
             ),
         ]
     )
-    recognizer = FakeRecognizer(["first", "second"])
-
-    text_series = ocr_image_series_with_paddle(
-        image_series,
-        recognizer=recognizer,
+    FakeRecognizer.texts = ["first", "second"]
+    FakeRecognizer.instances = []
+    monkeypatch.setattr(
+        "scinoephile.image.ocr.paddle.PaddleRecognizer",
+        FakeRecognizer,
     )
+
+    text_series = ocr_image_series_with_paddle(image_series)
 
     assert [(event.start, event.end, event.text) for event in text_series] == [
         (1000, 2000, "first"),
         (3000, 4000, "second"),
     ]
+    recognizer = FakeRecognizer.instances[0]
     assert [image.size for image in recognizer.images] == [(50, 48), (52, 49)]
+
+
+def test_ocr_image_series_with_paddle_logs_progress(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test PaddleOCR image series processing logs OCR progress.
+
+    Arguments:
+        caplog: pytest log capture fixture
+        monkeypatch: pytest monkeypatch fixture
+    """
+    image_series = ImageSeries(
+        events=[
+            ImageSubtitle(
+                start=1000,
+                end=2000,
+                img=Image.new("RGBA", (10, 8), (255, 255, 255, 0)),
+            ),
+            ImageSubtitle(
+                start=3000,
+                end=4000,
+                img=Image.new("RGBA", (12, 9), (255, 255, 255, 0)),
+            ),
+        ]
+    )
+    FakeRecognizer.texts = ["first", "second"]
+    FakeRecognizer.instances = []
+    monkeypatch.setattr(
+        "scinoephile.image.ocr.paddle.PaddleRecognizer",
+        FakeRecognizer,
+    )
+
+    with caplog.at_level("INFO", logger="scinoephile.image.ocr.paddle"):
+        ocr_image_series_with_paddle(image_series)
+
+    assert [
+        record.message
+        for record in caplog.records
+        if record.name == "scinoephile.image.ocr.paddle"
+    ] == [
+        "OCRing subtitle 1/2 with PaddleOCR",
+        "OCRing subtitle 2/2 with PaddleOCR",
+    ]
 
 
 def test_ocr_image_series_with_paddle_uses_runtime_cache(
@@ -83,35 +186,16 @@ def test_ocr_image_series_with_paddle_uses_runtime_cache(
         tmp_path: temporary path fixture
     """
     cache_dir_path = tmp_path / "cache"
-    observed_cache_dir_paths = []
-
-    class FakeDefaultRecognizer(FakeRecognizer):
-        """Fake default recognizer with cache directory tracking."""
-
-        def __init__(
-            self,
-            *,
-            language: str,
-            cache_dir_path: Path | None = None,
-            min_confidence: float = 0.0,
-        ):
-            """Initialize.
-
-            Arguments:
-                language: PaddleOCR language code
-                cache_dir_path: directory in which to cache OCR results
-                min_confidence: minimum confidence to include
-            """
-            super().__init__([language])
-            observed_cache_dir_paths.append(cache_dir_path)
+    FakeRecognizer.texts = [Language.zho_hans.tag]
+    FakeRecognizer.instances = []
 
     monkeypatch.setattr(
         "scinoephile.image.ocr.paddle.get_runtime_cache_dir_path",
         lambda *parts: cache_dir_path,
     )
     monkeypatch.setattr(
-        "scinoephile.image.ocr.paddle.PaddleOcrRecognizer",
-        FakeDefaultRecognizer,
+        "scinoephile.image.ocr.paddle.PaddleRecognizer",
+        FakeRecognizer,
     )
     image_series = ImageSeries(
         events=[
@@ -123,24 +207,57 @@ def test_ocr_image_series_with_paddle_uses_runtime_cache(
         ]
     )
 
-    text_series = ocr_image_series_with_paddle(image_series, language="en")
+    text_series = ocr_image_series_with_paddle(
+        image_series,
+        language=Language.zho_hans,
+        min_confidence=0.8,
+    )
 
-    assert [event.text for event in text_series] == ["en"]
-    assert observed_cache_dir_paths == [cache_dir_path]
+    assert [event.text for event in text_series] == ["zho-Hans"]
+    recognizer = FakeRecognizer.instances[0]
+    assert recognizer.cache_dir_path == cache_dir_path
+    assert recognizer.language is Language.zho_hans
+    assert recognizer.min_confidence == 0.8
 
 
 @pytest.mark.parametrize(
-    ("script", "expected"),
+    "exception",
     [
-        ("simplified", "ch"),
-        ("traditional", "chinese_cht"),
+        ImportError("missing paddle dependency"),
+        OSError("cache read failed"),
+        RuntimeError("paddle request failed"),
+        ValueError("invalid paddle response"),
     ],
 )
-def test_get_paddle_zho_code(script: ChineseScript, expected: str):
-    """Test PaddleOCR language code selection for Chinese scripts.
+def test_ocr_image_series_with_paddle_wraps_processing_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    exception: Exception,
+):
+    """Test PaddleOCR image series processing wraps implementation errors.
 
     Arguments:
-        script: Chinese script
-        expected: expected PaddleOCR language code
+        monkeypatch: pytest monkeypatch fixture
+        exception: implementation exception raised during OCR
     """
-    assert get_paddle_zho_code(script) == expected
+    FailingRecognizer.exception = exception
+    monkeypatch.setattr(
+        "scinoephile.image.ocr.paddle.PaddleRecognizer",
+        FailingRecognizer,
+    )
+    image_series = ImageSeries(
+        events=[
+            ImageSubtitle(
+                start=1000,
+                end=2000,
+                img=Image.new("RGBA", (10, 8), (255, 255, 255, 0)),
+            ),
+        ]
+    )
+
+    with pytest.raises(
+        ScinoephileError,
+        match="Unable to OCR image series with PaddleOCR",
+    ) as excinfo:
+        ocr_image_series_with_paddle(image_series)
+
+    assert excinfo.value.__cause__ is exception

--- a/test/image/ocr/tesseract/test_engine.py
+++ b/test/image/ocr/tesseract/test_engine.py
@@ -10,19 +10,27 @@ import pytest
 import requests
 from PIL import Image
 
-from scinoephile.core import ScinoephileError
-from scinoephile.image.ocr.tesseract import TesseractOcrRecognizer
+from scinoephile.core import Language, ScinoephileError
+from scinoephile.image.ocr.tesseract import TesseractRecognizer
+from scinoephile.image.ocr.tesseract.tesseract_recognizer import (
+    _coerce_tesseract_language,
+)
 
 
-class CountingTesseractOcrRecognizer(TesseractOcrRecognizer):
+class CountingTesseractRecognizer(TesseractRecognizer):
     """Tesseract recognizer that counts uncached recognitions."""
 
-    def __init__(self, cache_dir_path: Path | None = None, *, language: str = "eng"):
+    def __init__(
+        self,
+        cache_dir_path: Path | None = None,
+        *,
+        language: Language = Language.eng,
+    ):
         """Initialize.
 
         Arguments:
             cache_dir_path: directory in which to cache OCR results
-            language: Tesseract language code
+            language: Scinoephile language
         """
         super().__init__(
             cache_dir_path=cache_dir_path,
@@ -42,12 +50,12 @@ class CountingTesseractOcrRecognizer(TesseractOcrRecognizer):
             recognized text
         """
         self.recognize_count += 1
-        return f"cached text {self.language}"
+        return f"cached text {self.tesseract_language_code}"
 
 
-def test_tesseract_ocr_recognizer_caches_results_by_image(tmp_path: Path):
+def test_tesseract_recognizer_caches_results_by_image(tmp_path: Path):
     """Test Tesseract recognizer caches OCR results by image content."""
-    recognizer = CountingTesseractOcrRecognizer(cache_dir_path=tmp_path)
+    recognizer = CountingTesseractRecognizer(cache_dir_path=tmp_path)
     image = Image.new("RGBA", (10, 8), (255, 255, 255, 0))
 
     assert recognizer.recognize_image(image) == "cached text eng"
@@ -57,36 +65,60 @@ def test_tesseract_ocr_recognizer_caches_results_by_image(tmp_path: Path):
     assert len(list(tmp_path.glob("*.json"))) == 1
 
 
-def test_tesseract_ocr_recognizer_caches_by_configuration(tmp_path: Path):
+@pytest.mark.parametrize(
+    ("language", "expected"),
+    [
+        ("en", Language.eng),
+        ("eng", Language.eng),
+        ("chi_sim", Language.zho_hans),
+        ("chi_tra", Language.zho_hant),
+        ("zho-Hans", Language.zho_hans),
+        ("zho-Hant", Language.zho_hant),
+    ],
+)
+def test_coerce_tesseract_language_accepts_current_and_legacy_codes(
+    language: str,
+    expected: Language,
+):
+    """Test Tesseract language coercion accepts supported language codes.
+
+    Arguments:
+        language: language code to coerce
+        expected: expected Scinoephile language
+    """
+    assert _coerce_tesseract_language(language) is expected
+
+
+def test_tesseract_recognizer_caches_by_configuration(tmp_path: Path):
     """Test Tesseract recognizer includes configuration in cache keys."""
-    english_recognizer = CountingTesseractOcrRecognizer(
+    english_recognizer = CountingTesseractRecognizer(
         cache_dir_path=tmp_path,
-        language="eng",
+        language=Language.eng,
     )
-    french_recognizer = CountingTesseractOcrRecognizer(
+    chinese_recognizer = CountingTesseractRecognizer(
         cache_dir_path=tmp_path,
-        language="fra",
+        language=Language.zho_hans,
     )
     image = Image.new("RGBA", (10, 8), (255, 255, 255, 0))
 
     assert english_recognizer.recognize_image(image) == "cached text eng"
-    assert french_recognizer.recognize_image(image) == "cached text fra"
+    assert chinese_recognizer.recognize_image(image) == "cached text chi_sim"
 
     assert english_recognizer.recognize_count == 1
-    assert french_recognizer.recognize_count == 1
+    assert chinese_recognizer.recognize_count == 1
     assert len(list(tmp_path.glob("*.json"))) == 2
 
 
-def test_tesseract_ocr_recognizer_cache_key_ignores_engine_version(tmp_path: Path):
+def test_tesseract_recognizer_cache_key_ignores_engine_version(tmp_path: Path):
     """Test Tesseract recognizer cache keys do not include an engine version."""
 
-    class VersionedCountingRecognizer(CountingTesseractOcrRecognizer):
+    class VersionedCountingRecognizer(CountingTesseractRecognizer):
         """Counting recognizer with a legacy cache version attribute."""
 
         engine_version = "unused-version"
 
     image = Image.new("RGBA", (10, 8), (255, 255, 255, 0))
-    unversioned_recognizer = CountingTesseractOcrRecognizer(cache_dir_path=tmp_path)
+    unversioned_recognizer = CountingTesseractRecognizer(cache_dir_path=tmp_path)
     versioned_recognizer = VersionedCountingRecognizer(cache_dir_path=tmp_path)
 
     assert unversioned_recognizer.recognize_image(image) == "cached text eng"
@@ -103,7 +135,7 @@ def test_tesseract_command_includes_hocr_tessdata_and_language(tmp_path: Path):
     tessdata_dir_path = tmp_path / "tessdata"
     tessdata_dir_path.mkdir()
 
-    class CommandCapturingRecognizer(TesseractOcrRecognizer):
+    class CommandCapturingRecognizer(TesseractRecognizer):
         """Recognizer that captures command arguments."""
 
         def _run_command(self, command: list[str]) -> tuple[int, str, str]:
@@ -124,7 +156,7 @@ def test_tesseract_command_includes_hocr_tessdata_and_language(tmp_path: Path):
 
     recognizer = CommandCapturingRecognizer(
         executable_path=Path("tesseract"),
-        language="eng",
+        language=Language.eng,
         tessdata_dir_path=tessdata_dir_path,
         skip_executable_validation=True,
     )
@@ -150,7 +182,7 @@ def test_tesseract_command_includes_hocr_tessdata_and_language(tmp_path: Path):
 def test_tesseract_chinese_hocr_words_are_joined_without_spaces():
     """Test Chinese hOCR word spans are joined without spaces."""
 
-    class ChineseRecognizer(TesseractOcrRecognizer):
+    class ChineseRecognizer(TesseractRecognizer):
         """Recognizer that writes Chinese hOCR output."""
 
         def _run_command(self, command: list[str]) -> tuple[int, str, str]:
@@ -176,7 +208,7 @@ def test_tesseract_chinese_hocr_words_are_joined_without_spaces():
 
     recognizer = ChineseRecognizer(
         executable_path=Path("tesseract"),
-        language="chi_sim",
+        language=Language.zho_hans,
         skip_executable_validation=True,
     )
 
@@ -190,7 +222,7 @@ def test_tesseract_detect_italics_runs_legacy_hocr_pass(tmp_path: Path):
     legacy_tessdata_dir_path.mkdir()
     (legacy_tessdata_dir_path / "eng.traineddata").touch()
 
-    class CommandCapturingRecognizer(TesseractOcrRecognizer):
+    class CommandCapturingRecognizer(TesseractRecognizer):
         """Recognizer that captures primary and legacy command arguments."""
 
         def _run_command(self, command: list[str]) -> tuple[int, str, str]:
@@ -225,7 +257,7 @@ def test_tesseract_detect_italics_runs_legacy_hocr_pass(tmp_path: Path):
     recognizer = CommandCapturingRecognizer(
         cache_dir_path=tmp_path,
         executable_path=Path("tesseract"),
-        language="eng",
+        language=Language.eng,
         detect_italics=True,
         skip_executable_validation=True,
     )
@@ -251,10 +283,10 @@ def test_tesseract_detect_italics_runs_legacy_hocr_pass(tmp_path: Path):
 def test_tesseract_detect_italics_rejects_non_english_language():
     """Test italic detection is only supported for English Tesseract OCR."""
     with pytest.raises(ValueError, match="only supported with language eng"):
-        TesseractOcrRecognizer(
+        TesseractRecognizer(
             executable_path=Path("tesseract"),
             detect_italics=True,
-            language="chi_sim",
+            language=Language.zho_hans,
             skip_executable_validation=True,
         )
 
@@ -294,7 +326,7 @@ def test_tesseract_detect_italics_downloads_missing_legacy_tessdata(
 
     monkeypatch.setattr(requests, "get", fake_get)
 
-    class CommandCapturingRecognizer(TesseractOcrRecognizer):
+    class CommandCapturingRecognizer(TesseractRecognizer):
         """Recognizer that writes primary and legacy hOCR output."""
 
         def _run_command(self, command: list[str]) -> tuple[int, str, str]:
@@ -315,7 +347,7 @@ def test_tesseract_detect_italics_downloads_missing_legacy_tessdata(
     recognizer = CommandCapturingRecognizer(
         cache_dir_path=tmp_path,
         executable_path=Path("tesseract"),
-        language="eng",
+        language=Language.eng,
         detect_italics=True,
         skip_executable_validation=True,
     )
@@ -360,7 +392,7 @@ def test_tesseract_detect_italics_reuses_existing_legacy_tessdata(
 
     monkeypatch.setattr(requests, "get", fail_get)
 
-    class CommandCapturingRecognizer(TesseractOcrRecognizer):
+    class CommandCapturingRecognizer(TesseractRecognizer):
         """Recognizer that writes primary and legacy hOCR output."""
 
         def _run_command(self, command: list[str]) -> tuple[int, str, str]:
@@ -381,7 +413,7 @@ def test_tesseract_detect_italics_reuses_existing_legacy_tessdata(
     recognizer = CommandCapturingRecognizer(
         cache_dir_path=tmp_path,
         executable_path=Path("tesseract"),
-        language="eng",
+        language=Language.eng,
         detect_italics=True,
         skip_executable_validation=True,
     )
@@ -396,7 +428,7 @@ def test_tesseract_blank_english_result_uses_legacy_fallback(tmp_path: Path):
     legacy_tessdata_dir_path.mkdir()
     (legacy_tessdata_dir_path / "eng.traineddata").touch()
 
-    class LegacyFallbackRecognizer(TesseractOcrRecognizer):
+    class LegacyFallbackRecognizer(TesseractRecognizer):
         """Recognizer that simulates blank primary OCR and useful legacy OCR."""
 
         def _run_command(self, command: list[str]) -> tuple[int, str, str]:
@@ -424,7 +456,7 @@ def test_tesseract_blank_english_result_uses_legacy_fallback(tmp_path: Path):
     recognizer = LegacyFallbackRecognizer(
         cache_dir_path=tmp_path,
         executable_path=Path("tesseract"),
-        language="eng",
+        language=Language.eng,
         skip_executable_validation=True,
     )
 
@@ -447,7 +479,7 @@ def test_tesseract_blank_chinese_result_uses_legacy_fallback(tmp_path: Path):
     legacy_tessdata_dir_path.mkdir()
     (legacy_tessdata_dir_path / "chi_tra.traineddata").touch()
 
-    class LegacyFallbackRecognizer(TesseractOcrRecognizer):
+    class LegacyFallbackRecognizer(TesseractRecognizer):
         """Recognizer that simulates blank primary OCR and useful legacy OCR."""
 
         def _run_command(self, command: list[str]) -> tuple[int, str, str]:
@@ -472,7 +504,7 @@ def test_tesseract_blank_chinese_result_uses_legacy_fallback(tmp_path: Path):
     recognizer = LegacyFallbackRecognizer(
         cache_dir_path=tmp_path,
         executable_path=Path("tesseract"),
-        language="chi_tra",
+        language=Language.zho_hant,
         skip_executable_validation=True,
     )
 
@@ -486,7 +518,7 @@ def test_tesseract_detect_italics_raises_clear_legacy_error(tmp_path: Path):
     legacy_tessdata_dir_path.mkdir()
     (legacy_tessdata_dir_path / "eng.traineddata").touch()
 
-    class LegacyFailingRecognizer(TesseractOcrRecognizer):
+    class LegacyFailingRecognizer(TesseractRecognizer):
         """Recognizer that simulates a missing legacy Tesseract model."""
 
         def _run_command(self, command: list[str]) -> tuple[int, str, str]:
@@ -531,7 +563,7 @@ def test_tesseract_raises_and_does_not_cache_when_output_is_missing(
         tmp_path: temporary directory path
     """
 
-    class MissingOutputRecognizer(TesseractOcrRecognizer):
+    class MissingOutputRecognizer(TesseractRecognizer):
         """Recognizer that simulates a successful command without hOCR output."""
 
         def _run_command(self, command: list[str]) -> tuple[int, str, str]:

--- a/test/image/ocr/tesseract/test_tesseract_series.py
+++ b/test/image/ocr/tesseract/test_tesseract_series.py
@@ -9,24 +9,62 @@ from pathlib import Path
 import pytest
 from PIL import Image
 
+import scinoephile.image.ocr.tesseract as tesseract_ocr
+from scinoephile.core import Language, ScinoephileError
 from scinoephile.image.ocr.tesseract import (
-    TesseractOcrRecognizer,
     ocr_image_series_with_tesseract,
+    tesseract_recognizer,
 )
 from scinoephile.image.subtitles import ImageSeries, ImageSubtitle
 
 
-class FakeTesseractRecognizer(TesseractOcrRecognizer):
+class FakeTesseractRecognizer:
     """Fake Tesseract recognizer for tests."""
 
-    def __init__(self, texts: list[str]):
+    texts: list[str] = []
+    """Texts to return from subsequent recognitions."""
+
+    instances: list[FakeTesseractRecognizer] = []
+    """Fake recognizer instances created by the OCR helper."""
+
+    def __init__(
+        self,
+        *,
+        cache_dir_path: Path | None = None,
+        executable_path: Path | str = "tesseract",
+        detect_italics: bool = False,
+        language: Language = Language.eng,
+        oem: int | None = 3,
+        psm: int = 6,
+        scale: int = 2,
+        skip_executable_validation: bool = False,
+        tessdata_dir_path: Path | None = None,
+    ):
         """Initialize.
 
         Arguments:
-            texts: texts to return from subsequent recognitions
+            cache_dir_path: directory in which to cache OCR results
+            executable_path: Tesseract executable path or command name
+            detect_italics: whether to run a legacy-engine pass for italics
+            language: Scinoephile language
+            oem: Tesseract OCR engine mode
+            psm: Tesseract page segmentation mode
+            scale: image preprocessing scale
+            skip_executable_validation: whether to skip executable validation
+            tessdata_dir_path: optional tessdata directory
         """
-        self.texts = texts
+        self.cache_dir_path = cache_dir_path
+        self.executable_path = executable_path
+        self.detect_italics = detect_italics
+        self.language = language
+        self.oem = oem
+        self.psm = psm
+        self.scale = scale
+        self.skip_executable_validation = skip_executable_validation
+        self.tessdata_dir_path = tessdata_dir_path
+        self.texts = list(type(self).texts)
         self.images: list[Image.Image] = []
+        type(self).instances.append(self)
 
     def recognize_image(self, image: Image.Image) -> str:
         """Recognize text from an image.
@@ -40,40 +78,53 @@ class FakeTesseractRecognizer(TesseractOcrRecognizer):
         return self.texts.pop(0)
 
 
-def test_ocr_image_series_with_tesseract_preserves_timings_and_sets_text():
-    """Test Tesseract image series processing preserves timings and text."""
-    image_series = ImageSeries(
-        events=[
-            ImageSubtitle(
-                start=1000,
-                end=2000,
-                img=Image.new("RGBA", (10, 8), (255, 255, 255, 0)),
-            ),
-            ImageSubtitle(
-                start=3000,
-                end=4000,
-                img=Image.new("RGBA", (12, 9), (255, 255, 255, 0)),
-            ),
-        ]
+class FailingTesseractRecognizer:
+    """Fake Tesseract recognizer that raises a configured exception."""
+
+    exception: Exception | None = None
+    """Exception raised during recognition."""
+
+    def __init__(self, **kwargs: object):
+        """Initialize.
+
+        Arguments:
+            **kwargs: ignored recognizer keyword arguments
+        """
+        _ = kwargs
+
+    def recognize_image(self, image: Image.Image) -> str:
+        """Recognize text from an image.
+
+        Arguments:
+            image: input image
+        Raises:
+            Exception: configured exception
+        """
+        _ = image
+        if self.exception is None:
+            raise AssertionError(
+                "FailingTesseractRecognizer.exception must be configured"
+            )
+        raise self.exception
+
+
+def test_tesseract_module_exposes_only_current_public_helpers():
+    """Test Tesseract module no longer exposes removed helper functions."""
+    assert not hasattr(tesseract_ocr, "get_tesseract_recognizer")
+    assert not hasattr(tesseract_ocr, "get_tesseract_language_code")
+    assert (
+        tesseract_ocr.TesseractRecognizerKwargs
+        is tesseract_recognizer.TesseractRecognizerKwargs
     )
-    recognizer = FakeTesseractRecognizer(["first", "second"])
-
-    text_series = ocr_image_series_with_tesseract(image_series, recognizer=recognizer)
-
-    assert [(event.start, event.end, event.text) for event in text_series] == [
-        (1000, 2000, "first"),
-        (3000, 4000, "second"),
-    ]
-    assert [image.size for image in recognizer.images] == [(10, 8), (12, 9)]
 
 
-def test_ocr_image_series_with_tesseract_logs_progress(
-    caplog: pytest.LogCaptureFixture,
+def test_ocr_image_series_with_tesseract_preserves_timings_and_sets_text(
+    monkeypatch: pytest.MonkeyPatch,
 ):
-    """Test Tesseract image series processing logs OCR progress.
+    """Test Tesseract image series processing preserves timings and text.
 
     Arguments:
-        caplog: pytest log capture fixture
+        monkeypatch: pytest monkeypatch fixture
     """
     image_series = ImageSeries(
         events=[
@@ -89,10 +140,56 @@ def test_ocr_image_series_with_tesseract_logs_progress(
             ),
         ]
     )
-    recognizer = FakeTesseractRecognizer(["first", "second"])
+    FakeTesseractRecognizer.texts = ["first", "second"]
+    FakeTesseractRecognizer.instances = []
+    monkeypatch.setattr(
+        "scinoephile.image.ocr.tesseract.TesseractRecognizer",
+        FakeTesseractRecognizer,
+    )
+
+    text_series = ocr_image_series_with_tesseract(image_series)
+
+    assert [(event.start, event.end, event.text) for event in text_series] == [
+        (1000, 2000, "first"),
+        (3000, 4000, "second"),
+    ]
+    recognizer = FakeTesseractRecognizer.instances[0]
+    assert [image.size for image in recognizer.images] == [(10, 8), (12, 9)]
+
+
+def test_ocr_image_series_with_tesseract_logs_progress(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test Tesseract image series processing logs OCR progress.
+
+    Arguments:
+        caplog: pytest log capture fixture
+        monkeypatch: pytest monkeypatch fixture
+    """
+    image_series = ImageSeries(
+        events=[
+            ImageSubtitle(
+                start=1000,
+                end=2000,
+                img=Image.new("RGBA", (10, 8), (255, 255, 255, 0)),
+            ),
+            ImageSubtitle(
+                start=3000,
+                end=4000,
+                img=Image.new("RGBA", (12, 9), (255, 255, 255, 0)),
+            ),
+        ]
+    )
+    FakeTesseractRecognizer.texts = ["first", "second"]
+    FakeTesseractRecognizer.instances = []
+    monkeypatch.setattr(
+        "scinoephile.image.ocr.tesseract.TesseractRecognizer",
+        FakeTesseractRecognizer,
+    )
 
     with caplog.at_level("INFO", logger="scinoephile.image.ocr.tesseract"):
-        ocr_image_series_with_tesseract(image_series, recognizer=recognizer)
+        ocr_image_series_with_tesseract(image_series)
 
     assert [
         record.message
@@ -115,57 +212,19 @@ def test_ocr_image_series_with_tesseract_uses_runtime_cache(
         tmp_path: temporary path fixture
     """
     cache_dir_path = tmp_path / "cache"
+    tessdata_dir_path = tmp_path / "tessdata"
     observed_cache_dir_paths = []
     observed_cache_namespaces = []
-
-    class FakeDefaultRecognizer(FakeTesseractRecognizer):
-        """Fake default recognizer with cache directory tracking."""
-
-        def __init__(
-            self,
-            *,
-            cache_dir_path: Path | None = None,
-            executable_path: Path | str = "tesseract",
-            detect_italics: bool = False,
-            language: str = "eng",
-            oem: int = 3,
-            psm: int = 6,
-            scale: int = 2,
-            skip_executable_validation: bool = False,
-            tessdata_dir_path: Path | None = None,
-        ):
-            """Initialize.
-
-            Arguments:
-                cache_dir_path: directory in which to cache OCR results
-                executable_path: Tesseract executable path or command name
-                detect_italics: whether to run a legacy-engine pass for italics
-                language: Tesseract language code
-                oem: Tesseract OCR engine mode
-                psm: Tesseract page segmentation mode
-                scale: image preprocessing scale
-                skip_executable_validation: whether to skip executable validation
-                tessdata_dir_path: optional tessdata directory
-            """
-            _ = (
-                executable_path,
-                detect_italics,
-                oem,
-                psm,
-                scale,
-                skip_executable_validation,
-                tessdata_dir_path,
-            )
-            super().__init__([language])
-            observed_cache_dir_paths.append(cache_dir_path)
+    FakeTesseractRecognizer.texts = [Language.eng.tag]
+    FakeTesseractRecognizer.instances = []
 
     monkeypatch.setattr(
         "scinoephile.image.ocr.tesseract.get_runtime_cache_dir_path",
         lambda *parts: observed_cache_namespaces.extend(parts) or cache_dir_path,
     )
     monkeypatch.setattr(
-        "scinoephile.image.ocr.tesseract.TesseractOcrRecognizer",
-        FakeDefaultRecognizer,
+        "scinoephile.image.ocr.tesseract.TesseractRecognizer",
+        FakeTesseractRecognizer,
     )
     image_series = ImageSeries(
         events=[
@@ -177,8 +236,71 @@ def test_ocr_image_series_with_tesseract_uses_runtime_cache(
         ]
     )
 
-    text_series = ocr_image_series_with_tesseract(image_series, language="eng")
+    text_series = ocr_image_series_with_tesseract(
+        image_series,
+        executable_path="custom-tesseract",
+        detect_italics=True,
+        language=Language.eng,
+        oem=None,
+        psm=7,
+        scale=3,
+        skip_executable_validation=True,
+        tessdata_dir_path=tessdata_dir_path,
+    )
 
     assert [event.text for event in text_series] == ["eng"]
+    recognizer = FakeTesseractRecognizer.instances[0]
+    observed_cache_dir_paths.append(recognizer.cache_dir_path)
     assert observed_cache_dir_paths == [cache_dir_path]
     assert observed_cache_namespaces == ["tesseract"]
+    assert recognizer.executable_path == "custom-tesseract"
+    assert recognizer.detect_italics is True
+    assert recognizer.language is Language.eng
+    assert recognizer.oem is None
+    assert recognizer.psm == 7
+    assert recognizer.scale == 3
+    assert recognizer.skip_executable_validation is True
+    assert recognizer.tessdata_dir_path == tessdata_dir_path
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        ImportError("missing tesseract dependency"),
+        OSError("cache read failed"),
+        RuntimeError("tesseract request failed"),
+        ValueError("invalid tesseract response"),
+    ],
+)
+def test_ocr_image_series_with_tesseract_wraps_processing_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    exception: Exception,
+):
+    """Test Tesseract image series processing wraps implementation errors.
+
+    Arguments:
+        monkeypatch: pytest monkeypatch fixture
+        exception: implementation exception raised during OCR
+    """
+    FailingTesseractRecognizer.exception = exception
+    monkeypatch.setattr(
+        "scinoephile.image.ocr.tesseract.TesseractRecognizer",
+        FailingTesseractRecognizer,
+    )
+    image_series = ImageSeries(
+        events=[
+            ImageSubtitle(
+                start=1000,
+                end=2000,
+                img=Image.new("RGBA", (10, 8), (255, 255, 255, 0)),
+            ),
+        ]
+    )
+
+    with pytest.raises(
+        ScinoephileError,
+        match="Unable to OCR image series with Tesseract",
+    ) as excinfo:
+        ocr_image_series_with_tesseract(image_series)
+
+    assert excinfo.value.__cause__ is exception


### PR DESCRIPTION
## Summary
- Rename Lens, PaddleOCR, and Tesseract recognizer modules/classes/exports to remove redundant provider suffixes.
- Simplify OCR image-series helpers to construct recognizers from keyword arguments and use runtime caches by default.
- Update direct workflow caller language mapping and targeted OCR engine/series tests for the new API.

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format ...`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix ...`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check ...`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest image/ocr/lens image/ocr/paddle image/ocr/tesseract`