### PR TITLE
Use list-shaped translation test cases

### DIFF
--- a/scinoephile/llms/translation/__init__.py
+++ b/scinoephile/llms/translation/__init__.py
@@ -4,6 +4,7 @@
 
 Package hierarchy (modules may import from any above):
 * prompt
+* models
 * manager
 * processor
 """
@@ -11,11 +12,21 @@ Package hierarchy (modules may import from any above):
 from __future__ import annotations
 
 from .manager import TranslationManager
+from .models import (
+    TranslationAnswer,
+    TranslationOutput,
+    TranslationQuery,
+    TranslationTestCase,
+)
 from .processor import TranslationProcessor
 from .prompt import TranslationPrompt
 
 __all__ = [
+    "TranslationAnswer",
     "TranslationManager",
+    "TranslationOutput",
     "TranslationPrompt",
     "TranslationProcessor",
+    "TranslationQuery",
+    "TranslationTestCase",
 ]

--- a/scinoephile/llms/translation/manager.py
+++ b/scinoephile/llms/translation/manager.py
@@ -1,10 +1,9 @@
 #  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
-"""Factories for translation LLM classes."""
+"""Factories for prompt-specific translation LLM classes."""
 
 from __future__ import annotations
 
-import re
 from functools import cache
 from typing import Any, ClassVar, cast
 
@@ -13,19 +12,25 @@ from pydantic import Field, create_model
 from scinoephile.core.llms import (
     Answer,
     Manager,
-    Prompt,
     Query,
     TestCase,
+    TestCaseSubtitle,
 )
 from scinoephile.core.llms.models import get_model_name
 
+from .models import (
+    TranslationAnswer,
+    TranslationOutput,
+    TranslationQuery,
+    TranslationTestCase,
+)
 from .prompt import TranslationPrompt
 
 __all__ = ["TranslationManager"]
 
 
 class TranslationManager(Manager):
-    """Factories for translation LLM classes."""
+    """Factories for prompt-specific translation LLM classes."""
 
     operation: ClassVar[str] = "translation"
     """Stable operation identifier used in persistence and CLIs."""
@@ -34,131 +39,163 @@ class TranslationManager(Manager):
 
     @classmethod
     @cache
-    def get_query_cls(
-        cls,
-        size: int,
-        prompt: TranslationPrompt,
-    ) -> type[Query]:
-        """Get concrete query class with provided configuration.
+    def get_answer_cls(cls, prompt: TranslationPrompt) -> type[Answer]:
+        """Get concrete answer class with prompt-specific JSON field aliases.
 
         Arguments:
-            size: number of subtitles in the block
-            prompt: text for LLM correspondence
-        Returns:
-            query model class
-        """
-        name = get_model_name("TranslationQuery", f"{size}_{prompt.name}")
-        fields: dict[str, Any] = {}
-        for idx in range(size):
-            key = prompt.input(idx + 1)
-            desc = prompt.input_desc(idx + 1)
-            fields[key] = (str, Field(..., description=desc, max_length=1000))
-
-        model = create_model(
-            name,
-            __base__=Query,
-            __module__=Query.__module__,
-            **fields,
-        )
-        model.prompt = prompt
-        setattr(model, "size", size)
-        return model
-
-    @classmethod
-    @cache
-    def get_answer_cls(
-        cls,
-        size: int,
-        prompt: TranslationPrompt,
-    ) -> type[Answer]:
-        """Get concrete answer class with provided configuration.
-
-        Arguments:
-            size: number of subtitles in the block
-            prompt: text for LLM correspondence
+            prompt: text and field aliases for LLM correspondence
         Returns:
             answer model class
         """
-        name = get_model_name("TranslationAnswer", f"{size}_{prompt.name}")
-        fields: dict[str, Any] = {}
-        for idx in range(size):
-            key = prompt.output(idx + 1)
-            desc = prompt.output_desc(idx + 1)
-            fields[key] = (str, Field(..., description=desc))
-
+        output_cls = cls.get_output_cls(prompt)
+        fields: dict[str, Any] = {
+            "outputs": (
+                list[output_cls],  # ty: ignore[invalid-type-form]
+                Field(
+                    ...,
+                    alias=prompt.outputs,
+                    description=prompt.outputs_desc,
+                    min_length=1,
+                ),
+            ),
+        }
         model = create_model(
-            name,
-            __base__=Answer,
-            __module__=Answer.__module__,
+            get_model_name("TranslationAnswer", prompt.name),
+            __base__=TranslationAnswer,
+            __module__=TranslationAnswer.__module__,
             **fields,
         )
         model.prompt = prompt
-        setattr(model, "size", size)
         return model
 
     @classmethod
     @cache
-    def get_test_case_cls(
-        cls,
-        size: int,
-        prompt: TranslationPrompt,
-    ) -> type[TestCase]:
-        """Get concrete test case class with provided configuration.
+    def get_output_cls(cls, prompt: TranslationPrompt) -> type[TranslationOutput]:
+        """Get output class with prompt-specific JSON field aliases.
 
         Arguments:
-            size: number of subtitles in the block
-            prompt: text for LLM correspondence
+            prompt: text and field aliases for LLM correspondence
         Returns:
-            test case model class
+            output model class
         """
-        name = get_model_name("TranslationTestCase", f"{size}_{prompt.name}")
-        query_cls = cls.get_query_cls(size, prompt)
-        answer_cls = cls.get_answer_cls(size, prompt)
-        fields = cls.get_test_case_fields(query_cls, answer_cls, prompt)
-        validators = cls.get_test_case_validators()
-
-        model = create_model(
-            name,
-            __base__=TestCase,
-            __module__=TestCase.__module__,
-            __validators__=validators,
+        fields: dict[str, Any] = {
+            "index": (
+                int,
+                Field(
+                    ...,
+                    alias=prompt.index,
+                    description=prompt.index_desc,
+                    ge=1,
+                ),
+            ),
+            "text": (
+                str,
+                Field(
+                    ...,
+                    alias=prompt.text,
+                    description=prompt.output_text_desc,
+                ),
+            ),
+        }
+        return create_model(
+            get_model_name("TranslationOutput", prompt.name),
+            __base__=TranslationOutput,
+            __module__=TranslationAnswer.__module__,
             **fields,
         )
-        model.query_cls = query_cls
-        model.answer_cls = answer_cls
+
+    @classmethod
+    @cache
+    def get_query_cls(cls, prompt: TranslationPrompt) -> type[Query]:
+        """Get concrete query class with prompt-specific JSON field aliases.
+
+        Arguments:
+            prompt: text and field aliases for LLM correspondence
+        Returns:
+            query model class
+        """
+        subtitle_cls = cls.get_subtitle_cls(prompt)
+        fields: dict[str, Any] = {
+            "subtitles": (
+                list[subtitle_cls],  # ty: ignore[invalid-type-form]
+                Field(
+                    ...,
+                    alias=prompt.subtitles,
+                    description=prompt.subtitles_desc,
+                    min_length=1,
+                ),
+            ),
+        }
+        model = create_model(
+            get_model_name("TranslationQuery", prompt.name),
+            __base__=TranslationQuery,
+            __module__=TranslationQuery.__module__,
+            **fields,
+        )
         model.prompt = prompt
-        setattr(model, "size", size)
-        setattr(model, "get_auto_verified", cls.get_auto_verified)
-        setattr(model, "get_min_difficulty", cls.get_min_difficulty)
         return model
 
     @classmethod
-    def get_test_case_cls_from_data(cls, data: dict) -> type[TestCase]:
-        """Get concrete test case class for canonical serialized data.
+    @cache
+    def get_subtitle_cls(cls, prompt: TranslationPrompt) -> type[TestCaseSubtitle]:
+        """Get subtitle class with prompt-specific JSON field aliases.
 
         Arguments:
-            data: data from JSON
+            prompt: text and field aliases for LLM correspondence
         Returns:
-            test case model class
+            subtitle model class
         """
-        prompt = cls.base_prompt
-        pattern = re.compile(rf"^{re.escape(prompt.input_pfx)}\d+$")
-        size = sum(1 for field in data["query"] if pattern.match(field))
-        return cls.get_test_case_cls(size=size, prompt=prompt)
+        fields: dict[str, Any] = {
+            "index": (
+                int,
+                Field(
+                    ...,
+                    alias=prompt.index,
+                    description=prompt.index_desc,
+                    ge=1,
+                ),
+            ),
+            "text": (
+                str,
+                Field(
+                    ...,
+                    alias=prompt.text,
+                    description=prompt.subtitle_text_desc,
+                    max_length=1000,
+                ),
+            ),
+        }
+        return create_model(
+            get_model_name("TranslationSubtitle", prompt.name),
+            __base__=TestCaseSubtitle,
+            __module__=TranslationQuery.__module__,
+            **fields,
+        )
 
     @classmethod
-    def get_test_case_cls_with_prompt(
-        cls,
-        test_case_cls: type[TestCase],
-        prompt: Prompt,
-    ) -> type[TestCase]:
-        """Get an equivalently sized test-case class for another prompt.
+    @cache
+    def get_test_case_cls(cls, prompt: TranslationPrompt) -> type[TestCase]:
+        """Get concrete test-case class for a prompt-independent list shape.
 
         Arguments:
-            test_case_cls: test-case class whose size should be preserved
-            prompt: prompt whose correspondence fields should be used
+            prompt: text and field aliases for LLM correspondence
         Returns:
-            equivalently sized test-case class
+            test-case model class
         """
-        size: int = getattr(test_case_cls, "size")
-        return cls.get_test_case_cls(size=size, prompt=cast(TranslationPrompt, prompt))
+        query_cls = cls.get_query_cls(prompt)
+        answer_cls = cls.get_answer_cls(prompt)
+        fields = cls.get_test_case_fields(query_cls, answer_cls, prompt)
+        validators = cls.get_test_case_validators()
+        model = create_model(
+            get_model_name("TranslationTestCase", prompt.name),
+            __base__=TranslationTestCase,
+            __module__=TranslationTestCase.__module__,
+            __validators__=validators,
+            **fields,
+        )
+        model.query_cls = cast(type[TranslationQuery], query_cls)
+        model.answer_cls = cast(type[TranslationAnswer], answer_cls)
+        model.prompt = prompt
+        setattr(model, "get_auto_verified", cls.get_auto_verified)
+        setattr(model, "get_min_difficulty", cls.get_min_difficulty)
+        return model

--- a/scinoephile/llms/translation/models.py
+++ b/scinoephile/llms/translation/models.py
@@ -1,0 +1,94 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Pydantic models for translation test cases."""
+
+from __future__ import annotations
+
+from typing import ClassVar, Self
+
+from pydantic import ConfigDict, Field, model_validator
+
+from scinoephile.core.llms import Answer, Query, TestCase, TestCaseSubtitle
+
+from .prompt import TranslationPrompt
+
+__all__ = [
+    "TranslationAnswer",
+    "TranslationOutput",
+    "TranslationQuery",
+    "TranslationTestCase",
+]
+
+
+_BASE_PROMPT = TranslationPrompt()
+
+
+class TranslationOutput(TestCaseSubtitle):
+    """Indexed translated subtitle text."""
+
+    text: str
+    """Translated subtitle text."""
+
+
+class TranslationQuery(Query):
+    """Subtitles to translate."""
+
+    model_config = ConfigDict(validate_by_name=True)
+
+    prompt: ClassVar[TranslationPrompt] = _BASE_PROMPT
+    """Text and field aliases for LLM correspondence."""
+    subtitles: list[TestCaseSubtitle] = Field(min_length=1)
+    """Subtitles to translate, in order."""
+
+    @model_validator(mode="after")
+    def validate_subtitle_indices(self) -> Self:
+        """Ensure subtitle indexes are consecutive, ordered, and begin at 1."""
+        indexes = [subtitle.index for subtitle in self.subtitles]
+        if indexes != list(range(1, len(indexes) + 1)):
+            raise ValueError(self.prompt.subtitle_indices_err)
+        return self
+
+
+class TranslationAnswer(Answer):
+    """Translated subtitles."""
+
+    model_config = ConfigDict(validate_by_name=True)
+
+    prompt: ClassVar[TranslationPrompt] = _BASE_PROMPT
+    """Text and field aliases for LLM correspondence."""
+    outputs: list[TranslationOutput] = Field(min_length=1)
+    """Translated subtitles, in order."""
+
+    @model_validator(mode="after")
+    def validate_output_indices(self) -> Self:
+        """Ensure output indexes are consecutive, ordered, and begin at 1."""
+        indexes = [output.index for output in self.outputs]
+        if indexes != list(range(1, len(indexes) + 1)):
+            raise ValueError(self.prompt.output_indices_err)
+        return self
+
+
+class TranslationTestCase(TestCase):
+    """Translation query, optional answer, and optimization metadata."""
+
+    query_cls: ClassVar[type[TranslationQuery]] = TranslationQuery
+    """Query model class."""
+    answer_cls: ClassVar[type[TranslationAnswer]] = TranslationAnswer
+    """Answer model class."""
+    prompt: ClassVar[TranslationPrompt] = _BASE_PROMPT
+    """Text and field aliases for LLM correspondence."""
+    query: TranslationQuery
+    """Subtitles to translate."""
+    answer: TranslationAnswer | None = None
+    """Translated subtitles, if available."""
+
+    @model_validator(mode="after")
+    def validate_output_correspondence(self) -> Self:
+        """Ensure answer outputs correspond exactly to query subtitles."""
+        if self.answer is None:
+            return self
+        subtitle_indexes = [subtitle.index for subtitle in self.query.subtitles]
+        output_indexes = [output.index for output in self.answer.outputs]
+        if output_indexes != subtitle_indexes:
+            raise ValueError(self.prompt.output_correspondence_err)
+        return self

--- a/scinoephile/llms/translation/processor.py
+++ b/scinoephile/llms/translation/processor.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from logging import getLogger
+from typing import cast
 
 from scinoephile.core.llms import Processor
 from scinoephile.core.llms.utils import save_test_cases_to_json
@@ -12,6 +13,7 @@ from scinoephile.core.subtitles import Series, get_concatenated_series
 from scinoephile.core.text import replace_control_characters
 
 from .manager import TranslationManager
+from .models import TranslationAnswer
 from .prompt import TranslationPrompt
 
 __all__ = ["TranslationProcessor"]
@@ -49,22 +51,29 @@ class TranslationProcessor(Processor):
                 break
 
             # Query LLM
-            test_case_cls = TranslationManager.get_test_case_cls(
-                len(block), self.prompt
-            )
+            test_case_cls = TranslationManager.get_test_case_cls(self.prompt)
             query_cls = test_case_cls.query_cls
-            query_kwargs: dict[str, str] = {}
-            for idx, subtitle in enumerate(block.events):
-                key = self.prompt.input(idx + 1)
-                query_kwargs[key] = subtitle.text_with_newline.strip()
-            query = query_cls(**query_kwargs)
+            query = query_cls.model_validate(
+                {
+                    "subtitles": [
+                        {
+                            "index": idx,
+                            "text": subtitle.text_with_newline.strip(),
+                        }
+                        for idx, subtitle in enumerate(block.events, 1)
+                    ]
+                }
+            )
             test_case = test_case_cls(query=query)
             test_case = self.queryer(test_case)
 
+            answer = cast(TranslationAnswer, test_case.answer)
+            output_text_by_index = {
+                output.index: output.text for output in answer.outputs
+            }
             output_series = Series()
-            for sub_idx, subtitle in enumerate(block):
-                key = self.prompt.output(sub_idx + 1)
-                output_text = getattr(test_case.answer, key)
+            for sub_idx, subtitle in enumerate(block, 1):
+                output_text = output_text_by_index[sub_idx]
                 output_subtitle = type(subtitle)(**subtitle.as_dict())
                 output_subtitle.text = replace_control_characters(output_text)
                 output_series.append(output_subtitle)

--- a/scinoephile/llms/translation/prompt.py
+++ b/scinoephile/llms/translation/prompt.py
@@ -16,18 +16,52 @@ class TranslationPrompt(Prompt):
     """Text for LLM correspondence for translation matters."""
 
     # Query fields
-    input_pfx: str = "input_"
-    """Prefix for input fields in query."""
+    subtitles: str = "subtitles"
+    """Name of subtitles field in query."""
 
-    input_desc_tpl: str = "Input {idx}"
-    """Description template for input fields in query."""
+    subtitles_desc: str = "Subtitles to translate, in order."
+    """Description of subtitles field in query."""
 
     # Answer fields
-    output_pfx: str = "output_"
-    """Prefix for output fields in answer."""
+    outputs: str = "outputs"
+    """Name of outputs field in answer."""
 
