### PR TITLE
Use static punctuation schema

### DIFF
--- a/scinoephile/llms/punctuation/__init__.py
+++ b/scinoephile/llms/punctuation/__init__.py
@@ -4,15 +4,20 @@
 
 Package hierarchy (modules may import from any above):
 * prompt
+* models
 * manager
 """
 
 from __future__ import annotations
 
 from .manager import PunctuationManager
+from .models import PunctuationAnswer, PunctuationQuery, PunctuationTestCase
 from .prompt import PunctuationPrompt
 
 __all__ = [
+    "PunctuationAnswer",
     "PunctuationManager",
     "PunctuationPrompt",
+    "PunctuationQuery",
+    "PunctuationTestCase",
 ]

--- a/scinoephile/llms/punctuation/manager.py
+++ b/scinoephile/llms/punctuation/manager.py
@@ -7,11 +7,12 @@ from __future__ import annotations
 from functools import cache
 from typing import Any, ClassVar
 
-from pydantic import Field, create_model, model_validator
+from pydantic import Field, create_model
 
-from scinoephile.core.llms import Answer, Manager, Query
+from scinoephile.core.llms import Answer, Manager, Query, TestCase
 from scinoephile.core.llms.models import get_model_name
 
+from .models import PunctuationAnswer, PunctuationQuery, PunctuationTestCase
 from .prompt import PunctuationPrompt
 
 __all__ = ["PunctuationManager"]
@@ -24,45 +25,8 @@ class PunctuationManager(Manager):
     """Stable operation identifier used in persistence and CLIs."""
     base_prompt: ClassVar[PunctuationPrompt] = PunctuationPrompt()
     """Base prompt defining persisted test-case field names."""
-
-    @classmethod
-    @cache
-    def get_query_cls(
-        cls,
-        prompt: PunctuationPrompt,
-    ) -> type[Query]:
-        """Get concrete query class with provided configuration.
-
-        Arguments:
-            prompt: text for LLM correspondence
-        Returns:
-            query model class
-        """
-        name = get_model_name("PunctuationQuery", prompt.name)
-        fields: dict[str, Any] = {
-            prompt.src_1: (
-                list[str],
-                Field(..., description=prompt.src_1_desc),
-            ),
-            prompt.src_2: (
-                str,
-                Field(..., description=prompt.src_2_desc),
-            ),
-        }
-
-        validators: dict[str, Any] = {
-            "validate_query": model_validator(mode="after")(cls.validate_query),
-        }
-
-        model = create_model(
-            name,
-            __base__=Query,
-            __module__=Query.__module__,
-            __validators__=validators,
-            **fields,
-        )
-        model.prompt = prompt
-        return model
+    test_case_base_cls: ClassVar[type[TestCase]] = PunctuationTestCase
+    """Static test-case model defining punctuation's semantic shape."""
 
     @classmethod
     @cache
@@ -70,64 +34,68 @@ class PunctuationManager(Manager):
         cls,
         prompt: PunctuationPrompt,
     ) -> type[Answer]:
-        """Get concrete answer class with provided configuration.
+        """Get concrete answer class with prompt-specific JSON field aliases.
 
         Arguments:
-            prompt: text for LLM correspondence
+            prompt: text and field aliases for LLM correspondence
         Returns:
             answer model class
         """
-        name = get_model_name("PunctuationAnswer", prompt.name)
         fields: dict[str, Any] = {
-            prompt.output: (
+            "output": (
                 str,
-                Field(..., description=prompt.output_desc),
+                Field(
+                    ...,
+                    alias=prompt.output,
+                    description=prompt.output_desc,
+                ),
             ),
         }
-
-        validators: dict[str, Any] = {
-            "validate_answer": model_validator(mode="after")(cls.validate_answer),
-        }
-
         model = create_model(
-            name,
-            __base__=Answer,
-            __module__=Answer.__module__,
-            __validators__=validators,
+            get_model_name("PunctuationAnswer", prompt.name),
+            __base__=PunctuationAnswer,
+            __module__=PunctuationAnswer.__module__,
             **fields,
         )
         model.prompt = prompt
         return model
 
-    @staticmethod
-    def validate_query(model: Query) -> Query:
-        """Ensure query is internally valid.
+    @classmethod
+    @cache
+    def get_query_cls(
+        cls,
+        prompt: PunctuationPrompt,
+    ) -> type[Query]:
+        """Get concrete query class with prompt-specific JSON field aliases.
 
         Arguments:
-            model: query to validate
+            prompt: text and field aliases for LLM correspondence
         Returns:
-            validated query
+            query model class
         """
