### PR TITLE
Generate Hans prompts from Hant

### DIFF
--- a/scinoephile/cli/yue/yue_process_cli.py
+++ b/scinoephile/cli/yue/yue_process_cli.py
@@ -269,7 +269,7 @@ class YueProcessCli(ScinoephileCliBase):
     @classmethod
     def _get_review_prompt_cls(
         cls, review_script: str
-    ) -> type[BlockReviewPromptZhoHans]:
+    ) -> type[BlockReviewPromptZhoHant]:
         """Get the block-review prompt class for the selected script.
 
         Arguments:

--- a/scinoephile/cli/yue/yue_review_vs_zho_cli.py
+++ b/scinoephile/cli/yue/yue_review_vs_zho_cli.py
@@ -186,7 +186,7 @@ class YueReviewVsZhoCli(ScinoephileCliBase):
     @classmethod
     def _get_line_review_prompt_cls(
         cls, script: str
-    ) -> type[YueLineReviewVsZhoPromptYueHans]:
+    ) -> type[YueLineReviewVsZhoPromptYueHant]:
         """Get the line-review prompt class for the selected script.
 
         Arguments:
@@ -201,7 +201,7 @@ class YueReviewVsZhoCli(ScinoephileCliBase):
     @classmethod
     def _get_block_review_prompt_cls(
         cls, script: str
-    ) -> type[YueBlockReviewVsZhoPromptYueHans]:
+    ) -> type[YueBlockReviewVsZhoPromptYueHant]:
         """Get the block review prompt class for the selected script.
 
         Arguments:

--- a/scinoephile/cli/yue/yue_transcribe_vs_zho_cli.py
+++ b/scinoephile/cli/yue/yue_transcribe_vs_zho_cli.py
@@ -247,7 +247,7 @@ class YueTranscribeVsZhoCli(ScinoephileCliBase):
     def _get_transcription_prompt_classes(
         cls, script: str
     ) -> tuple[
-        type[YueDeliniationVsZhoPromptYueHans], type[YuePunctuationVsZhoPromptYueHans]
+        type[YueDeliniationVsZhoPromptYueHant], type[YuePunctuationVsZhoPromptYueHant]
     ]:
         """Get transcription prompt classes for the selected script.
 

--- a/scinoephile/cli/zho/zho_process_cli.py
+++ b/scinoephile/cli/zho/zho_process_cli.py
@@ -269,7 +269,7 @@ class ZhoProcessCli(ScinoephileCliBase):
     @classmethod
     def _get_review_prompt_cls(
         cls, review_script: str
-    ) -> type[BlockReviewPromptZhoHans]:
+    ) -> type[BlockReviewPromptZhoHant]:
         """Get the block-review prompt class for the selected script.
 
         Arguments:

--- a/scinoephile/lang/yue/prompts.py
+++ b/scinoephile/lang/yue/prompts.py
@@ -7,43 +7,54 @@ from __future__ import annotations
 from abc import ABC
 from typing import ClassVar
 
-from scinoephile.lang.zho.prompts import PromptZhoHans
+from scinoephile.lang.zho.prompts import PromptZhoHans, PromptZhoHant
+from scinoephile.lang.zho.script.conversion import OpenCCConfig
 
-__all__ = ["PromptYueHans"]
+__all__ = [
+    "PromptYueHans",
+    "PromptYueHant",
+]
 
 
-class PromptYueHans(PromptZhoHans, ABC):
-    """LLM correspondence text for written Cantonese."""
+class PromptYueHant(PromptZhoHant, ABC):
+    """LLM correspondence text for traditional written Cantonese."""
 
     # Prompt
-    schema_intro: ClassVar[str] = "你嘅回覆一定要系一个有以下结构嘅 JSON 物件："
+    schema_intro: ClassVar[str] = "你嘅回覆一定要係一個有以下結構嘅 JSON 物件："
     """Text preceding schema description."""
 
-    few_shot_intro: ClassVar[str] = "下面系一啲查询同埋佢哋预期答案嘅例子："
+    few_shot_intro: ClassVar[str] = "下面係一啲查詢同埋佢哋預期答案嘅例子："
     """Text preceding few-shot examples."""
 
-    few_shot_query_intro: ClassVar[str] = "例子查询："
+    few_shot_query_intro: ClassVar[str] = "例子查詢："
     """Text preceding each few-shot example query."""
 
-    few_shot_answer_intro: ClassVar[str] = "预期答案："
+    few_shot_answer_intro: ClassVar[str] = "預期答案："
     """Text preceding each few-shot expected answer."""
 
     # Answer validation errors
     answer_invalid_pre: ClassVar[str] = (
-        "你之前嘅回覆唔系有效嘅 JSON，或者未符合预期嘅模式要求。错误详情："
+        "你之前嘅回覆唔係有效嘅 JSON，或者未符合預期嘅模式要求。錯誤詳情："
     )
     """Text preceding answer validation errors."""
 
     answer_invalid_post: ClassVar[str] = (
-        "请你再试一次，并且净系返返一个符合该模式要求嘅有效 JSON 物件。"
+        "請你再試一次，並且淨係返返一個符合該模式要求嘅有效 JSON 物件。"
     )
     """Text following answer validation errors."""
 
     # Test case validation errors
     test_case_invalid_pre: ClassVar[str] = (
-        "你之前嘅回覆系符合答案模式嘅有效 JSON，但唔适用于而家呢个特定查询。错误详情："
+        "你之前嘅回覆係符合答案模式嘅有效 JSON，但唔適用於而家呢個特定查詢。錯誤詳情："
     )
     """Text preceding test case validation errors."""
 
-    test_case_invalid_post: ClassVar[str] = "请你根据错误信息对你嘅回覆作相应修改。"
+    test_case_invalid_post: ClassVar[str] = "請你根據錯誤信息對你嘅回覆作相應修改。"
     """Text following test case validation errors."""
+
+
+class PromptYueHans(PromptYueHant, PromptZhoHans, ABC):
+    """LLM correspondence text for simplified written Cantonese."""
+
+    opencc_config = OpenCCConfig.hk2s
+    """Config for converting traditional Chinese characters from the parent class."""

--- a/scinoephile/lang/yue/prompts.py
+++ b/scinoephile/lang/yue/prompts.py
@@ -7,13 +7,9 @@ from __future__ import annotations
 from abc import ABC
 from typing import ClassVar
 
-from scinoephile.lang.zho.prompts import PromptZhoHans, PromptZhoHant
-from scinoephile.lang.zho.script.conversion import OpenCCConfig
+from scinoephile.lang.zho.prompts import PromptZhoHant
 
-__all__ = [
-    "PromptYueHans",
-    "PromptYueHant",
-]
+__all__ = ["PromptYueHant"]
 
 
 class PromptYueHant(PromptZhoHant, ABC):
@@ -51,10 +47,3 @@ class PromptYueHant(PromptZhoHant, ABC):
 
     test_case_invalid_post: ClassVar[str] = "請你根據錯誤信息對你嘅回覆作相應修改。"
     """Text following test case validation errors."""
-
-
-class PromptYueHans(PromptYueHant, PromptZhoHans, ABC):
-    """LLM correspondence text for simplified written Cantonese."""
-
-    opencc_config = OpenCCConfig.hk2s
-    """Config for converting traditional Chinese characters from the parent class."""

--- a/scinoephile/lang/zho/block_review/__init__.py
+++ b/scinoephile/lang/zho/block_review/__init__.py
@@ -74,7 +74,7 @@ def get_zho_block_reviewed(
 
 
 def get_zho_reviewer(
-    prompt_cls: type[BlockReviewPromptZhoHans] = BlockReviewPromptZhoHans,
+    prompt_cls: type[BlockReviewPromptZhoHant] = BlockReviewPromptZhoHans,
     test_cases: list[TestCase] | None = None,
     provider: LLMProvider | None = None,
     **kwargs: Unpack[ProcessorKwargs],

--- a/scinoephile/lang/zho/block_review/prompts.py
+++ b/scinoephile/lang/zho/block_review/prompts.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import ClassVar
 
 from scinoephile.core.text import dedent_and_compact
-from scinoephile.lang.zho.prompts import PromptZhoHans
+from scinoephile.lang.zho.prompts import PromptZhoHans, PromptZhoHant
 from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.llms.block_review import BlockReviewPrompt
 
@@ -17,59 +17,59 @@ __all__ = [
 ]
 
 
-class BlockReviewPromptZhoHans(BlockReviewPrompt, PromptZhoHans):
-    """LLM correspondence text for simplified standard Chinese block review."""
+class BlockReviewPromptZhoHant(BlockReviewPrompt, PromptZhoHant):
+    """LLM correspondence text for traditional standard Chinese block review."""
 
     # Prompt
     base_system_prompt: ClassVar[str] = dedent_and_compact("""
-        你负责校对中文字幕。
-        仅修正排版与错别字等排版性/输入性错误。
-        不要润色、改写、改动语气或用词，也不要根据上下文改剧情。
-        如果没有明显的错别字或排版错误，请保持原文不变。
-        对每条字幕，只有在需要修改时才提供修订后的字幕。
-        若需要修改，请返回完整的修订后字幕，并给出说明修改内容的备注。
-        若不需要修改，修订后字幕与备注均返回空字符串。""")
+        你負責校對中文字幕。
+        僅修正排版與錯別字等排版性/輸入性錯誤。
+        不要潤色、改寫、改動語氣或用詞，也不要根據上下文改劇情。
+        如果沒有明顯的錯別字或排版錯誤，請保持原文不變。
+        對每條字幕，只有在需要修改時才提供修訂後的字幕。
+        若需要修改，請返回完整的修訂後字幕，並給出說明修改內容的備註。
+        若不需要修改，修訂後字幕與備註均返回空字符串。""")
     """Base system prompt."""
 
     # Query fields
     input_pfx: ClassVar[str] = "zimu_"
     """Prefix for input fields in query."""
 
-    input_desc_tpl: ClassVar[str] = "第 {idx} 条字幕"
+    input_desc_tpl: ClassVar[str] = "第 {idx} 條字幕"
     """Description template for input fields in query."""
 
     # Answer fields
     output_pfx: ClassVar[str] = "xiugai_"
     """Prefix for output fields in answer."""
 
-    output_desc_tpl: ClassVar[str] = "第 {idx} 条修改后的字幕"
+    output_desc_tpl: ClassVar[str] = "第 {idx} 條修改後的字幕"
     """Description template for output fields in answer."""
 
     note_pfx: ClassVar[str] = "beizhu_"
     """Prefix for note fields in answer."""
 
-    note_desc_tpl: ClassVar[str] = "关于第 {idx} 条字幕修改的备注说明"
+    note_desc_tpl: ClassVar[str] = "關於第 {idx} 條字幕修改的備註說明"
     """Description template for note fields in answer."""
 
     # Test case errors
     output_unmodified_err_tpl: ClassVar[str] = (
-        "第 {idx} 条答案的修改文本与查询文本相同。如果不需要修改，应提供空字符串。"
+        "第 {idx} 條答案的修改文本與查詢文本相同。如果不需要修改，應提供空字符串。"
     )
     """Error template when output is present but unmodified."""
 
     note_missing_err_tpl: ClassVar[str] = (
-        "第 {idx} 条答案的文本已被修改，但未提供备注。如需修改，必须附带备注说明。"
+        "第 {idx} 條答案的文本已被修改，但未提供備註。如需修改，必須附帶備註說明。"
     )
     """Error template when note is missing for a change."""
 
     output_missing_err_tpl: ClassVar[str] = (
-        "第 {idx} 条答案的文本未修改，但提供了备注。如果不需要修改，应提供空字符串。"
+        "第 {idx} 條答案的文本未修改，但提供了備註。如果不需要修改，應提供空字符串。"
     )
     """Error template when output is missing for a note."""
 
 
-class BlockReviewPromptZhoHant(BlockReviewPromptZhoHans):
-    """LLM correspondence text for traditional standard Chinese block review."""
+class BlockReviewPromptZhoHans(BlockReviewPromptZhoHant, PromptZhoHans):
+    """LLM correspondence text for simplified standard Chinese block review."""
 
-    opencc_config = OpenCCConfig.s2t
-    """Config for converting simplified Chinese characters from the parent class."""
+    opencc_config = OpenCCConfig.t2s
+    """Config for converting traditional Chinese characters from the parent class."""

--- a/scinoephile/lang/zho/block_review/prompts.py
+++ b/scinoephile/lang/zho/block_review/prompts.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import ClassVar
 
 from scinoephile.core.text import dedent_and_compact
-from scinoephile.lang.zho.prompts import PromptZhoHans, PromptZhoHant
+from scinoephile.lang.zho.prompts import PromptZhoHant
 from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.llms.block_review import BlockReviewPrompt
 
@@ -68,7 +68,7 @@ class BlockReviewPromptZhoHant(BlockReviewPrompt, PromptZhoHant):
     """Error template when output is missing for a note."""
 
 
-class BlockReviewPromptZhoHans(BlockReviewPromptZhoHant, PromptZhoHans):
+class BlockReviewPromptZhoHans(BlockReviewPromptZhoHant):
     """LLM correspondence text for simplified standard Chinese block review."""
 
     opencc_config = OpenCCConfig.t2s

