### PR TITLE
Persist model settings to SQL

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -81,9 +81,11 @@ value, whose stable content-addressed name is used in generated model names.
 
 Optimization persistence stores each prompt alias with its content-addressed
 identifier, language, and complete set of string fields. Prompt and test-case
-SQLite stores own and create their tables independently; both table groups may
-coexist in one SQLite file without a global schema version or migration
-contract.
+SQLite stores own and create their tables independently. Model persistence uses
+immutable, content-addressed rows containing the provider, resolved model name,
+effective base URL, and non-secret inference settings. Credentials and provider
+client state are excluded. All table groups may coexist in one SQLite file
+without a global schema version or migration contract.
 
 ## Command Line Interface
 

--- a/scinoephile/optimization/persistence/__init__.py
+++ b/scinoephile/optimization/persistence/__init__.py
@@ -4,5 +4,5 @@
 
 Package hierarchy (modules may import from any above):
 * sqlite
-* prompts / test_cases
+* models / prompts / test_cases
 """

--- a/scinoephile/optimization/persistence/models/__init__.py
+++ b/scinoephile/optimization/persistence/models/__init__.py
@@ -1,0 +1,19 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Persistence utilities for LLM model configurations.
+
+Package hierarchy (modules may import from any above):
+* id
+* persisted_model
+* sqlite_store
+"""
+
+from __future__ import annotations
+
+from .persisted_model import PersistedModel
+from .sqlite_store import ModelSqliteStore
+
+__all__ = [
+    "ModelSqliteStore",
+    "PersistedModel",
+]