-        prompt: PunctuationPrompt = getattr(model, "prompt")
-        source_one = getattr(model, prompt.src_1, None)
-        source_two = getattr(model, prompt.src_2, None)
-        if not source_one:
-            raise ValueError(prompt.src_1_missing_err)
-        if not source_two:
-            raise ValueError(prompt.src_2_missing_err)
-        return model
-
-    @staticmethod
-    def validate_answer(model: Answer) -> Answer:
-        """Ensure answer is internally valid.
-
-        Arguments:
-            model: answer to validate
-        Returns:
-            validated answer
-        """
-        prompt: PunctuationPrompt = getattr(model, "prompt")
-        output = getattr(model, prompt.output, None)
-        if not output:
-            raise ValueError(prompt.output_missing_err)
+        fields: dict[str, Any] = {
+            "subtitles": (
+                list[str],
+                Field(
+                    ...,
+                    alias=prompt.src_1,
+                    description=prompt.src_1_desc,
+                ),
+            ),
+            "guide": (
+                str,
+                Field(
+                    ...,
+                    alias=prompt.src_2,
+                    description=prompt.src_2_desc,
+                ),
+            ),
+        }
+        model = create_model(
+            get_model_name("PunctuationQuery", prompt.name),
+            __base__=PunctuationQuery,
+            __module__=PunctuationQuery.__module__,
+            **fields,
+        )
+        model.prompt = prompt
         return model

--- a/scinoephile/llms/punctuation/models.py
+++ b/scinoephile/llms/punctuation/models.py
@@ -1,0 +1,73 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Pydantic models for punctuation test cases."""
+
+from __future__ import annotations
+
+from typing import ClassVar, Self
+
+from pydantic import model_validator
+
+from scinoephile.core.llms import Answer, Query, TestCase
+
+from .prompt import PunctuationPrompt
+
+__all__ = [
+    "PunctuationAnswer",
+    "PunctuationQuery",
+    "PunctuationTestCase",
+]
+
+
+_BASE_PROMPT = PunctuationPrompt()
+
+
+class PunctuationQuery(Query):
+    """Subtitle lines to punctuate and their guide subtitle."""
+
+    prompt: ClassVar[PunctuationPrompt] = _BASE_PROMPT
+    """Text and field aliases for LLM correspondence."""
+    subtitles: list[str]
+    """Subtitle lines to combine and punctuate, in order."""
+    guide: str
+    """Guide subtitle whose punctuation informs the output."""
+
+    @model_validator(mode="after")
+    def validate_required_fields(self) -> Self:
+        """Ensure subtitle lines and their guide are nonempty."""
+        if not self.subtitles:
+            raise ValueError(self.prompt.src_1_missing_err)
+        if not self.guide:
+            raise ValueError(self.prompt.src_2_missing_err)
+        return self
+
+
+class PunctuationAnswer(Answer):
+    """Combined and punctuated subtitle text."""
+
+    prompt: ClassVar[PunctuationPrompt] = _BASE_PROMPT
+    """Text and field aliases for LLM correspondence."""
+    output: str
+    """Combined and punctuated subtitle text."""
+
+    @model_validator(mode="after")
+    def validate_output(self) -> Self:
+        """Ensure output text is nonempty."""
+        if not self.output:
+            raise ValueError(self.prompt.output_missing_err)
+        return self
+
+
+class PunctuationTestCase(TestCase):
+    """Punctuation query, optional answer, and optimization metadata."""
+
+    query_cls: ClassVar[type[PunctuationQuery]] = PunctuationQuery
+    """Query model class."""
+    answer_cls: ClassVar[type[PunctuationAnswer]] = PunctuationAnswer
+    """Answer model class."""
+    prompt: ClassVar[PunctuationPrompt] = _BASE_PROMPT
+    """Text and field aliases for LLM correspondence."""
+    query: PunctuationQuery
+    """Subtitle lines and their punctuation guide."""
+    answer: PunctuationAnswer | None = None
+    """Combined and punctuated subtitle text, if available."""

--- a/scinoephile/multilang/yue_zho/transcription/aligner.py
+++ b/scinoephile/multilang/yue_zho/transcription/aligner.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from copy import deepcopy
 from logging import getLogger
 from pathlib import Path
+from typing import cast
 
 from pydantic import ValidationError
 
@@ -280,6 +281,7 @@ class Aligner:
 
         nascent_yw = AudioSeries(audio=alignment.yuewen.audio)
         nascent_sg = []
+        punctuation_prompt = cast(PunctuationPrompt, self.punctuation_queryer.prompt)
         for sg_idx in range(len(alignment.sync_groups)):
             # Get sync group
             sg = alignment.sync_groups[sg_idx]
@@ -307,7 +309,10 @@ class Aligner:
                 continue
 
             # Query for written Cantonese punctuation
-            test_case = alignment.get_punctuation_test_case(sg_idx)
+            test_case = alignment.get_punctuation_test_case(
+                sg_idx,
+                punctuation_prompt,
+            )
             if test_case is None:
                 logger.info(
                     f"Skipping sync group {sg_idx} with no written Cantonese subtitles"
@@ -324,8 +329,9 @@ class Aligner:
                     f"{test_case}\n"
                     f"Exception:\n{exc}"
                 )
-            prompt: PunctuationPrompt = getattr(test_case, "prompt")
-            yuewen_punctuated = getattr(test_case.answer, prompt.output, None)
+            yuewen_punctuated = None
+            if test_case.answer is not None:
+                yuewen_punctuated = test_case.answer.output
             yw = get_sub_merged(yws, text=yuewen_punctuated)
             yw.start = zw.start
             yw.end = zw.end

--- a/scinoephile/multilang/yue_zho/transcription/alignment.py
+++ b/scinoephile/multilang/yue_zho/transcription/alignment.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from pprint import pformat
+from typing import cast
 
 import numpy as np
 
@@ -20,13 +21,14 @@ from scinoephile.core.synchronization import (
     get_sync_overlap_matrix,
 )
 from scinoephile.llms.delineation import DelineationManager
+from scinoephile.llms.punctuation import PunctuationPrompt
 
 from .delineation import (
     YueDelineationVsZhoPromptYueHans,
 )
 from .punctuation import (
-    YuePunctuationVsZhoPromptYueHans,
     YueZhoPunctuationManager,
+    YueZhoPunctuationTestCase,
 )
 
 __all__ = ["Alignment"]
@@ -216,11 +218,16 @@ class Alignment:
         test_case = test_case_cls(query=test_case_cls.query_cls(**query_kwargs))
         return test_case
 
-    def get_punctuation_test_case(self, sg_idx: int) -> TestCase | None:
+    def get_punctuation_test_case(
+        self,
+        sg_idx: int,
+        prompt: PunctuationPrompt,
+    ) -> YueZhoPunctuationTestCase | None:
         """Get punctuation query for a sync group.
 
         Arguments:
