### PR TITLE
Enforce static test case invariants

### DIFF
--- a/scinoephile/core/llms/manager.py
+++ b/scinoephile/core/llms/manager.py
@@ -64,7 +64,11 @@ class Manager(ABC):
         query_cls = cls.get_query_cls(prompt)
         answer_cls = cls.get_answer_cls(prompt)
         fields = cls.get_test_case_fields(query_cls, answer_cls, prompt)
-        validators = cls.get_test_case_validators()
+        legacy_test_case = cls.test_case_base_cls is TestCase
+        if legacy_test_case:
+            validators = cls.get_test_case_validators()
+        else:
+            validators = {}
 
         model = create_model(
             get_model_name(cls.test_case_base_cls.__name__, prompt.name),
@@ -76,8 +80,9 @@ class Manager(ABC):
         model.query_cls = query_cls
         model.answer_cls = answer_cls
         model.prompt = prompt
-        setattr(model, "get_auto_verified", cls.get_auto_verified)
-        setattr(model, "get_min_difficulty", cls.get_min_difficulty)
+        if legacy_test_case:
+            setattr(model, "get_auto_verified", cls.get_auto_verified)
+            setattr(model, "get_min_difficulty", cls.get_min_difficulty)
         return model
 
     @classmethod
@@ -122,24 +127,9 @@ class Manager(ABC):
             validators dictionary for create_model
         """
         validators: dict[str, Any] = {
-            "enforce_min_difficulty": model_validator(mode="after")(
-                cls.enforce_min_difficulty
-            ),
             "validate_test_case": model_validator(mode="after")(cls.validate_test_case),
         }
         return validators
-
-    @staticmethod
-    def enforce_min_difficulty(model: TestCase) -> TestCase:
-        """Ensure difficulty reflects few-shot/split status if not already higher.
-
-        Arguments:
-            model: test case to validate
-        Returns:
-            validated test case
-        """
-        model.difficulty = max(model.difficulty, model.get_min_difficulty())
-        return model
 
     @staticmethod
     def get_auto_verified(model: TestCase) -> bool:

--- a/scinoephile/core/llms/test_case.py
+++ b/scinoephile/core/llms/test_case.py
@@ -6,9 +6,9 @@ from __future__ import annotations
 
 import json
 from abc import ABC
-from typing import ClassVar
+from typing import ClassVar, Self
 
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 from .answer import Answer
 from .prompt import Prompt
@@ -43,6 +43,16 @@ class TestCase(BaseModel, ABC):
     def __str__(self) -> str:
         """String representation."""
         return json.dumps(self.model_dump(), indent=2, ensure_ascii=False)
+
+    @model_validator(mode="after")
+    def enforce_min_difficulty(self) -> Self:
+        """Ensure difficulty is at least the model-defined minimum.
+
+        Returns:
+            validated test case
+        """
+        self.difficulty = max(self.difficulty, self.get_min_difficulty())
+        return self
 
     def get_auto_verified(self) -> bool:
         """Whether this test case should automatically be verified.

--- a/scinoephile/llms/gap_translation/manager.py
+++ b/scinoephile/llms/gap_translation/manager.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from functools import cache
-from typing import Any, ClassVar, cast
+from typing import Any, ClassVar
 
 from pydantic import Field, create_model
 
@@ -222,28 +222,3 @@ class GapTranslationManager(Manager):
             __module__=GapTranslationQuery.__module__,
             **fields,
         )
-
-    @staticmethod
-    def validate_test_case(model: TestCase) -> TestCase:
-        """Ensure outputs exactly fill the guide indexes absent from targets.
-
-        Arguments:
-            model: test case to validate
-        Returns:
-            validated test case
-        """
-        gap_model = cast(GapTranslationTestCase, model)
-        if gap_model.answer is None:
-            return model
-
-        target_indexes = {target.index for target in gap_model.query.targets}
-        expected_output_indexes = [
-            guide.index
-            for guide in gap_model.query.guides
-            if guide.index not in target_indexes
-        ]
-        output_indexes = [output.index for output in gap_model.answer.outputs]
-        if output_indexes != expected_output_indexes:
-            prompt: GapTranslationPrompt = getattr(model, "prompt")
-            raise ValueError(prompt.output_indices_mismatch_err)
-        return model