-    output_desc_tpl: str = "Output {idx}"
-    """Description template for output fields in answer."""
+    outputs_desc: str = "Translated subtitles, in order."
+    """Description of outputs field in answer."""
+
+    # Subtitle fields
+    index: str = "index"
+    """Name of index field in subtitle and output items."""
+
+    index_desc: str = "One-based subtitle index."
+    """Description of index field in subtitle and output items."""
+
+    text: str = "text"
+    """Name of text field in subtitle and output items."""
+
+    subtitle_text_desc: str = "Subtitle text to translate."
+    """Description of text field in subtitle items."""
+
+    output_text_desc: str = "Translated subtitle text."
+    """Description of text field in output items."""
+
+    # Query errors
+    subtitle_indices_err: str = (
+        "Query subtitle indexes must be consecutive, ordered, and begin at 1."
+    )
+    """Error when query subtitle indexes are invalid."""
+
+    # Answer errors
+    output_indices_err: str = (
+        "Answer output indexes must be consecutive, ordered, and begin at 1."
+    )
+    """Error when answer output indexes are invalid."""
+
+    # Test case errors
+    output_correspondence_err: str = (
+        "Answer output indexes must correspond exactly to query subtitle indexes."
+    )
+    """Error when answer outputs do not correspond to query subtitles."""
 
     # Dictionary tool
     dictionary_tool_name: str = ""
@@ -36,21 +70,3 @@ class TranslationPrompt(Prompt):
     """Description of dictionary lookup tool."""
     dictionary_tool_query_description: str = ""
     """Description of dictionary lookup query."""
-
-    # Query fields
-    def input(self, idx: int) -> str:
-        """Name of input field in query."""
-        return f"{self.input_pfx}{idx}"
-
-    def input_desc(self, idx: int) -> str:
-        """Description of input field in query."""
-        return self.input_desc_tpl.format(idx=idx)
-
-    # Answer fields
-    def output(self, idx: int) -> str:
-        """Name of output field in answer."""
-        return f"{self.output_pfx}{idx}"
-
-    def output_desc(self, idx: int) -> str:
-        """Description of output field in answer."""
-        return self.output_desc_tpl.format(idx=idx)

--- a/scinoephile/multilang/eng_yue/translation.py
+++ b/scinoephile/multilang/eng_yue/translation.py
@@ -31,17 +31,19 @@ EngYueTranslationPrompt = TranslationPrompt(
         phrasing. Preserve names, proper nouns, recurring terms, and subtitle markup
         when they are present and appropriate in the generated English subtitle.
 
-        Output only the generated English subtitle text in each answer field. Do not
-        include notes, explanations, labels, alternate translations, bracketed
-        commentary, or any text outside the subtitle itself.
+        Output only the generated English subtitle text in each output item's text
+        field. Do not include notes, explanations, labels, alternate translations,
+        bracketed commentary, or any text outside the subtitle itself.
         """),
-    input_pfx="yuewen_",
-    input_desc_tpl="Written Cantonese subtitle {idx} to translate",
-    output_pfx="eng_",
-    output_desc_tpl=(
-        "Generated English subtitle {idx} corresponding to written Cantonese "
-        "subtitle {idx}"
+    subtitles="yuewen",
+    subtitles_desc="Written Cantonese subtitles to translate, in order.",
+    outputs="eng",
+    outputs_desc=(
+        "Generated English subtitles corresponding to the written Cantonese "
+        "subtitles, in order."
     ),
+    subtitle_text_desc="Written Cantonese subtitle text to translate.",
+    output_text_desc="Generated English subtitle text.",
 )
 """Text for English translation from written Cantonese."""
 

--- a/scinoephile/multilang/eng_zho/translation.py
+++ b/scinoephile/multilang/eng_zho/translation.py
@@ -30,16 +30,18 @@ EngZhoTranslationPrompt = TranslationPrompt(
         proper nouns, recurring terms, and subtitle markup when they are present and
         appropriate in the generated English subtitle.
 
-        Output only the generated English subtitle text in each answer field. Do not
-        include notes, explanations, labels, alternate translations, bracketed
-        commentary, or any text outside the subtitle itself.
+        Output only the generated English subtitle text in each output item's text
+        field. Do not include notes, explanations, labels, alternate translations,
+        bracketed commentary, or any text outside the subtitle itself.
         """),
-    input_pfx="zho_",
-    input_desc_tpl="Chinese subtitle {idx} to translate",
-    output_pfx="eng_",
-    output_desc_tpl=(
-        "Generated English subtitle {idx} corresponding to Chinese subtitle {idx}"
+    subtitles="zho",
+    subtitles_desc="Chinese subtitles to translate, in order.",
+    outputs="eng",
+    outputs_desc=(
+        "Generated English subtitles corresponding to the Chinese subtitles, in order."
     ),
+    subtitle_text_desc="Chinese subtitle text to translate.",
+    output_text_desc="Generated English subtitle text.",
 )
 """Text for English translation from Chinese."""
 

