### PR TITLE
Simplify test case class factories

### DIFF
--- a/scinoephile/core/llms/answer.py
+++ b/scinoephile/core/llms/answer.py
@@ -8,7 +8,7 @@ import json
 from abc import ABC
 from typing import ClassVar
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from .prompt import Prompt
 
@@ -17,6 +17,8 @@ __all__ = ["Answer"]
 
 class Answer(BaseModel, ABC):
     """ABC for LLM answers."""
+
+    model_config = ConfigDict(validate_by_name=True)
 
     prompt: ClassVar[Prompt]
     """Text for LLM correspondence."""

--- a/scinoephile/core/llms/manager.py
+++ b/scinoephile/core/llms/manager.py
@@ -26,6 +26,8 @@ class Manager(ABC):
     """Stable operation identifier used in persistence and CLIs."""
     base_prompt: ClassVar[Prompt]
     """Base prompt defining persisted test-case field names."""
+    test_case_base_cls: ClassVar[type[TestCase]] = TestCase
+    """Static test-case model defining the operation's semantic shape."""
 
     @classmethod
     def get_query_cls(cls, prompt: Prompt) -> type[Query]:
@@ -65,9 +67,9 @@ class Manager(ABC):
         validators = cls.get_test_case_validators()
 
         model = create_model(
-            get_model_name(TestCase.__name__, prompt.name),
-            __base__=TestCase,
-            __module__=TestCase.__module__,
+            get_model_name(cls.test_case_base_cls.__name__, prompt.name),
+            __base__=cls.test_case_base_cls,
+            __module__=cls.test_case_base_cls.__module__,
             __validators__=validators,
             **fields,
         )
@@ -77,33 +79,6 @@ class Manager(ABC):
         setattr(model, "get_auto_verified", cls.get_auto_verified)
         setattr(model, "get_min_difficulty", cls.get_min_difficulty)
         return model
