### PR TITLE
Fix Windows full-suite failures

### DIFF
--- a/scinoephile/cli/utility/cache/output.py
+++ b/scinoephile/cli/utility/cache/output.py
@@ -29,7 +29,7 @@ def format_cache_entry(entry: CacheEntry) -> dict[str, Any]:
     """
     return {
         "namespace": entry.namespace,
-        "path": str(entry.relative_path),
+        "path": entry.relative_path.as_posix(),
         "size_bytes": entry.size_bytes,
         "file_count": entry.file_count,
         "modified_at": _format_datetime(entry.modified_at),

--- a/scinoephile/common/command_line_interface.py
+++ b/scinoephile/common/command_line_interface.py
@@ -128,7 +128,7 @@ class CommandLineInterface(ABC):
         log_file = kwargs.pop("log_file")
         if log_file:
             log_file_path = Path(log_file).resolve()
-            file_handler = FileHandler(log_file_path)
+            file_handler = FileHandler(log_file_path, encoding="utf-8")
             file_handler.setLevel(getLogger().level)
             formatter = Formatter(DEFAULT_LOG_FORMAT)
             file_handler.setFormatter(formatter)

--- a/scinoephile/common/logs.py
+++ b/scinoephile/common/logs.py
@@ -68,6 +68,10 @@ def set_logging_verbosity(verbosity: int):
 def _get_unicode_safe_stderr() -> TextIO:
     """Get stderr configured to tolerate messages outside the console code page.
 
+    Windows consoles may use legacy encodings such as cp1252, while CLI output can
+    include Chinese dictionary text or other Unicode characters. Replacing
+    unencodable characters prevents logging errors from interrupting CLI execution.
+
     Returns:
         standard error stream
     """

--- a/scinoephile/common/logs.py
+++ b/scinoephile/common/logs.py
@@ -4,7 +4,9 @@
 
 from __future__ import annotations
 
+import sys
 from logging import DEBUG, ERROR, INFO, WARNING, Formatter, StreamHandler, getLogger
+from typing import TextIO
 
 DEFAULT_LOG_FORMAT = "%(levelname)s: %(name)s: %(message)s"
 """Default format for log messages."""
@@ -45,7 +47,7 @@ def configure_logging(verbosity: int = 1, log_format: str | None = None):
     root_logger.handlers.clear()
 
     # Add console handler with formatter
-    console_handler = StreamHandler()
+    console_handler = StreamHandler(_get_unicode_safe_stderr())
     console_handler.setLevel(level)
     formatter = Formatter(log_format)
     console_handler.setFormatter(formatter)
@@ -61,3 +63,15 @@ def set_logging_verbosity(verbosity: int):
         verbosity: level of verbosity (0=ERROR, 1=WARNING, 2=INFO, 3+=DEBUG)
     """
     configure_logging(verbosity)
+
+
+def _get_unicode_safe_stderr() -> TextIO:
+    """Get stderr configured to tolerate messages outside the console code page.
+
+    Returns:
+        standard error stream
+    """
+    reconfigure = getattr(sys.stderr, "reconfigure", None)
+    if callable(reconfigure):
+        reconfigure(errors="backslashreplace")
+    return sys.stderr

--- a/scinoephile/common/testing.py
+++ b/scinoephile/common/testing.py
@@ -12,25 +12,16 @@ from platform import system
 from shlex import split
 from unittest.mock import patch
 
-import pytest
-
 from .command_line_interface import CommandLineInterface
 
-__all__ = ["run_cli_with_args"]
+__all__ = [
+    "create_symlink_or_skip",
+    "echo_command",
+    "run_cli_with_args",
+]
 
 
-def run_cli_with_args(cli: type[CommandLineInterface], args: str = ""):
-    """Run CommandLineInterface as if from shell with provided args.
-
-    Arguments:
-        cli: CommandLineInterface to run
-        args: Arguments to pass
-    """
-    with patch.object(sys, "argv", [getfile(cli)] + _split_cli_args(args)):
-        cli.main()
-
-
-def _create_symlink(
+def create_symlink_or_skip(
     symlink_path: Path, target_path: Path, *, target_is_directory: bool = False
 ):
     """Create a symlink, skipping when Windows privileges do not allow it.
@@ -44,11 +35,13 @@ def _create_symlink(
         symlink_path.symlink_to(target_path, target_is_directory=target_is_directory)
     except OSError as exc:
         if getattr(exc, "winerror", None) == 1314:
+            import pytest  # noqa: PLC0415
+
             pytest.skip("Windows symlink privilege is not available")
         raise
 
 
-def _echo_command(*arguments: str) -> list[str]:
+def echo_command(*arguments: str) -> list[str]:
     """Build a portable command that echoes arguments without shell expansion.
 
     Arguments:
@@ -66,6 +59,17 @@ def _echo_command(*arguments: str) -> list[str]:
         ),
         *arguments,
     ]
+
+
+def run_cli_with_args(cli: type[CommandLineInterface], args: str = ""):
+    """Run CommandLineInterface as if from shell with provided args.
+
+    Arguments:
+        cli: CommandLineInterface to run
+        args: Arguments to pass
+    """
+    with patch.object(sys, "argv", [getfile(cli)] + _split_cli_args(args)):
+        cli.main()
 
 
 def _split_cli_args(args: str) -> list[str]:

--- a/scinoephile/common/testing.py
+++ b/scinoephile/common/testing.py
@@ -27,6 +27,26 @@ def run_cli_with_args(cli: type[CommandLineInterface], args: str = ""):
         cli.main()
 
 
+def _echo_command(*arguments: str) -> list[str]:
+    """Build a portable command that echoes arguments without shell expansion.
+
+    Arguments:
+        *arguments: arguments to echo
+    Returns:
+        command argument list
+    """
+    return [
+        sys.executable,
+        "-c",
+        (
+            "import sys; "
+            "sys.stdout.reconfigure(encoding='utf-8'); "
+            "print(' '.join(sys.argv[1:]))"
+        ),
+        *arguments,
+    ]
+
+
 def _split_cli_args(args: str) -> list[str]:
     """Split command-line arguments using platform-appropriate rules.
 

--- a/scinoephile/common/testing.py
+++ b/scinoephile/common/testing.py
@@ -7,9 +7,12 @@ from __future__ import annotations
 import sys
 from ctypes import POINTER, byref, c_int, c_void_p, c_wchar_p
 from inspect import getfile
+from pathlib import Path
 from platform import system
 from shlex import split
 from unittest.mock import patch
+
+import pytest
 
 from .command_line_interface import CommandLineInterface
 
@@ -25,6 +28,24 @@ def run_cli_with_args(cli: type[CommandLineInterface], args: str = ""):
     """
     with patch.object(sys, "argv", [getfile(cli)] + _split_cli_args(args)):
         cli.main()