--- a/scinoephile/llms/gap_translation/models.py
+++ b/scinoephile/llms/gap_translation/models.py
@@ -93,3 +93,24 @@ class GapTranslationTestCase(TestCase):
     """Sparse targets and complete guides."""
     answer: GapTranslationAnswer | None = None
     """Translations for target gaps, if available."""
+
+    @model_validator(mode="after")
+    def validate_output_correspondence(self) -> Self:
+        """Ensure outputs exactly fill the guide indexes absent from targets.
+
+        Returns:
+            validated test case
+        """
+        if self.answer is None:
+            return self
+
+        target_indexes = {target.index for target in self.query.targets}
+        expected_output_indexes = [
+            guide.index
+            for guide in self.query.guides
+            if guide.index not in target_indexes
+        ]
+        output_indexes = [output.index for output in self.answer.outputs]
+        if output_indexes != expected_output_indexes:
+            raise ValueError(self.prompt.output_indices_mismatch_err)
+        return self

--- a/scinoephile/llms/guided_review/manager.py
+++ b/scinoephile/llms/guided_review/manager.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from functools import cache
-from typing import Any, ClassVar, cast
+from typing import Any, ClassVar
 
 from pydantic import Field, create_model
 
@@ -233,45 +233,3 @@ class GuidedReviewManager(Manager):
             __module__=GuidedReviewQuery.__module__,
             **fields,
         )
-
-    @staticmethod
-    def get_min_difficulty(model: TestCase) -> int:
-        """Get minimum difficulty based on whether any target is revised.
-
-        Arguments:
-            model: test case to inspect
-        Returns:
-            minimum difficulty
-        """
-        guided_review_model = cast(GuidedReviewTestCase, model)
-        if (
-            guided_review_model.answer is not None
-            and guided_review_model.answer.revisions
-        ):
-            return 1
-        return 0
-
-    @staticmethod
-    def validate_test_case(model: TestCase) -> TestCase:
-        """Ensure every answer revision changes a query target.
-
-        Arguments:
-            model: test case to validate
-        Returns:
-            validated test case
-        """
-        guided_review_model = cast(GuidedReviewTestCase, model)
-        if guided_review_model.answer is None:
-            return model
-
-        prompt: GuidedReviewPrompt = getattr(model, "prompt")
-        target_text_by_index = {
-            target.index: target.text for target in guided_review_model.query.targets
-        }
-        for revision in guided_review_model.answer.revisions:
-            target_text = target_text_by_index.get(revision.index)
-            if target_text is None:
-                raise ValueError(prompt.revision_index_missing_err(revision.index))
-            if revision.text == target_text:
-                raise ValueError(prompt.revision_unmodified_err(revision.index))
-        return model

--- a/scinoephile/llms/guided_review/models.py
+++ b/scinoephile/llms/guided_review/models.py
@@ -85,3 +85,35 @@ class GuidedReviewTestCase(TestCase):
     """Target and guide subtitles."""
     answer: GuidedReviewAnswer | None = None
     """Sparse target revisions, if available."""
+
+    def get_min_difficulty(self) -> int:
+        """Get minimum difficulty based on whether any target is revised.
+
+        Returns:
+            minimum difficulty
+        """
+        min_difficulty = super().get_min_difficulty()
+        if self.answer is not None and self.answer.revisions:
+            min_difficulty = max(min_difficulty, 1)
+        return min_difficulty
+
+    @model_validator(mode="after")
+    def validate_revision_correspondence(self) -> Self:
+        """Ensure every answer revision changes a query target.
+
+        Returns:
+            validated test case
+        """
+        if self.answer is None:
+            return self
+
+        target_text_by_index = {
+            target.index: target.text for target in self.query.targets
+        }
+        for revision in self.answer.revisions:
+            target_text = target_text_by_index.get(revision.index)
+            if target_text is None:
+                raise ValueError(self.prompt.revision_index_missing_err(revision.index))
+            if revision.text == target_text:
+                raise ValueError(self.prompt.revision_unmodified_err(revision.index))
+        return self

