### PR TITLE
Use static OCR fusion schema

### DIFF
--- a/scinoephile/llms/ocr_fusion/__init__.py
+++ b/scinoephile/llms/ocr_fusion/__init__.py
@@ -4,6 +4,7 @@
 
 Package hierarchy (modules may import from any above):
 * prompt
+* models
 * manager
 * processor
 """
@@ -11,11 +12,15 @@ Package hierarchy (modules may import from any above):
 from __future__ import annotations
 
 from .manager import OcrFusionManager
+from .models import OcrFusionAnswer, OcrFusionQuery, OcrFusionTestCase
 from .processor import OcrFusionProcessor
 from .prompt import OcrFusionPrompt
 
 __all__ = [
+    "OcrFusionAnswer",
     "OcrFusionManager",
     "OcrFusionProcessor",
     "OcrFusionPrompt",
+    "OcrFusionQuery",
+    "OcrFusionTestCase",
 ]

--- a/scinoephile/llms/ocr_fusion/manager.py
+++ b/scinoephile/llms/ocr_fusion/manager.py
@@ -7,11 +7,12 @@ from __future__ import annotations
 from functools import cache
 from typing import Any, ClassVar
 
-from pydantic import Field, create_model, model_validator
+from pydantic import Field, create_model
 
 from scinoephile.core.llms import Answer, Manager, Query, TestCase
 from scinoephile.core.llms.models import get_model_name
 
+from .models import OcrFusionAnswer, OcrFusionQuery, OcrFusionTestCase
 from .prompt import OcrFusionPrompt
 
 __all__ = ["OcrFusionManager"]
@@ -24,6 +25,8 @@ class OcrFusionManager(Manager):
     """Stable operation identifier used in persistence and CLIs."""
     base_prompt: ClassVar[OcrFusionPrompt] = OcrFusionPrompt()
     """Base prompt defining persisted test-case field names."""
+    test_case_base_cls: ClassVar[type[TestCase]] = OcrFusionTestCase
+    """Static test-case model defining OCR fusion's semantic shape."""
 
     @classmethod
     @cache
@@ -37,18 +40,20 @@ class OcrFusionManager(Manager):
         """
         name = get_model_name(Answer.__name__, prompt.name)
         fields: dict[str, Any] = {
-            prompt.output: (str, Field(..., description=prompt.output_desc)),
-            prompt.note: (str, Field(..., description=prompt.note_desc)),
-        }
-        validators: dict[str, Any] = {
-            "validate_answer": model_validator(mode="after")(cls.validate_answer),
+            "output": (
+                str,
+                Field(..., alias=prompt.output, description=prompt.output_desc),
+            ),
+            "note": (
+                str,
+                Field(..., alias=prompt.note, description=prompt.note_desc),
+            ),
         }
 
         model = create_model(
             name,
-            __base__=Answer,
+            __base__=OcrFusionAnswer,
             __module__=Answer.__module__,
-            __validators__=validators,
             **fields,
         )
         model.prompt = prompt
@@ -66,106 +71,21 @@ class OcrFusionManager(Manager):
         """
         name = get_model_name(Query.__name__, prompt.name)
         fields: dict[str, Any] = {
-            prompt.src_1: (str, Field(..., description=prompt.src_1_desc)),
-            prompt.src_2: (str, Field(..., description=prompt.src_2_desc)),
-        }
-        validators: dict[str, Any] = {
-            "validate_query": model_validator(mode="after")(cls.validate_query),
+            "source_one": (
+                str,
+                Field(..., alias=prompt.src_1, description=prompt.src_1_desc),
+            ),
+            "source_two": (
+                str,
+                Field(..., alias=prompt.src_2, description=prompt.src_2_desc),
+            ),
         }
 
         model = create_model(
             name,
-            __base__=Query,
+            __base__=OcrFusionQuery,
             __module__=Query.__module__,
-            __validators__=validators,
             **fields,
         )
         model.prompt = prompt
