### PR TITLE
Clean up OCR engine CLI error boundaries

### DIFF
--- a/scinoephile/cli/ocr/ocr_lens_cli.py
+++ b/scinoephile/cli/ocr/ocr_lens_cli.py
@@ -161,14 +161,7 @@ class OcrLensCli(ScinoephileCliBase):
                 language=language,
                 retries=retries,
             )
-        except (
-            ImportError,
-            NotADirectoryError,
-            OSError,
-            RuntimeError,
-            ScinoephileError,
-            ValueError,
-        ) as exc:
+        except ScinoephileError as exc:
             parser.error(str(exc))
 
         # Write outputs

--- a/scinoephile/cli/ocr/ocr_paddle_cli.py
+++ b/scinoephile/cli/ocr/ocr_paddle_cli.py
@@ -149,13 +149,7 @@ class OcrPaddleCli(ScinoephileCliBase):
                 image_series,
                 language=language,
             )
-        except (
-            FileNotFoundError,
-            NotADirectoryError,
-            ImportError,
-            ScinoephileError,
-            ValueError,
-        ) as exc:
+        except ScinoephileError as exc:
             parser.error(str(exc))
 
         # Write outputs

--- a/scinoephile/cli/ocr/ocr_tesseract_cli.py
+++ b/scinoephile/cli/ocr/ocr_tesseract_cli.py
@@ -168,11 +168,7 @@ class OcrTesseractCli(ScinoephileCliBase):
                 detect_italics=detect_italics,
                 language=language,
             )
-        except (
-            ImportError,
-            ScinoephileError,
-            ValueError,
-        ) as exc:
+        except ScinoephileError as exc:
             parser.error(str(exc))
 
         # Write outputs

--- a/test/cli/ocr/test_ocr_cli.py
+++ b/test/cli/ocr/test_ocr_cli.py
@@ -226,6 +226,7 @@ def test_ocr_paddle_cli_converts_image_subtitles_to_srt(
     )
 
     assert input_paths == [input_path.resolve()]
+    assert output_path.exists()
     assert observed_kwargs == [{"language": Language.zho_hant}]
     output = Series.load(output_path)
     assert [(event.start, event.end, event.text) for event in output] == [


### PR DESCRIPTION
## Summary
- Narrow OCR engine CLI error boundaries so they catch `ScinoephileError`, relying on recognizer/workflow layers to wrap user-facing lower-level failures.
- Keep the Paddle CLI regression assertion that verifies the output file is written.
- Split this focused cleanup out from the OCR validation web work; this PR contains no web UI, validation workflow, Flask dependency, package data, or `ValidationManager` changes.

## Notes
- I checked the optional OCR import `ty: ignore[unresolved-import]` comments, but `ty` still requires them on the updated `master` base because `chrome_lens_py` and `paddleocr` are optional and not installed in the focused environment.

## Checks
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/cli/ocr/ocr_lens_cli.py scinoephile/cli/ocr/ocr_paddle_cli.py scinoephile/cli/ocr/ocr_tesseract_cli.py scinoephile/image/ocr/lens/lens_recognizer.py scinoephile/image/ocr/paddle/paddle_recognizer.py test/cli/ocr/test_ocr_cli.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/cli/ocr/ocr_lens_cli.py scinoephile/cli/ocr/ocr_paddle_cli.py scinoephile/cli/ocr/ocr_tesseract_cli.py scinoephile/image/ocr/lens/lens_recognizer.py scinoephile/image/ocr/paddle/paddle_recognizer.py test/cli/ocr/test_ocr_cli.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/cli/ocr/ocr_lens_cli.py scinoephile/cli/ocr/ocr_paddle_cli.py scinoephile/cli/ocr/ocr_tesseract_cli.py scinoephile/image/ocr/lens/lens_recognizer.py scinoephile/image/ocr/paddle/paddle_recognizer.py test/cli/ocr/test_ocr_cli.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest cli/ocr/test_ocr_cli.py`