--- a/scinoephile/llms/review/manager.py
+++ b/scinoephile/llms/review/manager.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from functools import cache
-from typing import Any, ClassVar, cast
+from typing import Any, ClassVar
 
 from pydantic import Field, create_model
 
@@ -187,42 +187,3 @@ class ReviewManager(Manager):
             __module__=ReviewQuery.__module__,
             **fields,
         )
-
-    @staticmethod
-    def get_min_difficulty(model: TestCase) -> int:
-        """Get minimum difficulty based on whether any subtitle is revised.
-
-        Arguments:
-            model: test case to inspect
-        Returns:
-            minimum difficulty
-        """
-        review_model = cast(ReviewTestCase, model)
-        if review_model.answer is not None and review_model.answer.revisions:
-            return 1
-        return 0
-
-    @staticmethod
-    def validate_test_case(model: TestCase) -> TestCase:
-        """Ensure every answer revision changes a query subtitle.
-
-        Arguments:
-            model: test case to validate
-        Returns:
-            validated test case
-        """
-        review_model = cast(ReviewTestCase, model)
-        if review_model.answer is None:
-            return model
-
-        prompt: ReviewPrompt = getattr(model, "prompt")
-        query_text_by_index = {
-            subtitle.index: subtitle.text for subtitle in review_model.query.subtitles
-        }
-        for revision in review_model.answer.revisions:
-            input_text = query_text_by_index.get(revision.index)
-            if input_text is None:
-                raise ValueError(prompt.revision_index_missing_err(revision.index))
-            if revision.text == input_text:
-                raise ValueError(prompt.revision_unmodified_err(revision.index))
-        return model

--- a/scinoephile/llms/review/models.py
+++ b/scinoephile/llms/review/models.py
@@ -75,3 +75,35 @@ class ReviewTestCase(TestCase):
     """Subtitles to review."""
     answer: ReviewAnswer | None = None
     """Sparse subtitle revisions, if available."""
+
+    def get_min_difficulty(self) -> int:
+        """Get minimum difficulty based on whether any subtitle is revised.
+
+        Returns:
+            minimum difficulty
+        """
+        min_difficulty = super().get_min_difficulty()
+        if self.answer is not None and self.answer.revisions:
+            min_difficulty = max(min_difficulty, 1)
+        return min_difficulty
+
+    @model_validator(mode="after")
+    def validate_revision_correspondence(self) -> Self:
+        """Ensure every answer revision changes a query subtitle.
+
+        Returns:
+            validated test case
+        """
+        if self.answer is None:
+            return self
+
+        query_text_by_index = {
+            subtitle.index: subtitle.text for subtitle in self.query.subtitles
+        }
+        for revision in self.answer.revisions:
+            input_text = query_text_by_index.get(revision.index)
+            if input_text is None:
+                raise ValueError(self.prompt.revision_index_missing_err(revision.index))
+            if revision.text == input_text:
+                raise ValueError(self.prompt.revision_unmodified_err(revision.index))
+        return self

--- a/test/core/llms/test_manager.py
+++ b/test/core/llms/test_manager.py
@@ -4,6 +4,9 @@
 
 from __future__ import annotations
 
+from pytest import raises
+
+from scinoephile.core.llms import TestCase
 from scinoephile.llms.punctuation import PunctuationManager, PunctuationPrompt
 from scinoephile.llms.review import ReviewManager, ReviewPrompt, ReviewTestCase
 
@@ -31,6 +34,50 @@ _LOCALIZED_PUNCTUATION_PROMPT = PunctuationPrompt(
     output="result",
 )
 """Punctuation prompt using non-default correspondence field names."""
