### PR TITLE
Use list-shaped guided translation test cases

### DIFF
--- a/scinoephile/llms/guided_translation/__init__.py
+++ b/scinoephile/llms/guided_translation/__init__.py
@@ -4,6 +4,7 @@
 
 Package hierarchy (modules may import from any above):
 * prompt
+* models
 * manager
 * processor
 """
@@ -11,11 +12,21 @@ Package hierarchy (modules may import from any above):
 from __future__ import annotations
 
 from .manager import GuidedTranslationManager
+from .models import (
+    GuidedTranslationAnswer,
+    GuidedTranslationQuery,
+    GuidedTranslationSubtitle,
+    GuidedTranslationTestCase,
+)
 from .processor import GuidedTranslationProcessor
 from .prompt import GuidedTranslationPrompt
 
 __all__ = [
+    "GuidedTranslationAnswer",
     "GuidedTranslationManager",
     "GuidedTranslationProcessor",
     "GuidedTranslationPrompt",
+    "GuidedTranslationQuery",
+    "GuidedTranslationSubtitle",
+    "GuidedTranslationTestCase",
 ]

--- a/scinoephile/llms/guided_translation/manager.py
+++ b/scinoephile/llms/guided_translation/manager.py
@@ -1,32 +1,35 @@
 #  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
-"""Factories for guided translation LLM classes."""
+"""Factories for prompt-specific guided-translation LLM classes."""
 
 from __future__ import annotations
 
-import re
 from functools import cache
 from typing import Any, ClassVar, cast
 
 from pydantic import Field, create_model
 
-from scinoephile.core import ScinoephileError
 from scinoephile.core.llms import (
     Answer,
     Manager,
-    Prompt,
     Query,
     TestCase,
 )
 from scinoephile.core.llms.models import get_model_name
 
+from .models import (
+    GuidedTranslationAnswer,
+    GuidedTranslationQuery,
+    GuidedTranslationSubtitle,
+    GuidedTranslationTestCase,
+)
 from .prompt import GuidedTranslationPrompt
 
 __all__ = ["GuidedTranslationManager"]
 
 
 class GuidedTranslationManager(Manager):
-    """Factories for guided translation LLM classes."""
+    """Factories for prompt-specific guided-translation LLM classes."""
 
     operation: ClassVar[str] = "guided-translation"
     """Stable operation identifier used in persistence and CLIs."""
@@ -35,187 +38,216 @@ class GuidedTranslationManager(Manager):
 
     @classmethod
     @cache
-    def get_answer_cls(
-        cls,
-        source_one_size: int,
-        source_two_size: int,
-        prompt: GuidedTranslationPrompt,
-    ) -> type[Answer]:
-        """Get concrete answer class with provided configuration.
+    def get_answer_cls(cls, prompt: GuidedTranslationPrompt) -> type[Answer]:
+        """Get concrete answer class with prompt-specific JSON field aliases.
 
         Arguments:
-            source_one_size: number of subtitles in source one
-            source_two_size: number of subtitles in source two
-            prompt: text for LLM correspondence
+            prompt: text and field aliases for LLM correspondence
         Returns:
             answer model class
         """
-        cls._validate_sizes(source_one_size, source_two_size)
-
-        name = get_model_name(
-            "GuidedTranslationAnswer",
-            f"{source_one_size}_{source_two_size}_{prompt.name}",
-        )
-        fields: dict[str, Any] = {}
-        for idx in range(source_one_size):
-            key = prompt.output(idx + 1)
-            description = prompt.output_desc(idx + 1)
-            fields[key] = (str, Field(..., description=description))
-
+        output_cls = cls.get_output_cls(prompt)
+        fields: dict[str, Any] = {
+            "outputs": (
+                list[output_cls],  # ty: ignore[invalid-type-form]
+                Field(
+                    ...,
+                    alias=prompt.outputs,
+                    description=prompt.outputs_desc,
+                    min_length=1,
+                ),
+            ),
+        }
         model = create_model(
-            name,
-            __base__=Answer,
-            __module__=Answer.__module__,
+            get_model_name("GuidedTranslationAnswer", prompt.name),
+            __base__=GuidedTranslationAnswer,
+            __module__=GuidedTranslationAnswer.__module__,
             **fields,
         )
         model.prompt = prompt
-        setattr(model, "source_one_size", source_one_size)
-        setattr(model, "source_two_size", source_two_size)
         return model
 
     @classmethod
     @cache