-
-    @classmethod
-    def get_test_case_cls_from_data(cls, data: dict) -> type[TestCase]:
-        """Get concrete test case class for canonical serialized data.
-
-        Arguments:
-            data: data from JSON
-        Returns:
-            test case class
-        """
-        return cls.get_test_case_cls(cls.base_prompt)
-
-    @classmethod
-    def get_test_case_cls_with_prompt(
-        cls,
-        test_case_cls: type[TestCase],
-        prompt: Prompt,
-    ) -> type[TestCase]:
-        """Get an equivalently shaped test-case class for another prompt.
-
-        Arguments:
-            test_case_cls: test-case class whose shape should be preserved
-            prompt: prompt whose correspondence fields should be used
-        Returns:
-            equivalently shaped test-case class
-        """
-        return cls.get_test_case_cls(prompt=prompt)
 
     @classmethod
     def get_test_case_fields(

--- a/scinoephile/core/llms/query.py
+++ b/scinoephile/core/llms/query.py
@@ -8,7 +8,7 @@ import json
 from abc import ABC
 from typing import ClassVar
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from .models import make_hashable
 from .prompt import Prompt
@@ -18,6 +18,8 @@ __all__ = ["Query"]
 
 class Query(BaseModel, ABC):
     """ABC for LLM queries."""
+
+    model_config = ConfigDict(validate_by_name=True)
 
     prompt: ClassVar[Prompt]
     """Text for LLM correspondence."""

--- a/scinoephile/core/llms/utils.py
+++ b/scinoephile/core/llms/utils.py
@@ -38,15 +38,12 @@ def load_test_cases_from_json(
 
     test_cases: list[TestCase] = []
     for test_case_data in raw_test_cases:
-        base_test_case_cls = manager_cls.get_test_case_cls_from_data(test_case_data)
+        base_test_case_cls = manager_cls.get_test_case_cls(manager_cls.base_prompt)
         base_test_case = base_test_case_cls.model_validate(
             test_case_data,
             extra="forbid",
         )
-        test_case_cls = manager_cls.get_test_case_cls_with_prompt(
-            base_test_case_cls,
-            prompt,
-        )
+        test_case_cls = manager_cls.get_test_case_cls(prompt)
         test_cases.append(remap_test_case(base_test_case, test_case_cls))
 
     return test_cases
@@ -66,8 +63,7 @@ def save_test_cases_to_json(
     """
     data = []
     for test_case in test_cases:
-        base_test_case_cls = manager_cls.get_test_case_cls_with_prompt(
-            type(test_case),
+        base_test_case_cls = manager_cls.get_test_case_cls(
             manager_cls.base_prompt,
         )
         base_test_case = remap_test_case(test_case, base_test_case_cls)

--- a/scinoephile/llms/delineation/manager.py
+++ b/scinoephile/llms/delineation/manager.py
@@ -106,17 +106,6 @@ class DelineationManager(Manager):
         model.prompt = prompt
         return model
 
-    @classmethod
-    def get_test_case_cls_from_data(cls, data: dict) -> type[TestCase]:
-        """Get concrete test case class for canonical serialized data.
-
-        Arguments:
-            data: data from JSON
-        Returns:
-            test case model class
-        """
-        return cls.get_test_case_cls(cls.base_prompt)
-
     @staticmethod
     def get_min_difficulty(model: TestCase) -> int:
         """Get minimum difficulty based on the test case properties.

--- a/scinoephile/llms/gap_translation/manager.py
+++ b/scinoephile/llms/gap_translation/manager.py
@@ -35,6 +35,8 @@ class GapTranslationManager(Manager):
     """Stable operation identifier used in persistence and CLIs."""
     base_prompt: ClassVar[GapTranslationPrompt] = GapTranslationPrompt()
     """Base prompt defining persisted test-case field names."""
+    test_case_base_cls: ClassVar[type[TestCase]] = GapTranslationTestCase
+    """Static test-case model defining gap translation's semantic shape."""
 
     @classmethod
     @cache
@@ -220,34 +222,6 @@ class GapTranslationManager(Manager):
             __module__=GapTranslationQuery.__module__,
             **fields,
         )
-
-    @classmethod
-    @cache
-    def get_test_case_cls(cls, prompt: GapTranslationPrompt) -> type[TestCase]:
-        """Get test-case class for a prompt-independent list shape.
-
-        Arguments:
-            prompt: text and field aliases for LLM correspondence
-        Returns:
-            test-case model class
-        """
-        query_cls = cls.get_query_cls(prompt)
-        answer_cls = cls.get_answer_cls(prompt)
-        fields = cls.get_test_case_fields(query_cls, answer_cls, prompt)
-        validators = cls.get_test_case_validators()
-        model = create_model(
-            get_model_name("GapTranslationTestCase", prompt.name),
-            __base__=GapTranslationTestCase,
-            __module__=GapTranslationTestCase.__module__,
-            __validators__=validators,
-            **fields,
-        )
-        model.query_cls = cast(type[GapTranslationQuery], query_cls)
-        model.answer_cls = cast(type[GapTranslationAnswer], answer_cls)
-        model.prompt = prompt
-        setattr(model, "get_auto_verified", cls.get_auto_verified)
-        setattr(model, "get_min_difficulty", cls.get_min_difficulty)
-        return model
 
     @staticmethod
     def validate_test_case(model: TestCase) -> TestCase:

--- a/scinoephile/llms/gap_translation/models.py
+++ b/scinoephile/llms/gap_translation/models.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import ClassVar, Self
 
-from pydantic import ConfigDict, Field, model_validator
+from pydantic import Field, model_validator
 
 from scinoephile.core.llms import Answer, Query, TestCase, TestCaseSubtitle
 
@@ -32,8 +32,6 @@ class GapTranslationSubtitle(TestCaseSubtitle):
 
 class GapTranslationQuery(Query):
     """Sparse targets and complete guides for gap translation."""
-
-    model_config = ConfigDict(validate_by_name=True)
 
     prompt: ClassVar[GapTranslationPrompt] = _BASE_PROMPT
     """Text and field aliases for LLM correspondence."""
@@ -67,8 +65,6 @@ class GapTranslationQuery(Query):
 
 class GapTranslationAnswer(Answer):
     """Translations for every missing target index."""
-
-    model_config = ConfigDict(validate_by_name=True)
 
     prompt: ClassVar[GapTranslationPrompt] = _BASE_PROMPT
     """Text and field aliases for LLM correspondence."""

--- a/scinoephile/llms/guided_review/manager.py
+++ b/scinoephile/llms/guided_review/manager.py
@@ -36,6 +36,8 @@ class GuidedReviewManager(Manager):
     """Stable operation identifier used in persistence and CLIs."""
     base_prompt: ClassVar[GuidedReviewPrompt] = GuidedReviewPrompt()
     """Base prompt defining persisted test-case field names."""
+    test_case_base_cls: ClassVar[type[TestCase]] = GuidedReviewTestCase
+    """Static test-case model defining guided review's semantic shape."""
 
     @classmethod
     @cache
@@ -231,34 +233,6 @@ class GuidedReviewManager(Manager):
             __module__=GuidedReviewQuery.__module__,
             **fields,
         )
-
-    @classmethod
-    @cache
-    def get_test_case_cls(cls, prompt: GuidedReviewPrompt) -> type[TestCase]:
-        """Get concrete test-case class for a prompt-independent list shape.
-
-        Arguments:
-            prompt: text and field aliases for LLM correspondence
-        Returns:
-            test-case model class
-        """
-        query_cls = cls.get_query_cls(prompt)
-        answer_cls = cls.get_answer_cls(prompt)
-        fields = cls.get_test_case_fields(query_cls, answer_cls, prompt)
-        validators = cls.get_test_case_validators()
-        model = create_model(
-            get_model_name("GuidedReviewTestCase", prompt.name),
-            __base__=GuidedReviewTestCase,
-            __module__=GuidedReviewTestCase.__module__,
-            __validators__=validators,
-            **fields,
-        )
-        model.query_cls = cast(type[GuidedReviewQuery], query_cls)
-        model.answer_cls = cast(type[GuidedReviewAnswer], answer_cls)
-        model.prompt = prompt
-        setattr(model, "get_auto_verified", cls.get_auto_verified)
-        setattr(model, "get_min_difficulty", cls.get_min_difficulty)
-        return model
 
     @staticmethod
     def get_min_difficulty(model: TestCase) -> int:

--- a/scinoephile/llms/guided_review/models.py
+++ b/scinoephile/llms/guided_review/models.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import ClassVar, Self
 
-from pydantic import ConfigDict, Field, model_validator
+from pydantic import Field, model_validator
 
 from scinoephile.core.llms import (
     AnnotatedTestCaseSubtitle,
@@ -30,8 +30,6 @@ _BASE_PROMPT = GuidedReviewPrompt()
 
 class GuidedReviewQuery(Query):
     """Target and guide subtitles for guided review."""
-
-    model_config = ConfigDict(validate_by_name=True)
 
     prompt: ClassVar[GuidedReviewPrompt] = _BASE_PROMPT
     """Text and field aliases for LLM correspondence."""
@@ -59,8 +57,6 @@ class GuidedReviewQuery(Query):
 
 class GuidedReviewAnswer(Answer):
     """Sparse revisions for guided-review targets that require changes."""
-
-    model_config = ConfigDict(validate_by_name=True)
 
     prompt: ClassVar[GuidedReviewPrompt] = _BASE_PROMPT
     """Text and field aliases for LLM correspondence."""

--- a/scinoephile/llms/guided_translation/manager.py
+++ b/scinoephile/llms/guided_translation/manager.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from functools import cache
-from typing import Any, ClassVar, cast
+from typing import Any, ClassVar
 
 from pydantic import Field, create_model
 
@@ -35,6 +35,8 @@ class GuidedTranslationManager(Manager):
     """Stable operation identifier used in persistence and CLIs."""
     base_prompt: ClassVar[GuidedTranslationPrompt] = GuidedTranslationPrompt()
     """Base prompt defining persisted test-case field names."""
+    test_case_base_cls: ClassVar[type[TestCase]] = GuidedTranslationTestCase
+    """Static test-case model defining guided translation's semantic shape."""
 
     @classmethod
     @cache
@@ -223,31 +225,3 @@ class GuidedTranslationManager(Manager):
             __module__=GuidedTranslationQuery.__module__,
             **fields,
         )
-
-    @classmethod
-    @cache
-    def get_test_case_cls(cls, prompt: GuidedTranslationPrompt) -> type[TestCase]:
-        """Get concrete test-case class for a prompt-independent list shape.
-
-        Arguments:
-            prompt: text and field aliases for LLM correspondence
-        Returns:
-            test-case model class
-        """
-        query_cls = cls.get_query_cls(prompt)
-        answer_cls = cls.get_answer_cls(prompt)
-        fields = cls.get_test_case_fields(query_cls, answer_cls, prompt)
-        validators = cls.get_test_case_validators()
-        model = create_model(
-            get_model_name("GuidedTranslationTestCase", prompt.name),
-            __base__=GuidedTranslationTestCase,
-            __module__=GuidedTranslationTestCase.__module__,
-            __validators__=validators,
-            **fields,
-        )
-        model.query_cls = cast(type[GuidedTranslationQuery], query_cls)
-        model.answer_cls = cast(type[GuidedTranslationAnswer], answer_cls)
-        model.prompt = prompt
-        setattr(model, "get_auto_verified", cls.get_auto_verified)
-        setattr(model, "get_min_difficulty", cls.get_min_difficulty)
-        return model

--- a/scinoephile/llms/guided_translation/models.py
+++ b/scinoephile/llms/guided_translation/models.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import ClassVar, Self
 
-from pydantic import ConfigDict, Field, model_validator
+from pydantic import Field, model_validator
 
 from scinoephile.core.llms import Answer, Query, TestCase, TestCaseSubtitle
 
@@ -32,8 +32,6 @@ class GuidedTranslationSubtitle(TestCaseSubtitle):
 
 class GuidedTranslationQuery(Query):
     """Subtitles to translate and guide subtitles from the same block."""
-
-    model_config = ConfigDict(validate_by_name=True)
 
     prompt: ClassVar[GuidedTranslationPrompt] = _BASE_PROMPT
     """Text and field aliases for LLM correspondence."""
@@ -61,8 +59,6 @@ class GuidedTranslationQuery(Query):
 
 class GuidedTranslationAnswer(Answer):
     """Translated outputs corresponding to query subtitles."""
-
-    model_config = ConfigDict(validate_by_name=True)
 
     prompt: ClassVar[GuidedTranslationPrompt] = _BASE_PROMPT
     """Text and field aliases for LLM correspondence."""

--- a/scinoephile/llms/punctuation/manager.py
+++ b/scinoephile/llms/punctuation/manager.py
@@ -9,7 +9,7 @@ from typing import Any, ClassVar
 
 from pydantic import Field, create_model, model_validator
 
-from scinoephile.core.llms import Answer, Manager, Query, TestCase
+from scinoephile.core.llms import Answer, Manager, Query
 from scinoephile.core.llms.models import get_model_name
 
 from .prompt import PunctuationPrompt
@@ -98,17 +98,6 @@ class PunctuationManager(Manager):
         )
         model.prompt = prompt
         return model