+
+
+class _LegacyPunctuationManager(PunctuationManager):
+    """Legacy manager fixture with test-case callbacks."""
+
+    @staticmethod
+    def get_auto_verified(model: TestCase) -> bool:
+        """Automatically verify test cases that include an answer.
+
+        Arguments:
+            model: test case to inspect
+        Returns:
+            whether the test case should be automatically verified
+        """
+        return model.answer is not None
+
+    @staticmethod
+    def get_min_difficulty(model: TestCase) -> int:
+        """Require difficulty two for test cases that include an answer.
+
+        Arguments:
+            model: test case to inspect
+        Returns:
+            minimum difficulty
+        """
+        if model.answer is not None:
+            return 2
+        return 0
+
+    @staticmethod
+    def validate_test_case(model: TestCase) -> TestCase:
+        """Reject the sentinel invalid output.
+
+        Arguments:
+            model: test case to validate
+        Returns:
+            validated test case
+        """
+        if model.answer is None:
+            return model
+        prompt: PunctuationPrompt = getattr(model, "prompt")
+        if getattr(model.answer, prompt.output) == "invalid":
+            raise ValueError("Legacy test-case validator was called.")
+        return model
 
 
 def test_static_shape_factory_caches_and_isolates_prompt_aliases():
@@ -84,3 +131,27 @@ def test_legacy_factory_preserves_prompt_shaped_models():
     }
     assert test_case.answer is not None
     assert test_case.answer.model_dump() == {"result": "Hello"}
+
+
+def test_legacy_factory_preserves_manager_callbacks():
+    """Legacy test-case classes should retain manager-defined behavior."""
+    test_case_cls = _LegacyPunctuationManager.get_test_case_cls(
+        _LOCALIZED_PUNCTUATION_PROMPT
+    )
+
+    test_case = test_case_cls.model_validate(
+        {
+            "query": {"source_one": ["Hello"], "source_two": "Hello"},
+            "answer": {"result": "Hello"},
+        }
+    )
+
+    assert test_case.difficulty == 2
+    assert test_case.get_auto_verified()
+    with raises(ValueError, match="Legacy test-case validator was called"):
+        test_case_cls.model_validate(
+            {
+                "query": {"source_one": ["Hello"], "source_two": "Hello"},
+                "answer": {"result": "invalid"},
+            }
+        )

