### PR TITLE
Extract cache test helpers

### DIFF
--- a/test/cli/utility/cache/test_cache_clear_cli.py
+++ b/test/cli/utility/cache/test_cache_clear_cli.py
@@ -10,6 +10,7 @@ from pytest import CaptureFixture, raises
 
 from scinoephile.cli.utility.cache.cache_clear_cli import CacheClearCli
 from scinoephile.common.testing import run_cli_with_args
+from test.helpers.files import write_cache_file
 
 
 def test_cache_clear_dry_run(tmp_path: Path, capsys: CaptureFixture[str]):
@@ -19,7 +20,7 @@ def test_cache_clear_dry_run(tmp_path: Path, capsys: CaptureFixture[str]):
         tmp_path: temporary directory
         capsys: pytest capture fixture
     """
-    cache_path = _write_cache_file(tmp_path / "llm/one.json")
+    cache_path = write_cache_file(tmp_path / "llm/one.json")
 
     run_cli_with_args(
         CacheClearCli, f"--cache-dir {tmp_path} --namespace llm --dry-run"
@@ -38,9 +39,9 @@ def test_cache_clear_all_dry_run_limits_output(
         tmp_path: temporary directory
         capsys: pytest capture fixture
     """
-    _write_cache_file(tmp_path / "llm/one.json")
-    _write_cache_file(tmp_path / "llm/two.json")
-    _write_cache_file(tmp_path / "whisper/three.json")
+    write_cache_file(tmp_path / "llm/one.json")
+    write_cache_file(tmp_path / "llm/two.json")
+    write_cache_file(tmp_path / "whisper/three.json")
 
     run_cli_with_args(
         CacheClearCli, f"--cache-dir {tmp_path} --all --dry-run --limit 2"
@@ -57,8 +58,8 @@ def test_cache_clear_namespace_confirmed(tmp_path: Path):
     Arguments:
         tmp_path: temporary directory
     """
-    _write_cache_file(tmp_path / "llm/one.json")
-    whisper_path = _write_cache_file(tmp_path / "whisper/two.json")
+    write_cache_file(tmp_path / "llm/one.json")
+    whisper_path = write_cache_file(tmp_path / "whisper/two.json")
 
     run_cli_with_args(CacheClearCli, f"--cache-dir {tmp_path} --namespace llm --yes")
 
@@ -72,8 +73,8 @@ def test_cache_clear_all_confirmed(tmp_path: Path):
     Arguments:
         tmp_path: temporary directory
     """
-    _write_cache_file(tmp_path / "llm/one.json")
-    _write_cache_file(tmp_path / "whisper/two.json")
+    write_cache_file(tmp_path / "llm/one.json")
+    write_cache_file(tmp_path / "whisper/two.json")
 
     run_cli_with_args(CacheClearCli, f"--cache-dir {tmp_path} --all --yes")
 
@@ -101,16 +102,3 @@ def test_cache_clear_requires_confirmation(tmp_path: Path):
     with raises(SystemExit) as exc_info:
         run_cli_with_args(CacheClearCli, f"--cache-dir {tmp_path} --namespace llm")
     assert exc_info.value.code == 2
-
-
-def _write_cache_file(path: Path) -> Path:
-    """Write a cache file.
-
-    Arguments:
-        path: path to write
-    Returns:
-        written path
-    """
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text("{}", encoding="utf-8")
-    return path

--- a/test/cli/utility/cache/test_cache_list_cli.py
+++ b/test/cli/utility/cache/test_cache_list_cli.py
@@ -11,6 +11,7 @@ from pytest import CaptureFixture
 
 from scinoephile.cli.utility.cache.cache_list_cli import CacheListCli
 from scinoephile.common.testing import run_cli_with_args
+from test.helpers.files import write_cache_file
 
 
 def test_cache_list_text(tmp_path: Path, capsys: CaptureFixture[str]):
@@ -20,8 +21,8 @@ def test_cache_list_text(tmp_path: Path, capsys: CaptureFixture[str]):
         tmp_path: temporary directory
         capsys: pytest capture fixture
     """
-    _write_cache_file(tmp_path / "llm/one.json")
-    _write_cache_file(tmp_path / "whisper/two.json")
+    write_cache_file(tmp_path / "llm/one.json")
+    write_cache_file(tmp_path / "whisper/two.json")
 
     run_cli_with_args(CacheListCli, f"--cache-dir {tmp_path} --namespace llm")
 
@@ -35,7 +36,7 @@ def test_cache_list_json(tmp_path: Path, capsys: CaptureFixture[str]):
         tmp_path: temporary directory
         capsys: pytest capture fixture
     """
-    _write_cache_file(tmp_path / "llm/one.json")
+    write_cache_file(tmp_path / "llm/one.json")
 
     run_cli_with_args(CacheListCli, f"--cache-dir {tmp_path} --format json")
 
@@ -54,13 +55,3 @@ def test_cache_list_missing_root(tmp_path: Path, capsys: CaptureFixture[str]):
     run_cli_with_args(CacheListCli, f"--cache-dir {tmp_path / 'missing'}")
 
     assert capsys.readouterr().out == "No cache entries found.\n"
-
-
-def _write_cache_file(path: Path):
-    """Write a cache file.
-
-    Arguments:
-        path: path to write
-    """
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text("{}", encoding="utf-8")

--- a/test/cli/utility/cache/test_cache_prune_cli.py
+++ b/test/cli/utility/cache/test_cache_prune_cli.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-from os import utime
 from pathlib import Path
 from time import time
 
@@ -12,6 +11,7 @@ from pytest import CaptureFixture, raises
 
 from scinoephile.cli.utility.cache.cache_prune_cli import CachePruneCli
 from scinoephile.common.testing import run_cli_with_args
+from test.helpers.files import set_mtime, write_cache_file
 
 
 def test_cache_prune_dry_run(tmp_path: Path, capsys: CaptureFixture[str]):
@@ -21,7 +21,7 @@ def test_cache_prune_dry_run(tmp_path: Path, capsys: CaptureFixture[str]):
         tmp_path: temporary directory
         capsys: pytest capture fixture
     """
-    old_path = _write_cache_file(tmp_path / "llm/old.json")
+    old_path = write_cache_file(tmp_path / "llm/old.json")
     _set_old(old_path)
 
     run_cli_with_args(
@@ -38,8 +38,8 @@ def test_cache_prune_confirmed(tmp_path: Path):
     Arguments:
         tmp_path: temporary directory
     """
-    old_path = _write_cache_file(tmp_path / "llm/old.json")
-    new_path = _write_cache_file(tmp_path / "llm/new.json")
+    old_path = write_cache_file(tmp_path / "llm/old.json")
+    new_path = write_cache_file(tmp_path / "llm/new.json")
     _set_old(old_path)
 
     run_cli_with_args(CachePruneCli, f"--cache-dir {tmp_path} --older-than 30d --yes")
@@ -66,17 +66,4 @@ def _set_old(path: Path):
         path: path to modify
     """
     timestamp = time() - 60 * 60 * 24 * 40
-    utime(path, (timestamp, timestamp))
-
-
-def _write_cache_file(path: Path) -> Path:
-    """Write a cache file.
-
-    Arguments:
-        path: path to write
-    Returns:
-        written path
-    """
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text("{}", encoding="utf-8")
-    return path
+    set_mtime(path, timestamp)

--- a/test/cli/utility/cache/test_cache_stats_cli.py
+++ b/test/cli/utility/cache/test_cache_stats_cli.py
@@ -11,6 +11,7 @@ from pytest import CaptureFixture
 
 from scinoephile.cli.utility.cache.cache_stats_cli import CacheStatsCli
 from scinoephile.common.testing import run_cli_with_args
+from test.helpers.files import write_cache_file
 
 
 def test_cache_stats_json(tmp_path: Path, capsys: CaptureFixture[str]):
@@ -20,7 +21,7 @@ def test_cache_stats_json(tmp_path: Path, capsys: CaptureFixture[str]):
         tmp_path: temporary directory
         capsys: pytest capture fixture
     """
-    _write_cache_file(tmp_path / "llm/one.json", "one")
+    write_cache_file(tmp_path / "llm/one.json", "one")
 
     run_cli_with_args(CacheStatsCli, f"--cache-dir {tmp_path} --format json")
 
@@ -37,22 +38,11 @@ def test_cache_stats_namespace(tmp_path: Path, capsys: CaptureFixture[str]):
         tmp_path: temporary directory
         capsys: pytest capture fixture
     """
-    _write_cache_file(tmp_path / "llm/one.json")
-    _write_cache_file(tmp_path / "whisper/two.json")
+    write_cache_file(tmp_path / "llm/one.json")
+    write_cache_file(tmp_path / "whisper/two.json")
 
     run_cli_with_args(CacheStatsCli, f"--cache-dir {tmp_path} --namespace whisper")
 
     output = capsys.readouterr().out
     assert "whisper\t1 entries" in output
     assert "llm\t" not in output
-
-
-def _write_cache_file(path: Path, text: str = "{}"):
-    """Write a cache file.
-
-    Arguments:
-        path: path to write
-        text: text to write
-    """
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(text, encoding="utf-8")

--- a/test/core/cache/test_operations.py
+++ b/test/core/cache/test_operations.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from os import utime
 from pathlib import Path
 from time import time
 
@@ -19,6 +18,7 @@ from scinoephile.core.cache.operations import (
     get_cache_stats,
     prune_cache,
 )
+from test.helpers.files import set_mtime, write_cache_file
 
 
 def test_discover_cache_namespaces(tmp_path: Path):
@@ -27,9 +27,9 @@ def test_discover_cache_namespaces(tmp_path: Path):
     Arguments:
         tmp_path: temporary directory
     """
-    _write_cache_file(tmp_path / "llm/one.json")
-    _write_cache_file(tmp_path / "whisper/two.json")
-    _write_cache_file(tmp_path / "root.json")
+    write_cache_file(tmp_path / "llm/one.json")
+    write_cache_file(tmp_path / "whisper/two.json")
+    write_cache_file(tmp_path / "root.json")
 
     assert discover_cache_namespaces(tmp_path) == ["llm", "whisper"]
 
@@ -40,8 +40,8 @@ def test_get_cache_entries_filters_namespace(tmp_path: Path):
     Arguments:
         tmp_path: temporary directory
     """
-    _write_cache_file(tmp_path / "llm/one.json", "one")
-    _write_cache_file(tmp_path / "whisper/two.json", "two")
+    write_cache_file(tmp_path / "llm/one.json", "one")
+    write_cache_file(tmp_path / "whisper/two.json", "two")
 
     entries = get_cache_entries(tmp_path, namespace="llm")
 
@@ -66,7 +66,7 @@ def test_get_cache_entries_invalid_namespace(tmp_path: Path):
     Arguments:
         tmp_path: temporary directory
     """
-    _write_cache_file(tmp_path / "llm/one.json")
+    write_cache_file(tmp_path / "llm/one.json")
 
     with raises(ScinoephileError, match="was not found"):
         get_cache_entries(tmp_path, namespace="ocr")
@@ -78,9 +78,9 @@ def test_get_cache_stats(tmp_path: Path):
     Arguments:
         tmp_path: temporary directory
     """
-    _write_cache_file(tmp_path / "llm/one.json", "one")
-    _write_cache_file(tmp_path / "llm/two.json", "two")
-    _write_cache_file(tmp_path / "whisper/three.json", "three")
+    write_cache_file(tmp_path / "llm/one.json", "one")
+    write_cache_file(tmp_path / "llm/two.json", "two")
+    write_cache_file(tmp_path / "whisper/three.json", "three")
 
     stats_by_namespace = get_cache_stats(tmp_path)
     stats = {
@@ -101,12 +101,12 @@ def test_prune_cache(tmp_path: Path):
     Arguments:
         tmp_path: temporary directory
     """
-    old_path = _write_cache_file(tmp_path / "llm/old.json")
-    new_path = _write_cache_file(tmp_path / "llm/new.json")
+    old_path = write_cache_file(tmp_path / "llm/old.json")
+    new_path = write_cache_file(tmp_path / "llm/new.json")
     old_timestamp = time() - 60 * 60 * 24 * 40
     old_path.touch()
     new_path.touch()
-    _set_mtime(old_path, old_timestamp)
+    set_mtime(old_path, old_timestamp)
 
     deleted_entries = prune_cache(tmp_path, older_than=timedelta(days=30))
 
@@ -121,35 +121,11 @@ def test_clear_cache_namespace(tmp_path: Path):
     Arguments:
         tmp_path: temporary directory
     """
-    _write_cache_file(tmp_path / "llm/one.json")
-    whisper_path = _write_cache_file(tmp_path / "whisper/two.json")
+    write_cache_file(tmp_path / "llm/one.json")
+    whisper_path = write_cache_file(tmp_path / "whisper/two.json")
 
     deleted_entries = clear_cache(tmp_path, namespace="llm")
 
     assert [entry.relative_path for entry in deleted_entries] == [Path("llm/one.json")]
     assert not (tmp_path / "llm").exists()
     assert whisper_path.exists()
-
-
-def _set_mtime(path: Path, timestamp: float):
-    """Set a path modification and access time.
-
-    Arguments:
-        path: path to modify
-        timestamp: timestamp to set
-    """
-    utime(path, (timestamp, timestamp))
-
-
-def _write_cache_file(path: Path, text: str = "{}") -> Path:
-    """Write a cache file.
-
-    Arguments:
-        path: path to write
-        text: text to write
-    Returns:
-        written path
-    """
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(text, encoding="utf-8")
-    return path

--- a/test/helpers/files.py
+++ b/test/helpers/files.py
@@ -1,0 +1,37 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Shared file helpers for tests."""
+
+from __future__ import annotations
+
+from os import utime
+from pathlib import Path
+
+__all__ = [
+    "set_mtime",
+    "write_cache_file",
+]
+
+
+def set_mtime(path: Path, timestamp: float) -> None:
+    """Set a path modification and access time.
+
+    Arguments:
+        path: path to modify
+        timestamp: timestamp to set
+    """
+    utime(path, (timestamp, timestamp))
+
+
+def write_cache_file(path: Path, text: str = "{}") -> Path:
+    """Write a cache file.
+
+    Arguments:
+        path: path to write
+        text: text to write
+    Returns:
+        written path
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path

--- a/test/workflows/test_ocr_processing.py
+++ b/test/workflows/test_ocr_processing.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import os
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -22,6 +21,7 @@ from scinoephile.workflows.ocr_processing import (
     OcrProcessingWorkflow,
 )
 from test.helpers import parametrize
+from test.helpers.files import set_mtime
 
 OLD_MTIME = 1_700_000_000
 """Older file modification time used by timestamp-sensitive tests."""
@@ -53,16 +53,6 @@ def _image_series_with_texts(
             for subtitle, text in zip(image_series.events, texts)
         ]
     )
-
-
-def _set_mtime(file_path: Path, mtime: int):
-    """Set a deterministic file modification time.
-
-    Arguments:
-        file_path: file path to update
-        mtime: modification time as seconds since epoch
-    """
-    os.utime(file_path, (mtime, mtime))
 
 
 def _series_with_texts(texts: list[str]) -> Series:
@@ -758,8 +748,8 @@ def test_ocr_validation_keeps_newer_image_index_text(
     source_series = _series_with_texts(["fused 1", "fused 2"])
     source_path = output_dir_path / "fuse_clean.srt"
     source_series.save(source_path, format_="srt")
-    _set_mtime(source_path, OLD_MTIME)
-    _set_mtime(image_dir_path / "index.html", NEW_MTIME)
+    set_mtime(source_path, OLD_MTIME)
+    set_mtime(image_dir_path / "index.html", NEW_MTIME)
 
     def fake_validate_ocr(source: Path, outfile_path: Path, **kwargs: object):
         """Record text passed to validation."""
@@ -803,8 +793,8 @@ def test_ocr_validation_uses_newer_fuse_clean_text(
     source_series = _series_with_texts(["fused 1", "fused 2"])
     source_path = output_dir_path / "fuse_clean.srt"
     source_series.save(source_path, format_="srt")
-    _set_mtime(image_dir_path / "index.html", OLD_MTIME)
-    _set_mtime(source_path, NEW_MTIME)
+    set_mtime(image_dir_path / "index.html", OLD_MTIME)
+    set_mtime(source_path, NEW_MTIME)
 
     def fake_validate_ocr(source: Path, outfile_path: Path, **kwargs: object):
         """Record text passed to validation."""
@@ -848,8 +838,8 @@ def test_ocr_validation_uses_fuse_clean_for_blank_image_index(
     source_series = _series_with_texts(["fused 1", "fused 2"])
     source_path = output_dir_path / "fuse_clean.srt"
     source_series.save(source_path, format_="srt")
-    _set_mtime(source_path, OLD_MTIME)
-    _set_mtime(image_dir_path / "index.html", NEW_MTIME)
+    set_mtime(source_path, OLD_MTIME)
+    set_mtime(image_dir_path / "index.html", NEW_MTIME)
 
     def fake_validate_ocr(source: Path, outfile_path: Path, **kwargs: object):
         """Record text passed to validation."""


### PR DESCRIPTION
Extract set_mtime and write_cache_file into test.helpers.files and update call-sites in cache and OCR tests. No behavior changes outside helper extraction.