### PR TITLE
Add additional test cases using existing fixture data

### DIFF
--- a/test/core/test_stacking.py
+++ b/test/core/test_stacking.py
@@ -136,6 +136,18 @@ def test_get_stacked_series_overlap_error_includes_event_context():
     ("one_fixture", "two_fixture", "expected_fixture"),
     [
         param(
+            "acopopb_zho_hans_ocr_fuse_clean_validate_review_flatten",
+            "acopopb_eng_ocr_fuse_clean_validate_review_flatten",
+            "acopopb_zho_hans_eng",
+            id="acopopb-zho-hans-eng",
+        ),
+        param(
+            "acoptc_zho_hans_ocr_fuse_clean_validate_review_flatten",
+            "acoptc_eng_ocr_fuse_clean_validate_review_flatten",
+            "acoptc_zho_hans_eng",
+            id="acoptc-zho-hans-eng",
+        ),
+        param(
             "kob_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify_review",
             "kob_eng_ocr_fuse_clean_validate_review_flatten",
             "kob_zho_hans_eng",
@@ -148,10 +160,22 @@ def test_get_stacked_series_overlap_error_includes_event_context():
             id="mlamd-zho-hans-eng",
         ),
         param(
+            "mnt_zho_hans_fuse_clean_validate_review_flatten",
+            "mnt_eng_fuse_clean_validate_review_flatten",
+            "mnt_zho_hans_eng",
+            id="mnt-zho-hans-eng",
+        ),
+        param(
             "t_zho_hans_fuse_clean_validate_review_flatten",
             "t_eng_fuse_clean_validate_review_flatten",
             "t_zho_hans_eng",
             id="t-zho-hans-eng",
+        ),
+        param(
+            "tmm_zho_hans_ocr_fuse_clean_validate_review_flatten",
+            "tmm_eng_ocr_fuse_clean_validate_review_flatten",
+            "tmm_zho_hans_eng",
+            id="tmm-zho-hans-eng",
         ),
     ],
 )

--- a/test/lang/cmn/test_get_cmn_romanized.py
+++ b/test/lang/cmn/test_get_cmn_romanized.py
@@ -14,14 +14,49 @@ from test.helpers import assert_series_equal, parametrize
     ("series_fixture", "expected_fixture"),
     [
         param(
+            "acopopb_zho_hans_ocr_fuse_clean_validate_review_flatten",
+            "acopopb_zho_hans_ocr_fuse_clean_validate_review_flatten_romanize",
+            id="acopopb-zho-hans",
+        ),
+        param(
+            "acopopb_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify_review",
+            "acopopb_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify_review_romanize",
+            id="acopopb-zho-hant-simplify-review",
+        ),
+        param(
+            "acoptc_zho_hans_ocr_fuse_clean_validate_review_flatten",
+            "acoptc_zho_hans_ocr_fuse_clean_validate_review_flatten_romanize",
+            id="acoptc-zho-hans",
+        ),
+        param(
+            "acoptc_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify_review",
+            "acoptc_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify_review_romanize",
+            id="acoptc-zho-hant-simplify-review",
+        ),
+        param(
+            "kob_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify_review",
+            "kob_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify_review_romanize",
+            id="kob-zho-hant-simplify-review",
+        ),
+        param(
             "mlamd_zho_hans_fuse_clean_validate_review_flatten",
             "mlamd_zho_hans_fuse_clean_validate_review_flatten_romanize",
             id="mlamd-zho-hans",
         ),
         param(
+            "mlamd_zho_hant_fuse_clean_validate_review_flatten_simplify_review",
+            "mlamd_zho_hant_fuse_clean_validate_review_flatten_simplify_review_romanize",
+            id="mlamd-zho-hant-simplify-review",
+        ),
+        param(
             "mnt_zho_hans_fuse_clean_validate_review_flatten",
             "mnt_zho_hans_fuse_clean_validate_review_flatten_romanize",
             id="mnt-zho-hans",
+        ),
+        param(
+            "mnt_zho_hant_fuse_clean_validate_review_flatten_simplify_review",
+            "mnt_zho_hant_fuse_clean_validate_review_flatten_simplify_review_romanize",
+            id="mnt-zho-hant-simplify-review",
         ),
         param(
             "t_zho_hans_fuse_clean_validate_review_flatten",
@@ -32,6 +67,16 @@ from test.helpers import assert_series_equal, parametrize
             "t_zho_hant_fuse_clean_validate_review_flatten_simplify_review",
             "t_zho_hant_fuse_clean_validate_review_flatten_simplify_review_romanize",
             id="t-zho-hant-simplify-review",
+        ),
+        param(
+            "tmm_zho_hans_ocr_fuse_clean_validate_review_flatten",
+            "tmm_zho_hans_ocr_fuse_clean_validate_review_flatten_romanize",
+            id="tmm-zho-hans",
+        ),
+        param(
+            "tmm_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify_review",
+            "tmm_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify_review_romanize",
+            id="tmm-zho-hant-simplify-review",
         ),
     ],
 )