-
-    @classmethod
-    def get_test_case_cls_from_data(cls, data: dict) -> type[TestCase]:
-        """Get concrete test case class for canonical serialized data.
-
-        Arguments:
-            data: data from JSON
-        Returns:
-            test case model class
-        """
-        return cls.get_test_case_cls(cls.base_prompt)
 
     @staticmethod
     def validate_query(model: Query) -> Query:

--- a/scinoephile/llms/review/manager.py
+++ b/scinoephile/llms/review/manager.py
@@ -36,6 +36,8 @@ class ReviewManager(Manager):
     """Stable operation identifier used in persistence and CLIs."""
     base_prompt: ClassVar[ReviewPrompt] = ReviewPrompt()
     """Base prompt defining persisted test-case field names."""
+    test_case_base_cls: ClassVar[type[TestCase]] = ReviewTestCase
+    """Static test-case model defining review's semantic shape."""
 
     @classmethod
     @cache
@@ -185,34 +187,6 @@ class ReviewManager(Manager):
             __module__=ReviewQuery.__module__,
             **fields,
         )
-
-    @classmethod
-    @cache
-    def get_test_case_cls(cls, prompt: ReviewPrompt) -> type[TestCase]:
-        """Get concrete test-case class for a prompt-independent list shape.
-
-        Arguments:
-            prompt: text and field aliases for LLM correspondence
-        Returns:
-            test-case model class
-        """
-        query_cls = cls.get_query_cls(prompt)
-        answer_cls = cls.get_answer_cls(prompt)
-        fields = cls.get_test_case_fields(query_cls, answer_cls, prompt)
-        validators = cls.get_test_case_validators()
-        model = create_model(
-            get_model_name("ReviewTestCase", prompt.name),
-            __base__=ReviewTestCase,
-            __module__=ReviewTestCase.__module__,
-            __validators__=validators,
-            **fields,
-        )
-        model.query_cls = cast(type[ReviewQuery], query_cls)
-        model.answer_cls = cast(type[ReviewAnswer], answer_cls)
-        model.prompt = prompt
-        setattr(model, "get_auto_verified", cls.get_auto_verified)
-        setattr(model, "get_min_difficulty", cls.get_min_difficulty)
-        return model
 
     @staticmethod
     def get_min_difficulty(model: TestCase) -> int:

