### PR TITLE
Assorted fixes and formatting updates

### DIFF
--- a/scinoephile/lang/__init__.py
+++ b/scinoephile/lang/__init__.py
@@ -5,7 +5,7 @@
 This module may import from: common, core, image, llms
 
 Hierarchy within module (lower may import from higher)::
-* cmn / eng / zho
-* yue
+* eng / zho
+* cmn / yue
 * language_id
 """

--- a/scinoephile/lang/__init__.py
+++ b/scinoephile/lang/__init__.py
@@ -5,7 +5,7 @@
 This module may import from: common, core, image, llms
 
 Hierarchy within module (lower may import from higher)::
-* eng / zho
-* cmn / yue
+* cmn / eng / zho
+* yue
 * language_id
 """

--- a/scinoephile/lang/zho/script/conversion.py
+++ b/scinoephile/lang/zho/script/conversion.py
@@ -130,7 +130,6 @@ S2T_EXCLUSIONS: set[str] = {
 T2S_EXCLUSIONS: set[str] = {
     "喎",  # keep Cantonese sentence particle 喎; avoid 㖞
     "嗰",  # keep Cantonese demonstrative 嗰; avoid 𠮶
-    "搵",  # keep Cantonese 搵 "look for"; avoid 揾
     "痾",  # keep Cantonese 痾 "defecate"; avoid 疴
     "劏",  # keep Cantonese 劏 "slaughter"; avoid 㓥
     "噚",  # keep Cantonese 噚; avoid 㖊

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -7,8 +7,8 @@ from __future__ import annotations
 from collections.abc import Generator
 from pathlib import Path
 
-import pytest
 from PIL import Image
+from pytest import fixture
 
 from scinoephile.common.file import get_temp_directory_path, get_temp_file_path
 from scinoephile.image.subtitles import ImageSeries, ImageSubtitle
@@ -23,28 +23,28 @@ from test.data.t import *
 from test.data.tmm import *
 
 
-@pytest.fixture
+@fixture
 def database_path() -> Generator[Path]:
     """Provide a temporary SQLite database path."""
-    with get_temp_file_path(".db") as file_path:
-        yield file_path
+    with get_temp_file_path(".db") as temp_path:
+        yield temp_path
 
 
-@pytest.fixture
+@fixture
 def local_data_dir_path() -> Generator[Path]:
-    """Provide a temporary local data directory for tests."""
+    """Provide a temporary canonical local data directory."""
     with get_temp_directory_path() as dir_path:
         yield dir_path
 
 
-@pytest.fixture
+@fixture
 def runtime_data_dir_path() -> Generator[Path]:
-    """Provide a temporary runtime data directory for tests."""
+    """Provide a temporary runtime canonical data directory."""
     with get_temp_directory_path() as dir_path:
         yield dir_path
 
 
-@pytest.fixture
+@fixture
 def tiny_image_series() -> ImageSeries:
     """Small image subtitle series for tests that do not need full fixtures."""
     return ImageSeries(

--- a/test/helpers/cli.py
+++ b/test/helpers/cli.py
@@ -1,6 +1,6 @@
 #  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
-"""Shared helpers for inspecting CLI argument parser configuration."""
+"""Shared CLI inspection helpers for tests."""
 
 from __future__ import annotations
 
@@ -8,25 +8,27 @@ from argparse import Action, ArgumentParser
 
 from scinoephile.common import CommandLineInterface
 
-__all__ = ["get_cli_action", "get_cli_action_group_title", "get_parser_action"]
+__all__ = [
+    "get_cli_action",
+    "get_cli_action_group_title",
+    "get_parser_action",
+]
 
 
 def get_cli_action(cli: type[CommandLineInterface], option: str) -> Action:
-    """Get a parser action by option string for a CLI class.
+    """Get a CLI parser action by option string.
 
     Arguments:
         cli: CLI class to inspect
         option: option string to inspect
     Returns:
         matching argparse action
-    Raises:
-        AssertionError: if the option is not present
     """
     return get_parser_action(cli.argparser(), option)
 
 
 def get_cli_action_group_title(cli: type[CommandLineInterface], option: str) -> str:
-    """Get the group title for a parser option in a CLI parser.
+    """Get the group title for a CLI parser option.
 
     Arguments:
         cli: CLI class to inspect
@@ -34,7 +36,7 @@ def get_cli_action_group_title(cli: type[CommandLineInterface], option: str) -> 
     Returns:
         title of the argument group containing the option
     Raises:
-        AssertionError: if the option is not assigned to an argument group
+        AssertionError: if the option is not assigned to a group
     """
     parser = cli.argparser()
     action = get_parser_action(parser, option)
@@ -47,7 +49,7 @@ def get_cli_action_group_title(cli: type[CommandLineInterface], option: str) -> 
 
 
 def get_parser_action(parser: ArgumentParser, option: str) -> Action:
-    """Get a parser action by option string from an existing parser.
+    """Get a parser action by option string.
 
     Arguments:
         parser: parser to inspect

--- a/test/lang/zho/test_get_zho_flattened.py
+++ b/test/lang/zho/test_get_zho_flattened.py
@@ -9,8 +9,6 @@ from pytest import FixtureRequest, fail, param
 from scinoephile.lang.zho.flattening import get_zho_flattened
 from test.helpers import assert_series_equal, parametrize
 
-# noinspection PyProtectedMember
-
 
 @parametrize(
     ("series_fixture", "expected_fixture"),

--- a/test/web/ocr_validation/test_html_index.py
+++ b/test/web/ocr_validation/test_html_index.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from PIL import Image
 from pytest import raises
 
 from scinoephile.image.subtitles import ImageSeries
@@ -14,11 +13,12 @@ from scinoephile.web.ocr_validation.html_index import (
     load_html_entries,
     update_html_entry_text,
 )
+from test.helpers.ocr_validation import make_ocr_html_dir
 
 
 def test_load_html_entries_reads_existing_export(tmp_path: Path):
     """Test loading subtitle entries from existing image subtitle HTML."""
-    html_dir_path = _make_html_dir(tmp_path, text="old<br />text")
+    html_dir_path = make_ocr_html_dir(tmp_path, text="old<br />text")
 
     entries = load_html_entries(html_dir_path)
 
@@ -32,7 +32,7 @@ def test_load_html_entries_reads_existing_export(tmp_path: Path):
 
 def test_update_html_entry_text_rewrites_index_compatibly(tmp_path: Path):
     """Test updating one subtitle text in an OCR image HTML index."""
-    html_dir_path = _make_html_dir(tmp_path, text="old")
+    html_dir_path = make_ocr_html_dir(tmp_path, text="old")
 
     update_html_entry_text(html_dir_path, 0, "new\\Nline")
 
@@ -45,7 +45,7 @@ def test_update_html_entry_text_rewrites_index_compatibly(tmp_path: Path):
 
 def test_update_html_entry_text_does_not_touch_png(tmp_path: Path):
     """Test updating OCR text does not rewrite subtitle image files."""
-    html_dir_path = _make_html_dir(tmp_path, text="old")
+    html_dir_path = make_ocr_html_dir(tmp_path, text="old")
     image_path = html_dir_path / "0001.png"
     original_image_bytes = image_path.read_bytes()
 
@@ -56,7 +56,7 @@ def test_update_html_entry_text_does_not_touch_png(tmp_path: Path):
 
 def test_update_html_entry_text_rejects_negative_index(tmp_path: Path):
     """Test updating OCR text rejects negative subtitle indexes."""
-    html_dir_path = _make_html_dir(tmp_path, text="old")
+    html_dir_path = make_ocr_html_dir(tmp_path, text="old")
 
     with raises(IndexError, match="Subtitle index out of range: -1"):
         update_html_entry_text(html_dir_path, -1, "new")
@@ -64,43 +64,7 @@ def test_update_html_entry_text_rejects_negative_index(tmp_path: Path):
 
 def test_update_html_entry_text_rejects_out_of_range_index(tmp_path: Path):
     """Test updating OCR text rejects out-of-range subtitle indexes."""
-    html_dir_path = _make_html_dir(tmp_path, text="old")
+    html_dir_path = make_ocr_html_dir(tmp_path, text="old")
 
     with raises(IndexError, match="Subtitle index out of range: 1"):
         update_html_entry_text(html_dir_path, 1, "new")
-
-
-def _make_html_dir(tmp_path: Path, *, text: str) -> Path:
-    """Create an OCR image HTML directory.
-
-    Arguments:
-        tmp_path: pytest temporary directory path
-        text: HTML subtitle text content
-    Returns:
-        OCR image HTML directory path
-    """
-    html_dir_path = tmp_path / "image"
-    html_dir_path.mkdir()
-    Image.new("LA", (2, 2), (255, 255)).save(html_dir_path / "0001.png")
-    (html_dir_path / "index.html").write_text(
-        "\n".join(
-            [
-                "<!DOCTYPE html>",
-                "<html>",
-                "<head>",
-                '   <meta charset="UTF-8" />',
-                "   <title>Subtitle images</title>",
-                "</head>",
-                "<body>",
-                "#1:1,000->2,000"
-                "<div style='text-align:center'>"
-                "<img src='0001.png' />"
-                "<br /><div style='font-size:22px; background-color:WhiteSmoke'>"
-                f"{text}</div></div><br /><hr />",
-                "</body>",
-                "</html>",
-            ]
-        ),
-        encoding="utf-8",
-    )
-    return html_dir_path

--- a/test/web/ocr_validation/test_routes.py
+++ b/test/web/ocr_validation/test_routes.py
@@ -253,10 +253,7 @@ def test_char_concern_image_url_changes_after_accept(
     assert b'src="/subtitles/0/concern.png?v=char-dims-0-0-1"' not in response.data
 
 
-def test_index_renders_space_gap_choice_table(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
-):
+def test_index_renders_space_gap_choice_table(tmp_path: Path, monkeypatch: MonkeyPatch):
     """Test adjacent-or-space concerns render both choice actions."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="霆所")
     patch_ocr_validation_bboxes(
@@ -346,10 +343,7 @@ def test_text_update_route_rejects_missing_subtitle(tmp_path: Path):
     assert response.status_code == 404
 
 
-def test_concern_image_route_serves_png(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
-):
+def test_concern_image_route_serves_png(tmp_path: Path, monkeypatch: MonkeyPatch):
     """Test current concern images are rendered as PNG responses."""
     app = _char_concern_app(tmp_path, monkeypatch)
 
@@ -371,10 +365,7 @@ def test_concern_image_route_rejects_missing_subtitle(
     assert response.status_code == 404
 
 
-def test_char_concern_route_resolves_row(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
-):
+def test_char_concern_route_resolves_row(tmp_path: Path, monkeypatch: MonkeyPatch):
     """Test resolving the final character concern omits the completed row."""
     app = _char_concern_app(tmp_path, monkeypatch)
 
@@ -420,10 +411,7 @@ def test_char_concern_route_rejects_missing_subtitle(
     assert response.status_code == 404
 
 
-def test_gap_concern_route_resolves_row(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
-):
+def test_gap_concern_route_resolves_row(tmp_path: Path, monkeypatch: MonkeyPatch):
     """Test resolving the final gap concern persists text and omits the row."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="AB")
     patch_ocr_validation_bboxes(
@@ -482,10 +470,7 @@ def test_gap_concern_route_rejects_missing_subtitle(
     assert response.status_code == 404
 
 
-def _char_concern_app(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
-) -> Flask:
+def _char_concern_app(tmp_path: Path, monkeypatch: MonkeyPatch) -> Flask:
     """Create an app with one character dimension concern.
 
     Arguments:

--- a/test/web/ocr_validation/test_session.py
+++ b/test/web/ocr_validation/test_session.py
@@ -348,57 +348,6 @@ def test_session_reports_space_gap_concern(tmp_path: Path, monkeypatch: MonkeyPa
     assert row.concern.tab_prompt_display == "12-20"
 
 
-def test_existing_space_gap_does_not_update_cutoffs(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
-):
-    """Test stale whitespace does not train ambiguous gap cutoffs."""
-    html_dir_path = make_ocr_html_dir(tmp_path, text="A B")
-    patch_ocr_validation_bboxes(
-        monkeypatch,
-        [Bbox(0, 10, 0, 20), Bbox(14, 24, 0, 20)],
-    )
-    session = prepared_gap_session(html_dir_path, tmp_path)
-
-    row = session.subtitle_row(0)
-
-    assert row.status == ValidationStatus.NEEDS_ACTION
-    assert isinstance(row.concern, GapConcern)
-    assert row.concern.kind == ConcernKind.SPACE_GAP
-    assert session.manager.char_pair_gaps[("A", "B")] == (2, 6, 12, 20)
-
-
-def test_punctuation_ellipsis_gap_reports_existing_space_concern(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
-):
-    """Test punctuation before ellipsis keeps stale whitespace as a concern."""
-    html_dir_path = make_ocr_html_dir(tmp_path, text="！ ⋯")
-    patch_ocr_validation_bboxes(
-        monkeypatch,
-        [Bbox(0, 10, 0, 20), Bbox(67, 77, 0, 20)],
-    )
-    session = OcrValidationSession.from_dir_path(
-        html_dir_path,
-        cache_dir_path=tmp_path / "cache",
-    )
-    clear_validation_data(session)
-    session.manager.char_dims_by_n[1]["！"] = {(10, 20)}
-    session.manager.char_dims_by_n[1]["⋯"] = {(10, 20)}
-
-    row = session.subtitle_row(0)
-
-    assert row.text == "！ ⋯"
-    assert row.status == ValidationStatus.NEEDS_ACTION
-    assert isinstance(row.concern, GapConcern)
-    assert row.concern.kind == ConcernKind.SPACE_GAP
-    assert row.concern.char_1 == "！"
-    assert row.concern.char_2 == "⋯"
-    assert row.concern.gap == 57
-    assert session.manager.char_pair_gaps[("！", "⋯")] == (8, 89, 90, 200)
-    assert "！ ⋯" in (html_dir_path / "index.html").read_text(encoding="utf-8")
-
-
 def test_space_gap_choice_updates_index_text(tmp_path: Path, monkeypatch: MonkeyPatch):
     """Test resolving a space gap writes the expected space into index.html."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="AB")

--- a/test/web/ocr_validation/test_session.py
+++ b/test/web/ocr_validation/test_session.py
@@ -241,10 +241,7 @@ def test_session_does_not_write_outfile_on_init(tmp_path: Path):
     assert not outfile_path.exists()
 
 
-def test_session_reports_char_dims_concern(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
-):
+def test_session_reports_char_dims_concern(tmp_path: Path, monkeypatch: MonkeyPatch):
     """Test unknown character dimensions produce a bbox concern."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="A")
     patch_ocr_validation_bboxes(monkeypatch, [Bbox(0, 10, 0, 20)])
@@ -304,10 +301,7 @@ def test_accept_char_dims_marks_single_char_done(
     ) == "A,10,20\n"
 
 
-def test_contract_char_dims_reduces_selection(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
-):
+def test_contract_char_dims_reduces_selection(tmp_path: Path, monkeypatch: MonkeyPatch):
     """Test contracting character dimensions reduces the selected bbox count."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="A")
     patch_ocr_validation_bboxes(
@@ -333,10 +327,7 @@ def test_contract_char_dims_reduces_selection(
     assert not row.concern.can_contract
 
 
-def test_session_reports_space_gap_concern(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
-):
+def test_session_reports_space_gap_concern(tmp_path: Path, monkeypatch: MonkeyPatch):
     """Test ambiguous adjacent-or-space gaps produce a space concern."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="AB")
     patch_ocr_validation_bboxes(
@@ -357,10 +348,58 @@ def test_session_reports_space_gap_concern(
     assert row.concern.tab_prompt_display == "12-20"
 
 
-def test_space_gap_choice_updates_index_text(
+def test_existing_space_gap_does_not_update_cutoffs(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
 ):
+    """Test stale whitespace does not train ambiguous gap cutoffs."""
+    html_dir_path = make_ocr_html_dir(tmp_path, text="A B")
+    patch_ocr_validation_bboxes(
+        monkeypatch,
+        [Bbox(0, 10, 0, 20), Bbox(14, 24, 0, 20)],
+    )
+    session = prepared_gap_session(html_dir_path, tmp_path)
+
+    row = session.subtitle_row(0)
+
+    assert row.status == ValidationStatus.NEEDS_ACTION
+    assert isinstance(row.concern, GapConcern)
+    assert row.concern.kind == ConcernKind.SPACE_GAP
+    assert session.manager.char_pair_gaps[("A", "B")] == (2, 6, 12, 20)
+
+
+def test_punctuation_ellipsis_gap_reports_existing_space_concern(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+):
+    """Test punctuation before ellipsis keeps stale whitespace as a concern."""
+    html_dir_path = make_ocr_html_dir(tmp_path, text="！ ⋯")
+    patch_ocr_validation_bboxes(
+        monkeypatch,
+        [Bbox(0, 10, 0, 20), Bbox(67, 77, 0, 20)],
+    )
+    session = OcrValidationSession.from_dir_path(
+        html_dir_path,
+        cache_dir_path=tmp_path / "cache",
+    )
+    clear_validation_data(session)
+    session.manager.char_dims_by_n[1]["！"] = {(10, 20)}
+    session.manager.char_dims_by_n[1]["⋯"] = {(10, 20)}
+
+    row = session.subtitle_row(0)
+
+    assert row.text == "！ ⋯"
+    assert row.status == ValidationStatus.NEEDS_ACTION
+    assert isinstance(row.concern, GapConcern)
+    assert row.concern.kind == ConcernKind.SPACE_GAP
+    assert row.concern.char_1 == "！"
+    assert row.concern.char_2 == "⋯"
+    assert row.concern.gap == 57
+    assert session.manager.char_pair_gaps[("！", "⋯")] == (8, 89, 90, 200)
+    assert "！ ⋯" in (html_dir_path / "index.html").read_text(encoding="utf-8")
+
+
+def test_space_gap_choice_updates_index_text(tmp_path: Path, monkeypatch: MonkeyPatch):
     """Test resolving a space gap writes the expected space into index.html."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="AB")
     patch_ocr_validation_bboxes(
@@ -482,10 +521,7 @@ def test_fullwidth_latin_gap_uses_default_cutoffs(
     assert session.manager.char_pair_gaps[("你", "Ｋ")] == (22, 89, 90, 200)
 
 
-def test_adjacent_gap_choice_updates_cutoff(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
-):
+def test_adjacent_gap_choice_updates_cutoff(tmp_path: Path, monkeypatch: MonkeyPatch):
     """Test adjacent choice for an ambiguous gap updates the gap cutoffs."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="白了")
     patch_ocr_validation_bboxes(
@@ -521,9 +557,12 @@ def test_boundary_space_gap_updates_cutoff_without_concern(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
 ):
-    """Test matching space text updates cutoffs without a user concern."""
+    """Test boundary space text updates cutoffs without a user concern."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="A B")
-    patch_ocr_validation_bboxes(monkeypatch, [Bbox(0, 10, 0, 20), Bbox(15, 25, 0, 20)])
+    patch_ocr_validation_bboxes(
+        monkeypatch,
+        [Bbox(0, 10, 0, 20), Bbox(15, 25, 0, 20)],
+    )
     session = prepared_gap_session(html_dir_path, tmp_path)
 
     row = session.subtitle_row(0)
@@ -539,9 +578,12 @@ def test_boundary_tab_gap_updates_cutoff_without_concern(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
 ):
-    """Test matching tab text updates cutoffs without a user concern."""
+    """Test boundary tab text updates cutoffs without a user concern."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="A    B")
-    patch_ocr_validation_bboxes(monkeypatch, [Bbox(0, 10, 0, 20), Bbox(29, 39, 0, 20)])
+    patch_ocr_validation_bboxes(
+        monkeypatch,
+        [Bbox(0, 10, 0, 20), Bbox(29, 39, 0, 20)],
+    )
     session = prepared_gap_session(html_dir_path, tmp_path)
 
     row = session.subtitle_row(0)
@@ -623,10 +665,7 @@ def test_known_tab_gap_replaces_newline_without_concern(
     assert "A    B" in (html_dir_path / "index.html").read_text(encoding="utf-8")
 
 
-def test_tab_gap_choice_updates_index_text(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
-):
+def test_tab_gap_choice_updates_index_text(tmp_path: Path, monkeypatch: MonkeyPatch):
     """Test resolving a tab gap writes expected wide spacing into index.html."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="AB")
     patch_ocr_validation_bboxes(


### PR DESCRIPTION
## Summary

- Cherry-picked the requested changes from `feature/retain-romanized-punctuation` using:
  - `git checkout feature/retain-romanized-punctuation -- <paths>`
- Verified PR diff contains only these files:
  - `scinoephile/lang/zho/script/conversion.py`
  - `scinoephile/lang/__init__.py`
  - `test/helpers/cli.py`
  - `test/lang/zho/test_get_zho_flattened.py`
  - `test/web/ocr_validation/test_html_index.py`
  - `test/web/ocr_validation/test_routes.py`
  - `test/web/ocr_validation/test_session.py`
  - `test/conftest.py`
- Ran tests with `UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto`.

### Note
`test_module_hierarchy_docs_match_imports` currently fails on
`scinoephile/lang/__init__.py` hierarchy compactness after this change set.