--- a/test/lang/eng/test_get_eng_block_reviewed.py
+++ b/test/lang/eng/test_get_eng_block_reviewed.py
@@ -15,6 +15,7 @@ from scinoephile.lang.eng.block_review import (
     get_eng_block_reviewer,
 )
 from test.data.kob import get_kob_eng_block_review_test_cases
+from test.data.mlamd import get_mlamd_eng_block_review_test_cases
 from test.data.t import get_t_eng_block_review_test_cases
 from test.helpers import assert_series_equal, parametrize
 
@@ -27,6 +28,18 @@ from test.helpers import assert_series_equal, parametrize
             "kob_eng_ocr_fuse_clean_validate_review",
             get_kob_eng_block_review_test_cases,
             id="kob-eng",
+        ),
+        param(
+            "kob_eng_timewarp_clean",
+            "kob_eng_timewarp_clean_review",
+            get_kob_eng_block_review_test_cases,
+            id="kob-eng-timewarp",
+        ),
+        param(
+            "mlamd_eng_fuse_clean_validate",
+            "mlamd_eng_fuse_clean_validate_review",
+            get_mlamd_eng_block_review_test_cases,
+            id="mlamd-eng",
         ),
         param(
             "t_eng_fuse_clean_validate",

--- a/test/lang/eng/test_get_eng_cleaned.py
+++ b/test/lang/eng/test_get_eng_cleaned.py
@@ -44,9 +44,44 @@ def test_get_eng_text_cleaned(
     ("series_fixture", "expected_fixture"),
     [
         param(
+            "acopopb_eng_ocr_tesseract",
+            "acopopb_eng_ocr_tesseract_clean",
+            id="acopopb-eng-tesseract",
+        ),
+        param(
+            "acoptc_eng_ocr_fuse",
+            "acoptc_eng_ocr_fuse_clean",
+            id="acoptc-eng-fuse",
+        ),
+        param(
+            "acoptc_eng_ocr_lens",
+            "acoptc_eng_ocr_lens_clean",
+            id="acoptc-eng-lens",
+        ),
+        param(
+            "acoptc_eng_ocr_tesseract",
+            "acoptc_eng_ocr_tesseract_clean",
+            id="acoptc-eng-tesseract",
+        ),
+        param(
             "kob_eng_ocr_fuse",
             "kob_eng_ocr_fuse_clean",
             id="kob-eng-fuse",
+        ),
+        param(
+            "kob_eng_ocr_lens",
+            "kob_eng_ocr_lens_clean",
+            id="kob-eng-lens",
+        ),
+        param(
+            "kob_eng_ocr_tesseract",
+            "kob_eng_ocr_tesseract_clean",
+            id="kob-eng-tesseract",
+        ),
+        param(
+            "kob_eng_timewarp",
+            "kob_eng_timewarp_clean",
+            id="kob-eng-timewarp",
         ),
         param(
             "mlamd_eng_fuse",
@@ -54,9 +89,24 @@ def test_get_eng_text_cleaned(
             id="mlamd-eng-fuse",
         ),
         param(
+            "mlamd_eng_ocr_lens",
+            "mlamd_eng_ocr_lens_clean",
+            id="mlamd-eng-lens",
+        ),
+        param(
             "mnt_eng_fuse",
             "mnt_eng_fuse_clean",
             id="mnt-eng-fuse",
+        ),
+        param(
+            "mnt_eng_ocr_lens",
+            "mnt_eng_ocr_lens_clean",
+            id="mnt-eng-lens",
+        ),
+        param(
+            "mnt_eng_ocr_tesseract",
+            "mnt_eng_ocr_tesseract_clean",
+            id="mnt-eng-tesseract",
         ),
         param(
             "t_eng_fuse",
@@ -72,6 +122,21 @@ def test_get_eng_text_cleaned(
             "t_eng_ocr_tesseract",
             "t_eng_ocr_tesseract_clean",
             id="t-eng-tesseract",
+        ),
+        param(
+            "tmm_eng_ocr_fuse",
+            "tmm_eng_ocr_fuse_clean",
+            id="tmm-eng-fuse",
+        ),
+        param(
+            "tmm_eng_ocr_lens",
+            "tmm_eng_ocr_lens_clean",
+            id="tmm-eng-lens",
+        ),
+        param(
+            "tmm_eng_ocr_tesseract",
+            "tmm_eng_ocr_tesseract_clean",
+            id="tmm-eng-tesseract",
         ),
     ],
 )

--- a/test/lang/eng/test_get_eng_flattened.py
+++ b/test/lang/eng/test_get_eng_flattened.py
@@ -15,9 +15,24 @@ from test.helpers import assert_series_equal, parametrize
     ("series_fixture", "expected_fixture"),
     [
         param(
+            "acopopb_eng_ocr_fuse_clean_validate_review",
+            "acopopb_eng_ocr_fuse_clean_validate_review_flatten",
+            id="acopopb-eng",
+        ),
+        param(
+            "acoptc_eng_ocr_fuse_clean_validate_review",
+            "acoptc_eng_ocr_fuse_clean_validate_review_flatten",
+            id="acoptc-eng",
+        ),
+        param(
             "kob_eng_ocr_fuse_clean_validate_review",
             "kob_eng_ocr_fuse_clean_validate_review_flatten",
             id="kob-eng",
+        ),
+        param(
+            "kob_eng_timewarp_clean_review",
+            "kob_eng_timewarp_clean_review_flatten",
+            id="kob-eng-timewarp",
         ),
         param(
             "mlamd_eng_fuse_clean_validate_review",
@@ -33,6 +48,11 @@ from test.helpers import assert_series_equal, parametrize
             "t_eng_fuse_clean_validate_review",
             "t_eng_fuse_clean_validate_review_flatten",
             id="t-eng",
+        ),
+        param(
+            "tmm_eng_ocr_fuse_clean_validate_review",
+            "tmm_eng_ocr_fuse_clean_validate_review_flatten",
+            id="tmm-eng",
         ),
     ],
 )

--- a/test/lang/yue/test_get_yue_romanized.py
+++ b/test/lang/yue/test_get_yue_romanized.py
@@ -17,9 +17,39 @@ from test.helpers import assert_series_equal, parametrize
     ("series_fixture", "expected_fixture"),
     [
         param(
+            "acopopb_yue_hans_ocr_fuse_clean_validate_review_flatten",
+            "acopopb_yue_hans_ocr_fuse_clean_validate_review_flatten_romanize",
+            id="acopopb-yue-hans",
+        ),
+        param(
+            "acopopb_yue_hant_ocr_fuse_clean_validate_review_flatten_simplify_review",
+            "acopopb_yue_hant_ocr_fuse_clean_validate_review_flatten_simplify_review_romanize",
+            id="acopopb-yue-hant",
+        ),
+        param(
+            "acoptc_yue_hans_ocr_fuse_clean_validate_review_flatten",
+            "acoptc_yue_hans_ocr_fuse_clean_validate_review_flatten_romanize",
+            id="acoptc-yue-hans",
+        ),
+        param(
+            "acoptc_yue_hant_ocr_fuse_clean_validate_review_flatten_simplify_review",
+            "acoptc_yue_hant_ocr_fuse_clean_validate_review_flatten_simplify_review_romanize",
+            id="acoptc-yue-hant",
+        ),
+        param(
             "kob_yue_hans_timewarp_clean_flatten",
             "kob_yue_hans_timewarp_clean_flatten_romanize",
             id="kob-yue-hans",
+        ),
+        param(
+            "tmm_yue_hans_ocr_fuse_clean_validate_review_flatten",
+            "tmm_yue_hans_ocr_fuse_clean_validate_review_flatten_romanize",
+            id="tmm-yue-hans",
+        ),
+        param(
+            "tmm_yue_hant_ocr_fuse_clean_validate_review_flatten_simplify_review",
+            "tmm_yue_hant_ocr_fuse_clean_validate_review_flatten_simplify_review_romanize",
+            id="tmm-yue-hant",
         ),
     ],
 )

--- a/test/lang/zho/script/test_conversion.py
+++ b/test/lang/zho/script/test_conversion.py
@@ -88,9 +88,24 @@ def test_t2s_exclusions_are_raw_opencc_changes(text: str):
             id="kob-zho-hant",
         ),
         param(
+            "mlamd_zho_hant_fuse_clean_validate_review_flatten",
+            "mlamd_zho_hant_fuse_clean_validate_review_flatten_simplify",
+            id="mlamd-zho-hant",
+        ),
+        param(
+            "mnt_zho_hant_fuse_clean_validate_review_flatten",
+            "mnt_zho_hant_fuse_clean_validate_review_flatten_simplify",
+            id="mnt-zho-hant",
+        ),
+        param(
             "t_zho_hant_fuse_clean_validate_review_flatten",
             "t_zho_hant_fuse_clean_validate_review_flatten_simplify",
             id="t-zho-hant",
+        ),
+        param(
+            "tmm_zho_hant_ocr_fuse_clean_validate_review_flatten",
+            "tmm_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify",
+            id="tmm-zho-hant",
         ),
     ],
 )