--- a/scinoephile/llms/review/models.py
+++ b/scinoephile/llms/review/models.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import ClassVar, Self
 
-from pydantic import ConfigDict, Field, model_validator
+from pydantic import Field, model_validator
 
 from scinoephile.core.llms import (
     AnnotatedTestCaseSubtitle,
@@ -31,8 +31,6 @@ _BASE_PROMPT = ReviewPrompt()
 class ReviewQuery(Query):
     """Subtitles to review."""
 
-    model_config = ConfigDict(validate_by_name=True)
-
     prompt: ClassVar[ReviewPrompt] = _BASE_PROMPT
     """Text and field aliases for LLM correspondence."""
     subtitles: list[TestCaseSubtitle] = Field(min_length=1)
@@ -49,8 +47,6 @@ class ReviewQuery(Query):
 
 class ReviewAnswer(Answer):
     """Sparse revisions for subtitles that require changes."""
-
-    model_config = ConfigDict(validate_by_name=True)
 
     prompt: ClassVar[ReviewPrompt] = _BASE_PROMPT
     """Text and field aliases for LLM correspondence."""

--- a/scinoephile/llms/translation/manager.py
+++ b/scinoephile/llms/translation/manager.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from functools import cache
-from typing import Any, ClassVar, cast
+from typing import Any, ClassVar
 
 from pydantic import Field, create_model
 
@@ -36,6 +36,8 @@ class TranslationManager(Manager):
     """Stable operation identifier used in persistence and CLIs."""
     base_prompt: ClassVar[TranslationPrompt] = TranslationPrompt()
     """Base prompt defining persisted test-case field names."""
+    test_case_base_cls: ClassVar[type[TestCase]] = TranslationTestCase
+    """Static test-case model defining translation's semantic shape."""
 
     @classmethod
     @cache
@@ -171,31 +173,3 @@ class TranslationManager(Manager):
             __module__=TranslationQuery.__module__,
             **fields,
         )