-        return model
-
-    @staticmethod
-    def get_auto_verified(model: TestCase) -> bool:
-        """Whether this test case should automatically be verified.
-
-        Arguments:
-            model: test case to inspect
-        Returns:
-            whether the test case should be auto-verified
-        """
-        if model.answer is None:
-            return False
-
-        if model.get_min_difficulty() > 1:
-            return False
-
-        prompt: OcrFusionPrompt = getattr(model, "prompt")
-        source_one = getattr(model.query, prompt.src_1, None)
-        source_two = getattr(model.query, prompt.src_2, None)
-        output_text = getattr(model.answer, prompt.output, None)
-        if (
-            source_one is not None
-            and source_two is not None
-            and output_text is not None
-        ):
-            if source_one == output_text and "\n" not in source_one:
-                return True
-            if source_two == output_text and "\n" not in source_two:
-                return True
-        return Manager.get_auto_verified(model)
-
-    @staticmethod
-    def get_min_difficulty(model: TestCase) -> int:
-        """Get minimum difficulty based on the test case properties.
-
-        Arguments:
-            model: test case to inspect
-        Returns:
-            minimum difficulty
-        """
-        prompt: OcrFusionPrompt = getattr(model, "prompt")
-        min_difficulty = max(Manager.get_min_difficulty(model), 1)
-        if model.answer is None:
-            return min_difficulty
-
-        if output_text := getattr(model.answer, prompt.output):
-            if any(char in output_text for char in ("-", '"', "“", "”")):
-                min_difficulty = max(min_difficulty, 2)
-        return min_difficulty
-
-    @staticmethod
-    def validate_answer(model: Answer) -> Answer:
-        """Ensure answer is internally valid.
-
-        Arguments:
-            model: answer to validate
-        Returns:
-            validated answer
-        """
-        prompt: OcrFusionPrompt = getattr(model, "prompt")
-        output = getattr(model, prompt.output, None)
-        note = getattr(model, prompt.note, None)
-        if not output:
-            raise ValueError(prompt.output_missing_err)
-        if not note:
-            raise ValueError(prompt.note_missing_err)
-        return model
-
-    @staticmethod
-    def validate_query(model: Query) -> Query:
-        """Ensure query is internally valid.
-
-        Arguments:
-            model: query to validate
-        Returns:
-            validated query
-        """
-        prompt: OcrFusionPrompt = getattr(model, "prompt")
-        source_one = getattr(model, prompt.src_1, None)
-        source_two = getattr(model, prompt.src_2, None)
-        if not source_one:
-            raise ValueError(prompt.src_1_missing_err)
-        if not source_two:
-            raise ValueError(prompt.src_2_missing_err)
-        if source_one == source_two:
-            raise ValueError(prompt.src_1_src_2_equal_err)
         return model