--- a/test/lang/zho/test_get_zho_block_reviewed.py
+++ b/test/lang/zho/test_get_zho_block_reviewed.py
@@ -16,11 +16,25 @@ from scinoephile.lang.zho.block_review import (
     get_zho_block_reviewed,
     get_zho_reviewer,
 )
+from test.data.acopopb import (
+    get_acopopb_zho_hans_block_review_test_cases,
+    get_acopopb_zho_hant_simplify_block_review_test_cases,
+)
+from test.data.acoptc import (
+    get_acoptc_zho_hans_block_review_test_cases,
+    get_acoptc_zho_hant_simplify_block_review_test_cases,
+)
 from test.data.kob import get_kob_zho_hant_block_review_test_cases
+from test.data.mnt import get_mnt_zho_hant_block_review_test_cases
 from test.data.t import (
     get_t_zho_hans_block_review_test_cases,
     get_t_zho_hant_block_review_test_cases,
     get_t_zho_hant_simplify_block_review_test_cases,
+)
+from test.data.tmm import (
+    get_tmm_zho_hans_block_review_test_cases,
+    get_tmm_zho_hant_block_review_test_cases,
+    get_tmm_zho_hant_simplify_block_review_test_cases,
 )
 from test.helpers import assert_series_equal, parametrize
 
