### PR TITLE
Use package_root in tests

### DIFF
--- a/test/audio/transcription/test_whisper_transcriber.py
+++ b/test/audio/transcription/test_whisper_transcriber.py
@@ -18,6 +18,7 @@ from scinoephile.audio.transcription import get_segment_split_at_idx
 from scinoephile.audio.transcription.transcribed_segment import TranscribedSegment
 from scinoephile.audio.transcription.transcribed_word import TranscribedWord
 from scinoephile.audio.transcription.whisper_transcriber import WhisperTranscriber
+from scinoephile.common import package_root
 from scinoephile.common.subprocess import run_command
 from test.helpers import parametrize
 
@@ -30,7 +31,6 @@ _OPTIONAL_TRANSCRIPTION_MODULES = (
     "transformers",
     "whisper_timestamped",
 )
-_REPO_ROOT_PATH = Path(__file__).parents[3]
 
 
 @parametrize(
@@ -131,11 +131,11 @@ def test_transcription_imports_without_optional_runtime_dependencies():
     )
     env = os.environ.copy()
     env["PYTHONPATH"] = os.pathsep.join(
-        [str(_REPO_ROOT_PATH), env.get("PYTHONPATH", "")]
+        [str(package_root.parent), env.get("PYTHONPATH", "")]
     )
     exitcode, _, _ = run_command(
         [sys.executable, "-c", script],
-        cwd_path=_REPO_ROOT_PATH,
+        cwd_path=package_root.parent,
         env=env,
     )
 

--- a/test/image/ocr/validation/test_char_pair_gaps.py
+++ b/test/image/ocr/validation/test_char_pair_gaps.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from pytest import raises
 