-            sg_idx: Index of sync group
+            sg_idx: index of sync group
+            prompt: text and field aliases for LLM correspondence
         Returns:
             test case, or None if there are no written Cantonese subs to punctuate
         """
@@ -249,12 +256,12 @@ class Alignment:
         yws = [self.yuewen[i].text for i in yw_idxs]
 
         # Return punctuate query
-        prompt = YuePunctuationVsZhoPromptYueHans
         test_case_cls = YueZhoPunctuationManager.get_test_case_cls(prompt=prompt)
-        query_kwargs = {
-            prompt.src_2: zw,
-            prompt.src_1: yws,
-        }
-        # noinspection PyArgumentList
-        test_case = test_case_cls(query=test_case_cls.query_cls(**query_kwargs))
-        return test_case
+        query = test_case_cls.query_cls.model_validate(
+            {
+                "subtitles": yws,
+                "guide": zw,
+            }
+        )
+        test_case = test_case_cls(query=query)
+        return cast(YueZhoPunctuationTestCase, test_case)

--- a/scinoephile/multilang/yue_zho/transcription/punctuation.py
+++ b/scinoephile/multilang/yue_zho/transcription/punctuation.py
@@ -5,6 +5,9 @@
 from __future__ import annotations
 
 from functools import partial
+from typing import ClassVar, Self
+
+from pydantic import model_validator
 
 from scinoephile.core import Language
 from scinoephile.core.llms import TestCase
@@ -15,12 +18,17 @@ from scinoephile.core.text import (
 )
 from scinoephile.lang.yue.prompts import YUE_HANT_PROMPT_FIELDS
 from scinoephile.lang.zho.script.conversion import OpenCCConfig, get_zho_text_converted
-from scinoephile.llms.punctuation import PunctuationManager, PunctuationPrompt
+from scinoephile.llms.punctuation import (
+    PunctuationManager,
+    PunctuationPrompt,
+    PunctuationTestCase,
+)
 
 __all__ = [
     "YuePunctuationVsZhoPromptYueHans",
     "YuePunctuationVsZhoPromptYueHant",
     "YueZhoPunctuationManager",
+    "YueZhoPunctuationTestCase",
 ]
 
 
@@ -62,53 +70,48 @@ YuePunctuationVsZhoPromptYueHans = YuePunctuationVsZhoPromptYueHant.transformed(
 """Text for simplified written Cantonese/standard Chinese punctuation."""
 
 
-class YueZhoPunctuationManager(PunctuationManager):
-    """Factories for written Cantonese/standard Chinese punctuation LLM classes."""
+class YueZhoPunctuationTestCase(PunctuationTestCase):
+    """Written Cantonese punctuation guided by standard Chinese."""
 
-    @staticmethod
-    def get_min_difficulty(model: TestCase) -> int:
-        """Get minimum difficulty based on the test case properties.
+    def get_min_difficulty(self) -> int:
+        """Get minimum difficulty from output and guide punctuation.
 
-        Arguments:
-            model: test case to inspect
         Returns:
             minimum difficulty
         """
-        prompt: PunctuationPrompt = getattr(model, "prompt")
-        min_difficulty = PunctuationManager.get_min_difficulty(model)
-        if model.answer is None:
+        min_difficulty = super().get_min_difficulty()
+        if self.answer is None:
             return min_difficulty
 
