### PR TITLE
Preserve test cases during partial processing

### DIFF
--- a/scinoephile/common/file.py
+++ b/scinoephile/common/file.py
@@ -7,14 +7,16 @@ from __future__ import annotations
 from collections.abc import Generator
 from contextlib import contextmanager
 from logging import getLogger
-from os import remove
+from os import fsync, remove
 from pathlib import Path
 from shutil import move, rmtree
 from tempfile import NamedTemporaryFile, mkdtemp
+from typing import TextIO, cast
 
 __all__ = [
     "get_temp_directory_path",
     "get_temp_file_path",
+    "open_atomic_text_file",
     "rename_preexisting_output_path",
 ]
 
@@ -62,6 +64,44 @@ def get_temp_file_path(suffix: str | None = None) -> Generator[Path]:
                     f"temp_file_path encountered PermissionException '{exc}'; "
                     f"temporary file {temp_file_path}, will not be removed."
                 )
+
+
+@contextmanager
+def open_atomic_text_file(
+    output_path: Path,
+    *,
+    encoding: str = "utf-8",
+) -> Generator[TextIO]:
+    """Open a temporary text file that atomically replaces an output on success.
+
+    The temporary file is created beside the output so replacement remains on the
+    same filesystem. It is flushed and synchronized before replacement, and removed
+    if writing fails.
+
+    Arguments:
+        output_path: path to replace after writing succeeds
+        encoding: text encoding
+    Returns:
+        writable temporary text file
+    """
+    temp_file = NamedTemporaryFile(
+        "w",
+        delete=False,
+        dir=output_path.parent,
+        encoding=encoding,
+        prefix=f".{output_path.name}.",
+        suffix=".tmp",
+    )
+    temp_path = Path(temp_file.name)
+    try:
+        with temp_file:
+            yield cast(TextIO, temp_file)
+            temp_file.flush()
+            fsync(temp_file.fileno())
+        temp_path.replace(output_path)
+    except BaseException:
+        temp_path.unlink(missing_ok=True)
+        raise
 
 
 def rename_preexisting_output_path(output_path: Path):

--- a/scinoephile/core/llms/processor.py
+++ b/scinoephile/core/llms/processor.py
@@ -17,7 +17,7 @@ from .prompt import Prompt
 from .queryer import Queryer
 from .test_case import TestCase
 from .tool_box import ToolBox
-from .utils import load_test_cases_from_json
+from .utils import load_test_cases_from_json, save_test_cases_to_json
 
 __all__ = [
     "Processor",
@@ -34,8 +34,11 @@ class ProcessorKwargs(TypedDict, total=False):
     auto_verify: bool
     """Whether generated test cases should be marked verified."""
 
+    prune_test_cases: bool
+    """Whether to remove persisted test cases not encountered in the current run."""
+
     test_case_path: Path | None
-    """Path where encountered test cases are persisted."""
+    """Path where test cases are persisted."""
 
     tool_box: ToolBox | None
     """Available tools and handlers."""
@@ -59,6 +62,7 @@ class Processor(ABC):
         provider: LLMProvider,
         additional_context: str | None = None,
         auto_verify: bool = False,
+        prune_test_cases: bool = False,
         tool_box: ToolBox | None = None,
     ):
         """Initialize.
@@ -70,6 +74,7 @@ class Processor(ABC):
             provider: provider to use for queries
             additional_context: additional context to include in the system prompt
             auto_verify: automatically verify test cases if they meet selected criteria
+            prune_test_cases: remove persisted cases not encountered in this run
             tool_box: available tools and handlers
         """
         self.prompt = prompt
@@ -91,6 +96,8 @@ class Processor(ABC):
                 )
         self.test_case_path = test_case_path
         """Path to file containing test cases."""
+        self.prune_test_cases = prune_test_cases
+        """Whether to remove persisted cases not encountered in the current run."""
 
         self.queryer = Queryer(
             self.prompt,
@@ -103,3 +110,14 @@ class Processor(ABC):
             tool_box=tool_box,
         )
         """LLM queryer."""
