### PR TITLE
Add subtitle workflow helpers

### DIFF
--- a/scinoephile/image/subtitles/series.py
+++ b/scinoephile/image/subtitles/series.py
@@ -126,6 +126,19 @@ class ImageSeries(Series):
         """
         self._blocks = blocks
 
+    def copy_text_from(self, source: Series):
+        """Copy subtitle text from a source series into this image series.
+
+        Arguments:
+            source: source text subtitle series
+        Raises:
+            ScinoephileError: if source and image subtitle counts differ
+        """
+        if len(source) != len(self):
+            raise ScinoephileError(f"Length mismatch: {len(source)} vs {len(self)}")
+        for source_subtitle, image_subtitle in zip(source, self.events):
+            image_subtitle.text = source_subtitle.text
+
     @override
     def save(
         self,

--- a/scinoephile/media/subtitles/__init__.py
+++ b/scinoephile/media/subtitles/__init__.py
@@ -3,7 +3,7 @@
 """Subtitle media helpers.
 
 Package hierarchy (modules may import from any above):
-* cache
+* cache / selection
 * extraction / stats
 * details
 """

--- a/scinoephile/media/subtitles/selection.py
+++ b/scinoephile/media/subtitles/selection.py
@@ -1,0 +1,47 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Subtitle stream selection from media files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scinoephile.core import ScinoephileError
+from scinoephile.core.media import SubtitleStream
+from scinoephile.media.probe import get_subtitle_streams
+
+__all__ = ["get_media_subtitle_stream"]
+
+
+def get_media_subtitle_stream(
+    infile_path: Path,
+    stream_index: int | None,
+) -> SubtitleStream:
+    """Get selected image-based subtitle stream from a media input.
+
+    Arguments:
+        infile_path: media input file
+        stream_index: selected subtitle stream index
+    Returns:
+        selected subtitle stream
+    Raises:
+        ScinoephileError: if stream selection fails
+    """
+    if stream_index is None:
+        raise ScinoephileError("stream index is required for media OCR input")
+
+    try:
+        streams = get_subtitle_streams(infile_path)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise ScinoephileError(
+            f"Unable to inspect subtitle streams in {infile_path}: {exc}"
+        ) from exc
+
+    for stream in streams:
+        if stream.index == stream_index:
+            if stream.extension != "sup":
+                raise ScinoephileError(
+                    f"Subtitle stream {stream_index} is not an image-based SUP stream"
+                )
+            return stream
+    raise ScinoephileError(f"No subtitle stream {stream_index} found in {infile_path}")

--- a/test/image/subtitles/test_image_series.py
+++ b/test/image/subtitles/test_image_series.py
@@ -11,6 +11,7 @@ from PIL import Image
 
 from scinoephile.common.file import get_temp_directory_path
 from scinoephile.core import ScinoephileError
+from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.image.bbox import Bbox
 from scinoephile.image.subtitles import ImageSeries, ImageSubtitle
 
@@ -108,6 +109,49 @@ def test_image_series_load_wraps_input_path_errors(tmp_path: Path):
         ImageSeries.load(input_path)
 
     assert isinstance(excinfo.value.__cause__, OSError)
+
+
+def test_copy_text_from_mutates_image_subtitle_texts():
+    """Test copying text from a text series mutates image subtitles in place."""
+    image_subtitle = ImageSubtitle(
+        start=1000,
+        end=2000,
+        img=Image.new("LA", (2, 2), (0, 255)),
+        bboxes=[Bbox(0, 1, 2, 3)],
+        text="old",
+    )
+    image_series = ImageSeries(events=[image_subtitle])
+    text_series = Series(events=[Subtitle(start=1100, end=2100, text="new")])
+
+    image_series.copy_text_from(text_series)
+
+    assert image_series.events[0] is image_subtitle
+    assert image_series.events[0].start == 1000
+    assert image_series.events[0].end == 2000
+    assert image_series.events[0].text == "new"
+    assert image_series.events[0].bboxes == [Bbox(0, 1, 2, 3)]
+
+
+def test_copy_text_from_rejects_length_mismatch():
+    """Test copying text rejects length mismatches."""
+    image_series = ImageSeries(
+        events=[
+            ImageSubtitle(
+                start=1000,
+                end=2000,
+                img=Image.new("LA", (2, 2), (0, 255)),
+            )
+        ]
+    )
+    text_series = Series(
+        events=[
+            Subtitle(start=1000, end=2000, text="one"),
+            Subtitle(start=3000, end=4000, text="two"),
+        ]
+    )
+
+    with pytest.raises(ScinoephileError, match="Length mismatch: 2 vs 1"):
+        image_series.copy_text_from(text_series)
 
 
 def test_save_html(tiny_image_series: ImageSeries):

--- a/test/media/test_subtitles.py
+++ b/test/media/test_subtitles.py
@@ -13,6 +13,7 @@ from scinoephile.core import ScinoephileError
 from scinoephile.core.media import SubtitleStream
 from scinoephile.media.subtitles.cache import get_subtitle_cache_path
 from scinoephile.media.subtitles.extraction import extract_subtitle_stream
+from scinoephile.media.subtitles.selection import get_media_subtitle_stream
 
 
 def test_extract_subtitle_stream_copies_cached_stream(tmp_path: Path, caplog):
@@ -103,3 +104,69 @@ def test_extract_subtitle_stream_rejects_unknown_codec(tmp_path: Path):
             outfile_path=outfile_path,
             cache_dir_path=tmp_path / "cache",
         )
+
+
+def test_get_media_subtitle_stream_returns_matching_sup_stream(tmp_path: Path):
+    """Test media subtitle stream selection returns the matching SUP stream."""
+    infile_path = tmp_path / "video.mkv"
+    infile_path.touch()
+    stream = SubtitleStream(index=5, codec_name="hdmv_pgs_subtitle")
+
+    with patch(
+        "scinoephile.media.subtitles.selection.get_subtitle_streams",
+        return_value=[stream],
+    ) as get_subtitle_streams:
+        selected_stream = get_media_subtitle_stream(infile_path, 5)
+
+    assert selected_stream is stream
+    get_subtitle_streams.assert_called_once_with(infile_path)
+
+
+def test_get_media_subtitle_stream_requires_stream_index(tmp_path: Path):
+    """Test media subtitle stream selection requires a stream index."""
+    infile_path = tmp_path / "video.mkv"
+    infile_path.touch()
+
+    with pytest.raises(
+        ScinoephileError,
+        match="stream index is required for media OCR input",
+    ):
+        get_media_subtitle_stream(infile_path, None)
+
+
+def test_get_media_subtitle_stream_rejects_non_sup_stream(tmp_path: Path):
+    """Test media subtitle stream selection rejects non-SUP subtitle streams."""
+    infile_path = tmp_path / "video.mkv"
+    infile_path.touch()
+
+    with (
+        patch(
+            "scinoephile.media.subtitles.selection.get_subtitle_streams",
+            return_value=[SubtitleStream(index=5, codec_name="subrip")],
+        ),
+        pytest.raises(
+            ScinoephileError,
+            match="Subtitle stream 5 is not an image-based SUP stream",
+        ),
+    ):
+        get_media_subtitle_stream(infile_path, 5)
+
+
+def test_get_media_subtitle_stream_wraps_probe_errors(tmp_path: Path):
+    """Test media subtitle stream selection wraps probe failures."""
+    infile_path = tmp_path / "video.mkv"
+    infile_path.touch()
+
+    with (
+        patch(
+            "scinoephile.media.subtitles.selection.get_subtitle_streams",
+            side_effect=RuntimeError("ffprobe failed"),
+        ),
+        pytest.raises(
+            ScinoephileError,
+            match="Unable to inspect subtitle streams in .*video.mkv.*ffprobe failed",
+        ) as excinfo,
+    ):
+        get_media_subtitle_stream(infile_path, 5)
+
+    assert isinstance(excinfo.value.__cause__, RuntimeError)


### PR DESCRIPTION
## Summary
- Add `ImageSeries.copy_text_from(...)` to copy text into existing image subtitle events without changing timing, image data, or bounding boxes.
- Add media subtitle stream selection for required SUP/image subtitle streams.
- Add focused tests for the new helpers.

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/image/subtitles/series.py scinoephile/media/subtitles/__init__.py scinoephile/media/subtitles/selection.py test/image/subtitles/test_image_series.py test/media/test_subtitles.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/image/subtitles/series.py scinoephile/media/subtitles/__init__.py scinoephile/media/subtitles/selection.py test/image/subtitles/test_image_series.py test/media/test_subtitles.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/image/subtitles/series.py scinoephile/media/subtitles/__init__.py scinoephile/media/subtitles/selection.py test/image/subtitles/test_image_series.py test/media/test_subtitles.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest image/subtitles/test_image_series.py media/test_subtitles.py`