### PR TITLE
Handle malformed SUP streams during subtitle extraction

### DIFF
--- a/scinoephile/media/subtitles/cache.py
+++ b/scinoephile/media/subtitles/cache.py
@@ -29,6 +29,7 @@ def cache_subtitles(
     streams: list[SubtitleStream],
     *,
     cache_dir_path: Path | None = None,
+    render_images: bool = True,
 ):
     """Cache extracted subtitle streams.
 
@@ -36,6 +37,7 @@ def cache_subtitles(
         infile_path: media input file
         streams: subtitle streams to cache
         cache_dir_path: cache directory path
+        render_images: whether to render SUP streams to image directories
     """
     # Validate arguments
     if cache_dir_path is None:
@@ -83,22 +85,13 @@ def cache_subtitles(
         for _, stream_path in missing:
             logger.info(f"Saved subtitle stream to cache: {stream_path}")
 
-    # Render cached SUP subtitle streams to image directories
-    for stream in streams:
-        if stream.extension != "sup":
-            continue
-        stream_path = get_subtitle_cache_path(
+    # Render cached SUP subtitle streams to image directories when requested
+    if render_images:
+        _cache_image_subtitle_series(
             infile_path,
-            stream,
+            streams,
             cache_dir_path=cache_dir_path,
         )
-        image_dir_path = stream_path.parent / "image-series"
-        if (image_dir_path / "index.html").exists():
-            logger.info(f"Loaded image subtitle series from cache: {image_dir_path}")
-            continue
-        image_series = ImageSeries.load(stream_path)
-        image_series.save(image_dir_path)
-        logger.info(f"Saved image subtitle series to cache: {image_dir_path}")
 
 
 def get_subtitle_cache_path(
@@ -132,3 +125,33 @@ def get_subtitle_cache_path(
     encoded_payload = json.dumps(payload, sort_keys=True).encode("utf-8")
     cache_key = hashlib.sha256(encoded_payload).hexdigest()
     return cache_dir_path / cache_key / f"{stream.index}.{stream.extension}"
+
+
+def _cache_image_subtitle_series(
+    infile_path: Path,
+    streams: list[SubtitleStream],
+    *,
+    cache_dir_path: Path,
+):
+    """Render cached SUP subtitle streams to image directories.
+
+    Arguments:
+        infile_path: media input file
+        streams: subtitle streams to cache
+        cache_dir_path: cache directory path
+    """
+    for stream in streams:
+        if stream.extension != "sup":
+            continue
+        stream_path = get_subtitle_cache_path(
+            infile_path,
+            stream,
+            cache_dir_path=cache_dir_path,
+        )
+        image_dir_path = stream_path.parent / "image-series"
+        if (image_dir_path / "index.html").exists():
+            logger.info(f"Loaded image subtitle series from cache: {image_dir_path}")
+            continue
+        image_series = ImageSeries.load(stream_path)
+        image_series.save(image_dir_path)
+        logger.info(f"Saved image subtitle series to cache: {image_dir_path}")

--- a/scinoephile/media/subtitles/extraction.py
+++ b/scinoephile/media/subtitles/extraction.py
@@ -37,7 +37,12 @@ def extract_subtitle_stream(
     Returns:
         output path
     """
-    cache_subtitles(infile_path, [stream], cache_dir_path=cache_dir_path)
+    cache_subtitles(
+        infile_path,
+        [stream],
+        cache_dir_path=cache_dir_path,
+        render_images=False,
+    )
     stream_path = get_subtitle_cache_path(
         infile_path,
         stream,

--- a/scinoephile/workflows/subtitle_extraction.py
+++ b/scinoephile/workflows/subtitle_extraction.py
@@ -152,6 +152,7 @@ def extract_subtitles(
             infile_path,
             streams_to_extract,
             cache_dir_path=cache_dir_path,
+            render_images=False,
         )
 
     # Copy cached subtitle files into place and optionally render SUP image directories
@@ -166,14 +167,14 @@ def extract_subtitles(
             )
         handled_outputs.append(output)
         if output.stream.extension == "sup" and export_images:
-            handled_outputs.append(
-                _extract_sup_image_series(
-                    output.stream,
-                    output.path,
-                    output.path.with_suffix(""),
-                    overwrite=overwrite,
-                )
+            image_output = _try_extract_sup_image_series(
+                output.stream,
+                output.path,
+                output.path.with_suffix(""),
+                overwrite=overwrite,
             )
+            if image_output is not None:
+                handled_outputs.append(image_output)
     return SubtitleExtractionResult(infile_path=infile_path, outputs=handled_outputs)
 
 
@@ -411,3 +412,34 @@ def _extract_sup_image_series(
         stream=stream,
         path=output_dir_path,
     )
+
+
+def _try_extract_sup_image_series(
+    stream: SubtitleStream,
+    infile_path: Path,
+    output_dir_path: Path,
+    *,
+    overwrite: bool,
+) -> SubtitleExtractionOutput | None:
+    """Convert a SUP subtitle file to images, warning on parse failures.
+
+    Arguments:
+        stream: subtitle stream associated with the SUP file
+        infile_path: SUP subtitle file
+        output_dir_path: output image directory
+        overwrite: whether to overwrite existing output
+    Returns:
+        output handled for the image directory, if rendering succeeded
+    """
+    try:
+        return _extract_sup_image_series(
+            stream,
+            infile_path,
+            output_dir_path,
+            overwrite=overwrite,
+        )
+    except (OSError, RuntimeError, ValueError) as exc:
+        logger.warning(
+            f"Could not export SUP image series for stream #{stream.index}: {exc}"
+        )
+        return None

--- a/scinoephile/workflows/subtitle_extraction.py
+++ b/scinoephile/workflows/subtitle_extraction.py
@@ -438,7 +438,7 @@ def _try_extract_sup_image_series(
             output_dir_path,
             overwrite=overwrite,
         )
-    except (OSError, RuntimeError, ValueError) as exc:
+    except (OSError, RuntimeError, ScinoephileError, ValueError) as exc:
         logger.warning(
             f"Could not export SUP image series for stream #{stream.index}: {exc}"
         )

--- a/test/media/test_subtitle_analysis.py
+++ b/test/media/test_subtitle_analysis.py
@@ -236,6 +236,31 @@ def test_cache_subtitles_builds_image_cache_for_sup_stream(tmp_path: Path):
     assert (image_dir_path / "index.html").exists()
 
 
+def test_cache_subtitles_can_skip_image_cache_for_sup_stream(tmp_path: Path):
+    """Test subtitle caching can skip rendering cached SUP subtitle images.
+
+    Arguments:
+        tmp_path: temporary directory provided by pytest
+    """
+    infile_path = tmp_path / "video.mkv"
+    infile_path.write_bytes(b"video")
+    stream = SubtitleStream(index=2, language="zho", codec_name="hdmv_pgs_subtitle")
+    _cache_subtitle_stream(infile_path, stream, tmp_path / "cache", b"not a real sup")
+
+    with patch(
+        "scinoephile.media.subtitles.cache.ImageSeries.load",
+        side_effect=ValueError("SUP segment data is truncated."),
+    ) as load:
+        cache_subtitles(
+            infile_path,
+            [stream],
+            cache_dir_path=tmp_path / "cache",
+            render_images=False,
+        )
+
+    load.assert_not_called()
+
+
 def test_analyze_image_subtitle_stream_uses_cached_sampled_pngs(
     tmp_path: Path,
     monkeypatch,

--- a/test/media/test_subtitles.py
+++ b/test/media/test_subtitles.py
@@ -48,7 +48,10 @@ def test_extract_subtitle_stream_copies_cached_stream(tmp_path: Path, caplog):
     assert outfile_path.read_text(encoding="utf-8") == "cached subtitles"
     assert f"Created subtitle output directory: {outfile_path.parent}" in caplog.text
     cache.assert_called_once_with(
-        infile_path, [stream], cache_dir_path=tmp_path / "cache"
+        infile_path,
+        [stream],
+        cache_dir_path=tmp_path / "cache",
+        render_images=False,
     )
 
 
@@ -70,6 +73,7 @@ def test_extract_subtitle_stream_caches_missing_stream(tmp_path: Path):
         streams: list[SubtitleStream],
         *,
         cache_dir_path: Path | None = None,
+        render_images: bool = True,
     ):
         stream_path.parent.mkdir(parents=True)
         stream_path.write_text("new subtitles", encoding="utf-8")
@@ -87,7 +91,12 @@ def test_extract_subtitle_stream_caches_missing_stream(tmp_path: Path):
 
     assert extracted_path == outfile_path
     assert outfile_path.read_text(encoding="utf-8") == "new subtitles"
-    cache.assert_called_once_with(infile_path, [stream], cache_dir_path=cache_dir_path)
+    cache.assert_called_once_with(
+        infile_path,
+        [stream],
+        cache_dir_path=cache_dir_path,
+        render_images=False,
+    )
 
 
 def test_extract_subtitle_stream_rejects_unknown_codec(tmp_path: Path):

--- a/test/workflows/test_subtitle_extraction.py
+++ b/test/workflows/test_subtitle_extraction.py
@@ -62,6 +62,7 @@ def test_extract_subtitles_extracts_matching_streams(tmp_path: Path):
         infile_path,
         [streams[0], streams[2]],
         cache_dir_path=cache_dir_path,
+        render_images=False,
     )
     assert copy.call_args_list[0].args == (
         cache_eng_path,
@@ -244,6 +245,7 @@ def test_extract_subtitles_reports_overwritten_outputs(tmp_path: Path):
         infile_path,
         [stream],
         cache_dir_path=None,
+        render_images=False,
     )
     copy.assert_called_once_with(cache_path, outfile_path)
     assert result.outputs[0].status == SubtitleExtractionOutputStatus.OVERWRITTEN
@@ -297,6 +299,7 @@ def test_extract_subtitles_extracts_sup_streams_to_image_dirs(tmp_path: Path):
         infile_path,
         streams,
         cache_dir_path=cache_dir_path,
+        render_images=False,
     )
     assert [output.kind for output in result.outputs] == [
         SubtitleExtractionOutputKind.SUBTITLE,
@@ -307,6 +310,135 @@ def test_extract_subtitles_extracts_sup_streams_to_image_dirs(tmp_path: Path):
     assert result.outputs[-1].status == SubtitleExtractionOutputStatus.CREATED
     load.assert_called_once_with(output_dir_path / "zho-3.sup")
     image_series.save.assert_called_once_with(output_dir_path / "zho-3")
+
+
+def test_extract_subtitles_skips_sup_parsing_when_not_exporting_images(
+    tmp_path: Path,
+):
+    """Test extraction skips SUP image parsing when image export is disabled.
+
+    Arguments:
+        tmp_path: temporary directory provided by pytest
+    """
+    infile_path = tmp_path / "video.mkv"
+    infile_path.touch()
+    output_dir_path = tmp_path / "subtitles"
+    cache_dir_path = tmp_path / "cache"
+    cache_srt_path = cache_dir_path / "eng-8.srt"
+    cache_sup_path = cache_dir_path / "eng-10.sup"
+    streams = [
+        SubtitleStream(index=8, language="eng", codec_name="subrip"),
+        SubtitleStream(index=10, language="eng", codec_name="hdmv_pgs_subtitle"),
+    ]
+
+    with (
+        patch(
+            "scinoephile.workflows.subtitle_extraction.get_subtitle_streams",
+            return_value=streams,
+        ),
+        patch(
+            "scinoephile.workflows.subtitle_extraction.cache_subtitles"
+        ) as cache_subtitles,
+        patch(
+            "scinoephile.workflows.subtitle_extraction.get_subtitle_cache_path",
+            side_effect=[cache_srt_path, cache_sup_path],
+        ),
+        patch("scinoephile.workflows.subtitle_extraction.copy2") as copy,
+        patch(
+            "scinoephile.workflows.subtitle_extraction.ImageSeries.load",
+            side_effect=ValueError("SUP segment data is truncated."),
+        ) as load,
+    ):
+        result = extract_subtitles(
+            infile_path=infile_path,
+            languages=["eng"],
+            output_dir_path=output_dir_path,
+            cache_dir_path=cache_dir_path,
+        )
+
+    cache_subtitles.assert_called_once_with(
+        infile_path,
+        streams,
+        cache_dir_path=cache_dir_path,
+        render_images=False,
+    )
+    assert copy.call_args_list[0].args == (
+        cache_srt_path,
+        output_dir_path / "eng-8.srt",
+    )
+    assert copy.call_args_list[1].args == (
+        cache_sup_path,
+        output_dir_path / "eng-10.sup",
+    )
+    load.assert_not_called()
+    assert [output.path for output in result.outputs] == [
+        output_dir_path / "eng-8.srt",
+        output_dir_path / "eng-10.sup",
+    ]
+
+
+def test_extract_subtitles_warns_when_sup_image_export_fails(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Test extraction keeps subtitle files when SUP image export fails.
+
+    Arguments:
+        tmp_path: temporary directory provided by pytest
+        caplog: pytest log capture fixture
+    """
+    infile_path = tmp_path / "video.mkv"
+    infile_path.touch()
+    output_dir_path = tmp_path / "subtitles"
+    cache_dir_path = tmp_path / "cache"
+    cache_srt_path = cache_dir_path / "eng-8.srt"
+    cache_sup_path = cache_dir_path / "eng-10.sup"
+    streams = [
+        SubtitleStream(index=8, language="eng", codec_name="subrip"),
+        SubtitleStream(index=10, language="eng", codec_name="hdmv_pgs_subtitle"),
+    ]
+
+    caplog.set_level(
+        "WARNING",
+        logger="scinoephile.workflows.subtitle_extraction",
+    )
+    with (
+        patch(
+            "scinoephile.workflows.subtitle_extraction.get_subtitle_streams",
+            return_value=streams,
+        ),
+        patch(
+            "scinoephile.workflows.subtitle_extraction.cache_subtitles"
+        ) as cache_subtitles,
+        patch(
+            "scinoephile.workflows.subtitle_extraction.get_subtitle_cache_path",
+            side_effect=[cache_srt_path, cache_sup_path],
+        ),
+        patch("scinoephile.workflows.subtitle_extraction.copy2"),
+        patch(
+            "scinoephile.workflows.subtitle_extraction.ImageSeries.load",
+            side_effect=ValueError("SUP segment data is truncated."),
+        ),
+    ):
+        result = extract_subtitles(
+            infile_path=infile_path,
+            languages=["eng"],
+            output_dir_path=output_dir_path,
+            cache_dir_path=cache_dir_path,
+            export_images=True,
+        )
+
+    cache_subtitles.assert_called_once_with(
+        infile_path,
+        streams,
+        cache_dir_path=cache_dir_path,
+        render_images=False,
+    )
+    assert [output.path for output in result.outputs] == [
+        output_dir_path / "eng-8.srt",
+        output_dir_path / "eng-10.sup",
+    ]
+    assert "Could not export SUP image series for stream #10" in caplog.text
 
 
 def test_extract_subtitles_extracts_sup_file_to_image_dir_in_place(tmp_path: Path):

--- a/test/workflows/test_subtitle_extraction.py
+++ b/test/workflows/test_subtitle_extraction.py
@@ -417,7 +417,10 @@ def test_extract_subtitles_warns_when_sup_image_export_fails(
         patch("scinoephile.workflows.subtitle_extraction.copy2"),
         patch(
             "scinoephile.workflows.subtitle_extraction.ImageSeries.load",
-            side_effect=ValueError("SUP segment data is truncated."),
+            side_effect=ScinoephileError(
+                "Unable to load ImageSeries from eng-10.sup: "
+                "SUP segment data is truncated."
+            ),
         ),
     ):
         result = extract_subtitles(


### PR DESCRIPTION
## Summary
- Add an opt-in `render_images` switch to subtitle caching so plain extraction can cache/copy SUP files without parsing image segments.
- Update media subtitle extraction workflows to request non-rendering cache extraction first, then optionally render SUP images after subtitle files are copied.
- Warn and skip failed SUP image export instead of aborting already extractable subtitle outputs.
- Add regression coverage for malformed SUP parsing during `extract_subs` and for non-rendering SUP cache behavior.

## Verification
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest test\media\test_subtitles.py test\workflows\test_subtitle_extraction.py test\media\test_subtitle_analysis.py::test_cache_subtitles_can_skip_image_cache_for_sup_stream test\media\test_subtitle_analysis.py::test_cache_subtitles_builds_image_cache_for_sup_stream`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile\media\subtitles\cache.py scinoephile\media\subtitles\extraction.py scinoephile\workflows\subtitle_extraction.py test\media\test_subtitle_analysis.py test\media\test_subtitles.py test\workflows\test_subtitle_extraction.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile\media\subtitles\cache.py scinoephile\media\subtitles\extraction.py scinoephile\workflows\subtitle_extraction.py test\media\test_subtitle_analysis.py test\media\test_subtitles.py test\workflows\test_subtitle_extraction.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile\media\subtitles\cache.py scinoephile\media\subtitles\extraction.py scinoephile\workflows\subtitle_extraction.py test\media\test_subtitle_analysis.py test\media\test_subtitles.py test\workflows\test_subtitle_extraction.py`
- Reproduction command against `\\KDebiecNAS\Backup\Video\UHDBD Remux\Wall-E (2008).mkv` exits 0 and extracts/overwrites `eng-8.srt`, `eng-9.srt`, and `eng-10.sup`.

## Notes
- Full `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` was run and failed with pre-existing Windows environment issues unrelated to this change: cp1252 Unicode decode/logging errors, symlink-resolution failures, subprocess command expectation failures, and `Path.home()` failure in a test that clears environment variables.