### PR TITLE
Persist test cases with base prompt aliases

### DIFF
--- a/scinoephile/core/llms/utils.py
+++ b/scinoephile/core/llms/utils.py
@@ -67,7 +67,13 @@ def save_test_cases_to_json(
             manager_cls.base_prompt,
         )
         base_test_case = remap_test_case(test_case, base_test_case_cls)
-        data.append(base_test_case.model_dump(mode="json", exclude_defaults=True))
+        data.append(
+            base_test_case.model_dump(
+                mode="json",
+                by_alias=True,
+                exclude_defaults=True,
+            )
+        )
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     with open(output_path, "w", encoding="utf-8") as f:

--- a/scinoephile/optimization/persistence/test_cases/persisted_test_case.py
+++ b/scinoephile/optimization/persistence/test_cases/persisted_test_case.py
@@ -58,10 +58,10 @@ class PersistedTestCase:
             manager_cls.base_prompt,
         )
         base_test_case = remap_test_case(test_case, base_test_case_cls)
-        query = base_test_case.query.model_dump(mode="json")
+        query = base_test_case.query.model_dump(mode="json", by_alias=True)
         if base_test_case.answer is None:
             raise ScinoephileError("Optimization test cases must include an answer.")
-        answer = base_test_case.answer.model_dump(mode="json")
+        answer = base_test_case.answer.model_dump(mode="json", by_alias=True)
         test_case_id = get_test_case_id(query, answer, manager_cls)
         return cls(
             test_case_id=test_case_id,

--- a/test/core/llms/test_utils.py
+++ b/test/core/llms/test_utils.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import ClassVar
 
 from scinoephile.core import Language
 from scinoephile.core.llms.utils import (
@@ -13,6 +14,15 @@ from scinoephile.core.llms.utils import (
     save_test_cases_to_json,
 )
 from scinoephile.llms.review import ReviewManager, ReviewPrompt
+
+_BASE_REVIEW_PROMPT = ReviewPrompt(
+    subtitles="base_subtitles",
+    revisions="base_revisions",
+    index="base_index",
+    text="base_text",
+    note="base_note",
+)
+"""Review prompt whose aliases intentionally differ from semantic field names."""
 
 _LOCALIZED_REVIEW_PROMPT = ReviewPrompt(
     language=Language.zho_hans,
@@ -25,9 +35,20 @@ _LOCALIZED_REVIEW_PROMPT = ReviewPrompt(
 """Review prompt using localized correspondence field names."""
 
 
+class _AliasedBaseReviewManager(ReviewManager):
+    """Review manager with distinct semantic, base, and localized field names."""
+
+    operation: ClassVar[str] = "aliased-base-review"
+    """Stable operation identifier used in persistence."""
+    base_prompt: ClassVar[ReviewPrompt] = _BASE_REVIEW_PROMPT
+    """Prompt defining intentionally distinct persisted field names."""
+
+
 def test_json_uses_base_prompt_fields(tmp_path: Path):
     """JSON should persist base fields and load them into a concrete prompt."""
-    test_case_cls = ReviewManager.get_test_case_cls(_LOCALIZED_REVIEW_PROMPT)
+    test_case_cls = _AliasedBaseReviewManager.get_test_case_cls(
+        _LOCALIZED_REVIEW_PROMPT
+    )
     test_case = test_case_cls.model_validate(
         {
             "query": {"zimu": [{"xuhao": 1, "wenben": "original"}]},
@@ -45,13 +66,19 @@ def test_json_uses_base_prompt_fields(tmp_path: Path):
     )
     output_path = tmp_path / "test_cases.json"
 
-    save_test_cases_to_json(output_path, [test_case], ReviewManager)
+    save_test_cases_to_json(output_path, [test_case], _AliasedBaseReviewManager)
 
     assert json.loads(output_path.read_text(encoding="utf-8")) == [
         {
-            "query": {"subtitles": [{"index": 1, "text": "original"}]},
+            "query": {"base_subtitles": [{"base_index": 1, "base_text": "original"}]},
             "answer": {
-                "revisions": [{"index": 1, "text": "corrected", "note": "typo"}]
+                "base_revisions": [
+                    {
+                        "base_index": 1,
+                        "base_text": "corrected",
+                        "base_note": "typo",
+                    }
+                ]
             },
             "difficulty": 1,
             "verified": True,
@@ -59,7 +86,7 @@ def test_json_uses_base_prompt_fields(tmp_path: Path):
     ]
     loaded = load_test_cases_from_json(
         output_path,
-        ReviewManager,
+        _AliasedBaseReviewManager,
         _LOCALIZED_REVIEW_PROMPT,
     )
     assert loaded[0].query.model_dump(by_alias=True) == {

--- a/test/optimization/persistence/test_cases/test_optimization_test_cases_sync.py
+++ b/test/optimization/persistence/test_cases/test_optimization_test_cases_sync.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import ClassVar
 
 from pydantic import JsonValue
 from pytest import raises
@@ -23,6 +24,15 @@ from scinoephile.optimization.persistence.test_cases.id import get_test_case_id
 from scinoephile.optimization.persistence.test_cases.sync import (
     sync_test_cases,
 )
+
+_BASE_REVIEW_PROMPT = ReviewPrompt(
+    subtitles="base_subtitles",
+    revisions="base_revisions",
+    index="base_index",
+    text="base_text",
+    note="base_note",
+)
+"""Review prompt whose aliases intentionally differ from semantic field names."""
 
 _LOCALIZED_REVIEW_PROMPT = ReviewPrompt(
     subtitles="zimu",
@@ -43,6 +53,15 @@ _ALTERNATIVE_REVIEW_PROMPT = ReviewPrompt(
 """Review prompt using an alternative correspondence schema."""
 
 
+class _AliasedBaseReviewManager(ReviewManager):
+    """Review manager with distinct semantic, base, and localized field names."""
+
+    operation: ClassVar[str] = "aliased-base-review"
+    """Stable operation identifier used in persistence."""
+    base_prompt: ClassVar[ReviewPrompt] = _BASE_REVIEW_PROMPT
+    """Prompt defining intentionally distinct persisted field names."""
+
+
 def _get_translation_answer(text: str) -> dict[str, JsonValue]:
     """Get a canonical translation answer payload."""
     return {"outputs": [{"index": 1, "text": text}]}
@@ -53,10 +72,14 @@ def _get_translation_query(text: str) -> dict[str, JsonValue]:
     return {"subtitles": [{"index": 1, "text": text}]}
 
 
-def test_normalization_makes_prompt_field_aliases_share_identity():
-    """Equivalent field aliases should normalize to one SQL identity."""
-    localized_cls = ReviewManager.get_test_case_cls(_LOCALIZED_REVIEW_PROMPT)
-    alternative_cls = ReviewManager.get_test_case_cls(_ALTERNATIVE_REVIEW_PROMPT)
+def test_normalization_makes_prompt_field_aliases_share_identity(tmp_path: Path):
+    """Equivalent aliases should normalize to one base-aliased SQL identity."""
+    localized_cls = _AliasedBaseReviewManager.get_test_case_cls(
+        _LOCALIZED_REVIEW_PROMPT
+    )
+    alternative_cls = _AliasedBaseReviewManager.get_test_case_cls(
+        _ALTERNATIVE_REVIEW_PROMPT
+    )
     localized = localized_cls.model_validate(
         {
             "query": {"zimu": [{"xuhao": 1, "wenben": "original"}]},
@@ -87,20 +110,37 @@ def test_normalization_makes_prompt_field_aliases_share_identity():
     )
     localized_persisted = PersistedTestCase.from_test_case(
         localized,
-        ReviewManager,
+        _AliasedBaseReviewManager,
     )
     alternative_persisted = PersistedTestCase.from_test_case(
         alternative,
-        ReviewManager,
+        _AliasedBaseReviewManager,
     )
 
     assert localized_persisted.query == {
-        "subtitles": [{"index": 1, "text": "original"}]
+        "base_subtitles": [{"base_index": 1, "base_text": "original"}]
     }
     assert localized_persisted.answer == {
-        "revisions": [{"index": 1, "text": "corrected", "note": "typo"}]
+        "base_revisions": [
+            {
+                "base_index": 1,
+                "base_text": "corrected",
+                "base_note": "typo",
+            }
+        ]
     }
     assert localized_persisted.test_case_id == alternative_persisted.test_case_id
+
+    store = TestCaseSqliteStore(tmp_path / "test_cases.sqlite")
+    store.sync_source_paths(
+        {"aliases.json": [localized_persisted]},
+        manager_cls=_AliasedBaseReviewManager,
+        dry_run=False,
+    )
+    loaded = store.get_test_case(localized_persisted.test_case_id)
+    assert loaded is not None
+    assert loaded.query == localized_persisted.query
+    assert loaded.answer == localized_persisted.answer
 
 
 def test_sync_rejects_fields_outside_test_case_schema(tmp_path: Path):


### PR DESCRIPTION
## Summary

- serialize JSON test cases from the rebound base-prompt model with `by_alias=True`
- store base-prompt query and answer aliases in optimization persistence
- prove semantic, base, localized, and alternative-localized names normalize correctly
- cover nested aliases and SQLite round-trips

## Why

Stable semantic Python names may intentionally differ from both localized LLM aliases and canonical disk fields. Rebinding selected the base schema, but dumping without aliases would leak semantic names into JSON and SQLite once the remaining fixed shapes migrate.

## Validation

- `ruff format` and `ruff check --fix`
- `ty check`
- persistence-focused tests: 20 passed
- Queryer/alias/cache regressions: 15 passed
- tracked fixture contract: 85 passed
- full suite: 1,580 passed, 9 skipped
- independent cross-review: no findings