-    def get_query_cls(
+    def get_guide_cls(
         cls,
-        source_one_size: int,
-        source_two_size: int,
         prompt: GuidedTranslationPrompt,
-    ) -> type[Query]:
-        """Get concrete query class with provided configuration.
+    ) -> type[GuidedTranslationSubtitle]:
+        """Get guide-item class with prompt-specific JSON field aliases.
 
         Arguments:
-            source_one_size: number of subtitles in source one
-            source_two_size: number of subtitles in source two
-            prompt: text for LLM correspondence
+            prompt: text and field aliases for LLM correspondence
+        Returns:
+            guide-item model class
+        """
+        fields: dict[str, Any] = {
+            "index": (
+                int,
+                Field(
+                    ...,
+                    alias=prompt.index,
+                    description=prompt.index_desc,
+                    ge=1,
+                ),
+            ),
+            "text": (
+                str,
+                Field(
+                    ...,
+                    alias=prompt.text,
+                    description=prompt.guide_text_desc,
+                ),
+            ),
+        }
+        return create_model(
+            get_model_name("GuidedTranslationGuide", prompt.name),
+            __base__=GuidedTranslationSubtitle,
+            __module__=GuidedTranslationQuery.__module__,
+            **fields,
+        )
+
+    @classmethod
+    @cache
+    def get_output_cls(
+        cls,
+        prompt: GuidedTranslationPrompt,
+    ) -> type[GuidedTranslationSubtitle]:
+        """Get output-item class with prompt-specific JSON field aliases.
+
+        Arguments:
+            prompt: text and field aliases for LLM correspondence
+        Returns:
+            output-item model class
+        """
+        fields: dict[str, Any] = {
+            "index": (
+                int,
+                Field(
+                    ...,
+                    alias=prompt.index,
+                    description=prompt.index_desc,
+                    ge=1,
+                ),
+            ),
+            "text": (
+                str,
+                Field(
+                    ...,
+                    alias=prompt.text,
+                    description=prompt.output_text_desc,
+                ),
+            ),
+        }
+        return create_model(
+            get_model_name("GuidedTranslationOutput", prompt.name),
+            __base__=GuidedTranslationSubtitle,
+            __module__=GuidedTranslationAnswer.__module__,
+            **fields,
+        )
+
+    @classmethod
+    @cache
+    def get_query_cls(cls, prompt: GuidedTranslationPrompt) -> type[Query]:
+        """Get concrete query class with prompt-specific JSON field aliases.
+
+        Arguments:
+            prompt: text and field aliases for LLM correspondence
         Returns:
             query model class
         """
-        cls._validate_sizes(source_one_size, source_two_size)
-
-        name = get_model_name(
-            "GuidedTranslationQuery",
-            f"{source_one_size}_{source_two_size}_{prompt.name}",
-        )
-        fields: dict[str, Any] = {}
-        for idx in range(source_one_size):
-            key = prompt.src_1(idx + 1)
-            description = prompt.src_1_desc(idx + 1)
-            fields[key] = (str, Field(..., description=description))
-        for idx in range(source_two_size):
-            key = prompt.src_2(idx + 1)
-            description = prompt.src_2_desc(idx + 1)
-            fields[key] = (str, Field(..., description=description))
-
+        subtitle_cls = cls.get_subtitle_cls(prompt)
+        guide_cls = cls.get_guide_cls(prompt)
+        fields: dict[str, Any] = {
+            "subtitles": (
+                list[subtitle_cls],  # ty: ignore[invalid-type-form]
+                Field(
+                    ...,
+                    alias=prompt.subtitles,
+                    description=prompt.subtitles_desc,
+                    min_length=1,
+                ),
+            ),
+            "guides": (
+                list[guide_cls],  # ty: ignore[invalid-type-form]
+                Field(
+                    ...,
+                    alias=prompt.guides,
+                    description=prompt.guides_desc,
+                ),
+            ),
+        }
         model = create_model(
-            name,
-            __base__=Query,
-            __module__=Query.__module__,
+            get_model_name("GuidedTranslationQuery", prompt.name),
+            __base__=GuidedTranslationQuery,
+            __module__=GuidedTranslationQuery.__module__,
             **fields,
         )
         model.prompt = prompt
-        setattr(model, "source_one_size", source_one_size)
-        setattr(model, "source_two_size", source_two_size)
         return model
 
     @classmethod
     @cache
-    def get_test_case_cls(
+    def get_subtitle_cls(
         cls,
-        source_one_size: int,
-        source_two_size: int,
         prompt: GuidedTranslationPrompt,
-    ) -> type[TestCase]:
-        """Get concrete test case class with provided configuration.
+    ) -> type[GuidedTranslationSubtitle]:
+        """Get subtitle-item class with prompt-specific JSON field aliases.
 
         Arguments:
-            source_one_size: number of subtitles in source one
-            source_two_size: number of subtitles in source two
-            prompt: text for LLM correspondence
+            prompt: text and field aliases for LLM correspondence
         Returns:
-            test case model class
+            subtitle-item model class
         """
