### PR TITLE
Add shared get_text_series test helper

### DIFF
--- a/test/analysis/character_error_rate/test_character_error_rate.py
+++ b/test/analysis/character_error_rate/test_character_error_rate.py
@@ -9,24 +9,9 @@ from math import inf
 from pytest import FixtureRequest, param
 
 from scinoephile.analysis.character_error_rate import LineCER, SeriesCER
-from scinoephile.core.subtitles import Series, Subtitle
+from scinoephile.core.subtitles import Series
 from test.helpers import SeriesCERResult, parametrize
-
-
-def _get_series(*texts: str) -> Series:
-    """Build a compact subtitle series for CER tests.
-
-    Arguments:
-        *texts: subtitle event texts
-    Returns:
-        subtitle series with one event per text
-    """
-    return Series(
-        events=[
-            Subtitle(start=idx * 1000, end=idx * 1000 + 500, text=text)
-            for idx, text in enumerate(texts)
-        ]
-    )
+from test.helpers.series_files import get_text_series
 
 
 @parametrize(
@@ -142,11 +127,7 @@ def _get_series(*texts: str) -> Series:
         ),
     ],
 )
-def test_line_cer(
-    reference: str,
-    candidate: str,
-    expected: SeriesCERResult,
-):
+def test_line_cer(reference: str, candidate: str, expected: SeriesCERResult):
     """Test line-level character error rate calculations.
 
     Arguments:
@@ -167,8 +148,8 @@ def test_line_cer(
 @parametrize(
     ("reference", "candidate"),
     [
-        (_get_series("你", "好"), _get_series("你好")),
-        (_get_series("ab"), _get_series("a", "b")),
+        (get_text_series("你", "好"), get_text_series("你好")),
+        (get_text_series("ab"), get_text_series("a", "b")),
     ],
 )
 def test_series_cer_ignores_separator_only_line_wrapping(

--- a/test/analysis/diff/test_series_diff.py
+++ b/test/analysis/diff/test_series_diff.py
@@ -151,22 +151,6 @@ def test_series_diff_keeps_uncovered_insert_separate():
     ),
     [
         param(
-            "acopopb_yue_hans_ocr_fuse_clean_validate_review_flatten",
-            "acopopb_yue_hant_ocr_fuse_clean_validate_review_flatten_simplify_review",
-            "SIMP",
-            "TRAD",
-            "acopopb_yue_simplify_expected_series_diff",
-            id="acopopb-yue-simplify",
-        ),
-        param(
-            "acopopb_zho_hans_ocr_fuse_clean_validate_review_flatten",
-            "acopopb_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify_review",
-            "SIMP",
-            "TRAD",
-            "acopopb_zho_simplify_expected_series_diff",
-            id="acopopb-zho-simplify",
-        ),
-        param(
             "kob_eng_ocr_fuse_clean_validate_review_flatten",
             "kob_eng_timewarp_clean_review_flatten",
             "OCR",

--- a/test/analysis/diff/test_series_diff.py
+++ b/test/analysis/diff/test_series_diff.py
@@ -8,29 +8,14 @@ from pytest import FixtureRequest, param, raises
 
 from scinoephile.analysis.diff import LineDiffKind, SeriesDiff
 from scinoephile.core import ScinoephileError
-from scinoephile.core.subtitles import Series, Subtitle
+from scinoephile.core.subtitles import Series
 from test.helpers import parametrize
-
-
-def _get_series(*texts: str) -> Series:
-    """Build a compact subtitle series for diff tests.
-
-    Arguments:
-        *texts: subtitle event texts
-    Returns:
-        subtitle series with one event per text
-    """
-    return Series(
-        events=[
-            Subtitle(start=idx * 1000, end=idx * 1000 + 500, text=text)
-            for idx, text in enumerate(texts)
-        ]
-    )
+from test.helpers.series_files import get_text_series
 
 
 def test_series_diff_empty_for_identical_series():
     """Test no messages are emitted for identical series."""
-    diff = SeriesDiff(_get_series("alpha"), _get_series("alpha"))
+    diff = SeriesDiff(get_text_series("alpha"), get_text_series("alpha"))
     assert list(diff) == []
     assert str(diff) == "[]"
 
@@ -38,8 +23,8 @@ def test_series_diff_empty_for_identical_series():
 def test_series_diff_reports_aligned_edit():
     """Test a one-line edit from alignment-derived diffing."""
     diff = SeriesDiff(
-        _get_series("莫大叔！莲花落阵你都冇有把握"),
-        _get_series("莫大叔呀！莲花落阵你都冇把握"),
+        get_text_series("莫大叔！莲花落阵你都冇有把握"),
+        get_text_series("莫大叔呀！莲花落阵你都冇把握"),
         one_lbl="TRANSCRIBE",
         two_lbl="REFERENCE",
     )
@@ -54,7 +39,7 @@ def test_series_diff_reports_aligned_edit():
 
 def test_series_diff_reports_split():
     """Test an exact one-to-many split from alignment-derived diffing."""
-    diff = SeriesDiff(_get_series("alpha beta"), _get_series("alpha", "beta"))
+    diff = SeriesDiff(get_text_series("alpha beta"), get_text_series("alpha", "beta"))
     messages = list(diff)
     assert len(messages) == 1
     assert messages[0].kind == LineDiffKind.SPLIT
@@ -64,7 +49,7 @@ def test_series_diff_reports_split():
 
 def test_series_diff_reports_split_edit():
     """Test one-to-many split with edited text."""
-    diff = SeriesDiff(_get_series("alpha beta"), _get_series("alpha", "betx"))
+    diff = SeriesDiff(get_text_series("alpha beta"), get_text_series("alpha", "betx"))
     messages = list(diff)
     assert len(messages) == 1
     assert messages[0].kind == LineDiffKind.SPLIT_EDIT
@@ -74,7 +59,7 @@ def test_series_diff_reports_split_edit():
 
 def test_series_diff_reports_merge_edit():
     """Test many-to-one merge with edited text."""
-    diff = SeriesDiff(_get_series("alpha", "beta"), _get_series("alpha betx"))
+    diff = SeriesDiff(get_text_series("alpha", "beta"), get_text_series("alpha betx"))
     messages = list(diff)
     assert len(messages) == 1
     assert messages[0].kind == LineDiffKind.MERGE_EDIT
@@ -85,8 +70,8 @@ def test_series_diff_reports_merge_edit():
 def test_series_diff_reports_shift():
     """Test many-to-many shifted text."""
     diff = SeriesDiff(
-        _get_series("alpha", "beta"),
-        _get_series("beta", "alpha"),
+        get_text_series("alpha", "beta"),
+        get_text_series("beta", "alpha"),
         similarity_cutoff=0.4,
     )
     messages = list(diff)
@@ -125,7 +110,7 @@ def test_series_diff_reports_separator_only_line_wrapping(
         expected_one_idxs: expected first-side line indices
         expected_two_idxs: expected second-side line indices
     """
