### PR TITLE
Consolidate strict test case loading

### DIFF
--- a/scinoephile/core/llms/utils.py
+++ b/scinoephile/core/llms/utils.py
@@ -37,28 +37,37 @@ def load_test_cases_from_json(
     Returns:
         list of test cases
     """
-    with open(input_path, encoding="utf-8") as f:
-        raw_test_cases: object = json.load(f)
-
+    # Prepare prompt-specific test-case classes
     base_test_case_cls = manager_cls.get_test_case_cls(manager_cls.base_prompt)
-    base_test_cases = cast(
-        "list[TestCase]",
-        TypeAdapter(
-            list[base_test_case_cls]  # ty: ignore[invalid-type-form]
-        ).validate_python(
-            raw_test_cases,
-            by_alias=True,
-            by_name=False,
-            strict=True,
-            extra="forbid",
-            context={"alias_only": True},
-        ),
-    )
     test_case_cls = manager_cls.get_test_case_cls(prompt)
-    return [
-        test_case_cls.model_validate(base_test_case.model_dump(mode="json"))
-        for base_test_case in base_test_cases
-    ]
+
+    # Load serialized test cases
+    with open(input_path, encoding="utf-8") as input_file:
+        raw_test_cases: object = json.load(input_file)
+
+    # Validate using the base-prompt schema
+    base_test_case_list_type = (
+        list[base_test_case_cls]  # ty: ignore[invalid-type-form]
+    )
+    base_test_case_adapter = TypeAdapter(base_test_case_list_type)
+    validated_base_test_cases = base_test_case_adapter.validate_python(
+        raw_test_cases,
+        by_alias=True,
+        by_name=False,
+        strict=True,
+        extra="forbid",
+        context={"alias_only": True},
+    )
+    base_test_cases = cast("list[TestCase]", validated_base_test_cases)
+
+    # Convert to the requested prompt schema
+    test_cases: list[TestCase] = []
+    for base_test_case in base_test_cases:
+        test_case_data = base_test_case.model_dump(mode="json")
+        test_case = test_case_cls.model_validate(test_case_data)
+        test_cases.append(test_case)
+
+    return test_cases
 
 
 def save_test_cases_to_json(

--- a/scinoephile/core/llms/utils.py
+++ b/scinoephile/core/llms/utils.py
@@ -7,6 +7,9 @@ from __future__ import annotations
 import json
 from collections.abc import Iterable
 from pathlib import Path
+from typing import cast
+
+from pydantic import TypeAdapter
 
 from scinoephile.common.file import open_atomic_text_file
 
@@ -35,24 +38,27 @@ def load_test_cases_from_json(
         list of test cases
     """
     with open(input_path, encoding="utf-8") as f:
-        raw_test_cases: list[dict] = json.load(f)
+        raw_test_cases: object = json.load(f)
 
     base_test_case_cls = manager_cls.get_test_case_cls(manager_cls.base_prompt)
-    test_case_cls = manager_cls.get_test_case_cls(prompt)
-    test_cases: list[TestCase] = []
-    for test_case_data in raw_test_cases:
-        base_test_case = base_test_case_cls.model_validate(
-            test_case_data,
+    base_test_cases = cast(
+        "list[TestCase]",
+        TypeAdapter(
+            list[base_test_case_cls]  # ty: ignore[invalid-type-form]
+        ).validate_python(
+            raw_test_cases,
             by_alias=True,
             by_name=False,
+            strict=True,
             extra="forbid",
             context={"alias_only": True},
-        )
-        test_cases.append(
-            test_case_cls.model_validate(base_test_case.model_dump(mode="json"))
-        )
-
-    return test_cases
+        ),
+    )
+    test_case_cls = manager_cls.get_test_case_cls(prompt)
+    return [
+        test_case_cls.model_validate(base_test_case.model_dump(mode="json"))
+        for base_test_case in base_test_cases
+    ]
 
 
 def save_test_cases_to_json(

--- a/scinoephile/optimization/persistence/test_cases/sync.py
+++ b/scinoephile/optimization/persistence/test_cases/sync.py
@@ -4,16 +4,13 @@
 
 from __future__ import annotations
 
-import json
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import cast
-
-from pydantic import ValidationError
 
 from scinoephile.core.exceptions import ScinoephileError
 from scinoephile.core.llms import Manager
+from scinoephile.core.llms.utils import load_test_cases_from_json
 
 from .persisted_test_case import PersistedTestCase
 from .sqlite_store import TestCaseSqliteStore
@@ -95,58 +92,16 @@ def _load_test_cases(
         ScinoephileError: if the file cannot be loaded or contains an invalid case
     """
     try:
-        with open(input_path, encoding="utf-8") as input_file:
-            data = json.load(input_file)
-    except (OSError, json.JSONDecodeError) as exc:
+        test_cases = load_test_cases_from_json(
+            input_path,
+            manager_cls,
+            manager_cls.base_prompt,
+        )
+        return [
+            PersistedTestCase.from_test_case(test_case, manager_cls)
+            for test_case in test_cases
+        ]
+    except (OSError, ScinoephileError, TypeError, ValueError) as exc:
         raise ScinoephileError(
             f"Unable to load optimization test cases from {input_path}: {exc}"
         ) from exc
-    if not isinstance(data, list):
-        raise ScinoephileError(
-            f"Optimization test-case file {input_path} must contain a JSON array."
-        )
-
-    test_cases: list[PersistedTestCase] = []
-    for index, item in enumerate(data, start=1):
-        try:
-            if not isinstance(item, dict):
-                raise ScinoephileError("Each optimization test case must be an object.")
-            item_dict = cast("dict[str, object]", item)
-            test_case = _normalize_test_case(
-                item_dict,
-                manager_cls,
-            )
-        except (
-            AttributeError,
-            KeyError,
-            ScinoephileError,
-            TypeError,
-            ValidationError,
-        ) as exc:
-            raise ScinoephileError(
-                f"Invalid optimization test case {index} in {input_path}: {exc}"
-            ) from exc
-        test_cases.append(test_case)
-    return test_cases
-
-
-def _normalize_test_case(
-    data: dict[str, object],
-    manager_cls: type[Manager],
-) -> PersistedTestCase:
-    """Validate one test case using its operation's base prompt field names.
-
-    Arguments:
-        data: serialized test case
-        manager_cls: manager defining the operation and base prompt
-    Returns:
-        test case using base-prompt field names
-    Raises:
-        ScinoephileError: if the payload contains fields outside the prompt schema
-    """
-    test_case_cls = manager_cls.get_test_case_cls(manager_cls.base_prompt)
-    test_case = test_case_cls.model_validate(data, strict=True, extra="forbid")
-    return PersistedTestCase.from_test_case(
-        test_case,
-        manager_cls,
-    )

--- a/test/core/llms/test_utils.py
+++ b/test/core/llms/test_utils.py
@@ -184,6 +184,42 @@ def test_json_loading_rejects_non_base_fields(
         )
 
 
+@mark.parametrize(
+    "test_case_data",
+    [
+        {"query": []},
+        {"query": {"base_subtitles": "not a list"}},
+        {"query": {"base_subtitles": [{"base_index": "1", "base_text": "original"}]}},
+    ],
+    ids=["non-object-query", "non-list-subtitles", "coerced-index"],
+)
+def test_json_loading_is_strict(tmp_path: Path, test_case_data: dict):
+    """Repository JSON should reject values requiring type coercion."""
+    input_path = tmp_path / "test_cases.json"
+    input_path.write_text(json.dumps([test_case_data]), encoding="utf-8")
+
+    with raises(ValidationError):
+        load_test_cases_from_json(
+            input_path,
+            _AliasedBaseReviewManager,
+            _LOCALIZED_REVIEW_PROMPT,
+        )
+
+
+@mark.parametrize("contents", [{}, ["not an object"]])
+def test_json_loading_requires_an_array_of_objects(tmp_path: Path, contents: object):
+    """Repository test-case files should contain an array of objects."""
+    input_path = tmp_path / "test_cases.json"
+    input_path.write_text(json.dumps(contents), encoding="utf-8")
+
+    with raises(ValidationError):
+        load_test_cases_from_json(
+            input_path,
+            _AliasedBaseReviewManager,
+            _LOCALIZED_REVIEW_PROMPT,
+        )
+
+
 def test_save_preserves_existing_cases_unless_pruning(tmp_path: Path):
     """Saving a partial run should retain unencountered persisted cases."""
     output_path = tmp_path / "test_cases.json"

--- a/test/optimization/persistence/test_cases/test_optimization_test_cases_sync.py
+++ b/test/optimization/persistence/test_cases/test_optimization_test_cases_sync.py
@@ -171,6 +171,32 @@ def test_sync_rejects_fields_outside_test_case_schema(tmp_path: Path):
             )
 
 
+def test_sync_requires_base_prompt_aliases(tmp_path: Path):
+    """Optimization sync should use the shared base-alias-only JSON boundary."""
+    source_path = tmp_path / "source.json"
+    source_path.write_text(
+        json.dumps(
+            [
+                {
+                    "query": {"subtitles": [{"index": 1, "text": "original"}]},
+                    "answer": {
+                        "revisions": [{"index": 1, "text": "corrected", "note": "typo"}]
+                    },
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with raises(ScinoephileError, match="JSON input must use field aliases"):
+        sync_test_cases(
+            [source_path],
+            tmp_path / "test_cases.sqlite",
+            _AliasedBaseReviewManager,
+            dry_run=False,
+        )
+
+
 def test_sync_inserts_and_removes_provenance_by_source_path(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## Summary

- validate repository test-case files as strict arrays of base-prompt test-case objects through one shared loader
- make optimization JSON-to-SQLite synchronization delegate to that loader
- remove the duplicate single-case normalization path
- reject semantic/localized field names, unknown fields, malformed containers, and values requiring coercion consistently at every repository JSON entry point

## Why

The optimization synchronizer had its own direct `model_validate` path and did not activate the alias-only boundary added in #1081. As a result, it could accept JSON field names that normal repository loading rejected.

The shared loader now uses a `TypeAdapter` over the complete test-case list, preserving indexed validation locations while enforcing strict recursive validation.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format <changed Python files>`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix <changed Python files>`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check .`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto -q` (1,717 passed, 9 skipped)
- all 108 tracked test-case JSON fixtures round-trip canonically