+
+    def save_test_cases(self):
+        """Persist encountered test cases while retaining unencountered cases."""
+        if self.test_case_path is None or self.manager_cls is None:
+            return
+        save_test_cases_to_json(
+            self.test_case_path,
+            self.queryer.encountered_test_cases.values(),
+            self.manager_cls,
+            prune=self.prune_test_cases,
+        )

--- a/scinoephile/core/llms/utils.py
+++ b/scinoephile/core/llms/utils.py
@@ -5,8 +5,10 @@
 from __future__ import annotations
 
 import json
+import os
 from collections.abc import Iterable
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 
 from .manager import Manager
 from .prompt import Prompt
@@ -54,6 +56,8 @@ def save_test_cases_to_json(
     output_path: Path,
     test_cases: Iterable[TestCase],
     manager_cls: type[Manager],
+    *,
+    prune: bool = False,
 ):
     """Save test cases to JSON file.
 
@@ -61,10 +65,27 @@ def save_test_cases_to_json(
         output_path: path to JSON file to which to save
         test_cases: test cases to save
         manager_cls: manager class used to construct test case models
+        prune: whether to remove existing test cases that were not provided
     """
+    test_cases_to_save = list(test_cases)
+    if output_path.exists() and not prune:
+        existing_test_cases = load_test_cases_from_json(
+            output_path,
+            manager_cls,
+            manager_cls.base_prompt,
+        )
+        encountered_query_keys = {
+            test_case.query.key for test_case in test_cases_to_save
+        }
+        test_cases_to_save = [
+            test_case
+            for test_case in existing_test_cases
+            if test_case.query.key not in encountered_query_keys
+        ] + test_cases_to_save
+
     base_test_case_cls = manager_cls.get_test_case_cls(manager_cls.base_prompt)
     data = []
-    for test_case in test_cases:
+    for test_case in test_cases_to_save:
         base_test_case = base_test_case_cls.model_validate(
             test_case.model_dump(mode="json")
         )
@@ -77,5 +98,21 @@ def save_test_cases_to_json(
         )
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    with open(output_path, "w", encoding="utf-8") as f:
-        json.dump(data, f, ensure_ascii=False, indent=2)
+    temp_file = NamedTemporaryFile(
+        "w",
+        delete=False,
+        dir=output_path.parent,
+        encoding="utf-8",
+        prefix=f".{output_path.name}.",
+        suffix=".tmp",
+    )
+    temp_path = Path(temp_file.name)
+    try:
+        with temp_file:
+            json.dump(data, temp_file, ensure_ascii=False, indent=2)
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+        temp_path.replace(output_path)
+    except BaseException:
+        temp_path.unlink(missing_ok=True)
+        raise

--- a/scinoephile/core/llms/utils.py
+++ b/scinoephile/core/llms/utils.py
@@ -5,10 +5,10 @@
 from __future__ import annotations
 
 import json
-import os
 from collections.abc import Iterable
 from pathlib import Path
-from tempfile import NamedTemporaryFile
+
+from scinoephile.common.file import open_atomic_text_file
 
 from .manager import Manager
 from .prompt import Prompt
@@ -98,21 +98,5 @@ def save_test_cases_to_json(
         )
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    temp_file = NamedTemporaryFile(
-        "w",
-        delete=False,
-        dir=output_path.parent,
-        encoding="utf-8",
-        prefix=f".{output_path.name}.",
-        suffix=".tmp",
-    )
-    temp_path = Path(temp_file.name)
-    try:
-        with temp_file:
-            json.dump(data, temp_file, ensure_ascii=False, indent=2)
-            temp_file.flush()
-            os.fsync(temp_file.fileno())
-        temp_path.replace(output_path)
-    except BaseException:
-        temp_path.unlink(missing_ok=True)
-        raise
+    with open_atomic_text_file(output_path) as temp_file:
+        json.dump(data, temp_file, ensure_ascii=False, indent=2)

