### PR TITLE
Disable Paddle MKLDNN on Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,11 @@ ocr = [
     "paddleocr>=3.1.0",
     "paddlepaddle>=3.3.1; (platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')",
 ]
+ocr-cuda = [
+    "chrome-lens-py>=3.4.5",
+    "paddleocr>=3.1.0",
+    "paddlepaddle-gpu==3.2.2; platform_machine == 'AMD64' and sys_platform == 'win32'",
+]
 transcription = [
     "demucs-infer>=4.1.2",
     "huggingface-hub>=1.18.0",
@@ -122,3 +127,11 @@ scinoephile = [
 
 [tool.uv]
 package = true
+
+[[tool.uv.index]]
+name = "paddlepaddle-cu126"
+url = "https://www.paddlepaddle.org.cn/packages/stable/cu126/"
+explicit = true
+
+[tool.uv.sources]
+paddlepaddle-gpu = { index = "paddlepaddle-cu126" }

--- a/scinoephile/image/ocr/paddle/paddle_recognizer.py
+++ b/scinoephile/image/ocr/paddle/paddle_recognizer.py
@@ -10,6 +10,7 @@ import os
 from dataclasses import asdict
 from logging import getLogger
 from pathlib import Path
+from platform import system
 from typing import Any, TypedDict, override
 
 import numpy as np
@@ -97,6 +98,7 @@ class PaddleRecognizer:
             text_detection_model_name=_TEXT_DETECTION_MODEL_NAME,
             text_recognition_model_name=_TEXT_RECOGNITION_MODEL_NAME,
             textline_orientation_model_name=_TEXTLINE_ORIENTATION_MODEL_NAME,
+            enable_mkldnn=system() != "Windows",
         )
 
     @override

--- a/test/image/ocr/paddle/test_engine.py
+++ b/test/image/ocr/paddle/test_engine.py
@@ -67,10 +67,10 @@ def test_paddle_recognizer_caches_results_by_image(tmp_path: Path):
     assert len(list(tmp_path.glob("*.json"))) == 1
 
 
-def test_paddle_recognizer_uses_server_models(
+def test_paddle_recognizer_uses_server_models_and_disables_mkldnn_on_windows(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """Test PaddleOCR recognizer hardcodes PP-OCRv5 server models.
+    """Test PaddleOCR recognizer hardcodes server models and Windows MKL-DNN.
 
     Arguments:
         monkeypatch: pytest monkeypatch fixture
@@ -91,12 +91,51 @@ def test_paddle_recognizer_uses_server_models(
     paddleocr = ModuleType("paddleocr")
     setattr(paddleocr, "PaddleOCR", FakePaddleOCR)
     monkeypatch.setitem(sys.modules, "paddleocr", paddleocr)
+    monkeypatch.setattr(
+        "scinoephile.image.ocr.paddle.paddle_recognizer.system",
+        lambda: "Windows",
+    )
 
     PaddleRecognizer(language=Language.zho_hans)
 
     assert observed_kwargs["lang"] == "ch"
     assert observed_kwargs["text_detection_model_name"] == "PP-OCRv5_server_det"
     assert observed_kwargs["text_recognition_model_name"] == "PP-OCRv5_server_rec"
+    assert observed_kwargs["enable_mkldnn"] is False
+
+
+def test_paddle_recognizer_keeps_mkldnn_enabled_off_windows(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test PaddleOCR recognizer keeps MKL-DNN enabled off Windows.
+
+    Arguments:
+        monkeypatch: pytest monkeypatch fixture
+    """
+    observed_kwargs = {}
+
+    class FakePaddleOCR:
+        """Fake PaddleOCR implementation."""
+
+        def __init__(self, **kwargs: str | bool):
+            """Initialize.
+
+            Arguments:
+                **kwargs: PaddleOCR keyword arguments
+            """
+            observed_kwargs.update(kwargs)
+
+    paddleocr = ModuleType("paddleocr")
+    setattr(paddleocr, "PaddleOCR", FakePaddleOCR)
+    monkeypatch.setitem(sys.modules, "paddleocr", paddleocr)
+    monkeypatch.setattr(
+        "scinoephile.image.ocr.paddle.paddle_recognizer.system",
+        lambda: "Linux",
+    )
+
+    PaddleRecognizer(language=Language.zho_hans)
+
+    assert observed_kwargs["enable_mkldnn"] is True
 
 
 def test_paddle_recognizer_imports_paddleocr_only_when_needed():

--- a/test/test_project_metadata.py
+++ b/test/test_project_metadata.py
@@ -20,3 +20,22 @@ def test_web_dependencies_are_optional():
     assert any(
         dependency.startswith("flask") for dependency in optional_dependencies["web"]
     )
+
+
+def test_ocr_cuda_extra_uses_gpu_paddle_without_cpu_paddle():
+    """Test CUDA OCR dependencies do not include conflicting CPU Paddle."""
+    pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+
+    optional_dependencies = pyproject["project"]["optional-dependencies"]
+    ocr_cuda_dependencies = optional_dependencies["ocr-cuda"]
+
+    assert any(
+        dependency.startswith("paddlepaddle-gpu")
+        for dependency in ocr_cuda_dependencies
+    )
+    assert not any(
+        dependency.startswith("paddlepaddle")
+        and not dependency.startswith("paddlepaddle-gpu")
+        for dependency in ocr_cuda_dependencies
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1160,6 +1160,24 @@ wheels = [
 ]
 
 [[package]]
+name = "paddlepaddle-gpu"
+version = "3.2.2"
+source = { registry = "https://www.paddlepaddle.org.cn/packages/stable/cu126/" }
+dependencies = [
+    { name = "httpx", marker = "sys_platform == 'win32'" },
+    { name = "networkx", marker = "sys_platform == 'win32'" },
+    { name = "numpy", marker = "sys_platform == 'win32'" },
+    { name = "opt-einsum", marker = "sys_platform == 'win32'" },
+    { name = "pillow", marker = "sys_platform == 'win32'" },
+    { name = "protobuf", marker = "sys_platform == 'win32'" },
+    { name = "safetensors", marker = "sys_platform == 'win32'" },
+    { name = "typing-extensions", marker = "sys_platform == 'win32'" },
+]
+wheels = [
+    { url = "https://paddle-whl.bj.bcebos.com/stable/cu126/paddlepaddle-gpu/paddlepaddle_gpu-3.2.2-cp313-cp313-win_amd64.whl" },
+]
+
+[[package]]
 name = "paddlex"
 version = "3.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1780,6 +1798,11 @@ ocr = [
     { name = "paddleocr" },
     { name = "paddlepaddle", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
+ocr-cuda = [
+    { name = "chrome-lens-py" },
+    { name = "paddleocr" },
+    { name = "paddlepaddle-gpu", marker = "platform_machine == 'AMD64' and sys_platform == 'win32'" },
+]
 transcription = [
     { name = "demucs-infer" },
     { name = "huggingface-hub" },
@@ -1810,6 +1833,7 @@ requires-dist = [
     { name = "audioop-lts", specifier = ">=0.2.2" },
     { name = "beautifulsoup4", specifier = ">=4.14.3" },
     { name = "chrome-lens-py", marker = "extra == 'ocr'", specifier = ">=3.4.5" },
+    { name = "chrome-lens-py", marker = "extra == 'ocr-cuda'", specifier = ">=3.4.5" },
     { name = "demucs-infer", marker = "extra == 'transcription'", specifier = ">=4.1.2" },
     { name = "ffmpeg-python", specifier = ">=0.2.0" },
     { name = "flask", marker = "extra == 'web'", specifier = ">=3.1.3" },
@@ -1822,7 +1846,9 @@ requires-dist = [
     { name = "openai", specifier = ">=2.41.0" },
     { name = "opencc", specifier = ">=1.3.1" },
     { name = "paddleocr", marker = "extra == 'ocr'", specifier = ">=3.1.0" },
+    { name = "paddleocr", marker = "extra == 'ocr-cuda'", specifier = ">=3.1.0" },
     { name = "paddlepaddle", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'ocr') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'ocr') or (platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'ocr')", specifier = ">=3.3.1" },
+    { name = "paddlepaddle-gpu", marker = "platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'ocr-cuda'", specifier = "==3.2.2", index = "https://www.paddlepaddle.org.cn/packages/stable/cu126/" },
     { name = "pillow", specifier = ">=12.1.1" },
     { name = "pycantonese", specifier = ">=5.0.0" },
     { name = "pydantic", specifier = ">=2.13.4" },
@@ -1838,7 +1864,7 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.15.0" },
     { name = "whisper-timestamped", marker = "extra == 'transcription'", specifier = ">=1.15.9" },
 ]
-provides-extras = ["ocr", "transcription", "web"]
+provides-extras = ["ocr", "ocr-cuda", "transcription", "web"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
- Disable PaddleOCR MKL-DNN/oneDNN execution on Windows while preserving the existing default off Windows
- Add an `ocr-cuda` extra for Windows CUDA installs that uses `paddlepaddle-gpu==3.2.2` from Paddle's CUDA 12.6 index instead of the CPU `paddlepaddle` wheel
- Add regression coverage for the Windows/non-Windows PaddleOCR constructor behavior and for the CUDA extra avoiding conflicting CPU/GPU Paddle dependencies

## Root Cause
PaddleOCR 3.4.1 with paddlepaddle 3.3.1 fails on Windows CPU execution through oneDNN/MKLDNN for the Wall-E Simplified Chinese sample image with:

`ConvertPirAttribute2RuntimeAttribute not support [pir::ArrayAttribute<pir::DoubleAttribute>]`

Passing `enable_mkldnn=False` to `PaddleOCR` avoids the failing oneDNN path and lets PaddleOCR complete on the same image. CUDA installs also need a dependency path that does not let `uv sync` restore the CPU-only `paddlepaddle` wheel, so this PR adds `ocr-cuda` as a separate extra.

## CUDA Install Path
Windows users with a compatible NVIDIA GPU can install the CUDA 12.6 Paddle wheel through:

`UV_CACHE_DIR=/tmp/uv-cache uv sync --extra ocr-cuda`

The default `ocr` extra remains CPU-oriented and keeps the existing `paddlepaddle` dependency.

## Verification
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile\image\ocr\paddle\paddle_recognizer.py test\image\ocr\paddle\test_engine.py test\test_project_metadata.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile\image\ocr\paddle\paddle_recognizer.py test\image\ocr\paddle\test_engine.py test\test_project_metadata.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile\image\ocr\paddle\paddle_recognizer.py test\image\ocr\paddle\test_engine.py test\test_project_metadata.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest test\image\ocr\paddle -q`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest test\test_project_metadata.py -q`
- `UV_CACHE_DIR=/tmp/uv-cache uv sync --extra ocr-cuda --dry-run` -> would replace `paddlepaddle==3.3.1` with `paddlepaddle-gpu==3.2.2`
- Wall-E `0001.png` PaddleOCR repro returns `华特·迪斯尼`
- From `test`: `UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` -> `1289 passed, 9 skipped`