-        zhongwen = getattr(model.query, prompt.src_2, "")
-        yuewen_punctuated = getattr(model.answer, prompt.output, "")
-        if remove_non_punc_and_whitespace(yuewen_punctuated):
+        if remove_non_punc_and_whitespace(self.answer.output):
             min_difficulty = max(min_difficulty, 1)
-        if remove_non_punc_and_whitespace(zhongwen) != remove_non_punc_and_whitespace(
-            yuewen_punctuated
-        ):
+        if remove_non_punc_and_whitespace(
+            self.query.guide
+        ) != remove_non_punc_and_whitespace(self.answer.output):
             min_difficulty = max(min_difficulty, 2)
         return min_difficulty
 
-    @staticmethod
-    def validate_test_case(model: TestCase) -> TestCase:
+    @model_validator(mode="after")
+    def validate_output_characters(self) -> Self:
         """Ensure query and answer together are valid.
 
-        Arguments:
-            model: test case to validate
         Returns:
             validated test case
         """
-        prompt: PunctuationPrompt = getattr(model, "prompt")
-        if model.answer is None:
-            return model
-
-        yuewen_to_punctuate = getattr(model.query, prompt.src_1, None) or []
-        yuewen_punctuated = getattr(model.answer, prompt.output, None) or ""
+        if self.answer is None:
+            return self
 
         expected = "".join(
-            remove_punc_and_whitespace(subtitle) for subtitle in yuewen_to_punctuate
+            remove_punc_and_whitespace(subtitle) for subtitle in self.query.subtitles
         )
-        received = remove_punc_and_whitespace(yuewen_punctuated)
+        received = remove_punc_and_whitespace(self.answer.output)
         if expected != received:
-            raise ValueError(prompt.src_1_chars_changed_err(expected, received))
-        return model
+            raise ValueError(self.prompt.src_1_chars_changed_err(expected, received))
+        return self
+
+
+class YueZhoPunctuationManager(PunctuationManager):
+    """Factories for written Cantonese/standard Chinese punctuation LLM classes."""
+
+    test_case_base_cls: ClassVar[type[TestCase]] = YueZhoPunctuationTestCase
+    """Static test-case model defining Yue/Zho punctuation semantics."""

--- a/test/core/llms/test_manager.py
+++ b/test/core/llms/test_manager.py
@@ -4,10 +4,11 @@
 
 from __future__ import annotations
 
-from pytest import raises
-
-from scinoephile.core.llms import TestCase
-from scinoephile.llms.punctuation import PunctuationManager, PunctuationPrompt
+from scinoephile.llms.punctuation import (
+    PunctuationManager,
+    PunctuationPrompt,
+    PunctuationTestCase,
+)
 from scinoephile.llms.review import ReviewManager, ReviewPrompt, ReviewTestCase
 
 _LOCALIZED_REVIEW_PROMPT = ReviewPrompt(
@@ -34,50 +35,6 @@ _LOCALIZED_PUNCTUATION_PROMPT = PunctuationPrompt(
     output="result",
 )
 """Punctuation prompt using non-default correspondence field names."""
-
-
-class _LegacyPunctuationManager(PunctuationManager):
-    """Legacy manager fixture with test-case callbacks."""
-
-    @staticmethod
-    def get_auto_verified(model: TestCase) -> bool:
-        """Automatically verify test cases that include an answer.
-
-        Arguments:
-            model: test case to inspect
-        Returns:
-            whether the test case should be automatically verified
-        """
-        return model.answer is not None
-
-    @staticmethod
-    def get_min_difficulty(model: TestCase) -> int:
-        """Require difficulty two for test cases that include an answer.
-
-        Arguments:
-            model: test case to inspect
-        Returns:
-            minimum difficulty
-        """
-        if model.answer is not None:
-            return 2
-        return 0
-
-    @staticmethod
-    def validate_test_case(model: TestCase) -> TestCase:
-        """Reject the sentinel invalid output.
-
-        Arguments:
-            model: test case to validate
-        Returns:
-            validated test case
-        """
-        if model.answer is None:
-            return model
-        prompt: PunctuationPrompt = getattr(model, "prompt")
-        if getattr(model.answer, prompt.output) == "invalid":
-            raise ValueError("Legacy test-case validator was called.")
-        return model
 
 
 def test_static_shape_factory_caches_and_isolates_prompt_aliases():
@@ -108,50 +65,35 @@ def test_static_shape_factory_caches_and_isolates_prompt_aliases():
     }
 
 
-def test_legacy_factory_preserves_prompt_shaped_models():
-    """Legacy managers should retain prompt-named Python model fields."""
+def test_punctuation_factory_uses_static_fields_with_prompt_aliases():
+    """Punctuation models should use semantic fields and prompt aliases."""
     test_case_cls = PunctuationManager.get_test_case_cls(_LOCALIZED_PUNCTUATION_PROMPT)
 
     assert (
         PunctuationManager.get_test_case_cls(_LOCALIZED_PUNCTUATION_PROMPT)
         is test_case_cls
     )