--- a/test/core/llms/test_test_case.py
+++ b/test/core/llms/test_test_case.py
@@ -1,0 +1,57 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests for the core LLM test-case model."""
+
+from __future__ import annotations
+
+from scinoephile.core.llms import Answer, Prompt, Query, TestCase
+
+_PROMPT = Prompt()
+"""Prompt fixture for core test-case models."""
+
+
+class _Query(Query):
+    """Query fixture for core test-case models."""
+
+    text: str
+    """Query text."""
+
+
+class _Answer(Answer):
+    """Answer fixture for core test-case models."""
+
+    text: str
+    """Answer text."""
+
+
+class _TestCase(TestCase):
+    """Test-case fixture with a nonzero minimum difficulty."""
+
+    query: _Query
+    """Query fixture."""
+    answer: _Answer | None = None
+    """Optional answer fixture."""
+
+    def get_min_difficulty(self) -> int:
+        """Get the fixture's minimum difficulty.
+
+        Returns:
+            minimum difficulty
+        """
+        return 2
+
+
+_Query.prompt = _PROMPT
+_Answer.prompt = _PROMPT
+_TestCase.query_cls = _Query
+_TestCase.answer_cls = _Answer
+_TestCase.prompt = _PROMPT
+
+
+def test_test_case_enforces_minimum_difficulty_without_lowering_higher_values():
+    """Validation should floor difficulty without lowering an explicit value."""
+    minimum = _TestCase.model_validate({"query": {"text": "query"}, "difficulty": 0})
+    higher = _TestCase.model_validate({"query": {"text": "query"}, "difficulty": 3})
+
+    assert minimum.difficulty == 2
+    assert higher.difficulty == 3

--- a/test/llms/test_gap_translation.py
+++ b/test/llms/test_gap_translation.py
@@ -10,7 +10,7 @@ from typing import cast
 from unittest.mock import Mock
 
 from pydantic import ValidationError
-from pytest import raises
+from pytest import mark, raises
 
 from scinoephile import common
 from scinoephile.core import Language
@@ -228,11 +228,18 @@ def test_gap_translation_preserves_unbounded_text():
     answer_cls.model_validate({"outputs": [{"index": 2, "text": long_text}]})
 
 
-def test_test_case_requires_outputs_to_exactly_fill_gaps():
+@mark.parametrize(
+    "test_case_cls",
+    [
+        GapTranslationTestCase,
+        GapTranslationManager.get_test_case_cls(GapTranslationManager.base_prompt),
+    ],
+    ids=["static", "generated"],
+)
+def test_test_case_requires_outputs_to_exactly_fill_gaps(
+    test_case_cls: type[GapTranslationTestCase],
+):
     """Output indexes should exactly complement target indexes within guides."""
-    test_case_cls = GapTranslationManager.get_test_case_cls(
-        GapTranslationManager.base_prompt
-    )
     query = {
         "targets": [{"index": 1, "text": "one"}],
         "guides": [
@@ -250,19 +257,16 @@ def test_test_case_requires_outputs_to_exactly_fill_gaps():
             }
         )
 
-    test_case = cast(
-        GapTranslationTestCase,
-        test_case_cls.model_validate(
-            {
-                "query": query,
-                "answer": {
-                    "outputs": [
-                        {"index": 2, "text": "translated two"},
-                        {"index": 3, "text": "translated three"},
-                    ]
-                },
-            }
-        ),
+    test_case = test_case_cls.model_validate(
+        {
+            "query": query,
+            "answer": {
+                "outputs": [
+                    {"index": 2, "text": "translated two"},
+                    {"index": 3, "text": "translated three"},
+                ]
+            },
+        }
     )
     assert test_case.answer is not None
     assert [output.index for output in test_case.answer.outputs] == [2, 3]

--- a/test/llms/test_guided_review_models.py
+++ b/test/llms/test_guided_review_models.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from unittest.mock import Mock
 
 from pydantic import ValidationError
-from pytest import raises
+from pytest import mark, raises
 
 from scinoephile.core import Language
 from scinoephile.core.llms import LLMProvider, Queryer
@@ -22,6 +22,7 @@ from scinoephile.llms.guided_review import (
     GuidedReviewManager,
     GuidedReviewProcessor,
     GuidedReviewPrompt,
+    GuidedReviewTestCase,
 )
 
 _LOCALIZED_PROMPT = GuidedReviewPrompt(
@@ -162,11 +163,18 @@ def test_answer_requires_sparse_ordered_annotated_revisions():
         answer_cls.model_validate({"revisions": [{"index": 1, "text": "revision"}]})
 
 
-def test_test_case_rejects_missing_and_unmodified_revision_indexes():
+@mark.parametrize(
+    "test_case_cls",
+    [
+        GuidedReviewTestCase,
+        GuidedReviewManager.get_test_case_cls(GuidedReviewManager.base_prompt),
+    ],
+    ids=["static", "generated"],
+)
+def test_test_case_rejects_missing_and_unmodified_revision_indexes(
+    test_case_cls: type[GuidedReviewTestCase],
+):
     """Revisions should target and modify query target subtitles."""
-    test_case_cls = GuidedReviewManager.get_test_case_cls(
-        GuidedReviewManager.base_prompt
-    )
     query = {
         "targets": [{"index": 1, "text": "original"}],
         "guides": [{"index": 1, "text": "guide"}],
@@ -190,6 +198,31 @@ def test_test_case_rejects_missing_and_unmodified_revision_indexes():
                 },
             }
         )
+
+
+@mark.parametrize(
+    "test_case_cls",
+    [
+        GuidedReviewTestCase,
+        GuidedReviewManager.get_test_case_cls(GuidedReviewManager.base_prompt),
+    ],
+    ids=["static", "generated"],
+)
+def test_revisions_raise_minimum_difficulty(
+    test_case_cls: type[GuidedReviewTestCase],
+):
+    """A nonempty revisions list should require difficulty one."""
+    test_case = test_case_cls.model_validate(
+        {
+            "query": {
+                "targets": [{"index": 1, "text": "original"}],
+                "guides": [],
+            },
+            "answer": {"revisions": [{"index": 1, "text": "revised", "note": "typo"}]},
+        }
+    )
+
+    assert test_case.difficulty == 1
 
 
 def test_list_cardinality_does_not_change_model_class():

--- a/test/llms/test_guided_translation.py
+++ b/test/llms/test_guided_translation.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from unittest.mock import Mock
 
 from pydantic import ValidationError
-from pytest import raises
+from pytest import mark, raises
 
 from scinoephile.core import Language
 from scinoephile.core.llms import LLMProvider
@@ -22,6 +22,7 @@ from scinoephile.llms.guided_translation import (
     GuidedTranslationManager,
     GuidedTranslationProcessor,
     GuidedTranslationPrompt,
+    GuidedTranslationTestCase,
 )
 
 _LOCALIZED_PROMPT = GuidedTranslationPrompt(
@@ -104,12 +105,20 @@ def test_query_and_answer_require_consecutive_ordered_indexes():
     answer_cls.model_validate({"outputs": [{"index": 1, "text": long_text}]})
 
 
-def test_outputs_must_correspond_to_query_subtitles():
+@mark.parametrize(
+    "test_case_cls",
+    [
+        GuidedTranslationTestCase,
+        GuidedTranslationManager.get_test_case_cls(
+            GuidedTranslationManager.base_prompt
+        ),
+    ],
+    ids=["static", "generated"],
+)
+def test_outputs_must_correspond_to_query_subtitles(
+    test_case_cls: type[GuidedTranslationTestCase],
+):
     """Every query subtitle should have exactly one same-index output."""
-    test_case_cls = GuidedTranslationManager.get_test_case_cls(
-        GuidedTranslationManager.base_prompt
-    )
-
     with raises(ValidationError, match="correspond exactly"):
         test_case_cls.model_validate(
             {

--- a/test/llms/test_legacy_test_case_callbacks.py
+++ b/test/llms/test_legacy_test_case_callbacks.py
@@ -1,0 +1,122 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests for legacy manager-defined test-case callbacks."""
+
+from __future__ import annotations
+
+from pydantic import ValidationError
+from pytest import raises
+
+from scinoephile.llms.delineation import DelineationManager
+from scinoephile.llms.ocr_fusion import OcrFusionManager
+from scinoephile.llms.pairwise_review import PairwiseReviewManager
+from scinoephile.multilang.yue_zho.transcription.punctuation import (
+    YuePunctuationVsZhoPromptYueHans,
+    YueZhoPunctuationManager,
+)
+
+
+def test_pairwise_review_retains_validation_and_minimum_difficulty():
+    """Pairwise review should normalize unchanged output and score revisions."""
+    test_case_cls = PairwiseReviewManager.get_test_case_cls(
+        PairwiseReviewManager.base_prompt
+    )
+    unchanged = test_case_cls.model_validate(
+        {
+            "query": {"target": "original", "reference": "reference"},
+            "answer": {"output": "original", "note": "legacy"},
+        }
+    )
+    revised = test_case_cls.model_validate(
+        {
+            "query": {"target": "original", "reference": "reference"},
+            "answer": {"output": "corrected", "note": "typo"},
+        }
+    )
+
+    assert unchanged.answer is not None
+    assert unchanged.answer.model_dump() == {"output": "", "note": ""}
+    assert unchanged.difficulty == 0
+    assert revised.difficulty == 1
+    with raises(ValidationError, match="no note is provided"):
+        test_case_cls.model_validate(
+            {
+                "query": {"target": "original", "reference": "reference"},
+                "answer": {"output": "corrected", "note": ""},
+            }
+        )
+
+
+def test_ocr_fusion_retains_auto_verification_and_minimum_difficulty():
+    """OCR fusion should retain its legacy difficulty and verification rules."""
+    test_case_cls = OcrFusionManager.get_test_case_cls(OcrFusionManager.base_prompt)
+    simple = test_case_cls.model_validate(
+        {
+            "query": {"one": "source one", "two": "source two"},
+            "answer": {"output": "source one", "note": "selected source one"},
+        }
+    )
+    complex_case = test_case_cls.model_validate(
+        {
+            "query": {"one": "source-one", "two": "source two"},
+            "answer": {"output": "source-one", "note": "selected source one"},
+        }
+    )
+
+    assert simple.difficulty == 1
+    assert simple.get_auto_verified()
+    assert complex_case.difficulty == 2
+    assert not complex_case.get_auto_verified()
+
+
+def test_punctuation_retains_validation_and_minimum_difficulty():
+    """Localized punctuation should retain its manager-defined test-case rules."""
+    prompt = YuePunctuationVsZhoPromptYueHans
+    test_case_cls = YueZhoPunctuationManager.get_test_case_cls(prompt)
+    test_case = test_case_cls.model_validate(
+        {
+            "query": {prompt.src_1: ["你好"], prompt.src_2: "你好"},
+            "answer": {prompt.output: "你，好"},
+        }
+    )
+
+    assert test_case.difficulty == 2
+    with raises(ValidationError, match="does not match"):
+        test_case_cls.model_validate(
+            {
+                "query": {prompt.src_1: ["你好"], prompt.src_2: "你好"},
+                "answer": {prompt.output: "你壞"},
+            }
+        )
+
+
+def test_delineation_retains_validation_and_minimum_difficulty():
+    """Delineation should retain shifted-boundary validation and scoring."""
+    test_case_cls = DelineationManager.get_test_case_cls(DelineationManager.base_prompt)
+    query = {
+        "src_1_sub_1": "source one first",
+        "src_1_sub_2": "source one second",
+        "src_2_sub_1": "ab",
+        "src_2_sub_2": "cd",
+    }
+    shifted = test_case_cls.model_validate(
+        {
+            "query": query,
+            "answer": {
+                "src_2_sub_1_shifted": "abc",
+                "src_2_sub_2_shifted": "d",
+            },
+        }
+    )
+
+    assert shifted.difficulty == 1
+    with raises(ValidationError, match="are equal to query"):
+        test_case_cls.model_validate(
+            {
+                "query": query,
+                "answer": {
+                    "src_2_sub_1_shifted": "ab",
+                    "src_2_sub_2_shifted": "cd",
+                },
+            }
+        )