-
-    @classmethod
-    @cache
-    def get_test_case_cls(cls, prompt: TranslationPrompt) -> type[TestCase]:
-        """Get concrete test-case class for a prompt-independent list shape.
-
-        Arguments:
-            prompt: text and field aliases for LLM correspondence
-        Returns:
-            test-case model class
-        """
-        query_cls = cls.get_query_cls(prompt)
-        answer_cls = cls.get_answer_cls(prompt)
-        fields = cls.get_test_case_fields(query_cls, answer_cls, prompt)
-        validators = cls.get_test_case_validators()
-        model = create_model(
-            get_model_name("TranslationTestCase", prompt.name),
-            __base__=TranslationTestCase,
-            __module__=TranslationTestCase.__module__,
-            __validators__=validators,
-            **fields,
-        )
-        model.query_cls = cast(type[TranslationQuery], query_cls)
-        model.answer_cls = cast(type[TranslationAnswer], answer_cls)
-        model.prompt = prompt
-        setattr(model, "get_auto_verified", cls.get_auto_verified)
-        setattr(model, "get_min_difficulty", cls.get_min_difficulty)
-        return model

--- a/scinoephile/llms/translation/models.py
+++ b/scinoephile/llms/translation/models.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import ClassVar, Self
 
-from pydantic import ConfigDict, Field, model_validator
+from pydantic import Field, model_validator
 
 from scinoephile.core.llms import Answer, Query, TestCase, TestCaseSubtitle
 