-        cls._validate_sizes(source_one_size, source_two_size)
-
-        name = get_model_name(
-            "GuidedTranslationTestCase",
-            f"{source_one_size}_{source_two_size}_{prompt.name}",
+        fields: dict[str, Any] = {
+            "index": (
+                int,
+                Field(
+                    ...,
+                    alias=prompt.index,
+                    description=prompt.index_desc,
+                    ge=1,
+                ),
+            ),
+            "text": (
+                str,
+                Field(
+                    ...,
+                    alias=prompt.text,
+                    description=prompt.subtitle_text_desc,
+                ),
+            ),
+        }
+        return create_model(
+            get_model_name("GuidedTranslationSubtitle", prompt.name),
+            __base__=GuidedTranslationSubtitle,
+            __module__=GuidedTranslationQuery.__module__,
+            **fields,
         )
-        query_cls = cls.get_query_cls(source_one_size, source_two_size, prompt)
-        answer_cls = cls.get_answer_cls(source_one_size, source_two_size, prompt)
+
+    @classmethod
+    @cache
+    def get_test_case_cls(cls, prompt: GuidedTranslationPrompt) -> type[TestCase]:
+        """Get concrete test-case class for a prompt-independent list shape.
+
+        Arguments:
+            prompt: text and field aliases for LLM correspondence
+        Returns:
+            test-case model class
+        """
+        query_cls = cls.get_query_cls(prompt)
+        answer_cls = cls.get_answer_cls(prompt)
         fields = cls.get_test_case_fields(query_cls, answer_cls, prompt)
         validators = cls.get_test_case_validators()
-
         model = create_model(
-            name,
-            __base__=TestCase,
-            __module__=TestCase.__module__,
+            get_model_name("GuidedTranslationTestCase", prompt.name),
+            __base__=GuidedTranslationTestCase,
+            __module__=GuidedTranslationTestCase.__module__,
             __validators__=validators,
             **fields,
         )
-        model.query_cls = query_cls
-        model.answer_cls = answer_cls
+        model.query_cls = cast(type[GuidedTranslationQuery], query_cls)
+        model.answer_cls = cast(type[GuidedTranslationAnswer], answer_cls)
         model.prompt = prompt
-        setattr(model, "source_one_size", source_one_size)
-        setattr(model, "source_two_size", source_two_size)
         setattr(model, "get_auto_verified", cls.get_auto_verified)
         setattr(model, "get_min_difficulty", cls.get_min_difficulty)
         return model
-
-    @classmethod
-    def get_test_case_cls_from_data(cls, data: dict) -> type[TestCase]:
-        """Get concrete test case class for canonical serialized data.
-
-        Arguments:
-            data: data from JSON
-        Returns:
-            test case model class
-        """
-        prompt = cls.base_prompt
-        source_one_pattern = re.compile(rf"^{re.escape(prompt.src_1_pfx)}\d+$")
-        source_two_pattern = re.compile(rf"^{re.escape(prompt.src_2_pfx)}\d+$")
-        source_one_size = sum(
-            1 for field in data["query"] if source_one_pattern.match(field)
-        )
-        source_two_size = sum(
-            1 for field in data["query"] if source_two_pattern.match(field)
-        )
-        return cls.get_test_case_cls(
-            source_one_size=source_one_size,
-            source_two_size=source_two_size,
-            prompt=prompt,
-        )
-
-    @classmethod
-    def get_test_case_cls_with_prompt(
-        cls,
-        test_case_cls: type[TestCase],
-        prompt: Prompt,
-    ) -> type[TestCase]:
-        """Get an equivalently sized test-case class for another prompt.
-
-        Arguments:
-            test_case_cls: test-case class whose sizes should be preserved
-            prompt: prompt whose correspondence fields should be used
-        Returns:
-            equivalently sized test-case class
-        """
-        source_one_size: int = getattr(test_case_cls, "source_one_size")
-        source_two_size: int = getattr(test_case_cls, "source_two_size")
-        return cls.get_test_case_cls(
-            source_one_size=source_one_size,
-            source_two_size=source_two_size,
-            prompt=cast(GuidedTranslationPrompt, prompt),
-        )
-
-    @staticmethod
-    def _validate_sizes(source_one_size: int, source_two_size: int):
-        """Validate dynamic model sizes.
-
-        Arguments:
-            source_one_size: number of subtitles in source one
-            source_two_size: number of subtitles in source two
-        """
-        if source_one_size < 1:
-            raise ScinoephileError("Source one size must be at least 1.")
-        if source_two_size < 0:
-            raise ScinoephileError("Source two size must not be negative.")

--- a/scinoephile/llms/guided_translation/models.py
+++ b/scinoephile/llms/guided_translation/models.py
@@ -1,0 +1,104 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Pydantic models for guided-translation test cases."""
+
+from __future__ import annotations
+
+from typing import ClassVar, Self
+
+from pydantic import ConfigDict, Field, model_validator
+
+from scinoephile.core.llms import Answer, Query, TestCase, TestCaseSubtitle
+
+from .prompt import GuidedTranslationPrompt
+
+__all__ = [
+    "GuidedTranslationAnswer",
+    "GuidedTranslationQuery",
+    "GuidedTranslationSubtitle",
+    "GuidedTranslationTestCase",
+]
+
+
+_BASE_PROMPT = GuidedTranslationPrompt()
+
+
+class GuidedTranslationSubtitle(TestCaseSubtitle):
+    """Indexed subtitle text without a length restriction."""
+
+    text: str
+    """Subtitle text."""
+
+
+class GuidedTranslationQuery(Query):
+    """Subtitles to translate and guide subtitles from the same block."""
+
+    model_config = ConfigDict(validate_by_name=True)
+
+    prompt: ClassVar[GuidedTranslationPrompt] = _BASE_PROMPT
+    """Text and field aliases for LLM correspondence."""
+    subtitles: list[GuidedTranslationSubtitle] = Field(min_length=1)
+    """Source-language subtitles to translate, in order."""
+    guides: list[GuidedTranslationSubtitle]
+    """Target-language guide subtitles from the same block, in order."""
+
+    @model_validator(mode="after")
+    def validate_guide_indices(self) -> Self:
+        """Ensure guide indexes are consecutive, ordered, and begin at 1."""
+        indexes = [guide.index for guide in self.guides]
+        if indexes != list(range(1, len(indexes) + 1)):
+            raise ValueError(self.prompt.guide_indices_err)
+        return self
+
+    @model_validator(mode="after")
+    def validate_subtitle_indices(self) -> Self:
+        """Ensure subtitle indexes are consecutive, ordered, and begin at 1."""
+        indexes = [subtitle.index for subtitle in self.subtitles]
+        if indexes != list(range(1, len(indexes) + 1)):
+            raise ValueError(self.prompt.subtitle_indices_err)
+        return self
+
+
+class GuidedTranslationAnswer(Answer):
+    """Translated outputs corresponding to query subtitles."""
+
+    model_config = ConfigDict(validate_by_name=True)
+
+    prompt: ClassVar[GuidedTranslationPrompt] = _BASE_PROMPT
+    """Text and field aliases for LLM correspondence."""
+    outputs: list[GuidedTranslationSubtitle] = Field(min_length=1)
+    """Translated subtitles, in query-subtitle order."""
+
+    @model_validator(mode="after")
+    def validate_output_indices(self) -> Self:
+        """Ensure output indexes are consecutive, ordered, and begin at 1."""
+        indexes = [output.index for output in self.outputs]
+        if indexes != list(range(1, len(indexes) + 1)):
+            raise ValueError(self.prompt.output_indices_err)
+        return self
+
+
+class GuidedTranslationTestCase(TestCase):
+    """Guided-translation query, optional answer, and optimization metadata."""
+
+    query_cls: ClassVar[type[GuidedTranslationQuery]] = GuidedTranslationQuery
+    """Query model class."""
+    answer_cls: ClassVar[type[GuidedTranslationAnswer]] = GuidedTranslationAnswer
+    """Answer model class."""
+    prompt: ClassVar[GuidedTranslationPrompt] = _BASE_PROMPT
+    """Text and field aliases for LLM correspondence."""
+    query: GuidedTranslationQuery
+    """Subtitles to translate and optional guide subtitles."""
+    answer: GuidedTranslationAnswer | None = None
+    """Translated outputs, if available."""
+
+    @model_validator(mode="after")
+    def validate_output_correspondence(self) -> Self:
+        """Ensure answer outputs correspond exactly to query subtitles."""
+        if self.answer is None:
+            return self
+        subtitle_indexes = [subtitle.index for subtitle in self.query.subtitles]
+        output_indexes = [output.index for output in self.answer.outputs]
+        if output_indexes != subtitle_indexes:
+            raise ValueError(self.prompt.output_correspondence_err)
+        return self

--- a/scinoephile/llms/guided_translation/processor.py
+++ b/scinoephile/llms/guided_translation/processor.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from logging import getLogger
+from typing import cast
 
 from scinoephile.core.llms import Processor
 from scinoephile.core.llms.utils import save_test_cases_to_json
@@ -12,6 +13,7 @@ from scinoephile.core.pairs import get_block_pairs_by_pause
 from scinoephile.core.subtitles import Series, Subtitle, get_concatenated_series
 
 from .manager import GuidedTranslationManager
+from .models import GuidedTranslationAnswer
 from .prompt import GuidedTranslationPrompt
 
 __all__ = ["GuidedTranslationProcessor"]
@@ -57,28 +59,36 @@ class GuidedTranslationProcessor(Processor):
                 output_series_to_concatenate[blk_idx] = Series()
                 continue
 
-            test_case_cls = GuidedTranslationManager.get_test_case_cls(
-                source_one_size=len(one_blk),
-                source_two_size=len(two_blk),
-                prompt=self.prompt,
-            )
+            test_case_cls = GuidedTranslationManager.get_test_case_cls(self.prompt)
             query_cls = test_case_cls.query_cls
-            query_kwargs: dict[str, str] = {}
-            for sub_idx, sub in enumerate(one_blk.events, 1):
-                key = self.prompt.src_1(sub_idx)
-                query_kwargs[key] = sub.text_with_newline.strip()
-            for sub_idx, sub in enumerate(two_blk.events, 1):
-                key = self.prompt.src_2(sub_idx)
-                query_kwargs[key] = sub.text_with_newline.strip()
-
-            query = query_cls(**query_kwargs)
+            query = query_cls.model_validate(
+                {
+                    "subtitles": [
+                        {
+                            "index": idx,
+                            "text": subtitle.text_with_newline.strip(),
+                        }
+                        for idx, subtitle in enumerate(one_blk.events, 1)
+                    ],
+                    "guides": [
+                        {
+                            "index": idx,
+                            "text": guide.text_with_newline.strip(),
+                        }
+                        for idx, guide in enumerate(two_blk.events, 1)
+                    ],
+                }
+            )
             test_case = test_case_cls(query=query)
             test_case = self.queryer(test_case)
 
+            answer = cast(GuidedTranslationAnswer, test_case.answer)
+            output_text_by_index = {
+                output.index: output.text for output in answer.outputs
+            }
             output_series = Series()
             for sub_idx, sub in enumerate(one_blk.events, 1):
-                output_key = self.prompt.output(sub_idx)
-                output = getattr(test_case.answer, output_key)
+                output = output_text_by_index[sub_idx]
                 output_series.append(
                     Subtitle(start=sub.start, end=sub.end, text=output)
                 )

--- a/scinoephile/llms/guided_translation/prompt.py
+++ b/scinoephile/llms/guided_translation/prompt.py
@@ -16,24 +16,64 @@ class GuidedTranslationPrompt(Prompt):
     """Text for guided translation blocks."""
 
     # Query fields
-    src_1_pfx: str = "source_one_"
-    """Prefix for source one fields in query."""
+    subtitles: str = "subtitles"
+    """Name of subtitles field in query."""
 
-    src_1_desc_tpl: str = "Subtitle {idx} text from source one"
-    """Description template for source one fields in query."""
+    subtitles_desc: str = "Source-language subtitles to translate, in order."
+    """Description of subtitles field in query."""
 
-    src_2_pfx: str = "source_two_"
-    """Prefix for source two fields in query."""
+    guides: str = "guides"
+    """Name of guides field in query."""
 
-    src_2_desc_tpl: str = "Subtitle {idx} text from source two"
-    """Description template for source two fields in query."""
+    guides_desc: str = "Target-language guide subtitles from the same block."
+    """Description of guides field in query."""
 
     # Answer fields
-    output_pfx: str = "output_"
-    """Prefix for output fields in answer."""
+    outputs: str = "outputs"
+    """Name of outputs field in answer."""
 
-    output_desc_tpl: str = "Subtitle {idx} generated for source one subtitle {idx}"
-    """Description template for output fields in answer."""
+    outputs_desc: str = "Translated outputs corresponding to query subtitles."
+    """Description of outputs field in answer."""
+
+    # Subtitle fields
+    index: str = "index"
+    """Name of index field in subtitle, guide, and output items."""
+
+    index_desc: str = "One-based subtitle index."
+    """Description of index field in subtitle, guide, and output items."""
+
+    text: str = "text"
+    """Name of text field in subtitle, guide, and output items."""
+
+    subtitle_text_desc: str = "Source-language subtitle text to translate."
+    """Description of text field in subtitle items."""
+
+    guide_text_desc: str = "Target-language guide subtitle text."
+    """Description of text field in guide items."""
+
+    output_text_desc: str = "Translated subtitle text."
+    """Description of text field in output items."""
+
+    # Validation errors
+    guide_indices_err: str = (
+        "Query guide indexes must be consecutive, ordered, and begin at 1."
+    )
+    """Error when query guide indexes are invalid."""
+
+    subtitle_indices_err: str = (
+        "Query subtitle indexes must be consecutive, ordered, and begin at 1."
+    )
+    """Error when query subtitle indexes are invalid."""
+
+    output_indices_err: str = (
+        "Answer output indexes must be consecutive, ordered, and begin at 1."
+    )
+    """Error when answer output indexes are invalid."""
+
+    output_correspondence_err: str = (
+        "Answer output indexes must correspond exactly to query subtitle indexes."
+    )
+    """Error when answer outputs do not correspond to query subtitles."""
 
     # Dictionary tool
     dictionary_tool_name: str = ""
@@ -42,27 +82,3 @@ class GuidedTranslationPrompt(Prompt):
     """Description of dictionary lookup tool."""
     dictionary_tool_query_description: str = ""
     """Description of dictionary lookup query."""
-
-    def output(self, idx: int) -> str:
-        """Name of output field in answer."""
-        return f"{self.output_pfx}{idx}"
-
-    def output_desc(self, idx: int) -> str:
-        """Description of output subtitle field in answer."""
-        return self.output_desc_tpl.format(idx=idx)
-
-    def src_1(self, idx: int) -> str:
-        """Name of source one field in query."""
-        return f"{self.src_1_pfx}{idx}"
-
-    def src_1_desc(self, idx: int) -> str:
-        """Description of source one field in query."""
-        return self.src_1_desc_tpl.format(idx=idx)
-
-    def src_2(self, idx: int) -> str:
-        """Name of source two field in query."""
-        return f"{self.src_2_pfx}{idx}"
-
-    def src_2_desc(self, idx: int) -> str:
-        """Description of source two field in query."""
-        return self.src_2_desc_tpl.format(idx=idx)

--- a/scinoephile/multilang/eng_yue/translation.py
+++ b/scinoephile/multilang/eng_yue/translation.py
@@ -96,19 +96,22 @@ EngYueGuidedTranslationPrompt = GuidedTranslationPrompt(
         meaning while preserving established names and terms from the English
         reference.
 
-        Output only the generated English subtitle text in each answer field. Do not
-        include notes, explanations, labels, alternate translations, bracketed
-        commentary, or any text outside the subtitle itself. Preserve subtitle markup
-        only when it is appropriate for the generated English subtitle.
+        Output only the generated English subtitle text in each output item's text
+        field. Do not include notes, explanations, labels, alternate translations,
+        bracketed commentary, or any text outside the subtitle itself. Preserve
+        subtitle markup only when it is appropriate for the generated English
+        subtitle.
         """),
