### PR TITLE
Centralize pytest parametrize helper

### DIFF
--- a/test/analysis/character_error_rate/test_character_error_rate.py
+++ b/test/analysis/character_error_rate/test_character_error_rate.py
@@ -10,7 +10,7 @@ import pytest
 
 from scinoephile.analysis.character_error_rate import LineCER, SeriesCER
 from scinoephile.core.subtitles import Series, Subtitle
-from test.helpers import SeriesCERResult
+from test.helpers import SeriesCERResult, parametrize
 
 
 def _get_series(*texts: str) -> Series:
@@ -29,7 +29,7 @@ def _get_series(*texts: str) -> Series:
     )
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("reference", "candidate", "expected"),
     [
         (
@@ -164,7 +164,7 @@ def test_line_cer(
     assert result.reference_length == expected.reference_length
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("reference", "candidate"),
     [
         (_get_series("你", "好"), _get_series("你好")),
@@ -184,7 +184,7 @@ def test_series_cer_ignores_separator_only_line_wrapping(
     assert result.deletions == 0
 
 
-@pytest.mark.parametrize(
+@parametrize(
     (
         "reference_series_fixture_name",
         "candidate_series_fixture_name",

--- a/test/analysis/diff/test_series_diff.py
+++ b/test/analysis/diff/test_series_diff.py
@@ -9,6 +9,7 @@ import pytest
 from scinoephile.analysis.diff import LineDiffKind, SeriesDiff
 from scinoephile.core import ScinoephileError
 from scinoephile.core.subtitles import Series, Subtitle
+from test.helpers import parametrize
 
 
 def _get_series(*texts: str) -> Series:
@@ -95,7 +96,7 @@ def test_series_diff_reports_shift():
     assert messages[0].two_idxs == (0, 1)
 
 
-@pytest.mark.parametrize(
+@parametrize(
     (
         "one_texts",
         "two_texts",
@@ -155,7 +156,7 @@ def test_series_diff_keeps_uncovered_insert_separate():
     assert messages[0].two_texts == ("Damn!",)
 
 
-@pytest.mark.parametrize(
+@parametrize(
     (
         "one_fixture_name",
         "two_fixture_name",
@@ -271,7 +272,7 @@ def test_series_diff_get_stacked_str_can_include_equal_lines():
     ]
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("one_texts", "two_texts", "expected_lines"),
     [
         (

--- a/test/analysis/diff/test_series_diff_alignment.py
+++ b/test/analysis/diff/test_series_diff_alignment.py
@@ -4,10 +4,9 @@
 
 from __future__ import annotations
 
-import pytest
-
 from scinoephile.analysis.diff import LineDiffKind, SeriesDiff
 from scinoephile.core.subtitles import Series, Subtitle
+from test.helpers import parametrize
 
 
 def _get_series(*texts: str) -> Series:
@@ -206,7 +205,7 @@ def test_series_diff_pairs_one_sided_punctuation_with_context_line():
     assert messages[1].two_idxs == (1,)
 
 
-@pytest.mark.parametrize(
+@parametrize(
     (
         "one_texts",
         "two_texts",

--- a/test/analysis/line_alignment/test_line_alignment.py
+++ b/test/analysis/line_alignment/test_line_alignment.py
@@ -5,15 +5,15 @@
 from __future__ import annotations
 
 import numpy as np
-import pytest
 
 from scinoephile.analysis.line_alignment import (
     LineAlignment,
     LineAlignmentOperation,
 )
+from test.helpers import parametrize
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("one", "two", "expected_pairs"),
     [
         (

--- a/test/audio/transcription/test_whisper_transcriber.py
+++ b/test/audio/transcription/test_whisper_transcriber.py
@@ -19,6 +19,7 @@ from scinoephile.audio.transcription.transcribed_segment import TranscribedSegme
 from scinoephile.audio.transcription.transcribed_word import TranscribedWord
 from scinoephile.audio.transcription.whisper_transcriber import WhisperTranscriber
 from scinoephile.common.subprocess import run_command
+from test.helpers import parametrize
 
 _OPTIONAL_TRANSCRIPTION_MODULES = (
     "demucs_infer",
@@ -32,7 +33,7 @@ _OPTIONAL_TRANSCRIPTION_MODULES = (
 _REPO_ROOT_PATH = Path(__file__).parents[3]
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("field_name", "first_value", "second_value"),
     [
         ("use_vad", True, False),
@@ -75,7 +76,7 @@ def test_get_cache_path_separates_configuration(
     assert first_cache_path != second_cache_path
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("model_name", "expected"),
     [
         ("khleeloo/whisper-large-v3-cantonese", True),

--- a/test/cli/dictionary/test_dictionary_search_cli.py
+++ b/test/cli/dictionary/test_dictionary_search_cli.py
@@ -24,6 +24,7 @@ from scinoephile.core.dictionaries import (
     DictionarySource,
     DictionarySqliteStore,
 )
+from test.helpers import parametrize
 
 
 @pytest.fixture(scope="module")
@@ -121,7 +122,7 @@ def dictionary_database_dir_path() -> Generator[Path]:
         yield dir_path
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("query", "expected_output", "expectation"),
     [
         ("山坑", "山坑", nullcontext()),

--- a/test/cli/eng/test_eng_process_cli.py
+++ b/test/cli/eng/test_eng_process_cli.py
@@ -7,16 +7,14 @@ from __future__ import annotations
 from io import StringIO
 from unittest.mock import patch
 
-import pytest
-
 from scinoephile.cli.eng.eng_process_cli import EngProcessCli
 from scinoephile.common.file import get_temp_file_path
 from scinoephile.common.testing import run_cli_with_args
 from scinoephile.core.subtitles import Series
-from test.helpers import assert_series_equal, test_data_root
+from test.helpers import assert_series_equal, parametrize, test_data_root
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("input_path", "args", "expected_path"),
     [
         (
@@ -52,7 +50,7 @@ def test_eng_process_cli(
     assert_series_equal(output, expected)
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("input_path", "args", "expected_path"),
     [
         (

--- a/test/cli/helpers/test_io.py
+++ b/test/cli/helpers/test_io.py
@@ -16,9 +16,10 @@ from scinoephile.cli.helpers.io import read_image_series, read_series, write_ser
 from scinoephile.common.exceptions import NotAFileError
 from scinoephile.core import ScinoephileError
 from scinoephile.core.subtitles import Series, Subtitle
+from test.helpers import parametrize
 
 
-@pytest.mark.parametrize(
+@parametrize(
     "exception",
     [
         FileNotFoundError("missing image subtitles"),
@@ -50,7 +51,7 @@ def test_read_image_series_maps_file_errors_to_parser_error(
     assert str(exception) in stderr.getvalue()
 
 
-@pytest.mark.parametrize(
+@parametrize(
     "exception",
     [
         FileNotFoundError("missing subtitles"),
@@ -83,7 +84,7 @@ def test_read_series_maps_file_errors_to_parser_error(
     assert str(exception) in stderr.getvalue()
 
 
-@pytest.mark.parametrize(
+@parametrize(
     "exception",
     [
         ScinoephileError("invalid stdin subtitle series"),

--- a/test/cli/media/test_media_offset_cli.py
+++ b/test/cli/media/test_media_offset_cli.py
@@ -12,6 +12,7 @@ import pytest
 
 from scinoephile.cli.media.media_offset_cli import MediaOffsetCli
 from scinoephile.common.testing import run_cli_with_args
+from test.helpers import parametrize
 
 
 def test_media_offset_cli_reports_offset(
@@ -187,7 +188,7 @@ def test_media_offset_cli_rejects_start_time_argument(
     assert "unrecognized arguments: --start-time 600" in capsys.readouterr().err
 
 
-@pytest.mark.parametrize(
+@parametrize(
     "argument",
     [
         "--max-offset",

--- a/test/cli/media/test_media_probe_cli.py
+++ b/test/cli/media/test_media_probe_cli.py
@@ -13,6 +13,7 @@ from scinoephile.cli.media.media_probe_cli import MediaProbeCli
 from scinoephile.common.testing import run_cli_with_args
 from scinoephile.core.media import AudioStream, SubtitleStream, VideoStream
 from scinoephile.lang.zho.subtitles.analysis import ZhoSubtitleScriptAnalysis
+from test.helpers import parametrize
 
 
 def test_media_probe_cli_lists_all_streams(
@@ -64,7 +65,7 @@ def test_media_probe_cli_lists_all_streams(
     ]
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("script", "language"),
     [
         ("zho-Hant", "zho-Hant"),

--- a/test/cli/multi/test_multi_stack_cli.py
+++ b/test/cli/multi/test_multi_stack_cli.py
@@ -13,7 +13,7 @@ import pytest
 from scinoephile.cli.multi.multi_stack_cli import MultiStackCli
 from scinoephile.common.testing import run_cli_with_args
 from scinoephile.core.subtitles import Series
-from test.helpers import assert_series_equal
+from test.helpers import assert_series_equal, parametrize
 
 
 def test_multi_stack_cli_stacks_without_sync_by_default(tmp_path: Path):
@@ -66,7 +66,7 @@ def test_multi_stack_cli_can_sync_bottom_to_top_anchor(tmp_path: Path):
     assert_series_equal(Series.load(output_path), expected)
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("args", "expected_error"),
     [
         ("--sync-cutoff -0.01", "-0.01 is less than minimum value of 0.0"),

--- a/test/cli/multi/test_multi_sync_cli.py
+++ b/test/cli/multi/test_multi_sync_cli.py
@@ -13,7 +13,7 @@ import pytest
 from scinoephile.cli.multi.multi_sync_cli import MultiSyncCli
 from scinoephile.common.testing import run_cli_with_args
 from scinoephile.core.subtitles import Series
-from test.helpers import assert_series_equal
+from test.helpers import assert_series_equal, parametrize
 
 
 def test_multi_sync_cli_shifts_mobile_to_anchor_and_writes_file(
@@ -75,7 +75,7 @@ def test_multi_sync_cli_pipe(tmp_path: Path):
     assert_series_equal(output, expected)
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("args", "expected_error"),
     [
         ("--sync-cutoff -0.01", "-0.01 is less than minimum value of 0.0"),

--- a/test/cli/ocr/test_ocr_cli.py
+++ b/test/cli/ocr/test_ocr_cli.py
@@ -24,6 +24,7 @@ from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.image.subtitles import ImageSeries
 from test.helpers import (
     assert_series_equal,
+    parametrize,
     skip_if_ci,
     test_data_root,
 )
@@ -376,7 +377,7 @@ def test_ocr_tesseract_cli_rejects_italic_detection_for_non_english(
     assert "--detect-italics may only be used with --language eng" in stderr.getvalue()
 
 
-@pytest.mark.parametrize(
+@parametrize(
     (
         "cli",
         "load_target",
@@ -538,7 +539,7 @@ def test_ocr_lens_cli_matches_mlamd_sup_ocr_fixture(
     not getenv("SCINOEPHILE_RUN_MLAMD_PADDLE_OCR"),
     reason="Set SCINOEPHILE_RUN_MLAMD_PADDLE_OCR=1 to run full MLAMD PaddleOCR tests",
 )
-@pytest.mark.parametrize(
+@parametrize(
     (
         "sup_path",
         "language",

--- a/test/cli/test_cli_argument_choices.py
+++ b/test/cli/test_cli_argument_choices.py
@@ -6,8 +6,6 @@ from __future__ import annotations
 
 from argparse import Action
 
-import pytest
-
 from scinoephile.cli.multi.multi_stack_cli import MultiStackCli
 from scinoephile.cli.ocr.ocr_fuse_cli import OcrFuseCli
 from scinoephile.cli.ocr.ocr_lens_cli import OcrLensCli
@@ -23,11 +21,12 @@ from scinoephile.cli.zho.zho_process_cli import ZhoProcessCli
 from scinoephile.cli.zho.zho_translate_from_eng_cli import ZhoTranslateFromEngCli
 from scinoephile.cli.zho.zho_translate_from_yue_cli import ZhoTranslateFromYueCli
 from scinoephile.common import CommandLineInterface
+from test.helpers import parametrize
 
 OCR_LANGUAGE_METAVAR = "{eng,yue-Hans,yue-Hant,zho-Hans,zho-Hant}"
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("cli", "option", "metavar"),
     [
         (OcrFuseCli, "--language", "{eng,zho}"),

--- a/test/cli/test_cli_argument_groups.py
+++ b/test/cli/test_cli_argument_groups.py
@@ -30,6 +30,7 @@ from scinoephile.cli.zho.zho_process_cli import ZhoProcessCli
 from scinoephile.cli.zho.zho_translate_from_eng_cli import ZhoTranslateFromEngCli
 from scinoephile.cli.zho.zho_translate_from_yue_cli import ZhoTranslateFromYueCli
 from scinoephile.common import CommandLineInterface
+from test.helpers import parametrize
 
 LLM_CLIS: tuple[type[CommandLineInterface], ...] = (
     EngProcessCli,
@@ -49,7 +50,7 @@ LLM_CLIS: tuple[type[CommandLineInterface], ...] = (
 """CLI classes that expose shared LLM arguments."""
 
 
-@pytest.mark.parametrize("cli", LLM_CLIS)
+@parametrize("cli", LLM_CLIS)
 def test_llm_options_are_in_llm_argument_group(cli: type[CommandLineInterface]):
     """Test shared LLM options are grouped separately from operation options.
 
@@ -105,7 +106,7 @@ def test_add_llm_provider_args_bundles_standard_llm_options(tmp_path):
     assert default_namespace.llm_args == LlmArguments()
 
 
-@pytest.mark.parametrize("cli", (OcrProcessCli, OcrValidateCli))
+@parametrize("cli", (OcrProcessCli, OcrValidateCli))
 def test_ocr_web_options_are_in_web_argument_group(cli: type[CommandLineInterface]):
     """Test OCR web options are grouped separately from operation options.
 

--- a/test/cli/test_llm_cli.py
+++ b/test/cli/test_llm_cli.py
@@ -26,9 +26,10 @@ from scinoephile.cli.zho.zho_translate_from_eng_cli import ZhoTranslateFromEngCl
 from scinoephile.cli.zho.zho_translate_from_yue_cli import ZhoTranslateFromYueCli
 from scinoephile.common import CommandLineInterface
 from scinoephile.common.testing import run_cli_with_args
+from test.helpers import parametrize
 
 
-@pytest.mark.parametrize(
+@parametrize(
     "cli",
     [
         EngProcessCli,

--- a/test/cli/test_localized_cli_help.py
+++ b/test/cli/test_localized_cli_help.py
@@ -16,6 +16,7 @@ from scinoephile.cli.scinoephile_cli import ScinoephileCli
 from scinoephile.common import CommandLineInterface
 from scinoephile.common.testing import run_cli_with_args
 from scinoephile.core.cli import ScinoephileCliBase
+from test.helpers import parametrize
 
 
 def test_all_cli_help_text_has_chinese_localizations():
@@ -68,7 +69,7 @@ def test_all_cli_help_paths_do_not_create_default_cache_dir(
     assert not cache_dir_path.exists()
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("locale_name", "subcommand", "expected_fragment"),
     [
         (
@@ -195,7 +196,7 @@ def test_locale_precedence_uses_environment_variable():
     assert "Scinoephile 命令列介面" in output
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("locale_name", "expected_fragments"),
     [
         ("en", ("Command-line interface for Scinoephile", "subcommand")),
@@ -219,7 +220,7 @@ def test_scinoephile_help_localized(
         assert fragment in output
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("locale_name", "subcommand", "expected_fragment"),
     [
         ("en", "multi cer", "Calculate the Character Error Rate (CER)"),

--- a/test/cli/test_opencc_cli.py
+++ b/test/cli/test_opencc_cli.py
@@ -17,9 +17,10 @@ from scinoephile.cli.yue.yue_transcribe_vs_zho_cli import YueTranscribeVsZhoCli
 from scinoephile.cli.zho.zho_process_cli import ZhoProcessCli
 from scinoephile.common import CommandLineInterface
 from scinoephile.common.testing import run_cli_with_args
+from test.helpers import parametrize
 
 
-@pytest.mark.parametrize(
+@parametrize(
     "cli",
     [
         ZhoProcessCli,

--- a/test/cli/test_overwrite_argparse.py
+++ b/test/cli/test_overwrite_argparse.py
@@ -6,8 +6,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from scinoephile.cli.eng.eng_process_cli import EngProcessCli
 from scinoephile.cli.eng.eng_translate_from_yue_cli import EngTranslateFromYueCli
 from scinoephile.cli.eng.eng_translate_from_zho_cli import EngTranslateFromZhoCli
@@ -22,9 +20,10 @@ from scinoephile.cli.zho.zho_process_cli import ZhoProcessCli
 from scinoephile.cli.zho.zho_translate_from_eng_cli import ZhoTranslateFromEngCli
 from scinoephile.cli.zho.zho_translate_from_yue_cli import ZhoTranslateFromYueCli
 from scinoephile.common import CommandLineInterface
+from test.helpers import parametrize
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("cli_class", "args_template"),
     [
         (

--- a/test/cli/yue/test_yue_process_cli.py
+++ b/test/cli/yue/test_yue_process_cli.py
@@ -13,10 +13,10 @@ from scinoephile.cli.yue.yue_process_cli import YueProcessCli
 from scinoephile.common.file import get_temp_file_path
 from scinoephile.common.testing import run_cli_with_args
 from scinoephile.core.subtitles import Series
-from test.helpers import assert_series_equal, test_data_root
+from test.helpers import assert_series_equal, parametrize, test_data_root
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("input_path", "args", "expected_path"),
     [
         (
@@ -52,7 +52,7 @@ def test_yue_process_cli(
     assert_series_equal(output, expected)
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("input_path", "args", "expected_path"),
     [
         (

--- a/test/cli/zho/test_zho_process_cli.py
+++ b/test/cli/zho/test_zho_process_cli.py
@@ -14,10 +14,10 @@ from scinoephile.common.file import get_temp_file_path
 from scinoephile.common.testing import run_cli_with_args
 from scinoephile.core.subtitles import Series
 from scinoephile.llms.providers.deepseek_provider import DeepSeekProvider
-from test.helpers import assert_series_equal, test_data_root
+from test.helpers import assert_series_equal, parametrize, test_data_root
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("input_path", "args", "expected_path"),
     [
         (
@@ -58,7 +58,7 @@ def test_zho_process_cli(
     assert_series_equal(output, expected)
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("input_path", "args", "expected_path"),
     [
         (

--- a/test/common/subprocess/test_run_command.py
+++ b/test/common/subprocess/test_run_command.py
@@ -12,10 +12,11 @@ from time import monotonic
 import pytest
 
 from scinoephile.common.subprocess import run_command
+from test.helpers import parametrize
 from test.helpers.subprocess_cases import SUBPROCESS_SUCCESS_CASES
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("command", "expected_stdout_fragments"),
     [(command, fragments) for _, command, fragments in SUBPROCESS_SUCCESS_CASES],
     ids=[name for name, _, _ in SUBPROCESS_SUCCESS_CASES],

--- a/test/common/subprocess/test_run_command_live.py
+++ b/test/common/subprocess/test_run_command_live.py
@@ -13,10 +13,11 @@ from time import monotonic
 import pytest
 
 from scinoephile.common.subprocess import run_command_live
+from test.helpers import parametrize
 from test.helpers.subprocess_cases import SUBPROCESS_SUCCESS_CASES
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("command", "expected_stdout_fragments"),
     [(command, fragments) for _, command, fragments in SUBPROCESS_SUCCESS_CASES],
     ids=[name for name, _, _ in SUBPROCESS_SUCCESS_CASES],

--- a/test/common/test_command_line_interface.py
+++ b/test/common/test_command_line_interface.py
@@ -16,6 +16,7 @@ from scinoephile.common.command_line_interface import (
 )
 from scinoephile.common.testing import run_cli_with_args
 from test import helpers
+from test.helpers import parametrize
 
 
 class ArgsCaptureCli(CommandLineInterface):
@@ -106,7 +107,7 @@ class ReportTool(CommandLineInterface):
         pass
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("cli_cls", "expected_name"),
     [
         (TestCli, "test"),

--- a/test/common/test_duration.py
+++ b/test/common/test_duration.py
@@ -9,9 +9,10 @@ from datetime import timedelta
 import pytest
 
 from scinoephile.common.duration import parse_duration
+from test.helpers import parametrize
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("value", "expected"),
     [
         ("30s", timedelta(seconds=30)),

--- a/test/common/test_exceptions.py
+++ b/test/common/test_exceptions.py
@@ -4,8 +4,6 @@
 
 from __future__ import annotations
 
-import pytest
-
 from scinoephile.common.exceptions import (
     ArgumentConflictError,
     DirectoryExistsError,
@@ -17,9 +15,10 @@ from scinoephile.common.exceptions import (
     NotAFileOrDirectoryError,
     UnsupportedPlatformError,
 )
+from test.helpers import parametrize
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("exception_cls", "base_cls"),
     [
         (ArgumentConflictError, Exception),

--- a/test/common/test_logs.py
+++ b/test/common/test_logs.py
@@ -6,12 +6,11 @@ from __future__ import annotations
 
 from logging import DEBUG, ERROR, INFO, WARNING, getLogger
 
-import pytest
-
 from scinoephile.common.logs import set_logging_verbosity
+from test.helpers import parametrize
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("verbosity", "expected_level"),
     [
         (0, ERROR),

--- a/test/common/validation/test_val_float.py
+++ b/test/common/validation/test_val_float.py
@@ -11,9 +11,10 @@ import pytest
 
 from scinoephile.common.exceptions import ArgumentConflictError
 from scinoephile.common.validation import val_float
+from test.helpers import parametrize
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("value", "expected"),
     [
         (3.14, 3.14),
@@ -27,7 +28,7 @@ def test_val_float_accepts_scalar_values(value: float | int | str, expected: flo
     assert val_float(value) == expected
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("constraint", "value", "expected_error"),
     [
         ("min", -1.0, "less than minimum"),
@@ -55,7 +56,7 @@ def test_val_float_rejects_invalid_values_and_conflicting_constraints():
         val_float(5.0, min_value=5.0, max_value=5.0)
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("value", "expected"),
     [
         ([1.0, 2.0, 3.0], [1.0, 2.0, 3.0]),

--- a/test/common/validation/test_val_int.py
+++ b/test/common/validation/test_val_int.py
@@ -11,9 +11,10 @@ import pytest
 
 from scinoephile.common.exceptions import ArgumentConflictError
 from scinoephile.common.validation import val_int
+from test.helpers import parametrize
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("value", "expected"),
     [
         (5, 5),
@@ -27,7 +28,7 @@ def test_val_int_accepts_scalar_values(value: float | int | str, expected: int):
     assert val_int(value) == expected
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("constraint", "expected_error"),
     [
         ("min", "less than minimum"),
@@ -58,7 +59,7 @@ def test_val_int_rejects_invalid_values_and_conflicting_constraints():
         val_int(5, min_value=5, max_value=5)
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("value", "expected"),
     [
         ([1, 2, 3], [1, 2, 3]),

--- a/test/core/test_stacking.py
+++ b/test/core/test_stacking.py
@@ -13,7 +13,7 @@ from scinoephile.core.stacking import (
     get_stacked_series_from_groups,
 )
 from scinoephile.core.subtitles import Series, Subtitle
-from test.helpers import assert_series_equal
+from test.helpers import assert_series_equal, parametrize
 
 
 def test_get_stacked_series_does_not_overlap_union_timing():
@@ -38,7 +38,7 @@ def test_get_stacked_series_does_not_overlap_union_timing():
     assert output.events[1].start >= output.events[0].end
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("timing_mode", "expected_times"),
     [
         (StackTimingMode.TOP, [(1000, 2000), (2100, 3000)]),
@@ -87,7 +87,7 @@ def test_get_stacked_series_timing_mode_uses_available_timing_for_unpaired_subti
         assert [event.text for event in output.events] == ["A", "1"]
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("timing_mode", "expected_times"),
     [
         (StackTimingMode.TOP, [(1000, 1500), (1500, 2000)]),
@@ -132,7 +132,7 @@ def test_get_stacked_series_overlap_error_includes_event_context():
         get_stacked_series_from_groups(one, Series(), [([0], []), ([1], [])])
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("one_fixture", "two_fixture", "expected_fixture"),
     [
         pytest.param(

--- a/test/core/test_text.py
+++ b/test/core/test_text.py
@@ -13,6 +13,7 @@ from scinoephile.core.text import (
     normalize_ocr_confusables_to_ascii,
     sanitize_text,
 )
+from test.helpers import parametrize
 
 
 def test_get_char_type_handles_unnamed_control_char() -> None:
@@ -21,13 +22,13 @@ def test_get_char_type_handles_unnamed_control_char() -> None:
         get_char_type("\x00")
 
 
-@pytest.mark.parametrize("char", ["Ｋ", "Ａ", "１", "ｋ"])
+@parametrize("char", ["Ｋ", "Ａ", "１", "ｋ"])
 def test_get_char_type_handles_fullwidth_latin_forms(char: str) -> None:
     """Fullwidth Latin forms are classified as full-width characters."""
     assert get_char_type(char) == "full"
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("text", "expected"),
     [
         ("ＫＡＴＥ ｋａｔｅ １２３", "KATE kate 123"),
@@ -38,7 +39,7 @@ def test_normalize_fullwidth_alphanumerics(text: str, expected: str) -> None:
     assert normalize_fullwidth_alphanumerics(text) == expected
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("text", "expected"),
     [
         ("ΟΚ, οκ.", "OK, ok."),
@@ -49,7 +50,7 @@ def test_normalize_ocr_confusables_to_ascii(text: str, expected: str) -> None:
     assert normalize_ocr_confusables_to_ascii(text) == expected
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("text", "expected"),
     [
         ("好呀！\x00\x00你", "好呀！  你"),
@@ -60,7 +61,7 @@ def test_sanitize_text_replaces_control_chars(text: str, expected: str) -> None:
     assert sanitize_text(text) == expected
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("text", "expected"),
     [
         ("one\ntwo\tthree\r", "one\ntwo\tthree\r"),

--- a/test/dictionaries/cuhk/test_cuhk_dictionary_service.py
+++ b/test/dictionaries/cuhk/test_cuhk_dictionary_service.py
@@ -18,6 +18,7 @@ from scinoephile.core.dictionaries import (
     DictionarySqliteStore,
 )
 from scinoephile.dictionaries.cuhk import CuhkDictionaryService
+from test.helpers import parametrize
 
 
 @pytest.fixture
@@ -96,7 +97,7 @@ def service(
     return CuhkDictionaryService(database_path=database_path)
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("query", "expected", "expectation"),
     [
         ("", [], nullcontext()),

--- a/test/dictionaries/gzzj/test_gzzj_dictionary_service.py
+++ b/test/dictionaries/gzzj/test_gzzj_dictionary_service.py
@@ -12,6 +12,7 @@ import pytest
 
 from scinoephile.common.file import get_temp_file_path
 from scinoephile.dictionaries.gzzj import GzzjDictionaryService
+from test.helpers import parametrize
 
 
 @pytest.fixture
@@ -52,7 +53,7 @@ def service(database_path: Path, source_json_path: Path) -> GzzjDictionaryServic
     return service
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("query", "expected", "expectation"),
     [
         ("", [], nullcontext()),

--- a/test/dictionaries/test_dictionary_tools.py
+++ b/test/dictionaries/test_dictionary_tools.py
@@ -41,6 +41,7 @@ from scinoephile.multilang.yue_zho.line_review import (
     YueLineReviewVsZhoPromptYueHans,
     get_yue_vs_zho_line_reviewer,
 )
+from test.helpers import parametrize
 
 
 class StubDictionaryToolPrompt(DictionaryToolPrompt):
@@ -233,7 +234,7 @@ def test_lookup_dictionary_returns_compact_error_for_no_available_dictionaries(
     assert "gzzj" in response["error"]
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("prompt_cls", "factory"),
     [
         (YueGappedTranslationVsZhoPromptYueHans, get_yue_vs_zho_gapped_translator),

--- a/test/helpers/__init__.py
+++ b/test/helpers/__init__.py
@@ -31,11 +31,14 @@ __all__ = [
     "create_symlink_or_skip",
     "get_warning_messages",
     "get_usage_prefix",
+    "parametrize",
     "parametrized_fixture",
     "skip_if_ci",
     "skip_if_codex",
     "test_data_root",
 ]
+
+parametrize = mark.parametrize
 
 
 test_data_root = package_root.parent / "test/data"

--- a/test/image/ocr/lens/test_lens_recognizer.py
+++ b/test/image/ocr/lens/test_lens_recognizer.py
@@ -17,6 +17,7 @@ from PIL import Image
 from scinoephile.common.subprocess import run_command
 from scinoephile.core import Language
 from scinoephile.image.ocr.lens.lens_recognizer import LensRecognizer
+from test.helpers import parametrize
 
 
 class FakeLensApiError(RuntimeError):
@@ -155,7 +156,7 @@ def test_lens_recognizer_rejects_unsupported_languages():
         LensRecognizer(language=cast(Language, "korean"))
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("language", "expected_code"),
     [
         (Language.eng, "en"),

--- a/test/image/ocr/lens/test_lens_series.py
+++ b/test/image/ocr/lens/test_lens_series.py
@@ -12,6 +12,7 @@ from PIL import Image
 from scinoephile.core import Language, ScinoephileError
 from scinoephile.image.ocr.lens import ocr_image_series_with_lens
 from scinoephile.image.subtitles import ImageSeries, ImageSubtitle
+from test.helpers import parametrize
 from test.helpers.ocr_recognizers import FailingOcrRecognizer, RecordingOcrRecognizer
 
 
@@ -140,7 +141,7 @@ def test_ocr_image_series_with_lens_uses_runtime_cache(
     assert recognizer.kwargs["retries"] == 5
 
 
-@pytest.mark.parametrize(
+@parametrize(
     "exception",
     [
         ImportError("missing lens dependency"),

--- a/test/image/ocr/paddle/test_paddle_recognizer.py
+++ b/test/image/ocr/paddle/test_paddle_recognizer.py
@@ -20,6 +20,7 @@ from scinoephile.core import Language
 from scinoephile.image.ocr.paddle import PaddleRecognizer
 from scinoephile.image.ocr.paddle.bounding_box import PaddleOcrBoundingBox
 from scinoephile.image.ocr.paddle.text_result import PaddleOcrTextResult
+from test.helpers import parametrize
 
 
 class CountingPaddleRecognizer(PaddleRecognizer):
@@ -235,7 +236,7 @@ def test_paddle_recognizer_rejects_unsupported_languages():
         PaddleRecognizer(language=cast(Language, "korean"))
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("language", "expected_code"),
     [
         (Language.eng, "en"),

--- a/test/image/ocr/paddle/test_paddle_series.py
+++ b/test/image/ocr/paddle/test_paddle_series.py
@@ -12,6 +12,7 @@ from PIL import Image
 from scinoephile.core import Language, ScinoephileError
 from scinoephile.image.ocr.paddle import ocr_image_series_with_paddle
 from scinoephile.image.subtitles import ImageSeries, ImageSubtitle
+from test.helpers import parametrize
 from test.helpers.ocr_recognizers import FailingOcrRecognizer, RecordingOcrRecognizer
 
 
@@ -140,7 +141,7 @@ def test_ocr_image_series_with_paddle_uses_runtime_cache(
     assert recognizer.kwargs["min_confidence"] == 0.8
 
 
-@pytest.mark.parametrize(
+@parametrize(
     "exception",
     [
         ImportError("missing paddle dependency"),

--- a/test/image/ocr/tesseract/test_tesseract_recognizer.py
+++ b/test/image/ocr/tesseract/test_tesseract_recognizer.py
@@ -12,6 +12,7 @@ from PIL import Image
 
 from scinoephile.core import Language, ScinoephileError
 from scinoephile.image.ocr.tesseract import TesseractRecognizer
+from test.helpers import parametrize
 
 
 class CountingTesseractRecognizer(TesseractRecognizer):
@@ -62,7 +63,7 @@ def test_tesseract_recognizer_caches_results_by_image(tmp_path: Path):
     assert len(list(tmp_path.glob("*.json"))) == 1
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("language", "expected_code"),
     [
         (Language.eng, "eng"),

--- a/test/image/ocr/tesseract/test_tesseract_series.py
+++ b/test/image/ocr/tesseract/test_tesseract_series.py
@@ -14,6 +14,7 @@ from scinoephile.image.ocr.tesseract import (
     ocr_image_series_with_tesseract,
 )
 from scinoephile.image.subtitles import ImageSeries, ImageSubtitle
+from test.helpers import parametrize
 from test.helpers.ocr_recognizers import FailingOcrRecognizer, RecordingOcrRecognizer
 
 
@@ -159,7 +160,7 @@ def test_ocr_image_series_with_tesseract_uses_runtime_cache(
     assert recognizer.kwargs["tessdata_dir_path"] == tessdata_dir_path
 
 
-@pytest.mark.parametrize(
+@parametrize(
     "exception",
     [
         ImportError("missing tesseract dependency"),

--- a/test/image/subtitles/test_image_series.py
+++ b/test/image/subtitles/test_image_series.py
@@ -14,9 +14,10 @@ from scinoephile.core import ScinoephileError
 from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.image.bbox import Bbox
 from scinoephile.image.subtitles import ImageSeries, ImageSubtitle
+from test.helpers import parametrize
 
 
-@pytest.mark.parametrize(
+@parametrize(
     "input_path_fixture, expected_event_count, expected_first_size",
     [
         pytest.param(
@@ -54,7 +55,7 @@ def test_load_sup(
         assert event.img.size[1] > 0
 
 
-@pytest.mark.parametrize(
+@parametrize(
     "input_path_fixture, expected_event_count, expected_first_size",
     [
         pytest.param(

--- a/test/lang/cmn/test_get_cmn_pinyin_query_strings.py
+++ b/test/lang/cmn/test_get_cmn_pinyin_query_strings.py
@@ -4,12 +4,11 @@
 
 from __future__ import annotations
 
-import pytest
-
 from scinoephile.lang.cmn.romanization import get_cmn_pinyin_query_strings
+from test.helpers import parametrize
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("text", "expected"),
     [
         ("shàng biàn", ["shang4 bian4"]),

--- a/test/lang/cmn/test_get_cmn_romanized.py
+++ b/test/lang/cmn/test_get_cmn_romanized.py
@@ -7,10 +7,10 @@ from __future__ import annotations
 import pytest
 
 from scinoephile.lang.cmn.romanization import get_cmn_romanized, get_cmn_text_romanized
-from test.helpers import assert_series_equal
+from test.helpers import assert_series_equal, parametrize
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("series_fixture", "expected_fixture"),
     [
         pytest.param(
@@ -54,7 +54,7 @@ def test_get_cmn_romanized(
     assert_series_equal(output, request.getfixturevalue(expected_fixture))
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("text", "expected"),
     [
         ("你好世界", "nǐhǎo shìjiè"),

--- a/test/lang/cmn/test_is_accented_pinyin.py
+++ b/test/lang/cmn/test_is_accented_pinyin.py
@@ -4,13 +4,12 @@
 
 from __future__ import annotations
 
-import pytest
-
 from scinoephile.lang.cmn.romanization import is_accented_pinyin
+from test.helpers import parametrize
 from test.lang.test_language_id import LANGUAGE_ID_TEST_CASES
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("text", "expected"),
     [(case.text, case.is_accented_pinyin) for case in LANGUAGE_ID_TEST_CASES],
 )

--- a/test/lang/cmn/test_is_numbered_pinyin.py
+++ b/test/lang/cmn/test_is_numbered_pinyin.py
@@ -4,13 +4,12 @@
 
 from __future__ import annotations
 
-import pytest
-
 from scinoephile.lang.cmn.romanization import is_numbered_pinyin
+from test.helpers import parametrize
 from test.lang.test_language_id import LANGUAGE_ID_TEST_CASES
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("text", "expected"),
     [(case.text, case.is_numbered_pinyin) for case in LANGUAGE_ID_TEST_CASES],
 )

--- a/test/lang/eng/test_get_eng_block_reviewed.py
+++ b/test/lang/eng/test_get_eng_block_reviewed.py
@@ -16,10 +16,10 @@ from scinoephile.lang.eng.block_review import (
 )
 from test.data.kob import get_kob_eng_block_review_test_cases
 from test.data.t import get_t_eng_block_review_test_cases
-from test.helpers import assert_series_equal
+from test.helpers import assert_series_equal, parametrize
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("series_fixture", "expected_fixture", "test_case_loader"),
     [
         pytest.param(

--- a/test/lang/eng/test_get_eng_cleaned.py
+++ b/test/lang/eng/test_get_eng_cleaned.py
@@ -7,10 +7,10 @@ from __future__ import annotations
 import pytest
 
 from scinoephile.lang.eng.cleaning import get_eng_cleaned, get_eng_text_cleaned
-from test.helpers import assert_series_equal
+from test.helpers import assert_series_equal, parametrize
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("text", "expected"),
     [
         ("hello\\N-\\Nworld", "hello\\Nworld"),
@@ -40,7 +40,7 @@ def test_get_eng_text_cleaned(
     assert get_eng_text_cleaned(text) == expected
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("series_fixture", "expected_fixture"),
     [
         pytest.param(

--- a/test/lang/eng/test_get_eng_flattened.py
+++ b/test/lang/eng/test_get_eng_flattened.py
@@ -8,10 +8,10 @@ import pytest
 
 # noinspection PyProtectedMember
 from scinoephile.lang.eng.flattening import _get_eng_text_flattened, get_eng_flattened
-from test.helpers import assert_series_equal
+from test.helpers import assert_series_equal, parametrize
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("series_fixture", "expected_fixture"),
     [
         pytest.param(
@@ -65,7 +65,7 @@ def test_get_eng_flattened(
     assert_series_equal(output, request.getfixturevalue(expected_fixture))
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("text", "expected"),
     [
         ("line 1\nline 2", "line 1 line 2"),

--- a/test/lang/eng/test_get_eng_ocr_fused.py
+++ b/test/lang/eng/test_get_eng_ocr_fused.py
@@ -16,10 +16,10 @@ from test.data.kob import get_kob_eng_ocr_fusion_test_cases
 from test.data.mlamd import get_mlamd_eng_ocr_fusion_test_cases
 from test.data.mnt import get_mnt_eng_ocr_fusion_test_cases
 from test.data.t import get_t_eng_ocr_fusion_test_cases
-from test.helpers import assert_series_equal
+from test.helpers import assert_series_equal, parametrize
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("lens_fixture", "tesseract_fixture", "expected_fixture", "test_case_loader"),
     [
         pytest.param(

--- a/test/lang/test_language_id.py
+++ b/test/lang/test_language_id.py
@@ -4,9 +4,8 @@
 
 from __future__ import annotations
 
-import pytest
-
 from scinoephile.lang.language_id import LanguageId
+from test.helpers import parametrize
 
 LANGUAGE_ID_TEST_CASES: list[LanguageId] = [
     LanguageId(
@@ -156,7 +155,7 @@ LANGUAGE_ID_TEST_CASES: list[LanguageId] = [
 ]
 
 
-@pytest.mark.parametrize("case", LANGUAGE_ID_TEST_CASES)
+@parametrize("case", LANGUAGE_ID_TEST_CASES)
 def test_language_id_from_text(case: LanguageId):
     """Detect language ID features from text.
 

--- a/test/lang/yue/test_get_yue_converted.py
+++ b/test/lang/yue/test_get_yue_converted.py
@@ -10,9 +10,10 @@ import pytest
 
 from scinoephile.core import UnsupportedCharacterError
 from scinoephile.lang.yue.conversion import get_yue_converted
+from test.helpers import parametrize
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("text", "expected", "expectation"),
     [
         ("舂暈\ue527", "舂暈鷄", nullcontext()),

--- a/test/lang/yue/test_get_yue_jyutping_query_strings.py
+++ b/test/lang/yue/test_get_yue_jyutping_query_strings.py
@@ -4,12 +4,11 @@
 
 from __future__ import annotations
 
-import pytest
-
 from scinoephile.lang.yue.romanization import get_yue_jyutping_query_strings
+from test.helpers import parametrize
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("text", "expected"),
     [
         ("soeng6 bin6", ["soeng6 bin6"]),

--- a/test/lang/yue/test_get_yue_romanized.py
+++ b/test/lang/yue/test_get_yue_romanized.py
@@ -10,10 +10,10 @@ from scinoephile.lang.yue.romanization import (
     get_yue_romanized,
     get_yue_text_romanized,
 )
-from test.helpers import assert_series_equal
+from test.helpers import assert_series_equal, parametrize
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("series_fixture", "expected_fixture"),
     [
         pytest.param(
@@ -42,7 +42,7 @@ def test_get_yue_romanized(
     assert_series_equal(output, request.getfixturevalue(expected_fixture))
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("text", "expected"),
     [
         ("广东话", "gwóng dūng wá"),

--- a/test/lang/yue/test_is_accented_yale.py
+++ b/test/lang/yue/test_is_accented_yale.py
@@ -4,13 +4,12 @@
 
 from __future__ import annotations
 
-import pytest
-
 from scinoephile.lang.yue.romanization import is_accented_yale
+from test.helpers import parametrize
 from test.lang.test_language_id import LANGUAGE_ID_TEST_CASES
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("text", "expected"),
     [(case.text, case.is_accented_yale) for case in LANGUAGE_ID_TEST_CASES],
 )

--- a/test/lang/yue/test_is_numbered_jyutping.py
+++ b/test/lang/yue/test_is_numbered_jyutping.py
@@ -4,13 +4,12 @@
 
 from __future__ import annotations
 
-import pytest
-
 from scinoephile.lang.yue.romanization import is_numbered_jyutping
+from test.helpers import parametrize
 from test.lang.test_language_id import LANGUAGE_ID_TEST_CASES
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("text", "expected"),
     [(case.text, case.is_numbered_jyutping) for case in LANGUAGE_ID_TEST_CASES],
 )

--- a/test/lang/zho/script/test_conversion.py
+++ b/test/lang/zho/script/test_conversion.py
@@ -14,10 +14,10 @@ from scinoephile.lang.zho.script.conversion import (
     get_zho_converter,
     get_zho_text_converted,
 )
-from test.helpers import assert_series_equal
+from test.helpers import assert_series_equal, parametrize
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("text", "config", "expected"),
     [
         ("台臺", OpenCCConfig.s2t, "台臺"),
@@ -57,7 +57,7 @@ def test_get_zho_text_converted_applies_exclusions(
     assert get_zho_text_converted(text, config) == expected
 
 
-@pytest.mark.parametrize("text", sorted(S2T_EXCLUSIONS))
+@parametrize("text", sorted(S2T_EXCLUSIONS))
 def test_s2t_exclusions_are_raw_opencc_changes(text: str):
     """Test every simplified-to-traditional exclusion changes under raw OpenCC.
 
@@ -68,7 +68,7 @@ def test_s2t_exclusions_are_raw_opencc_changes(text: str):
     assert converted_text != text
 
 
-@pytest.mark.parametrize("text", sorted(T2S_EXCLUSIONS))
+@parametrize("text", sorted(T2S_EXCLUSIONS))
 def test_t2s_exclusions_are_raw_opencc_changes(text: str):
     """Test every traditional-to-simplified exclusion changes under raw OpenCC.
 
@@ -79,7 +79,7 @@ def test_t2s_exclusions_are_raw_opencc_changes(text: str):
     assert converted_text != text
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("series_fixture", "expected_fixture"),
     [
         pytest.param(
@@ -119,7 +119,7 @@ def test_get_zho_converted(
     )
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("text", "config", "expected"),
     [
         ("繁體中文", OpenCCConfig.t2s, "繁体中文"),

--- a/test/lang/zho/script/test_script_analysis.py
+++ b/test/lang/zho/script/test_script_analysis.py
@@ -4,17 +4,16 @@
 
 from __future__ import annotations
 
-import pytest
-
 from scinoephile.lang.zho.script.analysis import (
     get_zho_script_analysis,
     is_simplified,
     is_traditional,
 )
+from test.helpers import parametrize
 from test.lang.test_language_id import LANGUAGE_ID_TEST_CASES
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("text", "expected_script"),
     [
         ("简体中文汉字", "zho-Hans"),
@@ -40,7 +39,7 @@ def test_get_zho_script_analysis(text: str, expected_script: str | None):
     assert analysis.script == expected_script
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("text", "expected"),
     [(case.text, case.is_simplified) for case in LANGUAGE_ID_TEST_CASES],
 )
@@ -54,7 +53,7 @@ def test_is_simplified(text: str, expected: bool):
     assert is_simplified(text) is expected
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("text", "expected"),
     [(case.text, case.is_traditional) for case in LANGUAGE_ID_TEST_CASES],
 )

--- a/test/lang/zho/test_get_zho_block_reviewed.py
+++ b/test/lang/zho/test_get_zho_block_reviewed.py
@@ -22,10 +22,10 @@ from test.data.t import (
     get_t_zho_hant_block_review_test_cases,
     get_t_zho_hant_simplify_block_review_test_cases,
 )
-from test.helpers import assert_series_equal
+from test.helpers import assert_series_equal, parametrize
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("series_fixture", "expected_fixture", "test_case_loader", "prompt_cls"),
     [
         pytest.param(

--- a/test/lang/zho/test_get_zho_cleaned.py
+++ b/test/lang/zho/test_get_zho_cleaned.py
@@ -7,10 +7,10 @@ from __future__ import annotations
 import pytest
 
 from scinoephile.lang.zho.cleaning import get_zho_cleaned, get_zho_text_cleaned
-from test.helpers import assert_series_equal
+from test.helpers import assert_series_equal, parametrize
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("text", "expected"),
     [
         ('<font face="Monospace">{\\an7}中文\xa0測試</font>', "中文 測試"),
@@ -32,7 +32,7 @@ def test_get_zho_text_cleaned(text: str, expected: str):
     assert get_zho_text_cleaned(text) == expected
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("series_fixture", "expected_fixture"),
     [
         pytest.param(

--- a/test/lang/zho/test_get_zho_flattened.py
+++ b/test/lang/zho/test_get_zho_flattened.py
@@ -7,12 +7,12 @@ from __future__ import annotations
 import pytest
 
 from scinoephile.lang.zho.flattening import get_zho_flattened
-from test.helpers import assert_series_equal
+from test.helpers import assert_series_equal, parametrize
 
 # noinspection PyProtectedMember
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("series_fixture", "expected_fixture"),
     [
         pytest.param(

--- a/test/lang/zho/test_get_zho_ocr_fused.py
+++ b/test/lang/zho/test_get_zho_ocr_fused.py
@@ -22,10 +22,10 @@ from test.data.kob import get_kob_zho_hant_ocr_fusion_test_cases
 from test.data.mlamd import get_mlamd_zho_hans_ocr_fusion_test_cases
 from test.data.mnt import get_mnt_zho_hans_ocr_fusion_test_cases
 from test.data.t import get_t_zho_hans_ocr_fusion_test_cases
-from test.helpers import assert_series_equal
+from test.helpers import assert_series_equal, parametrize
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("lens_text", "paddle_text", "expected_text"),
     [
         pytest.param(
@@ -69,7 +69,7 @@ def test_get_zho_ocr_fused_treats_newline_forms_as_identical(
     provider.chat_completion.assert_not_called()
 
 
-@pytest.mark.parametrize(
+@parametrize(
     (
         "lens_fixture",
         "paddle_fixture",

--- a/test/llms/test_default_test_case_loading.py
+++ b/test/llms/test_default_test_case_loading.py
@@ -7,8 +7,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
 from scinoephile.common import package_root
 from scinoephile.core.llms import Manager, Prompt
 from scinoephile.lang.eng.block_review import BlockReviewPromptEng
@@ -56,6 +54,7 @@ from scinoephile.multilang.yue_zho.guided_translation import (
 from scinoephile.multilang.yue_zho.line_review import YueLineReviewVsZhoPromptYueHans
 from scinoephile.multilang.yue_zho.line_review.manager import YueZhoLineReviewManager
 from scinoephile.multilang.yue_zho.translation import YueTranslationVsZhoPromptYueHans
+from test.helpers import parametrize
 
 
 def _get_expected_case_count(relative_paths: tuple[Path, ...]) -> int:
@@ -77,7 +76,7 @@ def _get_expected_case_count(relative_paths: tuple[Path, ...]) -> int:
     return count
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("name", "manager_cls", "prompt_cls", "json_paths", "expected_paths"),
     [
         (

--- a/test/media/offset/video/test_video_offset.py
+++ b/test/media/offset/video/test_video_offset.py
@@ -19,6 +19,7 @@ from scinoephile.media.offset.video import (
     _sample_video_frames,
     get_video_offset,
 )
+from test.helpers import parametrize
 
 
 class _VideoOffsetKwargs(TypedDict, total=False):
@@ -403,7 +404,7 @@ def test_sample_video_frames_normalizes_brightness():
     assert samples[1].frame.std() == pytest.approx(1.0)
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("kwargs", "message"),
     [
         (

--- a/test/multilang/eng_zho/test_eng_zho_translation_wiring.py
+++ b/test/multilang/eng_zho/test_eng_zho_translation_wiring.py
@@ -8,8 +8,6 @@ from collections.abc import Callable
 from typing import cast
 from unittest.mock import Mock
 
-import pytest
-
 from scinoephile.core.llms import LLMProvider
 from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.llms.dual_n_minus_m_to_n import (
@@ -32,13 +30,14 @@ from scinoephile.multilang.eng_zho.translation import (
     get_eng_translated_from_zho,
     get_eng_zho_translator,
 )
+from test.helpers import parametrize
 
 _PromptCls = type[DualNToMPrompt] | type[DualNMinusMToNPrompt]
 _Processor = DualNToMProcessor | DualNMinusMToNProcessor
 _ProcessorFactory = Callable[..., _Processor]
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("prompt_cls", "src_1", "src_2", "output"),
     [
         (EngTranslationVsZhoPrompt, "zho_1", "context_1", "eng_1"),
@@ -65,7 +64,7 @@ def test_eng_zho_prompt_field_names(
     assert prompt_cls.output(1) == output
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("factory", "processor_cls", "prompt_cls"),
     [
         (get_eng_zho_translator, DualNToMProcessor, EngTranslationVsZhoPrompt),
@@ -102,7 +101,7 @@ def test_eng_zho_translator_factory_wiring(
     assert processor.queryer.provider is provider
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("mode", "uses_empty_context"),
     [
         ("regular", True),

--- a/test/multilang/yue_zho/test_get_yue_gap_translated_vs_zho.py
+++ b/test/multilang/yue_zho/test_get_yue_gap_translated_vs_zho.py
@@ -15,10 +15,10 @@ from scinoephile.multilang.yue_zho.gapped_translation import (
     get_yue_vs_zho_gapped_translator,
 )
 from test.data.mlamd import get_mlamd_yue_vs_zho_gapped_translation_test_cases
-from test.helpers import assert_series_equal
+from test.helpers import assert_series_equal, parametrize
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("yuewen_fixture", "zhongwen_fixture", "expected_fixture", "test_case_loader"),
     [
         pytest.param(

--- a/test/multilang/yue_zho/test_get_yue_line_reviewed_vs_zho.py
+++ b/test/multilang/yue_zho/test_get_yue_line_reviewed_vs_zho.py
@@ -15,10 +15,10 @@ from scinoephile.multilang.yue_zho.line_review import (
     get_yue_vs_zho_line_reviewer,
 )
 from test.data.mlamd import get_mlamd_yue_vs_zho_line_review_test_cases
-from test.helpers import assert_series_equal
+from test.helpers import assert_series_equal, parametrize
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("yuewen_fixture", "zhongwen_fixture", "expected_fixture", "test_case_loader"),
     [
         pytest.param(

--- a/test/multilang/yue_zho/test_get_yue_reviewed_vs_zho.py
+++ b/test/multilang/yue_zho/test_get_yue_reviewed_vs_zho.py
@@ -15,10 +15,10 @@ from scinoephile.multilang.yue_zho.block_review import (
     get_yue_vs_zho_block_reviewer,
 )
 from test.data.mlamd import get_mlamd_yue_vs_zho_block_review_test_cases
-from test.helpers import assert_series_equal
+from test.helpers import assert_series_equal, parametrize
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("yuewen_fixture", "zhongwen_fixture", "expected_fixture", "test_case_loader"),
     [
         pytest.param(

--- a/test/multilang/yue_zho/test_yue_zho_translation_wiring.py
+++ b/test/multilang/yue_zho/test_yue_zho_translation_wiring.py
@@ -8,8 +8,6 @@ from collections.abc import Callable
 from typing import cast
 from unittest.mock import Mock
 
-import pytest
-
 from scinoephile.core.llms import LLMProvider
 from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.llms.dual_n_to_m import DualNToMProcessor, DualNToMPrompt
@@ -23,11 +21,12 @@ from scinoephile.multilang.yue_zho.translation import (
     get_yue_translated_from_zho,
     get_yue_zho_translator,
 )
+from test.helpers import parametrize
 
 _ProcessorFactory = Callable[..., DualNToMProcessor]
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("prompt_cls", "src_1", "src_2", "output"),
     [
         (YueTranslationVsZhoPromptYueHans, "zhongwen_1", "context_1", "yuewen_1"),
@@ -58,7 +57,7 @@ def test_yue_zho_prompt_field_names(
     assert prompt_cls.output(1) == output
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("factory", "prompt_cls"),
     [
         (get_yue_zho_translator, YueTranslationVsZhoPromptYueHans),
@@ -88,7 +87,7 @@ def test_yue_zho_translator_factory_wiring(
     assert processor.queryer.provider is provider
 
 
-@pytest.mark.parametrize(
+@parametrize(
     ("mode", "uses_empty_context"),
     [
         ("regular", True),

--- a/test/workflows/test_ocr_processing.py
+++ b/test/workflows/test_ocr_processing.py
@@ -21,6 +21,7 @@ from scinoephile.workflows.ocr_processing import (
     OcrProcessingResult,
     OcrProcessingWorkflow,
 )
+from test.helpers import parametrize
 
 OLD_MTIME = 1_700_000_000
 """Older file modification time used by timestamp-sensitive tests."""
@@ -416,7 +417,7 @@ def test_process_eng_ocr_runs_lens_tesseract_and_fusion(
     ] == ["fused"]
 
 
-@pytest.mark.parametrize("process_ocr", [process_eng_ocr, process_zho_ocr])
+@parametrize("process_ocr", [process_eng_ocr, process_zho_ocr])
 def test_process_ocr_wraps_filesystem_errors(
     process_ocr: Callable[..., OcrProcessingResult],
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- Export `parametrize` from `test/helpers/__init__.py`.
- Replace direct `pytest.mark.parametrize` usage with `@parametrize(...)` in the targeted test files.
- Replace pytest-only `import pytest` usage with `from test.helpers import parametrize` where needed.

## Scope
- Test-only changes.
- No production code changes.