--- a/scinoephile/llms/gap_translation/processor.py
+++ b/scinoephile/llms/gap_translation/processor.py
@@ -11,7 +11,6 @@ import numpy as np
 
 from scinoephile.core import ScinoephileError
 from scinoephile.core.llms import Processor
-from scinoephile.core.llms.utils import save_test_cases_to_json
 from scinoephile.core.pairs import get_block_pairs_by_pause
 from scinoephile.core.subtitles import Series, Subtitle, get_concatenated_series
 from scinoephile.core.synchronization import get_sync_overlap_matrix
@@ -117,12 +116,7 @@ class GapTranslationProcessor(Processor):
             logger.info(f"Block {blk_idx}:\n{one_blk.to_simple_string()}")
             output_series_to_concatenate[blk_idx] = output_series
 
-        if self.test_case_path is not None:
-            save_test_cases_to_json(
-                self.test_case_path,
-                self.queryer.encountered_test_cases.values(),
-                self.manager_cls,
-            )
+        self.save_test_cases()
 
         output_series = get_concatenated_series(
             [s for s in output_series_to_concatenate if s is not None]

--- a/scinoephile/llms/guided_review/processor.py
+++ b/scinoephile/llms/guided_review/processor.py
@@ -8,7 +8,6 @@ from logging import getLogger
 from typing import cast
 
 from scinoephile.core.llms import Processor
-from scinoephile.core.llms.utils import save_test_cases_to_json
 from scinoephile.core.pairs import get_block_pairs_by_pause
 from scinoephile.core.subtitles import Series, get_concatenated_series
 from scinoephile.core.text import replace_control_characters
@@ -104,12 +103,7 @@ class GuidedReviewProcessor(Processor):
             logger.info(f"Block {block_idx}:\n{output_block.to_simple_string()}")
             output_blocks[block_idx] = output_block
 
-        if self.test_case_path is not None:
-            save_test_cases_to_json(
-                self.test_case_path,
-                self.queryer.encountered_test_cases.values(),
-                self.manager_cls,
-            )
+        self.save_test_cases()
 
         processed_blocks = [block for block in output_blocks if block is not None]
         if processed_blocks:

--- a/scinoephile/llms/guided_translation/processor.py
+++ b/scinoephile/llms/guided_translation/processor.py
@@ -8,7 +8,6 @@ from logging import getLogger
 from typing import cast
 
 from scinoephile.core.llms import Processor
-from scinoephile.core.llms.utils import save_test_cases_to_json
 from scinoephile.core.pairs import get_block_pairs_by_pause
 from scinoephile.core.subtitles import Series, Subtitle, get_concatenated_series
 
@@ -96,12 +95,7 @@ class GuidedTranslationProcessor(Processor):
             logger.info(f"Block {blk_idx}:\n{output_series.to_simple_string()}")
             output_series_to_concatenate[blk_idx] = output_series
 
-        if self.test_case_path is not None:
-            save_test_cases_to_json(
-                self.test_case_path,
-                self.queryer.encountered_test_cases.values(),
-                self.manager_cls,
-            )
+        self.save_test_cases()
 
         output_series_blocks = [
             series for series in output_series_to_concatenate if series is not None

--- a/scinoephile/llms/ocr_fusion/processor.py
+++ b/scinoephile/llms/ocr_fusion/processor.py
@@ -9,7 +9,6 @@ from typing import cast
 
 from scinoephile.core import ScinoephileError
 from scinoephile.core.llms import Processor
-from scinoephile.core.llms.utils import save_test_cases_to_json
 from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.core.synchronization import are_series_one_to_one
 
@@ -105,13 +104,7 @@ class OcrFusionProcessor(Processor):
             )
             output_subtitles.append(sub)
 
-        # Log test cases
-        if self.test_case_path is not None:
-            save_test_cases_to_json(
-                self.test_case_path,
-                self.queryer.encountered_test_cases.values(),
-                self.manager_cls,
-            )
+        self.save_test_cases()
 
         # Organize and return
         return Series(events=output_subtitles)

--- a/scinoephile/llms/pairwise_review/processor.py
+++ b/scinoephile/llms/pairwise_review/processor.py
@@ -10,7 +10,6 @@ from typing import cast
 import numpy as np
 
 from scinoephile.core.llms import Processor
-from scinoephile.core.llms.utils import save_test_cases_to_json
 from scinoephile.core.pairs import get_block_pairs_by_pause
 from scinoephile.core.subtitles import Series, get_concatenated_series
 from scinoephile.core.synchronization import get_sync_overlap_matrix
@@ -104,12 +103,7 @@ class PairwiseReviewProcessor(Processor):
             logger.info(f"Block {block_idx}:\n{output_block.to_simple_string()}")
             output_blocks[block_idx] = output_block
 
-        if self.test_case_path is not None:
-            save_test_cases_to_json(
-                self.test_case_path,
-                self.queryer.encountered_test_cases.values(),
-                self.manager_cls,
-            )
+        self.save_test_cases()
 
         processed_blocks = [block for block in output_blocks if block is not None]
         if processed_blocks:

--- a/scinoephile/llms/review/processor.py
+++ b/scinoephile/llms/review/processor.py
@@ -8,7 +8,6 @@ from logging import getLogger
 from typing import cast
 
 from scinoephile.core.llms import Processor
-from scinoephile.core.llms.utils import save_test_cases_to_json
 from scinoephile.core.subtitles import Series, get_concatenated_series
 from scinoephile.core.text import replace_control_characters
 
@@ -90,12 +89,7 @@ class ReviewProcessor(Processor):
             )
             output_series_to_concatenate[block_idx] = output_series
 