-    assert set(test_case_cls.query_cls.model_fields) == {"source_one", "source_two"}
-    assert set(test_case_cls.answer_cls.model_fields) == {"result"}
+    assert issubclass(test_case_cls, PunctuationTestCase)
+    assert set(test_case_cls.query_cls.model_fields) == {"subtitles", "guide"}
+    assert test_case_cls.query_cls.model_fields["subtitles"].alias == "source_one"
+    assert test_case_cls.query_cls.model_fields["guide"].alias == "source_two"
+    assert set(test_case_cls.answer_cls.model_fields) == {"output"}
+    assert test_case_cls.answer_cls.model_fields["output"].alias == "result"
 
     test_case = test_case_cls.model_validate(
         {
-            "query": {"source_one": ["Hello"], "source_two": "Hello"},
-            "answer": {"result": "Hello"},
+            "query": {"subtitles": ["Hello"], "guide": "Hello"},
+            "answer": {"output": "Hello"},
         }
     )
     assert test_case.query.model_dump() == {
+        "subtitles": ["Hello"],
+        "guide": "Hello",
+    }
+    assert test_case.answer is not None
+    assert test_case.answer.model_dump() == {"output": "Hello"}
+    assert test_case.query.model_dump(by_alias=True) == {
         "source_one": ["Hello"],
         "source_two": "Hello",
     }
-    assert test_case.answer is not None
-    assert test_case.answer.model_dump() == {"result": "Hello"}
-
-
-def test_legacy_factory_preserves_manager_callbacks():
-    """Legacy test-case classes should retain manager-defined behavior."""
-    test_case_cls = _LegacyPunctuationManager.get_test_case_cls(
-        _LOCALIZED_PUNCTUATION_PROMPT
-    )
-
-    test_case = test_case_cls.model_validate(
-        {
-            "query": {"source_one": ["Hello"], "source_two": "Hello"},
-            "answer": {"result": "Hello"},
-        }
-    )
-
-    assert test_case.difficulty == 2
-    assert test_case.get_auto_verified()
-    with raises(ValueError, match="Legacy test-case validator was called"):
-        test_case_cls.model_validate(
-            {
-                "query": {"source_one": ["Hello"], "source_two": "Hello"},
-                "answer": {"result": "invalid"},
-            }
-        )
+    assert test_case.answer.model_dump(by_alias=True) == {"result": "Hello"}

--- a/test/llms/test_legacy_test_case_callbacks.py
+++ b/test/llms/test_legacy_test_case_callbacks.py
@@ -10,10 +10,6 @@ from pytest import raises
 from scinoephile.llms.delineation import DelineationManager
 from scinoephile.llms.ocr_fusion import OcrFusionManager
 from scinoephile.llms.pairwise_review import PairwiseReviewManager
-from scinoephile.multilang.yue_zho.transcription.punctuation import (
-    YuePunctuationVsZhoPromptYueHans,
-    YueZhoPunctuationManager,
-)
 
 
 def test_pairwise_review_retains_validation_and_minimum_difficulty():
@@ -67,27 +63,6 @@ def test_ocr_fusion_retains_auto_verification_and_minimum_difficulty():
     assert simple.get_auto_verified()
     assert complex_case.difficulty == 2
     assert not complex_case.get_auto_verified()
-
-
-def test_punctuation_retains_validation_and_minimum_difficulty():
-    """Localized punctuation should retain its manager-defined test-case rules."""
-    prompt = YuePunctuationVsZhoPromptYueHans
-    test_case_cls = YueZhoPunctuationManager.get_test_case_cls(prompt)
-    test_case = test_case_cls.model_validate(
-        {
-            "query": {prompt.src_1: ["你好"], prompt.src_2: "你好"},
-            "answer": {prompt.output: "你，好"},
-        }
-    )
-
-    assert test_case.difficulty == 2
-    with raises(ValidationError, match="does not match"):
-        test_case_cls.model_validate(
-            {
-                "query": {prompt.src_1: ["你好"], prompt.src_2: "你好"},
-                "answer": {prompt.output: "你壞"},
-            }
-        )
 
 
 def test_delineation_retains_validation_and_minimum_difficulty():

