### PR TITLE
Clean up whitespace in tests

### DIFF
--- a/test/audio/transcription/test_demucs_separator.py
+++ b/test/audio/transcription/test_demucs_separator.py
@@ -47,9 +47,7 @@ def test_get_audio_segment_restores_mono_output():
     assert audio.channels == 1
 
 
-def test_demucs_model_loader_requires_transcription_extra(
-    monkeypatch: MonkeyPatch,
-):
+def test_demucs_model_loader_requires_transcription_extra(monkeypatch: MonkeyPatch):
     """Test Demucs import errors mention the transcription extra."""
     original_import = builtins.__import__
 

--- a/test/cli/eng/test_eng_process_cli.py
+++ b/test/cli/eng/test_eng_process_cli.py
@@ -24,11 +24,7 @@ from test.helpers import assert_series_equal, parametrize, test_data_root
         ),
     ],
 )
-def test_eng_process_cli(
-    input_path: str,
-    args: str,
-    expected_path: str,
-):
+def test_eng_process_cli(input_path: str, args: str, expected_path: str):
     """Test English processing CLI with file arguments.
 
     Arguments:

--- a/test/cli/media/test_media_extract_subs_cli.py
+++ b/test/cli/media/test_media_extract_subs_cli.py
@@ -72,9 +72,7 @@ def test_media_extract_subs_cli_renders_grouped_outputs(
     ]
 
 
-def test_media_extract_subs_cli_maps_workflow_errors_to_parser_errors(
-    tmp_path: Path,
-):
+def test_media_extract_subs_cli_maps_workflow_errors_to_parser_errors(tmp_path: Path):
     """Test media extract-subs CLI maps workflow errors to parser errors.
 
     Arguments:

--- a/test/cli/media/test_media_offset_cli.py
+++ b/test/cli/media/test_media_offset_cli.py
@@ -15,10 +15,7 @@ from scinoephile.common.testing import run_cli_with_args
 from test.helpers import parametrize
 
 
-def test_media_offset_cli_reports_offset(
-    tmp_path: Path,
-    capsys: CaptureFixture[str],
-):
+def test_media_offset_cli_reports_offset(tmp_path: Path, capsys: CaptureFixture[str]):
     """Test media offset CLI reports a human-readable offset result.
 
     Arguments:

--- a/test/cli/media/test_media_probe_cli.py
+++ b/test/cli/media/test_media_probe_cli.py
@@ -16,10 +16,7 @@ from scinoephile.lang.zho.subtitles.analysis import ZhoSubtitleScriptAnalysis
 from test.helpers import parametrize
 
 
-def test_media_probe_cli_lists_all_streams(
-    tmp_path: Path,
-    capsys: CaptureFixture[str],
-):
+def test_media_probe_cli_lists_all_streams(tmp_path: Path, capsys: CaptureFixture[str]):
     """Test media probe CLI lists all streams without packet counts.
 
     Arguments:

--- a/test/cli/multi/test_multi_diff_cli.py
+++ b/test/cli/multi/test_multi_diff_cli.py
@@ -12,10 +12,7 @@ from scinoephile.cli.multi.multi_diff_cli import MultiDiffCli
 from scinoephile.common.testing import run_cli_with_args
 
 
-def test_multi_diff_cli(
-    tmp_path: Path,
-    capsys: CaptureFixture,
-):
+def test_multi_diff_cli(tmp_path: Path, capsys: CaptureFixture):
     """Test multi diff CLI output.
 
     Arguments:
@@ -44,10 +41,7 @@ def test_multi_diff_cli(
     assert output == ("edit: REFERENCE[1] -> CANDIDATE[1]: '靠你了' -> '靠你喇！'\n")
 
 
-def test_multi_diff_cli_multiline_split_edit(
-    tmp_path: Path,
-    capsys: CaptureFixture,
-):
+def test_multi_diff_cli_multiline_split_edit(tmp_path: Path, capsys: CaptureFixture):
     """Test multi diff CLI output for multi-line alignment.
 
     Arguments:

--- a/test/cli/ocr/test_ocr_validate_cli.py
+++ b/test/cli/ocr/test_ocr_validate_cli.py
@@ -13,10 +13,7 @@ from scinoephile.common.testing import run_cli_with_args
 from scinoephile.core import ScinoephileError
 
 
-def test_ocr_validate_cli(
-    monkeypatch: MonkeyPatch,
-    tmp_path: Path,
-):
+def test_ocr_validate_cli(monkeypatch: MonkeyPatch, tmp_path: Path):
     """Test OCR validate CLI forwards noninteractive workflow arguments.
 
     Arguments:
@@ -82,10 +79,7 @@ def test_ocr_validate_cli(
     assert outfile_path.read_text(encoding="utf-8") == "validated"
 
 
-def test_ocr_validate_cli_web(
-    monkeypatch: MonkeyPatch,
-    tmp_path: Path,
-):
+def test_ocr_validate_cli_web(monkeypatch: MonkeyPatch, tmp_path: Path):
     """Test OCR validate CLI launches web validation.
 
     Arguments:

--- a/test/cli/utility/cache/test_argument_types.py
+++ b/test/cli/utility/cache/test_argument_types.py
@@ -20,10 +20,7 @@ def test_add_cache_dir_arg_resolves_runtime_cache_subpath():
     runtime_cache_parts: list[tuple[str, ...]] = []
     create_values: list[bool] = []
 
-    def get_runtime_cache_dir_path(
-        *parts: str,
-        create: bool,
-    ) -> Path:
+    def get_runtime_cache_dir_path(*parts: str, create: bool) -> Path:
         """Record runtime cache default arguments."""
         runtime_cache_parts.append(parts)
         create_values.append(create)

--- a/test/cli/zho/test_zho_process_cli.py
+++ b/test/cli/zho/test_zho_process_cli.py
@@ -32,11 +32,7 @@ from test.helpers import assert_series_equal, parametrize, test_data_root
         ),
     ],
 )
-def test_zho_process_cli(
-    input_path: str,
-    args: str,
-    expected_path: str,
-):
+def test_zho_process_cli(input_path: str, args: str, expected_path: str):
     """Test standard Chinese processing CLI with file arguments.
 
     Arguments:

--- a/test/common/test_command_line_interface.py
+++ b/test/common/test_command_line_interface.py
@@ -36,11 +36,7 @@ class ArgsCaptureCli(CommandLineInterface):
         parser.add_argument("--name", type=str, required=True)
 
     @classmethod
-    def _main(
-        cls,
-        *,
-        name: str,
-    ):
+    def _main(cls, *, name: str):
         """Execute test CLI."""
         cls.captured["name"] = name
 
@@ -59,11 +55,7 @@ class RequiredArgCli(CommandLineInterface):
         parser.add_argument("--name", required=True)
 
     @classmethod
-    def _main(
-        cls,
-        *,
-        name: str,
-    ):
+    def _main(cls, *, name: str):
         """Execute test CLI."""
 
 
@@ -260,9 +252,7 @@ def test_run_cli_with_args_quoted_values():
     assert ArgsCaptureCli.captured.get("name") == "value with spaces"
 
 
-def test_assert_cli_usage_failure_reports_streams(
-    monkeypatch: MonkeyPatch,
-):
+def test_assert_cli_usage_failure_reports_streams(monkeypatch: MonkeyPatch):
     """Test CLI usage assertion failures include expected and actual streams.
 
     Arguments:

--- a/test/helpers/ocr_validation.py
+++ b/test/helpers/ocr_validation.py
@@ -72,12 +72,7 @@ def make_ocr_html_dir(
     return html_dir_path
 
 
-def make_two_image_ocr_html_dir(
-    tmp_path: Path,
-    *,
-    text_1: str,
-    text_2: str,
-) -> Path:
+def make_two_image_ocr_html_dir(tmp_path: Path, *, text_1: str, text_2: str) -> Path:
     """Create an OCR image HTML directory with two subtitle images.
 
     Arguments:
@@ -153,10 +148,7 @@ def prepared_gap_session(
     return session
 
 
-def _write_html_index(
-    html_dir_path: Path,
-    rows: list[tuple[int, str, str, str, str]],
-):
+def _write_html_index(html_dir_path: Path, rows: list[tuple[int, str, str, str, str]]):
     """Write an OCR image HTML index.
 
     Arguments:

--- a/test/image/ocr/lens/test_lens_recognizer.py
+++ b/test/image/ocr/lens/test_lens_recognizer.py
@@ -308,9 +308,7 @@ def test_lens_recognizer_raises_last_request_error_after_retries(
     assert not list(tmp_path.glob("*.json"))
 
 
-def test_lens_recognizer_retries_in_one_asyncio_run(
-    monkeypatch: MonkeyPatch,
-):
+def test_lens_recognizer_retries_in_one_asyncio_run(monkeypatch: MonkeyPatch):
     """Test Google Lens retries within one asyncio.run call.
 
     Arguments:
@@ -352,9 +350,7 @@ def test_lens_recognizer_retries_in_one_asyncio_run(
     assert recognizer.predict_count == 3
 
 
-def test_lens_recognizer_waits_between_transient_retries(
-    monkeypatch: MonkeyPatch,
-):
+def test_lens_recognizer_waits_between_transient_retries(monkeypatch: MonkeyPatch):
     """Test Google Lens waits before retrying transient failures.
 
     Arguments:
@@ -375,9 +371,7 @@ def test_lens_recognizer_waits_between_transient_retries(
     assert delays == [1.5, 1.5]
 
 
-def test_lens_recognizer_retries_lens_api_errors(
-    monkeypatch: MonkeyPatch,
-):
+def test_lens_recognizer_retries_lens_api_errors(monkeypatch: MonkeyPatch):
     """Test Google Lens retries transient chrome-lens-py API errors.
 
     Arguments:
@@ -412,9 +406,7 @@ def test_lens_recognizer_does_not_retry_nontransient_errors():
     assert recognizer.predict_count == 1
 
 
-def test_lens_recognizer_rejects_uncached_calls_in_async_loop(
-    tmp_path: Path,
-):
+def test_lens_recognizer_rejects_uncached_calls_in_async_loop(tmp_path: Path):
     """Test uncached synchronous recognition fails clearly in an async loop.
 
     Arguments:
@@ -430,9 +422,7 @@ def test_lens_recognizer_rejects_uncached_calls_in_async_loop(
     asyncio.run(recognize())
 
 
-def test_lens_recognizer_import_error_is_actionable(
-    monkeypatch: MonkeyPatch,
-):
+def test_lens_recognizer_import_error_is_actionable(monkeypatch: MonkeyPatch):
     """Test missing chrome-lens-py dependency produces an actionable error.
 
     Arguments:
@@ -487,9 +477,7 @@ def test_lens_recognizer_imports_chrome_lens_py_only_when_needed():
     assert exitcode == 0
 
 
-def test_lens_recognizer_reuses_lens_api_client_per_instance(
-    monkeypatch: MonkeyPatch,
-):
+def test_lens_recognizer_reuses_lens_api_client_per_instance(monkeypatch: MonkeyPatch):
     """Test each Google Lens recognizer reuses one LensAPI client.
 
     Arguments:

--- a/test/image/ocr/paddle/test_paddle_recognizer.py
+++ b/test/image/ocr/paddle/test_paddle_recognizer.py
@@ -106,9 +106,7 @@ def test_paddle_recognizer_uses_server_models_and_disables_mkldnn_on_windows(
     assert observed_kwargs["enable_mkldnn"] is False
 
 
-def test_paddle_recognizer_keeps_mkldnn_enabled_off_windows(
-    monkeypatch: MonkeyPatch,
-):
+def test_paddle_recognizer_keeps_mkldnn_enabled_off_windows(monkeypatch: MonkeyPatch):
     """Test PaddleOCR recognizer keeps MKL-DNN enabled off Windows.
 
     Arguments:
@@ -140,9 +138,7 @@ def test_paddle_recognizer_keeps_mkldnn_enabled_off_windows(
     assert observed_kwargs["enable_mkldnn"] is True
 
 
-def test_paddle_recognizer_preserves_root_logger_level(
-    monkeypatch: MonkeyPatch,
-):
+def test_paddle_recognizer_preserves_root_logger_level(monkeypatch: MonkeyPatch):
     """Test PaddleOCR construction does not change root logging level.
 
     Arguments:

--- a/test/image/ocr/tesseract/test_tesseract_recognizer.py
+++ b/test/image/ocr/tesseract/test_tesseract_recognizer.py
@@ -558,9 +558,7 @@ def test_tesseract_detect_italics_raises_clear_legacy_error(tmp_path: Path):
     assert list(tmp_path.glob("*.json")) == []
 
 
-def test_tesseract_raises_and_does_not_cache_when_output_is_missing(
-    tmp_path: Path,
-):
+def test_tesseract_raises_and_does_not_cache_when_output_is_missing(tmp_path: Path):
     """Test successful Tesseract commands without hOCR output are not cached.
 
     Arguments:

--- a/test/lang/yue/test_get_yue_jyutping_query_strings.py
+++ b/test/lang/yue/test_get_yue_jyutping_query_strings.py
@@ -17,10 +17,7 @@ from test.helpers import parametrize
         ("séung", ["soeng2"]),
     ],
 )
-def test_get_yue_jyutping_query_strings(
-    text: str,
-    expected: list[str],
-):
+def test_get_yue_jyutping_query_strings(text: str, expected: list[str]):
     """Test get_yue_jyutping_query_strings.
 
     Arguments:

--- a/test/llms/providers/test_deepseek_provider.py
+++ b/test/llms/providers/test_deepseek_provider.py
@@ -47,9 +47,7 @@ def test_deepseek_constructs_client_with_base_url_and_env_api_key(
     assert client.kwargs["api_key"] == "dummy"
 
 
-def test_deepseek_api_key_override_wins_over_env(
-    monkeypatch: MonkeyPatch,
-):
+def test_deepseek_api_key_override_wins_over_env(monkeypatch: MonkeyPatch):
     """Test explicit api_key overrides the environment variable."""
     monkeypatch.setenv("DEEPSEEK_API_KEY", "env")
 

--- a/test/llms/providers/test_openai_provider.py
+++ b/test/llms/providers/test_openai_provider.py
@@ -30,9 +30,7 @@ def test_openai_constructs_client_with_explicit_api_key_and_base_url(
     assert client.kwargs["base_url"] == "https://example.invalid/v1"
 
 
-def test_openai_constructs_client_without_overrides(
-    monkeypatch: MonkeyPatch,
-):
+def test_openai_constructs_client_without_overrides(monkeypatch: MonkeyPatch):
     """Test OpenAIProvider uses SDK defaults when no overrides are supplied."""
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.setattr(openai_provider_base, "OpenAI", DummyOpenAI)

--- a/test/workflows/test_subtitle_extraction.py
+++ b/test/workflows/test_subtitle_extraction.py
@@ -287,9 +287,7 @@ def test_extract_subtitles_extracts_sup_streams_to_image_dirs(tmp_path: Path):
     assert (output_dir_path / "zho-3" / "index.html").exists()
 
 
-def test_extract_subtitles_skips_sup_parsing_when_not_exporting_images(
-    tmp_path: Path,
-):
+def test_extract_subtitles_skips_sup_parsing_when_not_exporting_images(tmp_path: Path):
     """Test extraction skips SUP image parsing when image export is disabled.
 
     Arguments:


### PR DESCRIPTION
## Summary
- Cherry-picks formatting-only whitespace-only changes from `feature/retain-romanized-punctuation` into the listed test files.
- Restricts updates to those files only with unchanged AST semantics.
- Excludes behavior changes, fixture output edits, and production code changes.