-        if self.test_case_path is not None:
-            save_test_cases_to_json(
-                self.test_case_path,
-                self.queryer.encountered_test_cases.values(),
-                self.manager_cls,
-            )
+        self.save_test_cases()
 
         output_series_blocks = [
             series for series in output_series_to_concatenate if series is not None

--- a/scinoephile/llms/translation/processor.py
+++ b/scinoephile/llms/translation/processor.py
@@ -8,7 +8,6 @@ from logging import getLogger
 from typing import cast
 
 from scinoephile.core.llms import Processor
-from scinoephile.core.llms.utils import save_test_cases_to_json
 from scinoephile.core.subtitles import Series, get_concatenated_series
 from scinoephile.core.text import replace_control_characters
 
@@ -87,13 +86,7 @@ class TranslationProcessor(Processor):
             )
             output_series_to_concatenate[block_idx] = output_series
 
-        # Log test cases
-        if self.test_case_path is not None:
-            save_test_cases_to_json(
-                self.test_case_path,
-                self.queryer.encountered_test_cases.values(),
-                self.manager_cls,
-            )
+        self.save_test_cases()
 
         # Organize and return
         output_series_blocks = [

--- a/test/common/file/test_open_atomic_text_file.py
+++ b/test/common/file/test_open_atomic_text_file.py
@@ -1,0 +1,38 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests of common.file.open_atomic_text_file."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pytest import raises
+
+from scinoephile.common.file import open_atomic_text_file
+
+
+def test_open_atomic_text_file_replaces_output_on_success(tmp_path: Path):
+    """Test output is replaced only after the context exits successfully."""
+    output_path = tmp_path / "output.txt"
+    output_path.write_text("original", encoding="utf-8")
+
+    with open_atomic_text_file(output_path) as temp_file:
+        temp_file.write("replacement")
+        assert output_path.read_text(encoding="utf-8") == "original"
+
+    assert output_path.read_text(encoding="utf-8") == "replacement"
+    assert list(tmp_path.glob(".output.txt.*.tmp")) == []
+
+
+def test_open_atomic_text_file_preserves_output_on_failure(tmp_path: Path):
+    """Test failed writes preserve output and remove the temporary file."""
+    output_path = tmp_path / "output.txt"
+    output_path.write_text("original", encoding="utf-8")
+
+    with raises(OSError, match="write failed"):
+        with open_atomic_text_file(output_path) as temp_file:
+            temp_file.write("incomplete")
+            raise OSError("write failed")
+
+    assert output_path.read_text(encoding="utf-8") == "original"
+    assert list(tmp_path.glob(".output.txt.*.tmp")) == []

--- a/test/core/llms/test_utils.py
+++ b/test/core/llms/test_utils.py
@@ -7,6 +7,9 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import ClassVar
+from unittest.mock import patch
+
+from pytest import raises
 
 from scinoephile.core import Language
 from scinoephile.core.llms.utils import (
@@ -42,6 +45,34 @@ class _AliasedBaseReviewManager(ReviewManager):
     """Stable operation identifier used in persistence."""
     base_prompt: ClassVar[ReviewPrompt] = _BASE_REVIEW_PROMPT
     """Prompt defining intentionally distinct persisted field names."""
+
+
+def _get_test_case(original: str, corrected: str):
+    """Build an aliased review test case.
+
+    Arguments:
+        original: original subtitle text
+        corrected: corrected subtitle text
+    Returns:
+        review test case
+    """
+    test_case_cls = _AliasedBaseReviewManager.get_test_case_cls(
+        _LOCALIZED_REVIEW_PROMPT
+    )
+    return test_case_cls.model_validate(
+        {
+            "query": {"subtitles": [{"index": 1, "text": original}]},
+            "answer": {
+                "revisions": [
+                    {
+                        "index": 1,
+                        "text": corrected,
+                        "note": "typo",
+                    }
+                ]
+            },
+        }
+    )
 
 
 def test_json_uses_base_prompt_fields(tmp_path: Path):
@@ -96,3 +127,76 @@ def test_json_uses_base_prompt_fields(tmp_path: Path):
     assert loaded[0].answer.model_dump(by_alias=True) == {
         "xiugai": [{"xuhao": 1, "wenben": "corrected", "beizhu": "typo"}]
     }
+
+
+def test_save_preserves_existing_cases_unless_pruning(tmp_path: Path):
+    """Saving a partial run should retain unencountered persisted cases."""
+    output_path = tmp_path / "test_cases.json"
+    existing_test_case = _get_test_case("existing", "existing corrected")
+    encountered_test_case = _get_test_case("encountered", "encountered corrected")
+    save_test_cases_to_json(
+        output_path,
+        [existing_test_case],
+        _AliasedBaseReviewManager,
+    )
+
+    save_test_cases_to_json(
+        output_path,
+        [encountered_test_case],
+        _AliasedBaseReviewManager,
+    )
+
+    loaded = load_test_cases_from_json(
+        output_path,
+        _AliasedBaseReviewManager,
+        _LOCALIZED_REVIEW_PROMPT,
+    )
+    assert [
+        test_case.query.model_dump()["subtitles"][0]["text"] for test_case in loaded
+    ] == [
+        "existing",
+        "encountered",
+    ]
+
+    save_test_cases_to_json(
+        output_path,
+        [encountered_test_case],
+        _AliasedBaseReviewManager,
+        prune=True,
+    )
+
+    loaded = load_test_cases_from_json(
+        output_path,
+        _AliasedBaseReviewManager,
+        _LOCALIZED_REVIEW_PROMPT,
+    )
+    assert [
+        test_case.query.model_dump()["subtitles"][0]["text"] for test_case in loaded
+    ] == ["encountered"]
+
+
+def test_save_replaces_existing_file_atomically(tmp_path: Path):
+    """A failed save should leave the existing file unchanged."""
+    output_path = tmp_path / "test_cases.json"
+    save_test_cases_to_json(
+        output_path,
+        [_get_test_case("existing", "existing corrected")],
+        _AliasedBaseReviewManager,
+    )
+    original_contents = output_path.read_bytes()
+
+    with (
+        patch(
+            "scinoephile.core.llms.utils.json.dump",
+            side_effect=OSError("write failed"),
+        ),
+        raises(OSError, match="write failed"),
+    ):
+        save_test_cases_to_json(
+            output_path,
+            [_get_test_case("new", "new corrected")],
+            _AliasedBaseReviewManager,
+        )
+
+    assert output_path.read_bytes() == original_contents
+    assert list(tmp_path.glob(".test_cases.json.*.tmp")) == []

--- a/test/llms/test_review.py
+++ b/test/llms/test_review.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from unittest.mock import Mock
 
 from pydantic import ValidationError
@@ -12,7 +13,14 @@ from pytest import mark, raises
 
 from scinoephile.core import Language
 from scinoephile.core.llms import LLMProvider, Queryer
-from scinoephile.llms.review import ReviewManager, ReviewPrompt, ReviewTestCase
+from scinoephile.core.llms.utils import save_test_cases_to_json
+from scinoephile.core.subtitles import Series, Subtitle
+from scinoephile.llms.review import (
+    ReviewManager,
+    ReviewProcessor,
+    ReviewPrompt,
+    ReviewTestCase,
+)
 
 _LOCALIZED_PROMPT = ReviewPrompt(
     language=Language.zho_hant,
@@ -84,6 +92,56 @@ def test_queryer_corresponds_using_prompt_aliases():
     assert '"xuhao"' in messages[0]["content"]
     assert '"wenben"' in messages[0]["content"]
     assert '"beizhu"' in messages[0]["content"]
+
+
+def test_partial_processing_preserves_unencountered_test_cases(tmp_path: Path):
+    """Stopping before processing should not erase persisted test cases."""
+    test_case_cls = ReviewManager.get_test_case_cls(ReviewManager.base_prompt)
+    existing_test_case = test_case_cls.model_validate(
+        {
+            "query": {"subtitles": [{"index": 1, "text": "existing"}]},
+            "answer": {"revisions": []},
+            "verified": True,
+        }
+    )
+    test_case_path = tmp_path / "review.json"
+    save_test_cases_to_json(test_case_path, [existing_test_case], ReviewManager)
+    original_contents = test_case_path.read_bytes()
+    processor = ReviewProcessor(
+        ReviewManager.base_prompt,
+        test_case_path=test_case_path,
+        provider=Mock(spec=LLMProvider),
+    )
+    series = Series(events=[Subtitle(start=0, end=1000, text="existing")])
+
+    processor.process(series, stop_at_idx=0)
+
+    assert test_case_path.read_bytes() == original_contents
+
+
+def test_partial_processing_prunes_only_when_requested(tmp_path: Path):
+    """Explicit pruning should remove cases not encountered in the current run."""
+    test_case_cls = ReviewManager.get_test_case_cls(ReviewManager.base_prompt)
+    existing_test_case = test_case_cls.model_validate(
+        {
+            "query": {"subtitles": [{"index": 1, "text": "existing"}]},
+            "answer": {"revisions": []},
+            "verified": True,
+        }
+    )
+    test_case_path = tmp_path / "review.json"
+    save_test_cases_to_json(test_case_path, [existing_test_case], ReviewManager)
+    processor = ReviewProcessor(
+        ReviewManager.base_prompt,
+        test_case_path=test_case_path,
+        provider=Mock(spec=LLMProvider),
+        prune_test_cases=True,
+    )
+    series = Series(events=[Subtitle(start=0, end=1000, text="existing")])
+
+    processor.process(series, stop_at_idx=0)
+
+    assert json.loads(test_case_path.read_text(encoding="utf-8")) == []
 
 
 def test_query_requires_consecutive_ordered_indexes():


### PR DESCRIPTION
## Summary

- preserve persisted test cases that are not encountered during a partial processor run
- add an explicit `prune_test_cases` option for full replacement behavior
- write test-case JSON through a same-directory temporary file and atomically replace the destination
- centralize persistence across all seven LLM processors

## Root cause

Processors saved only `Queryer.encountered_test_cases`, so stopping before all blocks were processed could replace a populated JSON file with a subset or `[]`.

## Validation

- `ruff format` and `ruff check --fix` on changed Python files
- `ty check` on changed Python files
- focused persistence, review, and 85-file JSON fixture suite: 99 passed
- full suite: 1,681 passed, 9 skipped