--- a/scinoephile/multilang/yue_eng/translation.py
+++ b/scinoephile/multilang/yue_eng/translation.py
@@ -38,13 +38,21 @@ YueEngTranslationPromptYueHant = TranslationPrompt(
         可以調整措辭令佢更似自然粵文字幕。專名、固定稱呼、重複術語同字幕標記
         要喺適合時保留或者按粵語習慣處理。
 
-        輸出內容只可以係生成嘅粵文字幕正文。絕對唔好附加英文、備註、解釋、標籤、
-        替代譯文、方括號內容、括號內容，或者任何字幕以外嘅説明。
+        每個輸出項目嘅文本欄只可以係生成嘅粵文字幕正文。絕對唔好附加英文、備註、
+        解釋、標籤、替代譯文、方括號內容、括號內容，或者任何字幕以外嘅説明。
         """),
-    input_pfx="eng_",
-    input_desc_tpl="要翻譯成粵文嘅英文字幕 {idx}",
-    output_pfx="yuewen_",
-    output_desc_tpl="字幕 {idx} 對應嘅粵文譯文",
+    subtitles="eng",
+    subtitles_desc="按順序排列、要翻譯成粵文嘅英文字幕",
+    outputs="yuewen",
+    outputs_desc="按輸入字幕順序排列嘅粵文譯文",
+    index="xuhao",
+    index_desc="由 1 開始嘅字幕序號",
+    text="wenben",
+    subtitle_text_desc="要翻譯成粵文嘅英文字幕文本",
+    output_text_desc="完整粵文譯文",
+    subtitle_indices_err="查詢字幕序號必須由 1 開始、連續並按順序排列。",
+    output_indices_err="答案輸出序號必須由 1 開始、連續並按順序排列。",
+    output_correspondence_err="答案輸出序號必須同查詢字幕序號完全對應。",
 )
 """Text for traditional written Cantonese translation from English."""
 

--- a/scinoephile/multilang/yue_zho/translation.py
+++ b/scinoephile/multilang/yue_zho/translation.py
@@ -38,13 +38,21 @@ YueZhoTranslationPromptYueHant = TranslationPrompt(
         可以調整措辭令佢更似自然粵文字幕。專名、固定稱呼、重複術語同字幕標記
         要喺適合時保留或者按粵語習慣處理。
 
-        輸出內容只可以係生成嘅粵文字幕正文。絕對唔好附加英文、備註、解釋、標籤、
-        替代譯文、方括號內容、括號內容，或者任何字幕以外嘅説明。
+        每個輸出項目嘅文本欄只可以係生成嘅粵文字幕正文。絕對唔好附加英文、備註、
+        解釋、標籤、替代譯文、方括號內容、括號內容，或者任何字幕以外嘅説明。
         """),
-    input_pfx="zhongwen_",
-    input_desc_tpl="要翻譯成粵文嘅中文字幕 {idx}",
-    output_pfx="yuewen_",
-    output_desc_tpl="字幕 {idx} 對應嘅粵文譯文",
+    subtitles="zhongwen",
+    subtitles_desc="按順序排列、要翻譯成粵文嘅中文字幕",
+    outputs="yuewen",
+    outputs_desc="按輸入字幕順序排列嘅粵文譯文",
+    index="xuhao",
+    index_desc="由 1 開始嘅字幕序號",
+    text="wenben",
+    subtitle_text_desc="要翻譯成粵文嘅中文字幕文本",
+    output_text_desc="完整粵文譯文",
+    subtitle_indices_err="查詢字幕序號必須由 1 開始、連續並按順序排列。",
+    output_indices_err="答案輸出序號必須由 1 開始、連續並按順序排列。",
+    output_correspondence_err="答案輸出序號必須同查詢字幕序號完全對應。",
 )
 """Text for traditional written Cantonese translation from Chinese."""
 

--- a/scinoephile/multilang/zho_eng/translation.py
+++ b/scinoephile/multilang/zho_eng/translation.py
@@ -35,13 +35,21 @@ ZhoEngTranslationPromptZhoHant = TranslationPrompt(
         更像自然的中文字幕。專名、固定稱呼、重複術語和字幕標記要在適合時保留
         或按中文習慣處理。
 
-        輸出內容只能是生成的中文字幕正文。不要附加備註、解釋、標籤、替代譯文、
-        方括號內容、括號內容，或任何字幕以外的說明。
+        每個輸出項目的文本欄只能是生成的中文字幕正文。不要附加備註、解釋、標籤、
+        替代譯文、方括號內容、括號內容，或任何字幕以外的說明。
         """),
-    input_pfx="eng_",
-    input_desc_tpl="要翻譯成標準中文的英文字幕 {idx}",
-    output_pfx="zhongwen_",
-    output_desc_tpl="字幕 {idx} 對應的標準中文譯文",
+    subtitles="eng",
+    subtitles_desc="按順序排列、要翻譯成標準中文的英文字幕",
+    outputs="zhongwen",
+    outputs_desc="按輸入字幕順序排列的標準中文譯文",
+    index="xuhao",
+    index_desc="從 1 開始的字幕序號",
+    text="wenben",
+    subtitle_text_desc="要翻譯成標準中文的英文字幕文本",
+    output_text_desc="完整標準中文譯文",
+    subtitle_indices_err="查詢字幕序號必須從 1 開始、連續並按順序排列。",
+    output_indices_err="答案輸出序號必須從 1 開始、連續並按順序排列。",
+    output_correspondence_err="答案輸出序號必須與查詢字幕序號完全對應。",
 )
 """Text for traditional standard Chinese translation from English."""
 

--- a/scinoephile/multilang/zho_yue/translation.py
+++ b/scinoephile/multilang/zho_yue/translation.py
@@ -35,13 +35,21 @@ ZhoYueTranslationPromptZhoHant = TranslationPrompt(
         更像自然的標準中文字幕。專名、固定稱呼、重複術語和字幕標記要在適合時
         保留或按標準中文習慣處理。
 
-        輸出內容只能是生成的中文字幕正文。不要附加英文、備註、解釋、標籤、
-        替代譯文、方括號內容、括號內容，或任何字幕以外的說明。
+        每個輸出項目的文本欄只能是生成的中文字幕正文。不要附加英文、備註、解釋、
+        標籤、替代譯文、方括號內容、括號內容，或任何字幕以外的說明。
         """),