--- a/scinoephile/optimization/persistence/models/id.py
+++ b/scinoephile/optimization/persistence/models/id.py
@@ -1,0 +1,44 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Identifiers for persisted LLM model configurations."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+
+from pydantic import JsonValue
+
+__all__ = ["get_model_id"]
+
+
+def get_model_id(
+    provider_name: str,
+    model_name: str,
+    base_url: str | None,
+    settings: Mapping[str, JsonValue],
+) -> str:
+    """Compute a canonical identifier for a model configuration.
+
+    Arguments:
+        provider_name: stable LLM provider name
+        model_name: provider model identifier
+        base_url: effective provider API base URL
+        settings: non-secret inference settings
+    Returns:
+        deterministic hexadecimal identifier
+    """
+    payload_json = json.dumps(
+        {
+            "base_url": base_url,
+            "model": model_name,
+            "provider": provider_name,
+            "settings": dict(settings),
+        },
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return hashlib.sha256(payload_json.encode()).hexdigest()

--- a/scinoephile/optimization/persistence/models/persisted_model.py
+++ b/scinoephile/optimization/persistence/models/persisted_model.py
@@ -1,0 +1,166 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Persisted LLM model configuration."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import cast
+from urllib.parse import parse_qsl, urlsplit
+
+from pydantic import JsonValue
+
+from scinoephile.core.exceptions import ScinoephileError
+
+from .id import get_model_id
+
+__all__ = ["PersistedModel"]
+
+
+@dataclass(frozen=True, slots=True)
+class PersistedModel:
+    """An immutable model configuration loaded from SQLite."""
+
+    model_id: str
+    """Deterministic identifier derived from the complete model configuration."""
+    provider_name: str
+    """Stable LLM provider name."""
+    model_name: str
+    """Provider model identifier."""
+    base_url: str | None
+    """Effective provider API base URL, if explicitly configured."""
+    settings: dict[str, JsonValue]
+    """Non-secret inference settings that affect model behavior."""
+
+    @classmethod
+    def from_config(
+        cls,
+        provider_name: str,
+        model_name: str,
+        *,
+        base_url: str | None = None,
+        settings: Mapping[str, JsonValue] | None = None,
+    ) -> PersistedModel:
+        """Create a persisted model from an effective runtime configuration.
+
+        Arguments:
+            provider_name: stable LLM provider name
+            model_name: resolved provider model identifier
+            base_url: effective provider API base URL
+            settings: non-secret inference settings
+        Returns:
+            content-addressed model configuration
+        Raises:
+            ScinoephileError: if the configuration is empty, invalid, or contains
+                credentials
+        """
+        provider_name = provider_name.strip()
+        model_name = model_name.strip()
+        if not provider_name:
+            raise ScinoephileError("Persisted model provider name must not be empty.")
+        if not model_name:
+            raise ScinoephileError("Persisted model name must not be empty.")
+
+        if base_url is not None:
+            base_url = base_url.strip()
+            if not base_url:
+                base_url = None
+        _validate_base_url(base_url)
+
+        try:
+            settings_json = json.dumps(
+                dict(settings or {}),
+                allow_nan=False,
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+            loaded_settings: JsonValue = json.loads(settings_json)
+        except (TypeError, ValueError) as exc:
+            raise ScinoephileError(
+                "Persisted model settings must be valid JSON."
+            ) from exc
+        if not isinstance(loaded_settings, dict):
+            raise ScinoephileError("Persisted model settings must be a JSON object.")
+        normalized_settings = cast("dict[str, JsonValue]", loaded_settings)
+        _validate_no_credentials(normalized_settings)
+
+        return cls(
+            model_id=get_model_id(
+                provider_name,
+                model_name,
+                base_url,
+                normalized_settings,
+            ),
+            provider_name=provider_name,
+            model_name=model_name,
+            base_url=base_url,
+            settings=normalized_settings,
+        )
+
+
+def _is_credential_name(name: str) -> bool:
+    """Return whether a configuration key appears to contain credentials.
+
+    Arguments:
+        name: configuration key name
+    Returns:
+        whether the name denotes credential material
+    """
+    normalized_name = name.casefold().replace("-", "_")
+    if normalized_name in {"api_key", "authorization"}:
+        return True
+    if normalized_name.endswith("_api_key"):
+        return True
+    final_part = normalized_name.rsplit("_", maxsplit=1)[-1]
+    return final_part in {
+        "credential",
+        "credentials",
+        "password",
+        "secret",
+        "token",
+    }
+
+
+def _validate_base_url(base_url: str | None):
+    """Validate that a base URL does not embed credentials.
+
+    Arguments:
+        base_url: effective provider API base URL
+    Raises:
+        ScinoephileError: if the URL contains credential material
+    """
+    if base_url is None:
+        return
+    parsed_url = urlsplit(base_url)
+    if parsed_url.username is not None or parsed_url.password is not None:
+        raise ScinoephileError("Persisted model base URL must not contain credentials.")
+    if any(_is_credential_name(name) for name, _ in parse_qsl(parsed_url.query)):
+        raise ScinoephileError(
+            "Persisted model base URL must not contain credential query parameters."
+        )
+
+
+def _validate_no_credentials(value: JsonValue, path: str = "settings"):
+    """Validate that JSON settings do not contain credential fields.
+
+    Arguments:
+        value: JSON value to inspect
+        path: dotted path used in errors
+    Raises:
+        ScinoephileError: if a credential-bearing field is present
+    """
+    if isinstance(value, dict):
+        for name, child in value.items():
+            child_path = f"{path}.{name}"
+            if _is_credential_name(name):
+                raise ScinoephileError(
+                    f"Persisted model settings must not contain credentials at "
+                    f"{child_path}."
+                )
+            _validate_no_credentials(child, child_path)
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            _validate_no_credentials(child, f"{path}[{index}]")

--- a/scinoephile/optimization/persistence/models/persisted_model.py
+++ b/scinoephile/optimization/persistence/models/persisted_model.py
@@ -109,19 +109,21 @@ def _is_credential_name(name: str) -> bool:
     Returns:
         whether the name denotes credential material
     """
-    normalized_name = name.casefold().replace("-", "_")
-    if normalized_name in {"api_key", "authorization"}:
+    compact_name = "".join(
+        character for character in name.casefold() if character.isalnum()
+    )
+    if compact_name == "authorization":
         return True
-    if normalized_name.endswith("_api_key"):
-        return True
-    final_part = normalized_name.rsplit("_", maxsplit=1)[-1]
-    return final_part in {
-        "credential",
-        "credentials",
-        "password",
-        "secret",
-        "token",
-    }
+    return compact_name.endswith(
+        (
+            "apikey",
+            "credential",
+            "credentials",
+            "password",
+            "secret",
+            "token",
+        )
+    )
 
 
 def _validate_base_url(base_url: str | None):

--- a/scinoephile/optimization/persistence/models/sqlite_store.py
+++ b/scinoephile/optimization/persistence/models/sqlite_store.py
@@ -1,0 +1,175 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""SQLite persistence for LLM model configurations."""
+
+from __future__ import annotations
+
+from logging import getLogger
+
+from sqlalchemy import (
+    CheckConstraint,
+    Column,
+    Index,
+    MetaData,
+    Table,
+    Text,
+    inspect,
+    select,
+)
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.engine import RowMapping
+
+from scinoephile.core.exceptions import ScinoephileError
+from scinoephile.optimization.persistence.sqlite import (
+    OptimizationSqliteStore,
+    deserialize_json,
+    serialize_json,
+)
+
+from .id import get_model_id
+from .persisted_model import PersistedModel
+
+__all__ = ["ModelSqliteStore"]
+
+logger = getLogger(__name__)
+
+
+class ModelSqliteStore(OptimizationSqliteStore):
+    """SQLite persistence and lookup for model configurations."""
+
+    _metadata = MetaData()
+    """SQLAlchemy metadata owned by model persistence."""
+
+    _models = Table(
+        "models",
+        _metadata,
+        Column("model_id", Text, primary_key=True),
+        Column("provider", Text, nullable=False),
+        Column("model", Text, nullable=False),
+        Column("base_url", Text),
+        Column("settings_json", Text, nullable=False),
+        CheckConstraint(
+            "json_valid(settings_json)",
+            name="models_settings_json_valid",
+        ),
+        CheckConstraint(
+            "json_type(settings_json) = 'object'",
+            name="models_settings_json_object",
+        ),
+        Index("models_provider_model", "provider", "model"),
+    )
+    """Content-addressed model configurations."""
+
+    def add_model(self, model: PersistedModel) -> bool:
+        """Add a model configuration if it is not already stored.
+
+        Arguments:
+            model: model configuration to store
+        Returns:
+            whether the model configuration was inserted
+        Raises:
+            ScinoephileError: if the model ID does not match its configuration
+        """
+        canonical_model = PersistedModel.from_config(
+            model.provider_name,
+            model.model_name,
+            base_url=model.base_url,
+            settings=model.settings,
+        )
+        if model.model_id != canonical_model.model_id:
+            raise ScinoephileError(
+                f"Model {model.model_id} does not match its content-addressed ID."
+            )
+
+        self.create_schema()
+        with self.engine.begin() as connection:
+            result = connection.execute(
+                sqlite_insert(self._models)
+                .values(
+                    model_id=model.model_id,
+                    provider=model.provider_name,
+                    model=model.model_name,
+                    base_url=model.base_url,
+                    settings_json=serialize_json(model.settings),
+                )
+                .on_conflict_do_nothing(index_elements=[self._models.c.model_id])
+            )
+            if result.rowcount:
+                logger.info(f"Stored model configuration {model.model_id}")
+                return True
+
+            row = (
+                connection.execute(
+                    select(self._models).where(
+                        self._models.c.model_id == model.model_id
+                    )
+                )
+                .mappings()
+                .one()
+            )
+            if self._row_to_model(row) != canonical_model:
+                raise ScinoephileError(
+                    f"Stored model {model.model_id} does not match its configuration."
+                )
+            return False
+
+    def get_model(self, model_id: str) -> PersistedModel | None:
+        """Fetch a model configuration by ID.
+
+        Arguments:
+            model_id: model configuration identifier
+        Returns:
+            persisted model configuration, if present
+        """
+        if not self.database_path.exists():
+            return None
+        with self.engine.connect() as connection:
+            if not inspect(connection).has_table("models"):
+                return None
+            row = (
+                connection.execute(
+                    select(self._models).where(self._models.c.model_id == model_id)
+                )
+                .mappings()
+                .first()
+            )
+            if row is None:
+                return None
+            return self._row_to_model(row)
+
+    @staticmethod
+    def _row_to_model(row: RowMapping) -> PersistedModel:
+        """Convert a model row to a model configuration.
+
+        Arguments:
+            row: model row
+        Returns:
+            persisted model configuration
+        Raises:
+            ScinoephileError: if persisted content is invalid
+        """
+        model_id = str(row["model_id"])
+        base_url_value = row["base_url"]
+        base_url = None
+        if base_url_value is not None:
+            base_url = str(base_url_value)
+        model = PersistedModel.from_config(
+            str(row["provider"]),
+            str(row["model"]),
+            base_url=base_url,
+            settings=deserialize_json(
+                row["settings_json"],
+                f"Persisted model {model_id} settings",
+            ),
+        )
+        expected_id = get_model_id(
+            model.provider_name,
+            model.model_name,
+            model.base_url,
+            model.settings,
+        )
+        if model_id != expected_id:
+            raise ScinoephileError(
+                f"Persisted model {model_id} does not match its content-addressed ID."
+            )
+        return model

--- a/test/optimization/persistence/models/test_optimization_models_id.py
+++ b/test/optimization/persistence/models/test_optimization_models_id.py
@@ -1,0 +1,57 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests for model configuration identity."""
+
+from __future__ import annotations
+
+from pydantic import JsonValue
+
+from scinoephile.optimization.persistence.models.id import get_model_id
+
+
+def test_model_id_is_content_addressed():
+    """Provider, model, base URL, and settings should determine identity."""
+    settings: dict[str, JsonValue] = {
+        "reasoning": {"effort": "medium"},
+        "temperature": 0.2,
+    }
+    model_id = get_model_id(
+        "openai",
+        "gpt-5.4-mini",
+        "https://api.openai.com/v1",
+        settings,
+    )
+
+    assert model_id == get_model_id(
+        "openai",
+        "gpt-5.4-mini",
+        "https://api.openai.com/v1",
+        {
+            "temperature": 0.2,
+            "reasoning": {"effort": "medium"},
+        },
+    )
+    assert model_id != get_model_id(
+        "deepseek",
+        "gpt-5.4-mini",
+        "https://api.openai.com/v1",
+        settings,
+    )
+    assert model_id != get_model_id(
+        "openai",
+        "gpt-5.4",
+        "https://api.openai.com/v1",
+        settings,
+    )
+    assert model_id != get_model_id(
+        "openai",
+        "gpt-5.4-mini",
+        None,
+        settings,
+    )
+    assert model_id != get_model_id(
+        "openai",
+        "gpt-5.4-mini",
+        "https://api.openai.com/v1",
+        {"reasoning": {"effort": "high"}, "temperature": 0.2},
+    )

--- a/test/optimization/persistence/models/test_optimization_models_sqlite_store.py
+++ b/test/optimization/persistence/models/test_optimization_models_sqlite_store.py
@@ -1,0 +1,128 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests for SQLite model configuration persistence."""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import closing
+from dataclasses import replace
+from pathlib import Path
+
+from pytest import raises
+
+from scinoephile.core import ScinoephileError
+from scinoephile.lang.eng.review import ReviewPromptEng
+from scinoephile.llms.review import ReviewManager
+from scinoephile.optimization.persistence.models import (
+    ModelSqliteStore,
+    PersistedModel,
+)
+from scinoephile.optimization.persistence.prompts import (
+    PersistedPrompt,
+    PromptSqliteStore,
+)
+from scinoephile.optimization.persistence.test_cases import TestCaseSqliteStore
+
+
+def test_store_round_trips_and_is_idempotent(tmp_path: Path):
+    """Model configurations should round-trip and insert only once.
+
+    Arguments:
+        tmp_path: temporary directory
+    """
+    database_path = tmp_path / "optimization.sqlite"
+    store = ModelSqliteStore(database_path)
+    model = PersistedModel.from_config(
+        "deepseek",
+        "deepseek-v4-flash",
+        base_url="https://api.deepseek.com",
+        settings={"reasoning": {"effort": "high"}},
+    )
+
+    assert store.add_model(model)
+    assert not store.add_model(model)
+    assert store.get_model(model.model_id) == model
+
+    with closing(sqlite3.connect(database_path)) as connection:
+        columns = {
+            str(row[1]) for row in connection.execute("PRAGMA table_info(models)")
+        }
+    assert columns == {
+        "base_url",
+        "model",
+        "model_id",
+        "provider",
+        "settings_json",
+    }
+
+
+def test_store_rejects_invalid_content_addressed_id(tmp_path: Path):
+    """Writes should reject a model ID that does not match its configuration.
+
+    Arguments:
+        tmp_path: temporary directory
+    """
+    database_path = tmp_path / "optimization.sqlite"
+    store = ModelSqliteStore(database_path)
+    model = PersistedModel.from_config("openai", "gpt-5.4-mini")
+
+    with raises(ScinoephileError, match="content-addressed ID"):
+        store.add_model(replace(model, model_id="incorrect"))
+    assert not database_path.exists()
+
+
+def test_store_rejects_corrupted_content(tmp_path: Path):
+    """Reads should reject rows whose content no longer matches their ID.
+
+    Arguments:
+        tmp_path: temporary directory
+    """
+    database_path = tmp_path / "optimization.sqlite"
+    store = ModelSqliteStore(database_path)
+    model = PersistedModel.from_config("openai", "gpt-5.4-mini")
+    store.add_model(model)
+    with closing(sqlite3.connect(database_path)) as connection:
+        connection.execute(
+            "UPDATE models SET base_url = ? WHERE model_id = ?",
+            ("https://example.com/v1", model.model_id),
+        )
+        connection.commit()
+
+    with raises(ScinoephileError, match="content-addressed ID"):
+        store.get_model(model.model_id)
+
+
+def test_store_shares_database_with_other_optimization_stores(tmp_path: Path):
+    """Optimization stores should coexist in one SQLite database.
+
+    Arguments:
+        tmp_path: temporary directory
+    """
+    database_path = tmp_path / "optimization.sqlite"
+    model_store = ModelSqliteStore(database_path)
+    prompt_store = PromptSqliteStore(database_path)
+    test_case_store = TestCaseSqliteStore(database_path)
+    model = PersistedModel.from_config("openai", "gpt-5.4-mini")
+    prompt = PersistedPrompt.from_prompt(ReviewPromptEng, ReviewManager)
+
+    model_store.add_model(model)
+    prompt_store.sync_aliases({"review-eng": prompt}, dry_run=False)
+    test_case_store.create_schema()
+
+    assert model_store.get_model(model.model_id) == model
+    assert prompt_store.get_prompt_by_alias("review-eng") == prompt
+    assert test_case_store.get_test_case("missing") is None
+
+
+def test_store_reads_prompt_only_database_as_empty(tmp_path: Path):
+    """The model store should treat an absent peer table as empty.
+
+    Arguments:
+        tmp_path: temporary directory
+    """
+    database_path = tmp_path / "optimization.sqlite"
+    PromptSqliteStore(database_path).create_schema()
+    store = ModelSqliteStore(database_path)
+
+    assert store.get_model("missing") is None

--- a/test/optimization/persistence/models/test_optimization_persisted_model.py
+++ b/test/optimization/persistence/models/test_optimization_persisted_model.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from math import nan
 
-from pytest import raises
+from pytest import mark, raises
 
 from scinoephile.core import ScinoephileError
 from scinoephile.optimization.persistence.models import PersistedModel
@@ -43,17 +43,24 @@ def test_creation_rejects_credentials_in_base_url():
         PersistedModel.from_config(
             "openai-compatible",
             "model",
-            base_url="https://example.com/v1?api_key=secret",
+            base_url="https://example.com/v1?apiKey=secret",
         )
 
 
-def test_creation_rejects_credentials_in_nested_settings():
+@mark.parametrize(
+    "credential_name",
+    ["api_key", "Authorization", "apiKey", "clientSecret", "accessToken"],
+)
+def test_creation_rejects_credentials_in_nested_settings(credential_name: str):
     """Settings should not persist credential-bearing fields."""
-    with raises(ScinoephileError, match=r"settings.headers.Authorization"):
+    with raises(
+        ScinoephileError,
+        match=rf"settings.headers.{credential_name}",
+    ):
         PersistedModel.from_config(
             "openai-compatible",
             "model",
-            settings={"headers": {"Authorization": "Bearer secret"}},
+            settings={"headers": {credential_name: "secret"}},
         )
 
 

--- a/test/optimization/persistence/models/test_optimization_persisted_model.py
+++ b/test/optimization/persistence/models/test_optimization_persisted_model.py
@@ -1,0 +1,67 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests for persisted model configuration creation."""
+
+from __future__ import annotations
+
+from math import nan
+
+from pytest import raises
+
+from scinoephile.core import ScinoephileError
+from scinoephile.optimization.persistence.models import PersistedModel
+
+
+def test_creation_normalizes_effective_configuration():
+    """Model creation should preserve effective non-secret configuration."""
+    model = PersistedModel.from_config(
+        " openai ",
+        " gpt-5.4-mini ",
+        base_url=" https://api.openai.com/v1 ",
+        settings={"reasoning": {"effort": "medium"}, "seed": 1},
+    )
+
+    assert model.provider_name == "openai"
+    assert model.model_name == "gpt-5.4-mini"
+    assert model.base_url == "https://api.openai.com/v1"
+    assert model.settings == {
+        "reasoning": {"effort": "medium"},
+        "seed": 1,
+    }
+
+
+def test_creation_rejects_credentials_in_base_url():
+    """Base URLs should not persist embedded credentials."""
+    with raises(ScinoephileError, match="base URL must not contain credentials"):
+        PersistedModel.from_config(
+            "openai-compatible",
+            "model",
+            base_url="https://user:password@example.com/v1",
+        )
+
+    with raises(ScinoephileError, match="credential query parameters"):
+        PersistedModel.from_config(
+            "openai-compatible",
+            "model",
+            base_url="https://example.com/v1?api_key=secret",
+        )
+
+
+def test_creation_rejects_credentials_in_nested_settings():
+    """Settings should not persist credential-bearing fields."""
+    with raises(ScinoephileError, match=r"settings.headers.Authorization"):
+        PersistedModel.from_config(
+            "openai-compatible",
+            "model",
+            settings={"headers": {"Authorization": "Bearer secret"}},
+        )
+
+
+def test_creation_rejects_non_json_settings():
+    """Settings should be finite JSON values."""
+    with raises(ScinoephileError, match="valid JSON"):
+        PersistedModel.from_config(
+            "openai",
+            "gpt-5.4-mini",
+            settings={"temperature": nan},
+        )


### PR DESCRIPTION
## Summary

- add content-addressed persistence for LLM model configurations
- track provider, resolved model name, effective base URL, and extensible inference settings
- reject credentials in settings and base URLs, including camelCase and separator variants
- add an idempotent SQLite store that coexists with prompt and test-case persistence

## Scope

This is a library-only persistence layer. It does not add a model registry, CLI synchronization, result execution, or result persistence.

## Validation

- `uv run ruff format` on changed Python files
- `uv run ruff check --fix` on changed Python files
- `uv run ty check` on changed Python files
- focused model-persistence suite: 14 passed
- full parallel suite: 1,453 passed, 9 skipped
- `git diff --check`

Closes #1044