--- a/scinoephile/llms/ocr_fusion/models.py
+++ b/scinoephile/llms/ocr_fusion/models.py
@@ -1,0 +1,171 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Pydantic models for OCR-fusion test cases."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import ClassVar, Self
+
+from pydantic import model_validator
+
+from scinoephile.core.llms import Answer, Query, TestCase
+
+from .prompt import OcrFusionPrompt
+
+__all__ = [
+    "OcrFusionAnswer",
+    "OcrFusionQuery",
+    "OcrFusionTestCase",
+]
+
+
+_BASE_PROMPT = OcrFusionPrompt()
+
+
+class OcrFusionQuery(Query):
+    """Subtitle text from two OCR sources to fuse."""
+
+    prompt: ClassVar[OcrFusionPrompt] = _BASE_PROMPT
+    """Text and field aliases for LLM correspondence."""
+    source_one: str
+    """Subtitle text from source one."""
+    source_two: str
+    """Subtitle text from source two."""
+
+    @model_validator(mode="after")
+    def validate_sources(self) -> Self:
+        """Ensure both source texts are present and differ.
+
+        Returns:
+            validated query
+        """
+        if not self.source_one:
+            raise ValueError(self.prompt.src_1_missing_err)
+        if not self.source_two:
+            raise ValueError(self.prompt.src_2_missing_err)
+        if self.source_one == self.source_two:
+            raise ValueError(self.prompt.src_1_src_2_equal_err)
+        return self
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_sources_present(cls, value: object) -> object:
+        """Ensure both source fields are present before field validation.
+
+        Arguments:
+            value: raw query data
+        Returns:
+            raw query data after presence validation
+        """
+        if not isinstance(value, Mapping):
+            return value
+
+        source_one_alias = cls.model_fields["source_one"].alias
+        source_one_present = "source_one" in value
+        if source_one_alias is not None:
+            source_one_present = source_one_present or source_one_alias in value
+        if not source_one_present:
+            raise ValueError(cls.prompt.src_1_missing_err)
+
+        source_two_alias = cls.model_fields["source_two"].alias
+        source_two_present = "source_two" in value
+        if source_two_alias is not None:
+            source_two_present = source_two_present or source_two_alias in value
+        if not source_two_present:
+            raise ValueError(cls.prompt.src_2_missing_err)
+        return value
+
+
+class OcrFusionAnswer(Answer):
+    """Fused subtitle text and an explanation of the selected output."""
+
+    prompt: ClassVar[OcrFusionPrompt] = _BASE_PROMPT
+    """Text and field aliases for LLM correspondence."""
+    output: str
+    """Fused subtitle text."""
+    note: str
+    """Explanation of the fused output."""
+
+    @model_validator(mode="after")
+    def validate_content(self) -> Self:
+        """Ensure output and note text are present.
+
+        Returns:
+            validated answer
+        """
+        if not self.output:
+            raise ValueError(self.prompt.output_missing_err)
+        if not self.note:
+            raise ValueError(self.prompt.note_missing_err)
+        return self
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_content_present(cls, value: object) -> object:
+        """Ensure output and note fields are present before field validation.
+
+        Arguments:
+            value: raw answer data
+        Returns:
+            raw answer data after presence validation
+        """
+        if not isinstance(value, Mapping):
+            return value
+
+        output_alias = cls.model_fields["output"].alias
+        output_present = "output" in value
+        if output_alias is not None:
+            output_present = output_present or output_alias in value
+        if not output_present:
+            raise ValueError(cls.prompt.output_missing_err)
+
+        note_alias = cls.model_fields["note"].alias
+        note_present = "note" in value
+        if note_alias is not None:
+            note_present = note_present or note_alias in value
+        if not note_present:
+            raise ValueError(cls.prompt.note_missing_err)
+        return value
+
+
+class OcrFusionTestCase(TestCase):
+    """OCR-fusion query, optional answer, and optimization metadata."""
+
+    query_cls: ClassVar[type[OcrFusionQuery]] = OcrFusionQuery
+    """Query model class."""
+    answer_cls: ClassVar[type[OcrFusionAnswer]] = OcrFusionAnswer
+    """Answer model class."""
+    prompt: ClassVar[OcrFusionPrompt] = _BASE_PROMPT
+    """Text and field aliases for LLM correspondence."""
+    query: OcrFusionQuery
+    """Subtitle text from two OCR sources."""
+    answer: OcrFusionAnswer | None = None
+    """Fused subtitle text and explanation, if available."""
+
+    def get_auto_verified(self) -> bool:
+        """Whether this test case should automatically be verified.
+
+        Returns:
+            whether the test case should be auto-verified
+        """
+        if self.answer is None or self.get_min_difficulty() > 1:
+            return False
+        if self.query.source_one == self.answer.output:
+            return "\n" not in self.query.source_one
+        if self.query.source_two == self.answer.output:
+            return "\n" not in self.query.source_two
+        return super().get_auto_verified()
+
+    def get_min_difficulty(self) -> int:
+        """Get minimum difficulty based on the fused output.
+
+        Returns:
+            minimum difficulty
+        """
+        min_difficulty = max(super().get_min_difficulty(), 1)
+        if self.answer is not None and any(
+            char in self.answer.output for char in ("-", '"', "“", "”")
+        ):
+            min_difficulty = max(min_difficulty, 2)
+        return min_difficulty

--- a/scinoephile/llms/ocr_fusion/processor.py
+++ b/scinoephile/llms/ocr_fusion/processor.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from logging import getLogger
+from typing import cast
 
 from scinoephile.core import ScinoephileError
 from scinoephile.core.llms import Processor
@@ -13,6 +14,7 @@ from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.core.synchronization import are_series_one_to_one
 
 from .manager import OcrFusionManager
+from .models import OcrFusionAnswer
 from .prompt import OcrFusionPrompt
 
 __all__ = ["OcrFusionProcessor"]
@@ -91,12 +93,12 @@ class OcrFusionProcessor(Processor):
             # Query LLM
             test_case_cls = OcrFusionManager.get_test_case_cls(prompt)
             query_cls = test_case_cls.query_cls
