### PR TITLE
Use static pairwise review schema

### DIFF
--- a/scinoephile/llms/pairwise_review/__init__.py
+++ b/scinoephile/llms/pairwise_review/__init__.py
@@ -4,6 +4,7 @@
 
 Package hierarchy (modules may import from any above):
 * prompt
+* models
 * manager
 * processor
 """
@@ -11,11 +12,19 @@ Package hierarchy (modules may import from any above):
 from __future__ import annotations
 
 from .manager import PairwiseReviewManager
+from .models import (
+    PairwiseReviewAnswer,
+    PairwiseReviewQuery,
+    PairwiseReviewTestCase,
+)
 from .processor import PairwiseReviewProcessor
 from .prompt import PairwiseReviewPrompt
 
 __all__ = [
+    "PairwiseReviewAnswer",
     "PairwiseReviewManager",
     "PairwiseReviewProcessor",
     "PairwiseReviewPrompt",
+    "PairwiseReviewQuery",
+    "PairwiseReviewTestCase",
 ]

--- a/scinoephile/llms/pairwise_review/manager.py
+++ b/scinoephile/llms/pairwise_review/manager.py
@@ -1,6 +1,6 @@
 #  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
-"""Factories for pairwise-review LLM classes."""
+"""Factories for prompt-specific pairwise-review LLM classes."""
 
 from __future__ import annotations
 
@@ -12,18 +12,25 @@ from pydantic import Field, create_model
 from scinoephile.core.llms import Answer, Manager, Query, TestCase
 from scinoephile.core.llms.models import get_model_name
 
+from .models import (
+    PairwiseReviewAnswer,
+    PairwiseReviewQuery,
+    PairwiseReviewTestCase,
+)
 from .prompt import PairwiseReviewPrompt
 
 __all__ = ["PairwiseReviewManager"]
 
 
 class PairwiseReviewManager(Manager):
-    """Factories for pairwise-review LLM classes."""
+    """Factories for prompt-specific pairwise-review LLM classes."""
 
     operation: ClassVar[str] = "pairwise-review"
     """Stable operation identifier used in persistence and CLIs."""
     base_prompt: ClassVar[PairwiseReviewPrompt] = PairwiseReviewPrompt()
     """Base prompt defining persisted test-case field names."""
+    test_case_base_cls: ClassVar[type[TestCase]] = PairwiseReviewTestCase
+    """Static test-case model defining pairwise review's semantic shape."""
 
     @classmethod
     @cache
@@ -31,27 +38,37 @@ class PairwiseReviewManager(Manager):
         cls,
         prompt: PairwiseReviewPrompt,
     ) -> type[Answer]:
-        """Get concrete answer class with provided configuration.
+        """Get concrete answer class with prompt-specific JSON field aliases.
 
         Arguments:
-            prompt: text for LLM correspondence
+            prompt: text and field aliases for LLM correspondence
         Returns:
             answer model class
         """
         fields: dict[str, Any] = {
-            prompt.output: (
+            "output": (
                 str,
-                Field("", description=prompt.output_desc, max_length=1000),
+                Field(
+                    "",
+                    alias=prompt.output,
+                    description=prompt.output_desc,
+                    max_length=1000,
+                ),
             ),
-            prompt.note: (
+            "note": (
                 str,
-                Field("", description=prompt.note_desc, max_length=1000),
+                Field(
+                    "",
+                    alias=prompt.note,
+                    description=prompt.note_desc,
+                    max_length=1000,
+                ),
             ),
         }
         model = create_model(
             get_model_name("PairwiseReviewAnswer", prompt.name),
-            __base__=Answer,
-            __module__=Answer.__module__,
+            __base__=PairwiseReviewAnswer,
+            __module__=PairwiseReviewAnswer.__module__,
             **fields,
         )
         model.prompt = prompt
@@ -63,74 +80,38 @@ class PairwiseReviewManager(Manager):
         cls,
         prompt: PairwiseReviewPrompt,
     ) -> type[Query]:
-        """Get concrete query class with provided configuration.
+        """Get concrete query class with prompt-specific JSON field aliases.
 
         Arguments:
-            prompt: text for LLM correspondence
+            prompt: text and field aliases for LLM correspondence
         Returns:
             query model class
         """
         fields: dict[str, Any] = {
-            prompt.target: (
+            "target": (
                 str,
-                Field(..., description=prompt.target_desc, max_length=1000),
+                Field(
+                    ...,
+                    alias=prompt.target,
+                    description=prompt.target_desc,
+                    max_length=1000,
+                ),
             ),
-            prompt.reference: (
+            "reference": (
                 str,
-                Field(..., description=prompt.reference_desc, max_length=1000),
+                Field(
+                    ...,
+                    alias=prompt.reference,
+                    description=prompt.reference_desc,
+                    max_length=1000,
+                ),
             ),
         }
         model = create_model(
             get_model_name("PairwiseReviewQuery", prompt.name),
-            __base__=Query,
-            __module__=Query.__module__,
+            __base__=PairwiseReviewQuery,
+            __module__=PairwiseReviewQuery.__module__,
             **fields,
         )
         model.prompt = prompt
-        return model
-
-    @staticmethod
-    def get_min_difficulty(model: TestCase) -> int:
-        """Get minimum difficulty based on whether the target is revised.
-
-        Arguments:
-            model: test case to inspect
-        Returns:
-            minimum difficulty
-        """
-        if model.answer is None:
-            return 0
-        prompt: PairwiseReviewPrompt = getattr(model, "prompt")
-        target = getattr(model.query, prompt.target)
-        output = getattr(model.answer, prompt.output)
-        if output and output != target:
-            return 1
-        return 0
-
-    @staticmethod
-    def validate_test_case(model: TestCase) -> TestCase:
-        """Ensure an output and its note are internally consistent.
-
-        Unchanged full-text outputs from legacy pairwise-review data are normalized to
-        the empty-string convention used by the other review operations.
-
-        Arguments:
-            model: test case to validate
-        Returns:
-            validated test case
-        """
-        if model.answer is None:
-            return model
-
-        prompt: PairwiseReviewPrompt = getattr(model, "prompt")
-        target = getattr(model.query, prompt.target)
-        output = getattr(model.answer, prompt.output)
-        note = getattr(model.answer, prompt.note)
-        if output == target:
-            setattr(model.answer, prompt.output, "")
-            setattr(model.answer, prompt.note, "")
-        elif output and not note:
-            raise ValueError(prompt.note_missing_err)
-        elif not output and note:
-            raise ValueError(prompt.output_missing_err)
         return model

--- a/scinoephile/llms/pairwise_review/models.py
+++ b/scinoephile/llms/pairwise_review/models.py
@@ -1,0 +1,96 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Pydantic models for pairwise-review test cases."""
+
+from __future__ import annotations
+
+from typing import ClassVar, Self
+
+from pydantic import Field, model_validator
+
+from scinoephile.core.llms import Answer, Query, TestCase
+
+from .prompt import PairwiseReviewPrompt
+
+__all__ = [
+    "PairwiseReviewAnswer",
+    "PairwiseReviewQuery",
+    "PairwiseReviewTestCase",
+]
+
+
+_BASE_PROMPT = PairwiseReviewPrompt()
+
+
+class PairwiseReviewQuery(Query):
+    """Target subtitle and its corresponding reference subtitle."""
+
+    prompt: ClassVar[PairwiseReviewPrompt] = _BASE_PROMPT
+    """Text and field aliases for LLM correspondence."""
+    target: str = Field(max_length=1000)
+    """Subtitle text to review."""
+    reference: str = Field(max_length=1000)
+    """Corresponding reference subtitle text."""
+
+
+class PairwiseReviewAnswer(Answer):
+    """Optional revision of a target subtitle and explanatory note."""
+
+    prompt: ClassVar[PairwiseReviewPrompt] = _BASE_PROMPT
+    """Text and field aliases for LLM correspondence."""
+    output: str = Field("", max_length=1000)
+    """Revised target subtitle, removal marker, or empty string if unchanged."""
+    note: str = Field("", max_length=1000)
+    """Explanation of the revision, or an empty string."""
+
+
+class PairwiseReviewTestCase(TestCase):
+    """Pairwise-review query, optional answer, and optimization metadata."""
+
+    query_cls: ClassVar[type[PairwiseReviewQuery]] = PairwiseReviewQuery
+    """Query model class."""
+    answer_cls: ClassVar[type[PairwiseReviewAnswer]] = PairwiseReviewAnswer
+    """Answer model class."""
+    prompt: ClassVar[PairwiseReviewPrompt] = _BASE_PROMPT
+    """Text and field aliases for LLM correspondence."""
+    query: PairwiseReviewQuery
+    """Target subtitle and corresponding reference subtitle."""
+    answer: PairwiseReviewAnswer | None = None
+    """Target revision and note, if available."""
+
+    def get_min_difficulty(self) -> int:
+        """Get minimum difficulty based on whether the target is revised.
+
+        Returns:
+            minimum difficulty
+        """
+        min_difficulty = super().get_min_difficulty()
+        if (
+            self.answer is not None
+            and self.answer.output
+            and self.answer.output != self.query.target
+        ):
+            min_difficulty = max(min_difficulty, 1)
+        return min_difficulty
+
+    @model_validator(mode="after")
+    def validate_output_note_correspondence(self) -> Self:
+        """Normalize unchanged output and require revisions and notes together.
+
+        Unchanged full-text outputs from legacy pairwise-review data are normalized to
+        the empty-string convention used by the other review operations.
+
+        Returns:
+            validated test case
+        """
+        if self.answer is None:
+            return self
+
+        if self.answer.output == self.query.target:
+            self.answer.output = ""
+            self.answer.note = ""
+        elif self.answer.output and not self.answer.note:
+            raise ValueError(self.prompt.note_missing_err)
+        elif not self.answer.output and self.answer.note:
+            raise ValueError(self.prompt.output_missing_err)
+        return self

--- a/scinoephile/llms/pairwise_review/processor.py
+++ b/scinoephile/llms/pairwise_review/processor.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from logging import getLogger
+from typing import cast
 
 import numpy as np
 
@@ -16,6 +17,7 @@ from scinoephile.core.synchronization import get_sync_overlap_matrix
 from scinoephile.core.text import replace_control_characters
 
 from .manager import PairwiseReviewManager
+from .models import PairwiseReviewAnswer
 from .prompt import PairwiseReviewPrompt
 
 __all__ = ["PairwiseReviewProcessor"]
@@ -81,15 +83,16 @@ class PairwiseReviewProcessor(Processor):
                 reference_text = reference_subtitle.text_with_newline.strip()
                 output_text = ""
                 if target_text != reference_text:
-                    query = query_cls(
-                        **{
-                            self.prompt.target: target_text,
-                            self.prompt.reference: reference_text,
+                    query = query_cls.model_validate(
+                        {
+                            "target": target_text,
+                            "reference": reference_text,
                         }
                     )
                     test_case = test_case_cls(query=query)
                     test_case = self.queryer(test_case)
-                    output_text = getattr(test_case.answer, self.prompt.output)
+                    answer = cast(PairwiseReviewAnswer, test_case.answer)
+                    output_text = answer.output
 
                 if output_text == "�":
                     continue

--- a/test/llms/test_legacy_test_case_callbacks.py
+++ b/test/llms/test_legacy_test_case_callbacks.py
@@ -9,38 +9,6 @@ from pytest import raises
 
 from scinoephile.llms.delineation import DelineationManager
 from scinoephile.llms.ocr_fusion import OcrFusionManager
-from scinoephile.llms.pairwise_review import PairwiseReviewManager
-
-
-def test_pairwise_review_retains_validation_and_minimum_difficulty():
-    """Pairwise review should normalize unchanged output and score revisions."""
-    test_case_cls = PairwiseReviewManager.get_test_case_cls(
-        PairwiseReviewManager.base_prompt
-    )
-    unchanged = test_case_cls.model_validate(
-        {
-            "query": {"target": "original", "reference": "reference"},
-            "answer": {"output": "original", "note": "legacy"},
-        }
-    )
-    revised = test_case_cls.model_validate(
-        {
-            "query": {"target": "original", "reference": "reference"},
-            "answer": {"output": "corrected", "note": "typo"},
-        }
-    )
-
-    assert unchanged.answer is not None
-    assert unchanged.answer.model_dump() == {"output": "", "note": ""}
-    assert unchanged.difficulty == 0
-    assert revised.difficulty == 1
-    with raises(ValidationError, match="no note is provided"):
-        test_case_cls.model_validate(
-            {
-                "query": {"target": "original", "reference": "reference"},
-                "answer": {"output": "corrected", "note": ""},
-            }
-        )
 
 
 def test_ocr_fusion_retains_auto_verification_and_minimum_difficulty():

--- a/test/llms/test_pairwise_review_models.py
+++ b/test/llms/test_pairwise_review_models.py
@@ -1,0 +1,442 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests for static pairwise-review LLM models and prompt aliases."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import cast
+from unittest.mock import Mock
+
+from pydantic import ValidationError
+from pytest import mark, raises
+
+from scinoephile.core import Language
+from scinoephile.core.llms import LLMProvider, Queryer
+from scinoephile.core.llms.models import get_model_name
+from scinoephile.core.llms.utils import (
+    load_test_cases_from_json,
+    save_test_cases_to_json,
+)
+from scinoephile.core.subtitles import Series, Subtitle
+from scinoephile.llms.pairwise_review import (
+    PairwiseReviewAnswer,
+    PairwiseReviewManager,
+    PairwiseReviewProcessor,
+    PairwiseReviewPrompt,
+    PairwiseReviewQuery,
+    PairwiseReviewTestCase,
+)
+from test.helpers import test_data_root
+
+_LOCALIZED_PROMPT = PairwiseReviewPrompt(
+    language=Language.zho_hant,
+    target="mubiao",
+    target_desc="要校對的字幕",
+    reference="cankao",
+    reference_desc="對應的參考字幕",
+    output="shuchu",
+    output_desc="修改後的字幕，沒有修改時為空字串",
+    note="beizhu",
+    note_desc="修改說明，沒有修改時為空字串",
+    note_missing_err="本地化答案缺少修改說明。",
+    output_missing_err="本地化答案缺少修改字幕。",
+)
+"""Pairwise-review prompt with localized correspondence field names."""
+
+_FIXTURES = [
+    (
+        "kob/output/yue-Hans_transcribe/multilang/yue_zho/pairwise_review/cuda.json",
+        2486,
+        1120,
+    ),
+    (
+        "kob/output/yue-Hans_transcribe/multilang/yue_zho/pairwise_review/mps.json",
+        1309,
+        632,
+    ),
+    (
+        "mlamd/output/yue-Hans_transcribe/multilang/yue_zho/pairwise_review/cuda.json",
+        808,
+        516,
+    ),
+    (
+        "mlamd/output/yue-Hans_transcribe/multilang/yue_zho/pairwise_review/mps.json",
+        802,
+        511,
+    ),
+]
+"""Tracked pairwise-review fixture paths, case counts, and unchanged counts."""
+
+
+def test_static_models_use_semantic_fields():
+    """Public static models should be usable without a manager factory."""
+    query = PairwiseReviewQuery(target="original", reference="reference")
+    answer = PairwiseReviewAnswer(output="corrected", note="typo")
+    test_case = PairwiseReviewTestCase(query=query, answer=answer)
+
+    assert PairwiseReviewTestCase.query_cls is PairwiseReviewQuery
+    assert PairwiseReviewTestCase.answer_cls is PairwiseReviewAnswer
+    assert test_case.model_dump() == {
+        "query": {"target": "original", "reference": "reference"},
+        "answer": {"output": "corrected", "note": "typo"},
+        "difficulty": 1,
+        "few_shot": False,
+        "verified": False,
+    }
+
+
+def test_manager_generates_aliases_without_changing_semantic_fields_or_schema():
+    """Generated models should retain stable fields and prompt-specific schemas."""
+    test_case_cls = PairwiseReviewManager.get_test_case_cls(_LOCALIZED_PROMPT)
+    test_case = cast(
+        PairwiseReviewTestCase,
+        test_case_cls.model_validate(
+            {
+                "query": {"mubiao": "原文", "cankao": "參考"},
+                "answer": {"shuchu": "修改", "beizhu": "修正錯字"},
+            }
+        ),
+    )
+
+    assert issubclass(test_case_cls, PairwiseReviewTestCase)
+    assert list(test_case_cls.query_cls.model_fields) == ["target", "reference"]
+    assert list(test_case_cls.answer_cls.model_fields) == ["output", "note"]
+    assert test_case.query.target == "原文"
+    assert test_case.query.reference == "參考"
+    assert test_case.query.model_dump(by_alias=True) == {
+        "mubiao": "原文",
+        "cankao": "參考",
+    }
+    assert test_case.answer is not None
+    assert test_case.answer.output == "修改"
+    assert test_case.answer.note == "修正錯字"
+    assert test_case.answer.model_dump(by_alias=True) == {
+        "shuchu": "修改",
+        "beizhu": "修正錯字",
+    }
+
+    query_schema = test_case_cls.query_cls.model_json_schema(by_alias=True)
+    answer_schema = test_case_cls.answer_cls.model_json_schema(by_alias=True)
+    assert query_schema["title"] == get_model_name(
+        "PairwiseReviewQuery", _LOCALIZED_PROMPT.name
+    )
+    assert answer_schema["title"] == get_model_name(
+        "PairwiseReviewAnswer", _LOCALIZED_PROMPT.name
+    )
+    assert list(query_schema["properties"]) == ["mubiao", "cankao"]
+    assert query_schema["required"] == ["mubiao", "cankao"]
+    assert query_schema["properties"]["mubiao"]["description"] == (
+        _LOCALIZED_PROMPT.target_desc
+    )
+    assert query_schema["properties"]["cankao"]["description"] == (
+        _LOCALIZED_PROMPT.reference_desc
+    )
+    assert query_schema["properties"]["mubiao"]["maxLength"] == 1000
+    assert query_schema["properties"]["cankao"]["maxLength"] == 1000
+    assert list(answer_schema["properties"]) == ["shuchu", "beizhu"]
+    assert "required" not in answer_schema
+    assert answer_schema["properties"]["shuchu"]["description"] == (
+        _LOCALIZED_PROMPT.output_desc
+    )
+    assert answer_schema["properties"]["beizhu"]["description"] == (
+        _LOCALIZED_PROMPT.note_desc
+    )
+    assert answer_schema["properties"]["shuchu"]["default"] == ""
+    assert answer_schema["properties"]["beizhu"]["default"] == ""
+    assert answer_schema["properties"]["shuchu"]["maxLength"] == 1000
+    assert answer_schema["properties"]["beizhu"]["maxLength"] == 1000
+
+
+def test_queryer_corresponds_using_prompt_aliases():
+    """Queryer should send aliased queries and request aliased answers."""
+    test_case_cls = PairwiseReviewManager.get_test_case_cls(_LOCALIZED_PROMPT)
+    test_case = cast(
+        PairwiseReviewTestCase,
+        test_case_cls.model_validate(
+            {"query": {"target": "原文", "reference": "參考"}}
+        ),
+    )
+    provider = Mock(spec=LLMProvider)
+    provider.chat_completion.return_value = '{"shuchu": "修改", "beizhu": "修正錯字"}'
+    queryer = Queryer(_LOCALIZED_PROMPT, provider=provider, max_attempts=1)
+
+    result = queryer(test_case)
+
+    assert result.answer is not None
+    assert result.answer.output == "修改"
+    assert result.answer.note == "修正錯字"
+    messages, answer_cls, _ = provider.chat_completion.call_args.args
+    assert answer_cls is test_case_cls.answer_cls
+    assert json.loads(messages[1]["content"]) == {
+        "mubiao": "原文",
+        "cankao": "參考",
+    }
+    assert f'"title": "{answer_cls.__name__}"' in messages[0]["content"]
+    assert '"shuchu"' in messages[0]["content"]
+    assert '"beizhu"' in messages[0]["content"]
+
+
+@mark.parametrize(
+    "test_case_cls",
+    [
+        PairwiseReviewTestCase,
+        PairwiseReviewManager.get_test_case_cls(PairwiseReviewManager.base_prompt),
+    ],
+    ids=["static", "generated"],
+)
+def test_unchanged_full_output_is_normalized(
+    test_case_cls: type[PairwiseReviewTestCase],
+):
+    """Legacy unchanged full-text outputs and notes should become empty strings."""
+    test_case = test_case_cls.model_validate(
+        {
+            "query": {"target": "original", "reference": "reference"},
+            "answer": {"output": "original", "note": "legacy note"},
+        }
+    )
+
+    assert test_case.answer is not None
+    assert test_case.answer.model_dump() == {"output": "", "note": ""}
+    assert test_case.difficulty == 0
+
+
+@mark.parametrize(
+    "test_case_cls",
+    [
+        PairwiseReviewTestCase,
+        PairwiseReviewManager.get_test_case_cls(PairwiseReviewManager.base_prompt),
+    ],
+    ids=["static", "generated"],
+)
+def test_output_and_note_must_be_provided_together(
+    test_case_cls: type[PairwiseReviewTestCase],
+):
+    """A changed or removal output should have a note, and vice versa."""
+    query = {"target": "original", "reference": "reference"}
+
+    with raises(ValidationError, match="target is revised, but no note is provided"):
+        test_case_cls.model_validate(
+            {
+                "query": query,
+                "answer": {"output": "corrected", "note": ""},
+            }
+        )
+    with raises(ValidationError, match="target is unchanged, but a note is provided"):
+        test_case_cls.model_validate(
+            {
+                "query": query,
+                "answer": {"output": "", "note": "typo"},
+            }
+        )
+
+
+@mark.parametrize(
+    ("answer", "difficulty"),
+    [
+        (None, 0),
+        ({}, 0),
+        ({"output": "", "note": ""}, 0),
+        ({"output": "original", "note": "legacy note"}, 0),
+        ({"output": "corrected", "note": "typo"}, 1),
+        ({"output": "�", "note": "no corresponding content"}, 1),
+    ],
+    ids=[
+        "unanswered",
+        "defaults",
+        "unchanged",
+        "legacy-unchanged",
+        "revised",
+        "removed",
+    ],
+)
+@mark.parametrize(
+    "test_case_cls",
+    [
+        PairwiseReviewTestCase,
+        PairwiseReviewManager.get_test_case_cls(PairwiseReviewManager.base_prompt),
+    ],
+    ids=["static", "generated"],
+)
+def test_minimum_difficulty_covers_every_answer_state(
+    answer: dict[str, str] | None,
+    difficulty: int,
+    test_case_cls: type[PairwiseReviewTestCase],
+):
+    """Only a changed or removal output should require difficulty one."""
+    data: dict[str, object] = {
+        "query": {"target": "original", "reference": "reference"}
+    }
+    if answer is not None:
+        data["answer"] = answer
+
+    test_case = test_case_cls.model_validate(data)
+
+    assert test_case.difficulty == difficulty
+
+
+@mark.parametrize(
+    "test_case_cls",
+    [
+        PairwiseReviewTestCase,
+        PairwiseReviewManager.get_test_case_cls(PairwiseReviewManager.base_prompt),
+    ],
+    ids=["static", "generated"],
+)
+def test_existing_difficulty_and_text_length_bounds_are_preserved(
+    test_case_cls: type[PairwiseReviewTestCase],
+):
+    """Explicit higher difficulty and every legacy 1000-character bound should hold."""
+    long_text = "x" * 1001
+    test_case = test_case_cls.model_validate(
+        {
+            "query": {"target": "original", "reference": "reference"},
+            "answer": {"output": "corrected", "note": "typo"},
+            "difficulty": 2,
+        }
+    )
+    assert test_case.difficulty == 2
+
+    with raises(ValidationError, match="at most 1000 characters"):
+        test_case_cls.model_validate(
+            {"query": {"target": long_text, "reference": "reference"}}
+        )
+    with raises(ValidationError, match="at most 1000 characters"):
+        test_case_cls.model_validate(
+            {"query": {"target": "original", "reference": long_text}}
+        )
+    with raises(ValidationError, match="at most 1000 characters"):
+        test_case_cls.model_validate(
+            {
+                "query": {"target": "original", "reference": "reference"},
+                "answer": {"output": long_text, "note": "note"},
+            }
+        )
+    with raises(ValidationError, match="at most 1000 characters"):
+        test_case_cls.model_validate(
+            {
+                "query": {"target": "original", "reference": "reference"},
+                "answer": {"output": "corrected", "note": long_text},
+            }
+        )
+
+
+def test_generated_test_case_uses_prompt_specific_validation_errors():
+    """Static validators should read errors from each generated model's prompt."""
+    test_case_cls = PairwiseReviewManager.get_test_case_cls(_LOCALIZED_PROMPT)
+    query = {"target": "原文", "reference": "參考"}
+
+    with raises(ValidationError, match=_LOCALIZED_PROMPT.note_missing_err):
+        test_case_cls.model_validate(
+            {"query": query, "answer": {"output": "修改", "note": ""}}
+        )
+    with raises(ValidationError, match=_LOCALIZED_PROMPT.output_missing_err):
+        test_case_cls.model_validate(
+            {"query": query, "answer": {"output": "", "note": "修改說明"}}
+        )
+
+
+def test_json_persistence_uses_base_fields_and_loads_localized_aliases(
+    tmp_path: Path,
+):
+    """JSON should persist base fields and reload prompt-specific aliases."""
+    test_case_cls = PairwiseReviewManager.get_test_case_cls(_LOCALIZED_PROMPT)
+    test_case = test_case_cls.model_validate(
+        {
+            "query": {"mubiao": "原文", "cankao": "參考"},
+            "answer": {"shuchu": "修改", "beizhu": "修正錯字"},
+            "verified": True,
+        }
+    )
+    output_path = tmp_path / "pairwise_review.json"
+
+    save_test_cases_to_json(output_path, [test_case], PairwiseReviewManager)
+
+    assert json.loads(output_path.read_text(encoding="utf-8")) == [
+        {
+            "query": {"target": "原文", "reference": "參考"},
+            "answer": {"output": "修改", "note": "修正錯字"},
+            "difficulty": 1,
+            "verified": True,
+        }
+    ]
+    loaded = load_test_cases_from_json(
+        output_path,
+        PairwiseReviewManager,
+        _LOCALIZED_PROMPT,
+    )
+    assert loaded[0].query.model_dump(by_alias=True) == {
+        "mubiao": "原文",
+        "cankao": "參考",
+    }
+    assert loaded[0].answer is not None
+    assert loaded[0].answer.model_dump(by_alias=True) == {
+        "shuchu": "修改",
+        "beizhu": "修正錯字",
+    }
+
+
+def test_processor_builds_and_consumes_semantic_fields():
+    """Processor should use stable attributes while corresponding with aliases."""
+    provider = Mock(spec=LLMProvider)
+    provider.chat_completion.return_value = '{"shuchu": "修改", "beizhu": "修正錯字"}'
+    processor = PairwiseReviewProcessor(_LOCALIZED_PROMPT, provider=provider)
+    processor.queryer.cache_dir_path = None
+    target = Series(events=[Subtitle(start=0, end=1000, text="原文")])
+    reference = Series(events=[Subtitle(start=0, end=1000, text="參考")])
+
+    output = processor.process(target, reference)
+
+    assert [subtitle.text for subtitle in output] == ["修改"]
+    messages = provider.chat_completion.call_args.args[0]
+    assert json.loads(messages[1]["content"]) == {
+        "mubiao": "原文",
+        "cankao": "參考",
+    }
+
+
+@mark.parametrize(
+    ("relative_path", "expected_count", "expected_unchanged_count"),
+    _FIXTURES,
+    ids=[relative_path for relative_path, _, _ in _FIXTURES],
+)
+def test_tracked_fixtures_round_trip_model_equivalently(
+    relative_path: str,
+    expected_count: int,
+    expected_unchanged_count: int,
+    tmp_path: Path,
+):
+    """All tracked files should save and reload after legacy normalization."""
+    input_path = test_data_root / relative_path
+    raw_test_cases = json.loads(input_path.read_text(encoding="utf-8"))
+    test_cases = load_test_cases_from_json(
+        input_path,
+        PairwiseReviewManager,
+        PairwiseReviewManager.base_prompt,
+    )
+
+    unchanged_count = 0
+    for raw_test_case, test_case in zip(raw_test_cases, test_cases, strict=True):
+        if raw_test_case["answer"]["output"] != raw_test_case["query"]["target"]:
+            continue
+        unchanged_count += 1
+        assert test_case.answer is not None
+        answer = cast(PairwiseReviewAnswer, test_case.answer)
+        assert answer.output == ""
+        assert answer.note == ""
+
+    assert len(test_cases) == expected_count
+    assert unchanged_count == expected_unchanged_count
+
+    output_path = tmp_path / Path(relative_path).name
+    save_test_cases_to_json(output_path, test_cases, PairwiseReviewManager)
+    reloaded = load_test_cases_from_json(
+        output_path,
+        PairwiseReviewManager,
+        PairwiseReviewManager.base_prompt,
+    )
+
+    assert [test_case.model_dump(mode="json") for test_case in reloaded] == [
+        test_case.model_dump(mode="json") for test_case in test_cases
+    ]


### PR DESCRIPTION
## Summary

- add static pairwise-review query, answer, and test-case models
- use stable `target`, `reference`, `output`, and `note` fields with prompt aliases
- move normalization, answer/note correspondence, and minimum difficulty into the static test case
- update the processor to use semantic attributes
- preserve all LLM-facing query/answer schemas and canonical persistence keys

## Why

Pairwise review still used prompt strings as Python field names. Static semantic models remove that dynamic shape without sacrificing localized JSON correspondence or the legacy unchanged-output normalization contract.

## Validation

- `ruff format` and `ruff check --fix`
- `ty check`
- focused tests: 140 passed in independent review
- all 4 tracked files / 5,405 cases match master model digests
- all 7 prompt variants / 37,835 loaded models match
- full suite: 1,622 passed, 9 skipped
- independent cross-review: no findings