-    input_pfx="yuewen_",
-    input_desc_tpl="要翻譯成標準中文的粵文字幕 {idx}",
-    output_pfx="zhongwen_",
-    output_desc_tpl="字幕 {idx} 對應的標準中文譯文",
+    subtitles="yuewen",
+    subtitles_desc="按順序排列、要翻譯成標準中文的粵文字幕",
+    outputs="zhongwen",
+    outputs_desc="按輸入字幕順序排列的標準中文譯文",
+    index="xuhao",
+    index_desc="從 1 開始的字幕序號",
+    text="wenben",
+    subtitle_text_desc="要翻譯成標準中文的粵文字幕文本",
+    output_text_desc="完整標準中文譯文",
+    subtitle_indices_err="查詢字幕序號必須從 1 開始、連續並按順序排列。",
+    output_indices_err="答案輸出序號必須從 1 開始、連續並按順序排列。",
+    output_correspondence_err="答案輸出序號必須與查詢字幕序號完全對應。",
 )
 """Text for traditional standard Chinese translation from written Cantonese."""
 

--- a/test/llms/test_translation.py
+++ b/test/llms/test_translation.py
@@ -1,0 +1,234 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests for list-shaped translation LLM models."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+from pydantic import ValidationError
+from pytest import raises
+
+from scinoephile.core import Language
+from scinoephile.core.llms import LLMProvider, Queryer
+from scinoephile.core.llms.utils import (
+    load_test_cases_from_json,
+    save_test_cases_to_json,
+)
+from scinoephile.core.subtitles import Series, Subtitle
+from scinoephile.llms.translation import (
+    TranslationManager,
+    TranslationProcessor,
+    TranslationPrompt,
+)
+
+_LOCALIZED_PROMPT = TranslationPrompt(
+    language=Language.zho_hant,
+    subtitles="zimu",
+    outputs="fanyi",
+    index="xuhao",
+    text="wenben",
+)
+"""Translation prompt with Chinese correspondence field names."""
+
+
+def test_prompt_aliases_are_used_for_llm_correspondence():
+    """Generated schemas and JSON should use prompt-specific aliases."""
+    test_case_cls = TranslationManager.get_test_case_cls(_LOCALIZED_PROMPT)
+    test_case = test_case_cls.model_validate(
+        {
+            "query": {
+                "zimu": [
+                    {"xuhao": 1, "wenben": "原文一"},
+                    {"xuhao": 2, "wenben": "原文二"},
+                ]
+            },
+            "answer": {
+                "fanyi": [
+                    {"xuhao": 1, "wenben": "譯文一"},
+                    {"xuhao": 2, "wenben": "譯文二"},
+                ]
+            },
+        }
+    )
+
+    assert test_case.query.model_dump(by_alias=True) == {
+        "zimu": [
+            {"xuhao": 1, "wenben": "原文一"},
+            {"xuhao": 2, "wenben": "原文二"},
+        ]
+    }
+    assert test_case.answer is not None
+    assert test_case.answer.model_dump(by_alias=True) == {
+        "fanyi": [
+            {"xuhao": 1, "wenben": "譯文一"},
+            {"xuhao": 2, "wenben": "譯文二"},
+        ]
+    }
+    assert set(test_case_cls.query_cls.model_json_schema()["properties"]) == {"zimu"}
+    assert set(test_case_cls.answer_cls.model_json_schema()["properties"]) == {"fanyi"}
+
+
+def test_queryer_corresponds_using_prompt_aliases():
+    """Queryer should send aliased queries and request aliased answers."""
+    test_case_cls = TranslationManager.get_test_case_cls(_LOCALIZED_PROMPT)
+    test_case = test_case_cls.model_validate(
+        {"query": {"subtitles": [{"index": 1, "text": "原文"}]}}
+    )
+    provider = Mock(spec=LLMProvider)
+    provider.chat_completion.return_value = (
+        '{"fanyi": [{"xuhao": 1, "wenben": "譯文"}]}'
+    )
+    queryer = Queryer(_LOCALIZED_PROMPT, provider=provider, max_attempts=1)
+
+    result = queryer(test_case)
+
+    assert result.answer is not None
+    messages = provider.chat_completion.call_args.args[0]
+    assert json.loads(messages[1]["content"]) == {
+        "zimu": [{"xuhao": 1, "wenben": "原文"}]
+    }
+    assert '"fanyi"' in messages[0]["content"]
+    assert '"xuhao"' in messages[0]["content"]
+    assert '"wenben"' in messages[0]["content"]
+
+
+def test_query_and_answer_require_nonempty_consecutive_indexes():
+    """Translation lists should be nonempty, consecutive, ordered, and one-based."""
+    query_cls = TranslationManager.get_query_cls(TranslationManager.base_prompt)
+    answer_cls = TranslationManager.get_answer_cls(TranslationManager.base_prompt)
+
+    with raises(ValidationError, match="at least 1 item"):
+        query_cls.model_validate({"subtitles": []})
+    with raises(ValidationError, match="consecutive, ordered, and begin at 1"):
+        query_cls.model_validate(
+            {
+                "subtitles": [
+                    {"index": 1, "text": "one"},
+                    {"index": 3, "text": "three"},
+                ]
+            }
+        )
+    with raises(ValidationError, match="at least 1 item"):
+        answer_cls.model_validate({"outputs": []})
+    with raises(ValidationError, match="consecutive, ordered, and begin at 1"):
+        answer_cls.model_validate(
+            {
+                "outputs": [
+                    {"index": 2, "text": "two"},
+                    {"index": 1, "text": "one"},
+                ]
+            }
+        )
+
+
+def test_answer_indexes_must_correspond_to_query_indexes():
+    """Every query subtitle should have exactly one corresponding output."""
+    test_case_cls = TranslationManager.get_test_case_cls(TranslationManager.base_prompt)
+
+    with raises(ValidationError, match="correspond exactly"):
+        test_case_cls.model_validate(
+            {
+                "query": {
+                    "subtitles": [
+                        {"index": 1, "text": "one"},
+                        {"index": 2, "text": "two"},
+                    ]
+                },
+                "answer": {"outputs": [{"index": 1, "text": "translated"}]},
+            }
+        )
+
+
+def test_translation_preserves_text_length_bounds():
+    """Input text should remain bounded while output text remains unbounded."""
+    query_cls = TranslationManager.get_query_cls(TranslationManager.base_prompt)
+    answer_cls = TranslationManager.get_answer_cls(TranslationManager.base_prompt)
+    long_text = "x" * 1001
+
+    with raises(ValidationError, match="at most 1000 characters"):
+        query_cls.model_validate({"subtitles": [{"index": 1, "text": long_text}]})
+    answer = answer_cls.model_validate({"outputs": [{"index": 1, "text": long_text}]})
+
+    assert answer.model_dump()["outputs"][0]["text"] == long_text
+
+
+def test_json_uses_base_prompt_fields(tmp_path: Path):
+    """JSON should persist base fields and load them into a concrete prompt."""
+    test_case_cls = TranslationManager.get_test_case_cls(_LOCALIZED_PROMPT)
+    test_case = test_case_cls.model_validate(
+        {
+            "query": {"zimu": [{"xuhao": 1, "wenben": "原文"}]},
+            "answer": {"fanyi": [{"xuhao": 1, "wenben": "譯文"}]},
+            "verified": True,
+        }
+    )
+    output_path = tmp_path / "test_cases.json"
+
+    save_test_cases_to_json(output_path, [test_case], TranslationManager)
+
+    assert json.loads(output_path.read_text(encoding="utf-8")) == [
+        {
+            "query": {"subtitles": [{"index": 1, "text": "原文"}]},
+            "answer": {"outputs": [{"index": 1, "text": "譯文"}]},
+            "verified": True,
+        }
+    ]
+    loaded = load_test_cases_from_json(
+        output_path,
+        TranslationManager,
+        _LOCALIZED_PROMPT,
+    )
+    assert loaded[0].query.model_dump(by_alias=True) == {
+        "zimu": [{"xuhao": 1, "wenben": "原文"}]
+    }
+    assert loaded[0].answer is not None
+    assert loaded[0].answer.model_dump(by_alias=True) == {
+        "fanyi": [{"xuhao": 1, "wenben": "譯文"}]
+    }
+
+
+def test_processor_uses_indexed_subtitles_and_outputs():
+    """Translation processor should build and consume the indexed list shape."""
+    test_case_cls = TranslationManager.get_test_case_cls(_LOCALIZED_PROMPT)
+    test_case = test_case_cls.model_validate(
+        {
+            "query": {
+                "subtitles": [
+                    {"index": 1, "text": "original one"},
+                    {"index": 2, "text": "original two"},
+                ]
+            },
+            "answer": {
+                "outputs": [
+                    {"index": 1, "text": "translated one"},
+                    {"index": 2, "text": "translated two"},
+                ]
+            },
+            "verified": True,
+        }
+    )
+    block = Series(
+        [
+            Subtitle(start=0, end=1000, text="original one"),
+            Subtitle(start=1000, end=2000, text="original two"),
+        ]
+    )
+    series = Series(list(block.events))
+    series.blocks = [block]
+    provider = Mock(spec=LLMProvider)
+    processor = TranslationProcessor(
+        _LOCALIZED_PROMPT,
+        [test_case],
+        provider=provider,
+    )
+
+    output = processor.process(series)
+
+    assert [subtitle.text for subtitle in output] == [
+        "translated one",
+        "translated two",
+    ]
+    provider.chat_completion.assert_not_called()