-    src_1_pfx="yuewen_",
-    src_1_desc_tpl="Written Cantonese subtitle {idx} to translate",
-    src_2_pfx="eng_reference_",
-    src_2_desc_tpl="Original English reference subtitle {idx} from the same block",
-    output_pfx="eng_",
-    output_desc_tpl=(
-        "Generated English subtitle {idx} corresponding to written Cantonese "
-        "subtitle {idx}"
+    subtitles="yuewen",
+    subtitles_desc="Written Cantonese subtitles to translate, in order",
+    guides="eng_reference",
+    guides_desc="Original English reference subtitles from the same block, in order",
+    outputs="eng",
+    outputs_desc="Generated English subtitles corresponding to the input subtitles",
+    subtitle_text_desc="Written Cantonese subtitle to translate",
+    guide_text_desc="Original English reference subtitle from the same block",
+    output_text_desc=(
+        "Generated English subtitle corresponding to a written Cantonese subtitle"
     ),
 )
 """Text for guided translation of English from written Cantonese."""

--- a/scinoephile/multilang/eng_zho/translation.py
+++ b/scinoephile/multilang/eng_zho/translation.py
@@ -92,18 +92,20 @@ EngZhoGuidedTranslationPrompt = GuidedTranslationPrompt(
         English, prioritize the Chinese meaning while preserving established names
         and terms from the English reference.
 
-        Output only the generated English subtitle text in each answer field. Do not
-        include notes, explanations, labels, alternate translations, bracketed
-        commentary, or any text outside the subtitle itself. Preserve subtitle markup
-        only when it is appropriate for the generated English subtitle.
+        Output only the generated English subtitle text in each output item's text
+        field. Do not include notes, explanations, labels, alternate translations,
+        bracketed commentary, or any text outside the subtitle itself. Preserve
+        subtitle markup only when it is appropriate for the generated English
+        subtitle.
         """),
-    src_1_pfx="zho_",
-    src_1_desc_tpl="Chinese subtitle {idx} to translate",
-    src_2_pfx="eng_reference_",
-    src_2_desc_tpl="Original English reference subtitle {idx} from the same block",
-    output_pfx="eng_",
-    output_desc_tpl=(
-        "Generated English subtitle {idx} corresponding to Chinese subtitle {idx}"
-    ),
+    subtitles="zho",
+    subtitles_desc="Chinese subtitles to translate, in order",
+    guides="eng_reference",
+    guides_desc="Original English reference subtitles from the same block, in order",
+    outputs="eng",
+    outputs_desc="Generated English subtitles corresponding to the input subtitles",
+    subtitle_text_desc="Chinese subtitle to translate",
+    guide_text_desc="Original English reference subtitle from the same block",
+    output_text_desc="Generated English subtitle corresponding to a Chinese subtitle",
 )
 """Text for guided translation of English from Chinese with English guidance."""

--- a/scinoephile/multilang/yue_eng/translation.py
+++ b/scinoephile/multilang/yue_eng/translation.py
@@ -106,15 +106,25 @@ YueEngGuidedTranslationPromptYueHant = GuidedTranslationPrompt(
         如果英文字幕同既有粵文字幕有分別，要優先按英文意思翻譯，同時保留
         已經建立好嘅名詞同稱呼。
 
-        輸出內容只可以係生成嘅粵文字幕正文。絕對唔好附加英文、備註、解釋、標籤、
-        替代譯文、方括號內容、括號內容，或者任何字幕以外嘅説明。
+        每個輸出項目嘅文本欄只可以係生成嘅粵文字幕正文。絕對唔好附加英文、備註、
+        解釋、標籤、替代譯文、方括號內容、括號內容，或者任何字幕以外嘅説明。
         """),
