### PR TITLE
Share dictionary fixtures

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,9 +4,13 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
+from pathlib import Path
+
 import pytest
 from PIL import Image
 
+from scinoephile.common.file import get_temp_directory_path, get_temp_file_path
 from scinoephile.image.subtitles import ImageSeries, ImageSubtitle
 
 # ruff: noqa: F401 F403
@@ -17,6 +21,27 @@ from test.data.mlamd import *
 from test.data.mnt import *
 from test.data.t import *
 from test.data.tmm import *
+
+
+@pytest.fixture
+def database_path() -> Generator[Path]:
+    """Provide a temporary SQLite database path."""
+    with get_temp_file_path(".db") as file_path:
+        yield file_path
+
+
+@pytest.fixture
+def local_data_dir_path() -> Generator[Path]:
+    """Provide a temporary local data directory for tests."""
+    with get_temp_directory_path() as dir_path:
+        yield dir_path
+
+
+@pytest.fixture
+def runtime_data_dir_path() -> Generator[Path]:
+    """Provide a temporary runtime data directory for tests."""
+    with get_temp_directory_path() as dir_path:
+        yield dir_path
 
 
 @pytest.fixture

--- a/test/core/dictionaries/test_sqlite_store.py
+++ b/test/core/dictionaries/test_sqlite_store.py
@@ -5,26 +5,17 @@
 from __future__ import annotations
 
 import sqlite3
-from collections.abc import Generator
 from contextlib import closing
 from pathlib import Path
 
 from pytest import fixture
 
-from scinoephile.common.file import get_temp_file_path
 from scinoephile.core.dictionaries import (
     DictionaryDefinition,
     DictionaryEntry,
     DictionarySource,
     DictionarySqliteStore,
 )
-
-
-@fixture
-def database_path() -> Generator[Path]:
-    """Provide a temporary SQLite database path."""
-    with get_temp_file_path(".db") as temp_path:
-        yield temp_path
 
 
 @fixture

--- a/test/dictionaries/cuhk/test_cuhk_dictionary_service.py
+++ b/test/dictionaries/cuhk/test_cuhk_dictionary_service.py
@@ -4,13 +4,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from contextlib import AbstractContextManager, nullcontext
 from pathlib import Path
 
 from pytest import fixture, raises
 
