### PR TITLE
OCR engine CLI language cleanup

### DIFF
--- a/scinoephile/cli/ocr/ocr_lens_cli.py
+++ b/scinoephile/cli/ocr/ocr_lens_cli.py
@@ -9,12 +9,14 @@ from pathlib import Path
 
 from scinoephile.cli.helpers.io import read_image_series, write_series
 from scinoephile.common.argument_parsing import (
+    enum_arg,
+    enum_metavar,
     get_arg_groups_by_name,
     input_file_or_dir_arg,
     int_arg,
     output_file_arg,
 )
-from scinoephile.core import ScinoephileError
+from scinoephile.core import Language, ScinoephileError
 from scinoephile.core.cli import ScinoephileCliBase
 from scinoephile.image.ocr.lens import ocr_image_series_with_lens
 
@@ -22,8 +24,8 @@ __all__ = ["OcrLensCli"]
 
 OCR_LENS_LOCALIZATIONS: dict[str, dict[str, str]] = {
     "zh-hans": {
-        "Google Lens language code such as en, zh-CN, or zh-TW (default: en)": (
-            "Google Lens 语言代码，例如 en、zh-CN 或 zh-TW（默认：en）"
+        "language of the OCR text to recognize (default: %(default)s)": (
+            "要识别的 OCR 文本语言（默认：%(default)s）"
         ),
         "Google Lens request attempts per uncached image (default: %(default)s)": (
             "每张未缓存图像的 Google Lens 请求尝试次数（默认：%(default)s）"
@@ -38,8 +40,8 @@ OCR_LENS_LOCALIZATIONS: dict[str, dict[str, str]] = {
         "recognized subtitle outfile path": "识别后字幕输出文件路径",
     },
     "zh-hant": {
-        "Google Lens language code such as en, zh-CN, or zh-TW (default: en)": (
-            "Google Lens 語言代碼，例如 en、zh-CN 或 zh-TW（預設：en）"
+        "language of the OCR text to recognize (default: %(default)s)": (
+            "要識別的 OCR 文字語言（預設：%(default)s）"
         ),
         "Google Lens request attempts per uncached image (default: %(default)s)": (
             "每張未快取影像的 Google Lens 請求嘗試次數（預設：%(default)s）"
@@ -94,8 +96,10 @@ class OcrLensCli(ScinoephileCliBase):
         # Operation arguments
         arg_groups["operation arguments"].add_argument(
             "--language",
-            default="en",
-            help="Google Lens language code such as en, zh-CN, or zh-TW (default: en)",
+            default=Language.eng,
+            metavar=enum_metavar(Language),
+            type=enum_arg(Language),
+            help="language of the OCR text to recognize (default: %(default)s)",
         )
         arg_groups["operation arguments"].add_argument(
             "--retries",
@@ -136,7 +140,7 @@ class OcrLensCli(ScinoephileCliBase):
         *,
         _parser: ArgumentParser | None = None,
         infile_path: Path,
-        language: str,
+        language: Language,
         outfile_path: Path,
         overwrite: bool,
         retries: int,

--- a/scinoephile/cli/ocr/ocr_paddle_cli.py
+++ b/scinoephile/cli/ocr/ocr_paddle_cli.py
@@ -9,11 +9,13 @@ from pathlib import Path
 
 from scinoephile.cli.helpers.io import read_image_series, write_series
 from scinoephile.common.argument_parsing import (
+    enum_arg,
+    enum_metavar,
     get_arg_groups_by_name,
     input_file_or_dir_arg,
     output_file_arg,
 )
-from scinoephile.core import ScinoephileError
+from scinoephile.core import Language, ScinoephileError
 from scinoephile.core.cli import ScinoephileCliBase
 from scinoephile.image.ocr.paddle import ocr_image_series_with_paddle
 
@@ -21,12 +23,8 @@ __all__ = ["OcrPaddleCli"]
 
 OCR_PADDLE_LOCALIZATIONS: dict[str, dict[str, str]] = {
     "zh-hans": {
-        (
-            "PaddleOCR language code: en (English), ch (simplified Chinese "
-            "and English), chinese_cht (traditional Chinese)"
-        ): (
-            "PaddleOCR 语言代码：en（英语），ch（简体中文和英语），"
-            "chinese_cht（繁体中文）"
+        "language of the OCR text to recognize (default: %(default)s)": (
+            "要识别的 OCR 文本语言（默认：%(default)s）"
         ),
         "PaddleOCR requires the optional PaddleOCR runtime dependencies.": (
             "PaddleOCR 需要可选的 PaddleOCR 运行时依赖。"
@@ -39,12 +37,8 @@ OCR_PADDLE_LOCALIZATIONS: dict[str, dict[str, str]] = {
         "recognized subtitle outfile path": "识别后字幕输出文件路径",
     },
     "zh-hant": {
-        (
-            "PaddleOCR language code: en (English), ch (simplified Chinese "
-            "and English), chinese_cht (traditional Chinese)"
-        ): (
-            "PaddleOCR 語言代碼：en（英語），ch（簡體中文和英語），"
-            "chinese_cht（繁體中文）"
+        "language of the OCR text to recognize (default: %(default)s)": (
+            "要識別的 OCR 文字語言（預設：%(default)s）"
         ),
         "PaddleOCR requires the optional PaddleOCR runtime dependencies.": (
             "PaddleOCR 需要可選的 PaddleOCR 執行時依賴。"
@@ -100,12 +94,10 @@ class OcrPaddleCli(ScinoephileCliBase):
         # Operation arguments
         arg_groups["operation arguments"].add_argument(
             "--language",
-            choices=("ch", "chinese_cht", "en"),
-            default="en",
-            help=(
-                "PaddleOCR language code: en (English), ch (simplified Chinese "
-                "and English), chinese_cht (traditional Chinese)"
-            ),
+            default=Language.eng,
+            metavar=enum_metavar(Language),
+            type=enum_arg(Language),
+            help="language of the OCR text to recognize (default: %(default)s)",
         )
 
         # Output arguments
@@ -139,7 +131,7 @@ class OcrPaddleCli(ScinoephileCliBase):
         _parser: ArgumentParser | None = None,
         infile_path: Path,
         outfile_path: Path,
-        language: str,
+        language: Language,
         overwrite: bool,
     ):
         """Execute with provided keyword arguments."""

--- a/scinoephile/cli/ocr/ocr_tesseract_cli.py
+++ b/scinoephile/cli/ocr/ocr_tesseract_cli.py
@@ -9,11 +9,13 @@ from pathlib import Path
 
 from scinoephile.cli.helpers.io import read_image_series, write_series
 from scinoephile.common.argument_parsing import (
+    enum_arg,
+    enum_metavar,
     get_arg_groups_by_name,
     input_file_or_dir_arg,
     output_file_arg,
 )
-from scinoephile.core import ScinoephileError
+from scinoephile.core import Language, ScinoephileError
 from scinoephile.core.cli import ScinoephileCliBase
 from scinoephile.image.ocr.tesseract import ocr_image_series_with_tesseract
 
@@ -24,9 +26,8 @@ OCR_TESSERACT_LOCALIZATIONS: dict[str, dict[str, str]] = {
         "Recognize image subtitles with Tesseract OCR.": (
             "使用 Tesseract OCR 识别图像字幕。"
         ),
-        "Tesseract language code installed in Tesseract, such as eng or chi_sim "
-        "(default: %(default)s)": (
-            "Tesseract 中已安装的语言代码，例如 eng 或 chi_sim（默认：%(default)s）"
+        "language of the OCR text to recognize (default: %(default)s)": (
+            "要识别的 OCR 文本语言（默认：%(default)s）"
         ),
         "Tesseract requires the system tesseract executable and language data.": (
             "Tesseract 需要系统 tesseract 可执行文件和语言数据。"
@@ -44,9 +45,8 @@ OCR_TESSERACT_LOCALIZATIONS: dict[str, dict[str, str]] = {
         "Recognize image subtitles with Tesseract OCR.": (
             "使用 Tesseract OCR 識別影像字幕。"
         ),
-        "Tesseract language code installed in Tesseract, such as eng or chi_sim "
-        "(default: %(default)s)": (
-            "Tesseract 中已安裝的語言代碼，例如 eng 或 chi_sim（預設：%(default)s）"
+        "language of the OCR text to recognize (default: %(default)s)": (
+            "要識別的 OCR 文字語言（預設：%(default)s）"
         ),
         "Tesseract requires the system tesseract executable and language data.": (
             "Tesseract 需要系統 tesseract 可執行檔和語言資料。"
@@ -104,11 +104,10 @@ class OcrTesseractCli(ScinoephileCliBase):
         # Operation arguments
         arg_groups["operation arguments"].add_argument(
             "--language",
-            default="eng",
-            help=(
-                "Tesseract language code installed in Tesseract, such as eng or "
-                "chi_sim (default: %(default)s)"
-            ),
+            default=Language.eng,
+            metavar=enum_metavar(Language),
+            type=enum_arg(Language),
+            help="language of the OCR text to recognize (default: %(default)s)",
         )
         arg_groups["operation arguments"].add_argument(
             "--detect-italics",
@@ -148,7 +147,7 @@ class OcrTesseractCli(ScinoephileCliBase):
         infile_path: Path,
         outfile_path: Path,
         detect_italics: bool,
-        language: str,
+        language: Language,
         overwrite: bool,
     ):
         """Execute with provided keyword arguments."""
@@ -156,7 +155,7 @@ class OcrTesseractCli(ScinoephileCliBase):
         parser = _parser or cls.argparser()
         if outfile_path.exists() and not overwrite:
             parser.error(f"{outfile_path} already exists")
-        if detect_italics and language != "eng":
+        if detect_italics and language is not Language.eng:
             parser.error("--detect-italics may only be used with --language eng")
 
         # Read inputs

--- a/scinoephile/lang/zho/subtitles/analysis.py
+++ b/scinoephile/lang/zho/subtitles/analysis.py
@@ -10,6 +10,7 @@ from dataclasses import asdict, dataclass
 from logging import getLogger
 from pathlib import Path
 
+from scinoephile.core import Language
 from scinoephile.core.language import is_chinese_language_tag
 from scinoephile.core.media import SubtitleStream
 from scinoephile.core.paths import get_runtime_cache_dir_path
@@ -25,8 +26,8 @@ __all__ = [
 
 _DEFAULT_ZHO_SUBTITLE_SAMPLE_SIZE = 4
 """Default number of image subtitle samples to OCR."""
-_ZHO_SUBTITLE_OCR_LANGUAGES = ("ch", "chinese_cht")
-"""PaddleOCR languages to compare for Chinese subtitle script analysis."""
+_ZHO_SUBTITLE_OCR_LANGUAGES = (Language.zho_hans, Language.zho_hant)
+"""Languages to compare for Chinese subtitle script analysis."""
 
 logger = getLogger(__name__)
 
@@ -171,7 +172,7 @@ def _get_image_subtitle_sample_analysis(
         traditional_count=reference_analysis.traditional_count,
         shared_count=reference_analysis.shared_count,
         sample_indexes=tuple(sample_indexes),
-        ocr_languages=_ZHO_SUBTITLE_OCR_LANGUAGES,
+        ocr_languages=tuple(language.tag for language in _ZHO_SUBTITLE_OCR_LANGUAGES),
         failure_reason=failure_reason,
     )
 
@@ -204,7 +205,9 @@ def _get_subtitle_analysis_cache_path(
         "stream_index": stream.index,
         "codec_name": stream.codec_name,
         "sample_size": sample_size,
-        "ocr_languages": _ZHO_SUBTITLE_OCR_LANGUAGES,
+        "ocr_languages": tuple(
+            language.tag for language in _ZHO_SUBTITLE_OCR_LANGUAGES
+        ),
     }
     encoded_payload = json.dumps(payload, sort_keys=True).encode("utf-8")
     cache_key = hashlib.sha256(encoded_payload).hexdigest()

--- a/test/cli/ocr/test_ocr_cli.py
+++ b/test/cli/ocr/test_ocr_cli.py
@@ -19,6 +19,7 @@ from scinoephile.cli.ocr import (
 from scinoephile.common import CommandLineInterface
 from scinoephile.common.file import get_temp_file_path
 from scinoephile.common.testing import run_cli_with_args
+from scinoephile.core import Language
 from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.image.subtitles import ImageSeries
 from test.helpers import (
@@ -85,6 +86,8 @@ def test_ocr_lens_cli_help_lists_language_and_retry_options_only():
     assert stderr.getvalue() == ""
     help_text = " ".join(stdout.getvalue().split())
     assert "--language" in help_text
+    assert "{eng,zho-Hans,zho-Hant}" in help_text
+    assert "zh-CN" not in help_text
     assert "--retries" in help_text
     assert "--api-key" not in help_text
     assert "--client-region" not in help_text
@@ -134,19 +137,20 @@ def test_ocr_lens_cli_converts_image_subtitles_to_srt(
     output_path = tmp_path / "ocr.srt"
     run_cli_with_args(
         OcrLensCli,
-        f"--infile {input_path} --outfile {output_path} --language zh-CN --retries 5",
+        f"--infile {input_path} --outfile {output_path} "
+        "--language zho-Hans --retries 5",
     )
 
     assert input_paths == [input_path.resolve()]
-    assert observed_kwargs == [{"language": "zh-CN", "retries": 5}]
+    assert observed_kwargs == [{"language": Language.zho_hans, "retries": 5}]
     output = Series.load(output_path)
     assert [(event.start, event.end, event.text) for event in output] == [
         (1000, 2000, "recognized")
     ]
 
 
-def test_ocr_paddle_cli_help_lists_language_codes():
-    """Test PaddleOCR CLI help lists common subtitle language codes."""
+def test_ocr_paddle_cli_help_lists_language_options():
+    """Test PaddleOCR CLI help lists supported Scinoephile language options."""
     stdout = StringIO()
     stderr = StringIO()
     with pytest.raises(SystemExit) as excinfo:
@@ -157,13 +161,12 @@ def test_ocr_paddle_cli_help_lists_language_codes():
     assert excinfo.value.code == 0
     assert stderr.getvalue() == ""
     help_text = " ".join(stdout.getvalue().split())
-    assert "en (English)" in help_text
-    assert "ch (simplified Chinese and English)" in help_text
-    assert "chinese_cht (traditional Chinese)" in help_text
+    assert "{eng,zho-Hans,zho-Hant}" in help_text
+    assert "chinese_cht" not in help_text
 
 
-def test_ocr_tesseract_cli_help_lists_default_language():
-    """Test Tesseract OCR CLI help lists default language code."""
+def test_ocr_tesseract_cli_help_lists_language_options():
+    """Test Tesseract OCR CLI help lists supported Scinoephile language options."""
     stdout = StringIO()
     stderr = StringIO()
     with pytest.raises(SystemExit) as excinfo:
@@ -174,8 +177,8 @@ def test_ocr_tesseract_cli_help_lists_default_language():
     assert excinfo.value.code == 0
     assert stderr.getvalue() == ""
     help_text = " ".join(stdout.getvalue().split())
-    assert "Tesseract language code installed in Tesseract" in help_text
-    assert "such as eng or chi_sim (default: eng)" in help_text
+    assert "{eng,zho-Hans,zho-Hant}" in help_text
+    assert "chi_sim" not in help_text
     assert "run a second legacy-engine pass to detect italic text" in help_text
 
 
@@ -197,6 +200,7 @@ def test_ocr_paddle_cli_converts_image_subtitles_to_srt(
         tiny_image_series,
     )
     input_path = _write_placeholder_sup_path(tmp_path)
+    observed_kwargs = []
 
     def fake_ocr_image_series_with_paddle(*args: object, **kwargs: object) -> Series:
         """Fake PaddleOCR image series processing.
@@ -207,6 +211,7 @@ def test_ocr_paddle_cli_converts_image_subtitles_to_srt(
         Returns:
             text subtitle series
         """
+        observed_kwargs.append(kwargs)
         return Series(events=[Subtitle(start=1000, end=2000, text="recognized")])
 
     monkeypatch.setattr(
@@ -217,10 +222,11 @@ def test_ocr_paddle_cli_converts_image_subtitles_to_srt(
     output_path = tmp_path / "ocr.srt"
     run_cli_with_args(
         OcrPaddleCli,
-        f"--infile {input_path} --outfile {output_path}",
+        f"--infile {input_path} --language zho-Hant --outfile {output_path}",
     )
 
     assert input_paths == [input_path.resolve()]
+    assert observed_kwargs == [{"language": Language.zho_hant}]
     output = Series.load(output_path)
     assert [(event.start, event.end, event.text) for event in output] == [
         (1000, 2000, "recognized")
@@ -257,7 +263,7 @@ def test_ocr_tesseract_cli_converts_image_subtitles_to_srt(
         """
         assert kwargs == {
             "detect_italics": False,
-            "language": "eng",
+            "language": Language.eng,
         }
         return Series(events=[Subtitle(start=1000, end=2000, text="recognized")])
 
@@ -309,7 +315,7 @@ def test_ocr_tesseract_cli_passes_italic_detection_options(
         """
         assert kwargs == {
             "detect_italics": True,
-            "language": "eng",
+            "language": Language.eng,
         }
         return Series(events=[Subtitle(start=1000, end=2000, text="recognized")])
 
@@ -358,7 +364,7 @@ def test_ocr_tesseract_cli_rejects_italic_detection_for_non_english(
             run_cli_with_args(
                 OcrTesseractCli,
                 f"--infile {input_path} "
-                "--language chi_sim "
+                "--language zho-Hans "
                 "--detect-italics "
                 f"--outfile {output_path}",
             )
@@ -382,16 +388,16 @@ def test_ocr_tesseract_cli_rejects_italic_detection_for_non_english(
             "scinoephile.cli.helpers.io.ImageSeries.load",
             "scinoephile.cli.ocr.ocr_lens_cli.ocr_image_series_with_lens",
             "scinoephile.cli.ocr.ocr_lens_cli.write_series",
-            "--language zh-CN --retries 5",
-            {"language": "zh-CN", "retries": 5},
+            "--language zho-Hans --retries 5",
+            {"language": Language.zho_hans, "retries": 5},
         ),
         (
             OcrPaddleCli,
             "scinoephile.cli.helpers.io.ImageSeries.load",
             "scinoephile.cli.ocr.ocr_paddle_cli.ocr_image_series_with_paddle",
             "scinoephile.cli.ocr.ocr_paddle_cli.write_series",
-            "--language ch",
-            {"language": "ch"},
+            "--language zho-Hans",
+            {"language": Language.zho_hans},
         ),
         (
             OcrTesseractCli,
@@ -399,7 +405,7 @@ def test_ocr_tesseract_cli_rejects_italic_detection_for_non_english(
             "scinoephile.cli.ocr.ocr_tesseract_cli.ocr_image_series_with_tesseract",
             "scinoephile.cli.ocr.ocr_tesseract_cli.write_series",
             "--detect-italics",
-            {"detect_italics": True, "language": "eng"},
+            {"detect_italics": True, "language": Language.eng},
         ),
     ],
 )
@@ -514,7 +520,7 @@ def test_ocr_lens_cli_matches_mlamd_sup_ocr_fixture(
         run_cli_with_args(
             OcrLensCli,
             f"--infile {full_sup_path} "
-            "--language en "
+            "--language eng "
             f"--outfile {output_path} "
             "--overwrite",
         )
@@ -538,12 +544,12 @@ def test_ocr_lens_cli_matches_mlamd_sup_ocr_fixture(
     [
         (
             "mlamd/input/zho-Hans_ocr/source.sup",
-            "ch",
+            "zho-Hans",
             "mlamd/output/zho-Hans_ocr/paddle.srt",
         ),
         (
             "mlamd/input/zho-Hant_ocr/source.sup",
-            "chinese_cht",
+            "zho-Hant",
             "mlamd/output/zho-Hant_ocr/paddle.srt",
         ),
     ],
@@ -560,7 +566,7 @@ def test_ocr_paddle_cli_matches_mlamd_sup_ocr_fixtures(
     Arguments:
         monkeypatch: pytest monkeypatch fixture
         sup_path: source SUP subtitle path
-        language: PaddleOCR language code
+        language: Scinoephile language tag
         expected_path: expected OCR subtitle fixture path
         tmp_path: temporary path fixture
     """

--- a/test/cli/test_cli_argument_choices.py
+++ b/test/cli/test_cli_argument_choices.py
@@ -10,7 +10,10 @@ import pytest
 
 from scinoephile.cli.multi.multi_stack_cli import MultiStackCli
 from scinoephile.cli.ocr.ocr_fuse_cli import OcrFuseCli
+from scinoephile.cli.ocr.ocr_lens_cli import OcrLensCli
+from scinoephile.cli.ocr.ocr_paddle_cli import OcrPaddleCli
 from scinoephile.cli.ocr.ocr_process_cli import OcrProcessCli
+from scinoephile.cli.ocr.ocr_tesseract_cli import OcrTesseractCli
 from scinoephile.cli.ocr.ocr_validate_cli import OcrValidateCli
 from scinoephile.cli.yue.yue_process_cli import YueProcessCli
 from scinoephile.cli.yue.yue_review_vs_zho_cli import YueReviewVsZhoCli
@@ -27,8 +30,11 @@ from scinoephile.common import CommandLineInterface
     ("cli", "option", "metavar"),
     [
         (OcrFuseCli, "--language", "{eng,zho}"),
+        (OcrLensCli, "--language", "{eng,zho-Hans,zho-Hant}"),
+        (OcrPaddleCli, "--language", "{eng,zho-Hans,zho-Hant}"),
         (OcrProcessCli, "--language", "{eng,zho}"),
         (OcrProcessCli, "--script", "{simplified,traditional}"),
+        (OcrTesseractCli, "--language", "{eng,zho-Hans,zho-Hant}"),
         (OcrValidateCli, "--language", "{eng,zho}"),
         (MultiStackCli, "--sync", "{anchor-top,anchor-bottom,off}"),
         (YueProcessCli, "--proofread", "{simplified,traditional}"),

--- a/test/media/test_subtitle_analysis.py
+++ b/test/media/test_subtitle_analysis.py
@@ -12,7 +12,7 @@ import ffmpeg
 import pytest
 from PIL import Image
 
-from scinoephile.core import ScinoephileError
+from scinoephile.core import Language, ScinoephileError
 from scinoephile.core.media import SubtitleStream
 from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.image.subtitles import ImageSeries, ImageSubtitle
@@ -260,8 +260,9 @@ def test_analyze_image_subtitle_stream_uses_cached_sampled_pngs(
     def fake_ocr_image_series_with_paddle(
         sampled_series: ImageSeries,
         *,
-        language: str,
+        language: Language,
     ) -> Series:
+        assert language in (Language.zho_hans, Language.zho_hant)
         ocr_sizes.append(
             [cast(ImageSubtitle, event).img.size for event in sampled_series]
         )


### PR DESCRIPTION
## Summary
- Update Lens, PaddleOCR, and Tesseract engine CLIs to parse `--language` as `scinoephile.core.Language` with shared enum metavar/help text.
- Pass `Language.zho_hans` and `Language.zho_hant` to PaddleOCR during Chinese image subtitle analysis while keeping cache-facing OCR language fields as strings.
- Update targeted CLI and subtitle-analysis tests for Scinoephile language tags and `Language` values.

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/cli/ocr/ocr_lens_cli.py scinoephile/cli/ocr/ocr_paddle_cli.py scinoephile/cli/ocr/ocr_tesseract_cli.py scinoephile/lang/zho/subtitles/analysis.py test/cli/ocr/test_ocr_cli.py test/cli/test_cli_argument_choices.py test/media/test_subtitle_analysis.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/cli/ocr/ocr_lens_cli.py scinoephile/cli/ocr/ocr_paddle_cli.py scinoephile/cli/ocr/ocr_tesseract_cli.py scinoephile/lang/zho/subtitles/analysis.py test/cli/ocr/test_ocr_cli.py test/cli/test_cli_argument_choices.py test/media/test_subtitle_analysis.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/cli/ocr/ocr_lens_cli.py scinoephile/cli/ocr/ocr_paddle_cli.py scinoephile/cli/ocr/ocr_tesseract_cli.py scinoephile/lang/zho/subtitles/analysis.py test/cli/ocr/test_ocr_cli.py test/cli/test_cli_argument_choices.py test/media/test_subtitle_analysis.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest cli/ocr/test_ocr_cli.py cli/test_cli_argument_choices.py media/test_subtitle_analysis.py`