-    src_1_pfx="eng_",
-    src_1_desc_tpl="要翻譯成粵文嘅英文字幕 {idx}",
-    src_2_pfx="yuewen_reference_",
-    src_2_desc_tpl="同一段場景嘅既有粵文參考字幕 {idx}",
-    output_pfx="yuewen_",
-    output_desc_tpl="字幕 {idx} 對應嘅粵文譯文",
+    subtitles="eng",
+    subtitles_desc="按順序排列、要翻譯成粵文嘅英文字幕",
+    guides="yuewen_reference",
+    guides_desc="同一段場景嘅既有粵文參考字幕",
+    outputs="yuewen",
+    outputs_desc="同查詢英文字幕逐一對應嘅粵文譯文",
+    index="xuhao",
+    index_desc="由 1 開始嘅字幕序號",
+    text="wenben",
+    subtitle_text_desc="要翻譯成粵文嘅英文字幕文本",
+    guide_text_desc="同一段場景嘅既有粵文參考字幕文本",
+    output_text_desc="同查詢英文字幕對應嘅粵文譯文文本",
+    guide_indices_err="查詢參考字幕序號必須由 1 開始、連續並按順序排列。",
+    subtitle_indices_err="查詢字幕序號必須由 1 開始、連續並按順序排列。",
+    output_indices_err="答案輸出序號必須由 1 開始、連續並按順序排列。",
+    output_correspondence_err="答案輸出序號必須同查詢字幕序號完全對應。",
 )
 """Text for traditional guided written Cantonese translation from English."""
 