@@ -29,11 +43,46 @@ from test.helpers import assert_series_equal, parametrize
     ("series_fixture", "expected_fixture", "test_case_loader", "prompt_cls"),
     [
         param(
+            "acopopb_zho_hans_ocr_fuse_clean_validate",
+            "acopopb_zho_hans_ocr_fuse_clean_validate_review",
+            get_acopopb_zho_hans_block_review_test_cases,
+            BlockReviewPromptZhoHans,
+            id="acopopb-zho-hans",
+        ),
+        param(
+            "acopopb_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify",
+            "acopopb_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify_review",
+            get_acopopb_zho_hant_simplify_block_review_test_cases,
+            BlockReviewPromptZhoHans,
+            id="acopopb-zho-hant-simplify",
+        ),
+        param(
+            "acoptc_zho_hans_ocr_fuse_clean_validate",
+            "acoptc_zho_hans_ocr_fuse_clean_validate_review",
+            get_acoptc_zho_hans_block_review_test_cases,
+            BlockReviewPromptZhoHans,
+            id="acoptc-zho-hans",
+        ),
+        param(
+            "acoptc_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify",
+            "acoptc_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify_review",
+            get_acoptc_zho_hant_simplify_block_review_test_cases,
+            BlockReviewPromptZhoHans,
+            id="acoptc-zho-hant-simplify",
+        ),
+        param(
             "kob_zho_hant_ocr_fuse_clean_validate",
             "kob_zho_hant_ocr_fuse_clean_validate_review",
             get_kob_zho_hant_block_review_test_cases,
             BlockReviewPromptZhoHant,
             id="kob-zho-hant",
+        ),
+        param(
+            "mnt_zho_hant_fuse_clean_validate",
+            "mnt_zho_hant_fuse_clean_validate_review",
+            get_mnt_zho_hant_block_review_test_cases,
+            BlockReviewPromptZhoHant,
+            id="mnt-zho-hant",
         ),
         param(
             "t_zho_hans_fuse_clean_validate",
@@ -55,6 +104,27 @@ from test.helpers import assert_series_equal, parametrize
             get_t_zho_hant_simplify_block_review_test_cases,
             BlockReviewPromptZhoHans,
             id="t-zho-hant-simplify",
+        ),
+        param(
+            "tmm_zho_hans_ocr_fuse_clean_validate",
+            "tmm_zho_hans_ocr_fuse_clean_validate_review",
+            get_tmm_zho_hans_block_review_test_cases,
+            BlockReviewPromptZhoHans,
+            id="tmm-zho-hans",
+        ),
+        param(
+            "tmm_zho_hant_ocr_fuse_clean_validate",
+            "tmm_zho_hant_ocr_fuse_clean_validate_review",
+            get_tmm_zho_hant_block_review_test_cases,
+            BlockReviewPromptZhoHant,
+            id="tmm-zho-hant",
+        ),
+        param(
+            "tmm_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify",
+            "tmm_zho_hant_ocr_fuse_clean_validate_review_flatten_simplify_review",
+            get_tmm_zho_hant_simplify_block_review_test_cases,
+            BlockReviewPromptZhoHans,
+            id="tmm-zho-hant-simplify",
         ),
     ],
 )

