### PR TITLE
Refactor tests to explicit pytest symbol imports (non-mark/parametrize)

### DIFF
--- a/test/analysis/character_error_rate/test_character_error_rate.py
+++ b/test/analysis/character_error_rate/test_character_error_rate.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from math import inf
 
-import pytest
+from pytest import FixtureRequest, param
 
 from scinoephile.analysis.character_error_rate import LineCER, SeriesCER
 from scinoephile.core.subtitles import Series, Subtitle
@@ -191,13 +191,13 @@ def test_series_cer_ignores_separator_only_line_wrapping(
         "expected_fixture_name",
     ),
     [
-        pytest.param(
+        param(
             "kob_yue_hans_timewarp_clean_flatten",
             "kob_yue_hans_transcribe",
             "kob_yue_hans_transcribe_expected_cer",
             id="kob-yue-transcribe",
         ),
-        pytest.param(
+        param(
             "kob_yue_hans_timewarp_clean_flatten",
             "kob_yue_hans_transcribe_review_translate_block_review",
             "kob_yue_hans_transcribe_review_translate_block_review_expected_cer",
@@ -209,7 +209,7 @@ def test_series_cer(
     reference_series_fixture_name: str,
     candidate_series_fixture_name: str,
     expected_fixture_name: str,
-    request: pytest.FixtureRequest,
+    request: FixtureRequest,
 ):
     """Test series-level character error rate calculations.
 
@@ -231,3 +231,4 @@ def test_series_cer(
     assert result.deletions == expected.deletions
     assert result.correct == expected.correct
     assert result.reference_length == expected.reference_length
+

--- a/test/analysis/diff/test_series_diff.py
+++ b/test/analysis/diff/test_series_diff.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-import pytest
+from pytest import FixtureRequest, param, raises
 
 from scinoephile.analysis.diff import LineDiffKind, SeriesDiff
 from scinoephile.core import ScinoephileError
@@ -165,7 +165,7 @@ def test_series_diff_keeps_uncovered_insert_separate():
         "expected_fixture_name",
     ),
     [
-        pytest.param(
+        param(
             "kob_eng_ocr_fuse_clean_validate_review_flatten",
             "kob_eng_timewarp_clean_review_flatten",
             "OCR",
@@ -173,7 +173,7 @@ def test_series_diff_keeps_uncovered_insert_separate():
             "kob_eng_expected_series_diff",
             id="kob-eng-ocr-vs-srt",
         ),
-        pytest.param(
+        param(
             "mlamd_zho_hans_fuse_clean_validate_review_flatten",
             "mlamd_zho_hant_fuse_clean_validate_review_flatten_simplify_review",
             "SIMP",
@@ -181,7 +181,7 @@ def test_series_diff_keeps_uncovered_insert_separate():
             "mlamd_zho_simplify_expected_series_diff",
             id="mlamd-zho-simplify",
         ),
-        pytest.param(
+        param(
             "mnt_zho_hans_fuse_clean_validate_review_flatten",
             "mnt_zho_hant_fuse_clean_validate_review_flatten_simplify_review",
             "SIMP",
@@ -189,7 +189,7 @@ def test_series_diff_keeps_uncovered_insert_separate():
             "mnt_zho_simplify_expected_series_diff",
             id="mnt-zho-simplify",
         ),
-        pytest.param(
+        param(
             "t_zho_hans_fuse_clean_validate_review_flatten",
             "t_zho_hant_fuse_clean_validate_review_flatten_simplify_review",
             "SIMP",
@@ -205,7 +205,7 @@ def test_series_diff_matches_expected_fixture(
     one_label: str,
     two_label: str,
     expected_fixture_name: str,
-    request: pytest.FixtureRequest,
+    request: FixtureRequest,
 ):
     """Test end-to-end series diffs against stored fixture expectations.
 
@@ -324,5 +324,6 @@ def test_series_diff_get_stacked_str_rejects_non_one_to_one_third_series():
     two = _get_series("alpha", "beta")
     three = _get_series("source alpha beta", "extra")
 
-    with pytest.raises(ScinoephileError, match="one-to-one matched"):
+    with raises(ScinoephileError, match="one-to-one matched"):
         SeriesDiff(one, two).get_stacked_str(color=False, three=three)
+

--- a/test/audio/subtitles/test_audio_series.py
+++ b/test/audio/subtitles/test_audio_series.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
+from pytest import raises
 from pydub import AudioSegment
 from pydub.exceptions import CouldntDecodeError
 
@@ -23,7 +23,7 @@ def test_audio_series_load_wraps_input_path_errors(tmp_path: Path):
     """
     input_path = tmp_path / "missing"
 
-    with pytest.raises(
+    with raises(
         ScinoephileError,
         match="Unable to load AudioSeries from .*missing",
     ) as excinfo:
@@ -49,7 +49,7 @@ def test_audio_series_load_wraps_decode_errors(tmp_path: Path):
         "scinoephile.audio.subtitles.series.AudioSegment.from_wav",
         side_effect=CouldntDecodeError("invalid audio"),
     ):
-        with pytest.raises(
+        with raises(
             ScinoephileError,
             match="Unable to load AudioSeries from .*input: invalid audio",
         ) as excinfo:
@@ -68,10 +68,11 @@ def test_audio_series_save_wraps_output_path_errors(tmp_path: Path):
     output_path.touch()
     series = AudioSeries(audio=AudioSegment.silent(duration=1000))
 
-    with pytest.raises(
+    with raises(
         ScinoephileError,
         match="Unable to save AudioSeries to .*audio_output",
     ) as excinfo:
         series.save(output_path)
 
     assert isinstance(excinfo.value.__cause__, OSError)
+

--- a/test/audio/subtitles/test_audio_series_load_from_media.py
+++ b/test/audio/subtitles/test_audio_series_load_from_media.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import ffmpeg
-import pytest
+from pytest import raises
 from pydub import AudioSegment
 from pydub.exceptions import CouldntDecodeError
 
@@ -102,7 +102,7 @@ def test_audio_series_extract_audio_track_wraps_ffmpeg_errors():
         "scinoephile.audio.subtitles.series.ffmpeg.input",
         return_value=fake_ffmpeg_input,
     ):
-        with pytest.raises(
+        with raises(
             ScinoephileError,
             match="Could not extract audio stream 12 from video.mkv",
         ) as excinfo:
@@ -189,7 +189,7 @@ def test_audio_series_load_from_media_wraps_input_path_errors(tmp_path: Path):
     Arguments:
         tmp_path: pytest temporary directory path
     """
-    with pytest.raises(
+    with raises(
         ScinoephileError,
         match="Unable to load AudioSeries from media .*missing.mkv",
     ) as excinfo:
@@ -222,7 +222,7 @@ def test_audio_series_load_from_media_wraps_decode_errors():
                         "scinoephile.audio.subtitles.series.AudioSegment.from_wav",
                         side_effect=CouldntDecodeError("invalid audio"),
                     ):
-                        with pytest.raises(
+                        with raises(
                             ScinoephileError,
                             match="Unable to load AudioSeries from media",
                         ) as excinfo:
@@ -248,7 +248,7 @@ def test_audio_series_load_from_media_rejects_invalid_stream_index():
                     "streams": [{"index": 1, "codec_type": "audio", "channels": 2}]
                 },
             ):
-                with pytest.raises(ScinoephileError, match="No stream index 2"):
+                with raises(ScinoephileError, match="No stream index 2"):
                     AudioSeries.load_from_media(
                         media_path=media_path,
                         subtitle_path=subtitle_path,
@@ -273,7 +273,7 @@ def test_audio_series_load_from_media_rejects_non_audio_stream_index():
                     ]
                 },
             ):
-                with pytest.raises(
+                with raises(
                     ScinoephileError, match="Stream index 0 is not an audio stream"
                 ):
                     AudioSeries.load_from_media(
@@ -302,3 +302,4 @@ def _write_selected_audio(
         audio_output_path,
         format="wav",
     )
+

--- a/test/audio/transcription/test_demucs_separator.py
+++ b/test/audio/transcription/test_demucs_separator.py
@@ -9,7 +9,7 @@ from collections.abc import Mapping, Sequence
 from unittest.mock import Mock, patch
 
 import numpy as np
-import pytest
+from pytest import importorskip, MonkeyPatch, raises
 from pydub import AudioSegment
 
 from scinoephile.audio.transcription.demucs_separator import DemucsSeparator
@@ -48,7 +48,7 @@ def test_get_audio_segment_restores_mono_output():
 
 
 def test_demucs_model_loader_requires_transcription_extra(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test Demucs import errors mention the transcription extra."""
     original_import = builtins.__import__
@@ -66,13 +66,13 @@ def test_demucs_model_loader_requires_transcription_extra(
 
     monkeypatch.setattr(builtins, "__import__", import_without_demucs)
 
-    with pytest.raises(ImportError, match="'transcription' extra"):
+    with raises(ImportError, match="'transcription' extra"):
         DemucsSeparator._get_model_loader()
 
 
 def test_separate_vocals_uses_default_demucs_shifts():
     """Test Demucs separation relies on library-default shift behavior."""
-    torch = pytest.importorskip("torch")
+    torch = importorskip("torch")
     separator = DemucsSeparator()
     separator._model = Mock(samplerate=16000, sources=["vocals"])
     separator._model.to.return_value = separator._model
@@ -94,3 +94,4 @@ def test_separate_vocals_uses_default_demucs_shifts():
     assert output_audio.frame_rate == input_audio.frame_rate
     assert len(apply_model_kwargs) == 1
     assert "shifts" not in apply_model_kwargs[0]
+

--- a/test/audio/transcription/test_whisper_transcriber.py
+++ b/test/audio/transcription/test_whisper_transcriber.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from textwrap import dedent
 from unittest.mock import Mock
 
-import pytest
+from pytest import importorskip, MonkeyPatch, raises
 
 from scinoephile.audio.transcription import get_segment_split_at_idx
 from scinoephile.audio.transcription.transcribed_segment import TranscribedSegment
@@ -91,7 +91,7 @@ def test_model_name_is_huggingface_repo_id_rejects_local_paths(
     expected: bool,
 ):
     """Test HuggingFace retry is skipped for local filesystem paths."""
-    pytest.importorskip("huggingface_hub")
+    importorskip("huggingface_hub")
     transcriber = WhisperTranscriber(model_name=model_name)
 
     assert transcriber._model_name_is_huggingface_repo_id() is expected
@@ -142,7 +142,7 @@ def test_transcription_imports_without_optional_runtime_dependencies():
     assert exitcode == 0
 
 
-def test_whisper_module_requires_transcription_extra(monkeypatch: pytest.MonkeyPatch):
+def test_whisper_module_requires_transcription_extra(monkeypatch: MonkeyPatch):
     """Test Whisper import errors mention the transcription extra."""
     original_import = builtins.__import__
 
@@ -159,7 +159,7 @@ def test_whisper_module_requires_transcription_extra(monkeypatch: pytest.MonkeyP
 
     monkeypatch.setattr(builtins, "__import__", import_without_whisper)
 
-    with pytest.raises(ImportError, match="'transcription' extra"):
+    with raises(ImportError, match="'transcription' extra"):
         WhisperTranscriber._get_whisper_module()
 
 
@@ -240,10 +240,11 @@ def test_get_segment_split_at_idx_includes_segment_details_in_error():
         words=None,
     )
 
-    with pytest.raises(ValueError) as exc_info:
+    with raises(ValueError) as exc_info:
         get_segment_split_at_idx(segment, 3)
 
     assert str(exc_info.value) == (
         "Cannot split segment without word timing data: "
         "id=9 start=156.4 end=161.29 text='照先生你就展示畀朕睇下係' text_len=12."
     )
+

--- a/test/cli/dictionary/build/test_dictionary_build_cuhk_cli.py
+++ b/test/cli/dictionary/build/test_dictionary_build_cuhk_cli.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
+from pytest import MonkeyPatch, skip
 import requests
 
 from scinoephile.cli.dictionary.build.dictionary_build_cuhk_cli import (
@@ -18,7 +18,7 @@ from test.helpers import skip_if_ci
 
 
 def test_dictionary_build_cuhk_cli_passes_cache_dir_to_service(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     tmp_path: Path,
 ):
     """Test CUHK CLI forwards parsed cache dirs without parser-time creation.
@@ -107,6 +107,7 @@ def test_dictionary_build_cuhk_cli():
                     "--request-timeout-seconds 10",
                 )
             except requests.RequestException as exc:
-                pytest.skip(f"CUHK build test requires network access: {exc}")
+                skip(f"CUHK build test requires network access: {exc}")
 
             assert database_path.exists()
+

--- a/test/cli/dictionary/build/test_dictionary_build_unihan_cli.py
+++ b/test/cli/dictionary/build/test_dictionary_build_unihan_cli.py
@@ -9,7 +9,7 @@ from io import StringIO
 from pathlib import Path
 from typing import Any
 
-import pytest
+from pytest import MonkeyPatch, raises
 
 from scinoephile.cli.dictionary.build.dictionary_build_unihan_cli import (
     DictionaryBuildUnihanCli,
@@ -19,7 +19,7 @@ from scinoephile.dictionaries.unihan import UnihanDictionaryService
 
 
 def test_dictionary_build_unihan_exits_cleanly_on_missing_archive_member(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Exit with status 1 when the service reports a missing archive member.
 
@@ -42,10 +42,11 @@ def test_dictionary_build_unihan_exits_cleanly_on_missing_archive_member(
 
     monkeypatch.setattr(UnihanDictionaryService, "build", _mock_build)
 
-    with pytest.raises(SystemExit) as excinfo:
+    with raises(SystemExit) as excinfo:
         with redirect_stdout(stdout):
             with redirect_stderr(stderr):
                 run_cli_with_args(DictionaryBuildUnihanCli, "")
 
     assert excinfo.value.code == 1
     assert stdout.getvalue() == ""
+

--- a/test/cli/dictionary/build/test_dictionary_build_wiktionary_cli.py
+++ b/test/cli/dictionary/build/test_dictionary_build_wiktionary_cli.py
@@ -9,7 +9,7 @@ from io import StringIO
 from pathlib import Path
 from typing import Any
 
-import pytest
+from pytest import MonkeyPatch, raises
 import requests
 
 from scinoephile.cli.dictionary.build.dictionary_build_wiktionary_cli import (
@@ -20,7 +20,7 @@ from scinoephile.dictionaries.wiktionary import WiktionaryDictionaryService
 
 
 def test_dictionary_build_wiktionary_exits_cleanly_on_missing_source(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Exit with status 1 when the service reports a missing source file.
 
@@ -43,7 +43,7 @@ def test_dictionary_build_wiktionary_exits_cleanly_on_missing_source(
 
     monkeypatch.setattr(WiktionaryDictionaryService, "build", _mock_build)
 
-    with pytest.raises(SystemExit) as excinfo:
+    with raises(SystemExit) as excinfo:
         with redirect_stdout(stdout):
             with redirect_stderr(stderr):
                 run_cli_with_args(DictionaryBuildWiktionaryCli, "")
@@ -53,7 +53,7 @@ def test_dictionary_build_wiktionary_exits_cleanly_on_missing_source(
 
 
 def test_dictionary_build_wiktionary_exits_cleanly_on_download_error(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Exit with status 1 when the service reports a download error.
 
@@ -76,10 +76,11 @@ def test_dictionary_build_wiktionary_exits_cleanly_on_download_error(
 
     monkeypatch.setattr(WiktionaryDictionaryService, "build", _mock_build)
 
-    with pytest.raises(SystemExit) as excinfo:
+    with raises(SystemExit) as excinfo:
         with redirect_stdout(stdout):
             with redirect_stderr(stderr):
                 run_cli_with_args(DictionaryBuildWiktionaryCli, "")
 
     assert excinfo.value.code == 1
     assert stdout.getvalue() == ""
+

--- a/test/cli/dictionary/test_dictionary_cli.py
+++ b/test/cli/dictionary/test_dictionary_cli.py
@@ -6,14 +6,14 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
+from pytest import MonkeyPatch
 
 from scinoephile.cli.dictionary.dictionary_cli import DictionaryCli
 from test.helpers import assert_cli_usage
 
 
 def test_dictionary_usage_does_not_create_default_cache_dir(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test dictionary usage output does not create default cache directories.
 
@@ -27,3 +27,4 @@ def test_dictionary_usage_does_not_create_default_cache_dir(
     assert_cli_usage((DictionaryCli,))
 
     assert not cache_dir_path.exists()
+

--- a/test/cli/dictionary/test_dictionary_search_cli.py
+++ b/test/cli/dictionary/test_dictionary_search_cli.py
@@ -13,7 +13,7 @@ from shlex import quote
 from subprocess import list2cmdline
 from unittest.mock import patch
 
-import pytest
+from pytest import CaptureFixture, fixture, raises
 
 from scinoephile.cli.dictionary.dictionary_search_cli import DictionarySearchCli
 from scinoephile.common.file import get_temp_directory_path, get_temp_file_path
@@ -27,7 +27,7 @@ from scinoephile.core.dictionaries import (
 from test.helpers import parametrize
 
 
-@pytest.fixture(scope="module")
+@fixture(scope="module")
 def dictionary_database_dir_path() -> Generator[Path]:
     """Build temporary databases for end-to-end search tests."""
     with get_temp_directory_path() as dir_path:
@@ -132,7 +132,7 @@ def dictionary_database_dir_path() -> Generator[Path]:
         (
             "gully",
             "Unsupported query 'gully'",
-            pytest.raises(SystemExit, match="1"),
+            raises(SystemExit, match="1"),
         ),
     ],
 )
@@ -221,7 +221,7 @@ def test_dictionary_search_cli_all_dictionaries_database_path_is_usage_error():
     with get_temp_directory_path() as temp_dir_path:
         database_path = temp_dir_path / "existing.db"
         database_path.touch()
-        with pytest.raises(SystemExit, match="2"):
+        with raises(SystemExit, match="2"):
             run_cli_with_args(
                 DictionarySearchCli,
                 f"--database-path {database_path} --dictionary-name all 共享",
@@ -230,7 +230,7 @@ def test_dictionary_search_cli_all_dictionaries_database_path_is_usage_error():
 
 def test_dictionary_search_cli_prints_no_matches(
     dictionary_database_dir_path: Path,
-    capsys: pytest.CaptureFixture,
+    capsys: CaptureFixture,
 ):
     """Test dictionary search reports no matches on stdout.
 
@@ -266,3 +266,4 @@ def _quote_cli_arg(value: str) -> str:
     if system() == "Windows":
         return list2cmdline([value])
     return quote(value)
+

--- a/test/cli/eng/test_eng_translate_from_yue_cli.py
+++ b/test/cli/eng/test_eng_translate_from_yue_cli.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-import pytest
+from pytest import raises
 
 from scinoephile.cli.eng.eng_translate_from_yue_cli import EngTranslateFromYueCli
 from scinoephile.common.file import get_temp_file_path
@@ -52,10 +52,11 @@ def test_eng_translate_from_yue_cli_rejects_gapped_and_guide_together():
         test_data_root / "mlamd/output/yue-Hans_transcribe/transcribe_review.srt"
     )
 
-    with pytest.raises(SystemExit, match="2"):
+    with raises(SystemExit, match="2"):
         run_cli_with_args(
             EngTranslateFromYueCli,
             f"--yue-infile {yue_input_path} "
             f"--eng-gapped-infile {eng_input_path} "
             f"--eng-guide-infile {eng_input_path}",
         )
+

--- a/test/cli/eng/test_eng_translate_from_zho_cli.py
+++ b/test/cli/eng/test_eng_translate_from_zho_cli.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-import pytest
+from pytest import raises
 
 from scinoephile.cli.eng.eng_translate_from_zho_cli import EngTranslateFromZhoCli
 from scinoephile.common.file import get_temp_file_path
@@ -87,10 +87,11 @@ def test_eng_translate_from_zho_cli_rejects_gapped_and_guide_together():
         "mnt/output/zho-Hans_ocr/fuse_clean_validate_review_flatten.srt"
     )
 
-    with pytest.raises(SystemExit, match="2"):
+    with raises(SystemExit, match="2"):
         run_cli_with_args(
             EngTranslateFromZhoCli,
             f"--zho-infile {zho_input_path} "
             f"--eng-gapped-infile {eng_input_path} "
             f"--eng-guide-infile {eng_input_path}",
         )
+

--- a/test/cli/helpers/test_io.py
+++ b/test/cli/helpers/test_io.py
@@ -10,7 +10,7 @@ from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
+from pytest import raises
 
 from scinoephile.cli.helpers.io import read_image_series, read_series, write_series
 from scinoephile.common.exceptions import NotAFileError
@@ -43,7 +43,7 @@ def test_read_image_series_maps_file_errors_to_parser_error(
     stderr = StringIO()
 
     with patch("scinoephile.cli.helpers.io.ImageSeries.load", side_effect=exception):
-        with pytest.raises(SystemExit) as excinfo:
+        with raises(SystemExit) as excinfo:
             with redirect_stderr(stderr):
                 read_image_series(parser, infile_path)
 
@@ -76,7 +76,7 @@ def test_read_series_maps_file_errors_to_parser_error(
     stderr = StringIO()
 
     with patch("scinoephile.cli.helpers.io.Series.load", side_effect=exception):
-        with pytest.raises(SystemExit) as excinfo:
+        with raises(SystemExit) as excinfo:
             with redirect_stderr(stderr):
                 read_series(parser, infile_path)
 
@@ -104,7 +104,7 @@ def test_read_series_maps_stdin_errors_to_parser_error(exception: Exception):
         with patch(
             "scinoephile.cli.helpers.io.Series.from_string", side_effect=exception
         ):
-            with pytest.raises(SystemExit) as excinfo:
+            with raises(SystemExit) as excinfo:
                 with redirect_stderr(stderr):
                     read_series(parser, "-", allow_stdin=True)
 
@@ -127,3 +127,4 @@ def test_write_series_defaults_to_srt_format(tmp_path: Path):
     output_text = outfile_path.read_text(encoding="utf-8")
     assert output_text.startswith("1\n00:00:01,000 --> 00:00:02,000\n")
     assert "[Script Info]" not in output_text
+

--- a/test/cli/media/test_media_extract_subs_cli.py
+++ b/test/cli/media/test_media_extract_subs_cli.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
+from pytest import CaptureFixture, raises
 
 from scinoephile.cli.media.media_extract_subs_cli import MediaExtractSubsCli
 from scinoephile.common.testing import run_cli_with_args
@@ -23,7 +23,7 @@ from scinoephile.workflows.subtitle_extraction import (
 
 def test_media_extract_subs_cli_renders_grouped_outputs(
     tmp_path: Path,
-    capsys: pytest.CaptureFixture[str],
+    capsys: CaptureFixture[str],
 ):
     """Test media extract-subs CLI renders workflow output groups.
 
@@ -88,7 +88,7 @@ def test_media_extract_subs_cli_maps_workflow_errors_to_parser_errors(
             "scinoephile.cli.media.media_extract_subs_cli.extract_subtitles",
             side_effect=ScinoephileError("No subtitle streams found"),
         ),
-        pytest.raises(SystemExit) as excinfo,
+        raises(SystemExit) as excinfo,
     ):
         run_cli_with_args(MediaExtractSubsCli, f"--infile {infile_path} -o {tmp_path}")
 
@@ -104,7 +104,8 @@ def test_media_extract_subs_cli_requires_output_dir(tmp_path: Path):
     infile_path = tmp_path / "video.mkv"
     infile_path.touch()
 
-    with pytest.raises(SystemExit) as excinfo:
+    with raises(SystemExit) as excinfo:
         run_cli_with_args(MediaExtractSubsCli, f"--infile {infile_path}")
 
     assert excinfo.value.code == 2
+

--- a/test/cli/media/test_media_offset_cli.py
+++ b/test/cli/media/test_media_offset_cli.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
-import pytest
+from pytest import CaptureFixture, raises
 
 from scinoephile.cli.media.media_offset_cli import MediaOffsetCli
 from scinoephile.common.testing import run_cli_with_args
@@ -17,7 +17,7 @@ from test.helpers import parametrize
 
 def test_media_offset_cli_reports_offset(
     tmp_path: Path,
-    capsys: pytest.CaptureFixture[str],
+    capsys: CaptureFixture[str],
 ):
     """Test media offset CLI reports a human-readable offset result.
 
@@ -73,7 +73,7 @@ def test_media_offset_cli_reports_offset(
 
 def test_media_offset_cli_reports_window_aggregate(
     tmp_path: Path,
-    capsys: pytest.CaptureFixture[str],
+    capsys: CaptureFixture[str],
 ):
     """Test media offset CLI reports multi-window aggregate results.
 
@@ -164,7 +164,7 @@ def test_media_offset_cli_reports_window_aggregate(
 
 def test_media_offset_cli_rejects_start_time_argument(
     tmp_path: Path,
-    capsys: pytest.CaptureFixture[str],
+    capsys: CaptureFixture[str],
 ):
     """Test media offset CLI no longer accepts a start time argument.
 
@@ -177,7 +177,7 @@ def test_media_offset_cli_rejects_start_time_argument(
     reference_infile_path.touch()
     target_infile_path.touch()
 
-    with pytest.raises(SystemExit):
+    with raises(SystemExit):
         run_cli_with_args(
             MediaOffsetCli,
             f"--reference-infile {reference_infile_path} "
@@ -201,7 +201,7 @@ def test_media_offset_cli_rejects_start_time_argument(
 def test_media_offset_cli_rejects_zero_positive_arguments(
     argument: str,
     tmp_path: Path,
-    capsys: pytest.CaptureFixture[str],
+    capsys: CaptureFixture[str],
 ):
     """Test media offset CLI rejects zero for positive arguments.
 
@@ -215,7 +215,7 @@ def test_media_offset_cli_rejects_zero_positive_arguments(
     reference_infile_path.touch()
     target_infile_path.touch()
 
-    with pytest.raises(SystemExit):
+    with raises(SystemExit):
         run_cli_with_args(
             MediaOffsetCli,
             f"--reference-infile {reference_infile_path} "
@@ -224,3 +224,4 @@ def test_media_offset_cli_rejects_zero_positive_arguments(
         )
 
     assert "is less than minimum value" in capsys.readouterr().err
+

--- a/test/cli/media/test_media_probe_cli.py
+++ b/test/cli/media/test_media_probe_cli.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
+from pytest import CaptureFixture, raises
 
 from scinoephile.cli.media.media_probe_cli import MediaProbeCli
 from scinoephile.common.testing import run_cli_with_args
@@ -18,7 +18,7 @@ from test.helpers import parametrize
 
 def test_media_probe_cli_lists_all_streams(
     tmp_path: Path,
-    capsys: pytest.CaptureFixture[str],
+    capsys: CaptureFixture[str],
 ):
     """Test media probe CLI lists all streams without packet counts.
 
@@ -74,7 +74,7 @@ def test_media_probe_cli_lists_all_streams(
 )
 def test_media_probe_cli_details_includes_chinese_script_in_stream_id(
     tmp_path: Path,
-    capsys: pytest.CaptureFixture[str],
+    capsys: CaptureFixture[str],
     script: str | None,
     language: str,
 ):
@@ -125,7 +125,7 @@ def test_media_probe_cli_details_includes_chinese_script_in_stream_id(
 
 def test_media_probe_cli_details_preserves_non_subtitle_streams(
     tmp_path: Path,
-    capsys: pytest.CaptureFixture[str],
+    capsys: CaptureFixture[str],
 ):
     """Test media probe CLI detail mode still lists non-subtitle streams.
 
@@ -191,7 +191,7 @@ def test_media_probe_cli_details_preserves_non_subtitle_streams(
 
 def test_media_probe_cli_details_omits_unreadable_subtitle_stats(
     tmp_path: Path,
-    capsys: pytest.CaptureFixture[str],
+    capsys: CaptureFixture[str],
 ):
     """Test media probe CLI survives unreadable subtitle stats.
 
@@ -231,7 +231,7 @@ def test_media_probe_cli_details_omits_unreadable_subtitle_stats(
 
 def test_media_probe_cli_force_check_script_checks_standalone_sup(
     tmp_path: Path,
-    capsys: pytest.CaptureFixture[str],
+    capsys: CaptureFixture[str],
 ):
     """Test forced script checking treats a standalone SUP file as Chinese.
 
@@ -280,7 +280,7 @@ def test_media_probe_cli_force_check_script_checks_standalone_sup(
 
 def test_media_probe_cli_force_check_script_rejects_non_sup(
     tmp_path: Path,
-    capsys: pytest.CaptureFixture[str],
+    capsys: CaptureFixture[str],
 ):
     """Test forced script checking rejects non-SUP inputs.
 
@@ -291,10 +291,11 @@ def test_media_probe_cli_force_check_script_rejects_non_sup(
     infile_path = tmp_path / "video.mkv"
     infile_path.touch()
 
-    with pytest.raises(SystemExit, match="2"):
+    with raises(SystemExit, match="2"):
         run_cli_with_args(
             MediaProbeCli,
             f"--infile {infile_path} --force-check-script",
         )
 
     assert "--force-check-script requires a SUP infile" in capsys.readouterr().err
+

--- a/test/cli/multi/test_multi_cer_cli.py
+++ b/test/cli/multi/test_multi_cer_cli.py
@@ -6,13 +6,13 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
+from pytest import CaptureFixture
 
 from scinoephile.cli.multi.multi_cer_cli import MultiCerCli
 from scinoephile.common.testing import run_cli_with_args
 
 
-def test_multi_cer_cli(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+def test_multi_cer_cli(tmp_path: Path, capsys: CaptureFixture[str]):
     """Test multi cer CLI output.
 
     Arguments:
@@ -43,3 +43,4 @@ def test_multi_cer_cli(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
     assert "Insertions: 0" in output
     assert "Deletions: 0" in output
     assert "Reference length: 3" in output
+

--- a/test/cli/multi/test_multi_diff_cli.py
+++ b/test/cli/multi/test_multi_diff_cli.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
+from pytest import CaptureFixture, raises
 
 from scinoephile.cli.multi.multi_diff_cli import MultiDiffCli
 from scinoephile.common.testing import run_cli_with_args
@@ -14,7 +14,7 @@ from scinoephile.common.testing import run_cli_with_args
 
 def test_multi_diff_cli(
     tmp_path: Path,
-    capsys: pytest.CaptureFixture,
+    capsys: CaptureFixture,
 ):
     """Test multi diff CLI output.
 
@@ -46,7 +46,7 @@ def test_multi_diff_cli(
 
 def test_multi_diff_cli_multiline_split_edit(
     tmp_path: Path,
-    capsys: pytest.CaptureFixture,
+    capsys: CaptureFixture,
 ):
     """Test multi diff CLI output for multi-line alignment.
 
@@ -82,7 +82,7 @@ def test_multi_diff_cli_multiline_split_edit(
 
 def test_multi_diff_cli_identical_series_prints_no_differences(
     tmp_path: Path,
-    capsys: pytest.CaptureFixture,
+    capsys: CaptureFixture,
 ):
     """Test multi diff reports when there are no differences.
 
@@ -118,9 +118,10 @@ def test_multi_diff_cli_rejects_old_one_two_flags(tmp_path: Path):
     reference_infile_path.write_text(content, encoding="utf-8")
     candidate_infile_path.write_text(content, encoding="utf-8")
 
-    with pytest.raises(SystemExit, match="2"):
+    with raises(SystemExit, match="2"):
         run_cli_with_args(
             MultiDiffCli,
             f"--one-infile {reference_infile_path} "
             f"--two-infile {candidate_infile_path}",
         )
+

--- a/test/cli/multi/test_multi_stack_cli.py
+++ b/test/cli/multi/test_multi_stack_cli.py
@@ -8,7 +8,7 @@ from contextlib import redirect_stderr
 from io import StringIO
 from pathlib import Path
 
-import pytest
+from pytest import raises
 
 from scinoephile.cli.multi.multi_stack_cli import MultiStackCli
 from scinoephile.common.testing import run_cli_with_args
@@ -97,7 +97,7 @@ def test_multi_stack_cli_rejects_invalid_tuning_options(
     bottom_path.write_text("1\n00:00:01,250 --> 00:00:02,250\nB\n", encoding="utf-8")
 
     stderr = StringIO()
-    with pytest.raises(SystemExit) as excinfo:
+    with raises(SystemExit) as excinfo:
         with redirect_stderr(stderr):
             run_cli_with_args(
                 MultiStackCli,
@@ -106,3 +106,4 @@ def test_multi_stack_cli_rejects_invalid_tuning_options(
 
     assert excinfo.value.code == 2
     assert expected_error in stderr.getvalue()
+

--- a/test/cli/multi/test_multi_sync_cli.py
+++ b/test/cli/multi/test_multi_sync_cli.py
@@ -8,7 +8,7 @@ from contextlib import redirect_stderr
 from io import StringIO
 from pathlib import Path
 
-import pytest
+from pytest import CaptureFixture, MonkeyPatch, raises
 
 from scinoephile.cli.multi.multi_sync_cli import MultiSyncCli
 from scinoephile.common.testing import run_cli_with_args
@@ -18,7 +18,7 @@ from test.helpers import assert_series_equal, parametrize
 
 def test_multi_sync_cli_shifts_mobile_to_anchor_and_writes_file(
     tmp_path: Path,
-    capsys: pytest.CaptureFixture[str],
+    capsys: CaptureFixture[str],
 ):
     """Test multi sync estimates offset, shifts mobile subtitles, and writes output.
 
@@ -60,7 +60,7 @@ def test_multi_sync_cli_pipe(tmp_path: Path):
     mobile_path.write_text("1\n00:00:01,250 --> 00:00:02,250\nB\n", encoding="utf-8")
 
     stdout_stream = StringIO()
-    with pytest.MonkeyPatch.context() as monkeypatch:
+    with MonkeyPatch.context() as monkeypatch:
         monkeypatch.setattr("scinoephile.cli.helpers.io.stdout", stdout_stream)
         run_cli_with_args(
             MultiSyncCli,
@@ -101,7 +101,7 @@ def test_multi_sync_cli_rejects_invalid_tuning_options(
     mobile_path.write_text("1\n00:00:01,250 --> 00:00:02,250\nB\n", encoding="utf-8")
 
     stderr = StringIO()
-    with pytest.raises(SystemExit) as excinfo:
+    with raises(SystemExit) as excinfo:
         with redirect_stderr(stderr):
             run_cli_with_args(
                 MultiSyncCli,
@@ -110,3 +110,4 @@ def test_multi_sync_cli_rejects_invalid_tuning_options(
 
     assert excinfo.value.code == 2
     assert expected_error in stderr.getvalue()
+

--- a/test/cli/multi/test_multi_timewarp_cli.py
+++ b/test/cli/multi/test_multi_timewarp_cli.py
@@ -8,7 +8,7 @@ from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
+from pytest import raises
 
 from scinoephile.cli.multi.multi_timewarp_cli import MultiTimewarpCli
 from scinoephile.common.testing import run_cli_with_args
@@ -116,9 +116,10 @@ def test_multi_timewarp_cli_rejects_old_one_two_index_flags(tmp_path: Path):
     anchor_path.write_text("1\n00:00:00,000 --> 00:00:01,000\nA\n", encoding="utf-8")
     mobile_path.write_text("1\n00:00:02,000 --> 00:00:03,000\nB\n", encoding="utf-8")
 
-    with pytest.raises(SystemExit, match="2"):
+    with raises(SystemExit, match="2"):
         run_cli_with_args(
             MultiTimewarpCli,
             f"--anchor-infile {anchor_path} --mobile-infile {mobile_path} "
             "--one-start-idx 1 --two-start-idx 1",
         )
+

--- a/test/cli/ocr/test_ocr_cli.py
+++ b/test/cli/ocr/test_ocr_cli.py
@@ -9,7 +9,7 @@ from io import StringIO
 from os import getenv
 from pathlib import Path
 
-import pytest
+from pytest import MonkeyPatch, raises
 
 from scinoephile.cli.ocr import (
     OcrLensCli,
@@ -33,7 +33,7 @@ OCR_LANGUAGE_METAVAR = "{eng,yue-Hans,yue-Hant,zho-Hans,zho-Hant}"
 
 
 def _patch_image_series_load(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     target: str,
     image_series: ImageSeries,
 ) -> list[Path]:
@@ -80,7 +80,7 @@ def test_ocr_lens_cli_help_lists_language_and_retry_options_only():
     """Test Google Lens CLI help lists supported operation options."""
     stdout = StringIO()
     stderr = StringIO()
-    with pytest.raises(SystemExit) as excinfo:
+    with raises(SystemExit) as excinfo:
         with redirect_stdout(stdout):
             with redirect_stderr(stderr):
                 run_cli_with_args(OcrLensCli, "-h")
@@ -101,7 +101,7 @@ def test_ocr_lens_cli_help_lists_language_and_retry_options_only():
 
 
 def test_ocr_lens_cli_converts_image_subtitles_to_srt(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     tmp_path: Path,
     tiny_image_series: ImageSeries,
 ):
@@ -156,7 +156,7 @@ def test_ocr_paddle_cli_help_lists_language_options():
     """Test PaddleOCR CLI help lists supported Scinoephile language options."""
     stdout = StringIO()
     stderr = StringIO()
-    with pytest.raises(SystemExit) as excinfo:
+    with raises(SystemExit) as excinfo:
         with redirect_stdout(stdout):
             with redirect_stderr(stderr):
                 run_cli_with_args(OcrPaddleCli, "-h")
@@ -172,7 +172,7 @@ def test_ocr_tesseract_cli_help_lists_language_options():
     """Test Tesseract OCR CLI help lists supported Scinoephile language options."""
     stdout = StringIO()
     stderr = StringIO()
-    with pytest.raises(SystemExit) as excinfo:
+    with raises(SystemExit) as excinfo:
         with redirect_stdout(stdout):
             with redirect_stderr(stderr):
                 run_cli_with_args(OcrTesseractCli, "-h")
@@ -186,7 +186,7 @@ def test_ocr_tesseract_cli_help_lists_language_options():
 
 
 def test_ocr_paddle_cli_converts_image_subtitles_to_srt(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     tmp_path: Path,
     tiny_image_series: ImageSeries,
 ):
@@ -238,7 +238,7 @@ def test_ocr_paddle_cli_converts_image_subtitles_to_srt(
 
 
 def test_ocr_tesseract_cli_converts_image_subtitles_to_srt(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     tmp_path: Path,
     tiny_image_series: ImageSeries,
 ):
@@ -290,7 +290,7 @@ def test_ocr_tesseract_cli_converts_image_subtitles_to_srt(
 
 
 def test_ocr_tesseract_cli_passes_italic_detection_options(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     tmp_path: Path,
     tiny_image_series: ImageSeries,
 ):
@@ -342,7 +342,7 @@ def test_ocr_tesseract_cli_passes_italic_detection_options(
 
 
 def test_ocr_tesseract_cli_rejects_italic_detection_for_non_english(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     tmp_path: Path,
 ):
     """Test Tesseract OCR CLI rejects italic detection for non-English OCR."""
@@ -363,7 +363,7 @@ def test_ocr_tesseract_cli_rejects_italic_detection_for_non_english(
         fail_ocr_image_series_with_tesseract,
     )
 
-    with pytest.raises(SystemExit) as excinfo:
+    with raises(SystemExit) as excinfo:
         with redirect_stderr(stderr):
             run_cli_with_args(
                 OcrTesseractCli,
@@ -414,7 +414,7 @@ def test_ocr_tesseract_cli_rejects_italic_detection_for_non_english(
     ],
 )
 def test_ocr_engine_clis_delegate_subtitle_outputs_to_writer(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     tmp_path: Path,
     tiny_image_series: ImageSeries,
     cli: type[CommandLineInterface],
@@ -507,7 +507,7 @@ def test_ocr_engine_clis_delegate_subtitle_outputs_to_writer(
     ),
 )
 def test_ocr_lens_cli_matches_mlamd_sup_ocr_fixture(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     tmp_path: Path,
 ):
     """Test Google Lens CLI against a full MLAMD SUP subtitle fixture.
@@ -559,7 +559,7 @@ def test_ocr_lens_cli_matches_mlamd_sup_ocr_fixture(
     ],
 )
 def test_ocr_paddle_cli_matches_mlamd_sup_ocr_fixtures(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     sup_path: str,
     language: str,
     expected_path: str,
@@ -590,3 +590,4 @@ def test_ocr_paddle_cli_matches_mlamd_sup_ocr_fixtures(
         expected = Series.load(full_expected_path)
 
     assert_series_equal(output, expected)
+

--- a/test/cli/ocr/test_ocr_fuse_zho_cli.py
+++ b/test/cli/ocr/test_ocr_fuse_zho_cli.py
@@ -8,7 +8,7 @@ from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
+from pytest import raises
 
 from scinoephile.cli.ocr.ocr_fuse_cli import OcrFuseCli
 from scinoephile.common.testing import run_cli_with_args
@@ -112,9 +112,10 @@ def test_ocr_fuse_zho_cli_rejects_bare_convert_flag(tmp_path: Path):
     write_srt_series(lens_path, "鏡頭")
     write_srt_series(paddle_path, "桨")
 
-    with pytest.raises(SystemExit, match="2"):
+    with raises(SystemExit, match="2"):
         run_cli_with_args(
             OcrFuseCli,
             f"--language zho --lens-infile {lens_path} "
             f"--paddle-infile {paddle_path} --clean --convert",
         )
+

--- a/test/cli/ocr/test_ocr_process_cli.py
+++ b/test/cli/ocr/test_ocr_process_cli.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
+from pytest import raises
 
 from scinoephile.cli.ocr.ocr_cli import OcrCli
 from scinoephile.cli.ocr.ocr_process_cli import OcrProcessCli
@@ -116,7 +116,7 @@ def test_ocr_process_cli_reports_workflow_errors(tmp_path: Path):
             "scinoephile.cli.ocr.ocr_process_cli.OcrProcessingWorkflow",
             side_effect=ScinoephileError("No subtitle stream 3 found"),
         ),
-        pytest.raises(SystemExit) as excinfo,
+        raises(SystemExit) as excinfo,
     ):
         run_cli_with_args(
             OcrProcessCli,
@@ -129,3 +129,4 @@ def test_ocr_process_cli_reports_workflow_errors(tmp_path: Path):
 def test_ocr_cli_includes_process_subcommand():
     """Test top-level OCR CLI exposes OCR processing."""
     assert OcrCli.subcommands()["process"] is OcrProcessCli
+

--- a/test/cli/ocr/test_ocr_validate_cli.py
+++ b/test/cli/ocr/test_ocr_validate_cli.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
+from pytest import CaptureFixture, MonkeyPatch, raises
 
 from scinoephile.cli.ocr.ocr_validate_cli import OcrValidateCli
 from scinoephile.common.testing import run_cli_with_args
@@ -14,7 +14,7 @@ from scinoephile.core import ScinoephileError
 
 
 def test_ocr_validate_cli(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     tmp_path: Path,
 ):
     """Test OCR validate CLI forwards noninteractive workflow arguments.
@@ -83,7 +83,7 @@ def test_ocr_validate_cli(
 
 
 def test_ocr_validate_cli_web(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     tmp_path: Path,
 ):
     """Test OCR validate CLI launches web validation.
@@ -150,7 +150,7 @@ def test_ocr_validate_cli_web(
 
 
 def test_ocr_validate_cli_web_rejects_sup_input(
-    capsys: pytest.CaptureFixture[str],
+    capsys: CaptureFixture[str],
     tmp_path: Path,
 ):
     """Test OCR validate web mode requires a prepared OCR image directory.
@@ -163,7 +163,7 @@ def test_ocr_validate_cli_web_rejects_sup_input(
     infile_path.write_bytes(b"unused")
     outfile_path = tmp_path / "validated.srt"
 
-    with pytest.raises(SystemExit, match="2"):
+    with raises(SystemExit, match="2"):
         run_cli_with_args(
             OcrValidateCli,
             f"--infile {infile_path} --interactive --outfile {outfile_path}",
@@ -174,8 +174,8 @@ def test_ocr_validate_cli_web_rejects_sup_input(
 
 
 def test_ocr_validate_cli_web_delegates_image_dir_validation(
-    capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
+    capsys: CaptureFixture[str],
+    monkeypatch: MonkeyPatch,
     tmp_path: Path,
 ):
     """Test web mode lets the session validate OCR image directory contents.
@@ -197,7 +197,7 @@ def test_ocr_validate_cli_web_delegates_image_dir_validation(
         fake_validate_ocr,
     )
 
-    with pytest.raises(SystemExit, match="2"):
+    with raises(SystemExit, match="2"):
         run_cli_with_args(
             OcrValidateCli,
             f"--infile {infile_path} --interactive "
@@ -206,3 +206,4 @@ def test_ocr_validate_cli_web_delegates_image_dir_validation(
 
     captured = capsys.readouterr()
     assert "session checked OCR image directory" in captured.err
+

--- a/test/cli/test_cli_argument_groups.py
+++ b/test/cli/test_cli_argument_groups.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from argparse import Action, ArgumentParser
 from pathlib import Path
 
-import pytest
+from pytest import raises
 
 from scinoephile.cli.eng.eng_process_cli import EngProcessCli
 from scinoephile.cli.eng.eng_translate_from_yue_cli import EngTranslateFromYueCli
@@ -137,7 +137,7 @@ def test_add_web_server_args_bundles_standard_host_and_port():
     default_namespace = parser.parse_args([])
     assert default_namespace.web_args == WebServerArguments()
 
-    with pytest.raises(SystemExit):
+    with raises(SystemExit):
         parser.parse_args(["--port", "65536"])
 
 
@@ -209,3 +209,4 @@ def _get_action_group_title(cli: type[CommandLineInterface], option: str) -> str
                 return group.title
             break
     raise AssertionError(f"{option} is not assigned to an argument group")
+

--- a/test/cli/test_llm_cli.py
+++ b/test/cli/test_llm_cli.py
@@ -9,7 +9,7 @@ from io import StringIO
 from os import environ
 from unittest.mock import patch
 
-import pytest
+from pytest import raises
 
 from scinoephile.cli.eng.eng_process_cli import EngProcessCli
 from scinoephile.cli.eng.eng_translate_from_yue_cli import EngTranslateFromYueCli
@@ -56,7 +56,7 @@ def test_list_llm_providers(cli: type[CommandLineInterface]):
     stdout = StringIO()
     stderr = StringIO()
 
-    with pytest.raises(SystemExit, match="0"):
+    with raises(SystemExit, match="0"):
         with redirect_stdout(stdout):
             with redirect_stderr(stderr):
                 run_cli_with_args(cli, "--list-llm-providers")
@@ -78,7 +78,7 @@ def test_list_llm_providers_uses_simplified_chinese_descriptions():
     stderr = StringIO()
 
     with patch.dict(environ, {"LC_ALL": "zh-hans"}, clear=False):
-        with pytest.raises(SystemExit, match="0"):
+        with raises(SystemExit, match="0"):
             with redirect_stdout(stdout):
                 with redirect_stderr(stderr):
                     run_cli_with_args(ZhoProcessCli, "--list-llm-providers")
@@ -96,5 +96,6 @@ def test_list_llm_providers_uses_simplified_chinese_descriptions():
 
 def test_llm_provider_arg_rejects_unknown_provider():
     """Test LLM provider argument rejects unknown provider names."""
-    with pytest.raises(SystemExit, match="2"):
+    with raises(SystemExit, match="2"):
         run_cli_with_args(ZhoProcessCli, "--llm-provider missing-provider")
+

--- a/test/cli/test_localized_cli_help.py
+++ b/test/cli/test_localized_cli_help.py
@@ -10,7 +10,7 @@ from os import environ
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
+from pytest import MonkeyPatch, raises
 
 from scinoephile.cli.scinoephile_cli import ScinoephileCli
 from scinoephile.common import CommandLineInterface
@@ -52,7 +52,7 @@ def test_all_cli_help_text_has_chinese_localizations():
 
 
 def test_all_cli_help_paths_do_not_create_default_cache_dir(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test CLI help construction does not create default cache directories.
 
@@ -295,7 +295,7 @@ def _run_help(args: str) -> str:
     """
     stdout = StringIO()
     stderr = StringIO()
-    with pytest.raises(SystemExit) as excinfo:
+    with raises(SystemExit) as excinfo:
         with redirect_stdout(stdout):
             with redirect_stderr(stderr):
                 run_cli_with_args(ScinoephileCli, args)
@@ -336,3 +336,4 @@ def _is_translatable_help_text(text: str) -> bool:
     return any(
         character.isascii() and character.isalpha() for character in text
     ) and not any("\u4e00" <= character <= "\u9fff" for character in text)
+

--- a/test/cli/test_opencc_cli.py
+++ b/test/cli/test_opencc_cli.py
@@ -9,7 +9,7 @@ from io import StringIO
 from os import environ
 from unittest.mock import patch
 
-import pytest
+from pytest import raises
 
 from scinoephile.cli.ocr.ocr_fuse_cli import OcrFuseCli
 from scinoephile.cli.yue.yue_process_cli import YueProcessCli
@@ -38,7 +38,7 @@ def test_list_opencc_configs(cli: type[CommandLineInterface]):
     stdout = StringIO()
     stderr = StringIO()
 
-    with pytest.raises(SystemExit, match="0"):
+    with raises(SystemExit, match="0"):
         with redirect_stdout(stdout):
             with redirect_stderr(stderr):
                 run_cli_with_args(cli, "--list-opencc-configs")
@@ -57,7 +57,7 @@ def test_list_opencc_configs_uses_traditional_chinese_descriptions():
     stderr = StringIO()
 
     with patch.dict(environ, {"LC_ALL": "zh-hant"}, clear=False):
-        with pytest.raises(SystemExit, match="0"):
+        with raises(SystemExit, match="0"):
             with redirect_stdout(stdout):
                 with redirect_stderr(stderr):
                     run_cli_with_args(ZhoProcessCli, "--list-opencc-configs")
@@ -68,3 +68,4 @@ def test_list_opencc_configs_uses_traditional_chinese_descriptions():
     assert "  hk2s  繁體中文（香港標準）轉簡體中文。\n" in listing
     assert "  s2hk  簡體中文轉繁體中文（香港標準）。\n" in listing
     assert "  t2s   繁體中文轉簡體中文。\n" in listing
+

--- a/test/cli/test_scinoephile_cli.py
+++ b/test/cli/test_scinoephile_cli.py
@@ -10,7 +10,7 @@ from os import environ
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
+from pytest import MonkeyPatch, raises
 
 from scinoephile.cli.scinoephile_cli import ScinoephileCli
 from scinoephile.common.testing import run_cli_with_args
@@ -18,7 +18,7 @@ from test.helpers import assert_cli_help
 
 
 def test_scinoephile_help_does_not_create_default_cache_dir(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test root help output does not create default cache directories.
 
@@ -38,7 +38,7 @@ def test_scinoephile_all_commands_lists_complete_hierarchy():
     """Test root CLI can list the complete subcommand hierarchy."""
     stdout = StringIO()
     stderr = StringIO()
-    with pytest.raises(SystemExit) as excinfo:
+    with raises(SystemExit) as excinfo:
         with redirect_stdout(stdout):
             with redirect_stderr(stderr):
                 run_cli_with_args(ScinoephileCli, "--all-commands")
@@ -107,7 +107,7 @@ def test_scinoephile_all_commands_localized():
     with patch.dict(environ, {"LC_ALL": "zh-hant"}):
         stdout = StringIO()
         stderr = StringIO()
-        with pytest.raises(SystemExit) as excinfo:
+        with raises(SystemExit) as excinfo:
             with redirect_stdout(stdout):
                 with redirect_stderr(stderr):
                     run_cli_with_args(ScinoephileCli, "--all-commands")
@@ -125,3 +125,4 @@ def test_scinoephile_all_commands_localized():
     assert "修改標準中文字幕" in output
     assert "香港中文大學現代標準漢語與粵語對照資料庫" not in output
     assert "由 2004 年第二版《廣州話正音字典》整理而成" not in output
+

--- a/test/cli/utility/cache/test_argument_types.py
+++ b/test/cli/utility/cache/test_argument_types.py
@@ -8,7 +8,7 @@ from argparse import ArgumentParser
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
+from pytest import raises
 
 from scinoephile.cli.helpers.cache import add_cache_dir_arg
 
@@ -71,7 +71,8 @@ def test_add_cache_dir_arg_rejects_existing_file(tmp_path: Path):
     cache_file_path.write_text("cache", encoding="utf-8")
 
     add_cache_dir_arg(cache_arg_group)
-    with pytest.raises(SystemExit) as excinfo:
+    with raises(SystemExit) as excinfo:
         parser.parse_args(["--cache-dir", str(cache_file_path)])
 
     assert excinfo.value.code == 2
+

--- a/test/cli/utility/cache/test_cache_clear_cli.py
+++ b/test/cli/utility/cache/test_cache_clear_cli.py
@@ -6,13 +6,13 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
+from pytest import CaptureFixture, raises
 
 from scinoephile.cli.utility.cache.cache_clear_cli import CacheClearCli
 from scinoephile.common.testing import run_cli_with_args
 
 
-def test_cache_clear_dry_run(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+def test_cache_clear_dry_run(tmp_path: Path, capsys: CaptureFixture[str]):
     """Test dry-run namespace clearing.
 
     Arguments:
@@ -30,7 +30,7 @@ def test_cache_clear_dry_run(tmp_path: Path, capsys: pytest.CaptureFixture[str])
 
 
 def test_cache_clear_all_dry_run_limits_output(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    tmp_path: Path, capsys: CaptureFixture[str]
 ):
     """Test all-namespace dry-run output is bounded.
 
@@ -87,7 +87,7 @@ def test_cache_clear_requires_scope(tmp_path: Path):
     Arguments:
         tmp_path: temporary directory
     """
-    with pytest.raises(SystemExit) as exc_info:
+    with raises(SystemExit) as exc_info:
         run_cli_with_args(CacheClearCli, f"--cache-dir {tmp_path} --dry-run")
     assert exc_info.value.code == 2
 
@@ -98,7 +98,7 @@ def test_cache_clear_requires_confirmation(tmp_path: Path):
     Arguments:
         tmp_path: temporary directory
     """
-    with pytest.raises(SystemExit) as exc_info:
+    with raises(SystemExit) as exc_info:
         run_cli_with_args(CacheClearCli, f"--cache-dir {tmp_path} --namespace llm")
     assert exc_info.value.code == 2
 
@@ -114,3 +114,4 @@ def _write_cache_file(path: Path) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("{}", encoding="utf-8")
     return path
+

--- a/test/cli/utility/cache/test_cache_list_cli.py
+++ b/test/cli/utility/cache/test_cache_list_cli.py
@@ -7,13 +7,13 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
+from pytest import CaptureFixture
 
 from scinoephile.cli.utility.cache.cache_list_cli import CacheListCli
 from scinoephile.common.testing import run_cli_with_args
 
 
-def test_cache_list_text(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+def test_cache_list_text(tmp_path: Path, capsys: CaptureFixture[str]):
     """Test text cache list output.
 
     Arguments:
@@ -28,7 +28,7 @@ def test_cache_list_text(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
     assert "llm\tllm/one.json" in capsys.readouterr().out
 
 
-def test_cache_list_json(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+def test_cache_list_json(tmp_path: Path, capsys: CaptureFixture[str]):
     """Test JSON cache list output.
 
     Arguments:
@@ -44,7 +44,7 @@ def test_cache_list_json(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
     assert entries[0]["path"] == "llm/one.json"
 
 
-def test_cache_list_missing_root(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+def test_cache_list_missing_root(tmp_path: Path, capsys: CaptureFixture[str]):
     """Test cache list output for a missing root.
 
     Arguments:
@@ -64,3 +64,4 @@ def _write_cache_file(path: Path):
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("{}", encoding="utf-8")
+

--- a/test/cli/utility/cache/test_cache_prune_cli.py
+++ b/test/cli/utility/cache/test_cache_prune_cli.py
@@ -8,13 +8,13 @@ from os import utime
 from pathlib import Path
 from time import time
 
-import pytest
+from pytest import CaptureFixture, raises
 
 from scinoephile.cli.utility.cache.cache_prune_cli import CachePruneCli
 from scinoephile.common.testing import run_cli_with_args
 
 
-def test_cache_prune_dry_run(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+def test_cache_prune_dry_run(tmp_path: Path, capsys: CaptureFixture[str]):
     """Test dry-run cache pruning.
 
     Arguments:
@@ -54,7 +54,7 @@ def test_cache_prune_requires_confirmation(tmp_path: Path):
     Arguments:
         tmp_path: temporary directory
     """
-    with pytest.raises(SystemExit) as exc_info:
+    with raises(SystemExit) as exc_info:
         run_cli_with_args(CachePruneCli, f"--cache-dir {tmp_path} --older-than 30d")
     assert exc_info.value.code == 2
 
@@ -80,3 +80,4 @@ def _write_cache_file(path: Path) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("{}", encoding="utf-8")
     return path
+

--- a/test/cli/utility/cache/test_cache_stats_cli.py
+++ b/test/cli/utility/cache/test_cache_stats_cli.py
@@ -7,13 +7,13 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
+from pytest import CaptureFixture
 
 from scinoephile.cli.utility.cache.cache_stats_cli import CacheStatsCli
 from scinoephile.common.testing import run_cli_with_args
 
 
-def test_cache_stats_json(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+def test_cache_stats_json(tmp_path: Path, capsys: CaptureFixture[str]):
     """Test JSON cache stats output.
 
     Arguments:
@@ -30,7 +30,7 @@ def test_cache_stats_json(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
     assert stats["total"]["entry_count"] == 1
 
 
-def test_cache_stats_namespace(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+def test_cache_stats_namespace(tmp_path: Path, capsys: CaptureFixture[str]):
     """Test namespace-filtered cache stats output.
 
     Arguments:
@@ -56,3 +56,4 @@ def _write_cache_file(path: Path, text: str = "{}"):
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
+

--- a/test/cli/yue/test_yue_process_cli.py
+++ b/test/cli/yue/test_yue_process_cli.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from io import StringIO
 from unittest.mock import patch
 
-import pytest
+from pytest import raises
 
 from scinoephile.cli.yue.yue_process_cli import YueProcessCli
 from scinoephile.common.file import get_temp_file_path
@@ -105,5 +105,6 @@ def test_yue_process_cli_rejects_bare_convert_flag():
     """Test written Cantonese processing CLI requires an explicit conversion config."""
     full_input_path = test_data_root / "kob/output/yue-Hans/timewarp_clean_flatten.srt"
 
-    with pytest.raises(SystemExit, match="2"):
+    with raises(SystemExit, match="2"):
         run_cli_with_args(YueProcessCli, f"--infile {full_input_path} --convert")
+

--- a/test/cli/yue/test_yue_transcribe_vs_zho_cli.py
+++ b/test/cli/yue/test_yue_transcribe_vs_zho_cli.py
@@ -8,7 +8,7 @@ from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO
 from unittest.mock import Mock, patch
 
-import pytest
+from pytest import raises
 
 from scinoephile.audio.subtitles import AudioSeries
 from scinoephile.cli.yue.yue_transcribe_vs_zho_cli import YueTranscribeVsZhoCli
@@ -35,7 +35,7 @@ def test_yue_transcribe_vs_zho_help_lists_transcription_options():
     stdout = StringIO()
     stderr = StringIO()
 
-    with pytest.raises(SystemExit, match="0"):
+    with raises(SystemExit, match="0"):
         with redirect_stdout(stdout):
             with redirect_stderr(stderr):
                 run_cli_with_args(YueTranscribeVsZhoCli, "-h")
@@ -146,7 +146,7 @@ def test_yue_transcribe_vs_zho_cli_rejects_bare_convert_flag():
     """Test written Cantonese CLI requires an explicit conversion config."""
     zhongwen_infile_path = test_data_root / "mnt/output/zho-Hans_ocr/fuse.srt"
     media_infile_path = "/tmp/test_media.mp4"
-    with pytest.raises(SystemExit, match="2"):
+    with raises(SystemExit, match="2"):
         run_cli_with_args(
             YueTranscribeVsZhoCli,
             f"--media-infile {media_infile_path} "
@@ -210,7 +210,7 @@ def test_yue_transcribe_vs_zho_cli_rejects_negative_stream_index():
     """Test written Cantonese transcribe-vs-zho CLI rejects negative stream indexes."""
     zhongwen_infile_path = test_data_root / "mnt/output/zho-Hans_ocr/fuse.srt"
     media_infile_path = "/tmp/test_media.mp4"
-    with pytest.raises(SystemExit, match="2"):
+    with raises(SystemExit, match="2"):
         run_cli_with_args(
             YueTranscribeVsZhoCli,
             f"--media-infile {media_infile_path} "
@@ -226,7 +226,7 @@ def test_yue_transcribe_vs_zho_cli_stream_errors_are_user_facing():
         "scinoephile.cli.yue.yue_transcribe_vs_zho_cli.AudioSeries.load_from_media",
         side_effect=ScinoephileError("No stream index 7 found"),
     ):
-        with pytest.raises(SystemExit, match="2"):
+        with raises(SystemExit, match="2"):
             run_cli_with_args(
                 YueTranscribeVsZhoCli,
                 f"--media-infile {media_infile_path} "
@@ -239,7 +239,7 @@ def test_yue_transcribe_vs_zho_cli_rejects_missing_subtitle_infile():
     media_infile_path = "/tmp/test_media.mp4"
     zhongwen_infile_path = "/tmp/missing_subtitles.srt"
 
-    with pytest.raises(SystemExit, match="2"):
+    with raises(SystemExit, match="2"):
         run_cli_with_args(
             YueTranscribeVsZhoCli,
             f"--media-infile {media_infile_path} --zho-infile {zhongwen_infile_path}",
@@ -251,7 +251,7 @@ def test_yue_transcribe_vs_zho_cli_rejects_missing_media_infile():
     zhongwen_infile_path = test_data_root / "mnt/output/zho-Hans_ocr/fuse.srt"
     media_infile_path = "/tmp/missing_media.mp4"
 
-    with pytest.raises(SystemExit, match="2"):
+    with raises(SystemExit, match="2"):
         run_cli_with_args(
             YueTranscribeVsZhoCli,
             f"--media-infile {media_infile_path} --zho-infile {zhongwen_infile_path}",
@@ -327,7 +327,7 @@ def test_yue_transcribe_vs_zho_cli_allows_stdin_subtitle_infile():
 
 def test_yue_transcribe_vs_zho_cli_rejects_two_stdin_infiles():
     """Test written Cantonese transcribe-vs-zho CLI rejects stdin for both inputs."""
-    with pytest.raises(SystemExit, match="2"):
+    with raises(SystemExit, match="2"):
         run_cli_with_args(
             YueTranscribeVsZhoCli,
             "--media-infile - --zho-infile -",
@@ -339,7 +339,7 @@ def test_yue_transcribe_vs_zho_cli_rejects_overwrite_without_outfile():
     zhongwen_infile_path = test_data_root / "mnt/output/zho-Hans_ocr/fuse.srt"
     media_infile_path = "/tmp/test_media.mp4"
 
-    with pytest.raises(SystemExit, match="2"):
+    with raises(SystemExit, match="2"):
         run_cli_with_args(
             YueTranscribeVsZhoCli,
             f"--media-infile {media_infile_path} "
@@ -352,9 +352,10 @@ def test_yue_transcribe_vs_zho_cli_rejects_old_zhongwen_infile_flag():
     zhongwen_infile_path = test_data_root / "mnt/output/zho-Hans_ocr/fuse.srt"
     media_infile_path = "/tmp/test_media.mp4"
 
-    with pytest.raises(SystemExit, match="2"):
+    with raises(SystemExit, match="2"):
         run_cli_with_args(
             YueTranscribeVsZhoCli,
             f"--media-infile {media_infile_path} "
             f"--zhongwen-infile {zhongwen_infile_path}",
         )
+

--- a/test/cli/yue/test_yue_translate_from_eng_cli.py
+++ b/test/cli/yue/test_yue_translate_from_eng_cli.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-import pytest
+from pytest import raises
 
 from scinoephile.cli.yue.yue_translate_from_eng_cli import YueTranslateFromEngCli
 from scinoephile.common.file import get_temp_file_path
@@ -52,10 +52,11 @@ def test_yue_translate_from_eng_cli_rejects_gapped_and_guide_together():
         test_data_root / "mlamd/output/yue-Hans_transcribe/transcribe_review.srt"
     )
 
-    with pytest.raises(SystemExit, match="2"):
+    with raises(SystemExit, match="2"):
         run_cli_with_args(
             YueTranslateFromEngCli,
             f"--eng-infile {eng_input_path} "
             f"--yue-gapped-infile {yue_input_path} "
             f"--yue-guide-infile {yue_input_path}",
         )
+

--- a/test/cli/yue/test_yue_translate_from_zho_cli.py
+++ b/test/cli/yue/test_yue_translate_from_zho_cli.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-import pytest
+from pytest import raises
 
 from scinoephile.cli.yue.yue_translate_from_zho_cli import YueTranslateFromZhoCli
 from scinoephile.common.file import get_temp_file_path
@@ -56,10 +56,11 @@ def test_yue_translate_from_zho_cli_rejects_gapped_and_guide_together():
         "mlamd/output/zho-Hans_ocr/fuse_clean_validate_review_flatten.srt"
     )
 
-    with pytest.raises(SystemExit, match="2"):
+    with raises(SystemExit, match="2"):
         run_cli_with_args(
             YueTranslateFromZhoCli,
             f"--zho-infile {zho_input_path} "
             f"--yue-gapped-infile {yue_input_path} "
             f"--yue-guide-infile {yue_input_path}",
         )
+

--- a/test/cli/zho/test_zho_process_cli.py
+++ b/test/cli/zho/test_zho_process_cli.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from io import StringIO
 from unittest.mock import patch
 
-import pytest
+from pytest import raises
 
 from scinoephile.cli.zho.zho_process_cli import ZhoProcessCli
 from scinoephile.common.file import get_temp_file_path
@@ -115,7 +115,7 @@ def test_zho_process_cli_rejects_bare_convert_flag():
         / "mnt/output/zho-Hant_ocr/fuse_clean_validate_review_flatten.srt"
     )
 
-    with pytest.raises(SystemExit, match="2"):
+    with raises(SystemExit, match="2"):
         run_cli_with_args(ZhoProcessCli, f"--infile {full_input_path} --convert")
 
 
@@ -156,3 +156,4 @@ def test_zho_process_cli_passes_llm_options_to_reviewer(tmp_path):
                     f"--llm-additional-content-file {context_path} "
                     f"--outfile {output_path}",
                 )
+

--- a/test/cli/zho/test_zho_translate_from_eng_cli.py
+++ b/test/cli/zho/test_zho_translate_from_eng_cli.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-import pytest
+from pytest import raises
 
 from scinoephile.cli.zho.zho_translate_from_eng_cli import ZhoTranslateFromEngCli
 from scinoephile.common.file import get_temp_file_path
@@ -50,10 +50,11 @@ def test_zho_translate_from_eng_cli_rejects_gapped_and_guide_together():
         "mlamd/output/zho-Hans_ocr/fuse_clean_validate_review_flatten.srt"
     )
 
-    with pytest.raises(SystemExit, match="2"):
+    with raises(SystemExit, match="2"):
         run_cli_with_args(
             ZhoTranslateFromEngCli,
             f"--eng-infile {eng_input_path} "
             f"--zho-gapped-infile {zho_input_path} "
             f"--zho-guide-infile {zho_input_path}",
         )
+

--- a/test/cli/zho/test_zho_translate_from_yue_cli.py
+++ b/test/cli/zho/test_zho_translate_from_yue_cli.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-import pytest
+from pytest import raises
 
 from scinoephile.cli.zho.zho_translate_from_yue_cli import ZhoTranslateFromYueCli
 from scinoephile.common.file import get_temp_file_path
@@ -54,10 +54,11 @@ def test_zho_translate_from_yue_cli_rejects_gapped_and_guide_together():
         "mlamd/output/zho-Hans_ocr/fuse_clean_validate_review_flatten.srt"
     )
 
-    with pytest.raises(SystemExit, match="2"):
+    with raises(SystemExit, match="2"):
         run_cli_with_args(
             ZhoTranslateFromYueCli,
             f"--yue-infile {yue_input_path} "
             f"--zho-gapped-infile {zho_input_path} "
             f"--zho-guide-infile {zho_input_path}",
         )
+

--- a/test/common/argument_parsing/test_get_validator.py
+++ b/test/common/argument_parsing/test_get_validator.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from argparse import ArgumentTypeError
 
-import pytest
+from pytest import raises
 
 from scinoephile.common.argument_parsing import get_validator
 
@@ -48,7 +48,7 @@ def test_get_validator_type_error():
 
     validator = get_validator(failing_func)
 
-    with pytest.raises(ArgumentTypeError):
+    with raises(ArgumentTypeError):
         validator("test")
 
 
@@ -69,5 +69,6 @@ def test_get_validator_os_error():
 
     validator = get_validator(failing_func)
 
-    with pytest.raises(ArgumentTypeError, match="Invalid path"):
+    with raises(ArgumentTypeError, match="Invalid path"):
         validator("test")
+

--- a/test/common/argument_parsing/test_validators.py
+++ b/test/common/argument_parsing/test_validators.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from argparse import ArgumentTypeError
 from pathlib import Path
 
-import pytest
+from pytest import raises
 
 from scinoephile.common.argument_parsing import (
     duration_arg,
@@ -28,7 +28,7 @@ def test_duration_arg():
 
     assert validator("12h").total_seconds() == 12 * 60 * 60
 
-    with pytest.raises(ArgumentTypeError, match="Invalid duration"):
+    with raises(ArgumentTypeError, match="Invalid duration"):
         validator("yesterday")
 
 
@@ -38,7 +38,7 @@ def test_float_arg():
 
     assert validator("5.5") == 5.5
 
-    with pytest.raises(ArgumentTypeError, match="less than minimum value"):
+    with raises(ArgumentTypeError, match="less than minimum value"):
         validator("-1.0")
 
 
@@ -48,7 +48,7 @@ def test_int_arg():
 
     assert validator("5") == 5
 
-    with pytest.raises(ArgumentTypeError, match="less than minimum value"):
+    with raises(ArgumentTypeError, match="less than minimum value"):
         validator("-1")
 
 
@@ -59,7 +59,7 @@ def test_str_arg():
     assert validator("option1") == "option1"
     assert validator("OPTION1") == "option1"
 
-    with pytest.raises(
+    with raises(
         ArgumentTypeError,
         match="'invalid' is not one of the supported values: option1, option2, option3",
     ):
@@ -77,7 +77,7 @@ def test_input_file_arg(tmp_path: Path):
     assert isinstance(result, Path)
     assert result.exists()
 
-    with pytest.raises(ArgumentTypeError, match="does not exist"):
+    with raises(ArgumentTypeError, match="does not exist"):
         validator(str(tmp_path / "nonexistent.txt"))
 
 
@@ -93,7 +93,7 @@ def test_input_file_or_dir_arg(tmp_path: Path):
     assert validator(str(test_file)) == test_file.resolve()
     assert validator(str(test_dir)) == test_dir.resolve()
 
-    with pytest.raises(ArgumentTypeError, match="does not exist"):
+    with raises(ArgumentTypeError, match="does not exist"):
         validator(str(tmp_path / "nonexistent"))
 
 
@@ -108,7 +108,7 @@ def test_input_dir_arg(tmp_path: Path):
     assert isinstance(result, Path)
     assert result.is_dir()
 
-    with pytest.raises(ArgumentTypeError, match="does not exist"):
+    with raises(ArgumentTypeError, match="does not exist"):
         validator(str(tmp_path / "nonexistent"))
 
 
@@ -130,7 +130,7 @@ def test_output_file_arg_rejects_existing_file_with_argparse_error(tmp_path: Pat
 
     validator = output_file_arg()
 
-    with pytest.raises(ArgumentTypeError, match="already exists"):
+    with raises(ArgumentTypeError, match="already exists"):
         validator(str(test_file))
 
 
@@ -167,5 +167,6 @@ def test_output_dir_arg_without_create_rejects_file_ancestor(tmp_path: Path):
 
     validator = output_dir_arg(create=False)
 
-    with pytest.raises(ArgumentTypeError, match="is not a directory"):
+    with raises(ArgumentTypeError, match="is not a directory"):
         validator(str(test_dir))
+

--- a/test/common/subprocess/test_run_command.py
+++ b/test/common/subprocess/test_run_command.py
@@ -9,7 +9,7 @@ import sys
 from pathlib import Path
 from time import monotonic
 
-import pytest
+from pytest import raises
 
 from scinoephile.common.subprocess import run_command
 from test.helpers import parametrize
@@ -55,7 +55,7 @@ def test_run_command_with_stderr():
 
 def test_run_command_failure_default():
     """Test running a command that fails with default acceptable exitcodes."""
-    with pytest.raises(ValueError, match="failed with exit code"):
+    with raises(ValueError, match="failed with exit code"):
         run_command([sys.executable, "-c", "import sys; sys.exit(1)"])
 
 
@@ -134,3 +134,4 @@ def test_run_command_unicode_output():
 
     assert exitcode == 0
     assert "Hello" in stdout
+

--- a/test/common/subprocess/test_run_command_live.py
+++ b/test/common/subprocess/test_run_command_live.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from subprocess import TimeoutExpired
 from time import monotonic
 
-import pytest
+from pytest import raises
 
 from scinoephile.common.subprocess import run_command_live
 from test.helpers import parametrize
@@ -55,7 +55,7 @@ def test_run_command_live_with_stderr():
 
 def test_run_command_live_failure_default():
     """Test running a command that fails with default acceptable exitcodes."""
-    with pytest.raises(ValueError, match="failed with exit code"):
+    with raises(ValueError, match="failed with exit code"):
         run_command_live([sys.executable, "-c", "import sys; sys.exit(1)"])
 
 
@@ -111,7 +111,7 @@ def test_run_command_live_with_env():
 def test_run_command_live_timeout():
     """Test command timeout behavior."""
     start_time = monotonic()
-    with pytest.raises(TimeoutExpired):
+    with raises(TimeoutExpired):
         run_command_live(
             [sys.executable, "-c", "import time; time.sleep(2)"], timeout=0
         )
@@ -129,3 +129,4 @@ def test_run_command_live_non_utf8_output():
     assert exitcode == 0
     assert stdout == "ÿ"
     assert stderr == ""
+

--- a/test/common/test_command_line_interface.py
+++ b/test/common/test_command_line_interface.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import ClassVar
 from unittest.mock import patch
 
-import pytest
+from pytest import MonkeyPatch, raises
 
 from scinoephile.common.command_line_interface import (
     CommandLineInterface,
@@ -261,7 +261,7 @@ def test_run_cli_with_args_quoted_values():
 
 
 def test_assert_cli_usage_failure_reports_streams(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test CLI usage assertion failures include expected and actual streams.
 
@@ -274,7 +274,7 @@ def test_assert_cli_usage_failure_reports_streams(
         lambda cli: "usage: intentionally-wrong.py",
     )
 
-    with pytest.raises(AssertionError) as excinfo:
+    with raises(AssertionError) as excinfo:
         helpers.assert_cli_usage((RequiredArgCli,))
 
     message = str(excinfo.value)
@@ -282,3 +282,4 @@ def test_assert_cli_usage_failure_reports_streams(
     assert "usage: intentionally-wrong.py" in message
     assert "Actual stderr:" in message
     assert "Actual stdout:" in message
+

--- a/test/common/test_csv.py
+++ b/test/common/test_csv.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-import pytest
+from pytest import raises
 
 from scinoephile.common.csv import (
     parse_csv_int_list,
@@ -14,13 +14,13 @@ from scinoephile.common.csv import (
 
 def test_parse_csv_int_list_empty():
     """Test parsing of empty integer list values."""
-    with pytest.raises(ValueError, match="--sizes must include at least one integer"):
+    with raises(ValueError, match="--sizes must include at least one integer"):
         parse_csv_int_list(" , ", name="--sizes")
 
 
 def test_parse_csv_int_list_invalid_value():
     """Test parsing of invalid integer list values."""
-    with pytest.raises(ValueError, match="Invalid integer 'x' in --sizes"):
+    with raises(ValueError, match="Invalid integer 'x' in --sizes"):
         parse_csv_int_list("1,x,3", name="--sizes")
 
 
@@ -42,3 +42,4 @@ def test_parse_csv_str_list_values():
 def test_parse_csv_str_list_whitespace():
     """Test parsing of whitespace-only string list."""
     assert parse_csv_str_list("   ") == []
+

--- a/test/common/test_duration.py
+++ b/test/common/test_duration.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-import pytest
+from pytest import raises
 
 from scinoephile.common.duration import parse_duration
 from test.helpers import parametrize
@@ -34,5 +34,6 @@ def test_parse_duration(value: str, expected: timedelta):
 
 def test_parse_duration_invalid():
     """Test that invalid durations fail clearly."""
-    with pytest.raises(ValueError, match="Invalid duration"):
+    with raises(ValueError, match="Invalid duration"):
         parse_duration("yesterday")
+

--- a/test/common/validation/test_val_executable.py
+++ b/test/common/validation/test_val_executable.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from pathlib import Path
 from platform import system
 
-import pytest
+from pytest import raises
 
 from scinoephile.common.exceptions import (
     ExecutableNotFoundError,
@@ -26,7 +26,7 @@ def test_val_executable_valid():
 
 def test_val_executable_not_found():
     """Test validation of non-existent executable."""
-    with pytest.raises(ExecutableNotFoundError):
+    with raises(ExecutableNotFoundError):
         val_executable("nonexistent_executable_12345")
 
 
@@ -37,7 +37,7 @@ def test_val_executable_unsupported_platform():
     all_platforms = {"Darwin", "Linux", "Windows"}
     other_platforms = all_platforms - {current_platform}
 
-    with pytest.raises(UnsupportedPlatformError):
+    with raises(UnsupportedPlatformError):
         val_executable("python3", supported_platforms=other_platforms)
 
 
@@ -53,3 +53,4 @@ def test_val_executable_returns_absolute_path():
     """Test that returned path is absolute."""
     result = val_executable("python3")
     assert result.is_absolute()
+

--- a/test/common/validation/test_val_float.py
+++ b/test/common/validation/test_val_float.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import Any, cast
 
-import pytest
+from pytest import raises
 
 from scinoephile.common.exceptions import ArgumentConflictError
 from scinoephile.common.validation import val_float
@@ -39,7 +39,7 @@ def test_val_float_rejects_scalar_constraint_violations(
     constraint: str, value: float, expected_error: str
 ):
     """Test float validation rejects scalar constraint violations."""
-    with pytest.raises(ValueError, match=expected_error):
+    with raises(ValueError, match=expected_error):
         if constraint == "min":
             val_float(value, min_value=0.0)
         else:
@@ -48,11 +48,11 @@ def test_val_float_rejects_scalar_constraint_violations(
 
 def test_val_float_rejects_invalid_values_and_conflicting_constraints():
     """Test float validation rejects invalid values and conflicting constraints."""
-    with pytest.raises(TypeError):
+    with raises(TypeError):
         val_float(cast(Any, None))
-    with pytest.raises(TypeError):
+    with raises(TypeError):
         val_float("invalid")
-    with pytest.raises(ArgumentConflictError, match="min_value must be less than"):
+    with raises(ArgumentConflictError, match="min_value must be less than"):
         val_float(5.0, min_value=5.0, max_value=5.0)
 
 
@@ -79,11 +79,12 @@ def test_val_float_applies_iterable_constraints():
     assert val_float([], n_values=0) == []
     assert val_float(x for x in [1.0, 2.0, 3.0]) == [1.0, 2.0, 3.0]
 
-    with pytest.raises(ValueError, match="is of length"):
+    with raises(ValueError, match="is of length"):
         val_float([1.0, 2.0], n_values=3)
-    with pytest.raises(ValueError, match="less than minimum"):
+    with raises(ValueError, match="less than minimum"):
         val_float([1.0, -1.0, 3.0], min_value=0.0)
-    with pytest.raises(ValueError, match="greater than maximum"):
+    with raises(ValueError, match="greater than maximum"):
         val_float([1.0, 11.0, 3.0], max_value=10.0)
-    with pytest.raises(TypeError):
+    with raises(TypeError):
         val_float([1.0, "invalid", 3.0])
+

--- a/test/common/validation/test_val_input_dir_path.py
+++ b/test/common/validation/test_val_input_dir_path.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
+from pytest import MonkeyPatch, raises
 
 from scinoephile.common.exceptions import DirectoryNotFoundError
 from scinoephile.common.validation import val_input_dir_path
@@ -27,9 +27,9 @@ def test_val_input_dir_path_rejects_missing_and_file_paths(tmp_path: Path):
     file_path = tmp_path / "test.txt"
     file_path.write_text("test content", encoding="utf-8")
 
-    with pytest.raises(DirectoryNotFoundError):
+    with raises(DirectoryNotFoundError):
         val_input_dir_path(tmp_path / "missing")
-    with pytest.raises(NotADirectoryError):
+    with raises(NotADirectoryError):
         val_input_dir_path(file_path)
 
 
@@ -49,14 +49,14 @@ def test_val_input_dir_path_handles_iterables(tmp_path: Path):
     ]
     assert val_input_dir_path([]) == []
 
-    with pytest.raises(DirectoryNotFoundError):
+    with raises(DirectoryNotFoundError):
         val_input_dir_path([dir_paths[0], tmp_path / "missing"])
-    with pytest.raises(NotADirectoryError):
+    with raises(NotADirectoryError):
         val_input_dir_path([dir_paths[0], file_path])
 
 
 def test_val_input_dir_path_expands_and_resolves_paths(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test input directory validation expands variables and resolves symlinks."""
     dir_path = tmp_path / "testdir"
@@ -66,3 +66,4 @@ def test_val_input_dir_path_expands_and_resolves_paths(
     monkeypatch.setenv("TEST_DIR", str(symlink_path))
 
     assert val_input_dir_path("$TEST_DIR") == dir_path.resolve()
+

--- a/test/common/validation/test_val_input_file_or_dir_path.py
+++ b/test/common/validation/test_val_input_file_or_dir_path.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
+from pytest import raises
 
 from scinoephile.common.validation import val_input_file_or_dir_path
 from test.helpers import create_symlink_or_skip
@@ -34,7 +34,7 @@ def test_val_input_file_or_dir_path_accepts_directory(tmp_path: Path):
 
 def test_val_input_file_or_dir_path_rejects_missing_path(tmp_path: Path):
     """Test input file-or-directory path validation rejects a missing path."""
-    with pytest.raises(FileNotFoundError):
+    with raises(FileNotFoundError):
         val_input_file_or_dir_path(tmp_path / "missing")
 
 
@@ -48,3 +48,4 @@ def test_val_input_file_or_dir_path_resolves_symlink(tmp_path: Path):
     result = val_input_file_or_dir_path(symlink_path)
 
     assert result == file_path.resolve()
+

--- a/test/common/validation/test_val_input_path.py
+++ b/test/common/validation/test_val_input_path.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
+from pytest import MonkeyPatch, raises
 
 from scinoephile.common.exceptions import NotAFileError
 from scinoephile.common.validation import val_input_path
@@ -27,9 +27,9 @@ def test_val_input_path_rejects_missing_and_directory_paths(tmp_path: Path):
     dir_path = tmp_path / "testdir"
     dir_path.mkdir()
 
-    with pytest.raises(FileNotFoundError):
+    with raises(FileNotFoundError):
         val_input_path(tmp_path / "missing.txt")
-    with pytest.raises(NotAFileError):
+    with raises(NotAFileError):
         val_input_path(dir_path)
 
 
@@ -47,14 +47,14 @@ def test_val_input_path_handles_iterables(tmp_path: Path):
     ]
     assert val_input_path([]) == []
 
-    with pytest.raises(FileNotFoundError):
+    with raises(FileNotFoundError):
         val_input_path([file_paths[0], tmp_path / "missing.txt"])
-    with pytest.raises(NotAFileError):
+    with raises(NotAFileError):
         val_input_path([file_paths[0], tmp_path])
 
 
 def test_val_input_path_expands_and_resolves_paths(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test input file validation expands variables and resolves symlinks."""
     file_path = tmp_path / "test.txt"
@@ -64,3 +64,4 @@ def test_val_input_path_expands_and_resolves_paths(
     monkeypatch.setenv("TEST_FILE", str(symlink_path))
 
     assert val_input_path("$TEST_FILE") == file_path.resolve()
+

--- a/test/common/validation/test_val_int.py
+++ b/test/common/validation/test_val_int.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import Any, cast
 
-import pytest
+from pytest import raises
 
 from scinoephile.common.exceptions import ArgumentConflictError
 from scinoephile.common.validation import val_int
@@ -40,7 +40,7 @@ def test_val_int_rejects_scalar_constraint_violations(
     constraint: str, expected_error: str
 ):
     """Test int validation rejects scalar constraint violations."""
-    with pytest.raises(ValueError, match=expected_error):
+    with raises(ValueError, match=expected_error):
         if constraint == "min":
             val_int(-1, min_value=0)
         elif constraint == "max":
@@ -51,11 +51,11 @@ def test_val_int_rejects_scalar_constraint_violations(
 
 def test_val_int_rejects_invalid_values_and_conflicting_constraints():
     """Test int validation rejects invalid values and conflicting constraints."""
-    with pytest.raises(TypeError):
+    with raises(TypeError):
         val_int(cast(Any, None))
-    with pytest.raises(TypeError):
+    with raises(TypeError):
         val_int("invalid")
-    with pytest.raises(ArgumentConflictError, match="min_value must be less than"):
+    with raises(ArgumentConflictError, match="min_value must be less than"):
         val_int(5, min_value=5, max_value=5)
 
 
@@ -78,13 +78,14 @@ def test_val_int_applies_iterable_constraints():
     assert val_int([], n_values=0) == []
     assert val_int(x for x in [1, 2, 3]) == [1, 2, 3]
 
-    with pytest.raises(ValueError, match="is of length"):
+    with raises(ValueError, match="is of length"):
         val_int([1, 2], n_values=3)
-    with pytest.raises(ValueError, match="less than minimum"):
+    with raises(ValueError, match="less than minimum"):
         val_int([1, -1, 3], min_value=0)
-    with pytest.raises(ValueError, match="greater than maximum"):
+    with raises(ValueError, match="greater than maximum"):
         val_int([1, 11, 3], max_value=10)
-    with pytest.raises(ValueError, match="is not one of"):
+    with raises(ValueError, match="is not one of"):
         val_int([1, 5], acceptable_values=[1, 2, 3])
-    with pytest.raises(TypeError):
+    with raises(TypeError):
         val_int([1, "invalid", 3])
+

--- a/test/common/validation/test_val_literal.py
+++ b/test/common/validation/test_val_literal.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-import pytest
+from pytest import raises
 
 from scinoephile.common.exceptions import ArgumentConflictError
 from scinoephile.common.validation import val_literal
@@ -22,13 +22,13 @@ def test_val_literal_literal_type_valid():
 
 def test_val_literal_non_literal():
     """Test validation with non-Literal type."""
-    with pytest.raises(ArgumentConflictError, match="does not contain Literal options"):
+    with raises(ArgumentConflictError, match="does not contain Literal options"):
         val_literal("red", str)
 
 
 def test_val_literal_type_alias_invalid():
     """Test validation with invalid value against a type alias."""
-    with pytest.raises(ValueError, match="not one of options"):
+    with raises(ValueError, match="not one of options"):
         val_literal("yellow", Color)
 
 
@@ -40,3 +40,4 @@ def test_val_literal_type_alias_valid_int():
 def test_val_literal_type_alias_valid_str():
     """Test validation of a valid str against a type alias."""
     assert val_literal("red", Color) == "red"
+

--- a/test/common/validation/test_val_output_dir_path.py
+++ b/test/common/validation/test_val_output_dir_path.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
+from pytest import MonkeyPatch, raises
 
 from scinoephile.common.validation import val_output_dir_path
 
@@ -32,7 +32,7 @@ def test_val_output_dir_path_respects_create_option(tmp_path: Path):
 
     assert val_output_dir_path(dir_path, create=False) == dir_path.resolve()
     assert not dir_path.exists()
-    with pytest.raises(NotADirectoryError):
+    with raises(NotADirectoryError):
         val_output_dir_path(file_path / "child", create=False)
 
 
@@ -41,7 +41,7 @@ def test_val_output_dir_path_rejects_file_paths(tmp_path: Path):
     file_path = tmp_path / "output.txt"
     file_path.write_text("test content", encoding="utf-8")
 
-    with pytest.raises(NotADirectoryError):
+    with raises(NotADirectoryError):
         val_output_dir_path(file_path)
 
 
@@ -61,12 +61,12 @@ def test_val_output_dir_path_handles_iterables(tmp_path: Path):
     assert new_dir_path.is_dir()
     assert val_output_dir_path(()) == []
 
-    with pytest.raises(NotADirectoryError):
+    with raises(NotADirectoryError):
         val_output_dir_path([existing_dir_path, file_path])
 
 
 def test_val_output_dir_path_expands_environment_variables(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test output directory validation expands environment variables."""
     dir_path = tmp_path / "outputdir"
@@ -74,3 +74,4 @@ def test_val_output_dir_path_expands_environment_variables(
 
     assert val_output_dir_path("$OUTPUT_DIR") == dir_path.resolve()
     assert dir_path.is_dir()
+

--- a/test/common/validation/test_val_output_path.py
+++ b/test/common/validation/test_val_output_path.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
+from pytest import MonkeyPatch, raises
 
 from scinoephile.common.exceptions import NotAFileError
 from scinoephile.common.validation import val_output_path
@@ -27,7 +27,7 @@ def test_val_output_path_respects_create_and_exist_ok(tmp_path: Path):
     file_path.write_text("existing content", encoding="utf-8")
     nested_path = tmp_path / "missing" / "output.txt"
 
-    with pytest.raises(FileExistsError):
+    with raises(FileExistsError):
         val_output_path(file_path)
     assert val_output_path(file_path, exist_ok=True) == file_path.resolve()
     assert val_output_path(nested_path, create=False) == nested_path.resolve()
@@ -36,7 +36,7 @@ def test_val_output_path_respects_create_and_exist_ok(tmp_path: Path):
 
 def test_val_output_path_rejects_directories(tmp_path: Path):
     """Test output file validation rejects directory paths."""
-    with pytest.raises(NotAFileError):
+    with raises(NotAFileError):
         val_output_path(tmp_path, exist_ok=True)
 
 
@@ -54,15 +54,16 @@ def test_val_output_path_handles_iterables(tmp_path: Path):
     ]
     assert val_output_path([]) == []
 
-    with pytest.raises(FileExistsError):
+    with raises(FileExistsError):
         val_output_path([file_paths[0], existing_path])
 
 
 def test_val_output_path_expands_environment_variables(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test output file validation expands environment variables."""
     file_path = tmp_path / "output.txt"
     monkeypatch.setenv("OUTPUT_FILE", str(file_path))
 
     assert val_output_path("$OUTPUT_FILE") == file_path.resolve()
+

--- a/test/common/validation/test_val_str.py
+++ b/test/common/validation/test_val_str.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-import pytest
+from pytest import raises
 
 from scinoephile.common.validation import val_str
 
@@ -24,7 +24,7 @@ def test_val_str_case_insensitive():
 
 def test_val_str_invalid_option():
     """Test validation with invalid option."""
-    with pytest.raises(
+    with raises(
         ValueError,
         match="'invalid' is not one of the supported values: option1, option2",
     ):
@@ -42,7 +42,7 @@ def test_val_str_invalid_type():
     Note: None is cast to string "None", which becomes "none" when lowercased.
     This doesn't match any of the provided options, so ValueError is raised.
     """
-    with pytest.raises(
+    with raises(
         ValueError,
         match="'none' is not one of the supported values: option1, option2",
     ):
@@ -51,7 +51,7 @@ def test_val_str_invalid_type():
 
 def test_val_str_empty_options():
     """Test validation with empty options list."""
-    with pytest.raises(ValueError, match="'any' is not one of the supported values: $"):
+    with raises(ValueError, match="'any' is not one of the supported values: $"):
         val_str("any", [])
 
 
@@ -70,3 +70,4 @@ def test_val_str_invalid_option_type():
     """
     assert val_str("none", [None, "option2"]) == "None"
     assert val_str("NONE", [None, "option2"]) == "None"
+

--- a/test/core/cache/test_operations.py
+++ b/test/core/cache/test_operations.py
@@ -9,7 +9,7 @@ from os import utime
 from pathlib import Path
 from time import time
 
-import pytest
+from pytest import raises
 
 from scinoephile.core import ScinoephileError
 from scinoephile.core.cache.operations import (
@@ -68,7 +68,7 @@ def test_get_cache_entries_invalid_namespace(tmp_path: Path):
     """
     _write_cache_file(tmp_path / "llm/one.json")
 
-    with pytest.raises(ScinoephileError, match="was not found"):
+    with raises(ScinoephileError, match="was not found"):
         get_cache_entries(tmp_path, namespace="ocr")
 
 
@@ -153,3 +153,4 @@ def _write_cache_file(path: Path, text: str = "{}") -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
     return path
+

--- a/test/core/cli/test_core_argument_types.py
+++ b/test/core/cli/test_core_argument_types.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from argparse import ArgumentTypeError
 
-import pytest
+from pytest import raises
 
 from scinoephile.core.cli.argument_types import language_arg
 
@@ -18,5 +18,6 @@ def test_language_arg_normalizes_language_tag():
 
 def test_language_arg_rejects_empty_tag():
     """Test language_arg rejects empty language tags."""
-    with pytest.raises(ArgumentTypeError, match="language tag may not be empty"):
+    with raises(ArgumentTypeError, match="language tag may not be empty"):
         language_arg("")
+

--- a/test/core/dictionaries/test_sqlite_store.py
+++ b/test/core/dictionaries/test_sqlite_store.py
@@ -9,7 +9,7 @@ from collections.abc import Generator
 from contextlib import closing
 from pathlib import Path
 
-import pytest
+from pytest import fixture
 
 from scinoephile.common.file import get_temp_file_path
 from scinoephile.core.dictionaries import (
@@ -20,14 +20,14 @@ from scinoephile.core.dictionaries import (
 )
 
 
-@pytest.fixture
+@fixture
 def database_path() -> Generator[Path]:
     """Provide a temporary SQLite database path."""
     with get_temp_file_path(".db") as temp_path:
         yield temp_path
 
 
-@pytest.fixture
+@fixture
 def sample_entries() -> list[DictionaryEntry]:
     """Provide deterministic dictionary entries for SQLite tests."""
     return [
@@ -55,7 +55,7 @@ def sample_entries() -> list[DictionaryEntry]:
     ]
 
 
-@pytest.fixture
+@fixture
 def sample_source() -> DictionarySource:
     """Provide deterministic dictionary source metadata."""
     return DictionarySource(
@@ -189,3 +189,4 @@ def test_sqlite_store_collapses_duplicate_entries_and_definitions(
             definitions=[definition],
         )
     ]
+

--- a/test/core/llms/test_openai_provider_base.py
+++ b/test/core/llms/test_openai_provider_base.py
@@ -8,7 +8,7 @@ from collections.abc import Callable
 from types import SimpleNamespace
 from typing import Any, cast
 
-import pytest
+from pytest import raises
 from openai import OpenAI
 
 from scinoephile.core.llms import OpenAIProviderBase
@@ -242,8 +242,9 @@ def test_tool_box_run_allows_handler_exceptions_to_propagate():
         """
         raise RuntimeError(f"bad args: {args}")
 
-    with pytest.raises(RuntimeError, match=r"bad args: \{'x': 1\}"):
+    with raises(RuntimeError, match=r"bad args: \{'x': 1\}"):
         _get_tool_box(handler).run(
             tool_name="do",
             raw_arguments='{"x": 1}',
         )
+

--- a/test/core/llms/test_provider_injection.py
+++ b/test/core/llms/test_provider_injection.py
@@ -8,7 +8,7 @@ from functools import cache
 from typing import Any, Unpack
 from unittest.mock import Mock
 
-import pytest
+from pytest import raises
 
 from scinoephile.core.llms import (
     Answer,
@@ -143,7 +143,7 @@ def test_queryer_requires_injected_provider():
     """Test queryer no longer constructs concrete providers by default."""
     queryer_cls = Queryer.get_queryer_cls(_Prompt)
 
-    with pytest.raises(TypeError):
+    with raises(TypeError):
         queryer_cls()
 
 
@@ -234,3 +234,4 @@ def test_processor_passes_injected_provider_to_queryer():
     processor = _Processor(prompt_cls=_Prompt, provider=provider)
 
     assert processor.queryer.provider is provider
+

--- a/test/core/media/test_streams.py
+++ b/test/core/media/test_streams.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-import pytest
+from pytest import raises
 
 from scinoephile.core import ScinoephileError
 from scinoephile.core.media.audio_stream import AudioStream
@@ -109,5 +109,6 @@ def test_subtitle_stream_rejects_unknown_codec():
     """Test subtitle stream output properties reject unknown codecs."""
     stream = SubtitleStream(index=2, language="eng", codec_name="unknown")
 
-    with pytest.raises(ScinoephileError, match="Unsupported subtitle codec unknown"):
+    with raises(ScinoephileError, match="Unsupported subtitle codec unknown"):
         stream.extension
+

--- a/test/core/subtitles/test_series.py
+++ b/test/core/subtitles/test_series.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
+from pytest import raises
 
 from scinoephile.common.file import get_temp_file_path
 from scinoephile.core import ScinoephileError
@@ -34,7 +34,7 @@ def test_series_load_wraps_input_path_errors(tmp_path: Path):
     """
     path = tmp_path / "missing.srt"
 
-    with pytest.raises(
+    with raises(
         ScinoephileError,
         match="Unable to load Series from .*missing.srt",
     ) as excinfo:
@@ -45,7 +45,7 @@ def test_series_load_wraps_input_path_errors(tmp_path: Path):
 
 def test_series_from_string_wraps_parser_errors():
     """Test subtitle parsing errors are user-facing."""
-    with pytest.raises(
+    with raises(
         ScinoephileError,
         match="Unable to parse Series from string",
     ):
@@ -60,7 +60,7 @@ def test_series_save_wraps_output_path_errors(tmp_path: Path):
     """
     series = Series(events=[Subtitle(start=1000, end=2000, text="Text")])
 
-    with pytest.raises(
+    with raises(
         ScinoephileError,
         match="Unable to save Series to ",
     ) as excinfo:
@@ -73,8 +73,9 @@ def test_series_to_string_wraps_serializer_errors():
     """Test subtitle string serialization errors are user-facing."""
     series = Series(events=[Subtitle(start=1000, end=2000, text="Text")])
 
-    with pytest.raises(
+    with raises(
         ScinoephileError,
         match="Unable to serialize Series to string",
     ):
         series.to_string(format_="unsupported")
+

--- a/test/core/synchronization/test_get_sync_groups.py
+++ b/test/core/synchronization/test_get_sync_groups.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-import pytest
+from pytest import raises
 
 from scinoephile.core import ScinoephileError
 from scinoephile.core.subtitles import Series, Subtitle
@@ -31,7 +31,7 @@ def test_get_sync_groups_exceeds_max_cutoff():
     two.events.append(Subtitle(start=0, end=100, text="3"))
 
     # This should raise ScinoephileError due to max_cutoff being exceeded
-    with pytest.raises(ScinoephileError) as exc_info:
+    with raises(ScinoephileError) as exc_info:
         get_sync_groups(one, two)
 
     # Verify the error message contains expected information
@@ -84,3 +84,4 @@ def test_get_sync_groups_sorts_unpaired_groups_by_timing():
         ([1], []),
         ([2], [2]),
     ]
+

--- a/test/core/synchronization/test_get_sync_offset_stats.py
+++ b/test/core/synchronization/test_get_sync_offset_stats.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-import pytest
+from pytest import approx, raises
 
 from scinoephile.core import ScinoephileError
 from scinoephile.core.subtitles import Series, Subtitle
@@ -20,12 +20,12 @@ def test_get_sync_offset_stats_uses_paired_group_midpoints():
 
     assert stats.sample_count == 1
     assert stats.skipped_group_count == 0
-    assert stats.mean_ms == pytest.approx(250.0)
-    assert stats.median_ms == pytest.approx(250.0)
-    assert stats.stdev_ms == pytest.approx(0.0)
-    assert stats.min_ms == pytest.approx(250.0)
-    assert stats.max_ms == pytest.approx(250.0)
-    assert stats.samples[0].offset_ms == pytest.approx(250.0)
+    assert stats.mean_ms == approx(250.0)
+    assert stats.median_ms == approx(250.0)
+    assert stats.stdev_ms == approx(0.0)
+    assert stats.min_ms == approx(250.0)
+    assert stats.max_ms == approx(250.0)
+    assert stats.samples[0].offset_ms == approx(250.0)
 
 
 def test_get_sync_offset_stats_uses_group_span_midpoints_for_many_to_one():
@@ -41,7 +41,7 @@ def test_get_sync_offset_stats_uses_group_span_midpoints_for_many_to_one():
     stats = get_sync_offset_stats(anchor, mobile)
 
     assert stats.sample_count == 1
-    assert stats.mean_ms == pytest.approx(100.0)
+    assert stats.mean_ms == approx(100.0)
     assert stats.samples[0].anchor_indexes == (0, 1)
     assert stats.samples[0].mobile_indexes == (0,)
 
@@ -60,7 +60,7 @@ def test_get_sync_offset_stats_skips_unpaired_groups():
 
     assert stats.sample_count == 1
     assert stats.skipped_group_count == 1
-    assert stats.mean_ms == pytest.approx(250.0)
+    assert stats.mean_ms == approx(250.0)
 
 
 def test_get_sync_offset_stats_skips_mobile_only_blocks():
@@ -78,7 +78,7 @@ def test_get_sync_offset_stats_skips_mobile_only_blocks():
 
     assert stats.sample_count == 1
     assert stats.skipped_group_count == 2
-    assert stats.mean_ms == pytest.approx(250.0)
+    assert stats.mean_ms == approx(250.0)
 
 
 def test_get_sync_offset_stats_raises_when_no_paired_groups():
@@ -86,5 +86,6 @@ def test_get_sync_offset_stats_raises_when_no_paired_groups():
     anchor = Series(events=[Subtitle(start=1000, end=2000, text="A")])
     mobile = Series(events=[Subtitle(start=7000, end=8000, text="1")])
 
-    with pytest.raises(ScinoephileError, match="No paired sync groups"):
+    with raises(ScinoephileError, match="No paired sync groups"):
         get_sync_offset_stats(anchor, mobile)
+

--- a/test/core/synchronization/test_get_sync_overlap_matrix.py
+++ b/test/core/synchronization/test_get_sync_overlap_matrix.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import numpy as np
-import pytest
+from pytest import raises
 
 from scinoephile.core import ScinoephileError
 from scinoephile.core.subtitles import Series, Subtitle
@@ -23,7 +23,7 @@ def test_get_sync_overlap_matrix_zero_duration_series_one():
     two.events.append(Subtitle(start=0, end=100, text="1"))
     two.events.append(Subtitle(start=100, end=200, text="2"))
 
-    with pytest.raises(ScinoephileError) as exc_info:
+    with raises(ScinoephileError) as exc_info:
         get_sync_overlap_matrix(one, two)
 
     error_msg = str(exc_info.value)
@@ -46,7 +46,7 @@ def test_get_sync_overlap_matrix_zero_duration_series_two():
     two.events.append(Subtitle(start=150, end=150, text="2"))  # Zero duration
     two.events.append(Subtitle(start=150, end=250, text="3"))
 
-    with pytest.raises(ScinoephileError) as exc_info:
+    with raises(ScinoephileError) as exc_info:
         get_sync_overlap_matrix(one, two)
 
     error_msg = str(exc_info.value)
@@ -69,7 +69,7 @@ def test_get_sync_overlap_matrix_negative_duration_series_one():
     two.events.append(Subtitle(start=0, end=100, text="1"))
     two.events.append(Subtitle(start=100, end=200, text="2"))
 
-    with pytest.raises(ScinoephileError) as exc_info:
+    with raises(ScinoephileError) as exc_info:
         get_sync_overlap_matrix(one, two)
 
     error_msg = str(exc_info.value)
@@ -92,7 +92,7 @@ def test_get_sync_overlap_matrix_negative_duration_series_two():
     two.events.append(Subtitle(start=300, end=200, text="2"))  # Negative duration
     two.events.append(Subtitle(start=300, end=400, text="3"))
 
-    with pytest.raises(ScinoephileError) as exc_info:
+    with raises(ScinoephileError) as exc_info:
         get_sync_overlap_matrix(one, two)
 
     error_msg = str(exc_info.value)
@@ -157,7 +157,7 @@ def test_get_sync_overlap_matrix_first_subtitle_zero_duration():
     two = Series()
     two.events.append(Subtitle(start=0, end=100, text="1"))
 
-    with pytest.raises(ScinoephileError) as exc_info:
+    with raises(ScinoephileError) as exc_info:
         get_sync_overlap_matrix(one, two)
 
     error_msg = str(exc_info.value)
@@ -175,7 +175,7 @@ def test_get_sync_overlap_matrix_last_subtitle_zero_duration():
     two = Series()
     two.events.append(Subtitle(start=0, end=100, text="1"))
 
-    with pytest.raises(ScinoephileError) as exc_info:
+    with raises(ScinoephileError) as exc_info:
         get_sync_overlap_matrix(one, two)
 
     error_msg = str(exc_info.value)
@@ -208,3 +208,4 @@ def test_get_sync_overlap_matrix_one_empty_series():
     # Empty series two should return empty matrix
     overlap = get_sync_overlap_matrix(one, two)
     assert overlap.shape == (1, 0)
+

--- a/test/core/test_core_language.py
+++ b/test/core/test_core_language.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-import pytest
+from pytest import raises
 
 from scinoephile.core import Language
 from scinoephile.core.language import is_chinese_language_tag, normalize_language_tag
@@ -57,7 +57,7 @@ def test_language_enum_parses_tags():
 
 def test_language_rejects_unsupported_tag():
     """Test unsupported language tags are rejected."""
-    with pytest.raises(ValueError, match="is not a valid Language"):
+    with raises(ValueError, match="is not a valid Language"):
         Language("")
 
 
@@ -81,3 +81,4 @@ def test_normalize_language_tag_normalizes_loose_tags():
     assert normalize_language_tag("ZHO-hant") == "zho-Hant"
     assert normalize_language_tag("ENG-US") == "eng-US"
     assert normalize_language_tag("zho-unknown") == "zho-Unknown"
+

--- a/test/core/test_stacking.py
+++ b/test/core/test_stacking.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-import pytest
+from pytest import FixtureRequest, param, raises
 
 from scinoephile.core.exceptions import ScinoephileError
 from scinoephile.core.stacking import (
@@ -125,7 +125,7 @@ def test_get_stacked_series_overlap_error_includes_event_context():
         ]
     )
 
-    with pytest.raises(
+    with raises(
         ScinoephileError,
         match=("events 1 and 2.*previous=1000-3000.*current=1000-1001"),
     ):
@@ -135,19 +135,19 @@ def test_get_stacked_series_overlap_error_includes_event_context():
 @parametrize(
     ("one_fixture", "two_fixture", "expected_fixture"),
     [
-        pytest.param(
+        param(
             "kob_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify_review",
             "kob_eng_ocr_fuse_clean_validate_review_flatten",
             "kob_zho_hans_eng",
             id="kob-zho-hans-eng",
         ),
-        pytest.param(
+        param(
             "mlamd_zho_hans_fuse_clean_validate_review_flatten",
             "mlamd_eng_fuse_clean_validate_review_flatten",
             "mlamd_zho_hans_eng",
             id="mlamd-zho-hans-eng",
         ),
-        pytest.param(
+        param(
             "t_zho_hans_fuse_clean_validate_review_flatten",
             "t_eng_fuse_clean_validate_review_flatten",
             "t_zho_hans_eng",
@@ -156,7 +156,7 @@ def test_get_stacked_series_overlap_error_includes_event_context():
     ],
 )
 def test_get_stacked_series(
-    request: pytest.FixtureRequest,
+    request: FixtureRequest,
     one_fixture: str,
     two_fixture: str,
     expected_fixture: str,
@@ -174,3 +174,4 @@ def test_get_stacked_series(
         request.getfixturevalue(two_fixture),
     )
     assert_series_equal(output, request.getfixturevalue(expected_fixture))
+

--- a/test/core/test_text.py
+++ b/test/core/test_text.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-import pytest
+from pytest import raises
 
 from scinoephile.core import ScinoephileError
 from scinoephile.core.text import (
@@ -18,7 +18,7 @@ from test.helpers import parametrize
 
 def test_get_char_type_handles_unnamed_control_char() -> None:
     """Unnamed control characters raise a ScinoephileError."""
-    with pytest.raises(ScinoephileError, match="<unnamed>"):
+    with raises(ScinoephileError, match="<unnamed>"):
         get_char_type("\x00")
 
 
@@ -70,3 +70,4 @@ def test_sanitize_text_replaces_control_chars(text: str, expected: str) -> None:
 def test_sanitize_text_preserves_text_whitespace(text: str, expected: str) -> None:
     """Line and tab whitespace are preserved."""
     assert sanitize_text(text) == expected
+

--- a/test/data/acopopb/__init__.py
+++ b/test/data/acopopb/__init__.py
@@ -10,7 +10,7 @@ from functools import cache
 from pathlib import Path
 from typing import Any
 
-import pytest
+from pytest import fixture
 
 from scinoephile.core.llms import TestCase
 from scinoephile.core.llms.utils import load_test_cases_from_json
@@ -332,91 +332,91 @@ def get_acopopb_zho_hant_simplify_block_review_test_cases(
     )
 
 
-@pytest.fixture
+@fixture
 def acopopb_eng_ocr_fuse() -> Series:
     """ACOPOPB English fused subtitles."""
     return Series.load(output_dir / "eng_ocr/fuse.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_eng_ocr_fuse_clean() -> Series:
     """ACOPOPB English fused and cleaned subtitles."""
     return Series.load(output_dir / "eng_ocr/fuse_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_eng_ocr_fuse_clean_validate() -> Series:
     """ACOPOPB English fused, cleaned, and validated subtitles."""
     return Series.load(output_dir / "eng_ocr/fuse_clean_validate.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_eng_ocr_fuse_clean_validate_review() -> Series:
     """ACOPOPB English fused, cleaned, validated, and reviewed subtitles."""
     return Series.load(output_dir / "eng_ocr/fuse_clean_validate_review.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_eng_ocr_fuse_clean_validate_review_flatten() -> Series:
     """ACOPOPB English fused, cleaned, validated, reviewed, and flattened subtitles."""
     return Series.load(output_dir / "eng_ocr/fuse_clean_validate_review_flatten.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_eng_ocr_lens() -> Series:
     """ACOPOPB English subtitles OCRed using Google Lens."""
     return Series.load(output_dir / "eng_ocr/lens.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_eng_ocr_lens_clean() -> Series:
     """ACOPOPB English Google Lens OCR subtitles, cleaned."""
     return Series.load(output_dir / "eng_ocr/lens_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_eng_ocr_tesseract() -> Series:
     """ACOPOPB English subtitles OCRed using Tesseract."""
     return Series.load(output_dir / "eng_ocr/tesseract.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_eng_ocr_tesseract_clean() -> Series:
     """ACOPOPB English Tesseract OCR subtitles, cleaned."""
     return Series.load(output_dir / "eng_ocr/tesseract_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_yue_hans_eng() -> Series:
     """ACOPOPB bilingual 简体粤文 and English subtitles."""
     return Series.load(output_dir / "yue-Hans_eng.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_yue_hans_ocr_fuse() -> Series:
     """ACOPOPB 简体粤文 fused subtitles."""
     return Series.load(output_dir / "yue-Hans_ocr/fuse.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_yue_hans_ocr_fuse_clean() -> Series:
     """ACOPOPB 简体粤文 fused and cleaned subtitles."""
     return Series.load(output_dir / "yue-Hans_ocr/fuse_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_yue_hans_ocr_fuse_clean_validate() -> Series:
     """ACOPOPB 简体粤文 fused, cleaned, and validated subtitles."""
     return Series.load(output_dir / "yue-Hans_ocr/fuse_clean_validate.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_yue_hans_ocr_fuse_clean_validate_review() -> Series:
     """ACOPOPB 简体粤文 fused, cleaned, validated, and reviewed subtitles."""
     return Series.load(output_dir / "yue-Hans_ocr/fuse_clean_validate_review.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_yue_hans_ocr_fuse_clean_validate_review_flatten() -> Series:
     """ACOPOPB 简体粤文 fused, cleaned, validated, reviewed, and flattened subtitles."""
     return Series.load(
@@ -424,7 +424,7 @@ def acopopb_yue_hans_ocr_fuse_clean_validate_review_flatten() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def acopopb_yue_hans_ocr_fuse_clean_validate_review_flatten_romanize() -> Series:
     """ACOPOPB 简体粤文 fused/cleaned/validated/reviewed/flattened romanized subtitles."""
     return Series.load(
@@ -432,55 +432,55 @@ def acopopb_yue_hans_ocr_fuse_clean_validate_review_flatten_romanize() -> Series
     )
 
 
-@pytest.fixture
+@fixture
 def acopopb_yue_hans_ocr_lens() -> Series:
     """ACOPOPB 简体粤文 subtitles OCRed using Google Lens."""
     return Series.load(output_dir / "yue-Hans_ocr/lens.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_yue_hans_ocr_lens_clean() -> Series:
     """ACOPOPB 简体粤文 Google Lens OCR subtitles, cleaned."""
     return Series.load(output_dir / "yue-Hans_ocr/lens_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_yue_hans_ocr_paddle() -> Series:
     """ACOPOPB 简体粤文 subtitles OCRed using PaddleOCR."""
     return Series.load(output_dir / "yue-Hans_ocr/paddle.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_yue_hans_ocr_paddle_clean() -> Series:
     """ACOPOPB 简体粤文 PaddleOCR subtitles, cleaned."""
     return Series.load(output_dir / "yue-Hans_ocr/paddle_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_yue_hant_ocr_fuse() -> Series:
     """ACOPOPB 繁體粵文 fused subtitles."""
     return Series.load(output_dir / "yue-Hant_ocr/fuse.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_yue_hant_ocr_fuse_clean() -> Series:
     """ACOPOPB 繁體粵文 fused and cleaned subtitles."""
     return Series.load(output_dir / "yue-Hant_ocr/fuse_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_yue_hant_ocr_fuse_clean_validate() -> Series:
     """ACOPOPB 繁體粵文 fused, cleaned, and validated subtitles."""
     return Series.load(output_dir / "yue-Hant_ocr/fuse_clean_validate.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_yue_hant_ocr_fuse_clean_validate_review() -> Series:
     """ACOPOPB 繁體粵文 fused, cleaned, validated, and reviewed subtitles."""
     return Series.load(output_dir / "yue-Hant_ocr/fuse_clean_validate_review.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_yue_hant_ocr_fuse_clean_validate_review_flatten() -> Series:
     """ACOPOPB 繁體粵文 fused, cleaned, validated, reviewed, and flattened subtitles."""
     return Series.load(
@@ -488,7 +488,7 @@ def acopopb_yue_hant_ocr_fuse_clean_validate_review_flatten() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def acopopb_yue_hant_ocr_fuse_clean_validate_review_flatten_simplify() -> Series:
     """ACOPOPB 繁體粵文 simplified fused/cleaned/validated/reviewed/flattened subtitles."""
     return Series.load(
@@ -496,7 +496,7 @@ def acopopb_yue_hant_ocr_fuse_clean_validate_review_flatten_simplify() -> Series
     )
 
 
-@pytest.fixture
+@fixture
 def acopopb_yue_hant_ocr_fuse_clean_validate_review_flatten_simplify_review() -> Series:
     """ACOPOPB 繁體粵文 simplified/reviewed fused/cleaned subtitles."""
     return Series.load(
@@ -506,7 +506,7 @@ def acopopb_yue_hant_ocr_fuse_clean_validate_review_flatten_simplify_review() ->
     )
 
 
-@pytest.fixture
+@fixture
 def acopopb_yue_hant_ocr_fuse_clean_validate_review_flatten_simplify_review_romanize() -> (
     Series
 ):
@@ -518,61 +518,61 @@ def acopopb_yue_hant_ocr_fuse_clean_validate_review_flatten_simplify_review_roma
     )
 
 
-@pytest.fixture
+@fixture
 def acopopb_yue_hant_ocr_lens() -> Series:
     """ACOPOPB 繁體粵文 subtitles OCRed using Google Lens."""
     return Series.load(output_dir / "yue-Hant_ocr/lens.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_yue_hant_ocr_lens_clean() -> Series:
     """ACOPOPB 繁體粵文 Google Lens OCR subtitles, cleaned."""
     return Series.load(output_dir / "yue-Hant_ocr/lens_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_yue_hant_ocr_paddle() -> Series:
     """ACOPOPB 繁體粵文 subtitles OCRed using PaddleOCR."""
     return Series.load(output_dir / "yue-Hant_ocr/paddle.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_yue_hant_ocr_paddle_clean() -> Series:
     """ACOPOPB 繁體粵文 PaddleOCR subtitles, cleaned."""
     return Series.load(output_dir / "yue-Hant_ocr/paddle_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_zho_hans_eng() -> Series:
     """ACOPOPB bilingual 简体中文 and English subtitles."""
     return Series.load(output_dir / "zho-Hans_eng.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_zho_hans_ocr_fuse() -> Series:
     """ACOPOPB 简体中文 fused subtitles."""
     return Series.load(output_dir / "zho-Hans_ocr/fuse.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_zho_hans_ocr_fuse_clean() -> Series:
     """ACOPOPB 简体中文 fused and cleaned subtitles."""
     return Series.load(output_dir / "zho-Hans_ocr/fuse_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_zho_hans_ocr_fuse_clean_validate() -> Series:
     """ACOPOPB 简体中文 fused, cleaned, and validated subtitles."""
     return Series.load(output_dir / "zho-Hans_ocr/fuse_clean_validate.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_zho_hans_ocr_fuse_clean_validate_review() -> Series:
     """ACOPOPB 简体中文 fused, cleaned, validated, and reviewed subtitles."""
     return Series.load(output_dir / "zho-Hans_ocr/fuse_clean_validate_review.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_zho_hans_ocr_fuse_clean_validate_review_flatten() -> Series:
     """ACOPOPB 简体中文 fused, cleaned, validated, reviewed, and flattened subtitles."""
     return Series.load(
@@ -580,7 +580,7 @@ def acopopb_zho_hans_ocr_fuse_clean_validate_review_flatten() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def acopopb_zho_hans_ocr_fuse_clean_validate_review_flatten_romanize() -> Series:
     """ACOPOPB 简体中文 fused/cleaned/validated/reviewed/flattened romanized subtitles."""
     return Series.load(
@@ -588,55 +588,55 @@ def acopopb_zho_hans_ocr_fuse_clean_validate_review_flatten_romanize() -> Series
     )
 
 
-@pytest.fixture
+@fixture
 def acopopb_zho_hans_ocr_lens() -> Series:
     """ACOPOPB 简体中文 subtitles OCRed using Google Lens."""
     return Series.load(output_dir / "zho-Hans_ocr/lens.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_zho_hans_ocr_lens_clean() -> Series:
     """ACOPOPB 简体中文 Google Lens OCR subtitles, cleaned."""
     return Series.load(output_dir / "zho-Hans_ocr/lens_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_zho_hans_ocr_paddle() -> Series:
     """ACOPOPB 简体中文 subtitles OCRed using PaddleOCR."""
     return Series.load(output_dir / "zho-Hans_ocr/paddle.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_zho_hans_ocr_paddle_clean() -> Series:
     """ACOPOPB 简体中文 PaddleOCR subtitles, cleaned."""
     return Series.load(output_dir / "zho-Hans_ocr/paddle_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_zho_hant_ocr_fuse() -> Series:
     """ACOPOPB 繁体中文 fused subtitles."""
     return Series.load(output_dir / "zho-Hant_ocr/fuse.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_zho_hant_ocr_fuse_clean() -> Series:
     """ACOPOPB 繁体中文 fused and cleaned subtitles."""
     return Series.load(output_dir / "zho-Hant_ocr/fuse_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_zho_hant_ocr_fuse_clean_validate() -> Series:
     """ACOPOPB 繁体中文 fused, cleaned, and validated subtitles."""
     return Series.load(output_dir / "zho-Hant_ocr/fuse_clean_validate.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_zho_hant_ocr_fuse_clean_validate_review() -> Series:
     """ACOPOPB 繁体中文 fused, cleaned, validated, and reviewed subtitles."""
     return Series.load(output_dir / "zho-Hant_ocr/fuse_clean_validate_review.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_zho_hant_ocr_fuse_clean_validate_review_flatten() -> Series:
     """ACOPOPB 繁体中文 fused, cleaned, validated, reviewed, and flattened subtitles."""
     return Series.load(
@@ -644,7 +644,7 @@ def acopopb_zho_hant_ocr_fuse_clean_validate_review_flatten() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def acopopb_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify() -> Series:
     """ACOPOPB 繁体中文 simplified fused/cleaned/validated/reviewed/flattened subtitles."""
     return Series.load(
@@ -652,7 +652,7 @@ def acopopb_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify() -> Series
     )
 
 
-@pytest.fixture
+@fixture
 def acopopb_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify_review() -> Series:
     """ACOPOPB 繁体中文 simplified/reviewed fused/cleaned subtitles."""
     return Series.load(
@@ -662,7 +662,7 @@ def acopopb_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify_review() ->
     )
 
 
-@pytest.fixture
+@fixture
 def acopopb_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify_review_romanize() -> (
     Series
 ):
@@ -674,25 +674,26 @@ def acopopb_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify_review_roma
     )
 
 
-@pytest.fixture
+@fixture
 def acopopb_zho_hant_ocr_lens() -> Series:
     """ACOPOPB 繁体中文 subtitles OCRed using Google Lens."""
     return Series.load(output_dir / "zho-Hant_ocr/lens.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_zho_hant_ocr_lens_clean() -> Series:
     """ACOPOPB 繁体中文 Google Lens OCR subtitles, cleaned."""
     return Series.load(output_dir / "zho-Hant_ocr/lens_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_zho_hant_ocr_paddle() -> Series:
     """ACOPOPB 繁体中文 subtitles OCRed using PaddleOCR."""
     return Series.load(output_dir / "zho-Hant_ocr/paddle.srt")
 
 
-@pytest.fixture
+@fixture
 def acopopb_zho_hant_ocr_paddle_clean() -> Series:
     """ACOPOPB 繁体中文 PaddleOCR subtitles, cleaned."""
     return Series.load(output_dir / "zho-Hant_ocr/paddle_clean.srt")
+

--- a/test/data/acoptc/__init__.py
+++ b/test/data/acoptc/__init__.py
@@ -10,7 +10,7 @@ from functools import cache
 from pathlib import Path
 from typing import Any
 
-import pytest
+from pytest import fixture
 
 from scinoephile.core.llms import TestCase
 from scinoephile.core.llms.utils import load_test_cases_from_json
@@ -108,19 +108,19 @@ input_path = title_root / "input"
 output_dir = title_root / "output"
 
 
-@pytest.fixture
+@fixture
 def acoptc_eng() -> Series:
     """ACOPTC English subtitles."""
     return Series.load(input_path / "eng.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_zho_hans() -> Series:
     """ACOPTC 简体中文 subtitles."""
     return Series.load(input_path / "zho-Hans.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_zho_hant() -> Series:
     """ACOPTC 繁体中文 subtitles."""
     return Series.load(input_path / "zho-Hant.srt")
@@ -354,91 +354,91 @@ def get_acoptc_zho_hant_simplify_block_review_test_cases(
     )
 
 
-@pytest.fixture
+@fixture
 def acoptc_eng_ocr_fuse() -> Series:
     """ACOPTC English fused subtitles."""
     return Series.load(output_dir / "eng_ocr/fuse.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_eng_ocr_fuse_clean() -> Series:
     """ACOPTC English fused and cleaned subtitles."""
     return Series.load(output_dir / "eng_ocr/fuse_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_eng_ocr_fuse_clean_validate() -> Series:
     """ACOPTC English fused, cleaned, and validated subtitles."""
     return Series.load(output_dir / "eng_ocr/fuse_clean_validate.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_eng_ocr_fuse_clean_validate_review() -> Series:
     """ACOPTC English fused, cleaned, validated, and reviewed subtitles."""
     return Series.load(output_dir / "eng_ocr/fuse_clean_validate_review.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_eng_ocr_fuse_clean_validate_review_flatten() -> Series:
     """ACOPTC English fused, cleaned, validated, reviewed, and flattened subtitles."""
     return Series.load(output_dir / "eng_ocr/fuse_clean_validate_review_flatten.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_eng_ocr_lens() -> Series:
     """ACOPTC English subtitles OCRed using Google Lens."""
     return Series.load(output_dir / "eng_ocr/lens.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_eng_ocr_lens_clean() -> Series:
     """ACOPTC English Google Lens OCR subtitles, cleaned."""
     return Series.load(output_dir / "eng_ocr/lens_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_eng_ocr_tesseract() -> Series:
     """ACOPTC English subtitles OCRed using Tesseract."""
     return Series.load(output_dir / "eng_ocr/tesseract.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_eng_ocr_tesseract_clean() -> Series:
     """ACOPTC English Tesseract OCR subtitles, cleaned."""
     return Series.load(output_dir / "eng_ocr/tesseract_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_yue_hans_eng() -> Series:
     """ACOPTC bilingual 简体粤文 and English subtitles."""
     return Series.load(output_dir / "yue-Hans_eng.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_yue_hans_ocr_fuse() -> Series:
     """ACOPTC 简体粤文 fused subtitles."""
     return Series.load(output_dir / "yue-Hans_ocr/fuse.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_yue_hans_ocr_fuse_clean() -> Series:
     """ACOPTC 简体粤文 fused and cleaned subtitles."""
     return Series.load(output_dir / "yue-Hans_ocr/fuse_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_yue_hans_ocr_fuse_clean_validate() -> Series:
     """ACOPTC 简体粤文 fused, cleaned, and validated subtitles."""
     return Series.load(output_dir / "yue-Hans_ocr/fuse_clean_validate.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_yue_hans_ocr_fuse_clean_validate_review() -> Series:
     """ACOPTC 简体粤文 fused, cleaned, validated, and reviewed subtitles."""
     return Series.load(output_dir / "yue-Hans_ocr/fuse_clean_validate_review.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_yue_hans_ocr_fuse_clean_validate_review_flatten() -> Series:
     """ACOPTC 简体粤文 fused, cleaned, validated, reviewed, and flattened subtitles."""
     return Series.load(
@@ -446,7 +446,7 @@ def acoptc_yue_hans_ocr_fuse_clean_validate_review_flatten() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def acoptc_yue_hans_ocr_fuse_clean_validate_review_flatten_romanize() -> Series:
     """ACOPTC 简体粤文 fused/cleaned/validated/reviewed/flattened romanized subtitles."""
     return Series.load(
@@ -454,55 +454,55 @@ def acoptc_yue_hans_ocr_fuse_clean_validate_review_flatten_romanize() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def acoptc_yue_hans_ocr_lens() -> Series:
     """ACOPTC 简体粤文 subtitles OCRed using Google Lens."""
     return Series.load(output_dir / "yue-Hans_ocr/lens.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_yue_hans_ocr_lens_clean() -> Series:
     """ACOPTC 简体粤文 Google Lens OCR subtitles, cleaned."""
     return Series.load(output_dir / "yue-Hans_ocr/lens_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_yue_hans_ocr_paddle() -> Series:
     """ACOPTC 简体粤文 subtitles OCRed using PaddleOCR."""
     return Series.load(output_dir / "yue-Hans_ocr/paddle.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_yue_hans_ocr_paddle_clean() -> Series:
     """ACOPTC 简体粤文 PaddleOCR subtitles, cleaned."""
     return Series.load(output_dir / "yue-Hans_ocr/paddle_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_yue_hant_ocr_fuse() -> Series:
     """ACOPTC 繁體粵文 fused subtitles."""
     return Series.load(output_dir / "yue-Hant_ocr/fuse.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_yue_hant_ocr_fuse_clean() -> Series:
     """ACOPTC 繁體粵文 fused and cleaned subtitles."""
     return Series.load(output_dir / "yue-Hant_ocr/fuse_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_yue_hant_ocr_fuse_clean_validate() -> Series:
     """ACOPTC 繁體粵文 fused, cleaned, and validated subtitles."""
     return Series.load(output_dir / "yue-Hant_ocr/fuse_clean_validate.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_yue_hant_ocr_fuse_clean_validate_review() -> Series:
     """ACOPTC 繁體粵文 fused, cleaned, validated, and reviewed subtitles."""
     return Series.load(output_dir / "yue-Hant_ocr/fuse_clean_validate_review.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_yue_hant_ocr_fuse_clean_validate_review_flatten() -> Series:
     """ACOPTC 繁體粵文 fused, cleaned, validated, reviewed, and flattened subtitles."""
     return Series.load(
@@ -510,7 +510,7 @@ def acoptc_yue_hant_ocr_fuse_clean_validate_review_flatten() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def acoptc_yue_hant_ocr_fuse_clean_validate_review_flatten_simplify() -> Series:
     """ACOPTC 繁體粵文 simplified fused/cleaned/validated/reviewed/flattened subtitles."""
     return Series.load(
@@ -518,7 +518,7 @@ def acoptc_yue_hant_ocr_fuse_clean_validate_review_flatten_simplify() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def acoptc_yue_hant_ocr_fuse_clean_validate_review_flatten_simplify_review() -> Series:
     """ACOPTC 繁體粵文 simplified/reviewed fused/cleaned subtitles."""
     return Series.load(
@@ -528,7 +528,7 @@ def acoptc_yue_hant_ocr_fuse_clean_validate_review_flatten_simplify_review() -> 
     )
 
 
-@pytest.fixture
+@fixture
 def acoptc_yue_hant_ocr_fuse_clean_validate_review_flatten_simplify_review_romanize() -> (
     Series
 ):
@@ -540,61 +540,61 @@ def acoptc_yue_hant_ocr_fuse_clean_validate_review_flatten_simplify_review_roman
     )
 
 
-@pytest.fixture
+@fixture
 def acoptc_yue_hant_ocr_lens() -> Series:
     """ACOPTC 繁體粵文 subtitles OCRed using Google Lens."""
     return Series.load(output_dir / "yue-Hant_ocr/lens.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_yue_hant_ocr_lens_clean() -> Series:
     """ACOPTC 繁體粵文 Google Lens OCR subtitles, cleaned."""
     return Series.load(output_dir / "yue-Hant_ocr/lens_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_yue_hant_ocr_paddle() -> Series:
     """ACOPTC 繁體粵文 subtitles OCRed using PaddleOCR."""
     return Series.load(output_dir / "yue-Hant_ocr/paddle.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_yue_hant_ocr_paddle_clean() -> Series:
     """ACOPTC 繁體粵文 PaddleOCR subtitles, cleaned."""
     return Series.load(output_dir / "yue-Hant_ocr/paddle_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_zho_hans_eng() -> Series:
     """ACOPTC bilingual 简体中文 and English subtitles."""
     return Series.load(output_dir / "zho-Hans_eng.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_zho_hans_ocr_fuse() -> Series:
     """ACOPTC 简体中文 fused subtitles."""
     return Series.load(output_dir / "zho-Hans_ocr/fuse.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_zho_hans_ocr_fuse_clean() -> Series:
     """ACOPTC 简体中文 fused and cleaned subtitles."""
     return Series.load(output_dir / "zho-Hans_ocr/fuse_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_zho_hans_ocr_fuse_clean_validate() -> Series:
     """ACOPTC 简体中文 fused, cleaned, and validated subtitles."""
     return Series.load(output_dir / "zho-Hans_ocr/fuse_clean_validate.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_zho_hans_ocr_fuse_clean_validate_review() -> Series:
     """ACOPTC 简体中文 fused, cleaned, validated, and reviewed subtitles."""
     return Series.load(output_dir / "zho-Hans_ocr/fuse_clean_validate_review.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_zho_hans_ocr_fuse_clean_validate_review_flatten() -> Series:
     """ACOPTC 简体中文 fused, cleaned, validated, reviewed, and flattened subtitles."""
     return Series.load(
@@ -602,7 +602,7 @@ def acoptc_zho_hans_ocr_fuse_clean_validate_review_flatten() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def acoptc_zho_hans_ocr_fuse_clean_validate_review_flatten_romanize() -> Series:
     """ACOPTC 简体中文 fused/cleaned/validated/reviewed/flattened romanized subtitles."""
     return Series.load(
@@ -610,55 +610,55 @@ def acoptc_zho_hans_ocr_fuse_clean_validate_review_flatten_romanize() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def acoptc_zho_hans_ocr_lens() -> Series:
     """ACOPTC 简体中文 subtitles OCRed using Google Lens."""
     return Series.load(output_dir / "zho-Hans_ocr/lens.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_zho_hans_ocr_lens_clean() -> Series:
     """ACOPTC 简体中文 Google Lens OCR subtitles, cleaned."""
     return Series.load(output_dir / "zho-Hans_ocr/lens_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_zho_hans_ocr_paddle() -> Series:
     """ACOPTC 简体中文 subtitles OCRed using PaddleOCR."""
     return Series.load(output_dir / "zho-Hans_ocr/paddle.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_zho_hans_ocr_paddle_clean() -> Series:
     """ACOPTC 简体中文 PaddleOCR subtitles, cleaned."""
     return Series.load(output_dir / "zho-Hans_ocr/paddle_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_zho_hant_ocr_fuse() -> Series:
     """ACOPTC 繁体中文 fused subtitles."""
     return Series.load(output_dir / "zho-Hant_ocr/fuse.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_zho_hant_ocr_fuse_clean() -> Series:
     """ACOPTC 繁体中文 fused and cleaned subtitles."""
     return Series.load(output_dir / "zho-Hant_ocr/fuse_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_zho_hant_ocr_fuse_clean_validate() -> Series:
     """ACOPTC 繁体中文 fused, cleaned, and validated subtitles."""
     return Series.load(output_dir / "zho-Hant_ocr/fuse_clean_validate.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_zho_hant_ocr_fuse_clean_validate_review() -> Series:
     """ACOPTC 繁体中文 fused, cleaned, validated, and reviewed subtitles."""
     return Series.load(output_dir / "zho-Hant_ocr/fuse_clean_validate_review.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_zho_hant_ocr_fuse_clean_validate_review_flatten() -> Series:
     """ACOPTC 繁体中文 fused, cleaned, validated, reviewed, and flattened subtitles."""
     return Series.load(
@@ -666,7 +666,7 @@ def acoptc_zho_hant_ocr_fuse_clean_validate_review_flatten() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def acoptc_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify() -> Series:
     """ACOPTC 繁体中文 simplified fused/cleaned/validated/reviewed/flattened subtitles."""
     return Series.load(
@@ -674,7 +674,7 @@ def acoptc_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def acoptc_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify_review() -> Series:
     """ACOPTC 繁体中文 simplified/reviewed fused/cleaned subtitles."""
     return Series.load(
@@ -684,7 +684,7 @@ def acoptc_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify_review() -> 
     )
 
 
-@pytest.fixture
+@fixture
 def acoptc_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify_review_romanize() -> (
     Series
 ):
@@ -696,25 +696,26 @@ def acoptc_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify_review_roman
     )
 
 
-@pytest.fixture
+@fixture
 def acoptc_zho_hant_ocr_lens() -> Series:
     """ACOPTC 繁体中文 subtitles OCRed using Google Lens."""
     return Series.load(output_dir / "zho-Hant_ocr/lens.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_zho_hant_ocr_lens_clean() -> Series:
     """ACOPTC 繁体中文 Google Lens OCR subtitles, cleaned."""
     return Series.load(output_dir / "zho-Hant_ocr/lens_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_zho_hant_ocr_paddle() -> Series:
     """ACOPTC 繁体中文 subtitles OCRed using PaddleOCR."""
     return Series.load(output_dir / "zho-Hant_ocr/paddle.srt")
 
 
-@pytest.fixture
+@fixture
 def acoptc_zho_hant_ocr_paddle_clean() -> Series:
     """ACOPTC 繁体中文 PaddleOCR subtitles, cleaned."""
     return Series.load(output_dir / "zho-Hant_ocr/paddle_clean.srt")
+

--- a/test/data/kob/__init__.py
+++ b/test/data/kob/__init__.py
@@ -10,7 +10,7 @@ from functools import cache
 from pathlib import Path
 from typing import TypedDict, Unpack
 
-import pytest
+from pytest import fixture
 
 from scinoephile.audio.subtitles import AudioSeries
 from scinoephile.core.llms import TestCase
@@ -106,19 +106,19 @@ class _KobTestCaseKwargs(TypedDict, total=False):
     """Keyword arguments forwarded to KOB test case loading helpers."""
 
 
-@pytest.fixture
+@fixture
 def kob_eng() -> Series:
     """KOB English subtitles."""
     return Series.load(input_dir / "eng.srt")
 
 
-@pytest.fixture
+@fixture
 def kob_yue_hans() -> Series:
     """KOB 简体粤文 subtitles (input)."""
     return Series.load(input_dir / "yue-Hans.srt")
 
 
-@pytest.fixture
+@fixture
 def kob_yue_hant() -> Series:
     """KOB 繁体粤文 subtitles."""
     return Series.load(input_dir / "yue-Hant.srt")
@@ -304,7 +304,7 @@ def get_kob_zho_hant_simplify_block_review_test_cases(
     )
 
 
-@pytest.fixture
+@fixture
 def kob_eng_expected_series_diff() -> list[str]:
     """Expected differences for KOB OCR English vs SRT English subtitles."""
     return [
@@ -457,121 +457,121 @@ def kob_eng_expected_series_diff() -> list[str]:
     ]
 
 
-@pytest.fixture
+@fixture
 def kob_eng_ocr_fuse() -> Series:
     """KOB English fused subtitles."""
     return Series.load(output_dir / "eng_ocr/fuse.srt")
 
 
-@pytest.fixture
+@fixture
 def kob_eng_ocr_fuse_clean() -> Series:
     """KOB English fused and cleaned subtitles."""
     return Series.load(output_dir / "eng_ocr/fuse_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def kob_eng_ocr_fuse_clean_validate() -> Series:
     """KOB English fused, cleaned, and validated subtitles."""
     return Series.load(output_dir / "eng_ocr/fuse_clean_validate.srt")
 
 
-@pytest.fixture
+@fixture
 def kob_eng_ocr_fuse_clean_validate_review() -> Series:
     """KOB English fused, cleaned, validated, and reviewed subtitles."""
     return Series.load(output_dir / "eng_ocr/fuse_clean_validate_review.srt")
 
 
-@pytest.fixture
+@fixture
 def kob_eng_ocr_fuse_clean_validate_review_flatten() -> Series:
     """KOB English fused, cleaned, validated, reviewed, and flattened subtitles."""
     return Series.load(output_dir / "eng_ocr/fuse_clean_validate_review_flatten.srt")
 
 
-@pytest.fixture
+@fixture
 def kob_eng_ocr_lens() -> Series:
     """KOB English subtitles OCRed using Google Lens."""
     return Series.load(output_dir / "eng_ocr/lens.srt")
 
 
-@pytest.fixture
+@fixture
 def kob_eng_ocr_lens_clean() -> Series:
     """KOB English Google Lens OCR subtitles, cleaned."""
     return Series.load(output_dir / "eng_ocr/lens_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def kob_eng_ocr_tesseract() -> Series:
     """KOB English subtitles OCRed using Tesseract."""
     return Series.load(output_dir / "eng_ocr/tesseract.srt")
 
 
-@pytest.fixture
+@fixture
 def kob_eng_ocr_tesseract_clean() -> Series:
     """KOB English Tesseract OCR subtitles, cleaned."""
     return Series.load(output_dir / "eng_ocr/tesseract_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def kob_eng_timewarp() -> Series:
     """KOB English timewarp subtitles."""
     return Series.load(output_dir / "eng/timewarp.srt")
 
 
-@pytest.fixture
+@fixture
 def kob_eng_timewarp_clean() -> Series:
     """KOB English timewarp and cleaned subtitles."""
     return Series.load(output_dir / "eng/timewarp_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def kob_eng_timewarp_clean_review() -> Series:
     """KOB English timewarp, cleaned, and reviewed subtitles."""
     return Series.load(output_dir / "eng/timewarp_clean_review.srt")
 
 
-@pytest.fixture
+@fixture
 def kob_eng_timewarp_clean_review_flatten() -> Series:
     """KOB English timewarp, cleaned, reviewed, and flattened subtitles."""
     return Series.load(output_dir / "eng/timewarp_clean_review_flatten.srt")
 
 
-@pytest.fixture
+@fixture
 def kob_yue_hans_audio() -> AudioSeries:
     """KOB 简体粤文 audio subtitles."""
     return AudioSeries.load(output_dir / "yue-Hans_transcribe/audio")
 
 
-@pytest.fixture
+@fixture
 def kob_yue_hans_timewarp() -> Series:
     """KOB 简体粤文 timewarp subtitles."""
     return Series.load(output_dir / "yue-Hans/timewarp.srt")
 
 
-@pytest.fixture
+@fixture
 def kob_yue_hans_timewarp_clean() -> Series:
     """KOB 简体粤文 timewarp and cleaned subtitles."""
     return Series.load(output_dir / "yue-Hans/timewarp_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def kob_yue_hans_timewarp_clean_flatten() -> Series:
     """KOB 简体粤文 timewarp, cleaned, and flattened subtitles."""
     return Series.load(output_dir / "yue-Hans/timewarp_clean_flatten.srt")
 
 
-@pytest.fixture
+@fixture
 def kob_yue_hans_timewarp_clean_flatten_romanize() -> Series:
     """KOB 简体粤文 timewarp/cleaned/flattened romanized subtitles."""
     return Series.load(output_dir / "yue-Hans/timewarp_clean_flatten_romanize.srt")
 
 
-@pytest.fixture
+@fixture
 def kob_yue_hans_transcribe() -> Series:
     """KOB 简体粤文 transcribed subtitles."""
     return Series.load(output_dir / "yue-Hans_transcribe/transcribe.srt")
 
 
-@pytest.fixture
+@fixture
 def kob_yue_hans_transcribe_expected_cer() -> SeriesCERResult:
     """Expected CER for KOB transcribed subtitles against flattened reference."""
     return SeriesCERResult(
@@ -584,13 +584,13 @@ def kob_yue_hans_transcribe_expected_cer() -> SeriesCERResult:
     )
 
 
-@pytest.fixture
+@fixture
 def kob_yue_hans_transcribe_review() -> Series:
     """KOB 简体粤文 transcribed and line reviewed subtitles."""
     return Series.load(output_dir / "yue-Hans_transcribe/transcribe_review.srt")
 
 
-@pytest.fixture
+@fixture
 def kob_yue_hans_transcribe_review_translate() -> Series:
     """KOB 简体粤文 transcribed/line-reviewed/translated subtitles."""
     return Series.load(
@@ -598,7 +598,7 @@ def kob_yue_hans_transcribe_review_translate() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def kob_yue_hans_transcribe_review_translate_block_review() -> Series:
     """KOB 简体粤文 transcribed/line-reviewed/translated/block-reviewed subtitles."""
     return Series.load(
@@ -608,7 +608,7 @@ def kob_yue_hans_transcribe_review_translate_block_review() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def kob_yue_hans_transcribe_review_translate_block_review_expected_cer() -> (
     SeriesCERResult
 ):
@@ -623,55 +623,55 @@ def kob_yue_hans_transcribe_review_translate_block_review_expected_cer() -> (
     )
 
 
-@pytest.fixture
+@fixture
 def kob_yue_hant_timewarp() -> Series:
     """KOB 繁體粵文 timewarp subtitles."""
     return Series.load(output_dir / "yue-Hant/timewarp.srt")
 
 
-@pytest.fixture
+@fixture
 def kob_yue_hant_timewarp_clean() -> Series:
     """KOB 繁體粵文 timewarp and cleaned subtitles."""
     return Series.load(output_dir / "yue-Hant/timewarp_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def kob_yue_hant_timewarp_clean_flatten() -> Series:
     """KOB 繁體粵文 timewarp, cleaned, and flattened subtitles."""
     return Series.load(output_dir / "yue-Hant/timewarp_clean_flatten.srt")
 
 
-@pytest.fixture
+@fixture
 def kob_zho_hans_eng() -> Series:
     """KOB Bilingual 简体中文 and English subtitles."""
     return Series.load(output_dir / "zho-Hans_eng.srt")
 
 
-@pytest.fixture
+@fixture
 def kob_zho_hant_ocr_fuse() -> Series:
     """KOB 繁体中文 fused subtitles."""
     return Series.load(output_dir / "zho-Hant_ocr/fuse.srt")
 
 
-@pytest.fixture
+@fixture
 def kob_zho_hant_ocr_fuse_clean() -> Series:
     """KOB 繁体中文 fused and cleaned subtitles."""
     return Series.load(output_dir / "zho-Hant_ocr/fuse_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def kob_zho_hant_ocr_fuse_clean_validate() -> Series:
     """KOB 繁体中文 fused, cleaned, and validated subtitles."""
     return Series.load(output_dir / "zho-Hant_ocr/fuse_clean_validate.srt")
 
 
-@pytest.fixture
+@fixture
 def kob_zho_hant_ocr_fuse_clean_validate_review() -> Series:
     """KOB 繁体中文 fused, cleaned, validated, and reviewed subtitles."""
     return Series.load(output_dir / "zho-Hant_ocr/fuse_clean_validate_review.srt")
 
 
-@pytest.fixture
+@fixture
 def kob_zho_hant_ocr_fuse_clean_validate_review_flatten() -> Series:
     """KOB 繁体中文 fused, cleaned, validated, reviewed, and flattened subtitles."""
     return Series.load(
@@ -679,7 +679,7 @@ def kob_zho_hant_ocr_fuse_clean_validate_review_flatten() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def kob_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify() -> Series:
     """KOB 繁体中文 simplified fused/cleaned/validated/reviewed/flattened subtitles."""
     return Series.load(
@@ -687,7 +687,7 @@ def kob_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def kob_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify_review() -> Series:
     """KOB 繁体中文 simplified/reviewed fused/cleaned subtitles."""
     return Series.load(
@@ -697,7 +697,7 @@ def kob_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify_review() -> Ser
     )
 
 
-@pytest.fixture
+@fixture
 def kob_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify_review_romanize(  # noqa: E501
 ) -> Series:
     """KOB 简体中文 simplified/reviewed fused/cleaned romanized subtitles."""
@@ -708,25 +708,26 @@ def kob_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify_review_romanize
     )
 
 
-@pytest.fixture
+@fixture
 def kob_zho_hant_ocr_lens() -> Series:
     """KOB 繁体中文 subtitles OCRed using Google Lens."""
     return Series.load(output_dir / "zho-Hant_ocr/lens.srt")
 
 
-@pytest.fixture
+@fixture
 def kob_zho_hant_ocr_lens_clean() -> Series:
     """KOB 繁体中文 Google Lens OCR subtitles, cleaned."""
     return Series.load(output_dir / "zho-Hant_ocr/lens_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def kob_zho_hant_ocr_paddle() -> Series:
     """KOB 繁体中文 subtitles OCRed using PaddleOCR."""
     return Series.load(output_dir / "zho-Hant_ocr/paddle.srt")
 
 
-@pytest.fixture
+@fixture
 def kob_zho_hant_ocr_paddle_clean() -> Series:
     """KOB 繁体中文 PaddleOCR subtitles, cleaned."""
     return Series.load(output_dir / "zho-Hant_ocr/paddle_clean.srt")
+

--- a/test/data/mlamd/__init__.py
+++ b/test/data/mlamd/__init__.py
@@ -10,7 +10,7 @@ from functools import cache
 from pathlib import Path
 from typing import Any
 
-import pytest
+from pytest import fixture
 
 from scinoephile.audio.subtitles import AudioSeries
 from scinoephile.core.llms import TestCase
@@ -125,19 +125,19 @@ input_dir = title_root / "input"
 output_dir = title_root / "output"
 
 
-@pytest.fixture
+@fixture
 def mlamd_eng_ocr_sup_path() -> Path:
     """Path to MLAMD English SUP subtitles."""
     return input_dir / "eng_ocr/source.sup"
 
 
-@pytest.fixture
+@fixture
 def mlamd_zho_hans_ocr_sup_path() -> Path:
     """Path to MLAMD 简体中文 SUP subtitles."""
     return input_dir / "zho-Hans_ocr/source.sup"
 
 
-@pytest.fixture
+@fixture
 def mlamd_zho_hant_ocr_sup_path() -> Path:
     """Path to MLAMD 繁体中文 SUP subtitles."""
     return input_dir / "zho-Hant_ocr/source.sup"
@@ -408,103 +408,103 @@ def get_mlamd_zho_hant_simplify_block_review_test_cases(
     )
 
 
-@pytest.fixture
+@fixture
 def mlamd_eng_fuse() -> Series:
     """MLAMD English fused subtitles."""
     return Series.load(output_dir / "eng_ocr/fuse.srt")
 
 
-@pytest.fixture
+@fixture
 def mlamd_eng_fuse_clean() -> Series:
     """MLAMD English fused and cleaned subtitles."""
     return Series.load(output_dir / "eng_ocr/fuse_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def mlamd_eng_fuse_clean_validate() -> Series:
     """MLAMD English fused, cleaned, and validated subtitles."""
     return Series.load(output_dir / "eng_ocr/fuse_clean_validate.srt")
 
 
-@pytest.fixture
+@fixture
 def mlamd_eng_fuse_clean_validate_review() -> Series:
     """MLAMD English fused, cleaned, validated, and reviewed subtitles."""
     return Series.load(output_dir / "eng_ocr/fuse_clean_validate_review.srt")
 
 
-@pytest.fixture
+@fixture
 def mlamd_eng_fuse_clean_validate_review_flatten() -> Series:
     """MLAMD English fused, cleaned, validated, reviewed, and flattened subtitles."""
     return Series.load(output_dir / "eng_ocr/fuse_clean_validate_review_flatten.srt")
 
 
-@pytest.fixture
+@fixture
 def mlamd_eng_image() -> ImageSeries:
     """MLAMD English image subtitles."""
     return ImageSeries.load(output_dir / "eng_ocr/image", encoding="utf-8")
 
 
-@pytest.fixture
+@fixture
 def mlamd_eng_image_path() -> Path:
     """Path to MLAMD English image subtitles."""
     return output_dir / "eng_ocr/image"
 
 
-@pytest.fixture
+@fixture
 def mlamd_eng_ocr_lens() -> Series:
     """MLAMD English subtitles OCRed using Google Lens."""
     return Series.load(output_dir / "eng_ocr/lens.srt")
 
 
-@pytest.fixture
+@fixture
 def mlamd_eng_ocr_lens_clean() -> Series:
     """MLAMD English Google Lens OCR subtitles, cleaned."""
     return Series.load(output_dir / "eng_ocr/lens_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def mlamd_eng_ocr_tesseract() -> Series:
     """MLAMD English subtitles OCRed using Tesseract."""
     return Series.load(output_dir / "eng_ocr/tesseract.srt")
 
 
-@pytest.fixture
+@fixture
 def mlamd_eng_ocr_tesseract_clean() -> Series:
     """MLAMD English Tesseract OCR subtitles, cleaned."""
     return Series.load(output_dir / "eng_ocr/tesseract_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def mlamd_yue_hans_audio() -> AudioSeries:
     """MLAMD 简体粤文 audio subtitles."""
     return AudioSeries.load(output_dir / "yue-Hans_transcribe/audio")
 
 
-@pytest.fixture
+@fixture
 def mlamd_yue_hans_audio_path() -> Path:
     """Path to MLAMD 简体粤文 audio subtitles."""
     return output_dir / "yue-Hans_transcribe/audio"
 
 
-@pytest.fixture
+@fixture
 def mlamd_yue_hans_eng() -> Series:
     """MLAMD Bilingual 简体粤文 and English subtitles."""
     return Series.load(output_dir / "yue-Hans_eng.srt")
 
 
-@pytest.fixture
+@fixture
 def mlamd_yue_hans_transcribe() -> Series:
     """MLAMD 简体粤文 transcribed subtitles."""
     return Series.load(output_dir / "yue-Hans_transcribe/transcribe.srt")
 
 
-@pytest.fixture
+@fixture
 def mlamd_yue_hans_transcribe_review() -> Series:
     """MLAMD 简体粤文 transcribed and line reviewed subtitles."""
     return Series.load(output_dir / "yue-Hans_transcribe/transcribe_review.srt")
 
 
-@pytest.fixture
+@fixture
 def mlamd_yue_hans_transcribe_review_translate() -> Series:
     """MLAMD 简体粤文 transcribed, line reviewed, and translated subtitles."""
     return Series.load(
@@ -512,7 +512,7 @@ def mlamd_yue_hans_transcribe_review_translate() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def mlamd_yue_hans_transcribe_review_translate_block_review() -> Series:
     """MLAMD 简体粤文 transcribed, line reviewed, translated, and block reviewed subtitles."""
     return Series.load(
@@ -522,37 +522,37 @@ def mlamd_yue_hans_transcribe_review_translate_block_review() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def mlamd_zho_hans_eng() -> Series:
     """MLAMD Bilingual 简体中文 and English series."""
     return Series.load(output_dir / "zho-Hans_eng.srt")
 
 
-@pytest.fixture
+@fixture
 def mlamd_zho_hans_fuse() -> Series:
     """MLAMD 简体中文 fused subtitles."""
     return Series.load(output_dir / "zho-Hans_ocr/fuse.srt")
 
 
-@pytest.fixture
+@fixture
 def mlamd_zho_hans_fuse_clean() -> Series:
     """MLAMD 简体中文 fused and cleaned subtitles."""
     return Series.load(output_dir / "zho-Hans_ocr/fuse_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def mlamd_zho_hans_fuse_clean_validate() -> Series:
     """MLAMD 简体中文 fused, cleaned, and validated subtitles."""
     return Series.load(output_dir / "zho-Hans_ocr/fuse_clean_validate.srt")
 
 
-@pytest.fixture
+@fixture
 def mlamd_zho_hans_fuse_clean_validate_review() -> Series:
     """MLAMD 简体中文 fused, cleaned, validated, and reviewed subtitles."""
     return Series.load(output_dir / "zho-Hans_ocr/fuse_clean_validate_review.srt")
 
 
-@pytest.fixture
+@fixture
 def mlamd_zho_hans_fuse_clean_validate_review_flatten() -> Series:
     """MLAMD 简体中文 fused, cleaned, validated, reviewed, and flattened subtitles."""
     return Series.load(
@@ -560,7 +560,7 @@ def mlamd_zho_hans_fuse_clean_validate_review_flatten() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def mlamd_zho_hans_fuse_clean_validate_review_flatten_merged_539(
     mlamd_zho_hans_fuse_clean_validate_review_flatten: Series,
 ) -> Series:
@@ -571,7 +571,7 @@ def mlamd_zho_hans_fuse_clean_validate_review_flatten_merged_539(
     )
 
 
-@pytest.fixture
+@fixture
 def mlamd_zho_hans_fuse_clean_validate_review_flatten_romanize() -> Series:
     """MLAMD 简体中文 fused/cleaned/validated/reviewed/flattened romanized subs."""
     return Series.load(
@@ -579,67 +579,67 @@ def mlamd_zho_hans_fuse_clean_validate_review_flatten_romanize() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def mlamd_zho_hans_image() -> ImageSeries:
     """MLAMD 简体中文 image subtitles."""
     return ImageSeries.load(output_dir / "zho-Hans_ocr/image", encoding="utf-8")
 
 
-@pytest.fixture
+@fixture
 def mlamd_zho_hans_image_path() -> Path:
     """Path to MLAMD 简体中文 image subtitles."""
     return output_dir / "zho-Hans_ocr/image"
 
 
-@pytest.fixture
+@fixture
 def mlamd_zho_hans_ocr_lens() -> Series:
     """MLAMD 简体中文 subtitles OCRed using Google Lens."""
     return Series.load(output_dir / "zho-Hans_ocr/lens.srt")
 
 
-@pytest.fixture
+@fixture
 def mlamd_zho_hans_ocr_lens_clean() -> Series:
     """MLAMD 简体中文 Google Lens OCR subtitles, cleaned."""
     return Series.load(output_dir / "zho-Hans_ocr/lens_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def mlamd_zho_hans_ocr_paddle() -> Series:
     """MLAMD 简体中文 subtitles OCRed using PaddleOCR."""
     return Series.load(output_dir / "zho-Hans_ocr/paddle.srt")
 
 
-@pytest.fixture
+@fixture
 def mlamd_zho_hans_ocr_paddle_clean() -> Series:
     """MLAMD 简体中文 PaddleOCR subtitles, cleaned."""
     return Series.load(output_dir / "zho-Hans_ocr/paddle_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def mlamd_zho_hant_fuse() -> Series:
     """MLAMD 繁体中文 fused subtitles."""
     return Series.load(output_dir / "zho-Hant_ocr/fuse.srt")
 
 
-@pytest.fixture
+@fixture
 def mlamd_zho_hant_fuse_clean() -> Series:
     """MLAMD 繁体中文 fused and cleaned subtitles."""
     return Series.load(output_dir / "zho-Hant_ocr/fuse_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def mlamd_zho_hant_fuse_clean_validate() -> Series:
     """MLAMD 繁体中文 fused, cleaned, and validated subtitles."""
     return Series.load(output_dir / "zho-Hant_ocr/fuse_clean_validate.srt")
 
 
-@pytest.fixture
+@fixture
 def mlamd_zho_hant_fuse_clean_validate_review() -> Series:
     """MLAMD 繁体中文 fused, cleaned, validated, and reviewed subtitles."""
     return Series.load(output_dir / "zho-Hant_ocr/fuse_clean_validate_review.srt")
 
 
-@pytest.fixture
+@fixture
 def mlamd_zho_hant_fuse_clean_validate_review_flatten() -> Series:
     """MLAMD 繁体中文 fused, cleaned, validated, reviewed, and flattened subtitles."""
     return Series.load(
@@ -647,7 +647,7 @@ def mlamd_zho_hant_fuse_clean_validate_review_flatten() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def mlamd_zho_hant_fuse_clean_validate_review_flatten_simplify() -> Series:
     """MLAMD 繁体中文 simplified fused/cleaned/validated/reviewed/flattened subs."""
     return Series.load(
@@ -655,7 +655,7 @@ def mlamd_zho_hant_fuse_clean_validate_review_flatten_simplify() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def mlamd_zho_hant_fuse_clean_validate_review_flatten_simplify_review() -> Series:
     """MLAMD 繁体中文 simplified/reviewed fused/cleaned subtitles."""
     return Series.load(
@@ -665,7 +665,7 @@ def mlamd_zho_hant_fuse_clean_validate_review_flatten_simplify_review() -> Serie
     )
 
 
-@pytest.fixture
+@fixture
 def mlamd_zho_hant_fuse_clean_validate_review_flatten_simplify_review_romanize() -> (
     Series
 ):
@@ -677,43 +677,43 @@ def mlamd_zho_hant_fuse_clean_validate_review_flatten_simplify_review_romanize()
     )
 
 
-@pytest.fixture
+@fixture
 def mlamd_zho_hant_image() -> ImageSeries:
     """MLAMD 繁体中文 image subtitles."""
     return ImageSeries.load(output_dir / "zho-Hant_ocr/image", encoding="utf-8")
 
 
-@pytest.fixture
+@fixture
 def mlamd_zho_hant_image_path() -> Path:
     """Path to MLAMD 繁体中文 image subtitles."""
     return output_dir / "zho-Hant_ocr/image"
 
 
-@pytest.fixture
+@fixture
 def mlamd_zho_hant_ocr_lens() -> Series:
     """MLAMD 繁体中文 subtitles OCRed using Google Lens."""
     return Series.load(output_dir / "zho-Hant_ocr/lens.srt")
 
 
-@pytest.fixture
+@fixture
 def mlamd_zho_hant_ocr_lens_clean() -> Series:
     """MLAMD 繁体中文 Google Lens OCR subtitles, cleaned."""
     return Series.load(output_dir / "zho-Hant_ocr/lens_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def mlamd_zho_hant_ocr_paddle() -> Series:
     """MLAMD 繁体中文 subtitles OCRed using PaddleOCR."""
     return Series.load(output_dir / "zho-Hant_ocr/paddle.srt")
 
 
-@pytest.fixture
+@fixture
 def mlamd_zho_hant_ocr_paddle_clean() -> Series:
     """MLAMD 繁体中文 PaddleOCR subtitles, cleaned."""
     return Series.load(output_dir / "zho-Hant_ocr/paddle_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def mlamd_zho_simplify_expected_series_diff() -> list[str]:
     """Expected differences for MLAMD Simplified vs Traditional subtitles."""
     return [
@@ -747,3 +747,4 @@ def mlamd_zho_simplify_expected_series_diff() -> list[str]:
         "edit: SIMP[847] -> TRAD[847]: '足有一寸厚' -> '足有一吋厚'",
         "edit: SIMP[855] -> TRAD[855]: '可是楝一双脚瓜站这儿⋯' -> '可是冻一双脚瓜站这儿⋯'",
     ]
+

--- a/test/data/mnt/__init__.py
+++ b/test/data/mnt/__init__.py
@@ -10,7 +10,7 @@ from functools import cache
 from pathlib import Path
 from typing import Any
 
-import pytest
+from pytest import fixture
 
 from scinoephile.core.llms import TestCase
 from scinoephile.core.llms.utils import load_test_cases_from_json
@@ -86,19 +86,19 @@ input_dir = title_root / "input"
 output_dir = title_root / "output"
 
 
-@pytest.fixture
+@fixture
 def mnt_jpn_eng() -> Series:
     """MNT Bilingual Japanese and English subtitles."""
     return Series.load(input_dir / "jpn_eng.srt")
 
 
-@pytest.fixture
+@fixture
 def mnt_yue_zho_hant() -> Series:
     """MNT 粤语 audio track 繁体粤文 subtitles."""
     return Series.load(input_dir / "yue_zho-Hant.srt")
 
 
-@pytest.fixture
+@fixture
 def mnt_zho_hant() -> Series:
     """MNT 繁体中文 series."""
     return Series.load(input_dir / "zho-Hant.srt")
@@ -256,103 +256,103 @@ def get_mnt_zho_hant_simplify_block_review_test_cases(
     )
 
 
-@pytest.fixture
+@fixture
 def mnt_eng_fuse() -> Series:
     """MNT English fused subtitles."""
     return Series.load(output_dir / "eng_ocr/fuse.srt")
 
 
-@pytest.fixture
+@fixture
 def mnt_eng_fuse_clean() -> Series:
     """MNT English fused and cleaned subtitles."""
     return Series.load(output_dir / "eng_ocr/fuse_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def mnt_eng_fuse_clean_validate() -> Series:
     """MNT English fused, cleaned, and validated subtitles."""
     return Series.load(output_dir / "eng_ocr/fuse_clean_validate.srt")
 
 
-@pytest.fixture
+@fixture
 def mnt_eng_fuse_clean_validate_review() -> Series:
     """MNT English fused, cleaned, validated, and reviewed subtitles."""
     return Series.load(output_dir / "eng_ocr/fuse_clean_validate_review.srt")
 
 
-@pytest.fixture
+@fixture
 def mnt_eng_fuse_clean_validate_review_flatten() -> Series:
     """MNT English fused, cleaned, validated, reviewed, and flattened subtitles."""
     return Series.load(output_dir / "eng_ocr/fuse_clean_validate_review_flatten.srt")
 
 
-@pytest.fixture
+@fixture
 def mnt_eng_ocr_lens() -> Series:
     """MNT English subtitles OCRed using Google Lens."""
     return Series.load(output_dir / "eng_ocr/lens.srt")
 
 
-@pytest.fixture
+@fixture
 def mnt_eng_ocr_lens_clean() -> Series:
     """MNT English Google Lens OCR subtitles, cleaned."""
     return Series.load(output_dir / "eng_ocr/lens_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def mnt_eng_ocr_tesseract() -> Series:
     """MNT English subtitles OCRed using Tesseract."""
     return Series.load(output_dir / "eng_ocr/tesseract.srt")
 
 
-@pytest.fixture
+@fixture
 def mnt_eng_ocr_tesseract_clean() -> Series:
     """MNT English Tesseract OCR subtitles, cleaned."""
     return Series.load(output_dir / "eng_ocr/tesseract_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def mnt_yue_eng() -> Series:
     """MNT English subtitles translated from 粤语 audio track subtitles."""
     return Series.load(output_dir / "yue_eng/eng.srt")
 
 
-@pytest.fixture
+@fixture
 def mnt_yue_zho_hans_eng() -> Series:
     """MNT Bilingual 简体粤文 and English subtitles for the 粤语 audio track."""
     return Series.load(output_dir / "yue_eng/zho-Hans_eng.srt")
 
 
-@pytest.fixture
+@fixture
 def mnt_zho_hans_eng() -> Series:
     """MNT bilingual 简体中文 and English subtitles."""
     return Series.load(output_dir / "zho-Hans_eng.srt")
 
 
-@pytest.fixture
+@fixture
 def mnt_zho_hans_fuse() -> Series:
     """MNT 简体中文 fused subtitles."""
     return Series.load(output_dir / "zho-Hans_ocr/fuse.srt")
 
 
-@pytest.fixture
+@fixture
 def mnt_zho_hans_fuse_clean() -> Series:
     """MNT 简体中文 fused and cleaned subtitles."""
     return Series.load(output_dir / "zho-Hans_ocr/fuse_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def mnt_zho_hans_fuse_clean_validate() -> Series:
     """MNT 简体中文 fused, cleaned, and validated subtitles."""
     return Series.load(output_dir / "zho-Hans_ocr/fuse_clean_validate.srt")
 
 
-@pytest.fixture
+@fixture
 def mnt_zho_hans_fuse_clean_validate_review() -> Series:
     """MNT 简体中文 fused, cleaned, validated, and reviewed subtitles."""
     return Series.load(output_dir / "zho-Hans_ocr/fuse_clean_validate_review.srt")
 
 
-@pytest.fixture
+@fixture
 def mnt_zho_hans_fuse_clean_validate_review_flatten() -> Series:
     """MNT 简体中文 fused, cleaned, validated, reviewed, and flattened subtitles."""
     return Series.load(
@@ -360,7 +360,7 @@ def mnt_zho_hans_fuse_clean_validate_review_flatten() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def mnt_zho_hans_fuse_clean_validate_review_flatten_romanize() -> Series:
     """MNT 简体中文 fused/cleaned/validated/reviewed/flattened romanized subtitles."""
     return Series.load(
@@ -368,55 +368,55 @@ def mnt_zho_hans_fuse_clean_validate_review_flatten_romanize() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def mnt_zho_hans_ocr_lens() -> Series:
     """MNT 简体中文 subtitles OCRed using Google Lens."""
     return Series.load(output_dir / "zho-Hans_ocr/lens.srt")
 
 
-@pytest.fixture
+@fixture
 def mnt_zho_hans_ocr_lens_clean() -> Series:
     """MNT 简体中文 Google Lens OCR subtitles, cleaned."""
     return Series.load(output_dir / "zho-Hans_ocr/lens_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def mnt_zho_hans_ocr_paddle() -> Series:
     """MNT 简体中文 subtitles OCRed using PaddleOCR."""
     return Series.load(output_dir / "zho-Hans_ocr/paddle.srt")
 
 
-@pytest.fixture
+@fixture
 def mnt_zho_hans_ocr_paddle_clean() -> Series:
     """MNT 简体中文 PaddleOCR subtitles, cleaned."""
     return Series.load(output_dir / "zho-Hans_ocr/paddle_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def mnt_zho_hant_fuse() -> Series:
     """MNT 繁体中文 fused subtitles."""
     return Series.load(output_dir / "zho-Hant_ocr/fuse.srt")
 
 
-@pytest.fixture
+@fixture
 def mnt_zho_hant_fuse_clean() -> Series:
     """MNT 繁体中文 fused and cleaned subtitles."""
     return Series.load(output_dir / "zho-Hant_ocr/fuse_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def mnt_zho_hant_fuse_clean_validate() -> Series:
     """MNT 繁体中文 fused, cleaned, and validated subtitles."""
     return Series.load(output_dir / "zho-Hant_ocr/fuse_clean_validate.srt")
 
 
-@pytest.fixture
+@fixture
 def mnt_zho_hant_fuse_clean_validate_review() -> Series:
     """MNT 繁体中文 fused, cleaned, validated, and reviewed subtitles."""
     return Series.load(output_dir / "zho-Hant_ocr/fuse_clean_validate_review.srt")
 
 
-@pytest.fixture
+@fixture
 def mnt_zho_hant_fuse_clean_validate_review_flatten() -> Series:
     """MNT 繁体中文 fused, cleaned, validated, reviewed, and flattened subtitles."""
     return Series.load(
@@ -424,7 +424,7 @@ def mnt_zho_hant_fuse_clean_validate_review_flatten() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def mnt_zho_hant_fuse_clean_validate_review_flatten_simplify() -> Series:
     """MNT 繁体中文 fused/cleaned/validated/reviewed/flattened/simplified subtitles."""
     return Series.load(
@@ -432,7 +432,7 @@ def mnt_zho_hant_fuse_clean_validate_review_flatten_simplify() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def mnt_zho_hant_fuse_clean_validate_review_flatten_simplify_review() -> Series:
     """MNT 繁体中文 simplified/reviewed fused/cleaned subtitles."""
     return Series.load(
@@ -442,7 +442,7 @@ def mnt_zho_hant_fuse_clean_validate_review_flatten_simplify_review() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def mnt_zho_hant_fuse_clean_validate_review_flatten_simplify_review_romanize() -> (
     Series
 ):
@@ -454,31 +454,31 @@ def mnt_zho_hant_fuse_clean_validate_review_flatten_simplify_review_romanize() -
     )
 
 
-@pytest.fixture
+@fixture
 def mnt_zho_hant_ocr_lens() -> Series:
     """MNT 繁体中文 subtitles OCRed using Google Lens."""
     return Series.load(output_dir / "zho-Hant_ocr/lens.srt")
 
 
-@pytest.fixture
+@fixture
 def mnt_zho_hant_ocr_lens_clean() -> Series:
     """MNT 繁体中文 Google Lens OCR subtitles, cleaned."""
     return Series.load(output_dir / "zho-Hant_ocr/lens_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def mnt_zho_hant_ocr_paddle() -> Series:
     """MNT 繁体中文 subtitles OCRed using PaddleOCR."""
     return Series.load(output_dir / "zho-Hant_ocr/paddle.srt")
 
 
-@pytest.fixture
+@fixture
 def mnt_zho_hant_ocr_paddle_clean() -> Series:
     """MNT 繁体中文 PaddleOCR subtitles, cleaned."""
     return Series.load(output_dir / "zho-Hant_ocr/paddle_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def mnt_zho_simplify_expected_series_diff() -> list[str]:
     """Expected differences for MNT Simplified vs Traditional subtitles."""
     return [
@@ -625,3 +625,4 @@ def mnt_zho_simplify_expected_series_diff() -> list[str]:
         "delete: SIMP[735] '谢谢观看' not present in TRAD",
         "insert: TRAD[736] '完' not present in SIMP",
     ]
+

--- a/test/data/t/__init__.py
+++ b/test/data/t/__init__.py
@@ -10,7 +10,7 @@ from functools import cache
 from pathlib import Path
 from typing import Any
 
-import pytest
+from pytest import fixture
 
 from scinoephile.core.llms import TestCase
 from scinoephile.core.llms.utils import load_test_cases_from_json
@@ -81,19 +81,19 @@ input_dir = title_root / "input"
 output_dir = title_root / "output"
 
 
-@pytest.fixture
+@fixture
 def t_eng() -> Series:
     """T English series."""
     return Series.load(input_dir / "eng.srt")
 
 
-@pytest.fixture
+@fixture
 def t_zho_hans() -> Series:
     """T 简体中文 series."""
     return Series.load(input_dir / "zho-Hans.srt")
 
 
-@pytest.fixture
+@fixture
 def t_zho_hant() -> Series:
     """T 繁体中文 series."""
     return Series.load(input_dir / "zho-Hant.srt")
@@ -232,91 +232,91 @@ def get_t_zho_hant_simplify_block_review_test_cases(
     )
 
 
-@pytest.fixture
+@fixture
 def t_eng_fuse() -> Series:
     """T English fused subtitles."""
     return Series.load(output_dir / "eng_ocr/fuse.srt")
 
 
-@pytest.fixture
+@fixture
 def t_eng_fuse_clean() -> Series:
     """T English fused and cleaned subtitles."""
     return Series.load(output_dir / "eng_ocr/fuse_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def t_eng_fuse_clean_validate() -> Series:
     """T English fused, cleaned, and validated subtitles."""
     return Series.load(output_dir / "eng_ocr/fuse_clean_validate.srt")
 
 
-@pytest.fixture
+@fixture
 def t_eng_fuse_clean_validate_review() -> Series:
     """T English fused, cleaned, validated, and reviewed subtitles."""
     return Series.load(output_dir / "eng_ocr/fuse_clean_validate_review.srt")
 
 
-@pytest.fixture
+@fixture
 def t_eng_fuse_clean_validate_review_flatten() -> Series:
     """T English fused, cleaned, validated, reviewed, and flattened subtitles."""
     return Series.load(output_dir / "eng_ocr/fuse_clean_validate_review_flatten.srt")
 
 
-@pytest.fixture
+@fixture
 def t_eng_ocr_lens() -> Series:
     """T English subtitles OCRed using Google Lens."""
     return Series.load(output_dir / "eng_ocr/lens.srt")
 
 
-@pytest.fixture
+@fixture
 def t_eng_ocr_lens_clean() -> Series:
     """T English Google Lens OCR subtitles, cleaned."""
     return Series.load(output_dir / "eng_ocr/lens_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def t_eng_ocr_tesseract() -> Series:
     """T English subtitles OCRed using Tesseract."""
     return Series.load(output_dir / "eng_ocr/tesseract.srt")
 
 
-@pytest.fixture
+@fixture
 def t_eng_ocr_tesseract_clean() -> Series:
     """T English Tesseract OCR subtitles, cleaned."""
     return Series.load(output_dir / "eng_ocr/tesseract_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def t_zho_hans_eng() -> Series:
     """T Bilingual 简体中文 and English series."""
     return Series.load(output_dir / "zho-Hans_eng.srt")
 
 
-@pytest.fixture
+@fixture
 def t_zho_hans_fuse() -> Series:
     """T 简体中文 fused subtitles."""
     return Series.load(output_dir / "zho-Hans_ocr/fuse.srt")
 
 
-@pytest.fixture
+@fixture
 def t_zho_hans_fuse_clean() -> Series:
     """T 简体中文 fused and cleaned subtitles."""
     return Series.load(output_dir / "zho-Hans_ocr/fuse_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def t_zho_hans_fuse_clean_validate() -> Series:
     """T 简体中文 fused, cleaned, and validated subtitles."""
     return Series.load(output_dir / "zho-Hans_ocr/fuse_clean_validate.srt")
 
 
-@pytest.fixture
+@fixture
 def t_zho_hans_fuse_clean_validate_review() -> Series:
     """T 简体中文 fused, cleaned, validated, and reviewed subtitles."""
     return Series.load(output_dir / "zho-Hans_ocr/fuse_clean_validate_review.srt")
 
 
-@pytest.fixture
+@fixture
 def t_zho_hans_fuse_clean_validate_review_flatten() -> Series:
     """T 简体中文 fused, cleaned, validated, reviewed, and flattened subtitles."""
     return Series.load(
@@ -324,7 +324,7 @@ def t_zho_hans_fuse_clean_validate_review_flatten() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def t_zho_hans_fuse_clean_validate_review_flatten_romanize() -> Series:
     """T 简体中文 fused/cleaned/validated/reviewed/flattened romanized subtitles."""
     return Series.load(
@@ -332,55 +332,55 @@ def t_zho_hans_fuse_clean_validate_review_flatten_romanize() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def t_zho_hans_ocr_lens() -> Series:
     """T 简体中文 subtitles OCRed using Google Lens."""
     return Series.load(output_dir / "zho-Hans_ocr/lens.srt")
 
 
-@pytest.fixture
+@fixture
 def t_zho_hans_ocr_lens_clean() -> Series:
     """T 简体中文 Google Lens OCR subtitles, cleaned."""
     return Series.load(output_dir / "zho-Hans_ocr/lens_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def t_zho_hans_ocr_paddle() -> Series:
     """T 简体中文 subtitles OCRed using PaddleOCR."""
     return Series.load(output_dir / "zho-Hans_ocr/paddle.srt")
 
 
-@pytest.fixture
+@fixture
 def t_zho_hans_ocr_paddle_clean() -> Series:
     """T 简体中文 PaddleOCR subtitles, cleaned."""
     return Series.load(output_dir / "zho-Hans_ocr/paddle_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def t_zho_hant_fuse() -> Series:
     """T 繁体中文 fused subtitles."""
     return Series.load(output_dir / "zho-Hant_ocr/fuse.srt")
 
 
-@pytest.fixture
+@fixture
 def t_zho_hant_fuse_clean() -> Series:
     """T 繁体中文 fused and cleaned subtitles."""
     return Series.load(output_dir / "zho-Hant_ocr/fuse_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def t_zho_hant_fuse_clean_validate() -> Series:
     """T 繁体中文 fused, cleaned, and validated subtitles."""
     return Series.load(output_dir / "zho-Hant_ocr/fuse_clean_validate.srt")
 
 
-@pytest.fixture
+@fixture
 def t_zho_hant_fuse_clean_validate_review() -> Series:
     """T 繁体中文 fused, cleaned, validated, and reviewed subtitles."""
     return Series.load(output_dir / "zho-Hant_ocr/fuse_clean_validate_review.srt")
 
 
-@pytest.fixture
+@fixture
 def t_zho_hant_fuse_clean_validate_review_flatten() -> Series:
     """T 繁体中文 fused, cleaned, validated, reviewed, and flattened subtitles."""
     return Series.load(
@@ -388,7 +388,7 @@ def t_zho_hant_fuse_clean_validate_review_flatten() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def t_zho_hant_fuse_clean_validate_review_flatten_simplify() -> Series:
     """T 繁体中文 fused/cleaned/validated/reviewed/flattened/simplified subtitles."""
     return Series.load(
@@ -396,7 +396,7 @@ def t_zho_hant_fuse_clean_validate_review_flatten_simplify() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def t_zho_hant_fuse_clean_validate_review_flatten_simplify_review() -> Series:
     """T 繁体中文 simplified/reviewed fused/cleaned subtitles."""
     return Series.load(
@@ -406,7 +406,7 @@ def t_zho_hant_fuse_clean_validate_review_flatten_simplify_review() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def t_zho_hant_fuse_clean_validate_review_flatten_simplify_review_romanize() -> Series:
     """T 繁体中文 simplified/reviewed fused/cleaned romanized subtitles."""
     return Series.load(
@@ -416,31 +416,31 @@ def t_zho_hant_fuse_clean_validate_review_flatten_simplify_review_romanize() -> 
     )
 
 
-@pytest.fixture
+@fixture
 def t_zho_hant_ocr_lens() -> Series:
     """T 繁体中文 subtitles OCRed using Google Lens."""
     return Series.load(output_dir / "zho-Hant_ocr/lens.srt")
 
 
-@pytest.fixture
+@fixture
 def t_zho_hant_ocr_lens_clean() -> Series:
     """T 繁体中文 Google Lens OCR subtitles, cleaned."""
     return Series.load(output_dir / "zho-Hant_ocr/lens_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def t_zho_hant_ocr_paddle() -> Series:
     """T 繁体中文 subtitles OCRed using PaddleOCR."""
     return Series.load(output_dir / "zho-Hant_ocr/paddle.srt")
 
 
-@pytest.fixture
+@fixture
 def t_zho_hant_ocr_paddle_clean() -> Series:
     """T 繁体中文 PaddleOCR subtitles, cleaned."""
     return Series.load(output_dir / "zho-Hant_ocr/paddle_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def t_zho_simplify_expected_series_diff() -> list[str]:
     """Expected differences for T Simplified vs Traditional subtitles."""
     return [
@@ -508,3 +508,4 @@ def t_zho_simplify_expected_series_diff() -> list[str]:
         "edit: SIMP[1148] -> TRAD[1148]: '现在位置在投诉大厦楼下' -> '现在位置在投诉人大厦楼下'",
         "edit: SIMP[1149] -> TRAD[1149]: '这里水静鹅飞，什么人也没有，完毕' -> '这里鸦雀无声，甚么人也没有，完毕'",
     ]
+

--- a/test/data/tmm/__init__.py
+++ b/test/data/tmm/__init__.py
@@ -10,7 +10,7 @@ from functools import cache
 from pathlib import Path
 from typing import Any
 
-import pytest
+from pytest import fixture
 
 from scinoephile.core.llms import TestCase
 from scinoephile.core.llms.utils import load_test_cases_from_json
@@ -332,91 +332,91 @@ def get_tmm_zho_hant_simplify_block_review_test_cases(
     )
 
 
-@pytest.fixture
+@fixture
 def tmm_eng_ocr_fuse() -> Series:
     """TMM English fused subtitles."""
     return Series.load(output_dir / "eng_ocr/fuse.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_eng_ocr_fuse_clean() -> Series:
     """TMM English fused and cleaned subtitles."""
     return Series.load(output_dir / "eng_ocr/fuse_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_eng_ocr_fuse_clean_validate() -> Series:
     """TMM English fused, cleaned, and validated subtitles."""
     return Series.load(output_dir / "eng_ocr/fuse_clean_validate.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_eng_ocr_fuse_clean_validate_review() -> Series:
     """TMM English fused, cleaned, validated, and reviewed subtitles."""
     return Series.load(output_dir / "eng_ocr/fuse_clean_validate_review.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_eng_ocr_fuse_clean_validate_review_flatten() -> Series:
     """TMM English fused, cleaned, validated, reviewed, and flattened subtitles."""
     return Series.load(output_dir / "eng_ocr/fuse_clean_validate_review_flatten.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_eng_ocr_lens() -> Series:
     """TMM English subtitles OCRed using Google Lens."""
     return Series.load(output_dir / "eng_ocr/lens.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_eng_ocr_lens_clean() -> Series:
     """TMM English Google Lens OCR subtitles, cleaned."""
     return Series.load(output_dir / "eng_ocr/lens_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_eng_ocr_tesseract() -> Series:
     """TMM English subtitles OCRed using Tesseract."""
     return Series.load(output_dir / "eng_ocr/tesseract.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_eng_ocr_tesseract_clean() -> Series:
     """TMM English Tesseract OCR subtitles, cleaned."""
     return Series.load(output_dir / "eng_ocr/tesseract_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_yue_hans_eng() -> Series:
     """TMM bilingual 简体粤文 and English subtitles."""
     return Series.load(output_dir / "yue-Hans_eng.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_yue_hans_ocr_fuse() -> Series:
     """TMM 简体粤文 fused subtitles."""
     return Series.load(output_dir / "yue-Hans_ocr/fuse.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_yue_hans_ocr_fuse_clean() -> Series:
     """TMM 简体粤文 fused and cleaned subtitles."""
     return Series.load(output_dir / "yue-Hans_ocr/fuse_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_yue_hans_ocr_fuse_clean_validate() -> Series:
     """TMM 简体粤文 fused, cleaned, and validated subtitles."""
     return Series.load(output_dir / "yue-Hans_ocr/fuse_clean_validate.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_yue_hans_ocr_fuse_clean_validate_review() -> Series:
     """TMM 简体粤文 fused, cleaned, validated, and reviewed subtitles."""
     return Series.load(output_dir / "yue-Hans_ocr/fuse_clean_validate_review.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_yue_hans_ocr_fuse_clean_validate_review_flatten() -> Series:
     """TMM 简体粤文 fused, cleaned, validated, reviewed, and flattened subtitles."""
     return Series.load(
@@ -424,7 +424,7 @@ def tmm_yue_hans_ocr_fuse_clean_validate_review_flatten() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def tmm_yue_hans_ocr_fuse_clean_validate_review_flatten_romanize() -> Series:
     """TMM 简体粤文 fused/cleaned/validated/reviewed/flattened romanized subtitles."""
     return Series.load(
@@ -432,55 +432,55 @@ def tmm_yue_hans_ocr_fuse_clean_validate_review_flatten_romanize() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def tmm_yue_hans_ocr_lens() -> Series:
     """TMM 简体粤文 subtitles OCRed using Google Lens."""
     return Series.load(output_dir / "yue-Hans_ocr/lens.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_yue_hans_ocr_lens_clean() -> Series:
     """TMM 简体粤文 Google Lens OCR subtitles, cleaned."""
     return Series.load(output_dir / "yue-Hans_ocr/lens_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_yue_hans_ocr_paddle() -> Series:
     """TMM 简体粤文 subtitles OCRed using PaddleOCR."""
     return Series.load(output_dir / "yue-Hans_ocr/paddle.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_yue_hans_ocr_paddle_clean() -> Series:
     """TMM 简体粤文 PaddleOCR subtitles, cleaned."""
     return Series.load(output_dir / "yue-Hans_ocr/paddle_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_yue_hant_ocr_fuse() -> Series:
     """TMM 繁體粵文 fused subtitles."""
     return Series.load(output_dir / "yue-Hant_ocr/fuse.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_yue_hant_ocr_fuse_clean() -> Series:
     """TMM 繁體粵文 fused and cleaned subtitles."""
     return Series.load(output_dir / "yue-Hant_ocr/fuse_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_yue_hant_ocr_fuse_clean_validate() -> Series:
     """TMM 繁體粵文 fused, cleaned, and validated subtitles."""
     return Series.load(output_dir / "yue-Hant_ocr/fuse_clean_validate.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_yue_hant_ocr_fuse_clean_validate_review() -> Series:
     """TMM 繁體粵文 fused, cleaned, validated, and reviewed subtitles."""
     return Series.load(output_dir / "yue-Hant_ocr/fuse_clean_validate_review.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_yue_hant_ocr_fuse_clean_validate_review_flatten() -> Series:
     """TMM 繁體粵文 fused, cleaned, validated, reviewed, and flattened subtitles."""
     return Series.load(
@@ -488,7 +488,7 @@ def tmm_yue_hant_ocr_fuse_clean_validate_review_flatten() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def tmm_yue_hant_ocr_fuse_clean_validate_review_flatten_simplify() -> Series:
     """TMM 繁體粵文 simplified fused/cleaned/validated/reviewed/flattened subtitles."""
     return Series.load(
@@ -496,7 +496,7 @@ def tmm_yue_hant_ocr_fuse_clean_validate_review_flatten_simplify() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def tmm_yue_hant_ocr_fuse_clean_validate_review_flatten_simplify_review() -> Series:
     """TMM 繁體粵文 simplified/reviewed fused/cleaned subtitles."""
     return Series.load(
@@ -506,7 +506,7 @@ def tmm_yue_hant_ocr_fuse_clean_validate_review_flatten_simplify_review() -> Ser
     )
 
 
-@pytest.fixture
+@fixture
 def tmm_yue_hant_ocr_fuse_clean_validate_review_flatten_simplify_review_romanize() -> (
     Series
 ):
@@ -518,61 +518,61 @@ def tmm_yue_hant_ocr_fuse_clean_validate_review_flatten_simplify_review_romanize
     )
 
 
-@pytest.fixture
+@fixture
 def tmm_yue_hant_ocr_lens() -> Series:
     """TMM 繁體粵文 subtitles OCRed using Google Lens."""
     return Series.load(output_dir / "yue-Hant_ocr/lens.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_yue_hant_ocr_lens_clean() -> Series:
     """TMM 繁體粵文 Google Lens OCR subtitles, cleaned."""
     return Series.load(output_dir / "yue-Hant_ocr/lens_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_yue_hant_ocr_paddle() -> Series:
     """TMM 繁體粵文 subtitles OCRed using PaddleOCR."""
     return Series.load(output_dir / "yue-Hant_ocr/paddle.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_yue_hant_ocr_paddle_clean() -> Series:
     """TMM 繁體粵文 PaddleOCR subtitles, cleaned."""
     return Series.load(output_dir / "yue-Hant_ocr/paddle_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_zho_hans_eng() -> Series:
     """TMM bilingual 简体中文 and English subtitles."""
     return Series.load(output_dir / "zho-Hans_eng.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_zho_hans_ocr_fuse() -> Series:
     """TMM 简体中文 fused subtitles."""
     return Series.load(output_dir / "zho-Hans_ocr/fuse.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_zho_hans_ocr_fuse_clean() -> Series:
     """TMM 简体中文 fused and cleaned subtitles."""
     return Series.load(output_dir / "zho-Hans_ocr/fuse_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_zho_hans_ocr_fuse_clean_validate() -> Series:
     """TMM 简体中文 fused, cleaned, and validated subtitles."""
     return Series.load(output_dir / "zho-Hans_ocr/fuse_clean_validate.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_zho_hans_ocr_fuse_clean_validate_review() -> Series:
     """TMM 简体中文 fused, cleaned, validated, and reviewed subtitles."""
     return Series.load(output_dir / "zho-Hans_ocr/fuse_clean_validate_review.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_zho_hans_ocr_fuse_clean_validate_review_flatten() -> Series:
     """TMM 简体中文 fused, cleaned, validated, reviewed, and flattened subtitles."""
     return Series.load(
@@ -580,7 +580,7 @@ def tmm_zho_hans_ocr_fuse_clean_validate_review_flatten() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def tmm_zho_hans_ocr_fuse_clean_validate_review_flatten_romanize() -> Series:
     """TMM 简体中文 fused/cleaned/validated/reviewed/flattened romanized subtitles."""
     return Series.load(
@@ -588,55 +588,55 @@ def tmm_zho_hans_ocr_fuse_clean_validate_review_flatten_romanize() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def tmm_zho_hans_ocr_lens() -> Series:
     """TMM 简体中文 subtitles OCRed using Google Lens."""
     return Series.load(output_dir / "zho-Hans_ocr/lens.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_zho_hans_ocr_lens_clean() -> Series:
     """TMM 简体中文 Google Lens OCR subtitles, cleaned."""
     return Series.load(output_dir / "zho-Hans_ocr/lens_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_zho_hans_ocr_paddle() -> Series:
     """TMM 简体中文 subtitles OCRed using PaddleOCR."""
     return Series.load(output_dir / "zho-Hans_ocr/paddle.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_zho_hans_ocr_paddle_clean() -> Series:
     """TMM 简体中文 PaddleOCR subtitles, cleaned."""
     return Series.load(output_dir / "zho-Hans_ocr/paddle_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_zho_hant_ocr_fuse() -> Series:
     """TMM 繁体中文 fused subtitles."""
     return Series.load(output_dir / "zho-Hant_ocr/fuse.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_zho_hant_ocr_fuse_clean() -> Series:
     """TMM 繁体中文 fused and cleaned subtitles."""
     return Series.load(output_dir / "zho-Hant_ocr/fuse_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_zho_hant_ocr_fuse_clean_validate() -> Series:
     """TMM 繁体中文 fused, cleaned, and validated subtitles."""
     return Series.load(output_dir / "zho-Hant_ocr/fuse_clean_validate.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_zho_hant_ocr_fuse_clean_validate_review() -> Series:
     """TMM 繁体中文 fused, cleaned, validated, and reviewed subtitles."""
     return Series.load(output_dir / "zho-Hant_ocr/fuse_clean_validate_review.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_zho_hant_ocr_fuse_clean_validate_review_flatten() -> Series:
     """TMM 繁体中文 fused, cleaned, validated, reviewed, and flattened subtitles."""
     return Series.load(
@@ -644,7 +644,7 @@ def tmm_zho_hant_ocr_fuse_clean_validate_review_flatten() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def tmm_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify() -> Series:
     """TMM 繁体中文 simplified fused/cleaned/validated/reviewed/flattened subtitles."""
     return Series.load(
@@ -652,7 +652,7 @@ def tmm_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify() -> Series:
     )
 
 
-@pytest.fixture
+@fixture
 def tmm_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify_review() -> Series:
     """TMM 繁体中文 simplified/reviewed fused/cleaned subtitles."""
     return Series.load(
@@ -662,7 +662,7 @@ def tmm_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify_review() -> Ser
     )
 
 
-@pytest.fixture
+@fixture
 def tmm_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify_review_romanize() -> (
     Series
 ):
@@ -674,25 +674,26 @@ def tmm_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify_review_romanize
     )
 
 
-@pytest.fixture
+@fixture
 def tmm_zho_hant_ocr_lens() -> Series:
     """TMM 繁体中文 subtitles OCRed using Google Lens."""
     return Series.load(output_dir / "zho-Hant_ocr/lens.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_zho_hant_ocr_lens_clean() -> Series:
     """TMM 繁体中文 Google Lens OCR subtitles, cleaned."""
     return Series.load(output_dir / "zho-Hant_ocr/lens_clean.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_zho_hant_ocr_paddle() -> Series:
     """TMM 繁体中文 subtitles OCRed using PaddleOCR."""
     return Series.load(output_dir / "zho-Hant_ocr/paddle.srt")
 
 
-@pytest.fixture
+@fixture
 def tmm_zho_hant_ocr_paddle_clean() -> Series:
     """TMM 繁体中文 PaddleOCR subtitles, cleaned."""
     return Series.load(output_dir / "zho-Hant_ocr/paddle_clean.srt")
+

--- a/test/dictionaries/cuhk/test_cuhk_dictionary_service.py
+++ b/test/dictionaries/cuhk/test_cuhk_dictionary_service.py
@@ -8,7 +8,7 @@ from collections.abc import Generator
 from contextlib import AbstractContextManager, nullcontext
 from pathlib import Path
 
-import pytest
+from pytest import fixture, raises
 
 from scinoephile.common.file import get_temp_file_path
 from scinoephile.core.dictionaries import (
@@ -21,14 +21,14 @@ from scinoephile.dictionaries.cuhk import CuhkDictionaryService
 from test.helpers import parametrize
 
 
-@pytest.fixture
+@fixture
 def database_path() -> Generator[Path]:
     """Provide a temporary SQLite database path."""
     with get_temp_file_path(".db") as temp_path:
         yield temp_path
 
 
-@pytest.fixture
+@fixture
 def sample_entries() -> list[DictionaryEntry]:
     """Provide deterministic dictionary entries for CUHK service tests."""
     return [
@@ -70,7 +70,7 @@ def sample_entries() -> list[DictionaryEntry]:
     ]
 
 
-@pytest.fixture
+@fixture
 def sample_source() -> DictionarySource:
     """Provide deterministic dictionary source metadata."""
     return DictionarySource(
@@ -85,7 +85,7 @@ def sample_source() -> DictionarySource:
     )
 
 
-@pytest.fixture
+@fixture
 def service(
     database_path: Path,
     sample_entries: list[DictionaryEntry],
@@ -107,7 +107,7 @@ def service(
         (
             "gully",
             None,
-            pytest.raises(
+            raises(
                 ValueError,
                 match="Could not infer a supported lookup format",
             ),
@@ -124,3 +124,4 @@ def test_lookup(
     with expectation:
         entries = service.lookup(query, limit=5)
         assert [entry.traditional for entry in entries] == expected
+

--- a/test/dictionaries/gzzj/test_gzzj_dictionary_service.py
+++ b/test/dictionaries/gzzj/test_gzzj_dictionary_service.py
@@ -8,14 +8,14 @@ from collections.abc import Generator
 from contextlib import AbstractContextManager, nullcontext
 from pathlib import Path
 
-import pytest
+from pytest import fixture, raises
 
 from scinoephile.common.file import get_temp_file_path
 from scinoephile.dictionaries.gzzj import GzzjDictionaryService
 from test.helpers import parametrize
 
 
-@pytest.fixture
+@fixture
 def source_json_path() -> Generator[Path]:
     """Provide a minimal temporary GZZJ source JSON file."""
     with get_temp_file_path(".json") as temp_path:
@@ -35,14 +35,14 @@ def source_json_path() -> Generator[Path]:
         yield temp_path
 
 
-@pytest.fixture
+@fixture
 def database_path() -> Generator[Path]:
     """Provide a temporary SQLite database path."""
     with get_temp_file_path(".db") as temp_path:
         yield temp_path
 
 
-@pytest.fixture
+@fixture
 def service(database_path: Path, source_json_path: Path) -> GzzjDictionaryService:
     """Provide a GZZJ service backed by deterministic JSON fixture data."""
     service = GzzjDictionaryService(
@@ -63,7 +63,7 @@ def service(database_path: Path, source_json_path: Path) -> GzzjDictionaryServic
         (
             "gully",
             None,
-            pytest.raises(
+            raises(
                 ValueError,
                 match="Could not infer a supported lookup format",
             ),
@@ -89,3 +89,4 @@ def test_build_normalizes_list_valued_headwords(service: GzzjDictionaryService):
     assert [entry.traditional for entry in entries] == ["仇", "仇"]
     assert [entry.simplified for entry in entries] == ["仇", "仇"]
     assert [entry.pinyin for entry in entries] == ["chou2", "chou2"]
+

--- a/test/dictionaries/kaifangcidian/test_kaifangcidian_dictionary_service.py
+++ b/test/dictionaries/kaifangcidian/test_kaifangcidian_dictionary_service.py
@@ -8,27 +8,27 @@ import csv
 from collections.abc import Generator
 from pathlib import Path
 
-import pytest
+from pytest import fixture, MonkeyPatch
 
 from scinoephile.common.file import get_temp_directory_path, get_temp_file_path
 from scinoephile.dictionaries.kaifangcidian import KaifangcidianDictionaryService
 
 
-@pytest.fixture
+@fixture
 def local_data_dir_path() -> Generator[Path]:
     """Provide a temporary canonical local data directory."""
     with get_temp_directory_path() as dir_path:
         yield dir_path
 
 
-@pytest.fixture
+@fixture
 def runtime_data_dir_path() -> Generator[Path]:
     """Provide a temporary runtime canonical data directory."""
     with get_temp_directory_path() as dir_path:
         yield dir_path
 
 
-@pytest.fixture
+@fixture
 def database_path() -> Generator[Path]:
     """Provide a temporary SQLite database path."""
     with get_temp_file_path(".db") as temp_path:
@@ -113,7 +113,7 @@ def test_build_downloads_when_local_csv_missing(
     database_path: Path,
     local_data_dir_path: Path,
     runtime_data_dir_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Build Kaifangcidian DB by downloading when local CSV is missing.
 
@@ -176,3 +176,4 @@ def test_build_updates_local_data_from_existing_runtime_csv(
     assert local_csv_path.read_text(encoding="utf-8") == runtime_csv_path.read_text(
         encoding="utf-8"
     )
+

--- a/test/dictionaries/kaifangcidian/test_kaifangcidian_downloader.py
+++ b/test/dictionaries/kaifangcidian/test_kaifangcidian_downloader.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-import pytest
+from pytest import MonkeyPatch
 import requests
 
 from scinoephile.dictionaries.kaifangcidian.downloader import KaifangcidianDownloader
@@ -26,7 +26,7 @@ class _MockResponse:
 
 
 def test_download_payloads_only_fetch_required_sources(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Download only the payloads currently used for canonical rows.
 
@@ -70,3 +70,4 @@ def test_parse_js_vars_supports_optional_semicolon():
         "ci": "ci payload",
         "jpzi": "jp payload",
     }
+

--- a/test/dictionaries/test_dictionary_tools.py
+++ b/test/dictionaries/test_dictionary_tools.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any, ClassVar, cast
 from unittest.mock import patch
 
-import pytest
+from pytest import fixture
 
 from scinoephile.common.file import get_temp_directory_path
 from scinoephile.core.dictionaries import (
@@ -57,7 +57,7 @@ class StubDictionaryToolPrompt(DictionaryToolPrompt):
     """Description of the dictionary lookup query parameter."""
 
 
-@pytest.fixture
+@fixture
 def dictionary_cache_dir_path() -> Generator[Path]:
     """Provide deterministic CUHK and GZZJ cache databases."""
     with get_temp_directory_path() as temp_dir_path:
@@ -253,3 +253,4 @@ def test_processors_use_prompt_dictionary_tooling(
         prompt_cls.dictionary_tool_name
     ]
     assert processor.queryer.tool_box.handler_names == [prompt_cls.dictionary_tool_name]
+

--- a/test/dictionaries/unihan/test_unihan_dictionary_service.py
+++ b/test/dictionaries/unihan/test_unihan_dictionary_service.py
@@ -8,28 +8,28 @@ from collections.abc import Generator
 from pathlib import Path
 from types import TracebackType
 
-import pytest
+from pytest import fixture, MonkeyPatch, raises
 import requests
 
 from scinoephile.common.file import get_temp_directory_path, get_temp_file_path
 from scinoephile.dictionaries.unihan import UnihanDictionaryService
 
 
-@pytest.fixture
+@fixture
 def local_data_dir_path() -> Generator[Path]:
     """Provide a temporary canonical local data directory."""
     with get_temp_directory_path() as dir_path:
         yield dir_path
 
 
-@pytest.fixture
+@fixture
 def runtime_data_dir_path() -> Generator[Path]:
     """Provide a temporary runtime canonical data directory."""
     with get_temp_directory_path() as dir_path:
         yield dir_path
 
 
-@pytest.fixture
+@fixture
 def database_path() -> Generator[Path]:
     """Provide a temporary SQLite database path."""
     with get_temp_file_path(".db") as temp_path:
@@ -93,7 +93,7 @@ def test_build_downloads_when_local_sources_missing(
     database_path: Path,
     local_data_dir_path: Path,
     runtime_data_dir_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Build Unihan DB by downloading when local source files are missing.
 
@@ -170,7 +170,7 @@ def test_build_updates_local_data_from_existing_runtime_files(
 
 def test_download_and_extract_raises_file_not_found_for_missing_archive_member(
     runtime_data_dir_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Raise FileNotFoundError when Unihan.zip is missing a required source file.
 
@@ -269,5 +269,6 @@ def test_download_and_extract_raises_file_not_found_for_missing_archive_member(
 
     service = UnihanDictionaryService(runtime_data_dir_path=runtime_data_dir_path)
 
-    with pytest.raises(FileNotFoundError, match="Unihan_Readings.txt"):
+    with raises(FileNotFoundError, match="Unihan_Readings.txt"):
         service._download_and_extract_to_runtime()
+

--- a/test/dictionaries/unihan/test_unihan_parser.py
+++ b/test/dictionaries/unihan/test_unihan_parser.py
@@ -7,13 +7,13 @@ from __future__ import annotations
 from collections.abc import Generator
 from pathlib import Path
 
-import pytest
+from pytest import fixture
 
 from scinoephile.common.file import get_temp_directory_path
 from scinoephile.dictionaries.unihan.parser import UnihanDictionaryParser
 
 
-@pytest.fixture
+@fixture
 def source_dir_path() -> Generator[Path]:
     """Provide a temporary directory for Unihan source fixtures."""
     with get_temp_directory_path() as dir_path:
@@ -136,3 +136,4 @@ def test_parse_readings_preserves_simplified_only_source_rows(source_dir_path: P
     assert entry.pinyin == "wan"
     assert entry.jyutping == "maan6"
     assert [definition.text for definition in entry.definitions] == ["ten thousand"]
+

--- a/test/dictionaries/wiktionary/test_wiktionary_dictionary_service.py
+++ b/test/dictionaries/wiktionary/test_wiktionary_dictionary_service.py
@@ -8,28 +8,28 @@ import json
 from collections.abc import Generator
 from pathlib import Path
 
-import pytest
+from pytest import fixture, MonkeyPatch, raises
 import requests
 
 from scinoephile.common.file import get_temp_directory_path, get_temp_file_path
 from scinoephile.dictionaries.wiktionary import WiktionaryDictionaryService
 
 
-@pytest.fixture
+@fixture
 def local_data_dir_path() -> Generator[Path]:
     """Provide a temporary canonical local data directory."""
     with get_temp_directory_path() as dir_path:
         yield dir_path
 
 
-@pytest.fixture
+@fixture
 def runtime_data_dir_path() -> Generator[Path]:
     """Provide a temporary runtime canonical data directory."""
     with get_temp_directory_path() as dir_path:
         yield dir_path
 
 
-@pytest.fixture
+@fixture
 def database_path() -> Generator[Path]:
     """Provide a temporary SQLite database path."""
     with get_temp_file_path(".db") as temp_path:
@@ -194,7 +194,7 @@ def test_build_downloads_when_no_source_jsonl_available(
     database_path: Path,
     local_data_dir_path: Path,
     runtime_data_dir_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Build Wiktionary DB by downloading when no source JSONL is available.
 
@@ -275,7 +275,7 @@ def test_build_raises_on_download_error(
     database_path: Path,
     local_data_dir_path: Path,
     runtime_data_dir_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Raise RequestException when Kaikki download fails.
 
@@ -303,5 +303,6 @@ def test_build_raises_on_download_error(
         service, "_download_to_runtime_jsonl", _download_to_runtime_jsonl
     )
 
-    with pytest.raises(requests.RequestException, match="network down"):
+    with raises(requests.RequestException, match="network down"):
         service.build(overwrite=True)
+

--- a/test/dictionaries/wiktionary/test_wiktionary_parser.py
+++ b/test/dictionaries/wiktionary/test_wiktionary_parser.py
@@ -8,13 +8,13 @@ import json
 from collections.abc import Generator
 from pathlib import Path
 
-import pytest
+from pytest import fixture
 
 from scinoephile.common.file import get_temp_file_path
 from scinoephile.dictionaries.wiktionary.parser import WiktionaryDictionaryParser
 
 
-@pytest.fixture
+@fixture
 def source_jsonl_path() -> Generator[Path]:
     """Provide a temporary Kaikki JSONL source path."""
     with get_temp_file_path(".jsonl") as temp_path:
@@ -179,3 +179,4 @@ def test_parse_accepts_legacy_hyphenated_pronunciation_key(source_jsonl_path: Pa
     assert len(entries) == 1
     assert entries[0].pinyin == "hang2"
     assert entries[0].jyutping == "hang4"
+

--- a/test/helpers/__init__.py
+++ b/test/helpers/__init__.py
@@ -12,8 +12,7 @@ from os import getenv
 from pathlib import Path
 from typing import Any
 
-import pytest
-from pytest import fixture, mark
+from pytest import fixture, mark, raises, skip
 
 from scinoephile.common import CommandLineInterface, package_root
 from scinoephile.common.testing import run_cli_with_args
@@ -53,7 +52,7 @@ def assert_cli_help(cli: tuple[type[CommandLineInterface], ...]):
     subcommands = build_subcommands(cli)
     stdout = StringIO()
     stderr = StringIO()
-    with pytest.raises(SystemExit) as excinfo:
+    with raises(SystemExit) as excinfo:
         with redirect_stdout(stdout):
             with redirect_stderr(stderr):
                 run_cli_with_args(cli[0], f"{subcommands} -h".strip())
@@ -71,7 +70,7 @@ def assert_cli_usage(cli: tuple[type[CommandLineInterface], ...]):
     subcommands = build_subcommands(cli)
     stdout = StringIO()
     stderr = StringIO()
-    with pytest.raises(SystemExit) as excinfo:
+    with raises(SystemExit) as excinfo:
         with redirect_stdout(stdout):
             with redirect_stderr(stderr):
                 run_cli_with_args(cli[0], subcommands)
@@ -133,7 +132,7 @@ def create_symlink_or_skip(
         symlink_path.symlink_to(target_path, target_is_directory=target_is_directory)
     except OSError as exc:
         if getattr(exc, "winerror", None) == 1314:
-            pytest.skip("Windows symlink privilege is not available")
+            skip("Windows symlink privilege is not available")
         raise
 
 
@@ -208,3 +207,4 @@ def skip_if_codex() -> Any:
         bool(getenv("CODEX_ENV_PYTHON_VERSION")),
         reason="Skip when running in Codex environment",
     )
+

--- a/test/helpers/ocr_validation.py
+++ b/test/helpers/ocr_validation.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
+from pytest import MonkeyPatch
 from PIL import Image
 
 from scinoephile.image.bbox import Bbox
@@ -102,7 +102,7 @@ def make_two_image_ocr_html_dir(
 
 
 def patch_ocr_validation_bboxes(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     bboxes: list[Bbox],
     *,
     target: str = "scinoephile.web.ocr_validation.session.get_bboxes",
@@ -189,3 +189,4 @@ def _write_html_index(
         ),
         encoding="utf-8",
     )
+

--- a/test/helpers/test_series_assertions.py
+++ b/test/helpers/test_series_assertions.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import cast
 
-import pytest
+from pytest import raises
 from pysubs2 import SSAFile
 
 from scinoephile.core.subtitles import Series, Subtitle
@@ -36,7 +36,7 @@ def test_assert_series_equal_reports_mismatching_subtitle():
         ]
     )
 
-    with pytest.raises(AssertionError) as excinfo:
+    with raises(AssertionError) as excinfo:
         assert_series_equal(actual, expected)
 
     message = str(excinfo.value)
@@ -50,7 +50,7 @@ def test_assert_series_equal_rejects_non_series_actual():
     actual = [Subtitle(start=1000, end=2000, text="same")]
     expected = Series(events=[Subtitle(start=1000, end=2000, text="same")])
 
-    with pytest.raises(AssertionError) as excinfo:
+    with raises(AssertionError) as excinfo:
         assert_series_equal(cast(SSAFile, actual), expected)
 
     assert str(excinfo.value) == "actual is not a subtitle series: list"
@@ -61,7 +61,8 @@ def test_assert_series_equal_rejects_non_series_expected():
     actual = Series(events=[Subtitle(start=1000, end=2000, text="same")])
     expected = [Subtitle(start=1000, end=2000, text="same")]
 
-    with pytest.raises(AssertionError) as excinfo:
+    with raises(AssertionError) as excinfo:
         assert_series_equal(actual, cast(SSAFile, expected))
 
     assert str(excinfo.value) == "expected is not a subtitle series: list"
+

--- a/test/image/ocr/lens/test_lens_recognizer.py
+++ b/test/image/ocr/lens/test_lens_recognizer.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from typing import Any, cast
 
-import pytest
+from pytest import MonkeyPatch, raises
 from PIL import Image
 
 from scinoephile.common.subprocess import run_command
@@ -70,7 +70,7 @@ class CountingLensRecognizer(LensRecognizer):
         return {"ocr_text": "\n".join(self.results[result_index])}
 
 
-def patch_google_lens_sleep(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+def patch_google_lens_sleep(monkeypatch: MonkeyPatch) -> list[float]:
     """Patch Google Lens retry sleeps and capture their delays.
 
     Arguments:
@@ -152,7 +152,7 @@ def test_normalize_lens_result_supports_object_results():
 
 def test_lens_recognizer_rejects_unsupported_languages():
     """Test Google Lens recognizer only supports English and Chinese."""
-    with pytest.raises(ValueError, match="not supported by Google Lens OCR"):
+    with raises(ValueError, match="not supported by Google Lens OCR"):
         LensRecognizer(language=cast(Language, "korean"))
 
 
@@ -167,7 +167,7 @@ def test_lens_recognizer_rejects_unsupported_languages():
     ],
 )
 def test_lens_recognizer_maps_supported_languages_to_engine_codes(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     language: Language,
     expected_code: str,
 ):
@@ -228,7 +228,7 @@ def test_lens_recognizer_formats_cached_results(tmp_path: Path):
 
 
 def test_lens_recognizer_does_not_cache_request_errors(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     tmp_path: Path,
 ):
     """Test transient Google Lens request errors are not cached as empty OCR.
@@ -244,7 +244,7 @@ def test_lens_recognizer_does_not_cache_request_errors(
     )
     image = Image.new("RGBA", (10, 8), (255, 255, 255, 0))
 
-    with pytest.raises(RuntimeError, match="Google Lens request error"):
+    with raises(RuntimeError, match="Google Lens request error"):
         recognizer.recognize_image(image)
 
     assert recognizer.predict_count == 3
@@ -252,7 +252,7 @@ def test_lens_recognizer_does_not_cache_request_errors(
 
 
 def test_lens_recognizer_retries_request_errors_before_caching(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     tmp_path: Path,
 ):
     """Test Google Lens retries transient request errors before caching success.
@@ -280,7 +280,7 @@ def test_lens_recognizer_retries_request_errors_before_caching(
 
 
 def test_lens_recognizer_raises_last_request_error_after_retries(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     tmp_path: Path,
 ):
     """Test Google Lens raises the last request error after retry exhaustion.
@@ -301,7 +301,7 @@ def test_lens_recognizer_raises_last_request_error_after_retries(
     recognizer.retries = 3
     image = Image.new("RGBA", (10, 8), (255, 255, 255, 0))
 
-    with pytest.raises(RuntimeError, match="attempt 3"):
+    with raises(RuntimeError, match="attempt 3"):
         recognizer.recognize_image(image)
 
     assert recognizer.predict_count == 3
@@ -309,7 +309,7 @@ def test_lens_recognizer_raises_last_request_error_after_retries(
 
 
 def test_lens_recognizer_retries_in_one_asyncio_run(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test Google Lens retries within one asyncio.run call.
 
@@ -353,7 +353,7 @@ def test_lens_recognizer_retries_in_one_asyncio_run(
 
 
 def test_lens_recognizer_waits_between_transient_retries(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test Google Lens waits before retrying transient failures.
 
@@ -376,7 +376,7 @@ def test_lens_recognizer_waits_between_transient_retries(
 
 
 def test_lens_recognizer_retries_lens_api_errors(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test Google Lens retries transient chrome-lens-py API errors.
 
@@ -406,7 +406,7 @@ def test_lens_recognizer_does_not_retry_nontransient_errors():
     )
     image = Image.new("RGBA", (10, 8), (255, 255, 255, 0))
 
-    with pytest.raises(ValueError, match="deterministic failure"):
+    with raises(ValueError, match="deterministic failure"):
         recognizer.recognize_image(image)
 
     assert recognizer.predict_count == 1
@@ -424,14 +424,14 @@ def test_lens_recognizer_rejects_uncached_calls_in_async_loop(
 
     async def recognize() -> None:
         """Run synchronous recognition from an async context."""
-        with pytest.raises(RuntimeError, match="cannot run uncached Google Lens OCR"):
+        with raises(RuntimeError, match="cannot run uncached Google Lens OCR"):
             recognizer.recognize_image(Image.new("RGBA", (10, 8), (255, 255, 255, 0)))
 
     asyncio.run(recognize())
 
 
 def test_lens_recognizer_import_error_is_actionable(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test missing chrome-lens-py dependency produces an actionable error.
 
@@ -466,7 +466,7 @@ def test_lens_recognizer_import_error_is_actionable(
 
     monkeypatch.setattr("builtins.__import__", fake_import)
 
-    with pytest.raises(ImportError, match="'ocr' extra"):
+    with raises(ImportError, match="'ocr' extra"):
         LensRecognizer._get_lens_api_class()
 
 
@@ -488,7 +488,7 @@ def test_lens_recognizer_imports_chrome_lens_py_only_when_needed():
 
 
 def test_lens_recognizer_reuses_lens_api_client_per_instance(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test each Google Lens recognizer reuses one LensAPI client.
 
@@ -528,3 +528,4 @@ def test_lens_recognizer_reuses_lens_api_client_per_instance(
     assert recognizer.recognize_image(Image.new("RGBA", (12, 9))) == "recognized"
 
     assert init_count == 1
+

--- a/test/image/ocr/lens/test_lens_series.py
+++ b/test/image/ocr/lens/test_lens_series.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
+from pytest import LogCaptureFixture, MonkeyPatch, raises
 from PIL import Image
 
 from scinoephile.core import Language, ScinoephileError
@@ -17,7 +17,7 @@ from test.helpers.ocr_recognizers import FailingOcrRecognizer, RecordingOcrRecog
 
 
 def test_ocr_image_series_with_lens_preserves_timings_and_sets_text(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test Google Lens image series processing preserves timings and text.
 
@@ -55,8 +55,8 @@ def test_ocr_image_series_with_lens_preserves_timings_and_sets_text(
 
 
 def test_ocr_image_series_with_lens_logs_progress(
-    caplog: pytest.LogCaptureFixture,
-    monkeypatch: pytest.MonkeyPatch,
+    caplog: LogCaptureFixture,
+    monkeypatch: MonkeyPatch,
 ):
     """Test Google Lens image series processing logs OCR progress.
 
@@ -98,7 +98,7 @@ def test_ocr_image_series_with_lens_logs_progress(
 
 
 def test_ocr_image_series_with_lens_uses_runtime_cache(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     tmp_path: Path,
 ):
     """Test Google Lens image series processing uses runtime cache by default.
@@ -152,7 +152,7 @@ def test_ocr_image_series_with_lens_uses_runtime_cache(
     ],
 )
 def test_ocr_image_series_with_lens_wraps_processing_errors(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     exception: Exception,
 ):
     """Test Lens image series processing wraps implementation errors.
@@ -176,10 +176,11 @@ def test_ocr_image_series_with_lens_wraps_processing_errors(
         ]
     )
 
-    with pytest.raises(
+    with raises(
         ScinoephileError,
         match="Unable to OCR image series with Google Lens",
     ) as excinfo:
         ocr_image_series_with_lens(image_series)
 
     assert excinfo.value.__cause__ is exception
+

--- a/test/image/ocr/paddle/test_paddle_recognizer.py
+++ b/test/image/ocr/paddle/test_paddle_recognizer.py
@@ -12,7 +12,7 @@ from types import ModuleType
 from typing import Any, cast
 
 import numpy as np
-import pytest
+from pytest import MonkeyPatch, raises
 from PIL import Image
 
 from scinoephile.common.subprocess import run_command
@@ -70,7 +70,7 @@ def test_paddle_recognizer_caches_results_by_image(tmp_path: Path):
 
 
 def test_paddle_recognizer_uses_server_models_and_disables_mkldnn_on_windows(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test PaddleOCR recognizer hardcodes server models and Windows MKL-DNN.
 
@@ -107,7 +107,7 @@ def test_paddle_recognizer_uses_server_models_and_disables_mkldnn_on_windows(
 
 
 def test_paddle_recognizer_keeps_mkldnn_enabled_off_windows(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test PaddleOCR recognizer keeps MKL-DNN enabled off Windows.
 
@@ -141,7 +141,7 @@ def test_paddle_recognizer_keeps_mkldnn_enabled_off_windows(
 
 
 def test_paddle_recognizer_preserves_root_logger_level(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test PaddleOCR construction does not change root logging level.
 
@@ -196,7 +196,7 @@ def test_paddle_recognizer_imports_paddleocr_only_when_needed():
     assert exitcode == 0
 
 
-def test_paddle_ocr_class_requires_ocr_extra(monkeypatch: pytest.MonkeyPatch):
+def test_paddle_ocr_class_requires_ocr_extra(monkeypatch: MonkeyPatch):
     """Test PaddleOCR import errors mention the OCR extra."""
     real_import = __import__
 
@@ -226,13 +226,13 @@ def test_paddle_ocr_class_requires_ocr_extra(monkeypatch: pytest.MonkeyPatch):
 
     monkeypatch.setattr("builtins.__import__", fake_import)
 
-    with pytest.raises(ImportError, match="'ocr' extra"):
+    with raises(ImportError, match="'ocr' extra"):
         PaddleRecognizer._get_paddle_ocr_class()
 
 
 def test_paddle_recognizer_rejects_unsupported_languages():
     """Test PaddleOCR recognizer only supports English and Chinese."""
-    with pytest.raises(ValueError, match="not supported by PaddleOCR"):
+    with raises(ValueError, match="not supported by PaddleOCR"):
         PaddleRecognizer(language=cast(Language, "korean"))
 
 
@@ -247,7 +247,7 @@ def test_paddle_recognizer_rejects_unsupported_languages():
     ],
 )
 def test_paddle_recognizer_maps_supported_languages_to_engine_codes(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     language: Language,
     expected_code: str,
 ):
@@ -342,3 +342,4 @@ def _result(text: str, left: float, top: float) -> PaddleOcrTextResult:
             bottom_left=(left, top + 20),
         ),
     )
+

--- a/test/image/ocr/paddle/test_paddle_series.py
+++ b/test/image/ocr/paddle/test_paddle_series.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
+from pytest import LogCaptureFixture, MonkeyPatch, raises
 from PIL import Image
 
 from scinoephile.core import Language, ScinoephileError
@@ -17,7 +17,7 @@ from test.helpers.ocr_recognizers import FailingOcrRecognizer, RecordingOcrRecog
 
 
 def test_ocr_image_series_with_paddle_preserves_timings_and_sets_text(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test PaddleOCR image series processing preserves timings and writes text.
 
@@ -55,8 +55,8 @@ def test_ocr_image_series_with_paddle_preserves_timings_and_sets_text(
 
 
 def test_ocr_image_series_with_paddle_logs_progress(
-    caplog: pytest.LogCaptureFixture,
-    monkeypatch: pytest.MonkeyPatch,
+    caplog: LogCaptureFixture,
+    monkeypatch: MonkeyPatch,
 ):
     """Test PaddleOCR image series processing logs OCR progress.
 
@@ -98,7 +98,7 @@ def test_ocr_image_series_with_paddle_logs_progress(
 
 
 def test_ocr_image_series_with_paddle_uses_runtime_cache(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     tmp_path: Path,
 ):
     """Test PaddleOCR image series processing uses the runtime cache by default.
@@ -151,7 +151,7 @@ def test_ocr_image_series_with_paddle_uses_runtime_cache(
     ],
 )
 def test_ocr_image_series_with_paddle_wraps_processing_errors(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     exception: Exception,
 ):
     """Test PaddleOCR image series processing wraps implementation errors.
@@ -175,10 +175,11 @@ def test_ocr_image_series_with_paddle_wraps_processing_errors(
         ]
     )
 
-    with pytest.raises(
+    with raises(
         ScinoephileError,
         match="Unable to OCR image series with PaddleOCR",
     ) as excinfo:
         ocr_image_series_with_paddle(image_series)
 
     assert excinfo.value.__cause__ is exception
+

--- a/test/image/ocr/tesseract/test_tesseract_recognizer.py
+++ b/test/image/ocr/tesseract/test_tesseract_recognizer.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
+from pytest import MonkeyPatch, raises
 import requests
 from PIL import Image
 
@@ -286,7 +286,7 @@ def test_tesseract_detect_italics_runs_legacy_hocr_pass(tmp_path: Path):
 
 def test_tesseract_detect_italics_rejects_non_english_language():
     """Test italic detection is only supported for English Tesseract OCR."""
-    with pytest.raises(ValueError, match="only supported with language eng"):
+    with raises(ValueError, match="only supported with language eng"):
         TesseractRecognizer(
             executable_path=Path("tesseract"),
             detect_italics=True,
@@ -296,7 +296,7 @@ def test_tesseract_detect_italics_rejects_non_english_language():
 
 
 def test_tesseract_detect_italics_downloads_missing_legacy_tessdata(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     tmp_path: Path,
 ):
     """Test italic detection downloads missing legacy traineddata lazily.
@@ -367,7 +367,7 @@ def test_tesseract_detect_italics_downloads_missing_legacy_tessdata(
 
 
 def test_tesseract_detect_italics_reuses_existing_legacy_tessdata(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     tmp_path: Path,
 ):
     """Test italic detection reuses cached legacy traineddata.
@@ -552,7 +552,7 @@ def test_tesseract_detect_italics_raises_clear_legacy_error(tmp_path: Path):
         skip_executable_validation=True,
     )
 
-    with pytest.raises(ScinoephileError, match="legacy Tesseract data"):
+    with raises(ScinoephileError, match="legacy Tesseract data"):
         recognizer.recognize_image(Image.new("RGBA", (2, 2)))
 
     assert list(tmp_path.glob("*.json")) == []
@@ -586,7 +586,8 @@ def test_tesseract_raises_and_does_not_cache_when_output_is_missing(
         skip_executable_validation=True,
     )
 
-    with pytest.raises(ValueError, match="did not produce hOCR output"):
+    with raises(ValueError, match="did not produce hOCR output"):
         recognizer.recognize_image(Image.new("RGBA", (2, 2)))
 
     assert list(tmp_path.glob("*.json")) == []
+

--- a/test/image/ocr/tesseract/test_tesseract_series.py
+++ b/test/image/ocr/tesseract/test_tesseract_series.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
+from pytest import LogCaptureFixture, MonkeyPatch, raises
 from PIL import Image
 
 from scinoephile.core import Language, ScinoephileError
@@ -19,7 +19,7 @@ from test.helpers.ocr_recognizers import FailingOcrRecognizer, RecordingOcrRecog
 
 
 def test_ocr_image_series_with_tesseract_preserves_timings_and_sets_text(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test Tesseract image series processing preserves timings and text.
 
@@ -57,8 +57,8 @@ def test_ocr_image_series_with_tesseract_preserves_timings_and_sets_text(
 
 
 def test_ocr_image_series_with_tesseract_logs_progress(
-    caplog: pytest.LogCaptureFixture,
-    monkeypatch: pytest.MonkeyPatch,
+    caplog: LogCaptureFixture,
+    monkeypatch: MonkeyPatch,
 ):
     """Test Tesseract image series processing logs OCR progress.
 
@@ -100,7 +100,7 @@ def test_ocr_image_series_with_tesseract_logs_progress(
 
 
 def test_ocr_image_series_with_tesseract_uses_runtime_cache(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     tmp_path: Path,
 ):
     """Test Tesseract image series processing uses runtime cache by default.
@@ -170,7 +170,7 @@ def test_ocr_image_series_with_tesseract_uses_runtime_cache(
     ],
 )
 def test_ocr_image_series_with_tesseract_wraps_processing_errors(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     exception: Exception,
 ):
     """Test Tesseract image series processing wraps implementation errors.
@@ -194,10 +194,11 @@ def test_ocr_image_series_with_tesseract_wraps_processing_errors(
         ]
     )
 
-    with pytest.raises(
+    with raises(
         ScinoephileError,
         match="Unable to OCR image series with Tesseract",
     ) as excinfo:
         ocr_image_series_with_tesseract(image_series)
 
     assert excinfo.value.__cause__ is exception
+

--- a/test/image/ocr/validation/test_char_pair_gaps.py
+++ b/test/image/ocr/validation/test_char_pair_gaps.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import csv
 from pathlib import Path
 
-import pytest
+from pytest import raises
 
 from scinoephile.image.ocr.validation.char_pair_gaps import (
     get_default_char_pair_cutoffs,
@@ -25,7 +25,7 @@ def test_load_char_pair_gaps_rejects_nonmonotonic_cutoffs(tmp_path: Path):
     file_path = tmp_path / "char_pair_gaps.csv"
     file_path.write_text("⋯,〝,46,24,90,200\n", encoding="utf-8")
 
-    with pytest.raises(ValueError, match="cutoffs must be monotonic"):
+    with raises(ValueError, match="cutoffs must be monotonic"):
         load_char_pair_gaps(file_path)
 
 
@@ -88,7 +88,8 @@ def test_save_char_pair_gaps_rejects_nonmonotonic_cutoffs(tmp_path: Path):
     """
     file_path = tmp_path / "char_pair_gaps.csv"
 
-    with pytest.raises(ValueError, match="cutoffs must be monotonic"):
+    with raises(ValueError, match="cutoffs must be monotonic"):
         save_char_pair_gaps({("⋯", "〝"): (46, 24, 90, 200)}, file_path)
 
     assert not file_path.exists()
+

--- a/test/image/ocr/validation/test_data_storage.py
+++ b/test/image/ocr/validation/test_data_storage.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-import pytest
+from pytest import raises
 
 from scinoephile.core import ScinoephileError
 from scinoephile.image.ocr.validation import ValidationManager, validation_manager
@@ -261,7 +261,7 @@ def test_validation_manager_wraps_cache_path_errors(tmp_path):
     cache_dir_path = tmp_path / "cache-file"
     cache_dir_path.write_text("not a directory", encoding="utf-8")
 
-    with pytest.raises(
+    with raises(
         ScinoephileError,
         match="Unable to initialize OCR validation data",
     ) as excinfo:
@@ -286,3 +286,4 @@ def test_validation_manager_writes_updates_to_repo_in_dev_mode(tmp_path, monkeyp
         "A,10,20\n"
     )
     assert not (cache_dir_path / "char_dims_1.csv").exists()
+

--- a/test/image/ocr/validation/test_validation_manager.py
+++ b/test/image/ocr/validation/test_validation_manager.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-import pytest
+from pytest import LogCaptureFixture, MonkeyPatch
 from PIL import Image
 
 from scinoephile.image.bbox import Bbox
@@ -17,8 +17,8 @@ from scinoephile.image.subtitles import ImageSeries, ImageSubtitle
 
 def test_validate_confident_space_gap_updates_text(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
+    monkeypatch: MonkeyPatch,
+    caplog: LogCaptureFixture,
 ):
     """Test confident space gap mismatches are corrected without warning."""
     monkeypatch.setattr(
@@ -37,8 +37,8 @@ def test_validate_confident_space_gap_updates_text(
 
 def test_validate_confident_adjacent_gap_updates_text(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
+    monkeypatch: MonkeyPatch,
+    caplog: LogCaptureFixture,
 ):
     """Test confident adjacent gap mismatches are corrected without warning."""
     monkeypatch.setattr(
@@ -57,8 +57,8 @@ def test_validate_confident_adjacent_gap_updates_text(
 
 def test_validate_confident_tab_gap_updates_newline_to_tab(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
+    monkeypatch: MonkeyPatch,
+    caplog: LogCaptureFixture,
 ):
     """Test confident tab gap replaces an OCR newline without warning."""
     monkeypatch.setattr(
@@ -77,8 +77,8 @@ def test_validate_confident_tab_gap_updates_newline_to_tab(
 
 def test_validate_ambiguous_gap_warns_without_updating_text(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
+    monkeypatch: MonkeyPatch,
+    caplog: LogCaptureFixture,
 ):
     """Test ambiguous gaps warn and leave the subtitle text unchanged."""
     monkeypatch.setattr(
@@ -135,7 +135,7 @@ def _series(text: str) -> ImageSeries:
     )
 
 
-def _warning_messages(caplog: pytest.LogCaptureFixture) -> list[str]:
+def _warning_messages(caplog: LogCaptureFixture) -> list[str]:
     """Get warning messages from a log capture fixture.
 
     Arguments:
@@ -148,3 +148,4 @@ def _warning_messages(caplog: pytest.LogCaptureFixture) -> list[str]:
         for record in caplog.records
         if record.levelno == logging.WARNING
     ]
+

--- a/test/image/subtitles/test_image_series.py
+++ b/test/image/subtitles/test_image_series.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
+from pytest import FixtureRequest, param, raises
 from PIL import Image
 
 from scinoephile.common.file import get_temp_directory_path
@@ -20,7 +20,7 @@ from test.helpers import parametrize
 @parametrize(
     "input_path_fixture, expected_event_count, expected_first_size",
     [
-        pytest.param(
+        param(
             "mlamd_eng_ocr_sup_path",
             942,
             (953, 63),
@@ -32,7 +32,7 @@ def test_load_sup(
     input_path_fixture: str,
     expected_event_count: int,
     expected_first_size: tuple[int, int],
-    request: pytest.FixtureRequest,
+    request: FixtureRequest,
 ):
     """Test loading SUP image subtitles.
 
@@ -58,7 +58,7 @@ def test_load_sup(
 @parametrize(
     "input_path_fixture, expected_event_count, expected_first_size",
     [
-        pytest.param(
+        param(
             "mlamd_eng_image_path",
             942,
             (953, 63),
@@ -70,7 +70,7 @@ def test_load_html(
     input_path_fixture: str,
     expected_event_count: int,
     expected_first_size: tuple[int, int],
-    request: pytest.FixtureRequest,
+    request: FixtureRequest,
 ):
     """Test loading HTML image subtitles.
 
@@ -101,7 +101,7 @@ def test_load_rejects_unsupported_input_file(tmp_path: Path):
     input_path = tmp_path / "subtitles.txt"
     input_path.write_text("not image subtitles", encoding="utf-8")
 
-    with pytest.raises(ScinoephileError, match="directory containing one index.html"):
+    with raises(ScinoephileError, match="directory containing one index.html"):
         ImageSeries.load(input_path)
 
 
@@ -113,7 +113,7 @@ def test_image_series_load_wraps_input_path_errors(tmp_path: Path):
     """
     input_path = tmp_path / "missing"
 
-    with pytest.raises(
+    with raises(
         ScinoephileError,
         match="Unable to load ImageSeries from .*missing",
     ) as excinfo:
@@ -161,7 +161,7 @@ def test_copy_text_from_rejects_length_mismatch():
         ]
     )
 
-    with pytest.raises(ScinoephileError, match="Length mismatch: 2 vs 1"):
+    with raises(ScinoephileError, match="Length mismatch: 2 vs 1"):
         image_series.copy_text_from(text_series)
 
 
@@ -197,7 +197,7 @@ def test_image_series_save_wraps_output_path_errors(
     output_path = tmp_path / "image_output"
     output_path.touch()
 
-    with pytest.raises(
+    with raises(
         ScinoephileError,
         match="Unable to save ImageSeries to .*image_output",
     ) as excinfo:
@@ -307,3 +307,4 @@ def test_text_font_size_uses_ascender_height_for_latin_bboxes():
     )
 
     assert series.text_font_size == 39
+

--- a/test/image/subtitles/test_sup.py
+++ b/test/image/subtitles/test_sup.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import numpy as np
-import pytest
+from pytest import raises
 
 from scinoephile.image.subtitles.sup import read_sup_image_array, read_sup_series
 
@@ -43,7 +43,7 @@ def test_read_sup_image_array_rejects_row_overflow():
     """Test SUP image RLE data cannot exceed the declared row width."""
     data = np.array([0x00, 0x02], dtype=np.uint8)
 
-    with pytest.raises(ValueError, match="declared row width"):
+    with raises(ValueError, match="declared row width"):
         read_sup_image_array(data, height=1, width=1)
 
 
@@ -68,7 +68,7 @@ def test_read_sup_series_rejects_truncated_segment_data():
         dtype=np.uint8,
     )
 
-    with pytest.raises(ValueError, match="segment data is truncated"):
+    with raises(ValueError, match="segment data is truncated"):
         read_sup_series(data)
 
 
@@ -145,5 +145,6 @@ def test_read_sup_series_rejects_truncated_palette_entry():
         dtype=np.uint8,
     )
 
-    with pytest.raises(ValueError, match="palette segment is truncated"):
+    with raises(ValueError, match="palette segment is truncated"):
         read_sup_series(data)
+

--- a/test/lang/cmn/test_get_cmn_romanized.py
+++ b/test/lang/cmn/test_get_cmn_romanized.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-import pytest
+from pytest import FixtureRequest, param
 
 from scinoephile.lang.cmn.romanization import get_cmn_romanized, get_cmn_text_romanized
 from test.helpers import assert_series_equal, parametrize
@@ -13,22 +13,22 @@ from test.helpers import assert_series_equal, parametrize
 @parametrize(
     ("series_fixture", "expected_fixture"),
     [
-        pytest.param(
+        param(
             "mlamd_zho_hans_fuse_clean_validate_review_flatten",
             "mlamd_zho_hans_fuse_clean_validate_review_flatten_romanize",
             id="mlamd-zho-hans",
         ),
-        pytest.param(
+        param(
             "mnt_zho_hans_fuse_clean_validate_review_flatten",
             "mnt_zho_hans_fuse_clean_validate_review_flatten_romanize",
             id="mnt-zho-hans",
         ),
-        pytest.param(
+        param(
             "t_zho_hans_fuse_clean_validate_review_flatten",
             "t_zho_hans_fuse_clean_validate_review_flatten_romanize",
             id="t-zho-hans",
         ),
-        pytest.param(
+        param(
             "t_zho_hant_fuse_clean_validate_review_flatten_simplify_review",
             "t_zho_hant_fuse_clean_validate_review_flatten_simplify_review_romanize",
             id="t-zho-hant-simplify-review",
@@ -36,7 +36,7 @@ from test.helpers import assert_series_equal, parametrize
     ],
 )
 def test_get_cmn_romanized(
-    request: pytest.FixtureRequest,
+    request: FixtureRequest,
     series_fixture: str,
     expected_fixture: str,
 ):
@@ -68,3 +68,4 @@ def test_get_mandarin_text_romanization(text: str, expected: str):
         expected: Expected romanization
     """
     assert get_cmn_text_romanized(text) == expected
+

--- a/test/lang/eng/test_get_eng_block_reviewed.py
+++ b/test/lang/eng/test_get_eng_block_reviewed.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from unittest.mock import Mock
 
-import pytest
+from pytest import FixtureRequest, param
 
 from scinoephile.core.llms import LLMProvider, TestCase
 from scinoephile.lang.eng.block_review import (
@@ -22,13 +22,13 @@ from test.helpers import assert_series_equal, parametrize
 @parametrize(
     ("series_fixture", "expected_fixture", "test_case_loader"),
     [
-        pytest.param(
+        param(
             "kob_eng_ocr_fuse_clean_validate",
             "kob_eng_ocr_fuse_clean_validate_review",
             get_kob_eng_block_review_test_cases,
             id="kob-eng",
         ),
-        pytest.param(
+        param(
             "t_eng_fuse_clean_validate",
             "t_eng_fuse_clean_validate_review",
             get_t_eng_block_review_test_cases,
@@ -37,7 +37,7 @@ from test.helpers import assert_series_equal, parametrize
     ],
 )
 def test_get_eng_block_reviewed(
-    request: pytest.FixtureRequest,
+    request: FixtureRequest,
     series_fixture: str,
     expected_fixture: str,
     test_case_loader: Callable[[], list[TestCase]],
@@ -64,3 +64,4 @@ def test_get_eng_block_reviewed(
     assert len(output) == len(expected)
     assert_series_equal(output, expected)
     provider.chat_completion.assert_not_called()
+

--- a/test/lang/eng/test_get_eng_cleaned.py
+++ b/test/lang/eng/test_get_eng_cleaned.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-import pytest
+from pytest import FixtureRequest, param
 
 from scinoephile.lang.eng.cleaning import get_eng_cleaned, get_eng_text_cleaned
 from test.helpers import assert_series_equal, parametrize
@@ -43,32 +43,32 @@ def test_get_eng_text_cleaned(
 @parametrize(
     ("series_fixture", "expected_fixture"),
     [
-        pytest.param(
+        param(
             "kob_eng_ocr_fuse",
             "kob_eng_ocr_fuse_clean",
             id="kob-eng-fuse",
         ),
-        pytest.param(
+        param(
             "mlamd_eng_fuse",
             "mlamd_eng_fuse_clean",
             id="mlamd-eng-fuse",
         ),
-        pytest.param(
+        param(
             "mnt_eng_fuse",
             "mnt_eng_fuse_clean",
             id="mnt-eng-fuse",
         ),
-        pytest.param(
+        param(
             "t_eng_fuse",
             "t_eng_fuse_clean",
             id="t-eng-fuse",
         ),
-        pytest.param(
+        param(
             "t_eng_ocr_lens",
             "t_eng_ocr_lens_clean",
             id="t-eng-lens",
         ),
-        pytest.param(
+        param(
             "t_eng_ocr_tesseract",
             "t_eng_ocr_tesseract_clean",
             id="t-eng-tesseract",
@@ -76,7 +76,7 @@ def test_get_eng_text_cleaned(
     ],
 )
 def test_get_eng_cleaned(
-    request: pytest.FixtureRequest,
+    request: FixtureRequest,
     series_fixture: str,
     expected_fixture: str,
 ):
@@ -92,3 +92,4 @@ def test_get_eng_cleaned(
         remove_empty=False,
     )
     assert_series_equal(output, request.getfixturevalue(expected_fixture))
+

--- a/test/lang/eng/test_get_eng_flattened.py
+++ b/test/lang/eng/test_get_eng_flattened.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-import pytest
+from pytest import fail, FixtureRequest, param
 
 # noinspection PyProtectedMember
 from scinoephile.lang.eng.flattening import _get_eng_text_flattened, get_eng_flattened
@@ -14,22 +14,22 @@ from test.helpers import assert_series_equal, parametrize
 @parametrize(
     ("series_fixture", "expected_fixture"),
     [
-        pytest.param(
+        param(
             "kob_eng_ocr_fuse_clean_validate_review",
             "kob_eng_ocr_fuse_clean_validate_review_flatten",
             id="kob-eng",
         ),
-        pytest.param(
+        param(
             "mlamd_eng_fuse_clean_validate_review",
             "mlamd_eng_fuse_clean_validate_review_flatten",
             id="mlamd-eng",
         ),
-        pytest.param(
+        param(
             "mnt_eng_fuse_clean_validate_review",
             "mnt_eng_fuse_clean_validate_review_flatten",
             id="mnt-eng",
         ),
-        pytest.param(
+        param(
             "t_eng_fuse_clean_validate_review",
             "t_eng_fuse_clean_validate_review_flatten",
             id="t-eng",
@@ -37,7 +37,7 @@ from test.helpers import assert_series_equal, parametrize
     ],
 )
 def test_get_eng_flattened(
-    request: pytest.FixtureRequest,
+    request: FixtureRequest,
     series_fixture: str,
     expected_fixture: str,
 ):
@@ -61,7 +61,7 @@ def test_get_eng_flattened(
     if errors:
         for error in errors:
             print(error)
-        pytest.fail(f"Found {len(errors)} discrepancies")
+        fail(f"Found {len(errors)} discrepancies")
     assert_series_equal(output, request.getfixturevalue(expected_fixture))
 
 
@@ -79,3 +79,4 @@ def test_get_eng_text_flattened(text: str, expected: str):
         expected: Expected flattened text
     """
     assert _get_eng_text_flattened(text) == expected
+

--- a/test/lang/eng/test_get_eng_ocr_fused.py
+++ b/test/lang/eng/test_get_eng_ocr_fused.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from unittest.mock import Mock
 
-import pytest
+from pytest import FixtureRequest, param
 
 from scinoephile.core.llms import LLMProvider, TestCase
 from scinoephile.lang.eng.cleaning import get_eng_cleaned
@@ -22,28 +22,28 @@ from test.helpers import assert_series_equal, parametrize
 @parametrize(
     ("lens_fixture", "tesseract_fixture", "expected_fixture", "test_case_loader"),
     [
-        pytest.param(
+        param(
             "kob_eng_ocr_lens",
             "kob_eng_ocr_tesseract",
             "kob_eng_ocr_fuse",
             get_kob_eng_ocr_fusion_test_cases,
             id="kob-eng",
         ),
-        pytest.param(
+        param(
             "mlamd_eng_ocr_lens",
             "mlamd_eng_ocr_tesseract",
             "mlamd_eng_fuse",
             get_mlamd_eng_ocr_fusion_test_cases,
             id="mlamd-eng",
         ),
-        pytest.param(
+        param(
             "mnt_eng_ocr_lens",
             "mnt_eng_ocr_tesseract",
             "mnt_eng_fuse",
             get_mnt_eng_ocr_fusion_test_cases,
             id="mnt-eng",
         ),
-        pytest.param(
+        param(
             "t_eng_ocr_lens",
             "t_eng_ocr_tesseract",
             "t_eng_fuse",
@@ -53,7 +53,7 @@ from test.helpers import assert_series_equal, parametrize
     ],
 )
 def test_get_eng_ocr_fused(
-    request: pytest.FixtureRequest,
+    request: FixtureRequest,
     lens_fixture: str,
     tesseract_fixture: str,
     expected_fixture: str,
@@ -83,3 +83,4 @@ def test_get_eng_ocr_fused(
     assert len(lens) == len(output)
     assert_series_equal(output, request.getfixturevalue(expected_fixture))
     provider.chat_completion.assert_not_called()
+

--- a/test/lang/yue/test_get_yue_converted.py
+++ b/test/lang/yue/test_get_yue_converted.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from contextlib import AbstractContextManager, nullcontext
 
-import pytest
+from pytest import raises
 
 from scinoephile.core import UnsupportedCharacterError
 from scinoephile.lang.yue.conversion import get_yue_converted
@@ -21,12 +21,12 @@ from test.helpers import parametrize
         (
             "過樹\uefbe",
             None,
-            pytest.raises(UnsupportedCharacterError),
+            raises(UnsupportedCharacterError),
         ),
         (
             "蝦\ueec9",
             None,
-            pytest.raises(UnsupportedCharacterError),
+            raises(UnsupportedCharacterError),
         ),
     ],
 )
@@ -45,3 +45,4 @@ def test_get_yue_converted(
     with expectation:
         output = get_yue_converted(text)
         assert output == expected
+

--- a/test/lang/yue/test_get_yue_romanized.py
+++ b/test/lang/yue/test_get_yue_romanized.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-import pytest
+from pytest import FixtureRequest, param
 
 from scinoephile.lang.yue.romanization import (
     get_yue_romanized,
@@ -16,7 +16,7 @@ from test.helpers import assert_series_equal, parametrize
 @parametrize(
     ("series_fixture", "expected_fixture"),
     [
-        pytest.param(
+        param(
             "kob_yue_hans_timewarp_clean_flatten",
             "kob_yue_hans_timewarp_clean_flatten_romanize",
             id="kob-yue-hans",
@@ -24,7 +24,7 @@ from test.helpers import assert_series_equal, parametrize
     ],
 )
 def test_get_yue_romanized(
-    request: pytest.FixtureRequest,
+    request: FixtureRequest,
     series_fixture: str,
     expected_fixture: str,
 ):
@@ -59,3 +59,4 @@ def test_get_yue_text_romanized(text: str, expected: str):
         expected: Expected romanization
     """
     assert get_yue_text_romanized(text) == expected
+

--- a/test/lang/zho/script/test_conversion.py
+++ b/test/lang/zho/script/test_conversion.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-import pytest
+from pytest import FixtureRequest, param
 
 from scinoephile.lang.zho.script.conversion import (
     S2T_EXCLUSIONS,
@@ -82,12 +82,12 @@ def test_t2s_exclusions_are_raw_opencc_changes(text: str):
 @parametrize(
     ("series_fixture", "expected_fixture"),
     [
-        pytest.param(
+        param(
             "kob_zho_hant_ocr_fuse_clean_validate_review_flatten",
             "kob_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify",
             id="kob-zho-hant",
         ),
-        pytest.param(
+        param(
             "t_zho_hant_fuse_clean_validate_review_flatten",
             "t_zho_hant_fuse_clean_validate_review_flatten_simplify",
             id="t-zho-hant",
@@ -95,7 +95,7 @@ def test_t2s_exclusions_are_raw_opencc_changes(text: str):
     ],
 )
 def test_get_zho_converted(
-    request: pytest.FixtureRequest,
+    request: FixtureRequest,
     series_fixture: str,
     expected_fixture: str,
 ):
@@ -135,3 +135,4 @@ def test_get_zho_converter(text: str, config: OpenCCConfig, expected: str):
         expected: Expected converted text
     """
     assert get_zho_converter(config).convert(text) == expected
+

--- a/test/lang/zho/test_get_zho_block_reviewed.py
+++ b/test/lang/zho/test_get_zho_block_reviewed.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from unittest.mock import Mock
 
-import pytest
+from pytest import FixtureRequest, param
 
 from scinoephile.core.llms import LLMProvider, TestCase
 from scinoephile.lang.zho.block_review import (
@@ -28,28 +28,28 @@ from test.helpers import assert_series_equal, parametrize
 @parametrize(
     ("series_fixture", "expected_fixture", "test_case_loader", "prompt_cls"),
     [
-        pytest.param(
+        param(
             "kob_zho_hant_ocr_fuse_clean_validate",
             "kob_zho_hant_ocr_fuse_clean_validate_review",
             get_kob_zho_hant_block_review_test_cases,
             BlockReviewPromptZhoHant,
             id="kob-zho-hant",
         ),
-        pytest.param(
+        param(
             "t_zho_hans_fuse_clean_validate",
             "t_zho_hans_fuse_clean_validate_review",
             get_t_zho_hans_block_review_test_cases,
             BlockReviewPromptZhoHans,
             id="t-zho-hans",
         ),
-        pytest.param(
+        param(
             "t_zho_hant_fuse_clean_validate",
             "t_zho_hant_fuse_clean_validate_review",
             get_t_zho_hant_block_review_test_cases,
             BlockReviewPromptZhoHant,
             id="t-zho-hant",
         ),
-        pytest.param(
+        param(
             "t_zho_hant_fuse_clean_validate_review_flatten_simplify",
             "t_zho_hant_fuse_clean_validate_review_flatten_simplify_review",
             get_t_zho_hant_simplify_block_review_test_cases,
@@ -59,7 +59,7 @@ from test.helpers import assert_series_equal, parametrize
     ],
 )
 def test_get_zho_block_reviewed(
-    request: pytest.FixtureRequest,
+    request: FixtureRequest,
     series_fixture: str,
     expected_fixture: str,
     test_case_loader: Callable[[], list[TestCase]],
@@ -89,3 +89,4 @@ def test_get_zho_block_reviewed(
     assert len(output) == len(expected)
     assert_series_equal(output, expected)
     provider.chat_completion.assert_not_called()
+

--- a/test/lang/zho/test_get_zho_cleaned.py
+++ b/test/lang/zho/test_get_zho_cleaned.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-import pytest
+from pytest import FixtureRequest, param
 
 from scinoephile.lang.zho.cleaning import get_zho_cleaned, get_zho_text_cleaned
 from test.helpers import assert_series_equal, parametrize
@@ -35,37 +35,37 @@ def test_get_zho_text_cleaned(text: str, expected: str):
 @parametrize(
     ("series_fixture", "expected_fixture"),
     [
-        pytest.param(
+        param(
             "kob_zho_hant_ocr_fuse",
             "kob_zho_hant_ocr_fuse_clean",
             id="kob-zho-hant-fuse",
         ),
-        pytest.param(
+        param(
             "mlamd_zho_hans_fuse",
             "mlamd_zho_hans_fuse_clean",
             id="mlamd-zho-hans-fuse",
         ),
-        pytest.param(
+        param(
             "mnt_zho_hans_fuse",
             "mnt_zho_hans_fuse_clean",
             id="mnt-zho-hans-fuse",
         ),
-        pytest.param(
+        param(
             "t_zho_hans_fuse",
             "t_zho_hans_fuse_clean",
             id="t-zho-hans-fuse",
         ),
-        pytest.param(
+        param(
             "t_zho_hans_ocr_paddle",
             "t_zho_hans_ocr_paddle_clean",
             id="t-zho-hans-paddle",
         ),
-        pytest.param(
+        param(
             "t_zho_hant_fuse",
             "t_zho_hant_fuse_clean",
             id="t-zho-hant-fuse",
         ),
-        pytest.param(
+        param(
             "t_zho_hant_ocr_paddle",
             "t_zho_hant_ocr_paddle_clean",
             id="t-zho-hant-paddle",
@@ -73,7 +73,7 @@ def test_get_zho_text_cleaned(text: str, expected: str):
     ],
 )
 def test_get_zho_cleaned(
-    request: pytest.FixtureRequest,
+    request: FixtureRequest,
     series_fixture: str,
     expected_fixture: str,
 ):
@@ -89,3 +89,4 @@ def test_get_zho_cleaned(
         remove_empty=False,
     )
     assert_series_equal(output, request.getfixturevalue(expected_fixture))
+

--- a/test/lang/zho/test_get_zho_flattened.py
+++ b/test/lang/zho/test_get_zho_flattened.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-import pytest
+from pytest import fail, FixtureRequest, param
 
 from scinoephile.lang.zho.flattening import get_zho_flattened
 from test.helpers import assert_series_equal, parametrize
@@ -15,27 +15,27 @@ from test.helpers import assert_series_equal, parametrize
 @parametrize(
     ("series_fixture", "expected_fixture"),
     [
-        pytest.param(
+        param(
             "kob_zho_hant_ocr_fuse_clean_validate_review",
             "kob_zho_hant_ocr_fuse_clean_validate_review_flatten",
             id="kob-zho-hant",
         ),
-        pytest.param(
+        param(
             "mlamd_zho_hans_fuse_clean_validate_review",
             "mlamd_zho_hans_fuse_clean_validate_review_flatten",
             id="mlamd-zho-hans",
         ),
-        pytest.param(
+        param(
             "mnt_zho_hant_fuse_clean_validate_review",
             "mnt_zho_hant_fuse_clean_validate_review_flatten",
             id="mnt-zho-hant",
         ),
-        pytest.param(
+        param(
             "t_zho_hans_fuse_clean_validate_review",
             "t_zho_hans_fuse_clean_validate_review_flatten",
             id="t-zho-hans",
         ),
-        pytest.param(
+        param(
             "t_zho_hant_fuse_clean_validate_review",
             "t_zho_hant_fuse_clean_validate_review_flatten",
             id="t-zho-hant",
@@ -43,7 +43,7 @@ from test.helpers import assert_series_equal, parametrize
     ],
 )
 def test_get_zho_flattened(
-    request: pytest.FixtureRequest,
+    request: FixtureRequest,
     series_fixture: str,
     expected_fixture: str,
 ):
@@ -66,5 +66,6 @@ def test_get_zho_flattened(
     if errors:
         for error in errors:
             print(error)
-        pytest.fail(f"Found {len(errors)} discrepancies")
+        fail(f"Found {len(errors)} discrepancies")
     assert_series_equal(output, request.getfixturevalue(expected_fixture))
+

--- a/test/lang/zho/test_get_zho_ocr_fused.py
+++ b/test/lang/zho/test_get_zho_ocr_fused.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from unittest.mock import Mock
 
-import pytest
+from pytest import FixtureRequest, param
 
 from scinoephile.core.llms import LLMProvider, TestCase
 from scinoephile.core.subtitles import Series, Subtitle
@@ -28,7 +28,7 @@ from test.helpers import assert_series_equal, parametrize
 @parametrize(
     ("lens_text", "paddle_text", "expected_text"),
     [
-        pytest.param(
+        param(
             "嗯达摩\n达摩祖师果然厉害",
             "嗯达摩\\N达摩祖师果然厉害",
             "嗯达摩\n达摩祖师果然厉害",
@@ -78,7 +78,7 @@ def test_get_zho_ocr_fused_treats_newline_forms_as_identical(
         "test_case_loader",
     ),
     [
-        pytest.param(
+        param(
             "kob_zho_hant_ocr_lens",
             "kob_zho_hant_ocr_paddle",
             "kob_zho_hant_ocr_fuse",
@@ -86,7 +86,7 @@ def test_get_zho_ocr_fused_treats_newline_forms_as_identical(
             get_kob_zho_hant_ocr_fusion_test_cases,
             id="kob-zho-hant",
         ),
-        pytest.param(
+        param(
             "mlamd_zho_hans_ocr_lens",
             "mlamd_zho_hans_ocr_paddle",
             "mlamd_zho_hans_fuse",
@@ -94,7 +94,7 @@ def test_get_zho_ocr_fused_treats_newline_forms_as_identical(
             get_mlamd_zho_hans_ocr_fusion_test_cases,
             id="mlamd-zho-hans",
         ),
-        pytest.param(
+        param(
             "mnt_zho_hans_ocr_lens",
             "mnt_zho_hans_ocr_paddle",
             "mnt_zho_hans_fuse",
@@ -102,7 +102,7 @@ def test_get_zho_ocr_fused_treats_newline_forms_as_identical(
             get_mnt_zho_hans_ocr_fusion_test_cases,
             id="mnt-zho-hans",
         ),
-        pytest.param(
+        param(
             "t_zho_hans_ocr_lens",
             "t_zho_hans_ocr_paddle",
             "t_zho_hans_fuse",
@@ -113,7 +113,7 @@ def test_get_zho_ocr_fused_treats_newline_forms_as_identical(
     ],
 )
 def test_get_zho_ocr_fused(
-    request: pytest.FixtureRequest,
+    request: FixtureRequest,
     lens_fixture: str,
     paddle_fixture: str,
     expected_fixture: str,
@@ -151,3 +151,4 @@ def test_get_zho_ocr_fused(
     assert len(output) == len(expected)
     assert_series_equal(output, expected)
     provider.chat_completion.assert_not_called()
+

--- a/test/llms/dual_n_to_m/test_manager.py
+++ b/test/llms/dual_n_to_m/test_manager.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-import pytest
+from pytest import raises
 
 from scinoephile.core import ScinoephileError
 from scinoephile.llms.dual_n_to_m import (
@@ -62,11 +62,12 @@ def test_get_test_case_cls_from_data_detects_both_source_sizes():
 
 def test_get_query_cls_rejects_empty_source_one():
     """Test source one must contain at least one subtitle."""
-    with pytest.raises(ScinoephileError):
+    with raises(ScinoephileError):
         DualNToMManager.get_query_cls(0, 1, _Prompt)
 
 
 def test_get_query_cls_rejects_negative_source_two():
     """Test source two size may not be negative."""
-    with pytest.raises(ScinoephileError):
+    with raises(ScinoephileError):
         DualNToMManager.get_query_cls(1, -1, _Prompt)
+

--- a/test/llms/dual_n_to_m/test_processor.py
+++ b/test/llms/dual_n_to_m/test_processor.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from unittest.mock import Mock
 
-import pytest
+from pytest import raises
 
 from scinoephile.core.llms import LLMProvider
 from scinoephile.core.subtitles import Series, Subtitle
@@ -79,5 +79,6 @@ def test_process_rejects_negative_stop_at_idx():
     source_one = Series([Subtitle(start=1000, end=2000, text="第一句")])
     source_two = Series([Subtitle(start=1000, end=2000, text="Reference")])
 
-    with pytest.raises(ValueError, match="stop_at_idx"):
+    with raises(ValueError, match="stop_at_idx"):
         processor.process(source_one, source_two, stop_at_idx=-1)
+

--- a/test/llms/providers/test_deepseek_provider.py
+++ b/test/llms/providers/test_deepseek_provider.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import cast
 
-import pytest
+from pytest import MonkeyPatch
 
 from scinoephile.core.llms import openai_provider_base
 from scinoephile.core.llms.tool import Tool
@@ -32,7 +32,7 @@ def _get_tool_box() -> ToolBox:
 
 
 def test_deepseek_constructs_client_with_base_url_and_env_api_key(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test DeepSeekProvider uses base_url and DEEPSEEK_API_KEY by default."""
     monkeypatch.setenv("DEEPSEEK_API_KEY", "dummy")
@@ -48,7 +48,7 @@ def test_deepseek_constructs_client_with_base_url_and_env_api_key(
 
 
 def test_deepseek_api_key_override_wins_over_env(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test explicit api_key overrides the environment variable."""
     monkeypatch.setenv("DEEPSEEK_API_KEY", "env")
@@ -79,3 +79,4 @@ def test_deepseek_beta_base_url_enables_strict_tools():
 
     function = cast(dict[str, object], tools[0]["function"])
     assert function["strict"] is True
+

--- a/test/llms/providers/test_openai_provider.py
+++ b/test/llms/providers/test_openai_provider.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import cast
 
-import pytest
+from pytest import MonkeyPatch
 
 from scinoephile.core.llms import openai_provider_base
 from scinoephile.llms.providers.openai_provider import OpenAIProvider
@@ -14,7 +14,7 @@ from test.helpers.openai import DummyOpenAI
 
 
 def test_openai_constructs_client_with_explicit_api_key_and_base_url(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test OpenAIProvider forwards explicit client overrides to OpenAI."""
     monkeypatch.setattr(openai_provider_base, "OpenAI", DummyOpenAI)
@@ -31,7 +31,7 @@ def test_openai_constructs_client_with_explicit_api_key_and_base_url(
 
 
 def test_openai_constructs_client_without_overrides(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test OpenAIProvider uses SDK defaults when no overrides are supplied."""
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
@@ -43,3 +43,4 @@ def test_openai_constructs_client_without_overrides(
     assert isinstance(client, DummyOpenAI)
     assert client.kwargs["api_key"] is None
     assert client.kwargs["base_url"] is None
+

--- a/test/llms/providers/test_registry.py
+++ b/test/llms/providers/test_registry.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import Any, ClassVar, Unpack
 from unittest.mock import Mock
 
-import pytest
+from pytest import fixture, raises
 
 from scinoephile.core import ScinoephileError
 from scinoephile.core.llms import Answer, LLMProvider
@@ -25,7 +25,7 @@ from scinoephile.llms.providers.registry import (
 )
 
 
-@pytest.fixture(autouse=True)
+@fixture(autouse=True)
 def restore_provider_registry():
     """Restore registered LLM providers after each test."""
     provider_factories = provider_registry._PROVIDER_FACTORIES.copy()
@@ -125,13 +125,13 @@ def test_get_provider_names_returns_registered_provider_names():
 
 def test_get_provider_raises_for_unknown_provider():
     """Test provider lookup fails for unknown provider names."""
-    with pytest.raises(ScinoephileError):
+    with raises(ScinoephileError):
         get_provider("missing-provider")
 
 
 def test_get_provider_description_raises_for_unknown_provider():
     """Test provider description lookup fails for unknown provider names."""
-    with pytest.raises(ScinoephileError):
+    with raises(ScinoephileError):
         get_provider_description("missing-provider")
 
 
@@ -166,3 +166,4 @@ class _LocalizedDummyProvider(_DummyProvider):
         "zh-hant": "本地化測試提供商。",
     }
     """Provider description translations keyed by locale."""
+

--- a/test/media/offset/video/test_video_offset.py
+++ b/test/media/offset/video/test_video_offset.py
@@ -11,7 +11,7 @@ from typing import Any, TypedDict
 from unittest.mock import patch
 
 import numpy as np
-import pytest
+from pytest import approx, raises
 
 from scinoephile.core import ScinoephileError
 from scinoephile.media.offset.video import (
@@ -97,7 +97,7 @@ def test_get_video_offset_uses_reference_frame_grid_for_fine_search():
             sample_windows=1,
         )
 
-    assert result.offset == pytest.approx(-20 * frame_duration)
+    assert result.offset == approx(-20 * frame_duration)
     assert result.offset_frames == -20
     assert result.best.offset_frames == -20
 
@@ -146,7 +146,7 @@ def test_get_video_offset_tolerates_brightness_shift():
         )
 
     assert result.offset == 1.0
-    assert result.best.score == pytest.approx(0.0)
+    assert result.best.score == approx(0.0)
 
 
 def test_get_video_offset_rejects_insufficient_matches():
@@ -154,7 +154,7 @@ def test_get_video_offset_rejects_insufficient_matches():
     reference_samples = _get_samples([0.0], [10])
     target_samples = _get_samples([1.0], [10])
 
-    with pytest.raises(ScinoephileError, match="Could not find enough"):
+    with raises(ScinoephileError, match="Could not find enough"):
         with (
             patch(
                 "scinoephile.media.offset.video.ffmpeg.probe",
@@ -181,7 +181,7 @@ def test_get_video_offset_rejects_missing_reference_frame_rate():
     reference_samples = _get_samples([0.0, 1.0, 2.0, 3.0], [10, 20, 30, 40])
     target_samples = _get_samples([1.0, 2.0, 3.0, 4.0], [10, 20, 30, 40])
 
-    with pytest.raises(ScinoephileError, match="reference video frame rate"):
+    with raises(ScinoephileError, match="reference video frame rate"):
         with (
             patch(
                 "scinoephile.media.offset.video.ffmpeg.probe",
@@ -250,7 +250,7 @@ def test_get_video_offset_samples_multiple_windows_and_aggregates_frames():
     assert [window.offset_frames for window in result.windows] == [-20, -20, -21]
     assert result.aggregate is not None
     assert result.offset_frames == -20
-    assert result.aggregate.mean_frames == pytest.approx(-20.333333)
+    assert result.aggregate.mean_frames == approx(-20.333333)
     assert result.aggregate.median_frames == -20
     assert result.aggregate.min_frames == -21
     assert result.aggregate.max_frames == -20
@@ -398,10 +398,10 @@ def test_sample_video_frames_normalizes_brightness():
             height=2,
         )
 
-    assert samples[0].frame.mean() == pytest.approx(0.0)
-    assert samples[0].frame.std() == pytest.approx(1.0)
-    assert samples[1].frame.mean() == pytest.approx(0.0)
-    assert samples[1].frame.std() == pytest.approx(1.0)
+    assert samples[0].frame.mean() == approx(0.0)
+    assert samples[0].frame.std() == approx(1.0)
+    assert samples[1].frame.mean() == approx(0.0)
+    assert samples[1].frame.std() == approx(1.0)
 
 
 @parametrize(
@@ -443,7 +443,7 @@ def test_get_video_offset_rejects_invalid_numeric_parameters(
         kwargs: invalid keyword arguments
         message: expected error message
     """
-    with pytest.raises(ValueError, match=message):
+    with raises(ValueError, match=message):
         get_video_offset(
             reference_infile_path=Path("reference.mkv"),
             target_infile_path=Path("target.mkv"),
@@ -463,7 +463,7 @@ def test_get_video_offset_propagates_sampling_failures():
             side_effect=ScinoephileError("Could not sample frames"),
         ),
     ):
-        with pytest.raises(ScinoephileError, match="Could not sample frames"):
+        with raises(ScinoephileError, match="Could not sample frames"):
             get_video_offset(
                 reference_infile_path=Path("reference.mkv"),
                 target_infile_path=Path("target.mkv"),
@@ -645,3 +645,4 @@ def _get_shifted_sample_pair(
         values,
     )
     return reference_samples, target_samples
+

--- a/test/media/subtitles/test_cache.py
+++ b/test/media/subtitles/test_cache.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 import ffmpeg
-import pytest
+from pytest import raises
 from PIL import Image
 
 from scinoephile.core import ScinoephileError
@@ -99,7 +99,7 @@ def test_cache_subtitles_wraps_ffmpeg_extraction_errors(tmp_path: Path):
             "scinoephile.media.subtitles.cache.ffmpeg.merge_outputs",
             return_value=merged_stream,
         ),
-        pytest.raises(ScinoephileError, match="Could not cache subtitle streams"),
+        raises(ScinoephileError, match="Could not cache subtitle streams"),
     ):
         cache_subtitles(
             infile_path,
@@ -269,3 +269,4 @@ class _RecordingMergedFfmpegStream:
         """
         _ = kwargs
         self.run_count += 1
+

--- a/test/media/subtitles/test_extraction.py
+++ b/test/media/subtitles/test_extraction.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
+from pytest import raises
 
 from scinoephile.core import ScinoephileError
 from scinoephile.core.media import SubtitleStream
@@ -93,10 +93,11 @@ def test_extract_subtitle_stream_rejects_unknown_codec(tmp_path: Path):
     outfile_path = tmp_path / "subtitles" / "eng-2.srt"
     outfile_path.parent.mkdir()
 
-    with pytest.raises(ScinoephileError, match="Unsupported subtitle codec unknown"):
+    with raises(ScinoephileError, match="Unsupported subtitle codec unknown"):
         extract_subtitle_stream(
             infile_path=infile_path,
             stream=SubtitleStream(index=2, language="eng", codec_name="unknown"),
             outfile_path=outfile_path,
             cache_dir_path=tmp_path / "cache",
         )
+

--- a/test/media/subtitles/test_selection.py
+++ b/test/media/subtitles/test_selection.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
+from pytest import raises
 
 from scinoephile.core import ScinoephileError
 from scinoephile.core.media import SubtitleStream
@@ -34,7 +34,7 @@ def test_get_media_subtitle_stream_requires_stream_index(tmp_path: Path):
     infile_path = tmp_path / "video.mkv"
     infile_path.touch()
 
-    with pytest.raises(
+    with raises(
         ScinoephileError,
         match="stream index is required for media OCR input",
     ):
@@ -51,7 +51,7 @@ def test_get_media_subtitle_stream_rejects_non_sup_stream(tmp_path: Path):
             "scinoephile.media.subtitles.selection.get_subtitle_streams",
             return_value=[SubtitleStream(index=5, codec_name="subrip")],
         ),
-        pytest.raises(
+        raises(
             ScinoephileError,
             match="Subtitle stream 5 is not an image-based SUP stream",
         ),
@@ -69,7 +69,7 @@ def test_get_media_subtitle_stream_wraps_probe_errors(tmp_path: Path):
             "scinoephile.media.subtitles.selection.get_subtitle_streams",
             side_effect=RuntimeError("ffprobe failed"),
         ),
-        pytest.raises(
+        raises(
             ScinoephileError,
             match="Unable to inspect subtitle streams in .*video.mkv.*ffprobe failed",
         ) as excinfo,
@@ -77,3 +77,4 @@ def test_get_media_subtitle_stream_wraps_probe_errors(tmp_path: Path):
         get_media_subtitle_stream(infile_path, 5)
 
     assert isinstance(excinfo.value.__cause__, RuntimeError)
+

--- a/test/multilang/yue_zho/test_get_yue_gap_translated_vs_zho.py
+++ b/test/multilang/yue_zho/test_get_yue_gap_translated_vs_zho.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from unittest.mock import Mock, patch
 
-import pytest
+from pytest import FixtureRequest, param
 
 from scinoephile.core.llms import LLMProvider, TestCase
 from scinoephile.multilang.yue_zho.gapped_translation import (
@@ -21,7 +21,7 @@ from test.helpers import assert_series_equal, parametrize
 @parametrize(
     ("yuewen_fixture", "zhongwen_fixture", "expected_fixture", "test_case_loader"),
     [
-        pytest.param(
+        param(
             "mlamd_yue_hans_transcribe_review",
             "mlamd_zho_hans_fuse_clean_validate_review_flatten_merged_539",
             "mlamd_yue_hans_transcribe_review_translate",
@@ -31,7 +31,7 @@ from test.helpers import assert_series_equal, parametrize
     ],
 )
 def test_get_yue_gapped_translated_vs_zho(
-    request: pytest.FixtureRequest,
+    request: FixtureRequest,
     yuewen_fixture: str,
     zhongwen_fixture: str,
     expected_fixture: str,
@@ -64,3 +64,4 @@ def test_get_yue_gapped_translated_vs_zho(
     )
     assert_series_equal(output, expected)
     provider.chat_completion.assert_not_called()
+

--- a/test/multilang/yue_zho/test_get_yue_line_reviewed_vs_zho.py
+++ b/test/multilang/yue_zho/test_get_yue_line_reviewed_vs_zho.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from unittest.mock import Mock, patch
 
-import pytest
+from pytest import FixtureRequest, param
 
 from scinoephile.core.llms import LLMProvider, TestCase
 from scinoephile.multilang.yue_zho.line_review import (
@@ -21,7 +21,7 @@ from test.helpers import assert_series_equal, parametrize
 @parametrize(
     ("yuewen_fixture", "zhongwen_fixture", "expected_fixture", "test_case_loader"),
     [
-        pytest.param(
+        param(
             "mlamd_yue_hans_transcribe",
             "mlamd_zho_hans_fuse_clean_validate_review_flatten_merged_539",
             "mlamd_yue_hans_transcribe_review",
@@ -31,7 +31,7 @@ from test.helpers import assert_series_equal, parametrize
     ],
 )
 def test_get_yue_line_reviewed_vs_zho(
-    request: pytest.FixtureRequest,
+    request: FixtureRequest,
     yuewen_fixture: str,
     zhongwen_fixture: str,
     expected_fixture: str,
@@ -64,3 +64,4 @@ def test_get_yue_line_reviewed_vs_zho(
     )
     assert_series_equal(output, expected)
     provider.chat_completion.assert_not_called()
+

--- a/test/multilang/yue_zho/test_get_yue_reviewed_vs_zho.py
+++ b/test/multilang/yue_zho/test_get_yue_reviewed_vs_zho.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from unittest.mock import Mock, patch
 
-import pytest
+from pytest import FixtureRequest, param
 
 from scinoephile.core.llms import LLMProvider, TestCase
 from scinoephile.multilang.yue_zho.block_review import (
@@ -21,7 +21,7 @@ from test.helpers import assert_series_equal, parametrize
 @parametrize(
     ("yuewen_fixture", "zhongwen_fixture", "expected_fixture", "test_case_loader"),
     [
-        pytest.param(
+        param(
             "mlamd_yue_hans_transcribe_review_translate",
             "mlamd_zho_hans_fuse_clean_validate_review_flatten_merged_539",
             "mlamd_yue_hans_transcribe_review_translate_block_review",
@@ -31,7 +31,7 @@ from test.helpers import assert_series_equal, parametrize
     ],
 )
 def test_get_yue_block_reviewed_vs_zho(
-    request: pytest.FixtureRequest,
+    request: FixtureRequest,
     yuewen_fixture: str,
     zhongwen_fixture: str,
     expected_fixture: str,
@@ -64,3 +64,4 @@ def test_get_yue_block_reviewed_vs_zho(
     )
     assert_series_equal(output, expected)
     provider.chat_completion.assert_not_called()
+

--- a/test/optimization/persistence/test_cases/test_optimization_test_cases_sqlite_store.py
+++ b/test/optimization/persistence/test_cases/test_optimization_test_cases_sqlite_store.py
@@ -8,7 +8,7 @@ import sqlite3
 from contextlib import closing
 from pathlib import Path
 
-import pytest
+from pytest import raises
 
 from scinoephile.core.llms import OperationSpec
 from scinoephile.multilang.yue_zho.transcription.punctuation import (
@@ -226,7 +226,7 @@ def test_store_rejects_configured_list_fields_over_max(tmp_path: Path):
         source_paths=["x.json"],
     )
 
-    with pytest.raises(ValueError, match="supports at most 10 items"):
+    with raises(ValueError, match="supports at most 10 items"):
         store.upsert_table_test_cases(table_name, [tc], source_path="x.json")
 
 
@@ -257,3 +257,4 @@ def test_store_source_path_index(tmp_path: Path):
     store.upsert_table_test_cases(table_name, [tc1, tc2], source_path="s1.json")
     by_s1 = store.get_test_cases_by_source_path(table_name, "s1.json")
     assert {x.test_case_id for x in by_s1} == {"a", "b"}
+

--- a/test/web/ocr_validation/test_app.py
+++ b/test/web/ocr_validation/test_app.py
@@ -10,7 +10,7 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import cast
 
-import pytest
+from pytest import LogCaptureFixture, MonkeyPatch, raises
 
 from scinoephile.common import package_root
 from scinoephile.common.subprocess import run_command
@@ -27,7 +27,7 @@ def test_create_app_uses_shared_web_static_dir():
     assert Path(app.static_folder) == package_root / "web/static"
 
 
-def test_create_app_import_error_is_actionable(monkeypatch: pytest.MonkeyPatch):
+def test_create_app_import_error_is_actionable(monkeypatch: MonkeyPatch):
     """Test missing Flask dependency produces an actionable error."""
     real_import = __import__
 
@@ -57,13 +57,13 @@ def test_create_app_import_error_is_actionable(monkeypatch: pytest.MonkeyPatch):
 
     monkeypatch.setattr("builtins.__import__", fake_import)
 
-    with pytest.raises(ScinoephileError, match="'web' extra") as excinfo:
+    with raises(ScinoephileError, match="'web' extra") as excinfo:
         create_app(cast(OcrValidationSession, object()))
 
     assert isinstance(excinfo.value.__cause__, ImportError)
 
 
-def test_run_app_wraps_server_errors(monkeypatch: pytest.MonkeyPatch):
+def test_run_app_wraps_server_errors(monkeypatch: MonkeyPatch):
     """Test web app server errors are user-facing."""
     monkeypatch.setattr(
         "scinoephile.web.ocr_validation.app._port_is_in_use",
@@ -80,7 +80,7 @@ def test_run_app_wraps_server_errors(monkeypatch: pytest.MonkeyPatch):
         ),
     )
 
-    with pytest.raises(
+    with raises(
         ScinoephileError,
         match=(
             "Unable to run OCR validation web app on 127.0.0.1:5000: "
@@ -92,7 +92,7 @@ def test_run_app_wraps_server_errors(monkeypatch: pytest.MonkeyPatch):
     assert isinstance(excinfo.value.__cause__, OSError)
 
 
-def test_run_app_import_error_is_actionable(monkeypatch: pytest.MonkeyPatch):
+def test_run_app_import_error_is_actionable(monkeypatch: MonkeyPatch):
     """Test missing Werkzeug dependency produces an actionable error."""
     real_import = __import__
 
@@ -122,15 +122,15 @@ def test_run_app_import_error_is_actionable(monkeypatch: pytest.MonkeyPatch):
 
     monkeypatch.setattr("builtins.__import__", fake_import)
 
-    with pytest.raises(ScinoephileError, match="'web' extra") as excinfo:
+    with raises(ScinoephileError, match="'web' extra") as excinfo:
         run_app(cast(OcrValidationSession, object()), "127.0.0.1", 5000)
 
     assert isinstance(excinfo.value.__cause__, ImportError)
 
 
 def test_run_app_uses_available_port_when_requested_port_is_in_use(
-    caplog: pytest.LogCaptureFixture,
-    monkeypatch: pytest.MonkeyPatch,
+    caplog: LogCaptureFixture,
+    monkeypatch: MonkeyPatch,
 ):
     """Test web app falls back when the requested port is already occupied."""
 
@@ -197,3 +197,4 @@ def test_web_package_imports_flask_only_when_needed():
     )
 
     assert exitcode == 0
+

--- a/test/web/ocr_validation/test_html_index.py
+++ b/test/web/ocr_validation/test_html_index.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
+from pytest import raises
 from PIL import Image
 
 from scinoephile.image.subtitles import ImageSeries
@@ -57,7 +57,7 @@ def test_update_html_entry_text_rejects_negative_index(tmp_path: Path):
     """Test updating OCR text rejects negative subtitle indexes."""
     html_dir_path = _make_html_dir(tmp_path, text="old")
 
-    with pytest.raises(IndexError, match="Subtitle index out of range: -1"):
+    with raises(IndexError, match="Subtitle index out of range: -1"):
         update_html_entry_text(html_dir_path, -1, "new")
 
 
@@ -65,7 +65,7 @@ def test_update_html_entry_text_rejects_out_of_range_index(tmp_path: Path):
     """Test updating OCR text rejects out-of-range subtitle indexes."""
     html_dir_path = _make_html_dir(tmp_path, text="old")
 
-    with pytest.raises(IndexError, match="Subtitle index out of range: 1"):
+    with raises(IndexError, match="Subtitle index out of range: 1"):
         update_html_entry_text(html_dir_path, 1, "new")
 
 
@@ -103,3 +103,4 @@ def _make_html_dir(tmp_path: Path, *, text: str) -> Path:
         encoding="utf-8",
     )
     return html_dir_path
+

--- a/test/web/ocr_validation/test_routes.py
+++ b/test/web/ocr_validation/test_routes.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from io import BytesIO
 from pathlib import Path
 
-import pytest
+from pytest import MonkeyPatch
 from flask import Flask
 from PIL import Image
 
@@ -52,7 +52,7 @@ def test_static_htmx_asset_is_served(tmp_path: Path):
 
 def test_index_renders_single_char_concern_image(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test character concerns render one focused image and table."""
     app = _char_concern_app(tmp_path, monkeypatch)
@@ -72,7 +72,7 @@ def test_index_renders_single_char_concern_image(
 
 def test_index_renders_char_concern_romanizations(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test character concern tables render romanizations below Hanzi."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="霆")
@@ -96,7 +96,7 @@ def test_index_renders_char_concern_romanizations(
 
 def test_index_omits_romanizations_for_unrecognized_symbol(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test character concern tables skip romanization for non-Hanzi symbols."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="▼")
@@ -118,7 +118,7 @@ def test_index_omits_romanizations_for_unrecognized_symbol(
 
 def test_index_reload_reassesses_cached_subtitles(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test index reloads rebuild cached validation states."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="A")
@@ -145,7 +145,7 @@ def test_index_reload_reassesses_cached_subtitles(
 
 def test_done_filter_route_toggles_ok_subtitles(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test the OK subtitle filter toggle updates the rendered list."""
     app = _done_app(tmp_path, monkeypatch)
@@ -220,7 +220,7 @@ def test_exit_route_saves_output_and_shuts_down_server(tmp_path: Path):
 
 def test_char_concern_image_url_changes_after_accept(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test accepting one character returns a fresh next concern image URL."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="AB")
@@ -253,7 +253,7 @@ def test_char_concern_image_url_changes_after_accept(
 
 def test_index_renders_space_gap_choice_table(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test adjacent-or-space concerns render both choice actions."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="霆所")
@@ -288,7 +288,7 @@ def test_index_renders_space_gap_choice_table(
 
 def test_validation_image_route_serves_bbox_png(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test validation row images are rendered with bbox overlays."""
     app = _done_app(tmp_path, monkeypatch)
@@ -304,7 +304,7 @@ def test_validation_image_route_serves_bbox_png(
 
 def test_validation_image_route_rejects_missing_subtitle(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test validation image route rejects an out-of-range subtitle index."""
     app = _done_app(tmp_path, monkeypatch)
@@ -346,7 +346,7 @@ def test_text_update_route_rejects_missing_subtitle(tmp_path: Path):
 
 def test_concern_image_route_serves_png(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test current concern images are rendered as PNG responses."""
     app = _char_concern_app(tmp_path, monkeypatch)
@@ -359,7 +359,7 @@ def test_concern_image_route_serves_png(
 
 def test_concern_image_route_rejects_missing_subtitle(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test concern image route rejects an out-of-range subtitle index."""
     app = _char_concern_app(tmp_path, monkeypatch)
@@ -371,7 +371,7 @@ def test_concern_image_route_rejects_missing_subtitle(
 
 def test_char_concern_route_resolves_row(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test resolving the final character concern omits the completed row."""
     app = _char_concern_app(tmp_path, monkeypatch)
@@ -388,7 +388,7 @@ def test_char_concern_route_resolves_row(
 
 def test_char_concern_route_rejects_invalid_action(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test character concern route rejects invalid actions."""
     app = _char_concern_app(tmp_path, monkeypatch)
@@ -404,7 +404,7 @@ def test_char_concern_route_rejects_invalid_action(
 
 def test_char_concern_route_rejects_missing_subtitle(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test character concern route rejects an out-of-range subtitle index."""
     app = _char_concern_app(tmp_path, monkeypatch)
@@ -420,7 +420,7 @@ def test_char_concern_route_rejects_missing_subtitle(
 
 def test_gap_concern_route_resolves_row(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test resolving the final gap concern persists text and omits the row."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="AB")
@@ -444,7 +444,7 @@ def test_gap_concern_route_resolves_row(
 
 def test_gap_concern_route_rejects_invalid_action(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test gap concern route rejects invalid actions."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="AB")
@@ -466,7 +466,7 @@ def test_gap_concern_route_rejects_invalid_action(
 
 def test_gap_concern_route_rejects_missing_subtitle(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test gap concern route rejects an out-of-range subtitle index."""
     app = _char_concern_app(tmp_path, monkeypatch)
@@ -482,7 +482,7 @@ def test_gap_concern_route_rejects_missing_subtitle(
 
 def _char_concern_app(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ) -> Flask:
     """Create an app with one character dimension concern.
 
@@ -554,7 +554,7 @@ def _assert_index_textarea(html: bytes):
 
 def _done_app(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     *,
     include_done_subtitles: bool = False,
 ) -> Flask:
@@ -598,3 +598,4 @@ def _session(
         make_ocr_html_dir(tmp_path, text=text),
         include_done_subtitles=include_done_subtitles,
     )
+

--- a/test/web/ocr_validation/test_session.py
+++ b/test/web/ocr_validation/test_session.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
+from pytest import MonkeyPatch, raises
 from PIL import Image
 
 from scinoephile.core import ScinoephileError
@@ -55,12 +55,12 @@ def test_session_requires_index_html_file(tmp_path: Path):
     html_dir_path.mkdir()
     (html_dir_path / "index.html").mkdir()
 
-    with pytest.raises(ScinoephileError, match="Expected .*index\\.html to be a file"):
+    with raises(ScinoephileError, match="Expected .*index\\.html to be a file"):
         OcrValidationSession.from_dir_path(html_dir_path)
 
 
 def test_session_wraps_image_series_load_errors(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     tmp_path: Path,
 ):
     """Test session construction wraps image series loading errors.
@@ -80,7 +80,7 @@ def test_session_wraps_image_series_load_errors(
         fake_load,
     )
 
-    with pytest.raises(
+    with raises(
         ScinoephileError,
         match="Unable to initialize OCR validation session from .*could not be loaded",
     ) as excinfo:
@@ -96,7 +96,7 @@ def test_concern_kind_excludes_done_state():
 
 def test_session_uses_one_font_size_for_series(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test editable font size is detected once for the whole series."""
     html_dir_path = make_two_image_ocr_html_dir(tmp_path, text_1="A", text_2="B")
@@ -146,7 +146,7 @@ def test_session_uses_cjk_letter_spacing(tmp_path: Path):
 
 def test_session_rebuilds_raw_bboxes_for_validation_state(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test web validation state ignores stale pre-merged bboxes."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="A")
@@ -173,7 +173,7 @@ def test_session_rebuilds_raw_bboxes_for_validation_state(
 
 def test_session_omits_done_rows_from_list_by_default(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test session row lists omit subtitles with no concerns by default."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="A")
@@ -192,7 +192,7 @@ def test_session_omits_done_rows_from_list_by_default(
 
 def test_session_includes_done_rows_in_list_when_enabled(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test the internal toggle can include subtitles with no concerns."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="A")
@@ -243,7 +243,7 @@ def test_session_does_not_write_outfile_on_init(tmp_path: Path):
 
 def test_session_reports_char_dims_concern(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test unknown character dimensions produce a bbox concern."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="A")
@@ -265,7 +265,7 @@ def test_session_reports_char_dims_concern(
 
 def test_session_reports_error_status_when_validation_cannot_continue(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test unrecoverable validation concerns produce an error row status."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="A")
@@ -284,7 +284,7 @@ def test_session_reports_error_status_when_validation_cannot_continue(
 
 def test_accept_char_dims_marks_single_char_done(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test accepting character dimensions resolves a single-character subtitle."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="A")
@@ -306,7 +306,7 @@ def test_accept_char_dims_marks_single_char_done(
 
 def test_contract_char_dims_reduces_selection(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test contracting character dimensions reduces the selected bbox count."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="A")
@@ -335,7 +335,7 @@ def test_contract_char_dims_reduces_selection(
 
 def test_session_reports_space_gap_concern(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test ambiguous adjacent-or-space gaps produce a space concern."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="AB")
@@ -359,7 +359,7 @@ def test_session_reports_space_gap_concern(
 
 def test_space_gap_choice_updates_index_text(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test resolving a space gap writes the expected space into index.html."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="AB")
@@ -380,7 +380,7 @@ def test_space_gap_choice_updates_index_text(
 
 def test_known_adjacent_gap_mismatch_updates_text_without_concern(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test known adjacent gaps with wrong text update without a user concern."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="臭　　和")
@@ -408,7 +408,7 @@ def test_known_adjacent_gap_mismatch_updates_text_without_concern(
 
 def test_fullwidth_latin_gap_uses_default_cutoffs(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test fullwidth Latin characters use default full-width gap cutoffs."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="你Ｋ")
@@ -433,7 +433,7 @@ def test_fullwidth_latin_gap_uses_default_cutoffs(
 
 def test_adjacent_gap_choice_updates_cutoff(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test adjacent choice for an ambiguous gap updates the gap cutoffs."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="白了")
@@ -468,7 +468,7 @@ def test_adjacent_gap_choice_updates_cutoff(
 
 def test_matching_space_gap_updates_cutoff_without_concern(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test matching space text updates cutoffs without a user concern."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="A B")
@@ -489,7 +489,7 @@ def test_matching_space_gap_updates_cutoff_without_concern(
 
 def test_matching_tab_gap_updates_cutoff_without_concern(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test matching tab text updates cutoffs without a user concern."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="A    B")
@@ -510,7 +510,7 @@ def test_matching_tab_gap_updates_cutoff_without_concern(
 
 def test_known_space_gap_mismatch_updates_text_without_concern(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test known space gaps with wrong text update without a user concern."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="呀 你")
@@ -538,7 +538,7 @@ def test_known_space_gap_mismatch_updates_text_without_concern(
 
 def test_known_tab_gap_mismatch_updates_text_without_concern(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test known tab gaps with wrong text update without a user concern."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="AB")
@@ -559,7 +559,7 @@ def test_known_tab_gap_mismatch_updates_text_without_concern(
 
 def test_known_tab_gap_replaces_newline_without_concern(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test known tab gaps with newline text update without a user concern."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="A<br />B")
@@ -580,7 +580,7 @@ def test_known_tab_gap_replaces_newline_without_concern(
 
 def test_tab_gap_choice_updates_index_text(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ):
     """Test resolving a tab gap writes expected wide spacing into index.html."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="AB")
@@ -597,3 +597,4 @@ def test_tab_gap_choice_updates_index_text(
     assert row.concern is None
     assert session.manager.char_pair_gaps[("A", "B")] == (2, 6, 12, 15)
     assert "A    B" in (html_dir_path / "index.html").read_text(encoding="utf-8")
+

--- a/test/workflows/test_ocr_processing.py
+++ b/test/workflows/test_ocr_processing.py
@@ -9,7 +9,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
-import pytest
+from pytest import MonkeyPatch, raises
 
 from scinoephile.core import Language, ScinoephileError
 from scinoephile.core.media import SubtitleStream
@@ -133,7 +133,7 @@ class _PatchedEngOcrPipeline:
 
     def __init__(
         self,
-        monkeypatch: pytest.MonkeyPatch,
+        monkeypatch: MonkeyPatch,
         image_series: ImageSeries,
         *,
         lens_texts: list[str] | None = None,
@@ -229,7 +229,7 @@ class _PatchedZhoOcrPipeline:
 
     def __init__(
         self,
-        monkeypatch: pytest.MonkeyPatch,
+        monkeypatch: MonkeyPatch,
         image_series: ImageSeries,
         *,
         lens_texts: list[str] | None = None,
@@ -358,7 +358,7 @@ def test_ocr_processing_workflow_rejects_invalid_language_in_init(tmp_path: Path
     """
     invalid_language: Any = "spa"
 
-    with pytest.raises(
+    with raises(
         ScinoephileError,
         match=(
             "language must be eng, yue-Hans, yue-Hant, zho-Hans, or zho-Hant, not spa"
@@ -372,7 +372,7 @@ def test_ocr_processing_workflow_rejects_invalid_language_in_init(tmp_path: Path
 
 
 def test_process_eng_ocr_runs_lens_tesseract_and_fusion(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     tmp_path: Path,
     tiny_image_series: ImageSeries,
 ):
@@ -420,7 +420,7 @@ def test_process_eng_ocr_runs_lens_tesseract_and_fusion(
 @parametrize("process_ocr", [process_eng_ocr, process_zho_ocr])
 def test_process_ocr_wraps_filesystem_errors(
     process_ocr: Callable[..., OcrProcessingResult],
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     tmp_path: Path,
 ):
     """Test OCR processing maps filesystem errors to user-facing errors.
@@ -446,7 +446,7 @@ def test_process_ocr_wraps_filesystem_errors(
         fake_load,
     )
 
-    with pytest.raises(
+    with raises(
         ScinoephileError,
         match=(
             "Unable to load OCR image subtitles from .*source.sup.*source.sup missing"
@@ -458,7 +458,7 @@ def test_process_ocr_wraps_filesystem_errors(
 
 
 def test_process_eng_ocr_can_clean_provider_outputs_before_fusion(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     tmp_path: Path,
     tiny_image_series: ImageSeries,
 ):
@@ -508,7 +508,7 @@ def test_process_eng_ocr_can_clean_provider_outputs_before_fusion(
 
 
 def test_process_eng_ocr_validates_fuse_clean_output(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     tmp_path: Path,
     tiny_image_series: ImageSeries,
 ):
@@ -571,7 +571,7 @@ def test_process_eng_ocr_validates_fuse_clean_output(
 
 
 def test_process_eng_ocr_interactive_launches_web_validation_for_sup(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     tmp_path: Path,
     tiny_image_series: ImageSeries,
 ):
@@ -661,7 +661,7 @@ def test_process_eng_ocr_interactive_launches_web_validation_for_sup(
 
 
 def test_process_eng_ocr_does_not_overwrite_existing_validation_images(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     tmp_path: Path,
     tiny_image_series: ImageSeries,
 ):
@@ -739,7 +739,7 @@ def test_process_eng_ocr_does_not_overwrite_existing_validation_images(
 
 
 def test_ocr_validation_keeps_newer_image_index_text(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     tmp_path: Path,
     tiny_image_series: ImageSeries,
 ):
@@ -784,7 +784,7 @@ def test_ocr_validation_keeps_newer_image_index_text(
 
 
 def test_ocr_validation_uses_newer_fuse_clean_text(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     tmp_path: Path,
     tiny_image_series: ImageSeries,
 ):
@@ -829,7 +829,7 @@ def test_ocr_validation_uses_newer_fuse_clean_text(
 
 
 def test_ocr_validation_uses_fuse_clean_for_blank_image_index(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     tmp_path: Path,
     tiny_image_series: ImageSeries,
 ):
@@ -873,7 +873,7 @@ def test_ocr_validation_uses_fuse_clean_for_blank_image_index(
 
 
 def test_process_zho_ocr_runs_lens_paddle_and_fusion(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     tmp_path: Path,
     tiny_image_series: ImageSeries,
 ):
@@ -917,7 +917,7 @@ def test_process_zho_ocr_runs_lens_paddle_and_fusion(
 
 
 def test_process_zho_ocr_can_clean_provider_outputs_before_fusion(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     tmp_path: Path,
     tiny_image_series: ImageSeries,
 ):
@@ -966,7 +966,7 @@ def test_process_zho_ocr_can_clean_provider_outputs_before_fusion(
 
 
 def test_process_zho_ocr_passes_zho_hant_languages_to_ocr_engines(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     tmp_path: Path,
     tiny_image_series: ImageSeries,
 ):
@@ -1000,7 +1000,7 @@ def test_process_zho_ocr_passes_zho_hant_languages_to_ocr_engines(
 
 
 def test_process_eng_ocr_media_input_loads_selected_subtitle_stream(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     tmp_path: Path,
     tiny_image_series: ImageSeries,
 ):
@@ -1048,7 +1048,7 @@ def test_process_eng_ocr_media_input_loads_selected_subtitle_stream(
 
 
 def test_process_eng_ocr_media_input_requires_matching_stream_index(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
     tmp_path: Path,
 ):
     """Test media OCR processing rejects missing subtitle stream indexes.
@@ -1064,10 +1064,11 @@ def test_process_eng_ocr_media_input_requires_matching_stream_index(
         lambda path: [SubtitleStream(index=5, codec_name="hdmv_pgs_subtitle")],
     )
 
-    with pytest.raises(ScinoephileError, match="No subtitle stream 7"):
+    with raises(ScinoephileError, match="No subtitle stream 7"):
         process_eng_ocr(
             source_path,
             tmp_path / "output",
             stream_index=7,
             validate=False,
         )
+

--- a/test/workflows/test_subtitle_extraction.py
+++ b/test/workflows/test_subtitle_extraction.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
+from pytest import LogCaptureFixture, raises
 from PIL import Image
 
 from scinoephile.core import ScinoephileError
@@ -342,7 +342,7 @@ def test_extract_subtitles_skips_sup_parsing_when_not_exporting_images(
 
 def test_extract_subtitles_warns_when_sup_image_export_fails(
     tmp_path: Path,
-    caplog: pytest.LogCaptureFixture,
+    caplog: LogCaptureFixture,
 ):
     """Test extraction keeps subtitle files when SUP image export fails.
 
@@ -489,7 +489,7 @@ def test_extract_subtitles_rejects_sup_file_without_subtitle_streams(tmp_path: P
             "scinoephile.workflows.subtitle_extraction.get_subtitle_streams",
             return_value=[],
         ),
-        pytest.raises(ScinoephileError, match="No subtitle streams found"),
+        raises(ScinoephileError, match="No subtitle streams found"),
     ):
         extract_subtitles(
             infile_path=infile_path,
@@ -513,3 +513,4 @@ def _image_series() -> ImageSeries:
             )
         ]
     )
+


### PR DESCRIPTION
## Summary
- Refactored pytest usage in modified test files to explicit `from pytest import ...` imports for non-mark/non-parametrize symbols.
- Updated existing usages like `pytest.raises(...)` -> `raises(...)`, etc., preserving behavior.
- Applied only to Python files under `test/**` that differ between `feature/retain-romanized-punctuation` and `master`.
- Left `mark` and `parametrize` as-is per request; no fixture output updates or production/helper refactors.