@@ -33,8 +33,6 @@ class TranslationOutput(TestCaseSubtitle):
 class TranslationQuery(Query):
     """Subtitles to translate."""
 
-    model_config = ConfigDict(validate_by_name=True)
-
     prompt: ClassVar[TranslationPrompt] = _BASE_PROMPT
     """Text and field aliases for LLM correspondence."""
     subtitles: list[TestCaseSubtitle] = Field(min_length=1)
@@ -51,8 +49,6 @@ class TranslationQuery(Query):
 
 class TranslationAnswer(Answer):
     """Translated subtitles."""
-
-    model_config = ConfigDict(validate_by_name=True)
 
     prompt: ClassVar[TranslationPrompt] = _BASE_PROMPT
     """Text and field aliases for LLM correspondence."""

--- a/scinoephile/optimization/persistence/test_cases/persisted_test_case.py
+++ b/scinoephile/optimization/persistence/test_cases/persisted_test_case.py
@@ -54,8 +54,7 @@ class PersistedTestCase:
         """
         if test_case.answer is None:
             raise ScinoephileError("Optimization test cases must include an answer.")
-        base_test_case_cls = manager_cls.get_test_case_cls_with_prompt(
-            type(test_case),
+        base_test_case_cls = manager_cls.get_test_case_cls(
             manager_cls.base_prompt,
         )
         base_test_case = remap_test_case(test_case, base_test_case_cls)

--- a/scinoephile/optimization/persistence/test_cases/sync.py
+++ b/scinoephile/optimization/persistence/test_cases/sync.py
@@ -144,7 +144,7 @@ def _normalize_test_case(
     Raises:
         ScinoephileError: if the payload contains fields outside the prompt schema
     """