--- a/test/lang/zho/test_get_zho_cleaned.py
+++ b/test/lang/zho/test_get_zho_cleaned.py
@@ -36,9 +36,79 @@ def test_get_zho_text_cleaned(text: str, expected: str):
     ("series_fixture", "expected_fixture"),
     [
         param(
+            "acopopb_zho_hans_ocr_fuse",
+            "acopopb_zho_hans_ocr_fuse_clean",
+            id="acopopb-zho-hans-fuse",
+        ),
+        param(
+            "acopopb_zho_hans_ocr_lens",
+            "acopopb_zho_hans_ocr_lens_clean",
+            id="acopopb-zho-hans-lens",
+        ),
+        param(
+            "acopopb_zho_hans_ocr_paddle",
+            "acopopb_zho_hans_ocr_paddle_clean",
+            id="acopopb-zho-hans-paddle",
+        ),
+        param(
+            "acopopb_zho_hant_ocr_fuse",
+            "acopopb_zho_hant_ocr_fuse_clean",
+            id="acopopb-zho-hant-fuse",
+        ),
+        param(
+            "acopopb_zho_hant_ocr_lens",
+            "acopopb_zho_hant_ocr_lens_clean",
+            id="acopopb-zho-hant-lens",
+        ),
+        param(
+            "acopopb_zho_hant_ocr_paddle",
+            "acopopb_zho_hant_ocr_paddle_clean",
+            id="acopopb-zho-hant-paddle",
+        ),
+        param(
+            "acoptc_zho_hans_ocr_fuse",
+            "acoptc_zho_hans_ocr_fuse_clean",
+            id="acoptc-zho-hans-fuse",
+        ),
+        param(
+            "acoptc_zho_hans_ocr_lens",
+            "acoptc_zho_hans_ocr_lens_clean",
+            id="acoptc-zho-hans-lens",
+        ),
+        param(
+            "acoptc_zho_hans_ocr_paddle",
+            "acoptc_zho_hans_ocr_paddle_clean",
+            id="acoptc-zho-hans-paddle",
+        ),
+        param(
+            "acoptc_zho_hant_ocr_fuse",
+            "acoptc_zho_hant_ocr_fuse_clean",
+            id="acoptc-zho-hant-fuse",
+        ),
+        param(
+            "acoptc_zho_hant_ocr_lens",
+            "acoptc_zho_hant_ocr_lens_clean",
+            id="acoptc-zho-hant-lens",
+        ),
+        param(
+            "acoptc_zho_hant_ocr_paddle",
+            "acoptc_zho_hant_ocr_paddle_clean",
+            id="acoptc-zho-hant-paddle",
+        ),
+        param(
             "kob_zho_hant_ocr_fuse",
             "kob_zho_hant_ocr_fuse_clean",
             id="kob-zho-hant-fuse",
+        ),
+        param(
+            "kob_zho_hant_ocr_lens",
+            "kob_zho_hant_ocr_lens_clean",
+            id="kob-zho-hant-lens",
+        ),
+        param(
+            "kob_zho_hant_ocr_paddle",
+            "kob_zho_hant_ocr_paddle_clean",
+            id="kob-zho-hant-paddle",
         ),
         param(
             "mlamd_zho_hans_fuse",
@@ -46,9 +116,49 @@ def test_get_zho_text_cleaned(text: str, expected: str):
             id="mlamd-zho-hans-fuse",
         ),
         param(
+            "mlamd_zho_hans_ocr_paddle",
+            "mlamd_zho_hans_ocr_paddle_clean",
+            id="mlamd-zho-hans-paddle",
+        ),
+        param(
+            "mlamd_zho_hant_fuse",
+            "mlamd_zho_hant_fuse_clean",
+            id="mlamd-zho-hant-fuse",
+        ),
+        param(
+            "mlamd_zho_hant_ocr_paddle",
+            "mlamd_zho_hant_ocr_paddle_clean",
+            id="mlamd-zho-hant-paddle",
+        ),
+        param(
             "mnt_zho_hans_fuse",
             "mnt_zho_hans_fuse_clean",
             id="mnt-zho-hans-fuse",
+        ),
+        param(
+            "mnt_zho_hans_ocr_lens",
+            "mnt_zho_hans_ocr_lens_clean",
+            id="mnt-zho-hans-lens",
+        ),
+        param(
+            "mnt_zho_hans_ocr_paddle",
+            "mnt_zho_hans_ocr_paddle_clean",
+            id="mnt-zho-hans-paddle",
+        ),
+        param(
+            "mnt_zho_hant_fuse",
+            "mnt_zho_hant_fuse_clean",
+            id="mnt-zho-hant-fuse",
+        ),
+        param(
+            "mnt_zho_hant_ocr_lens",
+            "mnt_zho_hant_ocr_lens_clean",
+            id="mnt-zho-hant-lens",
+        ),
+        param(
+            "mnt_zho_hant_ocr_paddle",
+            "mnt_zho_hant_ocr_paddle_clean",
+            id="mnt-zho-hant-paddle",
         ),
         param(
             "t_zho_hans_fuse",
@@ -69,6 +179,26 @@ def test_get_zho_text_cleaned(text: str, expected: str):
             "t_zho_hant_ocr_paddle",
             "t_zho_hant_ocr_paddle_clean",
             id="t-zho-hant-paddle",
+        ),
+        param(
+            "tmm_zho_hans_ocr_fuse",
+            "tmm_zho_hans_ocr_fuse_clean",
+            id="tmm-zho-hans-fuse",
+        ),
+        param(
+            "tmm_zho_hans_ocr_paddle",
+            "tmm_zho_hans_ocr_paddle_clean",
+            id="tmm-zho-hans-paddle",
+        ),
+        param(
+            "tmm_zho_hant_ocr_fuse",
+            "tmm_zho_hant_ocr_fuse_clean",
+            id="tmm-zho-hant-fuse",
+        ),
+        param(
+            "tmm_zho_hant_ocr_paddle",
+            "tmm_zho_hant_ocr_paddle_clean",
+            id="tmm-zho-hant-paddle",
         ),
     ],
 )

