### PR TITLE
Clarify style guidance for errors and CLI modules

### DIFF
--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -59,9 +59,11 @@
   when the shape is known.
 
 ## Exceptions
-* Prefer repository-specific exceptions from for domain-specific errors that should be user-facing.
-* Prefer built-in exceptions such as `ValueError` and `TypeError` for programming errors or invalid internal state.
-* When wrapping a caught exception, use exception chaining with `raise ... from err` to preserve context.
+* Raise `ScinoephileError` for Scinoephile domain failures that should be shown directly to CLI users.
+* Raise built-in exceptions such as `ValueError`, `TypeError`, `IndexError`, and `OSError` subclasses for programming errors, generic validation failures, and low-level helper or parser failures.
+* Public Scinoephile operations should wrap lower-level exceptions in `ScinoephileError` when callers should not need to know implementation-specific failure types.
+* CLI implementations should generally catch `ScinoephileError` and convert it to `parser.error(...)`.
+* When wrapping a caught exception, use exception chaining with `raise ... from exc` to preserve context.
 
 ## Logging
 * Use the `logging` module rather than `print` for any user-facing output in scripts or libraries.


### PR DESCRIPTION
## Summary

- Documentation-only split from the OCR validation web branch.
- Clarifies when to raise `ScinoephileError` versus built-in exceptions.
- Documents public-boundary exception wrapping, CLI conversion to `parser.error(...)`, and preserving exception chaining with `raise ... from exc`.

## Validation

- `git diff --name-status master...HEAD` reports only `M docs/STYLE.md`.
- Python lint/type/test commands were not run because this PR changes only Markdown documentation.