-            query_kwargs = {prompt.src_1: text_one, prompt.src_2: text_two}
-            query = query_cls(**query_kwargs)
+            query = query_cls(source_one=text_one, source_two=text_two)
             test_case = test_case_cls(query=query)
             test_case = self.queryer(test_case)
 
-            output_text = getattr(test_case.answer, prompt.output)
+            answer = cast(OcrFusionAnswer, test_case.answer)
+            output_text = answer.output
             sub = Subtitle(start=sub_one.start, end=sub_one.end, text=output_text)
             logger.info(
                 f"Subtitle {sub_idx + 1} processed:     {sub.text.replace('\n', '\\n')}"

--- a/test/llms/test_legacy_test_case_callbacks.py
+++ b/test/llms/test_legacy_test_case_callbacks.py
@@ -8,29 +8,6 @@ from pydantic import ValidationError
 from pytest import raises
 
 from scinoephile.llms.delineation import DelineationManager
-from scinoephile.llms.ocr_fusion import OcrFusionManager
-
-
-def test_ocr_fusion_retains_auto_verification_and_minimum_difficulty():
-    """OCR fusion should retain its legacy difficulty and verification rules."""
-    test_case_cls = OcrFusionManager.get_test_case_cls(OcrFusionManager.base_prompt)
-    simple = test_case_cls.model_validate(
-        {
-            "query": {"one": "source one", "two": "source two"},
-            "answer": {"output": "source one", "note": "selected source one"},
-        }
-    )
-    complex_case = test_case_cls.model_validate(
-        {
-            "query": {"one": "source-one", "two": "source two"},
-            "answer": {"output": "source-one", "note": "selected source one"},
-        }
-    )
-
-    assert simple.difficulty == 1
-    assert simple.get_auto_verified()
-    assert complex_case.difficulty == 2
-    assert not complex_case.get_auto_verified()
 
 
 def test_delineation_retains_validation_and_minimum_difficulty():

--- a/test/llms/test_ocr_fusion_models.py
+++ b/test/llms/test_ocr_fusion_models.py
@@ -1,0 +1,368 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests for static OCR-fusion LLM models and prompt aliases."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+from pydantic import ValidationError
+from pytest import mark, raises
+
+from scinoephile.core import Language
+from scinoephile.core.llms import Answer, LLMProvider, Query, Queryer
+from scinoephile.core.llms.models import get_model_name
+from scinoephile.core.llms.test_case_mapping import remap_test_case
+from scinoephile.core.llms.utils import (
+    load_test_cases_from_json,
+    save_test_cases_to_json,
+)
+from scinoephile.core.subtitles import Series, Subtitle
+from scinoephile.llms.ocr_fusion import (
+    OcrFusionAnswer,
+    OcrFusionManager,
+    OcrFusionProcessor,
+    OcrFusionPrompt,
+    OcrFusionQuery,
+    OcrFusionTestCase,
+)
+from scinoephile.optimization.persistence.test_cases import (
+    PersistedTestCase,
+    TestCaseSqliteStore,
+)
+from test.helpers import test_data_root
+
+_LOCALIZED_PROMPT = OcrFusionPrompt(
+    language=Language.zho_hant,
+    src_1="yilai",
+    src_1_desc="來源一字幕",
+    src_2="erlai",
+    src_2_desc="來源二字幕",
+    src_1_missing_err="必須提供來源一字幕。",
+    src_2_missing_err="必須提供來源二字幕。",
+    src_1_src_2_equal_err="兩個來源字幕必須不同。",
+    output="jieguo",
+    output_desc="融合後字幕",
+    note="shuoming",
+    note_desc="融合說明",
+    output_missing_err="必須提供融合後字幕。",
+    note_missing_err="必須提供融合說明。",
+)
+"""OCR-fusion prompt with localized correspondence field names and errors."""
+
+
+def test_static_models_use_semantic_fields():
+    """Public static models should use prompt-independent semantic fields."""
+    query = OcrFusionQuery(source_one="source one", source_two="source two")
+    answer = OcrFusionAnswer(output="source one", note="selected source one")
+    test_case = OcrFusionTestCase(query=query, answer=answer)
+
+    assert query.model_dump() == {
+        "source_one": "source one",
+        "source_two": "source two",
+    }
+    assert answer.model_dump() == {
+        "output": "source one",
+        "note": "selected source one",
+    }
+    assert test_case.query is query
+    assert test_case.answer is answer
+
+
+def test_generated_models_preserve_aliases_and_llm_schemas():
+    """Generated models should preserve localized aliases and legacy schemas."""
+    query_cls = OcrFusionManager.get_query_cls(_LOCALIZED_PROMPT)
+    answer_cls = OcrFusionManager.get_answer_cls(_LOCALIZED_PROMPT)
+
+    query = query_cls(source_one="來源一", source_two="來源二")
+    answer = answer_cls(output="融合結果", note="融合說明")
+
+    assert tuple(query_cls.model_fields) == ("source_one", "source_two")
+    assert tuple(answer_cls.model_fields) == ("output", "note")
+    assert query.model_dump() == {"source_one": "來源一", "source_two": "來源二"}
+    assert query.model_dump(by_alias=True) == {"yilai": "來源一", "erlai": "來源二"}
+    assert answer.model_dump(by_alias=True) == {
+        "jieguo": "融合結果",
+        "shuoming": "融合說明",
+    }
+
+    query_schema = query_cls.model_json_schema(by_alias=True)
+    answer_schema = answer_cls.model_json_schema(by_alias=True)
+    assert query_schema == {
+        "properties": {
+            "yilai": {
+                "description": "來源一字幕",
+                "title": "Yilai",
+                "type": "string",
+            },
+            "erlai": {
+                "description": "來源二字幕",
+                "title": "Erlai",
+                "type": "string",
+            },
+        },
+        "required": ["yilai", "erlai"],
+        "title": get_model_name(Query.__name__, _LOCALIZED_PROMPT.name),
+        "type": "object",
+    }
+    assert answer_schema == {
+        "properties": {
+            "jieguo": {
+                "description": "融合後字幕",
+                "title": "Jieguo",
+                "type": "string",
+            },
+            "shuoming": {
+                "description": "融合說明",
+                "title": "Shuoming",
+                "type": "string",
+            },
+        },
+        "required": ["jieguo", "shuoming"],
+        "title": get_model_name(Answer.__name__, _LOCALIZED_PROMPT.name),
+        "type": "object",
+    }
+
+
+def test_static_models_use_prompt_aware_validation_errors():
+    """Static models should reject absent, empty, or equal content."""
+    with raises(ValidationError, match="source one is required"):
+        OcrFusionQuery.model_validate({"source_two": "source two"})
+    with raises(ValidationError, match="source two is required"):
+        OcrFusionQuery.model_validate({"source_one": "source one"})
+    with raises(ValidationError, match="source one is required"):
+        OcrFusionQuery(source_one="", source_two="source two")
+    with raises(ValidationError, match="two sources must differ"):
+        OcrFusionQuery(source_one="same", source_two="same")
+    with raises(ValidationError, match="Output subtitle text is required"):
+        OcrFusionAnswer.model_validate({"note": "explanation"})
+    with raises(ValidationError, match="Explanation of output is required"):
+        OcrFusionAnswer.model_validate({"output": "fused"})
+    with raises(ValidationError, match="Output subtitle text is required"):
+        OcrFusionAnswer(output="", note="explanation")
+    with raises(ValidationError, match="Explanation of output is required"):
+        OcrFusionAnswer(output="fused", note="")
+
+
+def test_generated_models_use_localized_validation_errors():
+    """Generated models should validate aliases using their localized prompt."""
+    query_cls = OcrFusionManager.get_query_cls(_LOCALIZED_PROMPT)
+    answer_cls = OcrFusionManager.get_answer_cls(_LOCALIZED_PROMPT)
+
+    with raises(ValidationError, match="必須提供來源一字幕"):
+        query_cls.model_validate({"erlai": "來源二"})
+    with raises(ValidationError, match="必須提供來源二字幕"):
+        query_cls.model_validate({"yilai": "來源一"})
+    with raises(ValidationError, match="兩個來源字幕必須不同"):
+        query_cls.model_validate({"yilai": "相同", "erlai": "相同"})
+    with raises(ValidationError, match="必須提供融合後字幕"):
+        answer_cls.model_validate({"shuoming": "說明"})
+    with raises(ValidationError, match="必須提供融合說明"):
+        answer_cls.model_validate({"jieguo": "結果"})
+
+
+@mark.parametrize(
+    "test_case_cls",
+    [
+        OcrFusionTestCase,
+        OcrFusionManager.get_test_case_cls(OcrFusionManager.base_prompt),
+    ],
+    ids=["static", "generated"],
+)
+@mark.parametrize(
+    ("source_one", "source_two", "output", "expected_difficulty", "auto_verified"),
+    [
+        ("source one", "source two", None, 1, False),
+        ("source one", "source two", "source one", 1, True),
+        ("source one", "source two", "source two", 1, True),
+        ("source one", "source two", "fused", 1, False),
+        ("source\none", "source two", "source\none", 1, False),
+        ("source one", "source\ntwo", "source\ntwo", 1, False),
+        ("source-one", "source two", "source-one", 2, False),
+        ('source "one"', "source two", 'source "one"', 2, False),
+        ("“source one”", "source two", "“source one”", 2, False),
+    ],
+    ids=[
+        "no-answer",
+        "source-one",
+        "source-two",
+        "fused",
+        "source-one-multiline",
+        "source-two-multiline",
+        "hyphen",
+        "straight-quote",
+        "curly-quotes",
+    ],
+)
+def test_difficulty_and_auto_verification_matrix(
+    test_case_cls: type[OcrFusionTestCase],
+    source_one: str,
+    source_two: str,
+    output: str | None,
+    expected_difficulty: int,
+    auto_verified: bool,
+):
+    """Difficulty and auto-verification should retain legacy behavior."""
+    data: dict[str, object] = {
+        "query": {"source_one": source_one, "source_two": source_two}
+    }
+    if output is not None:
+        data["answer"] = {"output": output, "note": "explanation"}
+
+    test_case = test_case_cls.model_validate(data)
+
+    assert test_case.difficulty == expected_difficulty
+    assert test_case.get_auto_verified() is auto_verified
+
+
+def test_queryer_corresponds_using_prompt_aliases():
+    """Queryer should send and request localized correspondence fields."""
+    test_case_cls = OcrFusionManager.get_test_case_cls(_LOCALIZED_PROMPT)
+    test_case = test_case_cls.model_validate(
+        {"query": {"source_one": "來源一", "source_two": "來源二"}}
+    )
+    provider = Mock(spec=LLMProvider)
+    provider.chat_completion.return_value = (
+        '{"jieguo": "來源一", "shuoming": "採用來源一"}'
+    )
+    queryer = Queryer(_LOCALIZED_PROMPT, provider=provider, max_attempts=1)
+
+    result = queryer(test_case)
+
+    assert result.answer is not None
+    assert result.answer.model_dump() == {
+        "output": "來源一",
+        "note": "採用來源一",
+    }
+    messages = provider.chat_completion.call_args.args[0]
+    assert json.loads(messages[1]["content"]) == {
+        "yilai": "來源一",
+        "erlai": "來源二",
+    }
+    assert '"jieguo"' in messages[0]["content"]
+    assert '"shuoming"' in messages[0]["content"]
+
+
+def test_processor_uses_semantic_fields_at_runtime():
+    """Processor should build and consume the static semantic model shape."""
+    provider = Mock(spec=LLMProvider)
+    provider.chat_completion.return_value = (
+        '{"jieguo": "融合結果", "shuoming": "融合兩個來源"}'
+    )
+    processor = OcrFusionProcessor(_LOCALIZED_PROMPT, provider=provider)
+    processor.queryer.cache_dir_path = None
+    source_one = Series([Subtitle(start=0, end=1000, text="來源一")])
+    source_two = Series([Subtitle(start=0, end=1000, text="來源二")])
+
+    result = processor.process(source_one, source_two)
+
+    assert [subtitle.text for subtitle in result] == ["融合結果"]
+    messages = provider.chat_completion.call_args.args[0]
+    assert json.loads(messages[1]["content"]) == {
+        "yilai": "來源一",
+        "erlai": "來源二",
+    }
+
+
+def test_json_persistence_uses_base_prompt_aliases(tmp_path: Path):
+    """JSON should retain base one/two fields across localized round trips."""
+    test_case_cls = OcrFusionManager.get_test_case_cls(_LOCALIZED_PROMPT)
+    test_case = test_case_cls.model_validate(
+        {
+            "query": {"yilai": "來源一", "erlai": "來源二"},
+            "answer": {"jieguo": "來源一", "shuoming": "採用來源一"},
+            "verified": True,
+        }
+    )
+    output_path = tmp_path / "ocr_fusion.json"
+
+    save_test_cases_to_json(output_path, [test_case], OcrFusionManager)
+
+    assert json.loads(output_path.read_text(encoding="utf-8")) == [
+        {
+            "query": {"one": "來源一", "two": "來源二"},
+            "answer": {"output": "來源一", "note": "採用來源一"},
+            "difficulty": 1,
+            "verified": True,
+        }
+    ]
+    loaded = load_test_cases_from_json(
+        output_path,
+        OcrFusionManager,
+        _LOCALIZED_PROMPT,
+    )
+    assert loaded[0].query.model_dump(by_alias=True) == {
+        "yilai": "來源一",
+        "erlai": "來源二",
+    }
+    assert loaded[0].answer is not None
+    assert loaded[0].answer.model_dump(by_alias=True) == {
+        "jieguo": "來源一",
+        "shuoming": "採用來源一",
+    }
+
+
+def test_persisted_test_case_and_sqlite_use_base_prompt_aliases(tmp_path: Path):
+    """Normalized persistence should store base one/two query fields."""
+    test_case_cls = OcrFusionManager.get_test_case_cls(_LOCALIZED_PROMPT)
+    test_case = test_case_cls.model_validate(
+        {
+            "query": {"source_one": "來源一", "source_two": "來源二"},
+            "answer": {"output": "來源一", "note": "採用來源一"},
+        }
+    )
+
+    persisted = PersistedTestCase.from_test_case(test_case, OcrFusionManager)
+
+    assert persisted.query == {"one": "來源一", "two": "來源二"}
+    assert persisted.answer == {"output": "來源一", "note": "採用來源一"}
+
+    store = TestCaseSqliteStore(tmp_path / "test_cases.sqlite")
+    store.sync_source_paths(
+        {"ocr_fusion.json": [persisted]},
+        manager_cls=OcrFusionManager,
+        dry_run=False,
+    )
+    loaded = store.get_test_case(persisted.test_case_id)
+    assert loaded is not None
+    assert loaded.query == {"one": "來源一", "two": "來源二"}
+    assert loaded.answer == {"output": "來源一", "note": "採用來源一"}
+
+
+def test_repository_json_fixtures_round_trip_without_rewrite():
+    """All tracked OCR-fusion cases should survive localized model round trips."""
+    input_paths = sorted(test_data_root.glob("*/output/*/lang/*/ocr_fusion.json"))
+    base_test_case_cls = OcrFusionManager.get_test_case_cls(
+        OcrFusionManager.base_prompt
+    )
+    total_test_cases = 0
+
+    for input_path in input_paths:
+        raw_test_cases = json.loads(input_path.read_text(encoding="utf-8"))
+        localized_test_cases = load_test_cases_from_json(
+            input_path,
+            OcrFusionManager,
+            _LOCALIZED_PROMPT,
+        )
+        assert len(localized_test_cases) == len(raw_test_cases)
+        total_test_cases += len(localized_test_cases)
+
+        for raw_test_case, localized_test_case in zip(
+            raw_test_cases,
+            localized_test_cases,
+            strict=True,
+        ):
+            base_test_case = remap_test_case(localized_test_case, base_test_case_cls)
+            assert (
+                base_test_case.model_dump(
+                    mode="json",
+                    by_alias=True,
+                    exclude_defaults=True,
+                )
+                == raw_test_case
+            )
+
+    assert len(input_paths) == 26
+    assert total_test_cases == 10_580


### PR DESCRIPTION
## Summary

- add static OCR-fusion query, answer, and test-case models
- use stable `source_one` and `source_two` fields with prompt-localized aliases
- move source/content validation, difficulty, and auto-verification into static models
- update the processor to use semantic attributes
- retain base `one`/`two` JSON and SQLite persistence

## Why

OCR fusion still used localized prompt strings as Python field names. Stable semantic models remove that dynamic shape while retaining the exact LLM-facing schemas and canonical persistence contract.

## Validation

- `ruff format` and `ruff check --fix`
- `ty check`
- focused core/persistence tests: 53 passed
- fixture/language workflow tests: 111 passed
- all 6 prompt schemas match master exactly
- all 26 tracked files / 10,580 cases round-trip exactly and retain legacy behavior
- full suite: 1,621 passed, 9 skipped
- independent cross-review: no findings