--- a/scinoephile/lang/zho/ocr_fusion/__init__.py
+++ b/scinoephile/lang/zho/ocr_fusion/__init__.py
@@ -79,7 +79,7 @@ def get_zho_ocr_fused(
 
 
 def get_zho_ocr_fuser(
-    prompt_cls: type[OcrFusionPromptZhoHans] = OcrFusionPromptZhoHans,
+    prompt_cls: type[OcrFusionPromptZhoHant] = OcrFusionPromptZhoHans,
     test_cases: list[TestCase] | None = None,
     provider: LLMProvider | None = None,
     **kwargs: Unpack[ProcessorKwargs],

--- a/scinoephile/lang/zho/ocr_fusion/prompts.py
+++ b/scinoephile/lang/zho/ocr_fusion/prompts.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import ClassVar
 
 from scinoephile.core.text import dedent_and_compact
-from scinoephile.lang.zho.prompts import PromptZhoHans
+from scinoephile.lang.zho.prompts import PromptZhoHans, PromptZhoHant
 from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.llms.dual_1_to_1.ocr_fusion import OcrFusionPrompt
 
@@ -17,16 +17,16 @@ __all__ = [
 ]
 
 
-class OcrFusionPromptZhoHans(OcrFusionPrompt, PromptZhoHans):
-    """Text for LLM correspondence for simplified standard Chinese OCR fusion."""
+class OcrFusionPromptZhoHant(OcrFusionPrompt, PromptZhoHant):
+    """Text for LLM correspondence for traditional standard Chinese OCR fusion."""
 
     # Prompt
     base_system_prompt: ClassVar[str] = dedent_and_compact("""
-        你负责将来自两个不同来源的中文字幕 OCR 结果进行融合：Google Lens 和 PaddleOCR。
-        请遵循以下原则：
-        * Google Lens 在识别汉字方面更可靠。
-        * Google Lens 在标点符号方面更可靠。
-        * PaddleOCR 在换行格式方面更可靠。""")
+        你負責將來自兩個不同來源的中文字幕 OCR 結果進行融合：Google Lens 和 PaddleOCR。
+        請遵循以下原則：
+        * Google Lens 在識別漢字方面更可靠。
+        * Google Lens 在標點符號方面更可靠。
+        * PaddleOCR 在換行格式方面更可靠。""")
     """Base system prompt."""
 
     # Query fields
@@ -50,7 +50,7 @@ class OcrFusionPromptZhoHans(OcrFusionPrompt, PromptZhoHans):
     """Error when source two field is missing from query."""
 
     src_1_src_2_equal_err: ClassVar[str] = (
-        "Google Lens 与 PaddleOCR 的字幕文本不能完全相同。"
+        "Google Lens 與 PaddleOCR 的字幕文本不能完全相同。"
     )
     """Error when source one and two fields are equal in query."""
 
@@ -58,25 +58,25 @@ class OcrFusionPromptZhoHans(OcrFusionPrompt, PromptZhoHans):
     output: ClassVar[str] = "ronghe"
     """Name of output field in answer."""
 
-    output_desc: ClassVar[str] = "融合后的字幕文本"
+    output_desc: ClassVar[str] = "融合後的字幕文本"
     """Description of output field in answer."""
 
     note: ClassVar[str] = "beizhu"
     """Name of note field in answer."""
 
-    note_desc: ClassVar[str] = "对所做更正的说明"
+    note_desc: ClassVar[str] = "對所做更正的說明"
     """Description of note field in answer."""
 
     # Answer validation errors
-    output_missing_err: ClassVar[str] = "融合后的字幕文本不能为空。"
+    output_missing_err: ClassVar[str] = "融合後的字幕文本不能爲空。"
     """Error when output field is missing from answer."""
 
-    note_missing_err: ClassVar[str] = "更正说明不能为空。"
+    note_missing_err: ClassVar[str] = "更正說明不能爲空。"
     """Error when note field is missing from answer."""
 
 
-class OcrFusionPromptZhoHant(OcrFusionPromptZhoHans):
-    """Text for LLM correspondence for traditional standard Chinese OCR fusion."""
+class OcrFusionPromptZhoHans(OcrFusionPromptZhoHant, PromptZhoHans):
+    """Text for LLM correspondence for simplified standard Chinese OCR fusion."""
 
-    opencc_config = OpenCCConfig.s2t
-    """Config for converting simplified Chinese characters from the parent class."""
+    opencc_config = OpenCCConfig.t2s
+    """Config for converting traditional Chinese characters from the parent class."""

--- a/scinoephile/lang/zho/ocr_fusion/prompts.py
+++ b/scinoephile/lang/zho/ocr_fusion/prompts.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import ClassVar
 
 from scinoephile.core.text import dedent_and_compact
-from scinoephile.lang.zho.prompts import PromptZhoHans, PromptZhoHant
+from scinoephile.lang.zho.prompts import PromptZhoHant
 from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.llms.dual_1_to_1.ocr_fusion import OcrFusionPrompt
 
@@ -75,7 +75,7 @@ class OcrFusionPromptZhoHant(OcrFusionPrompt, PromptZhoHant):
     """Error when note field is missing from answer."""
 
 
-class OcrFusionPromptZhoHans(OcrFusionPromptZhoHant, PromptZhoHans):
+class OcrFusionPromptZhoHans(OcrFusionPromptZhoHant):
     """Text for LLM correspondence for simplified standard Chinese OCR fusion."""
 
     opencc_config = OpenCCConfig.t2s

--- a/scinoephile/lang/zho/prompts.py
+++ b/scinoephile/lang/zho/prompts.py
@@ -6,59 +6,63 @@ from __future__ import annotations
 
 from abc import ABC
 from inspect import isroutine
-from typing import Any, ClassVar
+from typing import ClassVar
 
 from scinoephile.core.llms import Prompt
 
 from .script.conversion import OpenCCConfig, get_zho_text_converted
 
-__all__ = ["PromptZhoHans"]
+__all__ = [
+    "PromptZhoHans",
+    "PromptZhoHant",
+]
 
 
-class PromptZhoHans(Prompt, ABC):
-    """LLM correspondence text for simplified standard Chinese."""
+class PromptZhoHant(Prompt, ABC):
+    """LLM correspondence text for traditional standard Chinese."""
 
     opencc_config: ClassVar[OpenCCConfig | None] = None
-    """Config for converting simplified Chinese characters from the parent class."""
+    """Config for converting Chinese characters from the parent class."""
 
     # Prompt
-    schema_intro: ClassVar[str] = "你的回复必须是一个具有以下结构的 JSON 对象："
+    schema_intro: ClassVar[str] = "你的回覆必須是一個具有以下結構的 JSON 對象："
     """Text preceding schema description."""
 
-    few_shot_intro: ClassVar[str] = "下面是一些查询及其预期答案的示例："
+    few_shot_intro: ClassVar[str] = "下面是一些查詢及其預期答案的示例："
     """Text preceding few-shot examples."""
 
-    few_shot_query_intro: ClassVar[str] = "示例查询："
+    few_shot_query_intro: ClassVar[str] = "示例查詢："
     """Text preceding each few-shot example query."""
 
-    few_shot_answer_intro: ClassVar[str] = "预期答案："
+    few_shot_answer_intro: ClassVar[str] = "預期答案："
     """Text preceding each few-shot expected answer."""
 
     # Answer validation errors
     answer_invalid_pre: ClassVar[str] = (
-        "你之前的回复不是有效的 JSON，或未符合预期的模式要求。错误详情："
+        "你之前的回覆不是有效的 JSON，或未符合預期的模式要求。錯誤詳情："
     )
     """Text preceding answer validation errors."""
 
     answer_invalid_post: ClassVar[str] = (
-        "请重新尝试，并仅返回一个符合该模式要求的有效 JSON 对象。"
+        "請重新嘗試，並僅返回一個符合該模式要求的有效 JSON 對象。"
     )
     """Text following answer validation errors."""
 
     # Test case validation errors
     test_case_invalid_pre: ClassVar[str] = (
-        "你之前的回复是符合答案模式的有效 JSON，但不适用于当前的特定查询。错误详情："
+        "你之前的回覆是符合答案模式的有效 JSON，但不適用於當前的特定查詢。錯誤詳情："
     )
     """Text preceding test case validation errors."""
 
-    test_case_invalid_post: ClassVar[str] = "请根据错误信息对你的回复进行相应修改。"
+    test_case_invalid_post: ClassVar[str] = "請根據錯誤信息對你的回覆進行相應修改。"
     """Text following test case validation errors."""
 
-    def __init_subclass__(cls, **kwargs: Any):
+    def __init_subclass__(cls, **kwargs: object):
         """Automatically convert class attributes using OpenCC configuration.
 
-        This metaclass hook automatically converts class attributes from simplified
-        to traditional Chinese (or vice versa) when a subclass sets `opencc_config`.
+        This metaclass hook automatically converts class attributes from the
+        parent Chinese script to the target script when a subclass explicitly sets
+        `opencc_config`.
         It walks through the method resolution order (MRO) and converts string values
         as well as strings within tuples, lists, and dictionaries inherited from
         parent classes that have not been explicitly overridden in the subclass.
@@ -68,7 +72,8 @@ class PromptZhoHans(Prompt, ABC):
         """
         super().__init_subclass__(**kwargs)
 
-        if cls.opencc_config is None:
+        config = cls.__dict__.get("opencc_config")
+        if not isinstance(config, OpenCCConfig):
             return
 
         for base in cls.__mro__[1:]:
@@ -86,12 +91,12 @@ class PromptZhoHans(Prompt, ABC):
                 if isinstance(value, (classmethod, staticmethod, property)):
                     continue
 
-                new_value = cls._convert_value(value, cls.opencc_config)
+                new_value = cls._convert_value(value, config)
                 if new_value is not value:
                     setattr(cls, name, new_value)
 
     @classmethod
-    def _convert_value(cls, value: Any, config: OpenCCConfig) -> Any:
+    def _convert_value(cls, value: object, config: OpenCCConfig) -> object:
         """Convert value to target Chinese script using OpenCC configuration.
 
         Arguments:
@@ -109,3 +114,10 @@ class PromptZhoHans(Prompt, ABC):
         if isinstance(value, dict):
             return {k: cls._convert_value(val, config) for k, val in value.items()}
         return value
+
+
+class PromptZhoHans(PromptZhoHant, ABC):
+    """LLM correspondence text for simplified standard Chinese."""
+
+    opencc_config = OpenCCConfig.t2s
+    """Config for converting traditional Chinese characters from the parent class."""

--- a/scinoephile/lang/zho/prompts.py
+++ b/scinoephile/lang/zho/prompts.py
@@ -12,10 +12,7 @@ from scinoephile.core.llms import Prompt
 
 from .script.conversion import OpenCCConfig, get_zho_text_converted
 
-__all__ = [
-    "PromptZhoHans",
-    "PromptZhoHant",
-]
+__all__ = ["PromptZhoHant"]
 
 
 class PromptZhoHant(Prompt, ABC):
@@ -114,10 +111,3 @@ class PromptZhoHant(Prompt, ABC):
         if isinstance(value, dict):
             return {k: cls._convert_value(val, config) for k, val in value.items()}
         return value
-
-
-class PromptZhoHans(PromptZhoHant, ABC):
-    """LLM correspondence text for simplified standard Chinese."""
-
-    opencc_config = OpenCCConfig.t2s
-    """Config for converting traditional Chinese characters from the parent class."""

--- a/scinoephile/multilang/yue_eng/translation.py
+++ b/scinoephile/multilang/yue_eng/translation.py
@@ -8,7 +8,7 @@ from typing import ClassVar
 
 from scinoephile.core.dictionaries import DictionaryToolPrompt
 from scinoephile.core.text import dedent_and_compact
-from scinoephile.lang.yue.prompts import PromptYueHans, PromptYueHant
+from scinoephile.lang.yue.prompts import PromptYueHant
 from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.llms.gap_translation import GapTranslationPrompt
 from scinoephile.llms.guided_translation import GuidedTranslationPrompt
@@ -72,7 +72,7 @@ class YueEngTranslationPromptYueHant(
     """Description template for generated written Cantonese output fields."""
 
 
-class YueEngTranslationPromptYueHans(YueEngTranslationPromptYueHant, PromptYueHans):
+class YueEngTranslationPromptYueHans(YueEngTranslationPromptYueHant):
     """Text for simplified written Cantonese translation from English."""
 
     opencc_config = OpenCCConfig.hk2s
@@ -151,9 +151,7 @@ class YueEngGapTranslationPromptYueHant(
         return cls.output_contains_note_err_tpl.format(idx=idx)
 
 
-class YueEngGapTranslationPromptYueHans(
-    YueEngGapTranslationPromptYueHant, PromptYueHans
-):
+class YueEngGapTranslationPromptYueHans(YueEngGapTranslationPromptYueHant):
     """Text for simplified written Cantonese gap translation using English."""
 
     opencc_config = OpenCCConfig.hk2s
@@ -216,9 +214,7 @@ class YueEngGuidedTranslationPromptYueHant(
     """Description template for generated written Cantonese output fields."""
 
 
-class YueEngGuidedTranslationPromptYueHans(
-    YueEngGuidedTranslationPromptYueHant, PromptYueHans
-):
+class YueEngGuidedTranslationPromptYueHans(YueEngGuidedTranslationPromptYueHant):
     """Text for simplified guided written Cantonese translation from English."""
 
     opencc_config = OpenCCConfig.hk2s

--- a/scinoephile/multilang/yue_eng/translation.py
+++ b/scinoephile/multilang/yue_eng/translation.py
@@ -8,7 +8,7 @@ from typing import ClassVar
 
 from scinoephile.core.dictionaries import DictionaryToolPrompt
 from scinoephile.core.text import dedent_and_compact
-from scinoephile.lang.yue.prompts import PromptYueHans
+from scinoephile.lang.yue.prompts import PromptYueHans, PromptYueHant
 from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.llms.gap_translation import GapTranslationPrompt
 from scinoephile.llms.guided_translation import GuidedTranslationPrompt
@@ -24,36 +24,36 @@ __all__ = [
 ]
 
 
-class YueEngTranslationPromptYueHans(
-    DictionaryToolPrompt, TranslationPrompt, PromptYueHans
+class YueEngTranslationPromptYueHant(
+    DictionaryToolPrompt, TranslationPrompt, PromptYueHant
 ):
-    """Text for simplified written Cantonese translation from English."""
+    """Text for traditional written Cantonese translation from English."""
 
     # Dictionary tool
     dictionary_tool_name: ClassVar[str] = "lookup_dictionary"
     """Name of the dictionary lookup tool."""
 
     dictionary_tool_description: ClassVar[str] = (
-        "查本地词典入面嘅粤语同普通话词条。工具会自动判断查询系汉字、拼音定粤拼。"
+        "查本地詞典入面嘅粵語同普通話詞條。工具會自動判斷查詢係漢字、拼音定粵拼。"
     )
     """Description of the dictionary lookup tool."""
 
     dictionary_tool_query_description: ClassVar[str] = (
-        "要查嘅普通话或者粤语词语，可以系汉字、拼音或者粤拼。"
+        "要查嘅普通話或者粵語詞語，可以係漢字、拼音或者粵拼。"
     )
     """Description of the dictionary lookup query parameter."""
 
     # Prompt
     base_system_prompt: ClassVar[str] = dedent_and_compact("""
-        你负责根据英文字幕，创作对应嘅粤文字幕。
+        你負責根據英文字幕，創作對應嘅粵文字幕。
 
-        每条英文字幕都要输出一条粤文字幕。译文要用自然、通顺嘅书面粤语，
-        准确表达英文字幕嘅意思、语气、戏剧意图同说话人意图。唔好逐字硬译；
-        可以调整措辞令佢更似自然粤文字幕。专名、固定称呼、重复术语同字幕标记
-        要喺适合时保留或者按粤语习惯处理。
+        每條英文字幕都要輸出一條粵文字幕。譯文要用自然、通順嘅書面粵語，
+        準確表達英文字幕嘅意思、語氣、戲劇意圖同説話人意圖。唔好逐字硬譯；
+        可以調整措辭令佢更似自然粵文字幕。專名、固定稱呼、重複術語同字幕標記
+        要喺適合時保留或者按粵語習慣處理。
 
-        输出内容只可以系生成嘅粤文字幕正文。绝对唔好附加英文、备注、解释、标签、
-        替代译文、方括号内容、括号内容，或者任何字幕以外嘅说明。
+        輸出內容只可以係生成嘅粵文字幕正文。絕對唔好附加英文、備註、解釋、標籤、
+        替代譯文、方括號內容、括號內容，或者任何字幕以外嘅説明。
         """)
     """Base system prompt."""
 
@@ -61,53 +61,53 @@ class YueEngTranslationPromptYueHans(
     input_pfx: ClassVar[str] = "eng_"
     """Prefix for English source fields in query."""
 
-    input_desc_tpl: ClassVar[str] = "要翻译成粤文嘅英文字幕 {idx}"
+    input_desc_tpl: ClassVar[str] = "要翻譯成粵文嘅英文字幕 {idx}"
     """Description template for English source fields in query."""
 
     # Answer fields
     output_pfx: ClassVar[str] = "yuewen_"
     """Prefix for generated written Cantonese output fields in answer."""
 
-    output_desc_tpl: ClassVar[str] = "字幕 {idx} 对应嘅粤文译文"
+    output_desc_tpl: ClassVar[str] = "字幕 {idx} 對應嘅粵文譯文"
     """Description template for generated written Cantonese output fields."""
 
 
-class YueEngTranslationPromptYueHant(YueEngTranslationPromptYueHans):
-    """Text for traditional written Cantonese translation from English."""
+class YueEngTranslationPromptYueHans(YueEngTranslationPromptYueHant, PromptYueHans):
+    """Text for simplified written Cantonese translation from English."""
 
-    opencc_config = OpenCCConfig.s2hk
-    """Config for converting simplified Chinese characters from the parent class."""
+    opencc_config = OpenCCConfig.hk2s
+    """Config for converting traditional Chinese characters from the parent class."""
 
 
-class YueEngGapTranslationPromptYueHans(
-    DictionaryToolPrompt, GapTranslationPrompt, PromptYueHans
+class YueEngGapTranslationPromptYueHant(
+    DictionaryToolPrompt, GapTranslationPrompt, PromptYueHant
 ):
-    """Text for simplified written Cantonese gap translation using English."""
+    """Text for traditional written Cantonese gap translation using English."""
 
     # Dictionary tool
     dictionary_tool_name: ClassVar[str] = "lookup_dictionary"
     """Name of the dictionary lookup tool."""
 
     dictionary_tool_description: ClassVar[str] = (
-        "查本地词典入面嘅粤语同普通话词条。工具会自动判断查询系汉字、拼音定粤拼。"
+        "查本地詞典入面嘅粵語同普通話詞條。工具會自動判斷查詢係漢字、拼音定粵拼。"
     )
     """Description of the dictionary lookup tool."""
 
     dictionary_tool_query_description: ClassVar[str] = (
-        "要查嘅普通话或者粤语词语，可以系汉字、拼音或者粤拼。"
+        "要查嘅普通話或者粵語詞語，可以係漢字、拼音或者粵拼。"
     )
     """Description of the dictionary lookup query parameter."""
 
     # Prompt
     base_system_prompt: ClassVar[str] = dedent_and_compact("""
-        你负责根据对应嘅英文字幕，补翻译缺失咗嘅粤文字幕。
-        只有当某行现有粤文字幕系空字串时，先需要提供译文。
-        如果某行已经有粤文内容，唔好改，嗰行请输出空字串。
-        译文要用自然、通顺嘅书面粤语，语气同用词要尽量贴近附近已有嘅粤文字幕。
-        英文字幕系意思来源；译文唔需要逐字对应，但要准确表达该行意思。
-        输出内容只可以系字幕正文本身，绝对唔好附加英文、备注、解释、标签、
-        方括号内容、括号内容，或者任何译文以外嘅说明。
-        如果唔需要翻译，就输出空字串。
+        你負責根據對應嘅英文字幕，補翻譯缺失咗嘅粵文字幕。
+        只有當某行現有粵文字幕係空字串時，先需要提供譯文。
+        如果某行已經有粵文內容，唔好改，嗰行請輸出空字串。
+        譯文要用自然、通順嘅書面粵語，語氣同用詞要儘量貼近附近已有嘅粵文字幕。
+        英文字幕係意思來源；譯文唔需要逐字對應，但要準確表達該行意思。
+        輸出內容只可以係字幕正文本身，絕對唔好附加英文、備註、解釋、標籤、
+        方括號內容、括號內容，或者任何譯文以外嘅説明。
+        如果唔需要翻譯，就輸出空字串。
         """)
     """Base system prompt."""
 
@@ -115,13 +115,13 @@ class YueEngGapTranslationPromptYueHans(
     src_1_pfx: ClassVar[str] = "yuewen_"
     """Prefix for source one fields in query."""
 
-    src_1_desc_tpl: ClassVar[str] = "字幕 {idx} 现有嘅粤文内容；如果系空就代表要翻译"
+    src_1_desc_tpl: ClassVar[str] = "字幕 {idx} 現有嘅粵文內容；如果係空就代表要翻譯"
     """Description template for source one fields in query."""
 
     src_2_pfx: ClassVar[str] = "eng_"
     """Prefix for source two fields in query."""
 
-    src_2_desc_tpl: ClassVar[str] = "字幕 {idx} 对应嘅英文字幕"
+    src_2_desc_tpl: ClassVar[str] = "字幕 {idx} 對應嘅英文字幕"
     """Description template for source two fields in query."""
 
     # Answer fields
@@ -129,19 +129,19 @@ class YueEngGapTranslationPromptYueHans(
     """Prefix for output fields in answer."""
 
     output_desc_tpl: ClassVar[str] = (
-        '字幕 {idx} 译好后嘅粤文正文；如果唔需要翻译请输出 ""。'
-        "唔好包含英文、备注、解释、标签或者括号说明。"
+        '字幕 {idx} 譯好後嘅粵文正文；如果唔需要翻譯請輸出 ""。'
+        "唔好包含英文、備註、解釋、標籤或者括號説明。"
     )
     """Description template for output fields in answer."""
 
     # Test case validation errors
     output_unmodified_err_tpl: ClassVar[str] = (
-        "字幕 {idx} 已经有粤文内容，嗰行输出必须系空字串。"
+        "字幕 {idx} 已經有粵文內容，嗰行輸出必須係空字串。"
     )
     """Error template when output is present but unmodified relative to source one."""
 
     output_contains_note_err_tpl: ClassVar[str] = (
-        "字幕 {idx} 包含英文或者备注说明；只可以输出粤文字幕正文。"
+        "字幕 {idx} 包含英文或者備註説明；只可以輸出粵文字幕正文。"
     )
     """Error template when output includes leaked note text."""
 
@@ -151,45 +151,47 @@ class YueEngGapTranslationPromptYueHans(
         return cls.output_contains_note_err_tpl.format(idx=idx)
 
 
-class YueEngGapTranslationPromptYueHant(YueEngGapTranslationPromptYueHans):
-    """Text for traditional written Cantonese gap translation using English."""
-
-    opencc_config = OpenCCConfig.s2hk
-    """Config for converting simplified Chinese characters from the parent class."""
-
-
-class YueEngGuidedTranslationPromptYueHans(
-    DictionaryToolPrompt, GuidedTranslationPrompt, PromptYueHans
+class YueEngGapTranslationPromptYueHans(
+    YueEngGapTranslationPromptYueHant, PromptYueHans
 ):
-    """Text for simplified guided written Cantonese translation from English."""
+    """Text for simplified written Cantonese gap translation using English."""
+
+    opencc_config = OpenCCConfig.hk2s
+    """Config for converting traditional Chinese characters from the parent class."""
+
+
+class YueEngGuidedTranslationPromptYueHant(
+    DictionaryToolPrompt, GuidedTranslationPrompt, PromptYueHant
+):
+    """Text for traditional guided written Cantonese translation from English."""
 
     # Dictionary tool
     dictionary_tool_name: ClassVar[str] = "lookup_dictionary"
     """Name of the dictionary lookup tool."""
 
     dictionary_tool_description: ClassVar[str] = (
-        "查本地词典入面嘅粤语同普通话词条。工具会自动判断查询系汉字、拼音定粤拼。"
+        "查本地詞典入面嘅粵語同普通話詞條。工具會自動判斷查詢係漢字、拼音定粵拼。"
     )
     """Description of the dictionary lookup tool."""
 
     dictionary_tool_query_description: ClassVar[str] = (
-        "要查嘅普通话或者粤语词语，可以系汉字、拼音或者粤拼。"
+        "要查嘅普通話或者粵語詞語，可以係漢字、拼音或者粵拼。"
     )
     """Description of the dictionary lookup query parameter."""
 
     # Prompt
     base_system_prompt: ClassVar[str] = dedent_and_compact("""
-        你负责根据英文字幕，创作对应嘅粤文字幕。你亦会收到同一段场景嘅
-        既有粤文字幕，作为参考材料。
+        你負責根據英文字幕，創作對應嘅粵文字幕。你亦會收到同一段場景嘅
+        既有粵文字幕，作為參考材料。
 
-        每条英文字幕都要输出一条粤文字幕。译文要准确表达英文字幕嘅意思、
-        语气、戏剧意图同说话人意图。既有粤文字幕系角色名、专名、重复术语、
-        语域同固定讲法嘅参考；当佢同英文字幕意思兼容时，尽量沿用。
-        如果英文字幕同既有粤文字幕有分别，要优先按英文意思翻译，同时保留
-        已经建立好嘅名词同称呼。
+        每條英文字幕都要輸出一條粵文字幕。譯文要準確表達英文字幕嘅意思、
+        語氣、戲劇意圖同説話人意圖。既有粵文字幕係角色名、專名、重複術語、
+        語域同固定講法嘅參考；當佢同英文字幕意思兼容時，儘量沿用。
+        如果英文字幕同既有粵文字幕有分別，要優先按英文意思翻譯，同時保留
+        已經建立好嘅名詞同稱呼。
 
-        输出内容只可以系生成嘅粤文字幕正文。绝对唔好附加英文、备注、解释、标签、
-        替代译文、方括号内容、括号内容，或者任何字幕以外嘅说明。
+        輸出內容只可以係生成嘅粵文字幕正文。絕對唔好附加英文、備註、解釋、標籤、
+        替代譯文、方括號內容、括號內容，或者任何字幕以外嘅説明。
         """)
     """Base system prompt."""
 
@@ -197,25 +199,27 @@ class YueEngGuidedTranslationPromptYueHans(
     src_1_pfx: ClassVar[str] = "eng_"
     """Prefix for English source fields in query."""
 
-    src_1_desc_tpl: ClassVar[str] = "要翻译成粤文嘅英文字幕 {idx}"
+    src_1_desc_tpl: ClassVar[str] = "要翻譯成粵文嘅英文字幕 {idx}"
     """Description template for English source fields in query."""
 
     src_2_pfx: ClassVar[str] = "yuewen_reference_"
     """Prefix for written Cantonese reference fields in query."""
 
-    src_2_desc_tpl: ClassVar[str] = "同一段场景嘅既有粤文参考字幕 {idx}"
+    src_2_desc_tpl: ClassVar[str] = "同一段場景嘅既有粵文參考字幕 {idx}"
     """Description template for written Cantonese reference fields in query."""
 
     # Answer fields
     output_pfx: ClassVar[str] = "yuewen_"
     """Prefix for generated written Cantonese output fields in answer."""
 
-    output_desc_tpl: ClassVar[str] = "字幕 {idx} 对应嘅粤文译文"
+    output_desc_tpl: ClassVar[str] = "字幕 {idx} 對應嘅粵文譯文"
     """Description template for generated written Cantonese output fields."""
 
 
-class YueEngGuidedTranslationPromptYueHant(YueEngGuidedTranslationPromptYueHans):
-    """Text for traditional guided written Cantonese translation from English."""
+class YueEngGuidedTranslationPromptYueHans(
+    YueEngGuidedTranslationPromptYueHant, PromptYueHans
+):
+    """Text for simplified guided written Cantonese translation from English."""
 
-    opencc_config = OpenCCConfig.s2hk
-    """Config for converting simplified Chinese characters from the parent class."""
+    opencc_config = OpenCCConfig.hk2s
+    """Config for converting traditional Chinese characters from the parent class."""

--- a/scinoephile/multilang/yue_zho/block_review/__init__.py
+++ b/scinoephile/multilang/yue_zho/block_review/__init__.py
@@ -73,7 +73,7 @@ def get_yue_block_reviewed_vs_zho(
 
 
 def get_yue_vs_zho_block_reviewer(
-    prompt_cls: type[YueBlockReviewVsZhoPromptYueHans] = (
+    prompt_cls: type[YueBlockReviewVsZhoPromptYueHant] = (
         YueBlockReviewVsZhoPromptYueHans
     ),
     test_cases: list[TestCase] | None = None,

--- a/scinoephile/multilang/yue_zho/block_review/prompts.py
+++ b/scinoephile/multilang/yue_zho/block_review/prompts.py
@@ -8,7 +8,7 @@ from typing import ClassVar
 
 from scinoephile.core.dictionaries import DictionaryToolPrompt
 from scinoephile.core.text import dedent_and_compact
-from scinoephile.lang.yue.prompts import PromptYueHans
+from scinoephile.lang.yue.prompts import PromptYueHans, PromptYueHant
 from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.llms.dual_n_to_n import DualNToNPrompt
 
@@ -18,36 +18,36 @@ __all__ = [
 ]
 
 
-class YueBlockReviewVsZhoPromptYueHans(
-    DictionaryToolPrompt, DualNToNPrompt, PromptYueHans
+class YueBlockReviewVsZhoPromptYueHant(
+    DictionaryToolPrompt, DualNToNPrompt, PromptYueHant
 ):
-    """Text for simplified written Cantonese block review against standard Chinese."""
+    """Text for traditional written Cantonese block review against standard Chinese."""
 
     # Dictionary tool
     dictionary_tool_name: ClassVar[str] = "lookup_dictionary"
     """Name of the dictionary lookup tool."""
 
     dictionary_tool_description: ClassVar[str] = (
-        "查本地词典入面嘅粤语同普通话词条。工具会自动判断查询系汉字、拼音定粤拼。"
+        "查本地詞典入面嘅粵語同普通話詞條。工具會自動判斷查詢係漢字、拼音定粵拼。"
     )
     """Description of the dictionary lookup tool."""
 
     dictionary_tool_query_description: ClassVar[str] = (
-        "要查嘅普通话或者粤语词语，可以系汉字、拼音或者粤拼。"
+        "要查嘅普通話或者粵語詞語，可以係漢字、拼音或者粵拼。"
     )
     """Description of the dictionary lookup query parameter."""
 
     # Prompt
     base_system_prompt: ClassVar[str] = dedent_and_compact("""
-        你负责为广东话语音嘅粤文字幕做最后审核。
-        呢一轮唔系重写字幕，而系做最后一层把关，只处理仍然明显有问题嘅粤文转写。
-        请专注检查转写是否准确，尤其系听错字、写错字、人物称呼前后唔一致，或者同整套字幕其他地方明显冲突嘅情况。
-        唔好评审文风、文法、语气或者措辞；如果原句本身已经系合理嘅粤语讲法，就唔好改。
-        中文字幕只系参考，唔需要同粤文逐字对应。
-        对于每一条粤文字幕，只有当你认为确实需要修改时，先回传修订后嘅完整粤文字幕。
-        如果某条粤文字幕唔需要修改，请为该字幕回传空字串。
-        如果有修改，请同时用英文附上一段简短备注，说明你改咗乜嘢。
-        如果冇需要修改，备注栏同样回传空字串。
+        你負責為廣東話語音嘅粵文字幕做最後審核。
+        呢一輪唔係重寫字幕，而係做最後一層把關，只處理仍然明顯有問題嘅粵文轉寫。
+        請專注檢查轉寫是否準確，尤其係聽錯字、寫錯字、人物稱呼前後唔一致，或者同整套字幕其他地方明顯衝突嘅情況。
+        唔好評審文風、文法、語氣或者措辭；如果原句本身已經係合理嘅粵語講法，就唔好改。
+        中文字幕只係參考，唔需要同粵文逐字對應。
+        對於每一條粵文字幕，只有當你認為確實需要修改時，先回傳修訂後嘅完整粵文字幕。
+        如果某條粵文字幕唔需要修改，請為該字幕回傳空字串。
+        如果有修改，請同時用英文附上一段簡短備註，説明你改咗乜嘢。
+        如果冇需要修改，備註欄同樣回傳空字串。
     """)
     """Base system prompt."""
 
@@ -55,7 +55,7 @@ class YueBlockReviewVsZhoPromptYueHans(
     src_1_pfx: ClassVar[str] = "yuewen_"
     """Prefix for source one fields in query."""
 
-    src_1_desc_tpl: ClassVar[str] = "字幕 {idx} 嘅粤文转写"
+    src_1_desc_tpl: ClassVar[str] = "字幕 {idx} 嘅粵文轉寫"
     """Description template for source one fields in query."""
 
     src_2_pfx: ClassVar[str] = "zhongwen_"
@@ -69,7 +69,7 @@ class YueBlockReviewVsZhoPromptYueHans(
     """Prefix for output fields in answer."""
 
     output_desc_tpl: ClassVar[str] = (
-        '字幕 {idx} 修订后嘅粤文；如果冇任何修改，请回传 ""。'
+        '字幕 {idx} 修訂後嘅粵文；如果冇任何修改，請回傳 ""。'
     )
     """Description template for output fields in answer."""
 
@@ -77,32 +77,32 @@ class YueBlockReviewVsZhoPromptYueHans(
     """Prefix for note fields in answer."""
 
     note_desc_tpl: ClassVar[str] = (
-        '字幕 {idx} 嘅备注（英文）；如果冇任何修改，请回传 ""。'
+        '字幕 {idx} 嘅備註（英文）；如果冇任何修改，請回傳 ""。'
     )
     """Description template for note fields in answer."""
 
     # Test case validation errors
     output_unmodified_err_tpl: ClassVar[str] = (
-        "答案入面嘅输出 {idx} 同查询入面嘅来源一 {idx} 完全一样；"
-        '如果冇修改，必须回传 ""。'
+        "答案入面嘅輸出 {idx} 同查詢入面嘅來源一 {idx} 完全一樣；"
+        '如果冇修改，必須回傳 ""。'
     )
     """Error template when output is present but unmodified relative to source one."""
 
     output_missing_note_present_err_tpl: ClassVar[str] = (
-        "答案入面嘅输出 {idx} 同查询入面嘅来源一 {idx} 完全一样，"
-        '但却提供咗备注；如果输出系 ""，就唔可以有任何备注。'
+        "答案入面嘅輸出 {idx} 同查詢入面嘅來源一 {idx} 完全一樣，"
+        '但卻提供咗備註；如果輸出係 ""，就唔可以有任何備註。'
     )
     """Error template when output is missing but note is present."""
 
     output_present_note_missing_err_tpl: ClassVar[str] = (
-        "答案入面嘅输出 {idx} 相对于查询入面嘅来源一 {idx} 有所修改，"
-        "但冇提供任何备注；如果有输出，就必须同时提供备注。"
+        "答案入面嘅輸出 {idx} 相對於查詢入面嘅來源一 {idx} 有所修改，"
+        "但冇提供任何備註；如果有輸出，就必須同時提供備註。"
     )
     """Error template when output is present but note is missing."""
 
 
-class YueBlockReviewVsZhoPromptYueHant(YueBlockReviewVsZhoPromptYueHans):
-    """Text for traditional written Cantonese block review against standard Chinese."""
+class YueBlockReviewVsZhoPromptYueHans(YueBlockReviewVsZhoPromptYueHant, PromptYueHans):
+    """Text for simplified written Cantonese block review against standard Chinese."""
 
-    opencc_config = OpenCCConfig.s2hk
-    """Config for converting simplified Chinese characters from the parent class."""
+    opencc_config = OpenCCConfig.hk2s
+    """Config for converting traditional Chinese characters from the parent class."""

--- a/scinoephile/multilang/yue_zho/block_review/prompts.py
+++ b/scinoephile/multilang/yue_zho/block_review/prompts.py
@@ -8,7 +8,7 @@ from typing import ClassVar
 
 from scinoephile.core.dictionaries import DictionaryToolPrompt
 from scinoephile.core.text import dedent_and_compact
-from scinoephile.lang.yue.prompts import PromptYueHans, PromptYueHant
+from scinoephile.lang.yue.prompts import PromptYueHant
 from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.llms.dual_n_to_n import DualNToNPrompt
 
@@ -101,7 +101,7 @@ class YueBlockReviewVsZhoPromptYueHant(
     """Error template when output is present but note is missing."""
 
 
-class YueBlockReviewVsZhoPromptYueHans(YueBlockReviewVsZhoPromptYueHant, PromptYueHans):
+class YueBlockReviewVsZhoPromptYueHans(YueBlockReviewVsZhoPromptYueHant):
     """Text for simplified written Cantonese block review against standard Chinese."""
 
     opencc_config = OpenCCConfig.hk2s

--- a/scinoephile/multilang/yue_zho/line_review/__init__.py
+++ b/scinoephile/multilang/yue_zho/line_review/__init__.py
@@ -82,7 +82,7 @@ def get_yue_line_reviewed_vs_zho(
 
 
 def get_yue_vs_zho_line_reviewer(
-    prompt_cls: type[YueLineReviewVsZhoPromptYueHans] = YueLineReviewVsZhoPromptYueHans,
+    prompt_cls: type[YueLineReviewVsZhoPromptYueHant] = YueLineReviewVsZhoPromptYueHans,
     test_cases: list[TestCase] | None = None,
     use_dictionary_tool: bool = True,
     provider: LLMProvider | None = None,

--- a/scinoephile/multilang/yue_zho/line_review/manager.py
+++ b/scinoephile/multilang/yue_zho/line_review/manager.py
@@ -9,7 +9,7 @@ from typing import ClassVar
 from scinoephile.core.llms import Answer, TestCase
 from scinoephile.llms.dual_1_to_1 import Dual1To1Manager
 
-from .prompts import YueLineReviewVsZhoPromptYueHans
+from .prompts import YueLineReviewVsZhoPromptYueHans, YueLineReviewVsZhoPromptYueHant
 
 __all__ = ["YueZhoLineReviewManager"]
 
@@ -17,7 +17,7 @@ __all__ = ["YueZhoLineReviewManager"]
 class YueZhoLineReviewManager(Dual1To1Manager):
     """Factories for written Cantonese vs. standard Chinese line-review LLM classes."""
 
-    prompt_cls: ClassVar[type[YueLineReviewVsZhoPromptYueHans]] = (
+    prompt_cls: ClassVar[type[YueLineReviewVsZhoPromptYueHant]] = (
         YueLineReviewVsZhoPromptYueHans
     )
     """Default prompt class."""
@@ -31,7 +31,7 @@ class YueZhoLineReviewManager(Dual1To1Manager):
         Returns:
             validated answer
         """
-        prompt_cls: type[YueLineReviewVsZhoPromptYueHans] = getattr(model, "prompt_cls")
+        prompt_cls: type[YueLineReviewVsZhoPromptYueHant] = getattr(model, "prompt_cls")
         output = getattr(model, prompt_cls.output, None)
         note = getattr(model, prompt_cls.note, None)
         if not output and not note:
@@ -47,7 +47,7 @@ class YueZhoLineReviewManager(Dual1To1Manager):
         Returns:
             validated test case
         """
-        prompt_cls: type[YueLineReviewVsZhoPromptYueHans] = getattr(model, "prompt_cls")
+        prompt_cls: type[YueLineReviewVsZhoPromptYueHant] = getattr(model, "prompt_cls")
         if model.answer is None:
             return model
 

--- a/scinoephile/multilang/yue_zho/line_review/processor.py
+++ b/scinoephile/multilang/yue_zho/line_review/processor.py
@@ -15,7 +15,7 @@ from scinoephile.core.subtitles import Series, Subtitle, get_concatenated_series
 from scinoephile.core.synchronization import get_sync_overlap_matrix
 
 from .manager import YueZhoLineReviewManager
-from .prompts import YueLineReviewVsZhoPromptYueHans
+from .prompts import YueLineReviewVsZhoPromptYueHant
 
 __all__ = ["YueZhoLineReviewProcessor"]
 
@@ -26,7 +26,7 @@ logger = getLogger(__name__)
 class YueZhoLineReviewProcessor(Processor):
     """Processes written Cantonese vs. standard Chinese line review."""
 
-    prompt_cls: type[YueLineReviewVsZhoPromptYueHans]
+    prompt_cls: type[YueLineReviewVsZhoPromptYueHant]
     """Text for LLM correspondence."""
 
     manager_cls = YueZhoLineReviewManager

--- a/scinoephile/multilang/yue_zho/line_review/prompts.py
+++ b/scinoephile/multilang/yue_zho/line_review/prompts.py
@@ -8,7 +8,7 @@ from typing import ClassVar
 
 from scinoephile.core.dictionaries import DictionaryToolPrompt
 from scinoephile.core.text import dedent_and_compact
-from scinoephile.lang.yue.prompts import PromptYueHans
+from scinoephile.lang.yue.prompts import PromptYueHans, PromptYueHant
 from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.llms.dual_1_to_1 import Dual1To1Prompt
 
@@ -18,92 +18,92 @@ __all__ = [
 ]
 
 
-class YueLineReviewVsZhoPromptYueHans(
-    DictionaryToolPrompt, Dual1To1Prompt, PromptYueHans
+class YueLineReviewVsZhoPromptYueHant(
+    DictionaryToolPrompt, Dual1To1Prompt, PromptYueHant
 ):
-    """Text for simplified written Cantonese line review against standard Chinese."""
+    """Text for traditional written Cantonese line review against standard Chinese."""
 
     # Dictionary tool
     dictionary_tool_name: ClassVar[str] = "lookup_dictionary"
     """Name of the dictionary lookup tool."""
 
     dictionary_tool_description: ClassVar[str] = (
-        "查本地词典入面嘅粤语同普通话词条。工具会自动判断查询系汉字、拼音定粤拼。"
+        "查本地詞典入面嘅粵語同普通話詞條。工具會自動判斷查詢係漢字、拼音定粵拼。"
     )
     """Description of the dictionary lookup tool."""
 
     dictionary_tool_query_description: ClassVar[str] = (
-        "要查嘅普通话或者粤语词语，可以系汉字、拼音或者粤拼。"
+        "要查嘅普通話或者粵語詞語，可以係漢字、拼音或者粵拼。"
     )
     """Description of the dictionary lookup query parameter."""
 
     # Prompt
     base_system_prompt: ClassVar[str] = dedent_and_compact("""
-        你负责为广东话语音嘅粤文字幕做校对。
-        作为参考，你会见到对应嘅中文字幕。
-        你嘅目标系纠正明显嘅转写错误，主要系听错字、写错字，同其他一眼可见嘅转写问题。
-        唔好为了贴近中文字幕而改写本来已经正确嘅粤文。
-        唔好调整语气、语法、助词、量词或者措辞，除非嗰啲地方本身就系转写错误。
-        只有当你认为原句明显有误时，先作修改。
-        如果发现粤文同中文字幕完全对唔上，说明呢行粤文系彻底误写，
-        请回传字符 "�" 作为粤文，并喺备注说明无对应。
+        你負責為廣東話語音嘅粵文字幕做校對。
+        作為參考，你會見到對應嘅中文字幕。
+        你嘅目標係糾正明顯嘅轉寫錯誤，主要係聽錯字、寫錯字，同其他一眼可見嘅轉寫問題。
+        唔好為了貼近中文字幕而改寫本來已經正確嘅粵文。
+        唔好調整語氣、語法、助詞、量詞或者措辭，除非嗰啲地方本身就係轉寫錯誤。
+        只有當你認為原句明顯有誤時，先作修改。
+        如果發現粵文同中文字幕完全對唔上，説明呢行粵文係徹底誤寫，
+        請回傳字符 "�" 作為粵文，並喺備註説明無對應。
 
-        记住：
-        - 粤文转写唔需要同中文字幕逐字对应。
-        - 讲者可能会用唔同嘅粤语讲法。
-        - 如果唔系转写错误，意义、语气同文法嘅差异都可以接受。
-        - 如果粤文入面有啲词同中文字幕睇落唔对应，咁可以查中文字幕入面相关词语，
-          睇下系咪有读音相近嘅粤语词被误写咗。
+        記住：
+        - 粵文轉寫唔需要同中文字幕逐字對應。
+        - 講者可能會用唔同嘅粵語講法。
+        - 如果唔係轉寫錯誤，意義、語氣同文法嘅差異都可以接受。
+        - 如果粵文入面有啲詞同中文字幕睇落唔對應，咁可以查中文字幕入面相關詞語，
+          睇下係咪有讀音相近嘅粵語詞被誤寫咗。
 
-        如果你有修改，请用英文一句话说明改动。
-        如果冇修改，备注请回传空字串。""")
+        如果你有修改，請用英文一句話説明改動。
+        如果冇修改，備註請回傳空字串。""")
     """Base system prompt."""
 
     # Query fields
     src_1: ClassVar[str] = "yuewen"
     """Name of source one field in query."""
 
-    src_1_desc: ClassVar[str] = "要校对嘅粤文字幕转写"
+    src_1_desc: ClassVar[str] = "要校對嘅粵文字幕轉寫"
     """Description of source one field in query."""
 
     src_2: ClassVar[str] = "zhongwen"
     """Name of source two field in query."""
 
-    src_2_desc: ClassVar[str] = "对应嘅中文字幕"
+    src_2_desc: ClassVar[str] = "對應嘅中文字幕"
     """Description of source two field in query."""
 
     # Query validation errors
-    src_1_missing_err: ClassVar[str] = "查询必须包含要校对嘅粤文字幕。"
+    src_1_missing_err: ClassVar[str] = "查詢必須包含要校對嘅粵文字幕。"
     """Error when source one field is missing from query."""
 
-    src_2_missing_err: ClassVar[str] = "查询必须包含中文字幕。"
+    src_2_missing_err: ClassVar[str] = "查詢必須包含中文字幕。"
     """Error when source two field is missing from query."""
 
-    src_1_src_2_equal_err: ClassVar[str] = "两份来源字幕唔可以完全一样。"
+    src_1_src_2_equal_err: ClassVar[str] = "兩份來源字幕唔可以完全一樣。"
     """Error when source one and two fields are equal in query."""
 
     # Answer fields
     output: ClassVar[str] = "xiugai"
     """Name of output field in answer."""
 
-    output_desc: ClassVar[str] = '校对后嘅粤文字幕（如需删掉请回传 "�"）'
+    output_desc: ClassVar[str] = '校對後嘅粵文字幕（如需刪掉請回傳 "�"）'
     """Description of output field in answer."""
 
     note: ClassVar[str] = "beizhu"
     """Name of note field in answer."""
 
-    note_desc: ClassVar[str] = "改动说明（英文）"
+    note_desc: ClassVar[str] = "改動説明（英文）"
     """Description of note field in answer."""
 
     # Answer validation errors
     output_missing_note_missing_err: ClassVar[str] = (
-        "答案必须包含改动说明（如无改动请回传空字串）。"
+        "答案必須包含改動説明（如無改動請回傳空字串）。"
     )
     """Error when output and note fields are both missing from answer."""
 
 
-class YueLineReviewVsZhoPromptYueHant(YueLineReviewVsZhoPromptYueHans):
-    """Text for traditional written Cantonese line review against standard Chinese."""
+class YueLineReviewVsZhoPromptYueHans(YueLineReviewVsZhoPromptYueHant, PromptYueHans):
+    """Text for simplified written Cantonese line review against standard Chinese."""
 
-    opencc_config = OpenCCConfig.s2hk
-    """Config for converting simplified Chinese characters from the parent class."""
+    opencc_config = OpenCCConfig.hk2s
+    """Config for converting traditional Chinese characters from the parent class."""

--- a/scinoephile/multilang/yue_zho/line_review/prompts.py
+++ b/scinoephile/multilang/yue_zho/line_review/prompts.py
@@ -8,7 +8,7 @@ from typing import ClassVar
 
 from scinoephile.core.dictionaries import DictionaryToolPrompt
 from scinoephile.core.text import dedent_and_compact
-from scinoephile.lang.yue.prompts import PromptYueHans, PromptYueHant
+from scinoephile.lang.yue.prompts import PromptYueHant
 from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.llms.dual_1_to_1 import Dual1To1Prompt
 
@@ -102,7 +102,7 @@ class YueLineReviewVsZhoPromptYueHant(
     """Error when output and note fields are both missing from answer."""
 
 
-class YueLineReviewVsZhoPromptYueHans(YueLineReviewVsZhoPromptYueHant, PromptYueHans):
+class YueLineReviewVsZhoPromptYueHans(YueLineReviewVsZhoPromptYueHant):
     """Text for simplified written Cantonese line review against standard Chinese."""
 
     opencc_config = OpenCCConfig.hk2s

--- a/scinoephile/multilang/yue_zho/transcription/__init__.py
+++ b/scinoephile/multilang/yue_zho/transcription/__init__.py
@@ -23,8 +23,15 @@ from scinoephile.llms import load_default_test_cases
 from scinoephile.llms.dual_2_to_2 import Dual2To2Manager
 from scinoephile.llms.providers.registry import get_provider
 
-from .deliniation import YueDeliniationVsZhoPromptYueHans
-from .punctuation import YuePunctuationVsZhoPromptYueHans, YueZhoPunctuationManager
+from .deliniation import (
+    YueDeliniationVsZhoPromptYueHans,
+    YueDeliniationVsZhoPromptYueHant,
+)
+from .punctuation import (
+    YuePunctuationVsZhoPromptYueHans,
+    YuePunctuationVsZhoPromptYueHant,
+    YueZhoPunctuationManager,
+)
 from .transcriber import (
     DEFAULT_YUE_WHISPER_MODEL_NAME,
     DemucsMode,
@@ -105,9 +112,9 @@ class YueZhoTranscriberKwargs(TypedDict, total=False):
     """provider to use for queries."""
     convert: OpenCCConfig | None
     """OpenCC configuration used for transcribed text conversion."""
-    deliniation_prompt_cls: type[YueDeliniationVsZhoPromptYueHans]
+    deliniation_prompt_cls: type[YueDeliniationVsZhoPromptYueHant]
     """prompt class used for alignment deliniation."""
-    punctuation_prompt_cls: type[YuePunctuationVsZhoPromptYueHans]
+    punctuation_prompt_cls: type[YuePunctuationVsZhoPromptYueHant]
     """prompt class used for transcription punctuation."""
     test_case_directory_path: Path | None
     """directory where encountered transcription test cases are persisted."""
@@ -147,10 +154,10 @@ def get_yue_vs_zho_transcriber(
     provider: LLMProvider | None = None,
     convert: OpenCCConfig | None = None,
     additional_context: str | None = None,
-    deliniation_prompt_cls: type[YueDeliniationVsZhoPromptYueHans] = (
+    deliniation_prompt_cls: type[YueDeliniationVsZhoPromptYueHant] = (
         YueDeliniationVsZhoPromptYueHans
     ),
-    punctuation_prompt_cls: type[YuePunctuationVsZhoPromptYueHans] = (
+    punctuation_prompt_cls: type[YuePunctuationVsZhoPromptYueHant] = (
         YuePunctuationVsZhoPromptYueHans
     ),
     test_case_directory_path: Path | None = None,

--- a/scinoephile/multilang/yue_zho/transcription/aligner.py
+++ b/scinoephile/multilang/yue_zho/transcription/aligner.py
@@ -26,8 +26,12 @@ from scinoephile.core.synchronization import get_sync_groups_string
 from scinoephile.core.text import remove_punc_and_whitespace
 
 from .alignment import Alignment
-from .deliniation import YueDeliniationVsZhoPromptYueHans
-from .punctuation import YuePunctuationVsZhoPromptYueHans
+from .deliniation import (
+    YueDeliniationVsZhoPromptYueHant,
+)
+from .punctuation import (
+    YuePunctuationVsZhoPromptYueHant,
+)
 
 __all__ = ["Aligner"]
 
@@ -124,7 +128,7 @@ class Aligner:
                 message = "Delineation query returned no answer."
                 logger.error(message)
                 raise ScinoephileError(message)
-            prompt_cls: type[YueDeliniationVsZhoPromptYueHans] = getattr(
+            prompt_cls: type[YueDeliniationVsZhoPromptYueHant] = getattr(
                 test_case, "prompt_cls"
             )
             yuewen_1_shifted = getattr(answer, prompt_cls.src_2_sub_1_shifted, None)
@@ -170,7 +174,7 @@ class Aligner:
         sg_2 = alignment.sync_groups[sg_2_idx]
 
         # Get written Cantonese
-        prompt_cls: type[YueDeliniationVsZhoPromptYueHans] = getattr(
+        prompt_cls: type[YueDeliniationVsZhoPromptYueHant] = getattr(
             query, "prompt_cls"
         )
         yw_1_idxs = sg_1[1]
@@ -325,7 +329,7 @@ class Aligner:
                     f"{test_case}\n"
                     f"Exception:\n{exc}"
                 )
-            prompt_cls: type[YuePunctuationVsZhoPromptYueHans] = getattr(
+            prompt_cls: type[YuePunctuationVsZhoPromptYueHant] = getattr(
                 test_case, "prompt_cls"
             )
             yuewen_punctuated = getattr(test_case.answer, prompt_cls.output, None)

--- a/scinoephile/multilang/yue_zho/transcription/alignment.py
+++ b/scinoephile/multilang/yue_zho/transcription/alignment.py
@@ -21,8 +21,13 @@ from scinoephile.core.synchronization import (
 )
 from scinoephile.llms.dual_2_to_2 import Dual2To2Manager
 
-from .deliniation import YueDeliniationVsZhoPromptYueHans
-from .punctuation import YuePunctuationVsZhoPromptYueHans, YueZhoPunctuationManager
+from .deliniation import (
+    YueDeliniationVsZhoPromptYueHans,
+)
+from .punctuation import (
+    YuePunctuationVsZhoPromptYueHans,
+    YueZhoPunctuationManager,
+)
 
 __all__ = ["Alignment"]
 

--- a/scinoephile/multilang/yue_zho/transcription/deliniation/prompt.py
+++ b/scinoephile/multilang/yue_zho/transcription/deliniation/prompt.py
@@ -8,6 +8,7 @@ from typing import ClassVar
 
 from scinoephile.core.text import dedent_and_compact
 from scinoephile.lang.eng.prompts import PromptEng
+from scinoephile.lang.yue.prompts import PromptYueHans, PromptYueHant
 from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.llms.dual_2_to_2 import Dual2To2Prompt
 
@@ -17,20 +18,20 @@ __all__ = [
 ]
 
 
-class YueDeliniationVsZhoPromptYueHans(Dual2To2Prompt, PromptEng):
-    """Text for LLM correspondence for simplified written Cantonese deliniation."""
+class YueDeliniationVsZhoPromptYueHant(Dual2To2Prompt, PromptEng, PromptYueHant):
+    """Text for LLM correspondence for traditional written Cantonese deliniation."""
 
     # Prompt
     base_system_prompt: ClassVar[str] = dedent_and_compact("""
-        你负责将广东话口语嘅简体粤文字幕同对应嘅中文字幕对齐。
-        你会收到一条中文字幕 (zhongwen_1) 同一条初步简体粤文字幕 (yuewen_1)，
-        以及第二条中文字幕 (zhongwen_2) 同第二条初步简体粤文字幕 (yuewen_2)。
-        请阅读 zhongwen_1、zhongwen_2 同 yuewen_1、yuewen_2，
-        调整 yuewen_1 同 yuewen_2 之间嘅分界，使内容同 zhongwen_1 同 zhongwen_2 对齐。
-        即系将 yuewen_1 末尾嘅字符移到 yuewen_2 开头，
-        或者将 yuewen_2 开头嘅字符移到 yuewen_1 末尾。
-        请喺 yuewen_1_yidong 同 yuewen_2_yidong 返回调整后嘅简体粤文字幕。
-        如果唔需要调整，请 yuewen_1_yidong 同 yuewen_2_yidong 都返回空字串。""")
+        你負責將廣東話口語嘅粵文字幕同對應嘅中文字幕對齊。
+        你會收到一條中文字幕 (zhongwen_1) 同一條初步粵文字幕 (yuewen_1)，
+        以及第二條中文字幕 (zhongwen_2) 同第二條初步粵文字幕 (yuewen_2)。
+        請閲讀 zhongwen_1、zhongwen_2 同 yuewen_1、yuewen_2，
+        調整 yuewen_1 同 yuewen_2 之間嘅分界，使內容同 zhongwen_1 同 zhongwen_2 對齊。
+        即係將 yuewen_1 末尾嘅字符移到 yuewen_2 開頭，
+        或者將 yuewen_2 開頭嘅字符移到 yuewen_1 末尾。
+        請喺 yuewen_1_yidong 同 yuewen_2_yidong 返回調整後嘅粵文字幕。
+        如果唔需要調整，請 yuewen_1_yidong 同 yuewen_2_yidong 都返回空字串。""")
     """Base system prompt."""
 
     # Query fields
@@ -49,18 +50,18 @@ class YueDeliniationVsZhoPromptYueHans(Dual2To2Prompt, PromptEng):
     src_2_sub_1: ClassVar[str] = "yuewen_1"
     """Name of source two subtitle one field in query."""
 
-    src_2_sub_1_desc: ClassVar[str] = "初步字幕1嘅简体粤文"
+    src_2_sub_1_desc: ClassVar[str] = "初步字幕1嘅粵文"
     """Description of source two subtitle one field in query."""
 
     src_2_sub_2: ClassVar[str] = "yuewen_2"
     """Name of source two subtitle two field in query."""
 
-    src_2_sub_2_desc: ClassVar[str] = "初步字幕2嘅简体粤文"
+    src_2_sub_2_desc: ClassVar[str] = "初步字幕2嘅粵文"
     """Description of source two subtitle two field in query."""
 
     # Query validation errors
     src_2_sub_1_sub_2_missing_err: ClassVar[str] = (
-        "查询要有 yuewen_1、yuewen_2，或者两个都有。"
+        "查詢要有 yuewen_1、yuewen_2，或者兩個都有。"
     )
     """Error when src_2_sub_1 and src_2_sub_2 fields are missing."""
 
@@ -68,24 +69,24 @@ class YueDeliniationVsZhoPromptYueHans(Dual2To2Prompt, PromptEng):
     src_2_sub_1_shifted: ClassVar[str] = "yuewen_1_yidong"
     """Name of shifted source two subtitle one field in answer."""
 
-    src_2_sub_1_shifted_desc: ClassVar[str] = "调整后字幕1嘅简体粤文"
+    src_2_sub_1_shifted_desc: ClassVar[str] = "調整後字幕1嘅粵文"
     """Description of shifted source two subtitle one field in answer."""
 
     src_2_sub_2_shifted: ClassVar[str] = "yuewen_2_yidong"
     """Name of shifted source two subtitle two field in answer."""
 
-    src_2_sub_2_shifted_desc: ClassVar[str] = "调整后字幕2嘅简体粤文"
+    src_2_sub_2_shifted_desc: ClassVar[str] = "調整後字幕2嘅粵文"
     """Description of shifted source two subtitle two field in answer."""
 
     # Test case validation errors
     src_2_sub_1_sub_2_unchanged_err: ClassVar[str] = (
-        "回答嘅 yuewen_1_yidong 同 yuewen_2_yidong 同查询嘅 yuewen_1、yuewen_2 "
-        "一样；如果唔需要调整，yuewen_1_yidong 同 yuewen_2_yidong 要返空字串。"
+        "回答嘅 yuewen_1_yidong 同 yuewen_2_yidong 同查詢嘅 yuewen_1、yuewen_2 "
+        "一樣；如果唔需要調整，yuewen_1_yidong 同 yuewen_2_yidong 要返空字串。"
     )
     """Error when src_2_sub_1 and src_2_sub_2 are unchanged."""
 
     src_2_chars_changed_err_tpl: ClassVar[str] = (
-        "回答里拼埋嘅 yuewen_1_yidong 同 yuewen_2_yidong 同查询拼埋嘅 yuewen_1 "
+        "回答裏拼埋嘅 yuewen_1_yidong 同 yuewen_2_yidong 同查詢拼埋嘅 yuewen_1 "
         "同 yuewen_2 唔一致：\n"
         "期望: {expected}\n"
         "收到: {received}"
@@ -107,8 +108,8 @@ class YueDeliniationVsZhoPromptYueHans(Dual2To2Prompt, PromptEng):
         )
 
 
-class YueDeliniationVsZhoPromptYueHant(YueDeliniationVsZhoPromptYueHans):
-    """Text for LLM correspondence for traditional written Cantonese deliniation."""
+class YueDeliniationVsZhoPromptYueHans(YueDeliniationVsZhoPromptYueHant, PromptYueHans):
+    """Text for LLM correspondence for simplified written Cantonese deliniation."""
 
-    opencc_config = OpenCCConfig.s2hk
-    """Config for converting simplified Chinese characters from the parent class."""
+    opencc_config = OpenCCConfig.hk2s
+    """Config for converting traditional Chinese characters from the parent class."""

--- a/scinoephile/multilang/yue_zho/transcription/deliniation/prompt.py
+++ b/scinoephile/multilang/yue_zho/transcription/deliniation/prompt.py
@@ -8,7 +8,7 @@ from typing import ClassVar
 
 from scinoephile.core.text import dedent_and_compact
 from scinoephile.lang.eng.prompts import PromptEng
-from scinoephile.lang.yue.prompts import PromptYueHans, PromptYueHant
+from scinoephile.lang.yue.prompts import PromptYueHant
 from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.llms.dual_2_to_2 import Dual2To2Prompt
 
@@ -108,7 +108,7 @@ class YueDeliniationVsZhoPromptYueHant(Dual2To2Prompt, PromptEng, PromptYueHant)
         )
 
 
-class YueDeliniationVsZhoPromptYueHans(YueDeliniationVsZhoPromptYueHant, PromptYueHans):
+class YueDeliniationVsZhoPromptYueHans(YueDeliniationVsZhoPromptYueHant):
     """Text for LLM correspondence for simplified written Cantonese deliniation."""
 
     opencc_config = OpenCCConfig.hk2s

--- a/scinoephile/multilang/yue_zho/transcription/punctuation/manager.py
+++ b/scinoephile/multilang/yue_zho/transcription/punctuation/manager.py
@@ -13,7 +13,7 @@ from scinoephile.core.text import (
 )
 from scinoephile.llms.dual_n_to_1 import DualNTo1Manager
 
-from .prompt import YuePunctuationVsZhoPromptYueHans
+from .prompt import YuePunctuationVsZhoPromptYueHans, YuePunctuationVsZhoPromptYueHant
 
 __all__ = ["YueZhoPunctuationManager"]
 
@@ -21,7 +21,7 @@ __all__ = ["YueZhoPunctuationManager"]
 class YueZhoPunctuationManager(DualNTo1Manager):
     """Factories for written Cantonese/standard Chinese punctuation LLM classes."""
 
-    prompt_cls: ClassVar[type[YuePunctuationVsZhoPromptYueHans]] = (
+    prompt_cls: ClassVar[type[YuePunctuationVsZhoPromptYueHant]] = (
         YuePunctuationVsZhoPromptYueHans
     )
     """Default prompt class."""
@@ -35,7 +35,7 @@ class YueZhoPunctuationManager(DualNTo1Manager):
         Returns:
             minimum difficulty
         """
-        prompt_cls: type[YuePunctuationVsZhoPromptYueHans] = getattr(
+        prompt_cls: type[YuePunctuationVsZhoPromptYueHant] = getattr(
             model, "prompt_cls"
         )
         min_difficulty = DualNTo1Manager.get_min_difficulty(model)
@@ -61,7 +61,7 @@ class YueZhoPunctuationManager(DualNTo1Manager):
         Returns:
             validated test case
         """
-        prompt_cls: type[YuePunctuationVsZhoPromptYueHans] = getattr(
+        prompt_cls: type[YuePunctuationVsZhoPromptYueHant] = getattr(
             model, "prompt_cls"
         )
         if model.answer is None:

--- a/scinoephile/multilang/yue_zho/transcription/punctuation/prompt.py
+++ b/scinoephile/multilang/yue_zho/transcription/punctuation/prompt.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import ClassVar
 
 from scinoephile.core.text import dedent_and_compact
-from scinoephile.lang.yue.prompts import PromptYueHans
+from scinoephile.lang.yue.prompts import PromptYueHans, PromptYueHant
 from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.llms.dual_n_to_1 import DualNTo1Prompt
 
@@ -17,51 +17,51 @@ __all__ = [
 ]
 
 
-class YuePunctuationVsZhoPromptYueHans(DualNTo1Prompt, PromptYueHans):
-    """Text for simplified written Cantonese/standard Chinese punctuation."""
+class YuePunctuationVsZhoPromptYueHant(DualNTo1Prompt, PromptYueHant):
+    """Text for traditional written Cantonese/standard Chinese punctuation."""
 
     # Prompt
     base_system_prompt: ClassVar[str] = dedent_and_compact("""
-        你负责将广东话口语嘅简体粤文字幕同对应嘅中文字幕对齐。
-        你会收到一条中文字幕，以及同一条字幕对应嘅多行简体粤文转写。
-        多行简体粤文代表口语停顿拆开嘅行。
-        你嘅主要任务系为简体粤文补上标点同空格。
-        请先将所有简体粤文行整理成一行，再参考中文字幕补上标点同空格。
-        必须包含所有简体粤文字，整理成一行。
-        唔好从中文字幕拷贝汉字。
-        只可以调整简体粤文嘅标点同空格以配合中文字幕。
-        除咗标点同空格之外唔好改任何简体粤文内容。""")
+        你負責將廣東話口語嘅粵文字幕同對應嘅中文字幕對齊。
+        你會收到一條中文字幕，以及同一條字幕對應嘅多行粵文轉寫。
+        多行粵文代表口語停頓拆開嘅行。
+        你嘅主要任務係為粵文補上標點同空格。
+        請先將所有粵文行整理成一行，再參考中文字幕補上標點同空格。
+        必須包含所有粵文字，整理成一行。
+        唔好從中文字幕拷貝漢字。
+        只可以調整粵文嘅標點同空格以配合中文字幕。
+        除咗標點同空格之外唔好改任何粵文內容。""")
     """Base system prompt."""
 
     # Query fields
     src_1: ClassVar[str] = "yuewen_to_punctuate"
     """Name of source one field in query."""
 
-    src_1_desc: ClassVar[str] = "要整理同加标点嘅简体粤文字幕行"
+    src_1_desc: ClassVar[str] = "要整理同加標點嘅粵文字幕行"
     """Description of source one field in query."""
 
     src_2: ClassVar[str] = "zhongwen"
     """Name of source two field in query."""
 
-    src_2_desc: ClassVar[str] = "对应嘅中文字幕"
+    src_2_desc: ClassVar[str] = "對應嘅中文字幕"
     """Description of source two field in query."""
 
     # Query validation errors
-    src_1_missing_err: ClassVar[str] = "查询必须包含要整理同加标点嘅简体粤文字幕行。"
+    src_1_missing_err: ClassVar[str] = "查詢必須包含要整理同加標點嘅粵文字幕行。"
     """Error when source one field is missing from query."""
 
-    src_2_missing_err: ClassVar[str] = "查询必须包含对应嘅中文字幕。"
+    src_2_missing_err: ClassVar[str] = "查詢必須包含對應嘅中文字幕。"
     """Error when source two field is missing from query."""
 
     # Answer fields
     output: ClassVar[str] = "yuewen_punctuated"
     """Name of output field in answer."""
 
-    output_desc: ClassVar[str] = "整理同加标点后嘅简体粤文字幕"
+    output_desc: ClassVar[str] = "整理同加標點後嘅粵文字幕"
     """Description of output field in answer."""
 
     # Answer validation errors
-    output_missing_err: ClassVar[str] = "答案必须包含整理同加标点后嘅简体粤文字幕。"
+    output_missing_err: ClassVar[str] = "答案必須包含整理同加標點後嘅粵文字幕。"
     """Error when output field is missing from answer."""
 
     # Test case validation errors
@@ -88,8 +88,8 @@ class YuePunctuationVsZhoPromptYueHans(DualNTo1Prompt, PromptYueHans):
         )
 
 
-class YuePunctuationVsZhoPromptYueHant(YuePunctuationVsZhoPromptYueHans):
-    """Text for traditional written Cantonese/standard Chinese punctuation."""
+class YuePunctuationVsZhoPromptYueHans(YuePunctuationVsZhoPromptYueHant, PromptYueHans):
+    """Text for simplified written Cantonese/standard Chinese punctuation."""
 
-    opencc_config = OpenCCConfig.s2hk
-    """Config for converting simplified Chinese characters from the parent class."""
+    opencc_config = OpenCCConfig.hk2s
+    """Config for converting traditional Chinese characters from the parent class."""

--- a/scinoephile/multilang/yue_zho/transcription/punctuation/prompt.py
+++ b/scinoephile/multilang/yue_zho/transcription/punctuation/prompt.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import ClassVar
 
 from scinoephile.core.text import dedent_and_compact
-from scinoephile.lang.yue.prompts import PromptYueHans, PromptYueHant
+from scinoephile.lang.yue.prompts import PromptYueHant
 from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.llms.dual_n_to_1 import DualNTo1Prompt
 
@@ -88,7 +88,7 @@ class YuePunctuationVsZhoPromptYueHant(DualNTo1Prompt, PromptYueHant):
         )
 
 
-class YuePunctuationVsZhoPromptYueHans(YuePunctuationVsZhoPromptYueHant, PromptYueHans):
+class YuePunctuationVsZhoPromptYueHans(YuePunctuationVsZhoPromptYueHant):
     """Text for simplified written Cantonese/standard Chinese punctuation."""
 
     opencc_config = OpenCCConfig.hk2s

--- a/scinoephile/multilang/yue_zho/transcription/transcriber.py
+++ b/scinoephile/multilang/yue_zho/transcription/transcriber.py
@@ -29,8 +29,12 @@ from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.llms.providers.registry import get_provider
 
 from .aligner import Aligner
-from .deliniation import YueDeliniationVsZhoPromptYueHans
-from .punctuation import YuePunctuationVsZhoPromptYueHans
+from .deliniation import (
+    YueDeliniationVsZhoPromptYueHant,
+)
+from .punctuation import (
+    YuePunctuationVsZhoPromptYueHant,
+)
 
 __all__ = [
     "DEFAULT_YUE_WHISPER_MODEL_NAME",
@@ -77,8 +81,8 @@ class YueTranscriber:
         provider: LLMProvider | None = None,
         convert: OpenCCConfig | None = None,
         additional_context: str | None = None,
-        deliniation_prompt_cls: type[YueDeliniationVsZhoPromptYueHans],
-        punctuation_prompt_cls: type[YuePunctuationVsZhoPromptYueHans],
+        deliniation_prompt_cls: type[YueDeliniationVsZhoPromptYueHant],
+        punctuation_prompt_cls: type[YuePunctuationVsZhoPromptYueHant],
         test_case_directory_path: Path,
         deliniation_test_cases: list[TestCase],
         punctuation_test_cases: list[TestCase],

--- a/scinoephile/multilang/yue_zho/translation.py
+++ b/scinoephile/multilang/yue_zho/translation.py
@@ -8,7 +8,7 @@ from typing import ClassVar
 
 from scinoephile.core.dictionaries import DictionaryToolPrompt
 from scinoephile.core.text import dedent_and_compact
-from scinoephile.lang.yue.prompts import PromptYueHans, PromptYueHant
+from scinoephile.lang.yue.prompts import PromptYueHant
 from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.llms.gap_translation import GapTranslationPrompt
 from scinoephile.llms.guided_translation import GuidedTranslationPrompt
@@ -72,7 +72,7 @@ class YueZhoTranslationPromptYueHant(
     """Description template for generated written Cantonese output fields."""
 
 
-class YueZhoTranslationPromptYueHans(YueZhoTranslationPromptYueHant, PromptYueHans):
+class YueZhoTranslationPromptYueHans(YueZhoTranslationPromptYueHant):
     """Text for simplified written Cantonese translation from Chinese."""
 
     opencc_config = OpenCCConfig.hk2s
@@ -153,9 +153,7 @@ class YueZhoGapTranslationPromptYueHant(
         return cls.output_contains_note_err_tpl.format(idx=idx)
 
 
-class YueZhoGapTranslationPromptYueHans(
-    YueZhoGapTranslationPromptYueHant, PromptYueHans
-):
+class YueZhoGapTranslationPromptYueHans(YueZhoGapTranslationPromptYueHant):
     """Text for simplified written Cantonese gap translation using Chinese."""
 
     opencc_config = OpenCCConfig.hk2s
@@ -218,9 +216,7 @@ class YueZhoGuidedTranslationPromptYueHant(
     """Description template for generated written Cantonese output fields."""
 
 
-class YueZhoGuidedTranslationPromptYueHans(
-    YueZhoGuidedTranslationPromptYueHant, PromptYueHans
-):
+class YueZhoGuidedTranslationPromptYueHans(YueZhoGuidedTranslationPromptYueHant):
     """Text for simplified guided written Cantonese translation from Chinese."""
 
     opencc_config = OpenCCConfig.hk2s

--- a/scinoephile/multilang/yue_zho/translation.py
+++ b/scinoephile/multilang/yue_zho/translation.py
@@ -8,7 +8,7 @@ from typing import ClassVar
 
 from scinoephile.core.dictionaries import DictionaryToolPrompt
 from scinoephile.core.text import dedent_and_compact
-from scinoephile.lang.yue.prompts import PromptYueHans
+from scinoephile.lang.yue.prompts import PromptYueHans, PromptYueHant
 from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.llms.gap_translation import GapTranslationPrompt
 from scinoephile.llms.guided_translation import GuidedTranslationPrompt
@@ -24,36 +24,36 @@ __all__ = [
 ]
 
 
-class YueZhoTranslationPromptYueHans(
-    DictionaryToolPrompt, TranslationPrompt, PromptYueHans
+class YueZhoTranslationPromptYueHant(
+    DictionaryToolPrompt, TranslationPrompt, PromptYueHant
 ):
-    """Text for simplified written Cantonese translation from Chinese."""
+    """Text for traditional written Cantonese translation from Chinese."""
 
     # Dictionary tool
     dictionary_tool_name: ClassVar[str] = "lookup_dictionary"
     """Name of the dictionary lookup tool."""
 
     dictionary_tool_description: ClassVar[str] = (
-        "查本地词典入面嘅粤语同普通话词条。工具会自动判断查询系汉字、拼音定粤拼。"
+        "查本地詞典入面嘅粵語同普通話詞條。工具會自動判斷查詢係漢字、拼音定粵拼。"
     )
     """Description of the dictionary lookup tool."""
 
     dictionary_tool_query_description: ClassVar[str] = (
-        "要查嘅普通话或者粤语词语，可以系汉字、拼音或者粤拼。"
+        "要查嘅普通話或者粵語詞語，可以係漢字、拼音或者粵拼。"
     )
     """Description of the dictionary lookup query parameter."""
 
     # Prompt
     base_system_prompt: ClassVar[str] = dedent_and_compact("""
-        你负责根据中文字幕，创作对应嘅粤文字幕。
+        你負責根據中文字幕，創作對應嘅粵文字幕。
 
-        每条中文字幕都要输出一条粤文字幕。译文要用自然、通顺嘅书面粤语，
-        准确表达中文字幕嘅意思、语气、戏剧意图同说话人意图。唔好逐字硬译；
-        可以调整措辞令佢更似自然粤文字幕。专名、固定称呼、重复术语同字幕标记
-        要喺适合时保留或者按粤语习惯处理。
+        每條中文字幕都要輸出一條粵文字幕。譯文要用自然、通順嘅書面粵語，
+        準確表達中文字幕嘅意思、語氣、戲劇意圖同説話人意圖。唔好逐字硬譯；
+        可以調整措辭令佢更似自然粵文字幕。專名、固定稱呼、重複術語同字幕標記
+        要喺適合時保留或者按粵語習慣處理。
 
-        输出内容只可以系生成嘅粤文字幕正文。绝对唔好附加英文、备注、解释、标签、
-        替代译文、方括号内容、括号内容，或者任何字幕以外嘅说明。
+        輸出內容只可以係生成嘅粵文字幕正文。絕對唔好附加英文、備註、解釋、標籤、
+        替代譯文、方括號內容、括號內容，或者任何字幕以外嘅説明。
         """)
     """Base system prompt."""
 
@@ -61,54 +61,54 @@ class YueZhoTranslationPromptYueHans(
     input_pfx: ClassVar[str] = "zhongwen_"
     """Prefix for Chinese source fields in query."""
 
-    input_desc_tpl: ClassVar[str] = "要翻译成粤文嘅中文字幕 {idx}"
+    input_desc_tpl: ClassVar[str] = "要翻譯成粵文嘅中文字幕 {idx}"
     """Description template for Chinese source fields in query."""
 
     # Answer fields
     output_pfx: ClassVar[str] = "yuewen_"
     """Prefix for generated written Cantonese output fields in answer."""
 
-    output_desc_tpl: ClassVar[str] = "字幕 {idx} 对应嘅粤文译文"
+    output_desc_tpl: ClassVar[str] = "字幕 {idx} 對應嘅粵文譯文"
     """Description template for generated written Cantonese output fields."""
 
 
-class YueZhoTranslationPromptYueHant(YueZhoTranslationPromptYueHans):
-    """Text for traditional written Cantonese translation from Chinese."""
+class YueZhoTranslationPromptYueHans(YueZhoTranslationPromptYueHant, PromptYueHans):
+    """Text for simplified written Cantonese translation from Chinese."""
 
-    opencc_config = OpenCCConfig.s2hk
-    """Config for converting simplified Chinese characters from the parent class."""
+    opencc_config = OpenCCConfig.hk2s
+    """Config for converting traditional Chinese characters from the parent class."""
 
 
-class YueZhoGapTranslationPromptYueHans(
-    DictionaryToolPrompt, GapTranslationPrompt, PromptYueHans
+class YueZhoGapTranslationPromptYueHant(
+    DictionaryToolPrompt, GapTranslationPrompt, PromptYueHant
 ):
-    """Text for simplified written Cantonese gap translation using Chinese."""
+    """Text for traditional written Cantonese gap translation using Chinese."""
 
     # Dictionary tool
     dictionary_tool_name: ClassVar[str] = "lookup_dictionary"
     """Name of the dictionary lookup tool."""
 
     dictionary_tool_description: ClassVar[str] = (
-        "查本地词典入面嘅粤语同普通话词条。工具会自动判断查询系汉字、拼音定粤拼。"
+        "查本地詞典入面嘅粵語同普通話詞條。工具會自動判斷查詢係漢字、拼音定粵拼。"
     )
     """Description of the dictionary lookup tool."""
 
     dictionary_tool_query_description: ClassVar[str] = (
-        "要查嘅普通话或者粤语词语，可以系汉字、拼音或者粤拼。"
+        "要查嘅普通話或者粵語詞語，可以係漢字、拼音或者粵拼。"
     )
     """Description of the dictionary lookup query parameter."""
 
     # Prompt
     base_system_prompt: ClassVar[str] = dedent_and_compact(
         """
-        你负责根据对应嘅中文字幕，补翻译缺失咗嘅粤文字幕。
-        只有当某行现有粤文字幕系空字串时，先需要提供译文。
-        如果某行已经有粤文内容，唔好改，嗰行请输出空字串。
-        译文要用自然、通顺嘅书面粤语，语气同用词要尽量贴近附近已有嘅粤文字幕。
-        中文字幕只系参考；译文唔需要逐字对应，但要准确表达该行意思。
-        输出内容只可以系字幕正文本身，绝对唔好附加英文、备注、解释、标签、
-        方括号内容、括号内容，或者任何译文以外嘅说明。
-        如果唔需要翻译，就输出空字串。
+        你負責根據對應嘅中文字幕，補翻譯缺失咗嘅粵文字幕。
+        只有當某行現有粵文字幕係空字串時，先需要提供譯文。
+        如果某行已經有粵文內容，唔好改，嗰行請輸出空字串。
+        譯文要用自然、通順嘅書面粵語，語氣同用詞要儘量貼近附近已有嘅粵文字幕。
+        中文字幕只係參考；譯文唔需要逐字對應，但要準確表達該行意思。
+        輸出內容只可以係字幕正文本身，絕對唔好附加英文、備註、解釋、標籤、
+        方括號內容、括號內容，或者任何譯文以外嘅説明。
+        如果唔需要翻譯，就輸出空字串。
         """
     )
     """Base system prompt."""
@@ -117,13 +117,13 @@ class YueZhoGapTranslationPromptYueHans(
     src_1_pfx: ClassVar[str] = "yuewen_"
     """Prefix for source one fields in query."""
 
-    src_1_desc_tpl: ClassVar[str] = "字幕 {idx} 现有嘅粤文内容；如果系空就代表要翻译"
+    src_1_desc_tpl: ClassVar[str] = "字幕 {idx} 現有嘅粵文內容；如果係空就代表要翻譯"
     """Description template for source one fields in query."""
 
     src_2_pfx: ClassVar[str] = "zhongwen_"
     """Prefix for source two fields in query."""
 
-    src_2_desc_tpl: ClassVar[str] = "字幕 {idx} 对应嘅中文字幕"
+    src_2_desc_tpl: ClassVar[str] = "字幕 {idx} 對應嘅中文字幕"
     """Description template for source two fields in query."""
 
     # Answer fields
@@ -131,19 +131,19 @@ class YueZhoGapTranslationPromptYueHans(
     """Prefix for output fields in answer."""
 
     output_desc_tpl: ClassVar[str] = (
-        '字幕 {idx} 译好后嘅粤文正文；如果唔需要翻译请输出 ""。'
-        "唔好包含英文、备注、解释、标签或者括号说明。"
+        '字幕 {idx} 譯好後嘅粵文正文；如果唔需要翻譯請輸出 ""。'
+        "唔好包含英文、備註、解釋、標籤或者括號説明。"
     )
     """Description template for output fields in answer."""
 
     # Test case validation errors
     output_unmodified_err_tpl: ClassVar[str] = (
-        "字幕 {idx} 已经有粤文内容，嗰行输出必须系空字串。"
+        "字幕 {idx} 已經有粵文內容，嗰行輸出必須係空字串。"
     )
     """Error template when output is present but unmodified relative to source one."""
 
     output_contains_note_err_tpl: ClassVar[str] = (
-        "字幕 {idx} 包含英文或者备注说明；只可以输出粤文字幕正文。"
+        "字幕 {idx} 包含英文或者備註説明；只可以輸出粵文字幕正文。"
     )
     """Error template when output includes leaked note text."""
 
@@ -153,45 +153,47 @@ class YueZhoGapTranslationPromptYueHans(
         return cls.output_contains_note_err_tpl.format(idx=idx)
 
 
-class YueZhoGapTranslationPromptYueHant(YueZhoGapTranslationPromptYueHans):
-    """Text for traditional written Cantonese gap translation using Chinese."""
-
-    opencc_config = OpenCCConfig.s2hk
-    """Config for converting simplified Chinese characters from the parent class."""
-
-
-class YueZhoGuidedTranslationPromptYueHans(
-    DictionaryToolPrompt, GuidedTranslationPrompt, PromptYueHans
+class YueZhoGapTranslationPromptYueHans(
+    YueZhoGapTranslationPromptYueHant, PromptYueHans
 ):
-    """Text for simplified guided written Cantonese translation from Chinese."""
+    """Text for simplified written Cantonese gap translation using Chinese."""
+
+    opencc_config = OpenCCConfig.hk2s
+    """Config for converting traditional Chinese characters from the parent class."""
+
+
+class YueZhoGuidedTranslationPromptYueHant(
+    DictionaryToolPrompt, GuidedTranslationPrompt, PromptYueHant
+):
+    """Text for traditional guided written Cantonese translation from Chinese."""
 
     # Dictionary tool
     dictionary_tool_name: ClassVar[str] = "lookup_dictionary"
     """Name of the dictionary lookup tool."""
 
     dictionary_tool_description: ClassVar[str] = (
-        "查本地词典入面嘅粤语同普通话词条。工具会自动判断查询系汉字、拼音定粤拼。"
+        "查本地詞典入面嘅粵語同普通話詞條。工具會自動判斷查詢係漢字、拼音定粵拼。"
     )
     """Description of the dictionary lookup tool."""
 
     dictionary_tool_query_description: ClassVar[str] = (
-        "要查嘅普通话或者粤语词语，可以系汉字、拼音或者粤拼。"
+        "要查嘅普通話或者粵語詞語，可以係漢字、拼音或者粵拼。"
     )
     """Description of the dictionary lookup query parameter."""
 
     # Prompt
     base_system_prompt: ClassVar[str] = dedent_and_compact("""
-        你负责根据中文字幕，创作对应嘅粤文字幕。你亦会收到同一段场景嘅
-        既有粤文字幕，作为参考材料。
+        你負責根據中文字幕，創作對應嘅粵文字幕。你亦會收到同一段場景嘅
+        既有粵文字幕，作為參考材料。
 
-        每条中文字幕都要输出一条粤文字幕。译文要准确表达中文字幕嘅意思、
-        语气、戏剧意图同说话人意图。既有粤文字幕系角色名、专名、重复术语、
-        语域同固定讲法嘅参考；当佢同中文字幕意思兼容时，尽量沿用。
-        如果中文字幕同既有粤文字幕有分别，要优先按中文字幕意思翻译，同时保留
-        已经建立好嘅名词同称呼。
+        每條中文字幕都要輸出一條粵文字幕。譯文要準確表達中文字幕嘅意思、
+        語氣、戲劇意圖同説話人意圖。既有粵文字幕係角色名、專名、重複術語、
+        語域同固定講法嘅參考；當佢同中文字幕意思兼容時，儘量沿用。
+        如果中文字幕同既有粵文字幕有分別，要優先按中文字幕意思翻譯，同時保留
+        已經建立好嘅名詞同稱呼。
 
-        输出内容只可以系生成嘅粤文字幕正文。绝对唔好附加英文、备注、解释、标签、
-        替代译文、方括号内容、括号内容，或者任何字幕以外嘅说明。
+        輸出內容只可以係生成嘅粵文字幕正文。絕對唔好附加英文、備註、解釋、標籤、
+        替代譯文、方括號內容、括號內容，或者任何字幕以外嘅説明。
         """)
     """Base system prompt."""
 
@@ -199,25 +201,27 @@ class YueZhoGuidedTranslationPromptYueHans(
     src_1_pfx: ClassVar[str] = "zhongwen_"
     """Prefix for Chinese source fields in query."""
 
-    src_1_desc_tpl: ClassVar[str] = "要翻译成粤文嘅中文字幕 {idx}"
+    src_1_desc_tpl: ClassVar[str] = "要翻譯成粵文嘅中文字幕 {idx}"
     """Description template for Chinese source fields in query."""
 
     src_2_pfx: ClassVar[str] = "yuewen_reference_"
     """Prefix for written Cantonese reference fields in query."""
 
-    src_2_desc_tpl: ClassVar[str] = "同一段场景嘅既有粤文参考字幕 {idx}"
+    src_2_desc_tpl: ClassVar[str] = "同一段場景嘅既有粵文參考字幕 {idx}"
     """Description template for written Cantonese reference fields in query."""
 
     # Answer fields
     output_pfx: ClassVar[str] = "yuewen_"
     """Prefix for generated written Cantonese output fields in answer."""
 
-    output_desc_tpl: ClassVar[str] = "字幕 {idx} 对应嘅粤文译文"
+    output_desc_tpl: ClassVar[str] = "字幕 {idx} 對應嘅粵文譯文"
     """Description template for generated written Cantonese output fields."""
 
 
-class YueZhoGuidedTranslationPromptYueHant(YueZhoGuidedTranslationPromptYueHans):
-    """Text for traditional guided written Cantonese translation from Chinese."""
+class YueZhoGuidedTranslationPromptYueHans(
+    YueZhoGuidedTranslationPromptYueHant, PromptYueHans
+):
+    """Text for simplified guided written Cantonese translation from Chinese."""
 
-    opencc_config = OpenCCConfig.s2hk
-    """Config for converting simplified Chinese characters from the parent class."""
+    opencc_config = OpenCCConfig.hk2s
+    """Config for converting traditional Chinese characters from the parent class."""

--- a/scinoephile/multilang/zho_eng/translation.py
+++ b/scinoephile/multilang/zho_eng/translation.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import ClassVar
 
 from scinoephile.core.text import dedent_and_compact
-from scinoephile.lang.zho.prompts import PromptZhoHans
+from scinoephile.lang.zho.prompts import PromptZhoHans, PromptZhoHant
 from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.llms.gap_translation import GapTranslationPrompt
 from scinoephile.llms.guided_translation import GuidedTranslationPrompt
@@ -23,20 +23,20 @@ __all__ = [
 ]
 
 
-class ZhoEngTranslationPromptZhoHans(TranslationPrompt, PromptZhoHans):
-    """Text for simplified standard Chinese translation from English."""
+class ZhoEngTranslationPromptZhoHant(TranslationPrompt, PromptZhoHant):
+    """Text for traditional standard Chinese translation from English."""
 
     # Prompt
     base_system_prompt: ClassVar[str] = dedent_and_compact("""
-        你负责根据英文字幕，创作对应的标准中文字幕。
+        你負責根據英文字幕，創作對應的標準中文字幕。
 
-        每条英文字幕都要输出一条标准中文字幕。译文要自然、通顺，准确表达英文字幕
-        的意思、语气、戏剧意图和说话人意图。不要逐字硬译；可以调整措辞，使其
-        更像自然的中文字幕。专名、固定称呼、重复术语和字幕标记要在适合时保留
-        或按中文习惯处理。
+        每條英文字幕都要輸出一條標準中文字幕。譯文要自然、通順，準確表達英文字幕
+        的意思、語氣、戲劇意圖和說話人意圖。不要逐字硬譯；可以調整措辭，使其
+        更像自然的中文字幕。專名、固定稱呼、重複術語和字幕標記要在適合時保留
+        或按中文習慣處理。
 
-        输出内容只能是生成的中文字幕正文。不要附加备注、解释、标签、替代译文、
-        方括号内容、括号内容，或任何字幕以外的说明。
+        輸出內容只能是生成的中文字幕正文。不要附加備註、解釋、標籤、替代譯文、
+        方括號內容、括號內容，或任何字幕以外的說明。
         """)
     """Base system prompt."""
 
@@ -44,37 +44,37 @@ class ZhoEngTranslationPromptZhoHans(TranslationPrompt, PromptZhoHans):
     input_pfx: ClassVar[str] = "eng_"
     """Prefix for English source fields in query."""
 
-    input_desc_tpl: ClassVar[str] = "要翻译成标准中文的英文字幕 {idx}"
+    input_desc_tpl: ClassVar[str] = "要翻譯成標準中文的英文字幕 {idx}"
     """Description template for English source fields in query."""
 
     # Answer fields
     output_pfx: ClassVar[str] = "zhongwen_"
     """Prefix for generated standard Chinese output fields in answer."""
 
-    output_desc_tpl: ClassVar[str] = "字幕 {idx} 对应的标准中文译文"
+    output_desc_tpl: ClassVar[str] = "字幕 {idx} 對應的標準中文譯文"
     """Description template for generated standard Chinese output fields."""
 
 
-class ZhoEngTranslationPromptZhoHant(ZhoEngTranslationPromptZhoHans):
-    """Text for traditional standard Chinese translation from English."""
+class ZhoEngTranslationPromptZhoHans(ZhoEngTranslationPromptZhoHant, PromptZhoHans):
+    """Text for simplified standard Chinese translation from English."""
 
-    opencc_config = OpenCCConfig.s2t
-    """Config for converting simplified Chinese characters from the parent class."""
+    opencc_config = OpenCCConfig.t2s
+    """Config for converting traditional Chinese characters from the parent class."""
 
 
-class ZhoEngGapTranslationPromptZhoHans(GapTranslationPrompt, PromptZhoHans):
-    """Text for simplified standard Chinese gap translation using English."""
+class ZhoEngGapTranslationPromptZhoHant(GapTranslationPrompt, PromptZhoHant):
+    """Text for traditional standard Chinese gap translation using English."""
 
     # Prompt
     base_system_prompt: ClassVar[str] = dedent_and_compact("""
-        你负责根据对应的英文字幕，补翻译缺失的标准中文字幕。
-        只有当某行现有中文字幕为空字符串时，才需要提供译文。
-        如果某行已经有中文内容，不要修改，该行请输出空字符串。
-        译文要自然、通顺，语气和用词要尽量贴近附近已有的中文字幕。
-        英文字幕是意思来源；译文不需要逐字对应，但要准确表达该行意思。
-        输出内容只能是字幕正文本身，不要附加英文、备注、解释、标签、
-        方括号内容、括号内容，或任何译文以外的说明。
-        如果不需要翻译，就输出空字符串。
+        你負責根據對應的英文字幕，補翻譯缺失的標準中文字幕。
+        只有當某行現有中文字幕爲空字符串時，才需要提供譯文。
+        如果某行已經有中文內容，不要修改，該行請輸出空字符串。
+        譯文要自然、通順，語氣和用詞要儘量貼近附近已有的中文字幕。
+        英文字幕是意思來源；譯文不需要逐字對應，但要準確表達該行意思。
+        輸出內容只能是字幕正文本身，不要附加英文、備註、解釋、標籤、
+        方括號內容、括號內容，或任何譯文以外的說明。
+        如果不需要翻譯，就輸出空字符串。
         """)
     """Base system prompt."""
 
@@ -82,13 +82,13 @@ class ZhoEngGapTranslationPromptZhoHans(GapTranslationPrompt, PromptZhoHans):
     src_1_pfx: ClassVar[str] = "zhongwen_"
     """Prefix for source one fields in query."""
 
-    src_1_desc_tpl: ClassVar[str] = "字幕 {idx} 现有的中文内容；如果为空就代表要翻译"
+    src_1_desc_tpl: ClassVar[str] = "字幕 {idx} 現有的中文內容；如果爲空就代表要翻譯"
     """Description template for source one fields in query."""
 
     src_2_pfx: ClassVar[str] = "eng_"
     """Prefix for source two fields in query."""
 
-    src_2_desc_tpl: ClassVar[str] = "字幕 {idx} 对应的英文字幕"
+    src_2_desc_tpl: ClassVar[str] = "字幕 {idx} 對應的英文字幕"
     """Description template for source two fields in query."""
 
     # Answer fields
@@ -96,19 +96,19 @@ class ZhoEngGapTranslationPromptZhoHans(GapTranslationPrompt, PromptZhoHans):
     """Prefix for output fields in answer."""
 
     output_desc_tpl: ClassVar[str] = (
-        '字幕 {idx} 译好后的标准中文正文；如果不需要翻译请输出 ""。'
-        "不要包含英文、备注、解释、标签或者括号说明。"
+        '字幕 {idx} 譯好後的標準中文正文；如果不需要翻譯請輸出 ""。'
+        "不要包含英文、備註、解釋、標籤或者括號說明。"
     )
     """Description template for output fields in answer."""
 
     # Test case validation errors
     output_unmodified_err_tpl: ClassVar[str] = (
-        "字幕 {idx} 已经有中文内容，该行输出必须为空字符串。"
+        "字幕 {idx} 已經有中文內容，該行輸出必須爲空字符串。"
     )
     """Error template when output is present but unmodified relative to source one."""
 
     output_contains_note_err_tpl: ClassVar[str] = (
-        "字幕 {idx} 包含英文或者备注说明；只可以输出中文字幕正文。"
+        "字幕 {idx} 包含英文或者備註說明；只可以輸出中文字幕正文。"
     )
     """Error template when output includes leaked note text."""
 
@@ -118,29 +118,31 @@ class ZhoEngGapTranslationPromptZhoHans(GapTranslationPrompt, PromptZhoHans):
         return cls.output_contains_note_err_tpl.format(idx=idx)
 
 
-class ZhoEngGapTranslationPromptZhoHant(ZhoEngGapTranslationPromptZhoHans):
-    """Text for traditional standard Chinese gap translation using English."""
+class ZhoEngGapTranslationPromptZhoHans(
+    ZhoEngGapTranslationPromptZhoHant, PromptZhoHans
+):
+    """Text for simplified standard Chinese gap translation using English."""
 
-    opencc_config = OpenCCConfig.s2t
-    """Config for converting simplified Chinese characters from the parent class."""
+    opencc_config = OpenCCConfig.t2s
+    """Config for converting traditional Chinese characters from the parent class."""
 
 
-class ZhoEngGuidedTranslationPromptZhoHans(GuidedTranslationPrompt, PromptZhoHans):
-    """Text for simplified guided standard Chinese translation from English."""
+class ZhoEngGuidedTranslationPromptZhoHant(GuidedTranslationPrompt, PromptZhoHant):
+    """Text for traditional guided standard Chinese translation from English."""
 
     # Prompt
     base_system_prompt: ClassVar[str] = dedent_and_compact("""
-        你负责根据英文字幕，创作对应的标准中文字幕。你也会收到同一段场景的
-        既有中文字幕，作为参考材料。
+        你負責根據英文字幕，創作對應的標準中文字幕。你也會收到同一段場景的
+        既有中文字幕，作爲參考材料。
 
-        每条英文字幕都要输出一条标准中文字幕。译文要准确表达英文字幕的意思、
-        语气、戏剧意图和说话人意图。既有中文字幕是角色名、专名、重复术语、
-        语域和固定说法的参考；当它和英文字幕意思兼容时，尽量沿用。
-        如果英文字幕和既有中文字幕有差异，要优先按英文意思翻译，同时保留
-        已经建立好的名词和称呼。
+        每條英文字幕都要輸出一條標準中文字幕。譯文要準確表達英文字幕的意思、
+        語氣、戲劇意圖和說話人意圖。既有中文字幕是角色名、專名、重複術語、
+        語域和固定說法的參考；當它和英文字幕意思兼容時，儘量沿用。
+        如果英文字幕和既有中文字幕有差異，要優先按英文意思翻譯，同時保留
+        已經建立好的名詞和稱呼。
 
-        输出内容只能是生成的中文字幕正文。不要附加英文、备注、解释、标签、
-        替代译文、方括号内容、括号内容，或任何字幕以外的说明。
+        輸出內容只能是生成的中文字幕正文。不要附加英文、備註、解釋、標籤、
+        替代譯文、方括號內容、括號內容，或任何字幕以外的說明。
         """)
     """Base system prompt."""
 
@@ -148,25 +150,27 @@ class ZhoEngGuidedTranslationPromptZhoHans(GuidedTranslationPrompt, PromptZhoHan
     src_1_pfx: ClassVar[str] = "eng_"
     """Prefix for English source fields in query."""
 
-    src_1_desc_tpl: ClassVar[str] = "要翻译成标准中文的英文字幕 {idx}"
+    src_1_desc_tpl: ClassVar[str] = "要翻譯成標準中文的英文字幕 {idx}"
     """Description template for English source fields in query."""
 
     src_2_pfx: ClassVar[str] = "zhongwen_reference_"
     """Prefix for standard Chinese reference fields in query."""
 
-    src_2_desc_tpl: ClassVar[str] = "同一段场景的既有标准中文参考字幕 {idx}"
+    src_2_desc_tpl: ClassVar[str] = "同一段場景的既有標準中文參考字幕 {idx}"
     """Description template for standard Chinese reference fields in query."""
 
     # Answer fields
     output_pfx: ClassVar[str] = "zhongwen_"
     """Prefix for generated standard Chinese output fields in answer."""
 
-    output_desc_tpl: ClassVar[str] = "字幕 {idx} 对应的标准中文译文"
+    output_desc_tpl: ClassVar[str] = "字幕 {idx} 對應的標準中文譯文"
     """Description template for generated standard Chinese output fields."""
 
 
-class ZhoEngGuidedTranslationPromptZhoHant(ZhoEngGuidedTranslationPromptZhoHans):
-    """Text for traditional guided standard Chinese translation from English."""
+class ZhoEngGuidedTranslationPromptZhoHans(
+    ZhoEngGuidedTranslationPromptZhoHant, PromptZhoHans
+):
+    """Text for simplified guided standard Chinese translation from English."""
 
-    opencc_config = OpenCCConfig.s2t
-    """Config for converting simplified Chinese characters from the parent class."""
+    opencc_config = OpenCCConfig.t2s
+    """Config for converting traditional Chinese characters from the parent class."""

--- a/scinoephile/multilang/zho_eng/translation.py
+++ b/scinoephile/multilang/zho_eng/translation.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import ClassVar
 
 from scinoephile.core.text import dedent_and_compact
-from scinoephile.lang.zho.prompts import PromptZhoHans, PromptZhoHant
+from scinoephile.lang.zho.prompts import PromptZhoHant
 from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.llms.gap_translation import GapTranslationPrompt
 from scinoephile.llms.guided_translation import GuidedTranslationPrompt
@@ -55,7 +55,7 @@ class ZhoEngTranslationPromptZhoHant(TranslationPrompt, PromptZhoHant):
     """Description template for generated standard Chinese output fields."""
 
 
-class ZhoEngTranslationPromptZhoHans(ZhoEngTranslationPromptZhoHant, PromptZhoHans):
+class ZhoEngTranslationPromptZhoHans(ZhoEngTranslationPromptZhoHant):
     """Text for simplified standard Chinese translation from English."""
 
     opencc_config = OpenCCConfig.t2s
@@ -118,9 +118,7 @@ class ZhoEngGapTranslationPromptZhoHant(GapTranslationPrompt, PromptZhoHant):
         return cls.output_contains_note_err_tpl.format(idx=idx)
 
 
-class ZhoEngGapTranslationPromptZhoHans(
-    ZhoEngGapTranslationPromptZhoHant, PromptZhoHans
-):
+class ZhoEngGapTranslationPromptZhoHans(ZhoEngGapTranslationPromptZhoHant):
     """Text for simplified standard Chinese gap translation using English."""
 
     opencc_config = OpenCCConfig.t2s
@@ -167,9 +165,7 @@ class ZhoEngGuidedTranslationPromptZhoHant(GuidedTranslationPrompt, PromptZhoHan
     """Description template for generated standard Chinese output fields."""
 
 
-class ZhoEngGuidedTranslationPromptZhoHans(
-    ZhoEngGuidedTranslationPromptZhoHant, PromptZhoHans
-):
+class ZhoEngGuidedTranslationPromptZhoHans(ZhoEngGuidedTranslationPromptZhoHant):
     """Text for simplified guided standard Chinese translation from English."""
 
     opencc_config = OpenCCConfig.t2s

--- a/scinoephile/multilang/zho_yue/translation.py
+++ b/scinoephile/multilang/zho_yue/translation.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import ClassVar
 
 from scinoephile.core.text import dedent_and_compact
-from scinoephile.lang.zho.prompts import PromptZhoHans, PromptZhoHant
+from scinoephile.lang.zho.prompts import PromptZhoHant
 from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.llms.gap_translation import GapTranslationPrompt
 from scinoephile.llms.guided_translation import GuidedTranslationPrompt
@@ -55,7 +55,7 @@ class ZhoYueTranslationPromptZhoHant(TranslationPrompt, PromptZhoHant):
     """Description template for generated standard Chinese output fields."""
 
 
-class ZhoYueTranslationPromptZhoHans(ZhoYueTranslationPromptZhoHant, PromptZhoHans):
+class ZhoYueTranslationPromptZhoHans(ZhoYueTranslationPromptZhoHant):
     """Text for simplified standard Chinese translation from written Cantonese."""
 
     opencc_config = OpenCCConfig.t2s
@@ -118,9 +118,7 @@ class ZhoYueGapTranslationPromptZhoHant(GapTranslationPrompt, PromptZhoHant):
         return cls.output_contains_note_err_tpl.format(idx=idx)
 
 
-class ZhoYueGapTranslationPromptZhoHans(
-    ZhoYueGapTranslationPromptZhoHant, PromptZhoHans
-):
+class ZhoYueGapTranslationPromptZhoHans(ZhoYueGapTranslationPromptZhoHant):
     """Text for simplified standard Chinese gap translation using Cantonese."""
 
     opencc_config = OpenCCConfig.t2s
@@ -167,9 +165,7 @@ class ZhoYueGuidedTranslationPromptZhoHant(GuidedTranslationPrompt, PromptZhoHan
     """Description template for generated standard Chinese output fields."""
 
 
-class ZhoYueGuidedTranslationPromptZhoHans(
-    ZhoYueGuidedTranslationPromptZhoHant, PromptZhoHans
-):
+class ZhoYueGuidedTranslationPromptZhoHans(ZhoYueGuidedTranslationPromptZhoHant):
     """Text for simplified guided standard Chinese translation from Cantonese."""
 
     opencc_config = OpenCCConfig.t2s

--- a/scinoephile/multilang/zho_yue/translation.py
+++ b/scinoephile/multilang/zho_yue/translation.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import ClassVar
 
 from scinoephile.core.text import dedent_and_compact
-from scinoephile.lang.zho.prompts import PromptZhoHans
+from scinoephile.lang.zho.prompts import PromptZhoHans, PromptZhoHant
 from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.llms.gap_translation import GapTranslationPrompt
 from scinoephile.llms.guided_translation import GuidedTranslationPrompt
@@ -23,20 +23,20 @@ __all__ = [
 ]
 
 
-class ZhoYueTranslationPromptZhoHans(TranslationPrompt, PromptZhoHans):
-    """Text for simplified standard Chinese translation from written Cantonese."""
+class ZhoYueTranslationPromptZhoHant(TranslationPrompt, PromptZhoHant):
+    """Text for traditional standard Chinese translation from written Cantonese."""
 
     # Prompt
     base_system_prompt: ClassVar[str] = dedent_and_compact("""
-        你负责根据粤文字幕，创作对应的标准中文字幕。
+        你負責根據粵文字幕，創作對應的標準中文字幕。
 
-        每条粤文字幕都要输出一条标准中文字幕。译文要自然、通顺，准确表达粤文字幕
-        的意思、语气、戏剧意图和说话人意图。不要逐字硬译；可以调整措辞，使其
-        更像自然的标准中文字幕。专名、固定称呼、重复术语和字幕标记要在适合时
-        保留或按标准中文习惯处理。
+        每條粵文字幕都要輸出一條標準中文字幕。譯文要自然、通順，準確表達粵文字幕
+        的意思、語氣、戲劇意圖和說話人意圖。不要逐字硬譯；可以調整措辭，使其
+        更像自然的標準中文字幕。專名、固定稱呼、重複術語和字幕標記要在適合時
+        保留或按標準中文習慣處理。
 
-        输出内容只能是生成的中文字幕正文。不要附加英文、备注、解释、标签、
-        替代译文、方括号内容、括号内容，或任何字幕以外的说明。
+        輸出內容只能是生成的中文字幕正文。不要附加英文、備註、解釋、標籤、
+        替代譯文、方括號內容、括號內容，或任何字幕以外的說明。
         """)
     """Base system prompt."""
 
@@ -44,37 +44,37 @@ class ZhoYueTranslationPromptZhoHans(TranslationPrompt, PromptZhoHans):
     input_pfx: ClassVar[str] = "yuewen_"
     """Prefix for written Cantonese source fields in query."""
 
-    input_desc_tpl: ClassVar[str] = "要翻译成标准中文的粤文字幕 {idx}"
+    input_desc_tpl: ClassVar[str] = "要翻譯成標準中文的粵文字幕 {idx}"
     """Description template for written Cantonese source fields in query."""
 
     # Answer fields
     output_pfx: ClassVar[str] = "zhongwen_"
     """Prefix for generated standard Chinese output fields in answer."""
 
-    output_desc_tpl: ClassVar[str] = "字幕 {idx} 对应的标准中文译文"
+    output_desc_tpl: ClassVar[str] = "字幕 {idx} 對應的標準中文譯文"
     """Description template for generated standard Chinese output fields."""
 
 
-class ZhoYueTranslationPromptZhoHant(ZhoYueTranslationPromptZhoHans):
-    """Text for traditional standard Chinese translation from written Cantonese."""
+class ZhoYueTranslationPromptZhoHans(ZhoYueTranslationPromptZhoHant, PromptZhoHans):
+    """Text for simplified standard Chinese translation from written Cantonese."""
 
-    opencc_config = OpenCCConfig.s2t
-    """Config for converting simplified Chinese characters from the parent class."""
+    opencc_config = OpenCCConfig.t2s
+    """Config for converting traditional Chinese characters from the parent class."""
 
 
-class ZhoYueGapTranslationPromptZhoHans(GapTranslationPrompt, PromptZhoHans):
-    """Text for simplified standard Chinese gap translation using Cantonese."""
+class ZhoYueGapTranslationPromptZhoHant(GapTranslationPrompt, PromptZhoHant):
+    """Text for traditional standard Chinese gap translation using Cantonese."""
 
     # Prompt
     base_system_prompt: ClassVar[str] = dedent_and_compact("""
-        你负责根据对应的粤文字幕，补翻译缺失的标准中文字幕。
-        只有当某行现有中文字幕为空字符串时，才需要提供译文。
-        如果某行已经有中文内容，不要修改，该行请输出空字符串。
-        译文要自然、通顺，语气和用词要尽量贴近附近已有的中文字幕。
-        粤文字幕是意思来源；译文不需要逐字对应，但要准确表达该行意思。
-        输出内容只能是字幕正文本身，不要附加英文、备注、解释、标签、
-        方括号内容、括号内容，或任何译文以外的说明。
-        如果不需要翻译，就输出空字符串。
+        你負責根據對應的粵文字幕，補翻譯缺失的標準中文字幕。
+        只有當某行現有中文字幕爲空字符串時，才需要提供譯文。
+        如果某行已經有中文內容，不要修改，該行請輸出空字符串。
+        譯文要自然、通順，語氣和用詞要儘量貼近附近已有的中文字幕。
+        粵文字幕是意思來源；譯文不需要逐字對應，但要準確表達該行意思。
+        輸出內容只能是字幕正文本身，不要附加英文、備註、解釋、標籤、
+        方括號內容、括號內容，或任何譯文以外的說明。
+        如果不需要翻譯，就輸出空字符串。
         """)
     """Base system prompt."""
 
@@ -82,13 +82,13 @@ class ZhoYueGapTranslationPromptZhoHans(GapTranslationPrompt, PromptZhoHans):
     src_1_pfx: ClassVar[str] = "zhongwen_"
     """Prefix for source one fields in query."""
 
-    src_1_desc_tpl: ClassVar[str] = "字幕 {idx} 现有的中文内容；如果为空就代表要翻译"
+    src_1_desc_tpl: ClassVar[str] = "字幕 {idx} 現有的中文內容；如果爲空就代表要翻譯"
     """Description template for source one fields in query."""
 
     src_2_pfx: ClassVar[str] = "yuewen_"
     """Prefix for source two fields in query."""
 
-    src_2_desc_tpl: ClassVar[str] = "字幕 {idx} 对应的粤文字幕"
+    src_2_desc_tpl: ClassVar[str] = "字幕 {idx} 對應的粵文字幕"
     """Description template for source two fields in query."""
 
     # Answer fields
@@ -96,19 +96,19 @@ class ZhoYueGapTranslationPromptZhoHans(GapTranslationPrompt, PromptZhoHans):
     """Prefix for output fields in answer."""
 
     output_desc_tpl: ClassVar[str] = (
-        '字幕 {idx} 译好后的标准中文正文；如果不需要翻译请输出 ""。'
-        "不要包含英文、备注、解释、标签或者括号说明。"
+        '字幕 {idx} 譯好後的標準中文正文；如果不需要翻譯請輸出 ""。'
+        "不要包含英文、備註、解釋、標籤或者括號說明。"
     )
     """Description template for output fields in answer."""
 
     # Test case validation errors
     output_unmodified_err_tpl: ClassVar[str] = (
-        "字幕 {idx} 已经有中文内容，该行输出必须为空字符串。"
+        "字幕 {idx} 已經有中文內容，該行輸出必須爲空字符串。"
     )
     """Error template when output is present but unmodified relative to source one."""
 
     output_contains_note_err_tpl: ClassVar[str] = (
-        "字幕 {idx} 包含英文或者备注说明；只可以输出中文字幕正文。"
+        "字幕 {idx} 包含英文或者備註說明；只可以輸出中文字幕正文。"
     )
     """Error template when output includes leaked note text."""
 
@@ -118,29 +118,31 @@ class ZhoYueGapTranslationPromptZhoHans(GapTranslationPrompt, PromptZhoHans):
         return cls.output_contains_note_err_tpl.format(idx=idx)
 
 
-class ZhoYueGapTranslationPromptZhoHant(ZhoYueGapTranslationPromptZhoHans):
-    """Text for traditional standard Chinese gap translation using Cantonese."""
+class ZhoYueGapTranslationPromptZhoHans(
+    ZhoYueGapTranslationPromptZhoHant, PromptZhoHans
+):
+    """Text for simplified standard Chinese gap translation using Cantonese."""
 
-    opencc_config = OpenCCConfig.s2t
-    """Config for converting simplified Chinese characters from the parent class."""
+    opencc_config = OpenCCConfig.t2s
+    """Config for converting traditional Chinese characters from the parent class."""
 
 
-class ZhoYueGuidedTranslationPromptZhoHans(GuidedTranslationPrompt, PromptZhoHans):
-    """Text for simplified guided standard Chinese translation from Cantonese."""
+class ZhoYueGuidedTranslationPromptZhoHant(GuidedTranslationPrompt, PromptZhoHant):
+    """Text for traditional guided standard Chinese translation from Cantonese."""
 
     # Prompt
     base_system_prompt: ClassVar[str] = dedent_and_compact("""
-        你负责根据粤文字幕，创作对应的标准中文字幕。你也会收到同一段场景的
-        既有中文字幕，作为参考材料。
+        你負責根據粵文字幕，創作對應的標準中文字幕。你也會收到同一段場景的
+        既有中文字幕，作爲參考材料。
 
-        每条粤文字幕都要输出一条标准中文字幕。译文要准确表达粤文字幕的意思、
-        语气、戏剧意图和说话人意图。既有中文字幕是角色名、专名、重复术语、
-        语域和固定说法的参考；当它和粤文字幕意思兼容时，尽量沿用。
-        如果粤文字幕和既有中文字幕有差异，要优先按粤文意思翻译，同时保留
-        已经建立好的名词和称呼。
+        每條粵文字幕都要輸出一條標準中文字幕。譯文要準確表達粵文字幕的意思、
+        語氣、戲劇意圖和說話人意圖。既有中文字幕是角色名、專名、重複術語、
+        語域和固定說法的參考；當它和粵文字幕意思兼容時，儘量沿用。
+        如果粵文字幕和既有中文字幕有差異，要優先按粵文意思翻譯，同時保留
+        已經建立好的名詞和稱呼。
 
-        输出内容只能是生成的中文字幕正文。不要附加英文、备注、解释、标签、
-        替代译文、方括号内容、括号内容，或任何字幕以外的说明。
+        輸出內容只能是生成的中文字幕正文。不要附加英文、備註、解釋、標籤、
+        替代譯文、方括號內容、括號內容，或任何字幕以外的說明。
         """)
     """Base system prompt."""
 
@@ -148,25 +150,27 @@ class ZhoYueGuidedTranslationPromptZhoHans(GuidedTranslationPrompt, PromptZhoHan
     src_1_pfx: ClassVar[str] = "yuewen_"
     """Prefix for written Cantonese source fields in query."""
 
-    src_1_desc_tpl: ClassVar[str] = "要翻译成标准中文的粤文字幕 {idx}"
+    src_1_desc_tpl: ClassVar[str] = "要翻譯成標準中文的粵文字幕 {idx}"
     """Description template for written Cantonese source fields in query."""
 
     src_2_pfx: ClassVar[str] = "zhongwen_reference_"
     """Prefix for standard Chinese reference fields in query."""
 
-    src_2_desc_tpl: ClassVar[str] = "同一段场景的既有标准中文参考字幕 {idx}"
+    src_2_desc_tpl: ClassVar[str] = "同一段場景的既有標準中文參考字幕 {idx}"
     """Description template for standard Chinese reference fields in query."""
 
     # Answer fields
     output_pfx: ClassVar[str] = "zhongwen_"
     """Prefix for generated standard Chinese output fields in answer."""
 
-    output_desc_tpl: ClassVar[str] = "字幕 {idx} 对应的标准中文译文"
+    output_desc_tpl: ClassVar[str] = "字幕 {idx} 對應的標準中文譯文"
     """Description template for generated standard Chinese output fields."""
 
 
-class ZhoYueGuidedTranslationPromptZhoHant(ZhoYueGuidedTranslationPromptZhoHans):
-    """Text for traditional guided standard Chinese translation from Cantonese."""
+class ZhoYueGuidedTranslationPromptZhoHans(
+    ZhoYueGuidedTranslationPromptZhoHant, PromptZhoHans
+):
+    """Text for simplified guided standard Chinese translation from Cantonese."""
 
-    opencc_config = OpenCCConfig.s2t
-    """Config for converting simplified Chinese characters from the parent class."""
+    opencc_config = OpenCCConfig.t2s
+    """Config for converting traditional Chinese characters from the parent class."""

--- a/scinoephile/workflows/srt_processing.py
+++ b/scinoephile/workflows/srt_processing.py
@@ -221,7 +221,7 @@ class SrtProcessingWorkflow:
         self,
         series: Series,
         *,
-        prompt_cls: type[BlockReviewPromptZhoHans] | None = None,
+        prompt_cls: type[BlockReviewPromptZhoHant] | None = None,
         output_name: str = "clean_review",
         test_case_name: str = "block_review.json",
         log_label: str = "Cleaned reviewed SRT output",


### PR DESCRIPTION
## Summary
- Make traditional Zho/Yue prompt classes the source text for Chinese prompt inheritance.
- Generate simplified Hans prompt classes from Hant parents using OpenCC `t2s` / `hk2s` conversion.
- Update prompt class typing so workflows accept the new Hant base prompt classes where both scripts are valid.

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format $(git ls-files --others --modified --exclude-standard -- '*.py')`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix $(git ls-files --others --modified --exclude-standard -- '*.py')`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check $(git ls-files --others --modified --exclude-standard -- '*.py')`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` (`1437 passed, 9 skipped`)

Closes #1021