### PR TITLE
Enforce strict LLM JSON boundaries

### DIFF
--- a/scinoephile/core/llms/__init__.py
+++ b/scinoephile/core/llms/__init__.py
@@ -3,8 +3,8 @@
 """Core code related to interactions with LLMs.
 
 Package hierarchy (modules may import from any above):
-* models / prompt / test_case_subtitle / tool
-* answer / query / tool_box
+* models / prompt / tool
+* answer / query / test_case_subtitle / tool_box
 * llm_provider / test_case
 * manager / openai_provider_base / queryer
 * utils

--- a/scinoephile/core/llms/answer.py
+++ b/scinoephile/core/llms/answer.py
@@ -8,17 +8,14 @@ import json
 from abc import ABC
 from typing import ClassVar
 
-from pydantic import BaseModel, ConfigDict
-
+from .models import LLMModel
 from .prompt import Prompt
 
 __all__ = ["Answer"]
 
 
-class Answer(BaseModel, ABC):
+class Answer(LLMModel, ABC):
     """ABC for LLM answers."""
-
-    model_config = ConfigDict(validate_by_name=True)
 
     prompt: ClassVar[Prompt]
     """Text for LLM correspondence."""

--- a/scinoephile/core/llms/models.py
+++ b/scinoephile/core/llms/models.py
@@ -5,12 +5,58 @@
 from __future__ import annotations
 
 import hashlib
+from collections.abc import Mapping
 from typing import Any
 
+from pydantic import BaseModel, ConfigDict, ValidationInfo, model_validator
+
 __all__ = [
+    "LLMModel",
     "get_model_name",
     "make_hashable",
 ]
+
+
+class LLMModel(BaseModel):
+    """Base model for LLM queries, answers, and test cases."""
+
+    model_config = ConfigDict(extra="forbid", validate_by_name=True)
+
+    @model_validator(mode="before")
+    @classmethod
+    def require_aliases_at_json_boundaries(
+        cls,
+        value: object,
+        info: ValidationInfo,
+    ) -> object:
+        """Reject semantic field names at alias-only JSON boundaries.
+
+        Arguments:
+            value: value to validate
+            info: Pydantic validation context
+        Returns:
+            value after canonical field-name validation
+        """
+        if not info.context or not info.context.get("alias_only"):
+            return value
+        if not isinstance(value, Mapping):
+            return value
+
+        noncanonical_fields = [
+            (field_name, field.alias)
+            for field_name, field in cls.model_fields.items()
+            if field.alias is not None
+            and field.alias != field_name
+            and field_name in value
+        ]
+        if noncanonical_fields:
+            replacements = ", ".join(
+                f"{field_name!r} (use {alias!r})"
+                for field_name, alias in noncanonical_fields
+            )
+            raise ValueError(f"JSON input must use field aliases: {replacements}.")
+
+        return value
 
 
 def get_model_name(base_name: str, suffix: str) -> str:

--- a/scinoephile/core/llms/query.py
+++ b/scinoephile/core/llms/query.py
@@ -8,18 +8,14 @@ import json
 from abc import ABC
 from typing import ClassVar
 
-from pydantic import BaseModel, ConfigDict
-
-from .models import make_hashable
+from .models import LLMModel, make_hashable
 from .prompt import Prompt
 
 __all__ = ["Query"]
 
 
-class Query(BaseModel, ABC):
+class Query(LLMModel, ABC):
     """ABC for LLM queries."""
-
-    model_config = ConfigDict(validate_by_name=True)
 
     prompt: ClassVar[Prompt]
     """Text for LLM correspondence."""

--- a/scinoephile/core/llms/queryer.py
+++ b/scinoephile/core/llms/queryer.py
@@ -130,7 +130,13 @@ class Queryer[TTestCase: TestCase]:
 
             # Validate answer
             try:
-                answer = self.test_case_cls.answer_cls.model_validate_json(content)
+                answer = self.test_case_cls.answer_cls.model_validate_json(
+                    content,
+                    by_alias=True,
+                    by_name=False,
+                    extra="forbid",
+                    context={"alias_only": True},
+                )
             except ValidationError as exc:
                 logger.error(
                     f"Query:\n{test_case.query}\n"

--- a/scinoephile/core/llms/test_case.py
+++ b/scinoephile/core/llms/test_case.py
@@ -8,16 +8,17 @@ import json
 from abc import ABC
 from typing import ClassVar, Self
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import Field, model_validator
 
 from .answer import Answer
+from .models import LLMModel
 from .prompt import Prompt
 from .query import Query
 
 __all__ = ["TestCase"]
 
 
-class TestCase(BaseModel, ABC):
+class TestCase(LLMModel, ABC):
     """ABC for LLM test cases."""
 
     __test__ = False

--- a/scinoephile/core/llms/test_case_subtitle.py
+++ b/scinoephile/core/llms/test_case_subtitle.py
@@ -4,7 +4,9 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import Field
+
+from .models import LLMModel
 
 __all__ = [
     "AnnotatedTestCaseSubtitle",
@@ -12,10 +14,8 @@ __all__ = [
 ]
 
 
-class TestCaseSubtitle(BaseModel):
+class TestCaseSubtitle(LLMModel):
     """Indexed subtitle text in an LLM test case."""
-
-    model_config = ConfigDict(validate_by_name=True)
 
     index: int = Field(ge=1)
     """One-based subtitle index."""

--- a/scinoephile/core/llms/utils.py
+++ b/scinoephile/core/llms/utils.py
@@ -43,7 +43,10 @@ def load_test_cases_from_json(
     for test_case_data in raw_test_cases:
         base_test_case = base_test_case_cls.model_validate(
             test_case_data,
+            by_alias=True,
+            by_name=False,
             extra="forbid",
+            context={"alias_only": True},
         )
         test_cases.append(
             test_case_cls.model_validate(base_test_case.model_dump(mode="json"))

--- a/scinoephile/llms/ocr_fusion/processor.py
+++ b/scinoephile/llms/ocr_fusion/processor.py
@@ -92,7 +92,9 @@ class OcrFusionProcessor(Processor):
             # Query LLM
             test_case_cls = self.test_case_cls
             query_cls = test_case_cls.query_cls
-            query = query_cls(source_one=text_one, source_two=text_two)
+            query = query_cls.model_validate(
+                {"source_one": text_one, "source_two": text_two}
+            )
             test_case = test_case_cls(query=query)
             test_case = self.queryer(test_case)
 

--- a/test/core/llms/test_test_case_subtitle.py
+++ b/test/core/llms/test_test_case_subtitle.py
@@ -22,6 +22,8 @@ def test_test_case_subtitle_requires_positive_index():
     assert subtitle.model_dump() == {"index": 1, "text": "subtitle"}
     with raises(ValidationError, match="greater than or equal to 1"):
         Subtitle(index=0, text="subtitle")
+    with raises(ValidationError, match="Extra inputs are not permitted"):
+        Subtitle.model_validate({"index": 1, "text": "subtitle", "unexpected": True})
 
 
 def test_annotated_test_case_subtitle_includes_note():

--- a/test/core/llms/test_utils.py
+++ b/test/core/llms/test_utils.py
@@ -9,7 +9,8 @@ from pathlib import Path
 from typing import ClassVar
 from unittest.mock import patch
 
-from pytest import raises
+from pydantic import ValidationError
+from pytest import mark, raises
 
 from scinoephile.core import Language
 from scinoephile.core.llms.utils import (
@@ -127,6 +128,60 @@ def test_json_uses_base_prompt_fields(tmp_path: Path):
     assert loaded[0].answer.model_dump(by_alias=True) == {
         "xiugai": [{"xuhao": 1, "wenben": "corrected", "beizhu": "typo"}]
     }
+
+
+@mark.parametrize(
+    "test_case_data",
+    [
+        {"query": {"subtitles": [{"index": 1, "text": "original"}]}},
+        {"query": {"zimu": [{"xuhao": 1, "wenben": "original"}]}},
+        {
+            "query": {
+                "base_subtitles": [
+                    {
+                        "base_index": 1,
+                        "base_text": "original",
+                        "unexpected": True,
+                    }
+                ]
+            }
+        },
+        {
+            "query": {
+                "base_subtitles": [{"base_index": 1, "base_text": "original"}],
+                "unexpected": True,
+            }
+        },
+        {
+            "query": {"base_subtitles": [{"base_index": 1, "base_text": "original"}]},
+            "unexpected": True,
+        },
+    ],
+    ids=[
+        "semantic-fields",
+        "localized-fields",
+        "unknown-subtitle-field",
+        "unknown-query-field",
+        "unknown-test-case-field",
+    ],
+)
+def test_json_loading_rejects_non_base_fields(
+    tmp_path: Path,
+    test_case_data: dict,
+):
+    """Repository JSON should contain only base prompt aliases."""
+    input_path = tmp_path / "test_cases.json"
+    input_path.write_text(
+        json.dumps([test_case_data], ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+    with raises(ValidationError):
+        load_test_cases_from_json(
+            input_path,
+            _AliasedBaseReviewManager,
+            _LOCALIZED_REVIEW_PROMPT,
+        )
 
 
 def test_save_preserves_existing_cases_unless_pruning(tmp_path: Path):

--- a/test/llms/test_delineation.py
+++ b/test/llms/test_delineation.py
@@ -159,6 +159,35 @@ def test_queryer_corresponds_using_prompt_aliases():
     assert '"shuchu_er"' in messages[0]["content"]
 
 
+@mark.parametrize(
+    "answer",
+    [
+        {"output_one": "甲乙"},
+        {"shuchu_yii": "甲乙"},
+    ],
+    ids=["semantic-name", "misspelled-alias"],
+)
+def test_queryer_rejects_noncanonical_answer_fields(answer: dict[str, str]):
+    """LLM answers should contain only the localized schema's field aliases."""
+    test_case_cls = DelineationManager.get_test_case_cls(_LOCALIZED_PROMPT)
+    test_case = test_case_cls.model_validate(
+        {
+            "query": {
+                "reference_one": "參考一",
+                "reference_two": "參考二",
+                "target_one": "甲",
+                "target_two": "乙",
+            }
+        }
+    )
+    provider = Mock(spec=LLMProvider)
+    provider.chat_completion.return_value = json.dumps(answer, ensure_ascii=False)
+    queryer = Queryer(test_case_cls, provider=provider, max_attempts=1)
+
+    with raises(ValidationError):
+        queryer(test_case)
+
+
 def test_static_models_validate_target_presence_and_boundary_shifts():
     """Static models should validate targets, shifts, characters, and difficulty."""
     query = {

--- a/test/llms/test_ocr_fusion_models.py
+++ b/test/llms/test_ocr_fusion_models.py
@@ -75,8 +75,8 @@ def test_generated_models_preserve_aliases_and_llm_schemas():
     query_cls = OcrFusionManager.get_query_cls(_LOCALIZED_PROMPT)
     answer_cls = OcrFusionManager.get_answer_cls(_LOCALIZED_PROMPT)
 
-    query = query_cls(source_one="來源一", source_two="來源二")
-    answer = answer_cls(output="融合結果", note="融合說明")
+    query = query_cls.model_validate({"source_one": "來源一", "source_two": "來源二"})
+    answer = answer_cls.model_validate({"output": "融合結果", "note": "融合說明"})
 
     assert tuple(query_cls.model_fields) == ("source_one", "source_two")
     assert tuple(answer_cls.model_fields) == ("output", "note")
@@ -90,6 +90,7 @@ def test_generated_models_preserve_aliases_and_llm_schemas():
     query_schema = query_cls.model_json_schema(by_alias=True)
     answer_schema = answer_cls.model_json_schema(by_alias=True)
     assert query_schema == {
+        "additionalProperties": False,
         "properties": {
             "yilai": {
                 "description": "來源一字幕",
@@ -107,6 +108,7 @@ def test_generated_models_preserve_aliases_and_llm_schemas():
         "type": "object",
     }
     assert answer_schema == {
+        "additionalProperties": False,
         "properties": {
             "jieguo": {
                 "description": "融合後字幕",


### PR DESCRIPTION
## Summary

- add a shared strict base for queries, answers, test cases, and subtitle items while retaining semantic-name validation for internal conversion
- require prompt aliases at the LLM boundary and base-prompt aliases when loading repository JSON
- reject unknown fields recursively and expose `additionalProperties: false` in generated schemas
- cover semantic-name responses, misspelled localized fields, non-base repository fields, and nested extra fields

## Behavior

Internal model conversion may continue to use semantic field names. JSON received from an LLM must use the active prompt's aliases, while repository JSON must use the manager's base prompt aliases.

This prevents a response such as `{"shuchu_yii": "甲乙"}` from being discarded as an unknown field and interpreted as Delineation's valid empty/no-change answer.

## Testing

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format <changed Python files>`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix <changed Python files>`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check <changed Python files>`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto -q` (1,711 passed, 9 skipped)