--- a/test/optimization/persistence/prompts/test_optimization_prompts_sqlite_store.py
+++ b/test/optimization/persistence/prompts/test_optimization_prompts_sqlite_store.py
@@ -60,8 +60,8 @@ def test_store_shares_database_with_test_cases(tmp_path: Path):
     prompt_store = PromptSqliteStore(database_path)
     test_case_store = TestCaseSqliteStore(database_path)
     prompt = PersistedPrompt.from_prompt(ReviewPromptEng, ReviewManager)
-    query: dict[str, JsonValue] = {"input_1": "Hello"}
-    answer: dict[str, JsonValue] = {"output_1": "Hello"}
+    query: dict[str, JsonValue] = {"subtitles": [{"index": 1, "text": "Hello"}]}
+    answer: dict[str, JsonValue] = {"outputs": [{"index": 1, "text": "Hello"}]}
     test_case = PersistedTestCase(
         test_case_id=get_test_case_id(query, answer, TranslationManager),
         operation=TranslationManager.operation,

--- a/test/optimization/persistence/test_cases/test_optimization_test_cases_id.py
+++ b/test/optimization/persistence/test_cases/test_optimization_test_cases_id.py
@@ -11,10 +11,20 @@ from scinoephile.llms.translation import TranslationManager
 from scinoephile.optimization.persistence.test_cases.id import get_test_case_id
 
 
+def _get_translation_answer(text: str) -> dict[str, JsonValue]:
+    """Get a canonical translation answer payload."""
+    return {"outputs": [{"index": 1, "text": text}]}
+
+
+def _get_translation_query(text: str) -> dict[str, JsonValue]:
+    """Get a canonical translation query payload."""
+    return {"subtitles": [{"index": 1, "text": text}]}
+
+
 def test_get_test_case_id_stable_for_same_payload():
     """Computing an ID twice for identical normalized data should match."""
-    query: dict[str, JsonValue] = {"input_1": "a"}
-    answer: dict[str, JsonValue] = {"output_1": "b"}
+    query = _get_translation_query("a")
+    answer = _get_translation_answer("b")
 
     assert get_test_case_id(
         query,
@@ -29,23 +39,23 @@ def test_get_test_case_id_stable_for_same_payload():
 
 def test_get_test_case_id_changes_with_answer():
     """Changing normalized answer content should change the computed ID."""
-    query: dict[str, JsonValue] = {"input_1": "a"}
+    query = _get_translation_query("a")
 
     assert get_test_case_id(
         query,
-        {"output_1": "b"},
+        _get_translation_answer("b"),
         TranslationManager,
     ) != get_test_case_id(
         query,
-        {"output_1": "c"},
+        _get_translation_answer("c"),
         TranslationManager,
     )
 
 
 def test_get_test_case_id_changes_with_operation():
     """Catalog scope should contribute to the content-addressed ID."""
-    query: dict[str, JsonValue] = {"input_1": "a"}
-    answer: dict[str, JsonValue] = {"output_1": "b"}
+    query = _get_translation_query("a")
+    answer = _get_translation_answer("b")
 
     assert get_test_case_id(
         query,

--- a/test/optimization/persistence/test_cases/test_optimization_test_cases_sync.py
+++ b/test/optimization/persistence/test_cases/test_optimization_test_cases_sync.py
@@ -43,6 +43,16 @@ _ALTERNATIVE_REVIEW_PROMPT = ReviewPrompt(
 """Review prompt using an alternative correspondence schema."""
 
 
+def _get_translation_answer(text: str) -> dict[str, JsonValue]:
+    """Get a canonical translation answer payload."""
+    return {"outputs": [{"index": 1, "text": text}]}
+
+
+def _get_translation_query(text: str) -> dict[str, JsonValue]:
+    """Get a canonical translation query payload."""
+    return {"subtitles": [{"index": 1, "text": text}]}
+
+
 def test_normalization_makes_prompt_field_aliases_share_identity():
     """Equivalent field aliases should normalize to one SQL identity."""
     localized_cls = ReviewManager.get_test_case_cls(_LOCALIZED_REVIEW_PROMPT)
@@ -98,13 +108,16 @@ def test_sync_rejects_fields_outside_test_case_schema(tmp_path: Path):
     source_path = tmp_path / "source.json"
     invalid_test_cases = [
         {
-            "query": {"input_1": "a"},
-            "answer": {"output_1": "b"},
+            "query": _get_translation_query("a"),
+            "answer": _get_translation_answer("b"),
             "unexpected": True,
         },
         {
-            "query": {"input_1": "a", "unexpected": True},
-            "answer": {"output_1": "b"},
+            "query": {
+                **_get_translation_query("a"),
+                "unexpected": True,
+            },
+            "answer": _get_translation_answer("b"),
         },
     ]
     for test_case in invalid_test_cases:
@@ -126,12 +139,12 @@ def test_sync_inserts_and_removes_provenance_by_source_path(
     monkeypatch.chdir(tmp_path)
     database_path = Path("test_cases.sqlite")
     source_path = Path("source.json")
-    deleted_query: dict[str, JsonValue] = {"input_1": "c"}
-    deleted_answer: dict[str, JsonValue] = {"output_1": "d"}
+    deleted_query = _get_translation_query("c")
+    deleted_answer = _get_translation_answer("d")
     first_data = [
         {
-            "query": {"input_1": "a"},
-            "answer": {"output_1": "b"},
+            "query": _get_translation_query("a"),
+            "answer": _get_translation_answer("b"),
             "verified": True,
         },
         {
@@ -174,7 +187,14 @@ def test_sync_canonicalizes_source_paths(tmp_path: Path, monkeypatch):
     database_path = Path("test_cases.sqlite")
     source_path = Path("source.json")
     source_path.write_text(
-        json.dumps([{"query": {"input_1": "a"}, "answer": {"output_1": "b"}}]),
+        json.dumps(
+            [
+                {
+                    "query": _get_translation_query("a"),
+                    "answer": _get_translation_answer("b"),
+                }
+            ]
+        ),
         encoding="utf-8",
     )
     first_report = sync_test_cases(
@@ -201,8 +221,8 @@ def test_sync_does_not_overwrite_sql_owned_metadata(tmp_path: Path):
     source_path = tmp_path / "source.json"
     data = [
         {
-            "query": {"input_1": "a"},
-            "answer": {"output_1": "b"},
+            "query": _get_translation_query("a"),
+            "answer": _get_translation_answer("b"),
             "difficulty": 1,
         }
     ]
@@ -254,15 +274,22 @@ def test_sync_validates_all_inputs_before_writing(tmp_path: Path):
     valid_path = tmp_path / "valid.json"
     invalid_path = tmp_path / "invalid.json"
     valid_path.write_text(
-        json.dumps([{"query": {"input_1": "a"}, "answer": {"output_1": "b"}}]),
+        json.dumps(
+            [
+                {
+                    "query": _get_translation_query("a"),
+                    "answer": _get_translation_answer("b"),
+                }
+            ]
+        ),
         encoding="utf-8",
     )
     invalid_path.write_text(
         json.dumps(
             [
                 {
-                    "query": {"input_1": "c"},
-                    "answer": {"output_1": "d"},
+                    "query": _get_translation_query("c"),
+                    "answer": _get_translation_answer("d"),
                     "difficulty": "hard",
                 }
             ]


### PR DESCRIPTION
## Summary

- Replace cardinality-specific dynamically generated translation models with static indexed-list query, answer, and test-case models.
- Preserve prompt-localized JSON aliases for LLM correspondence while keeping canonical base-prompt field names for persistence.
- Update processors, managers, authored prompts, and optimization persistence coverage for the new shape.

## Validation

- Ruff format/check and `ty` pass for changed Python files.
- Full suite: 1,468 passed, 9 skipped.
- Independent review: no actionable findings.

## Series

This is one of four independent test-case shape migrations. Because the translation-family PRs touch adjacent prompt definitions, the suggested merge order is standard translation, guided translation, then gap translation; guided review can merge independently.