+
+
+def _create_symlink(
+    symlink_path: Path, target_path: Path, *, target_is_directory: bool = False
+):
+    """Create a symlink, skipping when Windows privileges do not allow it.
+
+    Arguments:
+        symlink_path: path at which to create the symlink
+        target_path: symlink target path
+        target_is_directory: whether the target is a directory
+    """
+    try:
+        symlink_path.symlink_to(target_path, target_is_directory=target_is_directory)
+    except OSError as exc:
+        if getattr(exc, "winerror", None) == 1314:
+            pytest.skip("Windows symlink privilege is not available")
+        raise
 
 
 def _echo_command(*arguments: str) -> list[str]:

--- a/scinoephile/common/testing.py
+++ b/scinoephile/common/testing.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import sys
 from ctypes import POINTER, byref, c_int, c_void_p, c_wchar_p
 from inspect import getfile
-from os import name as os_name
+from platform import system
 from shlex import split
 from unittest.mock import patch
 
@@ -38,7 +38,7 @@ def _split_cli_args(args: str) -> list[str]:
     args = args.strip()
     if not args:
         return []
-    if os_name != "nt":
+    if system() != "Windows":
         return split(args)
 
     from ctypes import WinDLL  # noqa: PLC0415

--- a/scinoephile/common/testing.py
+++ b/scinoephile/common/testing.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import ctypes
 import sys
 from ctypes import POINTER, byref, c_int, c_void_p, c_wchar_p
 from inspect import getfile
@@ -64,13 +65,12 @@ def _split_cli_args(args: str) -> list[str]:
     if system() != "Windows":
         return split(args)
 
-    from ctypes import WinDLL  # noqa: PLC0415
-
     argc = c_int()
-    shell32 = WinDLL("shell32", use_last_error=True)
+    win_dll = getattr(ctypes, "WinDLL")
+    shell32 = win_dll("shell32", use_last_error=True)
     shell32.CommandLineToArgvW.argtypes = [c_wchar_p, POINTER(c_int)]
     shell32.CommandLineToArgvW.restype = POINTER(c_wchar_p)
-    kernel32 = WinDLL("kernel32", use_last_error=True)
+    kernel32 = win_dll("kernel32", use_last_error=True)
     kernel32.LocalFree.argtypes = [c_void_p]
     kernel32.LocalFree.restype = c_void_p
 

--- a/scinoephile/common/testing.py
+++ b/scinoephile/common/testing.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import sys
 from ctypes import POINTER, byref, c_int, c_void_p, c_wchar_p
 from inspect import getfile
-from pathlib import Path
 from platform import system
 from shlex import split
 from unittest.mock import patch
@@ -15,30 +14,9 @@ from unittest.mock import patch
 from .command_line_interface import CommandLineInterface
 
 __all__ = [
-    "create_symlink_or_skip",
     "echo_command",
     "run_cli_with_args",
 ]
-
-
-def create_symlink_or_skip(
-    symlink_path: Path, target_path: Path, *, target_is_directory: bool = False
-):
-    """Create a symlink, skipping when Windows privileges do not allow it.
-
-    Arguments:
-        symlink_path: path at which to create the symlink
-        target_path: symlink target path
-        target_is_directory: whether the target is a directory
-    """
-    try:
-        symlink_path.symlink_to(target_path, target_is_directory=target_is_directory)
-    except OSError as exc:
-        if getattr(exc, "winerror", None) == 1314:
-            import pytest  # noqa: PLC0415
-
-            pytest.skip("Windows symlink privilege is not available")
-        raise
 
 
 def echo_command(*arguments: str) -> list[str]:

--- a/scinoephile/core/paths.py
+++ b/scinoephile/core/paths.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from os import getenv
 from pathlib import Path
 from platform import system
+from tempfile import gettempdir
 
 from scinoephile.common.validation import val_output_dir_path
 
@@ -25,13 +26,32 @@ def get_runtime_cache_dir_path(*parts: str, create: bool = True) -> Path:
     if configured_cache_dir_path := getenv("SCINOEPHILE_CACHE_DIR"):
         cache_root_path = Path(configured_cache_dir_path)
     elif system() == "Darwin":
-        cache_root_path = Path.home() / "Library/Caches"
+        cache_root_path = _get_home_cache_root_path("Library", "Caches")
     elif system() == "Windows":
-        cache_root_path = Path(getenv("LOCALAPPDATA") or Path.home() / "AppData/Local")
+        if local_appdata := getenv("LOCALAPPDATA"):
+            cache_root_path = Path(local_appdata)
+        else:
+            cache_root_path = _get_home_cache_root_path("AppData", "Local")
+    elif xdg_cache_home := getenv("XDG_CACHE_HOME"):
+        cache_root_path = Path(xdg_cache_home)
     else:
-        cache_root_path = Path(getenv("XDG_CACHE_HOME") or Path.home() / ".cache")
+        cache_root_path = _get_home_cache_root_path(".cache")
 
     return val_output_dir_path(
         cache_root_path / "scinoephile" / Path(*parts),
         create=create,
     )
+
+
+def _get_home_cache_root_path(*parts: str) -> Path:
+    """Get a home-relative cache root path, falling back to temp if home is absent.
+
+    Arguments:
+        *parts: cache root components beneath the user home directory
+    Returns:
+        cache root path
+    """
+    try:
+        return Path.home() / Path(*parts)
+    except RuntimeError:
+        return Path(gettempdir())

--- a/scinoephile/core/paths.py
+++ b/scinoephile/core/paths.py
@@ -26,16 +26,13 @@ def get_runtime_cache_dir_path(*parts: str, create: bool = True) -> Path:
     if configured_cache_dir_path := getenv("SCINOEPHILE_CACHE_DIR"):
         cache_root_path = Path(configured_cache_dir_path)
     elif system() == "Darwin":