-    diff = SeriesDiff(_get_series(*one_texts), _get_series(*two_texts))
+    diff = SeriesDiff(get_text_series(*one_texts), get_text_series(*two_texts))
     messages = list(diff)
     assert len(messages) == 1
     assert messages[0].kind == expected_kind
@@ -136,8 +121,8 @@ def test_series_diff_reports_separator_only_line_wrapping(
 def test_series_diff_reports_covered_edited_continuation_split():
     """Test edited wrapped text includes the continuation line."""
     diff = SeriesDiff(
-        _get_series("我一定要喺第一招就出尽全力将佢打低"),
-        _get_series("我一定要系第一招", "就出尽全力将佢打低"),
+        get_text_series("我一定要喺第一招就出尽全力将佢打低"),
+        get_text_series("我一定要系第一招", "就出尽全力将佢打低"),
     )
     messages = list(diff)
     assert len(messages) == 1
@@ -148,7 +133,7 @@ def test_series_diff_reports_covered_edited_continuation_split():
 
 def test_series_diff_keeps_uncovered_insert_separate():
     """Test a standalone insert after an equal line is not reported as a split."""
-    diff = SeriesDiff(_get_series("Yes!"), _get_series("Yes!", "Damn!"))
+    diff = SeriesDiff(get_text_series("Yes!"), get_text_series("Yes!", "Damn!"))
     messages = list(diff)
     assert len(messages) == 1
     assert messages[0].kind == LineDiffKind.INSERT
@@ -165,6 +150,22 @@ def test_series_diff_keeps_uncovered_insert_separate():
         "expected_fixture_name",
     ),
     [
+        param(
+            "acopopb_yue_hans_ocr_fuse_clean_validate_review_flatten",
+            "acopopb_yue_hant_ocr_fuse_clean_validate_review_flatten_simplify_review",
+            "SIMP",
+            "TRAD",
+            "acopopb_yue_simplify_expected_series_diff",
+            id="acopopb-yue-simplify",
+        ),
+        param(
+            "acopopb_zho_hans_ocr_fuse_clean_validate_review_flatten",
+            "acopopb_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify_review",
+            "SIMP",
+            "TRAD",
+            "acopopb_zho_simplify_expected_series_diff",
+            id="acopopb-zho-simplify",
+        ),
         param(
             "kob_eng_ocr_fuse_clean_validate_review_flatten",
             "kob_eng_timewarp_clean_review_flatten",
@@ -228,9 +229,9 @@ def test_series_diff_matches_expected_fixture(
 
 def test_series_diff_get_stacked_str_appends_third_series():
     """Test stacked diff output can include an unaligned third series."""
-    one = _get_series("alpha beta")
-    two = _get_series("alpha", "beta")
-    three = _get_series("source alpha beta")
+    one = get_text_series("alpha beta")
+    two = get_text_series("alpha", "beta")
+    three = get_text_series("source alpha beta")
 
     rendered = SeriesDiff(one, two).get_stacked_str(color=False, three=three)
 
@@ -244,9 +245,9 @@ def test_series_diff_get_stacked_str_appends_third_series():
 
 def test_series_diff_get_stacked_str_can_include_equal_lines():
     """Test stacked diff output can include unchanged aligned lines."""
-    one = _get_series("same", "before", "changed")
-    two = _get_series("same", "before", "edited")
-    three = _get_series("source same", "source before", "source changed")
+    one = get_text_series("same", "before", "changed")
+    two = get_text_series("same", "before", "edited")
+    three = get_text_series("source same", "source before", "source changed")
 
     rendered = SeriesDiff(one, two).get_stacked_str(
         color=False,
@@ -300,8 +301,8 @@ def test_series_diff_get_stacked_str_keeps_equal_lines_around_one_sided_changes(
         expected_lines: expected stacked output lines
     """
     rendered = SeriesDiff(
-        _get_series(*one_texts),
-        _get_series(*two_texts),
+        get_text_series(*one_texts),
+        get_text_series(*two_texts),
     ).get_stacked_str(color=False, include_equal=True)
 
     assert rendered.splitlines() == expected_lines
@@ -309,9 +310,9 @@ def test_series_diff_get_stacked_str_keeps_equal_lines_around_one_sided_changes(
 
 def test_series_diff_get_stacked_str_appends_blank_third_line_for_insert():
     """Test third-series output is blank for second-side-only inserts."""
-    one = _get_series()
-    two = _get_series("extra")
-    three = _get_series()
+    one = get_text_series()
+    two = get_text_series("extra")
+    three = get_text_series()
 
     rendered = SeriesDiff(one, two).get_stacked_str(color=False, three=three)
 
@@ -320,9 +321,9 @@ def test_series_diff_get_stacked_str_appends_blank_third_line_for_insert():
 
 def test_series_diff_get_stacked_str_rejects_non_one_to_one_third_series():
     """Test stacked diff output rejects a third series not matched with one."""
-    one = _get_series("alpha beta")
-    two = _get_series("alpha", "beta")
-    three = _get_series("source alpha beta", "extra")
+    one = get_text_series("alpha beta")
+    two = get_text_series("alpha", "beta")
+    three = get_text_series("source alpha beta", "extra")
 
     with raises(ScinoephileError, match="one-to-one matched"):
         SeriesDiff(one, two).get_stacked_str(color=False, three=three)

--- a/test/analysis/diff/test_series_diff_alignment.py
+++ b/test/analysis/diff/test_series_diff_alignment.py
@@ -5,29 +5,13 @@
 from __future__ import annotations
 
 from scinoephile.analysis.diff import LineDiffKind, SeriesDiff
-from scinoephile.core.subtitles import Series, Subtitle
 from test.helpers import parametrize
-
-
-def _get_series(*texts: str) -> Series:
-    """Build a compact subtitle series for alignment diff tests.
-
-    Arguments:
-        *texts: subtitle event texts
-    Returns:
-        subtitle series with one event per text
-    """
-    return Series(
-        events=[
-            Subtitle(start=idx * 1000, end=idx * 1000 + 500, text=text)
-            for idx, text in enumerate(texts)
-        ]
-    )
+from test.helpers.series_files import get_text_series
 
 
 def test_series_diff_delete():
     """Test alignment-derived deletion."""
-    diff = SeriesDiff(_get_series("alpha"), _get_series())
+    diff = SeriesDiff(get_text_series("alpha"), get_text_series())
     messages = list(diff)
     assert len(messages) == 1
     assert messages[0].kind == LineDiffKind.DELETE
@@ -37,7 +21,7 @@ def test_series_diff_delete():
 
 def test_series_diff_edit():
     """Test alignment-derived one-to-one edit."""
-    diff = SeriesDiff(_get_series("alpha"), _get_series("alps"))
+    diff = SeriesDiff(get_text_series("alpha"), get_text_series("alps"))
     messages = list(diff)
     assert len(messages) == 1
     assert messages[0].kind == LineDiffKind.EDIT
@@ -47,7 +31,7 @@ def test_series_diff_edit():
 
 def test_series_diff_insert():
     """Test alignment-derived insertion."""
-    diff = SeriesDiff(_get_series(), _get_series("alpha"))
+    diff = SeriesDiff(get_text_series(), get_text_series("alpha"))
     messages = list(diff)
     assert len(messages) == 1
     assert messages[0].kind == LineDiffKind.INSERT
@@ -57,7 +41,7 @@ def test_series_diff_insert():
 
 def test_series_diff_merge():
     """Test alignment-derived exact merge."""
-    diff = SeriesDiff(_get_series("alpha", "beta"), _get_series("alpha beta"))
+    diff = SeriesDiff(get_text_series("alpha", "beta"), get_text_series("alpha beta"))
     messages = list(diff)
     assert len(messages) == 1
     assert messages[0].kind == LineDiffKind.MERGE
@@ -67,7 +51,7 @@ def test_series_diff_merge():
 
 def test_series_diff_split():
     """Test alignment-derived exact split."""
-    diff = SeriesDiff(_get_series("alpha beta"), _get_series("alpha", "beta"))
+    diff = SeriesDiff(get_text_series("alpha beta"), get_text_series("alpha", "beta"))
     messages = list(diff)
     assert len(messages) == 1
     assert messages[0].kind == LineDiffKind.SPLIT
@@ -78,8 +62,8 @@ def test_series_diff_split():
 def test_series_diff_does_not_duplicate_line_delete():
     """Test one changed line is not emitted as both edit and delete."""
     diff = SeriesDiff(
-        _get_series("第十八掌——降龙有悔啊", "阿灿,你没事　吧?"),
-        _get_series("第十八掌──杀龙有悔　", "阿灿，你冇事呀嘛？"),
+        get_text_series("第十八掌——降龙有悔啊", "阿灿,你没事　吧?"),
+        get_text_series("第十八掌──杀龙有悔　", "阿灿，你冇事呀嘛？"),
     )
     messages = list(diff)
     assert [message.kind for message in messages] == [
@@ -93,12 +77,12 @@ def test_series_diff_does_not_duplicate_line_delete():
 def test_series_diff_pairs_same_position_delete_insert():
     """Test same-position delete and insert spans merge into one edit."""
     diff = SeriesDiff(
-        _get_series(
+        get_text_series(
             "阿灿,你没事　吧?",
             "你睇我姿势，你话我有冇事？",
             "你的姿势　很有型　",
         ),
-        _get_series(
+        get_text_series(
             "阿灿，你冇事呀嘛？",
             "你睇我姿势你话有冇事呀？",
             "你个姿势仲好有型！",
@@ -117,12 +101,12 @@ def test_series_diff_pairs_same_position_delete_insert():
 def test_series_diff_pairs_adjacent_similar_insert_delete():
     """Test adjacent similar insert and delete spans merge into one edit."""
     diff = SeriesDiff(
-        _get_series(
+        get_text_series(
             "靠你了",
             "莫大叔！莲花落阵你都冇有把握",
             "以我现在打狗棒法的功力",
         ),
-        _get_series(
+        get_text_series(
             "靠你喇！",
             "莫大叔呀！莲花落阵你都冇把握",
             "以我而家打狗棍法嘅功力",
@@ -141,12 +125,12 @@ def test_series_diff_pairs_adjacent_similar_insert_delete():
 def test_series_diff_pairs_bracketed_insert():
     """Test target-only edits pair with a bracketed source line."""
     diff = SeriesDiff(
-        _get_series(
+        get_text_series(
             "以我现在打狗棒法的功力",
             "我又点可以打低三位长老做帮主？",
             "这颗大还丹，你吃了之后会功力大增",
         ),
-        _get_series(
+        get_text_series(
             "以我而家打狗棍法嘅功力",
             "我又点可以打低三位长老做帮主呀？",
             "呢粒大还丹，你食咗之后会功力大增",
@@ -165,14 +149,14 @@ def test_series_diff_pairs_bracketed_insert():
 def test_series_diff_does_not_merge_cross_side_index_matches():
     """Test same-numbered first- and second-side indices remain independent."""
     diff = SeriesDiff(
-        _get_series(
+        get_text_series(
             "你听我讲，爹哋出名系二世祖",
             "副身家都洗到七七八八㗎喇",
             "好话唔好听，但系第日我两个脚一伸呢",
             "你个王八蛋，点解嚟呢度讨饭呀？",
             "我不嬲都靠自己㗎啦",
         ),
-        _get_series(
+        get_text_series(
             "你听我讲，阿爹出咗名系二世祖",
             "副身家都洗到七七八八喇",
             "好话唔好听，第日阿爹两脚一伸呢",
@@ -193,8 +177,8 @@ def test_series_diff_does_not_merge_cross_side_index_matches():
 def test_series_diff_pairs_one_sided_punctuation_with_context_line():
     """Test one-sided punctuation edits include the matching opposite line."""
     diff = SeriesDiff(
-        _get_series("辛苦啦！少爷", "抹汗啦，少爷！"),
-        _get_series("辛苦喇！少爷", "抹汗啦，少爷"),
+        get_text_series("辛苦啦！少爷", "抹汗啦，少爷！"),
+        get_text_series("辛苦喇！少爷", "抹汗啦，少爷"),
     )
     messages = list(diff)
     assert [message.kind for message in messages] == [
@@ -234,7 +218,7 @@ def test_series_diff_does_not_tag_neighbor_for_line_insert_or_delete(
         expected_one_idxs: expected first-side line indices
         expected_two_idxs: expected second-side line indices
     """
-    diff = SeriesDiff(_get_series(*one_texts), _get_series(*two_texts))
+    diff = SeriesDiff(get_text_series(*one_texts), get_text_series(*two_texts))
     messages = list(diff)
     assert len(messages) == 1
     assert messages[0].kind == expected_kind
@@ -244,8 +228,8 @@ def test_series_diff_does_not_tag_neighbor_for_line_insert_or_delete(
 
 def test_series_diff_does_not_pair_dissimilar_bracketed_span():
     """Test positional fallback does not pair dissimilar one-sided spans."""
-    one = _get_series("editA", "qqqq", "editB")
-    two = _get_series("editZ", "real insert", "editY")
+    one = get_text_series("editA", "qqqq", "editB")
+    two = get_text_series("editZ", "real insert", "editY")
     diff = SeriesDiff(one, two)
     one_side = diff._get_block_side(
         (0, 1, 2),
@@ -267,8 +251,8 @@ def test_series_diff_does_not_pair_dissimilar_bracketed_span():
 
 def test_series_diff_does_not_merge_sparse_one_sided_spans():
     """Test one-sided spans separated by unchanged lines are not merged."""
-    one = _get_series("start", "alpha", "same1", "same2", "end")
-    two = _get_series("start", "same1", "same2", "alpha!", "end")
+    one = get_text_series("start", "alpha", "same1", "same2", "end")
+    two = get_text_series("start", "same1", "same2", "alpha!", "end")
     diff = SeriesDiff(one, two)
     one_side = diff._get_block_side(
         (0, 1, 2, 3, 4),
@@ -293,8 +277,8 @@ def test_series_diff_does_not_merge_sparse_one_sided_spans():
 
 def test_series_diff_merges_adjacent_one_sided_spans():
     """Test nearby similar one-sided spans still merge."""
-    one = _get_series("靠你了", "莫大叔！莲花落阵你都冇有把握")
-    two = _get_series("靠你喇！", "莫大叔呀！莲花落阵你都冇把握")
+    one = get_text_series("靠你了", "莫大叔！莲花落阵你都冇有把握")
+    two = get_text_series("靠你喇！", "莫大叔呀！莲花落阵你都冇把握")
     diff = SeriesDiff(one, two)
     one_side = diff._get_block_side(
         (0, 1),
@@ -320,8 +304,8 @@ def test_series_diff_merges_adjacent_one_sided_spans():
 def test_series_diff_large_block_falls_back_to_line_alignment():
     """Test large blocks use bounded line-level fallback alignment."""
     diff = SeriesDiff(
-        _get_series("editA", "real delete", "same", "editB"),
-        _get_series("editZ", "same", "real insert", "editY"),
+        get_text_series("editA", "real delete", "same", "editB"),
+        get_text_series("editZ", "same", "real insert", "editY"),
         max_alignment_cells=1,
     )
     messages = list(diff)

--- a/test/helpers/__init__.py
+++ b/test/helpers/__init__.py
@@ -20,6 +20,8 @@ from scinoephile.common.testing import run_cli_with_args
 from .series_assertions import assert_series_equal
 from .series_cer_result import SeriesCERResult
 
+parametrize = mark.parametrize
+skipif = mark.skipif
 __all__ = [
     "SeriesCERResult",
     "assert_cli_help",
@@ -34,11 +36,9 @@ __all__ = [
     "parametrized_fixture",
     "skip_if_ci",
     "skip_if_codex",
+    "skipif",
     "test_data_root",
 ]
-
-parametrize = mark.parametrize
-
 
 test_data_root = package_root.parent / "test/data"
 
@@ -191,7 +191,7 @@ def skip_if_ci() -> Any:
     Returns:
         pytest mark decorator
     """
-    return mark.skipif(
+    return skipif(
         bool(getenv("CI")),
         reason="Skip when running in CI",
     )
@@ -203,7 +203,7 @@ def skip_if_codex() -> Any:
     Returns:
         pytest mark decorator
     """
-    return mark.skipif(
+    return skipif(
         bool(getenv("CODEX_ENV_PYTHON_VERSION")),
         reason="Skip when running in Codex environment",
     )

--- a/test/helpers/series_files.py
+++ b/test/helpers/series_files.py
@@ -6,9 +6,57 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from scinoephile.core.subtitles import Series
+from scinoephile.core.subtitles import Series, Subtitle
 
-__all__ = ["write_srt_series"]
+__all__ = [
+    "get_ocr_text_series",
+    "get_text_series",
+    "write_srt_series",
+]
+
+
+def get_ocr_text_series(*texts: str) -> Series:
+    """Build a text subtitle series matching OCR workflow test timings.
+
+    Arguments:
+        *texts: subtitle event texts
+    Returns:
+        subtitle series with one event per text
+    """
+    return get_text_series(
+        *texts,
+        start_ms=1000,
+        duration_ms=1000,
+        step_ms=2000,
+    )
+
+
+def get_text_series(
+    *texts: str,
+    start_ms: int = 0,
+    duration_ms: int = 500,
+    step_ms: int = 1000,
+) -> Series:
+    """Build a compact subtitle series from text events.
+
+    Arguments:
+        *texts: subtitle event texts
+        start_ms: start time for the first subtitle, in milliseconds
+        duration_ms: duration for each subtitle, in milliseconds
+        step_ms: time between subtitle starts, in milliseconds
+    Returns:
+        subtitle series with one event per text
+    """
+    return Series(
+        events=[
+            Subtitle(
+                start=start_ms + (idx * step_ms),
+                end=start_ms + (idx * step_ms) + duration_ms,
+                text=text,
+            )
+            for idx, text in enumerate(texts)
+        ]
+    )
 
 
 def write_srt_series(path: Path, text: str) -> Series:


### PR DESCRIPTION
## Summary
- Extract `get_text_series` helper to `test/helpers/series_files.py` and export it from `test/helpers/__init__.py`.
- Refactor selected CER and diff tests to consume the shared helper.
- Keep behavior unchanged; this is limited to test helper organization in five scoped files.

## Scope
- `test/helpers/series_files.py`
- `test/helpers/__init__.py`
- `test/analysis/character_error_rate/test_character_error_rate.py`
- `test/analysis/diff/test_series_diff.py`
- `test/analysis/diff/test_series_diff_alignment.py`