--- a/scinoephile/multilang/yue_zho/translation.py
+++ b/scinoephile/multilang/yue_zho/translation.py
@@ -108,15 +108,25 @@ YueZhoGuidedTranslationPromptYueHant = GuidedTranslationPrompt(
         如果中文字幕同既有粵文字幕有分別，要優先按中文字幕意思翻譯，同時保留
         已經建立好嘅名詞同稱呼。
 
-        輸出內容只可以係生成嘅粵文字幕正文。絕對唔好附加英文、備註、解釋、標籤、
-        替代譯文、方括號內容、括號內容，或者任何字幕以外嘅説明。
+        每個輸出項目嘅文本欄只可以係生成嘅粵文字幕正文。絕對唔好附加英文、備註、
+        解釋、標籤、替代譯文、方括號內容、括號內容，或者任何字幕以外嘅説明。
         """),
-    src_1_pfx="zhongwen_",
-    src_1_desc_tpl="要翻譯成粵文嘅中文字幕 {idx}",
-    src_2_pfx="yuewen_reference_",
-    src_2_desc_tpl="同一段場景嘅既有粵文參考字幕 {idx}",
-    output_pfx="yuewen_",
-    output_desc_tpl="字幕 {idx} 對應嘅粵文譯文",
+    subtitles="zhongwen",
+    subtitles_desc="按順序排列、要翻譯成粵文嘅中文字幕",
+    guides="yuewen_reference",
+    guides_desc="同一段場景嘅既有粵文參考字幕",
+    outputs="yuewen",
+    outputs_desc="同查詢中文字幕逐一對應嘅粵文譯文",
+    index="xuhao",
+    index_desc="由 1 開始嘅字幕序號",
+    text="wenben",
+    subtitle_text_desc="要翻譯成粵文嘅中文字幕文本",
+    guide_text_desc="同一段場景嘅既有粵文參考字幕文本",
+    output_text_desc="同查詢中文字幕對應嘅粵文譯文文本",
+    guide_indices_err="查詢參考字幕序號必須由 1 開始、連續並按順序排列。",
+    subtitle_indices_err="查詢字幕序號必須由 1 開始、連續並按順序排列。",
+    output_indices_err="答案輸出序號必須由 1 開始、連續並按順序排列。",
+    output_correspondence_err="答案輸出序號必須同查詢字幕序號完全對應。",
 )
 """Text for traditional guided written Cantonese translation from Chinese."""
 

--- a/scinoephile/multilang/zho_eng/translation.py
+++ b/scinoephile/multilang/zho_eng/translation.py
@@ -97,15 +97,25 @@ ZhoEngGuidedTranslationPromptZhoHant = GuidedTranslationPrompt(
         如果英文字幕和既有中文字幕有差異，要優先按英文意思翻譯，同時保留
         已經建立好的名詞和稱呼。
 
-        輸出內容只能是生成的中文字幕正文。不要附加英文、備註、解釋、標籤、
-        替代譯文、方括號內容、括號內容，或任何字幕以外的說明。
+        每個輸出項目的文本欄只能是生成的中文字幕正文。不要附加英文、備註、解釋、
+        標籤、替代譯文、方括號內容、括號內容，或任何字幕以外的說明。
         """),
-    src_1_pfx="eng_",
-    src_1_desc_tpl="要翻譯成標準中文的英文字幕 {idx}",
-    src_2_pfx="zhongwen_reference_",
-    src_2_desc_tpl="同一段場景的既有標準中文參考字幕 {idx}",
-    output_pfx="zhongwen_",
-    output_desc_tpl="字幕 {idx} 對應的標準中文譯文",
+    subtitles="eng",
+    subtitles_desc="按順序排列、要翻譯成標準中文的英文字幕",
+    guides="zhongwen_reference",
+    guides_desc="同一段場景的既有標準中文參考字幕",
+    outputs="zhongwen",
+    outputs_desc="和查詢英文字幕逐一對應的標準中文譯文",
+    index="xuhao",
+    index_desc="從 1 開始的字幕序號",
+    text="wenben",
+    subtitle_text_desc="要翻譯成標準中文的英文字幕文本",
+    guide_text_desc="同一段場景的既有標準中文參考字幕文本",
+    output_text_desc="和查詢英文字幕對應的標準中文譯文文本",
+    guide_indices_err="查詢參考字幕序號必須從 1 開始、連續並按順序排列。",
+    subtitle_indices_err="查詢字幕序號必須從 1 開始、連續並按順序排列。",
+    output_indices_err="答案輸出序號必須從 1 開始、連續並按順序排列。",
+    output_correspondence_err="答案輸出序號必須與查詢字幕序號完全對應。",
 )
 """Text for traditional guided standard Chinese translation from English."""
 

