### PR TITLE
Validate LLM correspondence identities

### DIFF
--- a/scinoephile/core/llms/models.py
+++ b/scinoephile/core/llms/models.py
@@ -22,6 +22,38 @@ class LLMModel(BaseModel):
 
     model_config = ConfigDict(extra="forbid", validate_by_name=True)
 
+    @classmethod
+    def __pydantic_init_subclass__(cls, **kwargs: Any):
+        """Validate serialized field aliases after model construction.
+
+        Arguments:
+            **kwargs: arguments passed through Pydantic subclass initialization
+        """
+        super().__pydantic_init_subclass__(**kwargs)
+
+        fields_by_alias: dict[str, list[str]] = {}
+        for field_name, field_info in cls.model_fields.items():
+            alias = field_info.alias
+            if alias is None:
+                alias = field_name
+            if not alias.strip():
+                raise ValueError(
+                    f"{cls.__name__} field {field_name!r} must have a nonblank alias."
+                )
+            fields_by_alias.setdefault(alias, []).append(field_name)
+
+        duplicate_aliases = {
+            alias: field_names
+            for alias, field_names in fields_by_alias.items()
+            if len(field_names) > 1
+        }
+        if duplicate_aliases:
+            details = "; ".join(
+                f"{alias!r} is used by {', '.join(field_names)}"
+                for alias, field_names in duplicate_aliases.items()
+            )
+            raise ValueError(f"{cls.__name__} field aliases must be unique; {details}.")
+
     @model_validator(mode="before")
     @classmethod
     def require_aliases_at_json_boundaries(

--- a/scinoephile/core/llms/queryer.py
+++ b/scinoephile/core/llms/queryer.py
@@ -271,13 +271,19 @@ class Queryer[TTestCase: TestCase]:
         if self.cache_dir_path is None:
             return None
 
-        provider_identity_json = json.dumps(
-            self.provider.cache_identity,
+        cache_identity_json = json.dumps(
+            {
+                "provider": self.provider.cache_identity,
+                "test_case": {
+                    "module": self.test_case_cls.__module__,
+                    "qualname": self.test_case_cls.__qualname__,
+                },
+            },
             ensure_ascii=True,
             separators=(",", ":"),
             sort_keys=True,
         )
-        prompt_str = provider_identity_json + system_prompt + tools_json + query_prompt
+        prompt_str = cache_identity_json + system_prompt + tools_json + query_prompt
         sha256 = hashlib.sha256(prompt_str.encode("utf-8")).hexdigest()
         return self.cache_dir_path / f"{sha256}.json"
 

--- a/test/core/llms/test_manager.py
+++ b/test/core/llms/test_manager.py
@@ -4,6 +4,12 @@
 
 from __future__ import annotations
 
+from pytest import raises
+
+from scinoephile.llms.guided_translation import (
+    GuidedTranslationManager,
+    GuidedTranslationPrompt,
+)
 from scinoephile.llms.punctuation import (
     PunctuationManager,
     PunctuationPrompt,
@@ -166,3 +172,29 @@ def test_generated_test_case_inherits_stable_metadata_schema():
         "title": "Verified",
         "type": "boolean",
     }
+
+
+def test_prompt_specific_factory_allows_aliases_reused_across_objects():
+    """Query and answer objects may independently use the same alias."""
+    prompt = ReviewPrompt(subtitles="items", revisions="items")
+
+    test_case_cls = ReviewManager.get_test_case_cls(prompt)
+
+    assert test_case_cls.query_cls.model_fields["subtitles"].alias == "items"
+    assert test_case_cls.answer_cls.model_fields["revisions"].alias == "items"
+
+
+def test_prompt_specific_factory_rejects_blank_aliases():
+    """Generated JSON object field aliases must not be blank."""
+    prompt = ReviewPrompt(index=" ")
+
+    with raises(ValueError, match="must have a nonblank alias"):
+        ReviewManager.get_test_case_cls(prompt)
+
+
+def test_prompt_specific_factory_rejects_duplicate_aliases():
+    """Generated JSON object field aliases must be unique."""
+    prompt = GuidedTranslationPrompt(subtitles="items", guides="items")
+
+    with raises(ValueError, match="field aliases must be unique"):
+        GuidedTranslationManager.get_test_case_cls(prompt)

--- a/test/core/llms/test_provider_injection.py
+++ b/test/core/llms/test_provider_injection.py
@@ -450,6 +450,34 @@ def test_queryer_cache_is_namespaced_by_provider_model(tmp_path):
     assert len(provider_two.calls) == 1
 
 
+def test_queryer_cache_is_namespaced_by_test_case_class(tmp_path):
+    """Test compatible test-case classes do not share cached answers."""
+    provider_one = _RecordingProvider('{"output":"one"}')
+    queryer_one = Queryer(
+        _TestCase,
+        provider=provider_one,
+        cache_dir_path=tmp_path,
+        max_attempts=1,
+    )
+    test_case = _TestCase(query=_Query(text="input"))
+
+    result_one = queryer_one(test_case)
+
+    provider_two = _RecordingProvider('{"output":"two"}')
+    queryer_two = Queryer(
+        _CompatibleTestCase,
+        provider=provider_two,
+        cache_dir_path=tmp_path,
+        max_attempts=1,
+    )
+    result_two = queryer_two(test_case)
+
+    assert result_one.answer == _Answer(output="one")
+    assert result_two.answer == _Answer(output="two")
+    assert len(provider_one.calls) == 1
+    assert len(provider_two.calls) == 1
+
+
 def test_queryer_cache_is_namespaced_by_provider_implementation(tmp_path):
     """Test different provider implementations have different cache paths."""
     queryer_one = Queryer(


### PR DESCRIPTION
## Summary

- reject blank field aliases when prompt-specific LLM models are generated
- reject duplicate effective aliases within each query, answer, or nested item object
- allow the same alias to remain valid across separate JSON objects
- include the bound test-case class module and qualified name in runtime cache identity

## Why

Duplicate prompt aliases can collapse multiple semantic fields into one JSON property. For example, assigning `"items"` to both guided-translation query lists produced a malformed schema and allowed one input value to populate both fields.

Runtime cache identity already included provider configuration, prompts, tools, and query JSON, but omitted the test-case type. Compatible classes from different operations could therefore reuse one another's cached answer.

## Impact

Invalid prompt alias configurations now fail immediately when their generated model class is constructed. Existing valid prompts and persisted JSON are unchanged. Runtime LLM cache paths change once to include the test-case namespace.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/core/llms/models.py scinoephile/core/llms/queryer.py test/core/llms/test_manager.py test/core/llms/test_provider_injection.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/core/llms/models.py scinoephile/core/llms/queryer.py test/core/llms/test_manager.py test/core/llms/test_provider_injection.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/core/llms/models.py scinoephile/core/llms/queryer.py test/core/llms/test_manager.py test/core/llms/test_provider_injection.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` (1,721 passed, 9 skipped)