+from scinoephile.common import package_root
 from scinoephile.image.ocr.validation.char_pair_gaps import (
     get_default_char_pair_cutoffs,
     load_char_pair_gaps,
@@ -31,7 +32,7 @@ def test_load_char_pair_gaps_rejects_nonmonotonic_cutoffs(tmp_path: Path):
 
 def test_repo_char_pair_gaps_have_monotonic_cutoffs():
     """Test repository character pair gap data has ordered cutoffs."""
-    file_path = Path(__file__).parents[4] / "scinoephile/data/ocr/char_pair_gaps.csv"
+    file_path = package_root / "data/ocr/char_pair_gaps.csv"
 
     with file_path.open("r", encoding="utf-8", newline="") as handle:
         reader = csv.reader(handle)
@@ -46,7 +47,7 @@ def test_repo_char_pair_gaps_have_monotonic_cutoffs():
 
 def test_repo_char_pair_gaps_exclude_default_cutoffs():
     """Test repository character pair gap data stores only default overrides."""
-    file_path = Path(__file__).parents[4] / "scinoephile/data/ocr/char_pair_gaps.csv"
+    file_path = package_root / "data/ocr/char_pair_gaps.csv"
 
     with file_path.open("r", encoding="utf-8", newline="") as handle:
         reader = csv.reader(handle)

--- a/test/test_module_hierarchy.py
+++ b/test/test_module_hierarchy.py
@@ -9,14 +9,13 @@ from collections import defaultdict
 from functools import cache
 from pathlib import Path
 
-REPO_DIR_PATH = Path(__file__).resolve().parents[1]
-PACKAGE_DIR_PATH = REPO_DIR_PATH / "scinoephile"
+from scinoephile.common import package_root
 
 
 def test_module_hierarchy_docs_match_imports():
     """Test package hierarchy docs match the compact import hierarchy."""
     violations: list[str] = []
-    for init_path in sorted(PACKAGE_DIR_PATH.rglob("__init__.py")):
+    for init_path in sorted(package_root.rglob("__init__.py")):
         package_dir_path = init_path.parent
         child_names = get_child_names(package_dir_path)
         if len(child_names) < 2:
@@ -26,7 +25,7 @@ def test_module_hierarchy_docs_match_imports():
         documented_levels = get_documented_levels(init_path)
         if documented_levels is None:
             violations.append(
-                f"{init_path.relative_to(REPO_DIR_PATH)}: missing hierarchy block"
+                f"{init_path.relative_to(package_root.parent)}: missing hierarchy block"
             )
             continue
 
@@ -64,7 +63,8 @@ def test_module_hierarchy_docs_match_imports():
         expected_levels = get_compact_levels(edges)
         if documented_levels != expected_levels:
             violations.append(
-                f"{init_path.relative_to(REPO_DIR_PATH)}: hierarchy is not compact\n"
+                f"{init_path.relative_to(package_root.parent)}: "
+                "hierarchy is not compact\n"
                 f"  documented: {format_levels(documented_levels)}\n"
                 f"  expected:   {format_levels(expected_levels)}"
             )
@@ -78,7 +78,7 @@ def test_resolve_import_from_modules_includes_absolute_package_aliases():
     assert isinstance(node, ast.ImportFrom)
 
     imported_modules = resolve_import_from_modules(
-        file_path=REPO_DIR_PATH / "scinoephile/core/cache/operations.py",
+        file_path=package_root / "core/cache/operations.py",
         node=node,
         root_package_parts=["scinoephile", "core"],
     )
@@ -96,7 +96,7 @@ def test_resolve_import_from_modules_includes_relative_package_aliases():
     assert isinstance(node, ast.ImportFrom)
 
     imported_modules = resolve_import_from_modules(
-        file_path=REPO_DIR_PATH / "scinoephile/core/cache/cache_entry.py",
+        file_path=package_root / "core/cache/cache_entry.py",
         node=node,
         root_package_parts=["scinoephile", "core", "cache"],
     )
@@ -134,7 +134,7 @@ def get_package_dotted(package_dir_path: Path) -> str:
     Returns:
         dotted package name
     """
-    return ".".join(package_dir_path.relative_to(REPO_DIR_PATH).parts)
+    return ".".join(package_dir_path.relative_to(package_root.parent).parts)
 
 
 def get_documented_levels(init_path: Path) -> dict[int, list[str]] | None:
@@ -223,17 +223,20 @@ def get_documented_level_violations(
     violations: list[str] = []
     if duplicate_names:
         violations.append(
-            f"{init_path.relative_to(REPO_DIR_PATH)}: duplicated hierarchy entries: "
+            f"{init_path.relative_to(package_root.parent)}: "
+            "duplicated hierarchy entries: "
             f"{', '.join(duplicate_names)}"
         )
     if missing_names:
         violations.append(
-            f"{init_path.relative_to(REPO_DIR_PATH)}: missing hierarchy entries: "
+            f"{init_path.relative_to(package_root.parent)}: "
+            "missing hierarchy entries: "
             f"{', '.join(missing_names)}"
         )
     if extra_names:
         violations.append(
-            f"{init_path.relative_to(REPO_DIR_PATH)}: unknown hierarchy entries: "
+            f"{init_path.relative_to(package_root.parent)}: "
+            "unknown hierarchy entries: "
             f"{', '.join(extra_names)}"
         )
     return violations
@@ -351,7 +354,7 @@ def get_file_package_parts(file_path: Path) -> list[str]:
     Returns:
         package name parts
     """
-    relative_path = file_path.relative_to(REPO_DIR_PATH)
+    relative_path = file_path.relative_to(package_root.parent)
     if file_path.name == "__init__.py":
         return list(relative_path.parent.parts)
     return list(relative_path.parent.parts)
@@ -378,7 +381,7 @@ def get_import_order_violations(
             imported_level = documented_level_by_child[imported_name]
             if importer_level <= imported_level:
                 violations.append(
-                    f"{init_path.relative_to(REPO_DIR_PATH)}: "
+                    f"{init_path.relative_to(package_root.parent)}: "
                     f"{importer_name} imports {imported_name}, but "
                     f"{importer_name} is level {importer_level} and "
                     f"{imported_name} is level {imported_level}"
@@ -425,7 +428,8 @@ def get_cycle_violations(init_path: Path, edges: dict[str, set[str]]) -> list[st
             visit(child_name)
 
     return [
-        f"{init_path.relative_to(REPO_DIR_PATH)}: import cycle: {' -> '.join(cycle)}"
+        f"{init_path.relative_to(package_root.parent)}: "
+        f"import cycle: {' -> '.join(cycle)}"
         for cycle in sorted(cycles)
     ]
 

--- a/test/test_package_data.py
+++ b/test/test_package_data.py
@@ -12,13 +12,13 @@ from pathlib import Path
 
 import pytest
 
+from scinoephile.common import package_root
 from scinoephile.common.subprocess import run_command
 
 
 def test_installed_wheel_includes_runtime_data_files(tmp_path: Path):
     """Test installed wheels expose runtime data files under package_root."""
-    project_root_path = Path(__file__).resolve().parents[1]
-    build_source_dir_path = _copy_build_source(project_root_path, tmp_path / "source")
+    build_source_dir_path = _copy_build_source(package_root.parent, tmp_path / "source")
     source_data_dir_path = build_source_dir_path / "scinoephile/data"
     ignored_local_dump_path = (
         source_data_dir_path / "dictionaries/wiktionary/entries.jsonl"

--- a/test/test_style.py
+++ b/test/test_style.py
@@ -11,7 +11,6 @@ from pathlib import Path
 
 from scinoephile.common import package_root
 
-REPO_DIR_PATH = package_root.parent
 EXCLUDED_DIR_NAMES = {
     ".git",
     ".mypy_cache",
@@ -53,7 +52,7 @@ class StringInterpolationViolation:
             formatted violation
         """
         return (
-            f"{self.file_path.relative_to(REPO_DIR_PATH)}:"
+            f"{self.file_path.relative_to(package_root.parent)}:"
             f"{self.line_number}: {self.message}"
         )
 
@@ -63,7 +62,7 @@ def test_percent_interpolation_arguments_are_detected():
     tree = ast.parse('logger.warning("hello %s", name)')
 
     violations = get_string_interpolation_violations(
-        file_path=REPO_DIR_PATH / "sample.py",
+        file_path=package_root.parent / "sample.py",
         tree=tree,
     )
 
@@ -75,7 +74,7 @@ def test_percent_interpolation_arguments_are_detected():
 def test_python_sources_do_not_use_percent_string_interpolation():
     """Test Python sources do not use percent-style string interpolation."""
     violations: list[StringInterpolationViolation] = []
-    for file_path in get_python_files(REPO_DIR_PATH):
+    for file_path in get_python_files(package_root.parent):
         tree = ast.parse(
             file_path.read_text(encoding="utf-8"), filename=file_path.as_posix()
         )

--- a/test/test_style.py
+++ b/test/test_style.py
@@ -9,7 +9,9 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
-REPO_DIR_PATH = Path(__file__).resolve().parents[1]
+from scinoephile.common import package_root
+
+REPO_DIR_PATH = package_root.parent
 EXCLUDED_DIR_NAMES = {
     ".git",
     ".mypy_cache",


### PR DESCRIPTION
## Summary
- Use `package_root` from `scinoephile.common` for repository-root/path derivation in scoped test files.
- Replace ad-hoc relative `Path(...).parents`/`resolve` computations in tests with `package_root`-based equivalents.
- Scope constrained to test path-root cleanup only: `test/audio/transcription/test_whisper_transcriber.py`, `test/image/ocr/validation/test_char_pair_gaps.py`, `test/test_module_hierarchy.py`, `test/test_package_data.py`, `test/test_style.py`.

## Notes
- No production code changes.
- No `test/data/**/output/**` changes.
- `test/helpers/__init__.py` left unchanged to avoid unrelated pytest import/export churn.