--- a/scinoephile/multilang/zho_yue/translation.py
+++ b/scinoephile/multilang/zho_yue/translation.py
@@ -97,15 +97,25 @@ ZhoYueGuidedTranslationPromptZhoHant = GuidedTranslationPrompt(
         如果粵文字幕和既有中文字幕有差異，要優先按粵文意思翻譯，同時保留
         已經建立好的名詞和稱呼。
 
-        輸出內容只能是生成的中文字幕正文。不要附加英文、備註、解釋、標籤、
-        替代譯文、方括號內容、括號內容，或任何字幕以外的說明。
+        每個輸出項目的文本欄只能是生成的中文字幕正文。不要附加英文、備註、解釋、
+        標籤、替代譯文、方括號內容、括號內容，或任何字幕以外的說明。
         """),
-    src_1_pfx="yuewen_",
-    src_1_desc_tpl="要翻譯成標準中文的粵文字幕 {idx}",
-    src_2_pfx="zhongwen_reference_",
-    src_2_desc_tpl="同一段場景的既有標準中文參考字幕 {idx}",
-    output_pfx="zhongwen_",
-    output_desc_tpl="字幕 {idx} 對應的標準中文譯文",
+    subtitles="yuewen",
+    subtitles_desc="按順序排列、要翻譯成標準中文的粵文字幕",
+    guides="zhongwen_reference",
+    guides_desc="同一段場景的既有標準中文參考字幕",
+    outputs="zhongwen",
+    outputs_desc="和查詢粵文字幕逐一對應的標準中文譯文",
+    index="xuhao",
+    index_desc="從 1 開始的字幕序號",
+    text="wenben",
+    subtitle_text_desc="要翻譯成標準中文的粵文字幕文本",
+    guide_text_desc="同一段場景的既有標準中文參考字幕文本",
+    output_text_desc="和查詢粵文字幕對應的標準中文譯文文本",
+    guide_indices_err="查詢參考字幕序號必須從 1 開始、連續並按順序排列。",
+    subtitle_indices_err="查詢字幕序號必須從 1 開始、連續並按順序排列。",
+    output_indices_err="答案輸出序號必須從 1 開始、連續並按順序排列。",
+    output_correspondence_err="答案輸出序號必須與查詢字幕序號完全對應。",
 )
 """Text for traditional guided standard Chinese translation from Cantonese."""
 

--- a/test/data/prompts.py
+++ b/test/data/prompts.py
@@ -30,15 +30,16 @@ EngZhoYueGuidedTranslationPrompt = replace(
             meaning while preserving established names and terms from the English
             reference.
 
-            Output only the generated English subtitle text in each answer field. Do
-            not include notes, explanations, labels, alternate translations, bracketed
-            commentary, or any text outside the subtitle itself. Preserve subtitle
-            markup only when it is appropriate for the generated English subtitle.
+            Output only the generated English subtitle text in each output item's text
+            field. Do not include notes, explanations, labels, alternate translations,
+            bracketed commentary, or any text outside the subtitle itself. Preserve
+            subtitle markup only when it is appropriate for the generated English
+            subtitle.
             """),
-    src_1_desc_tpl="Chinese subtitle {idx} of Cantonese/Yue source to translate",
-    output_desc_tpl=(
-        "Generated English subtitle {idx} corresponding to Chinese subtitle {idx} "
-        "of Cantonese/Yue source"
+    subtitle_text_desc="Chinese subtitle of Cantonese/Yue source to translate",
+    output_text_desc=(
+        "Generated English subtitle corresponding to a Chinese subtitle of "
+        "Cantonese/Yue source"
     ),
 )
 """Text for guided English translation from Chinese subtitles of Yue source."""

