### PR TITLE
Trim prompt test case metadata fields

### DIFF
--- a/scinoephile/core/llms/manager.py
+++ b/scinoephile/core/llms/manager.py
@@ -63,7 +63,7 @@ class Manager(ABC):
         """
         query_cls = cls.get_query_cls(prompt)
         answer_cls = cls.get_answer_cls(prompt)
-        fields = cls.get_test_case_fields(query_cls, answer_cls, prompt)
+        fields = cls.get_test_case_fields(query_cls, answer_cls)
 
         model = create_model(
             get_model_name(cls.test_case_base_cls.__name__, prompt.name),
@@ -81,31 +81,17 @@ class Manager(ABC):
         cls,
         query_cls: type[Query],
         answer_cls: type[Answer],
-        prompt: Prompt,
     ) -> dict[str, Any]:
         """Get fields dictionary for dynamic TestCase class creation.
 
         Arguments:
             query_cls: query model class
             answer_cls: answer model class
-            prompt: text for LLM correspondence
         Returns:
             fields dictionary for create_model
         """
         fields: dict[str, Any] = {
             "query": (query_cls, Field(...)),
             "answer": (answer_cls | None, Field(default=None)),
-            "difficulty": (
-                int,
-                Field(0, description=prompt.difficulty_description),
-            ),
-            "few_shot": (
-                bool,
-                Field(False, description=prompt.few_shot_description),
-            ),
-            "verified": (
-                bool,
-                Field(False, description=prompt.verified_description),
-            ),
         }
         return fields

--- a/scinoephile/core/llms/prompt.py
+++ b/scinoephile/core/llms/prompt.py
@@ -33,12 +33,6 @@ class PromptLocalizationFields(TypedDict):
     """Text preceding answer validation errors."""
     answer_invalid_post: str
     """Text following answer validation errors."""
-    difficulty_description: str
-    """Description of 'difficulty' field."""
-    few_shot_description: str
-    """Description of 'few_shot' field."""
-    verified_description: str
-    """Description of 'verified' field."""
     test_case_invalid_pre: str
     """Text preceding test case validation errors."""
     test_case_invalid_post: str
@@ -69,18 +63,6 @@ class Prompt:
     """Text preceding answer validation errors."""
     answer_invalid_post: str = ""
     """Text following answer validation errors."""
-
-    # Test case field descriptions
-    difficulty_description: str = (
-        "Difficulty level of the test case, used for filtering."
-    )
-    """Description of 'difficulty' field."""
-    few_shot_description: str = "Whether to include test case in few-shot examples."
-    """Description of 'few_shot' field."""
-    verified_description: str = (
-        "Whether to include test case in the verified answers cache."
-    )
-    """Description of 'verified' field."""
 
     # Test case validation errors
     test_case_invalid_pre: str = ""

--- a/scinoephile/core/llms/test_case.py
+++ b/scinoephile/core/llms/test_case.py
@@ -8,7 +8,7 @@ import json
 from abc import ABC
 from typing import ClassVar, Self
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, Field, model_validator
 
 from .answer import Answer
 from .prompt import Prompt
@@ -33,11 +33,20 @@ class TestCase(BaseModel, ABC):
     """Query data for the test case."""
     answer: Answer | None = None
     """Answer data for the test case."""
-    difficulty: int = 0
+    difficulty: int = Field(
+        0,
+        description="Difficulty level of the test case, used for filtering.",
+    )
     """Difficulty level for filtering and prioritization."""
-    few_shot: bool = False
+    few_shot: bool = Field(
+        False,
+        description="Whether to include test case in few-shot examples.",
+    )
     """Whether the test case is included as a few-shot example."""
-    verified: bool = False
+    verified: bool = Field(
+        False,
+        description="Whether to include test case in the verified answers cache.",
+    )
     """Whether the test case answer has been verified."""
 
     def __str__(self) -> str:

--- a/scinoephile/lang/eng/prompts.py
+++ b/scinoephile/lang/eng/prompts.py
@@ -24,11 +24,6 @@ ENG_PROMPT_FIELDS: Final[PromptLocalizationFields] = {
         "Please try again and respond only with a valid JSON object matching the "
         "schema."
     ),
-    "difficulty_description": "Difficulty level of the test case, used for filtering.",
-    "few_shot_description": "Whether to include test case in few-shot examples.",
-    "verified_description": (
-        "Whether to include test case in the verified answers cache."
-    ),
     "test_case_invalid_pre": (
         "Your previous response was valid JSON compliant with the answer schema, but "
         "not valid for this specific query. Error details:"

--- a/scinoephile/lang/yue/prompts.py
+++ b/scinoephile/lang/yue/prompts.py
@@ -22,11 +22,6 @@ YUE_HANT_PROMPT_FIELDS: Final[PromptLocalizationFields] = {
     "answer_invalid_post": (
         "請你再試一次，並且淨係返返一個符合該模式要求嘅有效 JSON 物件。"
     ),
-    "difficulty_description": "Difficulty level of the test case, used for filtering.",
-    "few_shot_description": "Whether to include test case in few-shot examples.",
-    "verified_description": (
-        "Whether to include test case in the verified answers cache."
-    ),
     "test_case_invalid_pre": (
         "你之前嘅回覆係符合答案模式嘅有效 JSON，但唔適用於而家呢個特定查詢。錯誤詳情："
     ),

--- a/scinoephile/lang/zho/prompts.py
+++ b/scinoephile/lang/zho/prompts.py
@@ -20,11 +20,6 @@ ZHO_HANT_PROMPT_FIELDS: Final[PromptLocalizationFields] = {
         "你之前的回覆不是有效的 JSON，或未符合預期的模式要求。錯誤詳情："
     ),
     "answer_invalid_post": "請重新嘗試，並僅返回一個符合該模式要求的有效 JSON 對象。",
-    "difficulty_description": "Difficulty level of the test case, used for filtering.",
-    "few_shot_description": "Whether to include test case in few-shot examples.",
-    "verified_description": (
-        "Whether to include test case in the verified answers cache."
-    ),
     "test_case_invalid_pre": (
         "你之前的回覆是符合答案模式的有效 JSON，但不適用於當前的特定查詢。錯誤詳情："
     ),

--- a/test/core/llms/test_manager.py
+++ b/test/core/llms/test_manager.py
@@ -134,3 +134,35 @@ def test_punctuation_factory_uses_static_fields_with_prompt_aliases():
         "source_two": "Hello",
     }
     assert test_case.answer.model_dump(by_alias=True) == {"result": "Hello"}
+
+
+def test_generated_test_case_inherits_stable_metadata_schema():
+    """Generated test cases should preserve metadata order and field schemas."""
+    test_case_cls = ReviewManager.get_test_case_cls(_LOCALIZED_REVIEW_PROMPT)
+    schema = test_case_cls.model_json_schema(by_alias=True)
+
+    assert list(schema["properties"]) == [
+        "query",
+        "answer",
+        "difficulty",
+        "few_shot",
+        "verified",
+    ]
+    assert schema["properties"]["difficulty"] == {
+        "default": 0,
+        "description": "Difficulty level of the test case, used for filtering.",
+        "title": "Difficulty",
+        "type": "integer",
+    }
+    assert schema["properties"]["few_shot"] == {
+        "default": False,
+        "description": "Whether to include test case in few-shot examples.",
+        "title": "Few Shot",
+        "type": "boolean",
+    }
+    assert schema["properties"]["verified"] == {
+        "default": False,
+        "description": "Whether to include test case in the verified answers cache.",
+        "title": "Verified",
+        "type": "boolean",
+    }

--- a/test/core/llms/test_test_case.py
+++ b/test/core/llms/test_test_case.py
@@ -55,3 +55,34 @@ def test_test_case_enforces_minimum_difficulty_without_lowering_higher_values():
 
     assert minimum.difficulty == 2
     assert higher.difficulty == 3
+
+
+def test_test_case_metadata_fields_have_stable_schema():
+    """Test-case metadata should have stable order, defaults, and descriptions."""
+    schema = _TestCase.model_json_schema()
+
+    assert list(schema["properties"]) == [
+        "query",
+        "answer",
+        "difficulty",
+        "few_shot",
+        "verified",
+    ]
+    assert schema["properties"]["difficulty"] == {
+        "default": 0,
+        "description": "Difficulty level of the test case, used for filtering.",
+        "title": "Difficulty",
+        "type": "integer",
+    }
+    assert schema["properties"]["few_shot"] == {
+        "default": False,
+        "description": "Whether to include test case in few-shot examples.",
+        "title": "Few Shot",
+        "type": "boolean",
+    }
+    assert schema["properties"]["verified"] == {
+        "default": False,
+        "description": "Whether to include test case in the verified answers cache.",
+        "title": "Verified",
+        "type": "boolean",
+    }

--- a/test/llms/test_prompt_metadata.py
+++ b/test/llms/test_prompt_metadata.py
@@ -1,0 +1,249 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests for prompt metadata ownership and content-addressed identities."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import fields
+from pathlib import Path
+from typing import Any, Final, cast
+from unittest.mock import Mock
+
+from scinoephile.core.llms import LLMProvider, Manager, Prompt, Queryer
+from scinoephile.optimization.prompt_specs import PROMPT_SPECS
+
+_LEGACY_TEST_CASE_PROMPT_FIELDS: Final = {
+    "difficulty_description": (
+        "Difficulty level of the test case, used for filtering."
+    ),
+    "few_shot_description": "Whether to include test case in few-shot examples.",
+    "verified_description": (
+        "Whether to include test case in the verified answers cache."
+    ),
+}
+"""Prompt fields removed when test-case metadata became static."""
+
+
+def test_registered_prompt_model_and_cache_identities_change_once(
+    tmp_path: Path,
+):
+    """Removing metadata should change prompt, model, system, and cache identities."""
+    provider = Mock(spec=LLMProvider)
+
+    for manager_cls, prompt in _get_registered_prompts():
+        legacy_prompt = _get_legacy_prompt(prompt)
+        test_case_cls = manager_cls.get_test_case_cls(prompt)
+        legacy_test_case_cls = manager_cls.get_test_case_cls(legacy_prompt)
+
+        assert prompt.name != legacy_prompt.name
+        assert test_case_cls.__name__ != legacy_test_case_cls.__name__
+        assert (
+            test_case_cls.query_cls.__name__ != legacy_test_case_cls.query_cls.__name__
+        )
+        assert (
+            test_case_cls.answer_cls.__name__
+            != legacy_test_case_cls.answer_cls.__name__
+        )
+
+        queryer = Queryer(prompt, provider=provider)
+        legacy_queryer = Queryer(legacy_prompt, provider=provider)
+        answer_schema = test_case_cls.answer_cls.model_json_schema(by_alias=True)
+        legacy_answer_schema = legacy_test_case_cls.answer_cls.model_json_schema(
+            by_alias=True
+        )
+        system_prompt = queryer._get_system_prompt(test_case_cls.answer_cls)
+        legacy_system_prompt = legacy_queryer._get_system_prompt(
+            legacy_test_case_cls.answer_cls
+        )
+
+        assert system_prompt != legacy_system_prompt
+        assert _get_system_prompt_prefix(system_prompt, answer_schema) == (
+            _get_system_prompt_prefix(legacy_system_prompt, legacy_answer_schema)
+        )
+
+        queryer.cache_dir_path = tmp_path
+        legacy_queryer.cache_dir_path = tmp_path
+        tools_json = queryer.tool_box.to_json()
+        query_json = '{"same":"query"}'
+        cache_path = queryer._get_cache_path(system_prompt, tools_json, query_json)
+        legacy_cache_path = legacy_queryer._get_cache_path(
+            legacy_system_prompt,
+            tools_json,
+            query_json,
+        )
+
+        assert cache_path is not None
+        assert legacy_cache_path is not None
+        assert cache_path != legacy_cache_path
+
+
+def test_registered_query_and_answer_schemas_change_only_model_identifiers():
+    """Prompt hash changes should leave every correspondence schema structural."""
+    for manager_cls, prompt in _get_registered_prompts():
+        legacy_prompt = _get_legacy_prompt(prompt)
+        test_case_cls = manager_cls.get_test_case_cls(prompt)
+        legacy_test_case_cls = manager_cls.get_test_case_cls(legacy_prompt)
+
+        schema_pairs = [
+            (
+                test_case_cls.query_cls.model_json_schema(by_alias=True),
+                legacy_test_case_cls.query_cls.model_json_schema(by_alias=True),
+            ),
+            (
+                test_case_cls.answer_cls.model_json_schema(by_alias=True),
+                legacy_test_case_cls.answer_cls.model_json_schema(by_alias=True),
+            ),
+        ]
+        for schema, legacy_schema in schema_pairs:
+            assert schema != legacy_schema
+            assert json.dumps(
+                _normalize_schema_identifiers(schema),
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ) == json.dumps(
+                _normalize_schema_identifiers(legacy_schema),
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
+
+
+def _get_legacy_prompt(prompt: Prompt) -> Prompt:
+    """Get an equivalent prompt using its identity before metadata removal.
+
+    Arguments:
+        prompt: current prompt
+    Returns:
+        equivalent prompt whose name includes the removed metadata fields
+    """
+    prompt_cls = type(prompt)
+    legacy_prompt_cls = cast(
+        "type[Prompt]",
+        type(
+            prompt_cls.__name__,
+            (prompt_cls,),
+            {
+                "__module__": prompt_cls.__module__,
+                "name": property(_get_legacy_prompt_name),
+            },
+        ),
+    )
+    prompt_fields = {
+        field.name: getattr(prompt, field.name) for field in fields(prompt)
+    }
+    return legacy_prompt_cls(**prompt_fields)
+
+
+def _get_legacy_prompt_name(prompt: Prompt) -> str:
+    """Get a prompt's content-addressed name before metadata removal.
+
+    Arguments:
+        prompt: prompt whose name should be calculated
+    Returns:
+        legacy content-addressed name
+    """
+    prompt_fields = {
+        field.name: getattr(prompt, field.name)
+        for field in fields(prompt)
+        if field.name != "language"
+    }
+    prompt_fields.update(_LEGACY_TEST_CASE_PROMPT_FIELDS)
+    payload_json = json.dumps(
+        {
+            "fields": prompt_fields,
+            "language": prompt.language.tag,
+            "type": type(prompt).__name__,
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    digest = hashlib.sha256(payload_json.encode()).hexdigest()[:12]
+    language_name = prompt.language.tag.replace("-", "_")
+    return f"{type(prompt).__name__}_{language_name}_{digest}"
+
+
+def _get_registered_prompts() -> list[tuple[type[Manager], Prompt]]:
+    """Get unique registered manager and prompt pairs.
+
+    Returns:
+        registered manager and prompt pairs in deterministic order
+    """
+    prompt_pairs = {
+        (prompt_spec.manager_cls, prompt_spec.prompt)
+        for prompt_spec in PROMPT_SPECS.values()
+    }
+    return sorted(
+        prompt_pairs,
+        key=lambda pair: (pair[0].operation, pair[1].name),
+    )
+
+
+def _get_system_prompt_prefix(
+    system_prompt: str,
+    answer_schema: dict[str, Any],
+) -> str:
+    """Get system prompt text preceding its answer schema.
+
+    Arguments:
+        system_prompt: full system prompt
+        answer_schema: answer schema appended to the system prompt
+    Returns:
+        system prompt text preceding the schema
+    """
+    schema_suffix = f"{json.dumps(answer_schema, indent=4, ensure_ascii=False)}\n"
+    assert system_prompt.endswith(schema_suffix)
+    return system_prompt.removesuffix(schema_suffix)
+
+
+def _normalize_schema_identifiers(schema: dict[str, Any]) -> dict[str, Any]:
+    """Normalize content-addressed model identifiers in a JSON schema.
+
+    Field titles remain unchanged; only root/definition model titles, definition keys,
+    and references to those definitions are normalized.
+
+    Arguments:
+        schema: Pydantic JSON schema
+    Returns:
+        schema with content-addressed model identifiers normalized
+    """
+    definitions = schema.get("$defs", {})
+    assert isinstance(definitions, dict)
+    definition_names = {
+        name: f"definition_{idx}" for idx, name in enumerate(definitions)
+    }
+    title_names = dict(definition_names)
+    root_title = schema.get("title")
+    if isinstance(root_title, str):
+        title_names[root_title] = "root"
+
+    def normalize(value: Any) -> Any:
+        """Normalize schema identifiers recursively.
+
+        Arguments:
+            value: schema value
+        Returns:
+            normalized schema value
+        """
+        if isinstance(value, dict):
+            normalized: dict[str, Any] = {}
+            for key, child in value.items():
+                if key == "$defs":
+                    normalized[key] = {
+                        definition_names[name]: normalize(definition)
+                        for name, definition in child.items()
+                    }
+                elif key == "title" and child in title_names:
+                    normalized[key] = title_names[child]
+                else:
+                    normalized[key] = normalize(child)
+            return normalized
+        if isinstance(value, list):
+            return [normalize(child) for child in value]
+        if isinstance(value, str) and value.startswith("#/$defs/"):
+            definition_name = value.removeprefix("#/$defs/")
+            return f"#/$defs/{definition_names[definition_name]}"
+        return value
+
+    return normalize(schema)

--- a/test/optimization/persistence/prompts/test_optimization_persisted_prompt.py
+++ b/test/optimization/persistence/prompts/test_optimization_persisted_prompt.py
@@ -19,12 +19,9 @@ from scinoephile.optimization.persistence.prompts import PersistedPrompt
 
 _ALTERNATIVE_FEW_SHOT_REVIEW_PROMPT = replace(
     ReviewPromptEng,
-    difficulty_description="Different difficulty description.",
     few_shot_answer_intro="Different example answer:",
-    few_shot_description="Different few-shot flag description.",
     few_shot_intro="Different examples:",
     few_shot_query_intro="Different example query:",
-    verified_description="Different verified description.",
 )
 """English review prompt with different few-shot-only text."""
 
@@ -42,12 +39,13 @@ def test_conversion_includes_all_string_fields():
     assert baseline.prompt_id != alternative.prompt_id
     assert baseline.language == Language.eng
     assert alternative_attributes["few_shot_intro"] == "Different examples:"
-    assert alternative_attributes["difficulty_description"] == (
-        "Different difficulty description."
+    assert alternative_attributes["few_shot_query_intro"] == "Different example query:"
+    assert alternative_attributes["few_shot_answer_intro"] == (
+        "Different example answer:"
     )
-    assert alternative_attributes["verified_description"] == (
-        "Different verified description."
-    )
+    assert "difficulty_description" not in alternative_attributes
+    assert "few_shot_description" not in alternative_attributes
+    assert "verified_description" not in alternative_attributes
 
 
 def test_conversion_includes_operation_and_tool_attributes():


### PR DESCRIPTION
## Summary

- move test-case metadata descriptions onto the static core `TestCase` fields
- have managers dynamically replace only query and answer fields
- remove three unused metadata strings from `Prompt`, localization dictionaries, and persistence
- add cross-version schema and identity coverage for every registered operation/prompt pair

## Why

Difficulty, few-shot, and verified metadata are never sent to the LLM and their descriptions were identical English text in every localization. Keeping them in `Prompt` inflated prompt hashes and persistence identities without representing correspondence content.

## Impact

This intentionally causes one-time content-addressed identity churn: 58 unique registered prompts across 94 aliases, their generated model titles, system prompts, and cache paths receive new IDs. Existing cache entries become cold/orphaned. Query/answer schemas and JSON fixtures are otherwise unchanged.

## Validation

- `ruff format` and `ruff check --fix`
- `ty check`
- independent focused tests: 105 passed
- all 58 unique prompt pairs have byte-identical query/answer/TestCase schemas after normalizing only content-addressed identifiers
- all 85 tracked files / 31,081 cases round-trip unchanged
- full suite: 1,677 passed, 9 skipped
- independent cross-review: no findings