--- a/test/lang/zho/test_get_zho_flattened.py
+++ b/test/lang/zho/test_get_zho_flattened.py
@@ -16,6 +16,26 @@ from test.helpers import assert_series_equal, parametrize
     ("series_fixture", "expected_fixture"),
     [
         param(
+            "acopopb_zho_hans_ocr_fuse_clean_validate_review",
+            "acopopb_zho_hans_ocr_fuse_clean_validate_review_flatten",
+            id="acopopb-zho-hans",
+        ),
+        param(
+            "acopopb_zho_hant_ocr_fuse_clean_validate_review",
+            "acopopb_zho_hant_ocr_fuse_clean_validate_review_flatten",
+            id="acopopb-zho-hant",
+        ),
+        param(
+            "acoptc_zho_hans_ocr_fuse_clean_validate_review",
+            "acoptc_zho_hans_ocr_fuse_clean_validate_review_flatten",
+            id="acoptc-zho-hans",
+        ),
+        param(
+            "acoptc_zho_hant_ocr_fuse_clean_validate_review",
+            "acoptc_zho_hant_ocr_fuse_clean_validate_review_flatten",
+            id="acoptc-zho-hant",
+        ),
+        param(
             "kob_zho_hant_ocr_fuse_clean_validate_review",
             "kob_zho_hant_ocr_fuse_clean_validate_review_flatten",
             id="kob-zho-hant",
@@ -24,6 +44,16 @@ from test.helpers import assert_series_equal, parametrize
             "mlamd_zho_hans_fuse_clean_validate_review",
             "mlamd_zho_hans_fuse_clean_validate_review_flatten",
             id="mlamd-zho-hans",
+        ),
+        param(
+            "mlamd_zho_hant_fuse_clean_validate_review",
+            "mlamd_zho_hant_fuse_clean_validate_review_flatten",
+            id="mlamd-zho-hant",
+        ),
+        param(
+            "mnt_zho_hans_fuse_clean_validate_review",
+            "mnt_zho_hans_fuse_clean_validate_review_flatten",
+            id="mnt-zho-hans",
         ),
         param(
             "mnt_zho_hant_fuse_clean_validate_review",
@@ -39,6 +69,16 @@ from test.helpers import assert_series_equal, parametrize
             "t_zho_hant_fuse_clean_validate_review",
             "t_zho_hant_fuse_clean_validate_review_flatten",
             id="t-zho-hant",
+        ),
+        param(
+            "tmm_zho_hans_ocr_fuse_clean_validate_review",
+            "tmm_zho_hans_ocr_fuse_clean_validate_review_flatten",
+            id="tmm-zho-hans",
+        ),
+        param(
+            "tmm_zho_hant_ocr_fuse_clean_validate_review",
+            "tmm_zho_hant_ocr_fuse_clean_validate_review_flatten",
+            id="tmm-zho-hant",
         ),
     ],
 )