--- a/test/llms/test_punctuation.py
+++ b/test/llms/test_punctuation.py
@@ -1,0 +1,240 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests for static punctuation LLM models."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+from pydantic import ValidationError
+from pytest import mark, raises
+
+from scinoephile.core import Language
+from scinoephile.core.llms import LLMProvider, Queryer
+from scinoephile.core.llms.utils import (
+    load_test_cases_from_json,
+    save_test_cases_to_json,
+)
+from scinoephile.llms.punctuation import (
+    PunctuationManager,
+    PunctuationPrompt,
+)
+from scinoephile.multilang.yue_zho.transcription.punctuation import (
+    YuePunctuationVsZhoPromptYueHans,
+    YueZhoPunctuationManager,
+    YueZhoPunctuationTestCase,
+)
+from scinoephile.optimization.persistence.test_cases import PersistedTestCase
+from test.helpers import test_data_root
+
+_LOCALIZED_PROMPT = PunctuationPrompt(
+    language=Language.zho_hant,
+    src_1="zimu",
+    src_1_desc="要加標點嘅字幕行",
+    src_2="cankao",
+    src_2_desc="標點參考字幕",
+    output="jieguo",
+    output_desc="加標點後嘅字幕",
+)
+"""Punctuation prompt with Chinese correspondence field names."""
+
+_PUNCTUATION_PATHS = tuple(
+    sorted(
+        test_data_root.glob(
+            "*/output/*/multilang/yue_zho/transcription/punctuation/*.json"
+        )
+    )
+)
+"""Tracked punctuation test-case JSON paths."""
+
+
+def test_prompt_aliases_are_used_for_llm_correspondence():
+    """Generated schemas and JSON should use prompt-specific aliases."""
+    test_case_cls = PunctuationManager.get_test_case_cls(_LOCALIZED_PROMPT)
+    test_case = test_case_cls.model_validate(
+        {
+            "query": {"zimu": ["原文一", "原文二"], "cankao": "參考"},
+            "answer": {"jieguo": "原文一原文二"},
+        }
+    )
+
+    assert test_case.query.model_dump() == {
+        "subtitles": ["原文一", "原文二"],
+        "guide": "參考",
+    }
+    assert test_case.query.model_dump(by_alias=True) == {
+        "zimu": ["原文一", "原文二"],
+        "cankao": "參考",
+    }
+    assert test_case.answer is not None
+    assert test_case.answer.model_dump() == {"output": "原文一原文二"}
+    assert test_case.answer.model_dump(by_alias=True) == {"jieguo": "原文一原文二"}
+
+    query_schema = test_case_cls.query_cls.model_json_schema(by_alias=True)
+    answer_schema = test_case_cls.answer_cls.model_json_schema(by_alias=True)
+    assert query_schema["title"] == f"PunctuationQuery_{_LOCALIZED_PROMPT.name}"
+    assert list(query_schema["properties"]) == ["zimu", "cankao"]
+    assert query_schema["properties"]["zimu"]["description"] == "要加標點嘅字幕行"
+    assert query_schema["properties"]["cankao"]["description"] == "標點參考字幕"
+    assert answer_schema["title"] == f"PunctuationAnswer_{_LOCALIZED_PROMPT.name}"
+    assert list(answer_schema["properties"]) == ["jieguo"]
+    assert answer_schema["properties"]["jieguo"]["description"] == "加標點後嘅字幕"
+
+
+def test_queryer_corresponds_using_prompt_aliases():
+    """Queryer should send aliased queries and request aliased answers."""
+    test_case_cls = PunctuationManager.get_test_case_cls(_LOCALIZED_PROMPT)
+    test_case = test_case_cls.model_validate(
+        {"query": {"subtitles": ["原文"], "guide": "參考"}}
+    )
+    provider = Mock(spec=LLMProvider)
+    provider.chat_completion.return_value = '{"jieguo": "原文"}'
+    queryer = Queryer(_LOCALIZED_PROMPT, provider=provider, max_attempts=1)
+
+    result = queryer(test_case)
+
+    assert result.answer is not None
+    assert result.answer.model_dump() == {"output": "原文"}
+    messages = provider.chat_completion.call_args.args[0]
+    assert json.loads(messages[1]["content"]) == {
+        "zimu": ["原文"],
+        "cankao": "參考",
+    }
+    assert '"jieguo"' in messages[0]["content"]
+
+
+def test_query_and_answer_require_nonempty_fields():
+    """Punctuation queries and answers should reject empty required fields."""
+    query_cls = PunctuationManager.get_query_cls(_LOCALIZED_PROMPT)
+    answer_cls = PunctuationManager.get_answer_cls(_LOCALIZED_PROMPT)
+
+    with raises(ValidationError, match=_LOCALIZED_PROMPT.src_1_missing_err):
+        query_cls.model_validate({"subtitles": [], "guide": "參考"})
+    with raises(ValidationError, match=_LOCALIZED_PROMPT.src_2_missing_err):
+        query_cls.model_validate({"subtitles": ["原文"], "guide": ""})
+    with raises(ValidationError, match=_LOCALIZED_PROMPT.output_missing_err):
+        answer_cls.model_validate({"output": ""})
+
+
+def test_yue_zho_validation_and_minimum_difficulty_are_static():
+    """Yue/Zho punctuation semantics should live on the static test-case model."""
+    test_case_cls = YueZhoPunctuationManager.get_test_case_cls(
+        YuePunctuationVsZhoPromptYueHans
+    )
+    plain = test_case_cls.model_validate(
+        {
+            "query": {"subtitles": ["你好"], "guide": "你好"},
+            "answer": {"output": "你好"},
+        }
+    )
+    matching_punctuation = test_case_cls.model_validate(
+        {
+            "query": {"subtitles": ["你好"], "guide": "你，好"},
+            "answer": {"output": "你，好"},
+        }
+    )
+    different_punctuation = test_case_cls.model_validate(
+        {
+            "query": {"subtitles": ["你好"], "guide": "你好"},
+            "answer": {"output": "你，好"},
+        }
+    )
+    direct = YueZhoPunctuationTestCase.model_validate(
+        {
+            "query": {"subtitles": ["你好"], "guide": "你好"},
+            "answer": {"output": "你，好"},
+        }
+    )
+
+    assert plain.difficulty == 0
+    assert matching_punctuation.difficulty == 1
+    assert different_punctuation.difficulty == 2
+    assert direct.difficulty == 2
+    with raises(ValidationError, match="does not match"):
+        test_case_cls.model_validate(
+            {
+                "query": {"subtitles": ["你好"], "guide": "你好"},
+                "answer": {"output": "你壞"},
+            }
+        )
+
+
+def test_persistence_uses_base_prompt_aliases(tmp_path: Path):
+    """JSON and normalized persistence should use base prompt field aliases."""
+    test_case_cls = PunctuationManager.get_test_case_cls(_LOCALIZED_PROMPT)
+    test_case = test_case_cls.model_validate(
+        {
+            "query": {"zimu": ["原文"], "cankao": "參考"},
+            "answer": {"jieguo": "原文"},
+            "verified": True,
+        }
+    )
+    output_path = tmp_path / "punctuation.json"
+
+    save_test_cases_to_json(output_path, [test_case], PunctuationManager)
+
+    assert json.loads(output_path.read_text(encoding="utf-8")) == [
+        {
+            "query": {"one": ["原文"], "two": "參考"},
+            "answer": {"output": "原文"},
+            "verified": True,
+        }
+    ]
+    persisted = PersistedTestCase.from_test_case(test_case, PunctuationManager)
+    assert persisted.query == {"one": ["原文"], "two": "參考"}
+    assert persisted.answer == {"output": "原文"}
+
+    loaded = load_test_cases_from_json(
+        output_path,
+        PunctuationManager,
+        _LOCALIZED_PROMPT,
+    )
+    assert loaded[0].query.model_dump(by_alias=True) == {
+        "zimu": ["原文"],
+        "cankao": "參考",
+    }
+    assert loaded[0].answer is not None
+    assert loaded[0].answer.model_dump(by_alias=True) == {"jieguo": "原文"}
+
+
+def test_tracked_fixture_count():
+    """All four tracked punctuation files should contain 2,973 test cases."""
+    counts = [
+        len(json.loads(input_path.read_text(encoding="utf-8")))
+        for input_path in _PUNCTUATION_PATHS
+    ]
+
+    assert len(_PUNCTUATION_PATHS) == 4
+    assert sum(counts) == 2973
+
+
+@mark.parametrize(
+    "input_path",
+    _PUNCTUATION_PATHS,
+    ids=[
+        input_path.relative_to(test_data_root).as_posix()
+        for input_path in _PUNCTUATION_PATHS
+    ],
+)
+def test_tracked_fixture_round_trips_without_migration(
+    input_path: Path,
+    tmp_path: Path,
+):
+    """Tracked punctuation JSON should round-trip without schema changes."""
+    raw_data = json.loads(input_path.read_text(encoding="utf-8"))
+    test_cases = load_test_cases_from_json(
+        input_path,
+        YueZhoPunctuationManager,
+        YuePunctuationVsZhoPromptYueHans,
+    )
+    output_path = tmp_path / input_path.name
+
+    save_test_cases_to_json(
+        output_path,
+        test_cases,
+        YueZhoPunctuationManager,
+    )
+
+    assert json.loads(output_path.read_text(encoding="utf-8")) == raw_data