--- a/test/llms/test_review.py
+++ b/test/llms/test_review.py
@@ -8,11 +8,11 @@ import json
 from unittest.mock import Mock
 
 from pydantic import ValidationError
-from pytest import raises
+from pytest import mark, raises
 
 from scinoephile.core import Language
 from scinoephile.core.llms import LLMProvider, Queryer
-from scinoephile.llms.review import ReviewManager, ReviewPrompt
+from scinoephile.llms.review import ReviewManager, ReviewPrompt, ReviewTestCase
 
 _LOCALIZED_PROMPT = ReviewPrompt(
     language=Language.zho_hant,
@@ -21,6 +21,7 @@ _LOCALIZED_PROMPT = ReviewPrompt(
     index="xuhao",
     text="wenben",
     note="beizhu",
+    revision_index_missing_err_tpl="修訂序號 {idx} 未對應字幕。",
 )
 """Review prompt with Chinese correspondence field names."""
 
@@ -115,9 +116,18 @@ def test_answer_requires_unique_ordered_revision_indexes():
         )
 
 
-def test_test_case_rejects_missing_and_unmodified_revision_indexes():
+@mark.parametrize(
+    "test_case_cls",
+    [
+        ReviewTestCase,
+        ReviewManager.get_test_case_cls(ReviewManager.base_prompt),
+    ],
+    ids=["static", "generated"],
+)
+def test_test_case_rejects_missing_and_unmodified_revision_indexes(
+    test_case_cls: type[ReviewTestCase],
+):
     """Revisions should target and modify query subtitles."""