-from scinoephile.common.file import get_temp_file_path
 from scinoephile.core.dictionaries import (
     DictionaryDefinition,
     DictionaryEntry,
@@ -19,13 +17,6 @@ from scinoephile.core.dictionaries import (
 )
 from scinoephile.dictionaries.cuhk import CuhkDictionaryService
 from test.helpers import parametrize
-
-
-@fixture
-def database_path() -> Generator[Path]:
-    """Provide a temporary SQLite database path."""
-    with get_temp_file_path(".db") as temp_path:
-        yield temp_path
 
 
 @fixture

--- a/test/dictionaries/gzzj/test_gzzj_dictionary_service.py
+++ b/test/dictionaries/gzzj/test_gzzj_dictionary_service.py
@@ -36,13 +36,6 @@ def source_json_path() -> Generator[Path]:
 
 
 @fixture
-def database_path() -> Generator[Path]:
-    """Provide a temporary SQLite database path."""
-    with get_temp_file_path(".db") as temp_path:
-        yield temp_path
-
-
-@fixture
 def service(database_path: Path, source_json_path: Path) -> GzzjDictionaryService:
     """Provide a GZZJ service backed by deterministic JSON fixture data."""
     service = GzzjDictionaryService(

--- a/test/dictionaries/kaifangcidian/test_kaifangcidian_dictionary_service.py
+++ b/test/dictionaries/kaifangcidian/test_kaifangcidian_dictionary_service.py
@@ -5,34 +5,11 @@
 from __future__ import annotations
 
 import csv
-from collections.abc import Generator
 from pathlib import Path
 
-from pytest import MonkeyPatch, fixture
+from pytest import MonkeyPatch
 
-from scinoephile.common.file import get_temp_directory_path, get_temp_file_path
 from scinoephile.dictionaries.kaifangcidian import KaifangcidianDictionaryService
-
-
-@fixture
-def local_data_dir_path() -> Generator[Path]:
-    """Provide a temporary canonical local data directory."""
-    with get_temp_directory_path() as dir_path:
-        yield dir_path
-
-
-@fixture
-def runtime_data_dir_path() -> Generator[Path]:
-    """Provide a temporary runtime canonical data directory."""
-    with get_temp_directory_path() as dir_path:
-        yield dir_path
-
-
-@fixture
-def database_path() -> Generator[Path]:
-    """Provide a temporary SQLite database path."""
-    with get_temp_file_path(".db") as temp_path:
-        yield temp_path
 
 
 def _write_fixture_csv(csv_path: Path):

--- a/test/dictionaries/kaifangcidian/test_kaifangcidian_downloader.py
+++ b/test/dictionaries/kaifangcidian/test_kaifangcidian_downloader.py
@@ -25,9 +25,7 @@ class _MockResponse:
         """Raise no error for a successful mock response."""
 
 
-def test_download_payloads_only_fetch_required_sources(
-    monkeypatch: MonkeyPatch,
-):
+def test_download_payloads_only_fetch_required_sources(monkeypatch: MonkeyPatch):
     """Download only the payloads currently used for canonical rows.
 
     Arguments:

--- a/test/dictionaries/unihan/test_unihan_dictionary_service.py
+++ b/test/dictionaries/unihan/test_unihan_dictionary_service.py
@@ -4,36 +4,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from pathlib import Path
 from types import TracebackType
 
 import requests
-from pytest import MonkeyPatch, fixture, raises
+from pytest import MonkeyPatch, raises
 
-from scinoephile.common.file import get_temp_directory_path, get_temp_file_path
 from scinoephile.dictionaries.unihan import UnihanDictionaryService
-
-
-@fixture
-def local_data_dir_path() -> Generator[Path]:
-    """Provide a temporary canonical local data directory."""
-    with get_temp_directory_path() as dir_path:
-        yield dir_path
-
-
-@fixture
-def runtime_data_dir_path() -> Generator[Path]:
-    """Provide a temporary runtime canonical data directory."""
-    with get_temp_directory_path() as dir_path:
-        yield dir_path
-
-
-@fixture
-def database_path() -> Generator[Path]:
-    """Provide a temporary SQLite database path."""
-    with get_temp_file_path(".db") as temp_path:
-        yield temp_path
 
 
 def _write_fixture_sources(base_dir_path: Path):

--- a/test/dictionaries/wiktionary/test_wiktionary_dictionary_service.py
+++ b/test/dictionaries/wiktionary/test_wiktionary_dictionary_service.py
@@ -5,35 +5,12 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Generator
 from pathlib import Path
 
 import requests
-from pytest import MonkeyPatch, fixture, raises
+from pytest import MonkeyPatch, raises
 
-from scinoephile.common.file import get_temp_directory_path, get_temp_file_path
 from scinoephile.dictionaries.wiktionary import WiktionaryDictionaryService
-
-
-@fixture
-def local_data_dir_path() -> Generator[Path]:
-    """Provide a temporary canonical local data directory."""
-    with get_temp_directory_path() as dir_path:
-        yield dir_path
-
-
-@fixture
-def runtime_data_dir_path() -> Generator[Path]:
-    """Provide a temporary runtime canonical data directory."""
-    with get_temp_directory_path() as dir_path:
-        yield dir_path
-
-
-@fixture
-def database_path() -> Generator[Path]:
-    """Provide a temporary SQLite database path."""
-    with get_temp_file_path(".db") as temp_path:
-        yield temp_path
 
 
 def _write_fixture_jsonl(jsonl_path: Path):


### PR DESCRIPTION
## Summary
- Add shared dictionary temp-path fixtures in `test/conftest.py`.
- Use shared `database_path`, `local_data_dir_path`, and `runtime_data_dir_path` fixtures in dictionary tests.
- Keep `source_json_path` local to GZZJ tests only.
- Preserve behavior; no production or OCR/data changes.