-        cache_root_path = _get_home_cache_root_path("Library", "Caches")
+        cache_root_path = Path.home() / "Library/Caches"
     elif system() == "Windows":
-        if local_appdata := getenv("LOCALAPPDATA"):
-            cache_root_path = Path(local_appdata)
-        else:
-            cache_root_path = _get_home_cache_root_path("AppData", "Local")
+        cache_root_path = _get_windows_cache_root_path()
     elif xdg_cache_home := getenv("XDG_CACHE_HOME"):
         cache_root_path = Path(xdg_cache_home)
     else:
-        cache_root_path = _get_home_cache_root_path(".cache")
+        cache_root_path = Path.home() / ".cache"
 
     return val_output_dir_path(
         cache_root_path / "scinoephile" / Path(*parts),
@@ -43,15 +40,15 @@ def get_runtime_cache_dir_path(*parts: str, create: bool = True) -> Path:
     )
 
 
-def _get_home_cache_root_path(*parts: str) -> Path:
-    """Get a home-relative cache root path, falling back to temp if home is absent.
+def _get_windows_cache_root_path() -> Path:
+    """Get the Windows cache root path, falling back to temp if home is absent.
 
-    Arguments:
-        *parts: cache root components beneath the user home directory
     Returns:
         cache root path
     """
+    if local_appdata := getenv("LOCALAPPDATA"):
+        return Path(local_appdata)
     try:
-        return Path.home() / Path(*parts)
+        return Path.home() / "AppData/Local"
     except RuntimeError:
         return Path(gettempdir())

--- a/test/cli/dictionary/test_dictionary_search_cli.py
+++ b/test/cli/dictionary/test_dictionary_search_cli.py
@@ -7,8 +7,8 @@ from __future__ import annotations
 from collections.abc import Generator
 from contextlib import AbstractContextManager, nullcontext
 from os import environ
-from os import name as os_name
 from pathlib import Path
+from platform import system
 from shlex import quote
 from subprocess import list2cmdline
 from unittest.mock import patch
@@ -262,6 +262,6 @@ def _quote_cli_arg(value: str) -> str:
     Returns:
         quoted argument
     """
-    if os_name == "nt":
+    if system() == "Windows":
         return list2cmdline([value])
     return quote(value)

--- a/test/cli/dictionary/test_dictionary_search_cli.py
+++ b/test/cli/dictionary/test_dictionary_search_cli.py
@@ -7,8 +7,10 @@ from __future__ import annotations
 from collections.abc import Generator
 from contextlib import AbstractContextManager, nullcontext
 from os import environ
+from os import name as os_name
 from pathlib import Path
 from shlex import quote
+from subprocess import list2cmdline
 from unittest.mock import patch
 
 import pytest
@@ -162,7 +164,7 @@ def test_dictionary_search_cli(
                 f"--log-file {log_file_path} "
                 "--dictionary-name cuhk "
                 f"--database-path {database_path} "
-                f"--limit 3 {quote(query)}",
+                f"--limit 3 {_quote_cli_arg(query)}",
             )
         output = log_file_path.read_text(encoding="utf-8")
 
@@ -250,3 +252,16 @@ def test_dictionary_search_cli_prints_no_matches(
     output = capsys.readouterr().out
 
     assert output == "No matches found in cuhk for '冇呢個詞'.\n"
+
+
+def _quote_cli_arg(value: str) -> str:
+    """Quote one argument for the platform-specific test CLI splitter.
+
+    Arguments:
+        value: argument value to quote
+    Returns:
+        quoted argument
+    """
+    if os_name == "nt":
+        return list2cmdline([value])
+    return quote(value)

--- a/test/cli/eng/test_eng_process_cli.py
+++ b/test/cli/eng/test_eng_process_cli.py
@@ -72,7 +72,7 @@ def test_eng_process_cli_pipe(input_path: str, args: str, expected_path: str):
     """
     full_input_path = test_data_root / input_path
     full_expected_path = test_data_root / expected_path
-    input_text = full_input_path.read_text()
+    input_text = full_input_path.read_text(encoding="utf-8")
 
     stdin_stream = StringIO(input_text)
     stdout_stream = StringIO()

--- a/test/cli/yue/test_yue_process_cli.py
+++ b/test/cli/yue/test_yue_process_cli.py
@@ -72,7 +72,7 @@ def test_yue_process_cli_pipe(input_path: str, args: str, expected_path: str):
     """
     full_input_path = test_data_root / input_path
     full_expected_path = test_data_root / expected_path
-    input_text = full_input_path.read_text()
+    input_text = full_input_path.read_text(encoding="utf-8")
 
     stdin_stream = StringIO(input_text)
     stdout_stream = StringIO()

--- a/test/cli/yue/test_yue_transcribe_vs_zho_cli.py
+++ b/test/cli/yue/test_yue_transcribe_vs_zho_cli.py
@@ -422,7 +422,7 @@ def test_yue_transcribe_vs_zho_cli_allows_stdin_subtitle_infile():
     )
     yuewen_audio_series = Mock(spec=AudioSeries)
     stdout_stream = StringIO()