-    test_case_cls = ReviewManager.get_test_case_cls(ReviewManager.base_prompt)
     query = {"subtitles": [{"index": 1, "text": "original"}]}
 
     with raises(ValidationError, match="does not correspond to a query subtitle"):
@@ -140,9 +150,18 @@ def test_test_case_rejects_missing_and_unmodified_revision_indexes():
         )
 
 
-def test_revisions_raise_minimum_difficulty():
+@mark.parametrize(
+    "test_case_cls",
+    [
+        ReviewTestCase,
+        ReviewManager.get_test_case_cls(ReviewManager.base_prompt),
+    ],
+    ids=["static", "generated"],
+)
+def test_revisions_raise_minimum_difficulty(
+    test_case_cls: type[ReviewTestCase],
+):
     """A nonempty revisions list should require difficulty one."""
-    test_case_cls = ReviewManager.get_test_case_cls(ReviewManager.base_prompt)
     unchanged = test_case_cls.model_validate(
         {
             "query": {"subtitles": [{"index": 1, "text": "original"}]},
@@ -160,3 +179,18 @@ def test_revisions_raise_minimum_difficulty():
 
     assert unchanged.difficulty == 0
     assert changed.difficulty == 1
+
+
+def test_generated_test_case_uses_prompt_validation_errors():
+    """Generated test-case validators should use their localized prompt."""
+    test_case_cls = ReviewManager.get_test_case_cls(_LOCALIZED_PROMPT)
+
+    with raises(ValidationError, match="修訂序號 2 未對應字幕"):
+        test_case_cls.model_validate(
+            {
+                "query": {"subtitles": [{"index": 1, "text": "原文"}]},
+                "answer": {
+                    "revisions": [{"index": 2, "text": "修改", "note": "修正錯字"}]
+                },
+            }
+        )

--- a/test/llms/test_translation.py
+++ b/test/llms/test_translation.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from unittest.mock import Mock
 
 from pydantic import ValidationError
-from pytest import raises
+from pytest import mark, raises
 
 from scinoephile.core import Language
 from scinoephile.core.llms import LLMProvider, Queryer
@@ -22,6 +22,7 @@ from scinoephile.llms.translation import (
     TranslationManager,
     TranslationProcessor,
     TranslationPrompt,
+    TranslationTestCase,
 )
 
 _LOCALIZED_PROMPT = TranslationPrompt(
@@ -124,10 +125,18 @@ def test_query_and_answer_require_nonempty_consecutive_indexes():
         )
 
 
-def test_answer_indexes_must_correspond_to_query_indexes():
+@mark.parametrize(
+    "test_case_cls",
+    [
+        TranslationTestCase,
+        TranslationManager.get_test_case_cls(TranslationManager.base_prompt),
+    ],
+    ids=["static", "generated"],
+)
+def test_answer_indexes_must_correspond_to_query_indexes(
+    test_case_cls: type[TranslationTestCase],
+):
     """Every query subtitle should have exactly one corresponding output."""
-    test_case_cls = TranslationManager.get_test_case_cls(TranslationManager.base_prompt)
-
     with raises(ValidationError, match="correspond exactly"):
         test_case_cls.model_validate(
             {


### PR DESCRIPTION
## Summary

- enforce minimum difficulty in the core `TestCase` model
- move review, guided-review, and gap-translation correspondence rules into their static models
- let generated static-shape classes inherit model behavior without manager overrides
- retain manager callbacks only for the four remaining legacy fixed-shape operations
- add direct static-construction and legacy compatibility coverage

## Why

Static public models could previously accept cross-query/answer combinations that manager-generated models rejected. Validation and difficulty now belong to the semantic model itself, while the remaining fixed-shape migrations keep a tested temporary bridge.

## Validation

- `ruff format` and `ruff check --fix`
- `ty check`
- focused tests: 55 passed
- tracked fixtures: 31,081 cases across 85 files
- full current suite: 1,595 passed, 9 skipped
- independent cross-review: no findings