-    test_case_cls = manager_cls.get_test_case_cls_from_data(data)
+    test_case_cls = manager_cls.get_test_case_cls(manager_cls.base_prompt)
     test_case = test_case_cls.model_validate(data, strict=True, extra="forbid")
     return PersistedTestCase.from_test_case(
         test_case,

--- a/test/core/llms/test_manager.py
+++ b/test/core/llms/test_manager.py
@@ -1,0 +1,86 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests for shared LLM manager class factories."""
+
+from __future__ import annotations
+
+from scinoephile.llms.punctuation import PunctuationManager, PunctuationPrompt
+from scinoephile.llms.review import ReviewManager, ReviewPrompt, ReviewTestCase
+
+_LOCALIZED_REVIEW_PROMPT = ReviewPrompt(
+    subtitles="zimu",
+    revisions="xiugai",
+    index="xuhao",
+    text="wenben",
+    note="beizhu",
+)
+"""Review prompt using localized correspondence field names."""
+
+_ALTERNATIVE_REVIEW_PROMPT = ReviewPrompt(
+    subtitles="sources",
+    revisions="corrections",
+    index="position",
+    text="content",
+    note="explanation",
+)
+"""Review prompt using alternative correspondence field names."""
+
+_LOCALIZED_PUNCTUATION_PROMPT = PunctuationPrompt(
+    src_1="source_one",
+    src_2="source_two",
+    output="result",
+)
+"""Punctuation prompt using non-default correspondence field names."""
+
+
+def test_static_shape_factory_caches_and_isolates_prompt_aliases():
+    """Static-shape classes should be cached without sharing prompt aliases."""
+    localized_cls = ReviewManager.get_test_case_cls(_LOCALIZED_REVIEW_PROMPT)
+    alternative_cls = ReviewManager.get_test_case_cls(_ALTERNATIVE_REVIEW_PROMPT)
+
+    assert ReviewManager.get_test_case_cls(_LOCALIZED_REVIEW_PROMPT) is localized_cls
+    assert localized_cls is not alternative_cls
+    assert issubclass(localized_cls, ReviewTestCase)
+    assert localized_cls.query_cls.model_fields["subtitles"].alias == "zimu"
+    assert alternative_cls.query_cls.model_fields["subtitles"].alias == "sources"
+
+    test_case = localized_cls.model_validate(
+        {
+            "query": {"subtitles": [{"index": 1, "text": "original"}]},
+            "answer": {
+                "revisions": [{"index": 1, "text": "corrected", "note": "typo"}]
+            },
+        }
+    )
+    assert test_case.query.model_dump(by_alias=True) == {
+        "zimu": [{"xuhao": 1, "wenben": "original"}]
+    }
+    assert test_case.answer is not None
+    assert test_case.answer.model_dump(by_alias=True) == {
+        "xiugai": [{"xuhao": 1, "wenben": "corrected", "beizhu": "typo"}]
+    }
+
+
+def test_legacy_factory_preserves_prompt_shaped_models():
+    """Legacy managers should retain prompt-named Python model fields."""
+    test_case_cls = PunctuationManager.get_test_case_cls(_LOCALIZED_PUNCTUATION_PROMPT)
+
+    assert (
+        PunctuationManager.get_test_case_cls(_LOCALIZED_PUNCTUATION_PROMPT)
+        is test_case_cls
+    )
+    assert set(test_case_cls.query_cls.model_fields) == {"source_one", "source_two"}
+    assert set(test_case_cls.answer_cls.model_fields) == {"result"}
+
+    test_case = test_case_cls.model_validate(
+        {
+            "query": {"source_one": ["Hello"], "source_two": "Hello"},
+            "answer": {"result": "Hello"},
+        }
+    )
+    assert test_case.query.model_dump() == {
+        "source_one": ["Hello"],
+        "source_two": "Hello",
+    }
+    assert test_case.answer is not None
+    assert test_case.answer.model_dump() == {"result": "Hello"}


### PR DESCRIPTION
## Summary

- centralize prompt-bound test-case creation in `Manager`
- give migrated operations a static `test_case_base_cls`
- remove obsolete data/shape wrapper methods and simplify every caller
- inherit `validate_by_name=True` from core query and answer models
- retain and test the legacy fixed-shape compatibility seam

## Why

After all variable-cardinality shapes moved to static list models, their manager factories and persistence wrappers performed the same work repeatedly. This leaves one factory path while preserving the remaining fixed-shape migrations.

## Validation

- `ruff format` and `ruff check --fix`
- `ty check`
- focused tests: 49 passed
- full suite: 1,495 passed, 9 skipped
- independent cross-review: 85 targeted tests passed; 7,225 legacy fixed-shape fixture cases loaded; no findings