--- a/test/llms/test_guided_translation.py
+++ b/test/llms/test_guided_translation.py
@@ -1,0 +1,208 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests for list-shaped guided-translation LLM models."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+from pydantic import ValidationError
+from pytest import raises
+
+from scinoephile.core import Language
+from scinoephile.core.llms import LLMProvider
+from scinoephile.core.llms.utils import (
+    load_test_cases_from_json,
+    save_test_cases_to_json,
+)
+from scinoephile.core.subtitles import Series, Subtitle
+from scinoephile.llms.guided_translation import (
+    GuidedTranslationManager,
+    GuidedTranslationProcessor,
+    GuidedTranslationPrompt,
+)
+
+_LOCALIZED_PROMPT = GuidedTranslationPrompt(
+    language=Language.zho_hant,
+    subtitles="zimu",
+    guides="cankao",
+    outputs="shuchu",
+    index="xuhao",
+    text="wenben",
+)
+"""Guided-translation prompt with Chinese correspondence field names."""
+
+
+def test_prompt_aliases_are_used_for_llm_correspondence():
+    """Generated schemas and JSON should use prompt-specific aliases."""
+    test_case_cls = GuidedTranslationManager.get_test_case_cls(_LOCALIZED_PROMPT)
+    test_case = test_case_cls.model_validate(
+        {
+            "query": {
+                "zimu": [{"xuhao": 1, "wenben": "原文"}],
+                "cankao": [{"xuhao": 1, "wenben": "參考"}],
+            },
+            "answer": {
+                "shuchu": [{"xuhao": 1, "wenben": "譯文"}],
+            },
+        }
+    )
+
+    assert test_case.query.model_dump(by_alias=True) == {
+        "zimu": [{"xuhao": 1, "wenben": "原文"}],
+        "cankao": [{"xuhao": 1, "wenben": "參考"}],
+    }
+    assert test_case.answer is not None
+    assert test_case.answer.model_dump(by_alias=True) == {
+        "shuchu": [{"xuhao": 1, "wenben": "譯文"}],
+    }
+    assert set(test_case_cls.query_cls.model_json_schema()["properties"]) == {
+        "zimu",
+        "cankao",
+    }
+    assert set(test_case_cls.answer_cls.model_json_schema()["properties"]) == {"shuchu"}
+
+
+def test_query_and_answer_require_consecutive_ordered_indexes():
+    """Subtitle, guide, and output indexes should be consecutive and ordered."""
+    query_cls = GuidedTranslationManager.get_query_cls(
+        GuidedTranslationManager.base_prompt
+    )
+    answer_cls = GuidedTranslationManager.get_answer_cls(
+        GuidedTranslationManager.base_prompt
+    )
+
+    with raises(ValidationError, match="subtitle indexes must be consecutive"):
+        query_cls.model_validate(
+            {
+                "subtitles": [
+                    {"index": 1, "text": "one"},
+                    {"index": 3, "text": "three"},
+                ],
+                "guides": [],
+            }
+        )
+    with raises(ValidationError, match="guide indexes must be consecutive"):
+        query_cls.model_validate(
+            {
+                "subtitles": [{"index": 1, "text": "one"}],
+                "guides": [{"index": 2, "text": "two"}],
+            }
+        )
+    with raises(ValidationError, match="output indexes must be consecutive"):
+        answer_cls.model_validate({"outputs": [{"index": 2, "text": "two"}]})
+
+    long_text = "x" * 1001
+    query_cls.model_validate(
+        {
+            "subtitles": [{"index": 1, "text": long_text}],
+            "guides": [{"index": 1, "text": long_text}],
+        }
+    )
+    answer_cls.model_validate({"outputs": [{"index": 1, "text": long_text}]})
+
+
+def test_outputs_must_correspond_to_query_subtitles():
+    """Every query subtitle should have exactly one same-index output."""
+    test_case_cls = GuidedTranslationManager.get_test_case_cls(
+        GuidedTranslationManager.base_prompt
+    )
+
+    with raises(ValidationError, match="correspond exactly"):
+        test_case_cls.model_validate(
+            {
+                "query": {
+                    "subtitles": [
+                        {"index": 1, "text": "one"},
+                        {"index": 2, "text": "two"},
+                    ],
+                    "guides": [],
+                },
+                "answer": {"outputs": [{"index": 1, "text": "translated"}]},
+            }
+        )
+
+
+def test_processor_maps_indexed_outputs_to_subtitle_timing():
+    """Processor outputs should preserve source-subtitle ordering and timing."""
+    provider = Mock(spec=LLMProvider)
+    provider.chat_completion.return_value = json.dumps(
+        {
+            "shuchu": [
+                {"xuhao": 1, "wenben": "譯文一"},
+                {"xuhao": 2, "wenben": "譯文二"},
+            ]
+        },
+        ensure_ascii=False,
+    )
+    processor = GuidedTranslationProcessor(_LOCALIZED_PROMPT, provider=provider)
+    processor.queryer.cache_dir_path = None
+    source = Series(
+        events=[
+            Subtitle(start=0, end=1000, text="原文一"),
+            Subtitle(start=1000, end=2000, text="原文二"),
+        ]
+    )
+    guide = Series(events=[Subtitle(start=0, end=2000, text="參考")])
+
+    output = processor.process(source, guide)
+
+    assert output == Series(
+        events=[
+            Subtitle(start=0, end=1000, text="譯文一"),
+            Subtitle(start=1000, end=2000, text="譯文二"),
+        ]
+    )
+    messages = provider.chat_completion.call_args.args[0]
+    assert json.loads(messages[1]["content"]) == {
+        "zimu": [
+            {"xuhao": 1, "wenben": "原文一"},
+            {"xuhao": 2, "wenben": "原文二"},
+        ],
+        "cankao": [{"xuhao": 1, "wenben": "參考"}],
+    }
+    assert '"shuchu"' in messages[0]["content"]
+    assert '"xuhao"' in messages[0]["content"]
+    assert '"wenben"' in messages[0]["content"]
+
+
+def test_persistence_uses_base_prompt_field_names(tmp_path: Path):
+    """Persistence should use canonical names and reload localized aliases."""
+    test_case_cls = GuidedTranslationManager.get_test_case_cls(_LOCALIZED_PROMPT)
+    test_case = test_case_cls.model_validate(
+        {
+            "query": {
+                "subtitles": [{"index": 1, "text": "原文"}],
+                "guides": [],
+            },
+            "answer": {"outputs": [{"index": 1, "text": "譯文"}]},
+        }
+    )
+    output_path = tmp_path / "guided_translation.json"
+
+    save_test_cases_to_json(
+        output_path,
+        [test_case],
+        GuidedTranslationManager,
+    )
+
+    assert json.loads(output_path.read_text(encoding="utf-8")) == [
+        {
+            "query": {
+                "subtitles": [{"index": 1, "text": "原文"}],
+                "guides": [],
+            },
+            "answer": {"outputs": [{"index": 1, "text": "譯文"}]},
+        }
+    ]
+    loaded = load_test_cases_from_json(
+        output_path,
+        GuidedTranslationManager,
+        _LOCALIZED_PROMPT,
+    )
+    assert loaded[0].query.model_dump(by_alias=True) == {
+        "zimu": [{"xuhao": 1, "wenben": "原文"}],
+        "cankao": [],
+    }


### PR DESCRIPTION
## Summary

- Replace subtitle/guide cardinality-specific dynamic models with static indexed-list guided-translation models.
- Keep localized aliases for prompt-facing JSON while persisting canonical field names.
- Validate required subtitle and guide data, exact output-index correspondence, and the supported empty-guide case.
- Update processor reconstruction, authored prompts, and prompt test data.

## Validation

- Ruff format/check and `ty` pass for changed Python files.
- Full suite: 1,466 passed, 9 skipped.
- Independent review: no actionable findings.

## Series

This is one of four independent test-case shape migrations. Because the translation-family PRs touch adjacent prompt definitions, the suggested merge order is standard translation, guided translation, then gap translation; guided review can merge independently.