--- a/test/multilang/yue_zho/test_punctuation_alignment.py
+++ b/test/multilang/yue_zho/test_punctuation_alignment.py
@@ -1,0 +1,140 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests for punctuation test cases used during Yue/Zho alignment."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+from pydub import AudioSegment
+from pytest import MonkeyPatch
+
+from scinoephile.audio.subtitles import AudioSeries, AudioSubtitle
+from scinoephile.core.llms import Queryer
+from scinoephile.core.subtitles import Series, Subtitle
+from scinoephile.llms.punctuation import PunctuationPrompt
+from scinoephile.multilang.yue_zho.transcription import aligner as aligner_module
+from scinoephile.multilang.yue_zho.transcription.aligner import Aligner
+from scinoephile.multilang.yue_zho.transcription.alignment import Alignment
+from scinoephile.multilang.yue_zho.transcription.punctuation import (
+    YueZhoPunctuationTestCase,
+)
+
+_LOCALIZED_PROMPT = PunctuationPrompt(
+    src_1="zimu",
+    src_2="cankao",
+    output="jieguo",
+)
+"""Punctuation prompt using non-default correspondence field names."""
+
+
+def _get_alignment() -> Alignment:
+    """Get a one-group alignment that requires punctuation."""
+    zhongwen = Series(
+        events=[Subtitle(start=0, end=1000, text="你好！")],
+    )
+    yuewen = AudioSeries(
+        audio=AudioSegment.silent(duration=1000),
+        events=[AudioSubtitle(start=0, end=1000, text="你好")],
+    )
+    alignment = Alignment(zhongwen, yuewen)
+    alignment._sync_groups_override = [([0], [0])]
+    return alignment
+
+
+def _get_merged_subtitle(
+    subtitles: list[AudioSubtitle],
+    *,
+    text: str | None = None,
+) -> AudioSubtitle:
+    """Get a merged subtitle without requiring transcription segment fixtures."""
+    if text is None:
+        text = "".join(subtitle.text for subtitle in subtitles)
+    return AudioSubtitle(
+        start=subtitles[0].start,
+        end=subtitles[-1].end,
+        text=text,
+    )
+
+
+def test_alignment_constructs_semantic_fields_with_configured_prompt():
+    """Alignment should construct semantic fields using the provided prompt aliases."""
+    alignment = _get_alignment()
+
+    test_case = alignment.get_punctuation_test_case(0, _LOCALIZED_PROMPT)
+
+    assert test_case is not None
+    assert isinstance(test_case, YueZhoPunctuationTestCase)
+    assert test_case.prompt is _LOCALIZED_PROMPT
+    assert test_case.query.model_dump() == {
+        "subtitles": ["你好"],
+        "guide": "你好！",
+    }
+    assert test_case.query.model_dump(by_alias=True) == {
+        "zimu": ["你好"],
+        "cankao": "你好！",
+    }
+
+
+def test_aligner_uses_queryer_prompt_and_semantic_output(monkeypatch: MonkeyPatch):
+    """Aligner should propagate its prompt and consume semantic answer output."""
+    alignment = _get_alignment()
+    punctuation_queryer = Mock(spec=Queryer)
+    punctuation_queryer.prompt = _LOCALIZED_PROMPT
+
+    def add_answer(
+        test_case: YueZhoPunctuationTestCase,
+    ) -> YueZhoPunctuationTestCase:
+        """Add a valid punctuation answer to a test case."""
+        result = type(test_case).model_validate(
+            {
+                **test_case.model_dump(),
+                "answer": {"output": "你好！"},
+            }
+        )
+        return result
+
+    punctuation_queryer.side_effect = add_answer
+    monkeypatch.setattr(aligner_module, "get_sub_merged", _get_merged_subtitle)
+    aligner = Aligner(
+        delineation_queryer=Mock(spec=Queryer),
+        punctuation_queryer=punctuation_queryer,
+    )
+
+    aligner._punctuate(alignment)
+
+    encountered = punctuation_queryer.call_args.args[0]
+    assert encountered.prompt is _LOCALIZED_PROMPT
+    assert alignment.yuewen[0].text == "你好！"
+
+
+def test_aligner_falls_back_to_concatenation_after_invalid_answer(
+    monkeypatch: MonkeyPatch,
+):
+    """A rejected answer should retain the existing concatenation fallback."""
+    alignment = _get_alignment()
+    punctuation_queryer = Mock(spec=Queryer)
+    punctuation_queryer.prompt = _LOCALIZED_PROMPT
+
+    def reject_answer(
+        test_case: YueZhoPunctuationTestCase,
+    ) -> YueZhoPunctuationTestCase:
+        """Attempt to add an answer that changes subtitle characters."""
+        result = type(test_case).model_validate(
+            {
+                **test_case.model_dump(),
+                "answer": {"output": "你壞"},
+            }
+        )
+        return result
+
+    punctuation_queryer.side_effect = reject_answer
+    monkeypatch.setattr(aligner_module, "get_sub_merged", _get_merged_subtitle)
+    aligner = Aligner(
+        delineation_queryer=Mock(spec=Queryer),
+        punctuation_queryer=punctuation_queryer,
+    )
+
+    aligner._punctuate(alignment)
+
+    assert alignment.yuewen[0].text == "你好"


### PR DESCRIPTION
## Summary

- add static punctuation query, answer, and test-case models with stable semantic fields
- localize LLM JSON through prompt aliases while retaining base `one`/`two` persistence
- move Yue/Zho character preservation and difficulty rules into a specialized static test case
- update alignment and aligner consumers to use typed fields and the configured prompt
- preserve invalid-answer concatenation fallback

## Why

Punctuation still used prompt text as Python field names. Stable fields (`subtitles`, `guide`, `output`) remove that dynamic shape while retaining localized correspondence and canonical fixture keys.

## Validation

- `ruff format` and `ruff check --fix`
- `ty check`
- focused tests: 122 passed
- all 4 tracked punctuation files / 2,973 cases round-trip exactly
- full suite: 1,606 passed, 9 skipped
- independent cross-review: no findings