--- a/test/lang/zho/test_get_zho_ocr_fused.py
+++ b/test/lang/zho/test_get_zho_ocr_fused.py
@@ -20,7 +20,10 @@ from scinoephile.lang.zho.ocr_fusion import (
 )
 from test.data.kob import get_kob_zho_hant_ocr_fusion_test_cases
 from test.data.mlamd import get_mlamd_zho_hans_ocr_fusion_test_cases
-from test.data.mnt import get_mnt_zho_hans_ocr_fusion_test_cases
+from test.data.mnt import (
+    get_mnt_zho_hans_ocr_fusion_test_cases,
+    get_mnt_zho_hant_ocr_fusion_test_cases,
+)
 from test.data.t import get_t_zho_hans_ocr_fusion_test_cases
 from test.helpers import assert_series_equal, parametrize
 
@@ -101,6 +104,14 @@ def test_get_zho_ocr_fused_treats_newline_forms_as_identical(
             OcrFusionPromptZhoHans,
             get_mnt_zho_hans_ocr_fusion_test_cases,
             id="mnt-zho-hans",
+        ),
+        param(
+            "mnt_zho_hant_ocr_lens",
+            "mnt_zho_hant_ocr_paddle",
+            "mnt_zho_hant_fuse",
+            OcrFusionPromptZhoHant,
+            get_mnt_zho_hant_ocr_fusion_test_cases,
+            id="mnt-zho-hant",
         ),
         param(
             "t_zho_hans_ocr_lens",


### PR DESCRIPTION
## Summary

- Add parametrized test cases that exercise existing fixture data across stacking, English, Mandarin, Cantonese, and standard Chinese workflows.
- Keep the change test-only: no production code, fixture data, generated expected outputs, or behavior changes.
- Exclude candidate cases that depended on fixture/helper/output changes not present on `master` or romanization behavior changes.

## Validation

- `uv run ruff format` on changed Python files
- `uv run ruff check --fix` on changed Python files
- `uv run ty check` on changed Python files
- `cd test && uv run pytest -n auto`