-    stdin_stream = StringIO(zhongwen_infile_path.read_text())
+    stdin_stream = StringIO(zhongwen_infile_path.read_text(encoding="utf-8"))
 
     with patch("scinoephile.cli.helpers.io.stdin", stdin_stream):
         with patch(

--- a/test/cli/zho/test_zho_process_cli.py
+++ b/test/cli/zho/test_zho_process_cli.py
@@ -78,7 +78,7 @@ def test_zho_process_cli_pipe(input_path: str, args: str, expected_path: str):
     """
     full_input_path = test_data_root / input_path
     full_expected_path = test_data_root / expected_path
-    input_text = full_input_path.read_text()
+    input_text = full_input_path.read_text(encoding="utf-8")
 
     stdin_stream = StringIO(input_text)
     stdout_stream = StringIO()

--- a/test/common/subprocess/test_run_command.py
+++ b/test/common/subprocess/test_run_command.py
@@ -10,12 +10,12 @@ from time import monotonic
 import pytest
 
 from scinoephile.common.subprocess import run_command
-from scinoephile.common.testing import _echo_command
+from scinoephile.common.testing import echo_command
 
 
 def test_run_command_success_list():
     """Test running a successful command with list format."""
-    exitcode, stdout, stderr = run_command(_echo_command("Hello World"))
+    exitcode, stdout, stderr = run_command(echo_command("Hello World"))
 
     assert exitcode == 0
     assert "Hello World" in stdout
@@ -24,7 +24,7 @@ def test_run_command_success_list():
 
 def test_run_command_with_arguments():
     """Test running a command with multiple arguments."""
-    exitcode, stdout, stderr = run_command(_echo_command("arg1", "arg2", "arg3"))
+    exitcode, stdout, stderr = run_command(echo_command("arg1", "arg2", "arg3"))
 
     assert exitcode == 0
     assert "arg1" in stdout
@@ -34,7 +34,7 @@ def test_run_command_with_arguments():
 
 def test_run_command_with_spaces():
     """Test running a command with arguments containing spaces."""
-    exitcode, stdout, stderr = run_command(_echo_command("hello world"))
+    exitcode, stdout, stderr = run_command(echo_command("hello world"))
 
     assert exitcode == 0
     assert "hello world" in stdout
@@ -43,7 +43,7 @@ def test_run_command_with_spaces():
 def test_run_command_with_special_chars():
     """Test running a command with special shell characters."""
     # Test with characters that would be problematic with shell=True
-    exitcode, stdout, stderr = run_command(_echo_command("$HOME", "$(whoami)", "; ls"))
+    exitcode, stdout, stderr = run_command(echo_command("$HOME", "$(whoami)", "; ls"))
 
     assert exitcode == 0
     # These should be printed literally, not expanded
@@ -60,19 +60,19 @@ def test_run_command_injection_prevention():
     being executed as shell commands.
     """
     # This would be dangerous with shell=True, but is safe now
-    exitcode, stdout, stderr = run_command(_echo_command("test; rm -rf /"))
+    exitcode, stdout, stderr = run_command(echo_command("test; rm -rf /"))
 
     assert exitcode == 0
     # The semicolon and rm command should be in the output as literal text
     assert "test; rm -rf /" in stdout
 
     # Test pipe character
-    exitcode, stdout, stderr = run_command(_echo_command("test | cat /etc/passwd"))
+    exitcode, stdout, stderr = run_command(echo_command("test | cat /etc/passwd"))
     assert exitcode == 0
     assert "test | cat /etc/passwd" in stdout
 
     # Test backticks
-    exitcode, stdout, stderr = run_command(_echo_command("`whoami`"))
+    exitcode, stdout, stderr = run_command(echo_command("`whoami`"))
     assert exitcode == 0
     assert "`whoami`" in stdout
 
@@ -80,7 +80,7 @@ def test_run_command_injection_prevention():
 def test_run_command_with_quotes():
     """Test running a command with quoted arguments."""
     exitcode, stdout, stderr = run_command(
-        _echo_command("'single quotes'", '"double quotes"')
+        echo_command("'single quotes'", '"double quotes"')
     )
 
     assert exitcode == 0
@@ -132,7 +132,7 @@ def test_run_command_timeout():
 
 def test_run_command_unicode_output():
     """Test handling of unicode output."""
-    exitcode, stdout, stderr = run_command(_echo_command("Hello 世界"))
+    exitcode, stdout, stderr = run_command(echo_command("Hello 世界"))
 
     assert exitcode == 0
     assert "Hello" in stdout

--- a/test/common/subprocess/test_run_command.py
+++ b/test/common/subprocess/test_run_command.py
@@ -14,7 +14,7 @@ from scinoephile.common.subprocess import run_command
 
 def test_run_command_success_list():
     """Test running a successful command with list format."""
-    exitcode, stdout, stderr = run_command(["echo", "Hello World"])
+    exitcode, stdout, stderr = run_command(_echo_command("Hello World"))
 
     assert exitcode == 0
     assert "Hello World" in stdout
@@ -23,7 +23,7 @@ def test_run_command_success_list():
 
 def test_run_command_with_arguments():
     """Test running a command with multiple arguments."""
-    exitcode, stdout, stderr = run_command(["echo", "arg1", "arg2", "arg3"])
+    exitcode, stdout, stderr = run_command(_echo_command("arg1", "arg2", "arg3"))
 
     assert exitcode == 0
     assert "arg1" in stdout
@@ -33,7 +33,7 @@ def test_run_command_with_arguments():
 
 def test_run_command_with_spaces():
     """Test running a command with arguments containing spaces."""
-    exitcode, stdout, stderr = run_command(["echo", "hello world"])
+    exitcode, stdout, stderr = run_command(_echo_command("hello world"))
 
     assert exitcode == 0
     assert "hello world" in stdout
@@ -42,7 +42,7 @@ def test_run_command_with_spaces():
 def test_run_command_with_special_chars():
     """Test running a command with special shell characters."""
     # Test with characters that would be problematic with shell=True
-    exitcode, stdout, stderr = run_command(["echo", "$HOME", "$(whoami)", "; ls"])
+    exitcode, stdout, stderr = run_command(_echo_command("$HOME", "$(whoami)", "; ls"))
 
     assert exitcode == 0
     # These should be printed literally, not expanded
@@ -59,19 +59,19 @@ def test_run_command_injection_prevention():
     being executed as shell commands.
     """
     # This would be dangerous with shell=True, but is safe now
-    exitcode, stdout, stderr = run_command(["echo", "test; rm -rf /"])
+    exitcode, stdout, stderr = run_command(_echo_command("test; rm -rf /"))
 
     assert exitcode == 0
     # The semicolon and rm command should be in the output as literal text
     assert "test; rm -rf /" in stdout
 
     # Test pipe character
-    exitcode, stdout, stderr = run_command(["echo", "test | cat /etc/passwd"])
+    exitcode, stdout, stderr = run_command(_echo_command("test | cat /etc/passwd"))
     assert exitcode == 0
     assert "test | cat /etc/passwd" in stdout
 
     # Test backticks
-    exitcode, stdout, stderr = run_command(["echo", "`whoami`"])
+    exitcode, stdout, stderr = run_command(_echo_command("`whoami`"))
     assert exitcode == 0
     assert "`whoami`" in stdout
 
@@ -79,7 +79,7 @@ def test_run_command_injection_prevention():
 def test_run_command_with_quotes():
     """Test running a command with quoted arguments."""
     exitcode, stdout, stderr = run_command(
-        ["echo", "'single quotes'", '"double quotes"']
+        _echo_command("'single quotes'", '"double quotes"')
     )
 
     assert exitcode == 0
@@ -131,7 +131,7 @@ def test_run_command_timeout():
 
 def test_run_command_unicode_output():
     """Test handling of unicode output."""
-    exitcode, stdout, stderr = run_command(["echo", "Hello 世界"])
+    exitcode, stdout, stderr = run_command(_echo_command("Hello 世界"))
 
     assert exitcode == 0
     assert "Hello" in stdout
@@ -163,3 +163,23 @@ def test_run_command_with_path():
 
     assert exitcode == 0
     assert "test" in stdout
+
+
+def _echo_command(*arguments: str) -> list[str]:
+    """Build a portable command that echoes arguments without shell expansion.
+
+    Arguments:
+        *arguments: arguments to echo
+    Returns:
+        command argument list
+    """
+    return [
+        sys.executable,
+        "-c",
+        (
+            "import sys; "
+            "sys.stdout.reconfigure(encoding='utf-8'); "
+            "print(' '.join(sys.argv[1:]))"
+        ),
+        *arguments,
+    ]

--- a/test/common/subprocess/test_run_command.py
+++ b/test/common/subprocess/test_run_command.py
@@ -10,6 +10,7 @@ from time import monotonic
 import pytest
 
 from scinoephile.common.subprocess import run_command
+from scinoephile.common.testing import _echo_command
 
 
 def test_run_command_success_list():
@@ -163,23 +164,3 @@ def test_run_command_with_path():
 
     assert exitcode == 0
     assert "test" in stdout
-
-
-def _echo_command(*arguments: str) -> list[str]:
-    """Build a portable command that echoes arguments without shell expansion.
-
-    Arguments:
-        *arguments: arguments to echo
-    Returns:
-        command argument list
-    """
-    return [
-        sys.executable,
-        "-c",
-        (
-            "import sys; "
-            "sys.stdout.reconfigure(encoding='utf-8'); "
-            "print(' '.join(sys.argv[1:]))"
-        ),
-        *arguments,
-    ]

--- a/test/common/subprocess/test_run_command_live.py
+++ b/test/common/subprocess/test_run_command_live.py
@@ -11,6 +11,7 @@ from time import monotonic
 import pytest
 
 from scinoephile.common.subprocess import run_command_live
+from scinoephile.common.testing import _echo_command
 
 
 def test_run_command_live_success_list():
@@ -166,23 +167,3 @@ def test_run_command_live_non_utf8_output():
     assert exitcode == 0
     assert stdout == "ÿ"
     assert stderr == ""
-
-
-def _echo_command(*arguments: str) -> list[str]:
-    """Build a portable command that echoes arguments without shell expansion.
-
-    Arguments:
-        *arguments: arguments to echo
-    Returns:
-        command argument list
-    """
-    return [
-        sys.executable,
-        "-c",
-        (
-            "import sys; "
-            "sys.stdout.reconfigure(encoding='utf-8'); "
-            "print(' '.join(sys.argv[1:]))"
-        ),
-        *arguments,
-    ]

--- a/test/common/subprocess/test_run_command_live.py
+++ b/test/common/subprocess/test_run_command_live.py
@@ -11,12 +11,12 @@ from time import monotonic
 import pytest
 
 from scinoephile.common.subprocess import run_command_live
-from scinoephile.common.testing import _echo_command
+from scinoephile.common.testing import echo_command
 
 
 def test_run_command_live_success_list():
     """Test running a successful command with live output using list format."""
-    exitcode, stdout, stderr = run_command_live(_echo_command("Hello World"))
+    exitcode, stdout, stderr = run_command_live(echo_command("Hello World"))
 
     assert exitcode == 0
     assert "Hello World" in stdout
@@ -25,7 +25,7 @@ def test_run_command_live_success_list():
 
 def test_run_command_live_with_arguments():
     """Test running a command with multiple arguments."""
-    exitcode, stdout, stderr = run_command_live(_echo_command("arg1", "arg2", "arg3"))
+    exitcode, stdout, stderr = run_command_live(echo_command("arg1", "arg2", "arg3"))
 
     assert exitcode == 0
     assert "arg1" in stdout
@@ -35,7 +35,7 @@ def test_run_command_live_with_arguments():
 
 def test_run_command_live_with_spaces():
     """Test running a command with arguments containing spaces."""
-    exitcode, stdout, stderr = run_command_live(_echo_command("hello world"))
+    exitcode, stdout, stderr = run_command_live(echo_command("hello world"))
 
     assert exitcode == 0
     assert "hello world" in stdout
@@ -45,7 +45,7 @@ def test_run_command_live_with_special_chars():
     """Test running a command with special shell characters."""
     # Test with characters that would be problematic with shell=True
     exitcode, stdout, stderr = run_command_live(
-        _echo_command("$HOME", "$(whoami)", "; ls")
+        echo_command("$HOME", "$(whoami)", "; ls")
     )
 
     assert exitcode == 0
@@ -63,19 +63,19 @@ def test_run_command_live_injection_prevention():
     being executed as shell commands.
     """
     # This would be dangerous with shell=True, but is safe now
-    exitcode, stdout, stderr = run_command_live(_echo_command("test; rm -rf /"))
+    exitcode, stdout, stderr = run_command_live(echo_command("test; rm -rf /"))
 
     assert exitcode == 0
     # The semicolon and rm command should be in the output as literal text
     assert "test; rm -rf /" in stdout
 
     # Test pipe character
-    exitcode, stdout, stderr = run_command_live(_echo_command("test | cat /etc/passwd"))
+    exitcode, stdout, stderr = run_command_live(echo_command("test | cat /etc/passwd"))
     assert exitcode == 0
     assert "test | cat /etc/passwd" in stdout
 
     # Test backticks
-    exitcode, stdout, stderr = run_command_live(_echo_command("`whoami`"))
+    exitcode, stdout, stderr = run_command_live(echo_command("`whoami`"))
     assert exitcode == 0
     assert "`whoami`" in stdout
 
@@ -83,7 +83,7 @@ def test_run_command_live_injection_prevention():
 def test_run_command_live_with_quotes():
     """Test running a command with quoted arguments."""
     exitcode, stdout, stderr = run_command_live(
-        _echo_command("'single quotes'", '"double quotes"')
+        echo_command("'single quotes'", '"double quotes"')
     )
 
     assert exitcode == 0

--- a/test/common/subprocess/test_run_command_live.py
+++ b/test/common/subprocess/test_run_command_live.py
@@ -15,7 +15,7 @@ from scinoephile.common.subprocess import run_command_live
 
 def test_run_command_live_success_list():
     """Test running a successful command with live output using list format."""
-    exitcode, stdout, stderr = run_command_live(["echo", "Hello World"])
+    exitcode, stdout, stderr = run_command_live(_echo_command("Hello World"))
 
     assert exitcode == 0
     assert "Hello World" in stdout
@@ -24,7 +24,7 @@ def test_run_command_live_success_list():
 
 def test_run_command_live_with_arguments():
     """Test running a command with multiple arguments."""
-    exitcode, stdout, stderr = run_command_live(["echo", "arg1", "arg2", "arg3"])
+    exitcode, stdout, stderr = run_command_live(_echo_command("arg1", "arg2", "arg3"))
 
     assert exitcode == 0
     assert "arg1" in stdout
@@ -34,7 +34,7 @@ def test_run_command_live_with_arguments():
 
 def test_run_command_live_with_spaces():
     """Test running a command with arguments containing spaces."""
-    exitcode, stdout, stderr = run_command_live(["echo", "hello world"])
+    exitcode, stdout, stderr = run_command_live(_echo_command("hello world"))
 
     assert exitcode == 0
     assert "hello world" in stdout
@@ -43,7 +43,9 @@ def test_run_command_live_with_spaces():
 def test_run_command_live_with_special_chars():
     """Test running a command with special shell characters."""
     # Test with characters that would be problematic with shell=True
-    exitcode, stdout, stderr = run_command_live(["echo", "$HOME", "$(whoami)", "; ls"])
+    exitcode, stdout, stderr = run_command_live(
+        _echo_command("$HOME", "$(whoami)", "; ls")
+    )
 
     assert exitcode == 0
     # These should be printed literally, not expanded
@@ -60,19 +62,19 @@ def test_run_command_live_injection_prevention():
     being executed as shell commands.
     """
     # This would be dangerous with shell=True, but is safe now
-    exitcode, stdout, stderr = run_command_live(["echo", "test; rm -rf /"])
+    exitcode, stdout, stderr = run_command_live(_echo_command("test; rm -rf /"))
 
     assert exitcode == 0
     # The semicolon and rm command should be in the output as literal text
     assert "test; rm -rf /" in stdout
 
     # Test pipe character
-    exitcode, stdout, stderr = run_command_live(["echo", "test | cat /etc/passwd"])
+    exitcode, stdout, stderr = run_command_live(_echo_command("test | cat /etc/passwd"))
     assert exitcode == 0
     assert "test | cat /etc/passwd" in stdout
 
     # Test backticks
-    exitcode, stdout, stderr = run_command_live(["echo", "`whoami`"])
+    exitcode, stdout, stderr = run_command_live(_echo_command("`whoami`"))
     assert exitcode == 0
     assert "`whoami`" in stdout
 
@@ -80,7 +82,7 @@ def test_run_command_live_injection_prevention():
 def test_run_command_live_with_quotes():
     """Test running a command with quoted arguments."""
     exitcode, stdout, stderr = run_command_live(
-        ["echo", "'single quotes'", '"double quotes"']
+        _echo_command("'single quotes'", '"double quotes"')
     )
 
     assert exitcode == 0
@@ -164,3 +166,23 @@ def test_run_command_live_non_utf8_output():
     assert exitcode == 0
     assert stdout == "ÿ"
     assert stderr == ""
+
+
+def _echo_command(*arguments: str) -> list[str]:
+    """Build a portable command that echoes arguments without shell expansion.
+
+    Arguments:
+        *arguments: arguments to echo
+    Returns:
+        command argument list
+    """
+    return [
+        sys.executable,
+        "-c",
+        (
+            "import sys; "
+            "sys.stdout.reconfigure(encoding='utf-8'); "
+            "print(' '.join(sys.argv[1:]))"
+        ),
+        *arguments,
+    ]

--- a/test/common/validation/test_val_input_dir_path.py
+++ b/test/common/validation/test_val_input_dir_path.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from scinoephile.common.exceptions import DirectoryNotFoundError
+from scinoephile.common.testing import _create_symlink
 from scinoephile.common.validation import val_input_dir_path
 
 
@@ -161,21 +162,3 @@ def test_val_input_dir_path_expands_vars(
     result = val_input_dir_path("$TEST_DIR")
     assert result.exists()
     assert result.is_dir()
-
-
-def _create_symlink(
-    symlink_path: Path, target_path: Path, *, target_is_directory: bool = False
-):
-    """Create a symlink, skipping when Windows privileges do not allow it.
-
-    Arguments:
-        symlink_path: path at which to create the symlink
-        target_path: symlink target path
-        target_is_directory: whether the target is a directory
-    """
-    try:
-        symlink_path.symlink_to(target_path, target_is_directory=target_is_directory)
-    except OSError as exc:
-        if getattr(exc, "winerror", None) == 1314:
-            pytest.skip("Windows symlink privilege is not available")
-        raise

--- a/test/common/validation/test_val_input_dir_path.py
+++ b/test/common/validation/test_val_input_dir_path.py
@@ -9,8 +9,8 @@ from pathlib import Path
 import pytest
 
 from scinoephile.common.exceptions import DirectoryNotFoundError
-from scinoephile.common.testing import create_symlink_or_skip
 from scinoephile.common.validation import val_input_dir_path
+from test.helpers import create_symlink_or_skip
 
 
 def test_val_input_dir_path_valid(tmp_path: Path):

--- a/test/common/validation/test_val_input_dir_path.py
+++ b/test/common/validation/test_val_input_dir_path.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 
 from scinoephile.common.exceptions import DirectoryNotFoundError
-from scinoephile.common.testing import _create_symlink
+from scinoephile.common.testing import create_symlink_or_skip
 from scinoephile.common.validation import val_input_dir_path
 
 
@@ -67,7 +67,7 @@ def test_val_input_dir_path_resolves_symlink(tmp_path: Path):
     test_dir.mkdir()
 
     symlink = tmp_path / "linkdir"
-    _create_symlink(symlink, test_dir, target_is_directory=True)
+    create_symlink_or_skip(symlink, test_dir, target_is_directory=True)
 
     result = val_input_dir_path(symlink)
     assert result == test_dir.resolve()

--- a/test/common/validation/test_val_input_dir_path.py
+++ b/test/common/validation/test_val_input_dir_path.py
@@ -66,7 +66,7 @@ def test_val_input_dir_path_resolves_symlink(tmp_path: Path):
     test_dir.mkdir()
 
     symlink = tmp_path / "linkdir"
-    symlink.symlink_to(test_dir)
+    _create_symlink(symlink, test_dir, target_is_directory=True)
 
     result = val_input_dir_path(symlink)
     assert result == test_dir.resolve()
@@ -161,3 +161,21 @@ def test_val_input_dir_path_expands_vars(
     result = val_input_dir_path("$TEST_DIR")
     assert result.exists()
     assert result.is_dir()
+
+
+def _create_symlink(
+    symlink_path: Path, target_path: Path, *, target_is_directory: bool = False
+):
+    """Create a symlink, skipping when Windows privileges do not allow it.
+
+    Arguments:
+        symlink_path: path at which to create the symlink
+        target_path: symlink target path
+        target_is_directory: whether the target is a directory
+    """
+    try:
+        symlink_path.symlink_to(target_path, target_is_directory=target_is_directory)
+    except OSError as exc:
+        if getattr(exc, "winerror", None) == 1314:
+            pytest.skip("Windows symlink privilege is not available")
+        raise

--- a/test/common/validation/test_val_input_file_or_dir_path.py
+++ b/test/common/validation/test_val_input_file_or_dir_path.py
@@ -42,8 +42,26 @@ def test_val_input_file_or_dir_path_resolves_symlink(tmp_path: Path):
     file_path = tmp_path / "test.txt"
     file_path.write_text("test content")
     symlink_path = tmp_path / "link.txt"
-    symlink_path.symlink_to(file_path)
+    _create_symlink(symlink_path, file_path)
 
     result = val_input_file_or_dir_path(symlink_path)
 
     assert result == file_path.resolve()
+
+
+def _create_symlink(
+    symlink_path: Path, target_path: Path, *, target_is_directory: bool = False
+):
+    """Create a symlink, skipping when Windows privileges do not allow it.
+
+    Arguments:
+        symlink_path: path at which to create the symlink
+        target_path: symlink target path
+        target_is_directory: whether the target is a directory
+    """
+    try:
+        symlink_path.symlink_to(target_path, target_is_directory=target_is_directory)
+    except OSError as exc:
+        if getattr(exc, "winerror", None) == 1314:
+            pytest.skip("Windows symlink privilege is not available")
+        raise

--- a/test/common/validation/test_val_input_file_or_dir_path.py
+++ b/test/common/validation/test_val_input_file_or_dir_path.py
@@ -8,8 +8,8 @@ from pathlib import Path
 
 import pytest
 
-from scinoephile.common.testing import create_symlink_or_skip
 from scinoephile.common.validation import val_input_file_or_dir_path
+from test.helpers import create_symlink_or_skip
 
 
 def test_val_input_file_or_dir_path_accepts_file(tmp_path: Path):

--- a/test/common/validation/test_val_input_file_or_dir_path.py
+++ b/test/common/validation/test_val_input_file_or_dir_path.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from scinoephile.common.testing import _create_symlink
+from scinoephile.common.testing import create_symlink_or_skip
 from scinoephile.common.validation import val_input_file_or_dir_path
 
 
@@ -43,7 +43,7 @@ def test_val_input_file_or_dir_path_resolves_symlink(tmp_path: Path):
     file_path = tmp_path / "test.txt"
     file_path.write_text("test content")
     symlink_path = tmp_path / "link.txt"
-    _create_symlink(symlink_path, file_path)
+    create_symlink_or_skip(symlink_path, file_path)
 
     result = val_input_file_or_dir_path(symlink_path)
 

--- a/test/common/validation/test_val_input_file_or_dir_path.py
+++ b/test/common/validation/test_val_input_file_or_dir_path.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+from scinoephile.common.testing import _create_symlink
 from scinoephile.common.validation import val_input_file_or_dir_path
 
 
@@ -47,21 +48,3 @@ def test_val_input_file_or_dir_path_resolves_symlink(tmp_path: Path):
     result = val_input_file_or_dir_path(symlink_path)
 
     assert result == file_path.resolve()
-
-
-def _create_symlink(
-    symlink_path: Path, target_path: Path, *, target_is_directory: bool = False
-):
-    """Create a symlink, skipping when Windows privileges do not allow it.
-
-    Arguments:
-        symlink_path: path at which to create the symlink
-        target_path: symlink target path
-        target_is_directory: whether the target is a directory
-    """
-    try:
-        symlink_path.symlink_to(target_path, target_is_directory=target_is_directory)
-    except OSError as exc:
-        if getattr(exc, "winerror", None) == 1314:
-            pytest.skip("Windows symlink privilege is not available")
-        raise

--- a/test/common/validation/test_val_input_path.py
+++ b/test/common/validation/test_val_input_path.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 
 from scinoephile.common.exceptions import NotAFileError
-from scinoephile.common.testing import _create_symlink
+from scinoephile.common.testing import create_symlink_or_skip
 from scinoephile.common.validation import val_input_path
 
 
@@ -67,7 +67,7 @@ def test_val_input_path_resolves_symlink(tmp_path: Path):
     test_file.write_text("test content")
 
     symlink = tmp_path / "link.txt"
-    _create_symlink(symlink, test_file)
+    create_symlink_or_skip(symlink, test_file)
 
     result = val_input_path(symlink)
     assert result == test_file.resolve()

--- a/test/common/validation/test_val_input_path.py
+++ b/test/common/validation/test_val_input_path.py
@@ -9,8 +9,8 @@ from pathlib import Path
 import pytest
 
 from scinoephile.common.exceptions import NotAFileError
-from scinoephile.common.testing import create_symlink_or_skip
 from scinoephile.common.validation import val_input_path
+from test.helpers import create_symlink_or_skip
 
 
 def test_val_input_path_valid(tmp_path: Path):

--- a/test/common/validation/test_val_input_path.py
+++ b/test/common/validation/test_val_input_path.py
@@ -66,7 +66,7 @@ def test_val_input_path_resolves_symlink(tmp_path: Path):
     test_file.write_text("test content")
 
     symlink = tmp_path / "link.txt"
-    symlink.symlink_to(test_file)
+    _create_symlink(symlink, test_file)
 
     result = val_input_path(symlink)
     assert result == test_file.resolve()
@@ -157,3 +157,21 @@ def test_val_input_path_expands_vars(tmp_path: Path, monkeypatch: pytest.MonkeyP
     result = val_input_path("$TEST_FILE")
     assert result.exists()
     assert result.is_file()
+
+
+def _create_symlink(
+    symlink_path: Path, target_path: Path, *, target_is_directory: bool = False
+):
+    """Create a symlink, skipping when Windows privileges do not allow it.
+
+    Arguments:
+        symlink_path: path at which to create the symlink
+        target_path: symlink target path
+        target_is_directory: whether the target is a directory
+    """
+    try:
+        symlink_path.symlink_to(target_path, target_is_directory=target_is_directory)
+    except OSError as exc:
+        if getattr(exc, "winerror", None) == 1314:
+            pytest.skip("Windows symlink privilege is not available")
+        raise

--- a/test/common/validation/test_val_input_path.py
+++ b/test/common/validation/test_val_input_path.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from scinoephile.common.exceptions import NotAFileError
+from scinoephile.common.testing import _create_symlink
 from scinoephile.common.validation import val_input_path
 
 
@@ -157,21 +158,3 @@ def test_val_input_path_expands_vars(tmp_path: Path, monkeypatch: pytest.MonkeyP
     result = val_input_path("$TEST_FILE")
     assert result.exists()
     assert result.is_file()
-
-
-def _create_symlink(
-    symlink_path: Path, target_path: Path, *, target_is_directory: bool = False
-):
-    """Create a symlink, skipping when Windows privileges do not allow it.
-
-    Arguments:
-        symlink_path: path at which to create the symlink
-        target_path: symlink target path
-        target_is_directory: whether the target is a directory
-    """
-    try:
-        symlink_path.symlink_to(target_path, target_is_directory=target_is_directory)
-    except OSError as exc:
-        if getattr(exc, "winerror", None) == 1314:
-            pytest.skip("Windows symlink privilege is not available")
-        raise

--- a/test/core/test_paths.py
+++ b/test/core/test_paths.py
@@ -1,0 +1,18 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests for runtime path helpers."""
+
+from __future__ import annotations
+
+from os import environ
+from unittest.mock import patch
+
+from scinoephile.core.paths import get_runtime_cache_dir_path
+
+
+def test_get_runtime_cache_dir_path_handles_missing_home_environment():
+    """Test cache path resolution survives intentionally cleared environments."""
+    with patch.dict(environ, {}, clear=True):
+        cache_dir_path = get_runtime_cache_dir_path(create=False)
+
+    assert cache_dir_path.name == "scinoephile"

--- a/test/core/test_paths.py
+++ b/test/core/test_paths.py
@@ -10,9 +10,10 @@ from unittest.mock import patch
 from scinoephile.core.paths import get_runtime_cache_dir_path
 
 
-def test_get_runtime_cache_dir_path_handles_missing_home_environment():
-    """Test cache path resolution survives intentionally cleared environments."""
-    with patch.dict(environ, {}, clear=True):
-        cache_dir_path = get_runtime_cache_dir_path(create=False)
+def test_get_runtime_cache_dir_path_handles_windows_missing_home_environment():
+    """Test Windows cache path resolution survives cleared environments."""
+    with patch("scinoephile.core.paths.system", return_value="Windows"):
+        with patch.dict(environ, {}, clear=True):
+            cache_dir_path = get_runtime_cache_dir_path(create=False)
 
     assert cache_dir_path.name == "scinoephile"

--- a/test/helpers/__init__.py
+++ b/test/helpers/__init__.py
@@ -28,6 +28,7 @@ __all__ = [
     "assert_expected_warnings",
     "assert_series_equal",
     "build_subcommands",
+    "create_symlink_or_skip",
     "get_warning_messages",
     "get_usage_prefix",
     "parametrized_fixture",
@@ -113,6 +114,24 @@ def build_subcommands(cli: tuple[type[CommandLineInterface], ...]) -> str:
         subcommand string to append to the base CLI
     """
     return " ".join(f"{command.name()}" for command in cli[1:])
+
+
+def create_symlink_or_skip(
+    symlink_path: Path, target_path: Path, *, target_is_directory: bool = False
+):
+    """Create a symlink, skipping when Windows privileges do not allow it.
+
+    Arguments:
+        symlink_path: path at which to create the symlink
+        target_path: symlink target path
+        target_is_directory: whether the target is a directory
+    """
+    try:
+        symlink_path.symlink_to(target_path, target_is_directory=target_is_directory)
+    except OSError as exc:
+        if getattr(exc, "winerror", None) == 1314:
+            pytest.skip("Windows symlink privilege is not available")
+        raise
 
 
 def get_usage_prefix(cli: tuple[type[CommandLineInterface], ...]) -> str:


### PR DESCRIPTION
## Summary
- make CLI logging UTF-8-safe for log files and tolerant of Windows console code pages
- make runtime cache path resolution survive cleared environments without a discoverable home directory
- normalize cache CLI relative paths to POSIX-style output for stable text/JSON assertions
- update Windows-sensitive tests for UTF-8 fixture reads, platform-appropriate CLI quoting, portable subprocess commands, and unavailable symlink privileges

## Root causes
- Windows default cp1252 decoding/encoding could not handle UTF-8 subtitle fixtures or Chinese dictionary log messages.
- `Path.home()` raises when tests intentionally clear the environment, which broke default cache path construction during localized help generation.
- cache CLI output exposed platform-native separators, while tests and JSON consumers expected stable slash-separated relative paths.
- subprocess tests invoked `echo`, which is a shell built-in on Windows, while production intentionally uses `shell=False`.
- symlink tests assumed the current Windows account can create symlinks.
- dictionary CLI tests used POSIX `shlex.quote`, which is not valid for the Windows CLI splitter used by the test helper.

## Verification
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format <changed Python files>`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix <changed Python files>`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check <changed Python files>`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` -> 1287 passed, 9 skipped