### PR TITLE
Centralize prompt-specific model creation

### DIFF
--- a/scinoephile/core/llms/__init__.py
+++ b/scinoephile/core/llms/__init__.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from .answer import Answer
 from .llm_provider import ChatCompletionKwargs, LLMProvider
-from .manager import Manager
+from .manager import Manager, PromptModelField
 from .openai_provider_base import OpenAIProviderBase
 from .processor import Processor, ProcessorKwargs
 from .prompt import Prompt, PromptLocalizationFields
@@ -37,6 +37,7 @@ __all__ = [
     "ProcessorKwargs",
     "Prompt",
     "PromptLocalizationFields",
+    "PromptModelField",
     "Query",
     "Queryer",
     "TestCase",

--- a/scinoephile/core/llms/manager.py
+++ b/scinoephile/core/llms/manager.py
@@ -5,18 +5,36 @@
 from __future__ import annotations
 
 from abc import ABC
+from collections.abc import Mapping
+from copy import copy
+from dataclasses import dataclass
 from functools import cache
 from typing import Any, ClassVar
 
-from pydantic import Field, create_model
+from pydantic import create_model
 
 from .answer import Answer
-from .models import get_model_name
+from .models import LLMModel, get_model_name
 from .prompt import Prompt
 from .query import Query
 from .test_case import TestCase
 
-__all__ = ["Manager"]
+__all__ = [
+    "Manager",
+    "PromptModelField",
+]
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class PromptModelField:
+    """Prompt-specific changes to one semantic model field."""
+
+    alias: str | None = None
+    """Serialized field name, or None to retain the semantic name."""
+    annotation: Any = None
+    """Replacement field annotation, or None to retain the semantic annotation."""
+    description: str | None = None
+    """JSON schema description, or None to retain the semantic description."""
 
 
 class Manager(ABC):
@@ -30,15 +48,54 @@ class Manager(ABC):
     """Static test-case model defining the operation's semantic shape."""
 
     @classmethod
-    def get_query_cls(cls, prompt: Prompt) -> type[Query]:
-        """Get concrete query class with provided configuration.
+    def create_prompt_model[TModel: LLMModel](
+        cls,
+        base_cls: type[TModel],
+        prompt: Prompt,
+        field_configs: Mapping[str, PromptModelField],
+        *,
+        module: str | None = None,
+        name: str | None = None,
+    ) -> type[TModel]:
+        """Create a prompt-specific model from a semantic base model.
 
         Arguments:
-            prompt: text for LLM correspondence
+            base_cls: semantic model class whose shape and constraints are retained
+            prompt: text and field aliases for LLM correspondence
+            field_configs: prompt-specific field changes keyed by semantic field name
+            module: generated model module, or None to use the base model module
+            name: generated model base name, or None to use the base model name
         Returns:
-            query model class
+            prompt-specific model class
         """
-        raise NotImplementedError
+        fields: dict[str, Any] = {}
+        for field_name, field_config in field_configs.items():
+            field_info = copy(base_cls.model_fields[field_name])
+            if field_config.alias is not None:
+                field_info.alias = field_config.alias
+                field_info.validation_alias = field_config.alias
+                field_info.serialization_alias = field_config.alias
+            if field_config.description is not None:
+                field_info.description = field_config.description
+
+            annotation = field_config.annotation
+            if annotation is None:
+                annotation = field_info.annotation
+            fields[field_name] = (annotation, field_info)
+
+        if module is None:
+            module = base_cls.__module__
+        if name is None:
+            name = base_cls.__name__
+        model = create_model(
+            get_model_name(name, prompt.name),
+            __base__=base_cls,
+            __module__=module,
+            **fields,
+        )
+        if issubclass(model, (Answer, Query, TestCase)):
+            model.prompt = prompt
+        return model
 
     @classmethod
     def get_answer_cls(cls, prompt: Prompt) -> type[Answer]:
@@ -48,6 +105,17 @@ class Manager(ABC):
             prompt: text for LLM correspondence
         Returns:
             answer model class
+        """
+        raise NotImplementedError
+
+    @classmethod
+    def get_query_cls(cls, prompt: Prompt) -> type[Query]:
+        """Get concrete query class with provided configuration.
+
+        Arguments:
+            prompt: text for LLM correspondence
+        Returns:
+            query model class
         """
         raise NotImplementedError
 
@@ -63,35 +131,14 @@ class Manager(ABC):
         """
         query_cls = cls.get_query_cls(prompt)
         answer_cls = cls.get_answer_cls(prompt)
-        fields = cls.get_test_case_fields(query_cls, answer_cls)
-
-        model = create_model(
-            get_model_name(cls.test_case_base_cls.__name__, prompt.name),
-            __base__=cls.test_case_base_cls,
-            __module__=cls.test_case_base_cls.__module__,
-            **fields,
+        model = cls.create_prompt_model(
+            cls.test_case_base_cls,
+            prompt,
+            {
+                "query": PromptModelField(annotation=query_cls),
+                "answer": PromptModelField(annotation=answer_cls | None),
+            },
         )
         model.query_cls = query_cls
         model.answer_cls = answer_cls
-        model.prompt = prompt
         return model
-
-    @classmethod
-    def get_test_case_fields(
-        cls,
-        query_cls: type[Query],
-        answer_cls: type[Answer],
-    ) -> dict[str, Any]:
-        """Get fields dictionary for dynamic TestCase class creation.
-
-        Arguments:
-            query_cls: query model class
-            answer_cls: answer model class
-        Returns:
-            fields dictionary for create_model
-        """
-        fields: dict[str, Any] = {
-            "query": (query_cls, Field(...)),
-            "answer": (answer_cls | None, Field(default=None)),
-        }
-        return fields

--- a/scinoephile/llms/delineation/manager.py
+++ b/scinoephile/llms/delineation/manager.py
@@ -5,12 +5,15 @@
 from __future__ import annotations
 
 from functools import cache
-from typing import Any, ClassVar
+from typing import ClassVar
 
-from pydantic import Field, create_model
-
-from scinoephile.core.llms import Answer, Manager, Query, TestCase
-from scinoephile.core.llms.models import get_model_name
+from scinoephile.core.llms import (
+    Answer,
+    Manager,
+    PromptModelField,
+    Query,
+    TestCase,
+)
 
 from .models import DelineationAnswer, DelineationQuery, DelineationTestCase
 from .prompt import DelineationPrompt
@@ -23,7 +26,7 @@ class DelineationManager(Manager):
 
     operation: ClassVar[str] = "delineation"
     """Stable operation identifier used in persistence and CLIs."""
-    base_prompt: ClassVar[DelineationPrompt] = DelineationPrompt()
+    base_prompt: ClassVar[DelineationPrompt] = DelineationTestCase.prompt
     """Base prompt defining persisted test-case field names."""
     test_case_base_cls: ClassVar[type[TestCase]] = DelineationTestCase
     """Static test-case model defining delineation's semantic shape."""
@@ -41,32 +44,20 @@ class DelineationManager(Manager):
         Returns:
             answer model class
         """
-        fields: dict[str, Any] = {
-            "output_one": (
-                str,
-                Field(
-                    "",
+        return cls.create_prompt_model(
+            DelineationAnswer,
+            prompt,
+            {
+                "output_one": PromptModelField(
                     alias=prompt.src_2_sub_1_shifted,
                     description=prompt.src_2_sub_1_shifted_desc,
                 ),
-            ),
-            "output_two": (
-                str,
-                Field(
-                    "",
+                "output_two": PromptModelField(
                     alias=prompt.src_2_sub_2_shifted,
                     description=prompt.src_2_sub_2_shifted_desc,
                 ),
-            ),
-        }
-        model = create_model(
-            get_model_name("DelineationAnswer", prompt.name),
-            __base__=DelineationAnswer,
-            __module__=DelineationAnswer.__module__,
-            **fields,
+            },
         )
-        model.prompt = prompt
-        return model
 
     @classmethod
     @cache
@@ -81,45 +72,25 @@ class DelineationManager(Manager):
         Returns:
             query model class
         """
-        fields: dict[str, Any] = {
-            "reference_one": (
-                str,
-                Field(
-                    ...,
+        return cls.create_prompt_model(
+            DelineationQuery,
+            prompt,
+            {
+                "reference_one": PromptModelField(
                     alias=prompt.src_1_sub_1,
                     description=prompt.src_1_sub_1_desc,
                 ),
-            ),
-            "reference_two": (
-                str,
-                Field(
-                    ...,
+                "reference_two": PromptModelField(
                     alias=prompt.src_1_sub_2,
                     description=prompt.src_1_sub_2_desc,
                 ),
-            ),
-            "target_one": (
-                str,
-                Field(
-                    "",
+                "target_one": PromptModelField(
                     alias=prompt.src_2_sub_1,
                     description=prompt.src_2_sub_1_desc,
                 ),
-            ),
-            "target_two": (
-                str,
-                Field(
-                    "",
+                "target_two": PromptModelField(
                     alias=prompt.src_2_sub_2,
                     description=prompt.src_2_sub_2_desc,
                 ),
-            ),
-        }
-        model = create_model(
-            get_model_name("DelineationQuery", prompt.name),
-            __base__=DelineationQuery,
-            __module__=DelineationQuery.__module__,
-            **fields,
+            },
         )
-        model.prompt = prompt
-        return model

--- a/scinoephile/llms/gap_translation/manager.py
+++ b/scinoephile/llms/gap_translation/manager.py
@@ -5,17 +5,15 @@
 from __future__ import annotations
 
 from functools import cache
-from typing import Any, ClassVar
-
-from pydantic import Field, create_model
+from typing import ClassVar
 
 from scinoephile.core.llms import (
     Answer,
     Manager,
+    PromptModelField,
     Query,
     TestCase,
 )
-from scinoephile.core.llms.models import get_model_name
 
 from .models import (
     GapTranslationAnswer,
@@ -33,7 +31,7 @@ class GapTranslationManager(Manager):
 
     operation: ClassVar[str] = "gap-translation"
     """Stable operation identifier used in persistence and CLIs."""
-    base_prompt: ClassVar[GapTranslationPrompt] = GapTranslationPrompt()
+    base_prompt: ClassVar[GapTranslationPrompt] = GapTranslationTestCase.prompt
     """Base prompt defining persisted test-case field names."""
     test_case_base_cls: ClassVar[type[TestCase]] = GapTranslationTestCase
     """Static test-case model defining gap translation's semantic shape."""
@@ -49,29 +47,23 @@ class GapTranslationManager(Manager):
             answer model class
         """
         output_cls = cls.get_output_cls(prompt)
-        fields: dict[str, Any] = {
-            "outputs": (
-                list[output_cls],  # ty: ignore[invalid-type-form]
-                Field(
-                    ...,
+        return cls.create_prompt_model(
+            GapTranslationAnswer,
+            prompt,
+            {
+                "outputs": PromptModelField(
                     alias=prompt.outputs,
+                    annotation=list[output_cls],  # ty: ignore[invalid-type-form]
                     description=prompt.outputs_desc,
                 ),
-            ),
-        }
-        model = create_model(
-            get_model_name("GapTranslationAnswer", prompt.name),
-            __base__=GapTranslationAnswer,
-            __module__=GapTranslationAnswer.__module__,
-            **fields,
+            },
         )
-        model.prompt = prompt
-        return model
 
     @classmethod
     @cache
     def get_guide_cls(
-        cls, prompt: GapTranslationPrompt
+        cls,
+        prompt: GapTranslationPrompt,
     ) -> type[GapTranslationSubtitle]:
         """Get guide class with prompt-specific JSON field aliases.
 
@@ -80,30 +72,20 @@ class GapTranslationManager(Manager):
         Returns:
             guide model class
         """
-        fields: dict[str, Any] = {
-            "index": (
-                int,
-                Field(
-                    ...,
+        return cls.create_prompt_model(
+            GapTranslationSubtitle,
+            prompt,
+            {
+                "index": PromptModelField(
                     alias=prompt.index,
                     description=prompt.index_desc,
-                    ge=1,
                 ),
-            ),
-            "text": (
-                str,
-                Field(
-                    ...,
+                "text": PromptModelField(
                     alias=prompt.text,
                     description=prompt.guide_text_desc,
                 ),
-            ),
-        }
-        return create_model(
-            get_model_name("GapTranslationGuide", prompt.name),
-            __base__=GapTranslationSubtitle,
-            __module__=GapTranslationQuery.__module__,
-            **fields,
+            },
+            name="GapTranslationGuide",
         )
 
     @classmethod
@@ -119,30 +101,20 @@ class GapTranslationManager(Manager):
         Returns:
             output model class
         """
-        fields: dict[str, Any] = {
-            "index": (
-                int,
-                Field(
-                    ...,
+        return cls.create_prompt_model(
+            GapTranslationSubtitle,
+            prompt,
+            {
+                "index": PromptModelField(
                     alias=prompt.index,
                     description=prompt.index_desc,
-                    ge=1,
                 ),
-            ),
-            "text": (
-                str,
-                Field(
-                    ...,
+                "text": PromptModelField(
                     alias=prompt.text,
                     description=prompt.output_text_desc,
                 ),
-            ),
-        }
-        return create_model(
-            get_model_name("GapTranslationOutput", prompt.name),
-            __base__=GapTranslationSubtitle,
-            __module__=GapTranslationAnswer.__module__,
-            **fields,
+            },
+            name="GapTranslationOutput",
         )
 
     @classmethod
@@ -157,38 +129,28 @@ class GapTranslationManager(Manager):
         """
         target_cls = cls.get_target_cls(prompt)
         guide_cls = cls.get_guide_cls(prompt)
-        fields: dict[str, Any] = {
-            "targets": (
-                list[target_cls],  # ty: ignore[invalid-type-form]
-                Field(
-                    ...,
+        return cls.create_prompt_model(
+            GapTranslationQuery,
+            prompt,
+            {
+                "targets": PromptModelField(
                     alias=prompt.targets,
+                    annotation=list[target_cls],  # ty: ignore[invalid-type-form]
                     description=prompt.targets_desc,
                 ),
-            ),
-            "guides": (
-                list[guide_cls],  # ty: ignore[invalid-type-form]
-                Field(
-                    ...,
+                "guides": PromptModelField(
                     alias=prompt.guides,
+                    annotation=list[guide_cls],  # ty: ignore[invalid-type-form]
                     description=prompt.guides_desc,
-                    min_length=1,
                 ),
-            ),
-        }
-        model = create_model(
-            get_model_name("GapTranslationQuery", prompt.name),
-            __base__=GapTranslationQuery,
-            __module__=GapTranslationQuery.__module__,
-            **fields,
+            },
         )
-        model.prompt = prompt
-        return model
 
     @classmethod
     @cache
     def get_target_cls(
-        cls, prompt: GapTranslationPrompt
+        cls,
+        prompt: GapTranslationPrompt,
     ) -> type[GapTranslationSubtitle]:
         """Get target class with prompt-specific JSON field aliases.
 
@@ -197,28 +159,18 @@ class GapTranslationManager(Manager):
         Returns:
             target model class
         """
-        fields: dict[str, Any] = {
-            "index": (
-                int,
-                Field(
-                    ...,
+        return cls.create_prompt_model(
+            GapTranslationSubtitle,
+            prompt,
+            {
+                "index": PromptModelField(
                     alias=prompt.index,
                     description=prompt.index_desc,
-                    ge=1,
                 ),
-            ),
-            "text": (
-                str,
-                Field(
-                    ...,
+                "text": PromptModelField(
                     alias=prompt.text,
                     description=prompt.target_text_desc,
                 ),
-            ),
-        }
-        return create_model(
-            get_model_name("GapTranslationTarget", prompt.name),
-            __base__=GapTranslationSubtitle,
-            __module__=GapTranslationQuery.__module__,
-            **fields,
+            },
+            name="GapTranslationTarget",
         )

--- a/scinoephile/llms/guided_review/manager.py
+++ b/scinoephile/llms/guided_review/manager.py
@@ -5,25 +5,19 @@
 from __future__ import annotations
 
 from functools import cache
-from typing import Any, ClassVar
-
-from pydantic import Field, create_model
+from typing import ClassVar
 
 from scinoephile.core.llms import (
     AnnotatedTestCaseSubtitle,
     Answer,
     Manager,
+    PromptModelField,
     Query,
     TestCase,
     TestCaseSubtitle,
 )
-from scinoephile.core.llms.models import get_model_name
 
-from .models import (
-    GuidedReviewAnswer,
-    GuidedReviewQuery,
-    GuidedReviewTestCase,
-)
+from .models import GuidedReviewAnswer, GuidedReviewQuery, GuidedReviewTestCase
 from .prompt import GuidedReviewPrompt
 
 __all__ = ["GuidedReviewManager"]
@@ -34,7 +28,7 @@ class GuidedReviewManager(Manager):
 
     operation: ClassVar[str] = "guided-review"
     """Stable operation identifier used in persistence and CLIs."""
-    base_prompt: ClassVar[GuidedReviewPrompt] = GuidedReviewPrompt()
+    base_prompt: ClassVar[GuidedReviewPrompt] = GuidedReviewTestCase.prompt
     """Base prompt defining persisted test-case field names."""
     test_case_base_cls: ClassVar[type[TestCase]] = GuidedReviewTestCase
     """Static test-case model defining guided review's semantic shape."""
@@ -50,24 +44,17 @@ class GuidedReviewManager(Manager):
             answer model class
         """
         revision_cls = cls.get_revision_cls(prompt)
-        fields: dict[str, Any] = {
-            "revisions": (
-                list[revision_cls],  # ty: ignore[invalid-type-form]
-                Field(
-                    ...,
+        return cls.create_prompt_model(
+            GuidedReviewAnswer,
+            prompt,
+            {
+                "revisions": PromptModelField(
                     alias=prompt.revisions,
+                    annotation=list[revision_cls],  # ty: ignore[invalid-type-form]
                     description=prompt.revisions_desc,
                 ),
-            ),
-        }
-        model = create_model(
-            get_model_name("GuidedReviewAnswer", prompt.name),
-            __base__=GuidedReviewAnswer,
-            __module__=GuidedReviewAnswer.__module__,
-            **fields,
+            },
         )
-        model.prompt = prompt
-        return model
 
     @classmethod
     @cache
@@ -79,31 +66,21 @@ class GuidedReviewManager(Manager):
         Returns:
             guide model class
         """
-        fields: dict[str, Any] = {
-            "index": (
-                int,
-                Field(
-                    ...,
+        return cls.create_prompt_model(
+            TestCaseSubtitle,
+            prompt,
+            {
+                "index": PromptModelField(
                     alias=prompt.index,
                     description=prompt.index_desc,
-                    ge=1,
                 ),
-            ),
-            "text": (
-                str,
-                Field(
-                    ...,
+                "text": PromptModelField(
                     alias=prompt.text,
                     description=prompt.guide_text_desc,
-                    max_length=1000,
                 ),
-            ),
-        }
-        return create_model(
-            get_model_name("GuidedReviewGuide", prompt.name),
-            __base__=TestCaseSubtitle,
-            __module__=GuidedReviewQuery.__module__,
-            **fields,
+            },
+            module=GuidedReviewQuery.__module__,
+            name="GuidedReviewGuide",
         )
 
     @classmethod
@@ -118,33 +95,22 @@ class GuidedReviewManager(Manager):
         """
         target_cls = cls.get_target_cls(prompt)
         guide_cls = cls.get_guide_cls(prompt)
-        fields: dict[str, Any] = {
-            "targets": (
-                list[target_cls],  # ty: ignore[invalid-type-form]
-                Field(
-                    ...,
+        return cls.create_prompt_model(
+            GuidedReviewQuery,
+            prompt,
+            {
+                "targets": PromptModelField(
                     alias=prompt.targets,
+                    annotation=list[target_cls],  # ty: ignore[invalid-type-form]
                     description=prompt.targets_desc,
-                    min_length=1,
                 ),
-            ),
-            "guides": (
-                list[guide_cls],  # ty: ignore[invalid-type-form]
-                Field(
-                    ...,
+                "guides": PromptModelField(
                     alias=prompt.guides,
+                    annotation=list[guide_cls],  # ty: ignore[invalid-type-form]
                     description=prompt.guides_desc,
                 ),
-            ),
-        }
-        model = create_model(
-            get_model_name("GuidedReviewQuery", prompt.name),
-            __base__=GuidedReviewQuery,
-            __module__=GuidedReviewQuery.__module__,
-            **fields,
+            },
         )
-        model.prompt = prompt
-        return model
 
     @classmethod
     @cache
@@ -159,42 +125,25 @@ class GuidedReviewManager(Manager):
         Returns:
             revision model class
         """
-        fields: dict[str, Any] = {
-            "index": (
-                int,
-                Field(
-                    ...,
+        return cls.create_prompt_model(
+            AnnotatedTestCaseSubtitle,
+            prompt,
+            {
+                "index": PromptModelField(
                     alias=prompt.index,
                     description=prompt.index_desc,
-                    ge=1,
                 ),
-            ),
-            "text": (
-                str,
-                Field(
-                    ...,
+                "text": PromptModelField(
                     alias=prompt.text,
                     description=prompt.revision_text_desc,
-                    min_length=1,
-                    max_length=1000,
                 ),
-            ),
-            "note": (
-                str,
-                Field(
-                    ...,
+                "note": PromptModelField(
                     alias=prompt.note,
                     description=prompt.note_desc,
-                    min_length=1,
-                    max_length=1000,
                 ),
-            ),
-        }
-        return create_model(
-            get_model_name("GuidedReviewRevision", prompt.name),
-            __base__=AnnotatedTestCaseSubtitle,
-            __module__=GuidedReviewAnswer.__module__,
-            **fields,
+            },
+            module=GuidedReviewAnswer.__module__,
+            name="GuidedReviewRevision",
         )
 
     @classmethod
@@ -207,29 +156,19 @@ class GuidedReviewManager(Manager):
         Returns:
             target model class
         """
-        fields: dict[str, Any] = {
-            "index": (
-                int,
-                Field(
-                    ...,
+        return cls.create_prompt_model(
+            TestCaseSubtitle,
+            prompt,
+            {
+                "index": PromptModelField(
                     alias=prompt.index,
                     description=prompt.index_desc,
-                    ge=1,
                 ),
-            ),
-            "text": (
-                str,
-                Field(
-                    ...,
+                "text": PromptModelField(
                     alias=prompt.text,
                     description=prompt.target_text_desc,
-                    max_length=1000,
                 ),
-            ),
-        }
-        return create_model(
-            get_model_name("GuidedReviewTarget", prompt.name),
-            __base__=TestCaseSubtitle,
-            __module__=GuidedReviewQuery.__module__,
-            **fields,
+            },
+            module=GuidedReviewQuery.__module__,
+            name="GuidedReviewTarget",
         )

--- a/scinoephile/llms/guided_translation/manager.py
+++ b/scinoephile/llms/guided_translation/manager.py
@@ -5,17 +5,15 @@
 from __future__ import annotations
 
 from functools import cache
-from typing import Any, ClassVar
-
-from pydantic import Field, create_model
+from typing import ClassVar
 
 from scinoephile.core.llms import (
     Answer,
     Manager,
+    PromptModelField,
     Query,
     TestCase,
 )
-from scinoephile.core.llms.models import get_model_name
 
 from .models import (
     GuidedTranslationAnswer,
@@ -33,7 +31,7 @@ class GuidedTranslationManager(Manager):
 
     operation: ClassVar[str] = "guided-translation"
     """Stable operation identifier used in persistence and CLIs."""
-    base_prompt: ClassVar[GuidedTranslationPrompt] = GuidedTranslationPrompt()
+    base_prompt: ClassVar[GuidedTranslationPrompt] = GuidedTranslationTestCase.prompt
     """Base prompt defining persisted test-case field names."""
     test_case_base_cls: ClassVar[type[TestCase]] = GuidedTranslationTestCase
     """Static test-case model defining guided translation's semantic shape."""
@@ -49,25 +47,17 @@ class GuidedTranslationManager(Manager):
             answer model class
         """
         output_cls = cls.get_output_cls(prompt)
-        fields: dict[str, Any] = {
-            "outputs": (
-                list[output_cls],  # ty: ignore[invalid-type-form]
-                Field(
-                    ...,
+        return cls.create_prompt_model(
+            GuidedTranslationAnswer,
+            prompt,
+            {
+                "outputs": PromptModelField(
                     alias=prompt.outputs,
+                    annotation=list[output_cls],  # ty: ignore[invalid-type-form]
                     description=prompt.outputs_desc,
-                    min_length=1,
                 ),
-            ),
-        }
-        model = create_model(
-            get_model_name("GuidedTranslationAnswer", prompt.name),
-            __base__=GuidedTranslationAnswer,
-            __module__=GuidedTranslationAnswer.__module__,
-            **fields,
+            },
         )
-        model.prompt = prompt
-        return model
 
     @classmethod
     @cache
@@ -82,30 +72,20 @@ class GuidedTranslationManager(Manager):
         Returns:
             guide-item model class
         """
-        fields: dict[str, Any] = {
-            "index": (
-                int,
-                Field(
-                    ...,
+        return cls.create_prompt_model(
+            GuidedTranslationSubtitle,
+            prompt,
+            {
+                "index": PromptModelField(
                     alias=prompt.index,
                     description=prompt.index_desc,
-                    ge=1,
                 ),
-            ),
-            "text": (
-                str,
-                Field(
-                    ...,
+                "text": PromptModelField(
                     alias=prompt.text,
                     description=prompt.guide_text_desc,
                 ),
-            ),
-        }
-        return create_model(
-            get_model_name("GuidedTranslationGuide", prompt.name),
-            __base__=GuidedTranslationSubtitle,
-            __module__=GuidedTranslationQuery.__module__,
-            **fields,
+            },
+            name="GuidedTranslationGuide",
         )
 
     @classmethod
@@ -121,30 +101,20 @@ class GuidedTranslationManager(Manager):
         Returns:
             output-item model class
         """
-        fields: dict[str, Any] = {
-            "index": (
-                int,
-                Field(
-                    ...,
+        return cls.create_prompt_model(
+            GuidedTranslationSubtitle,
+            prompt,
+            {
+                "index": PromptModelField(
                     alias=prompt.index,
                     description=prompt.index_desc,
-                    ge=1,
                 ),
-            ),
-            "text": (
-                str,
-                Field(
-                    ...,
+                "text": PromptModelField(
                     alias=prompt.text,
                     description=prompt.output_text_desc,
                 ),
-            ),
-        }
-        return create_model(
-            get_model_name("GuidedTranslationOutput", prompt.name),
-            __base__=GuidedTranslationSubtitle,
-            __module__=GuidedTranslationAnswer.__module__,
-            **fields,
+            },
+            name="GuidedTranslationOutput",
         )
 
     @classmethod
@@ -159,33 +129,22 @@ class GuidedTranslationManager(Manager):
         """
         subtitle_cls = cls.get_subtitle_cls(prompt)
         guide_cls = cls.get_guide_cls(prompt)
-        fields: dict[str, Any] = {
-            "subtitles": (
-                list[subtitle_cls],  # ty: ignore[invalid-type-form]
-                Field(
-                    ...,
+        return cls.create_prompt_model(
+            GuidedTranslationQuery,
+            prompt,
+            {
+                "subtitles": PromptModelField(
                     alias=prompt.subtitles,
+                    annotation=list[subtitle_cls],  # ty: ignore[invalid-type-form]
                     description=prompt.subtitles_desc,
-                    min_length=1,
                 ),
-            ),
-            "guides": (
-                list[guide_cls],  # ty: ignore[invalid-type-form]
-                Field(
-                    ...,
+                "guides": PromptModelField(
                     alias=prompt.guides,
+                    annotation=list[guide_cls],  # ty: ignore[invalid-type-form]
                     description=prompt.guides_desc,
                 ),
-            ),
-        }
-        model = create_model(
-            get_model_name("GuidedTranslationQuery", prompt.name),
-            __base__=GuidedTranslationQuery,
-            __module__=GuidedTranslationQuery.__module__,
-            **fields,
+            },
         )
-        model.prompt = prompt
-        return model
 
     @classmethod
     @cache
@@ -200,28 +159,17 @@ class GuidedTranslationManager(Manager):
         Returns:
             subtitle-item model class
         """
-        fields: dict[str, Any] = {
-            "index": (
-                int,
-                Field(
-                    ...,
+        return cls.create_prompt_model(
+            GuidedTranslationSubtitle,
+            prompt,
+            {
+                "index": PromptModelField(
                     alias=prompt.index,
                     description=prompt.index_desc,
-                    ge=1,
                 ),
-            ),
-            "text": (
-                str,
-                Field(
-                    ...,
+                "text": PromptModelField(
                     alias=prompt.text,
                     description=prompt.subtitle_text_desc,
                 ),
-            ),
-        }
-        return create_model(
-            get_model_name("GuidedTranslationSubtitle", prompt.name),
-            __base__=GuidedTranslationSubtitle,
-            __module__=GuidedTranslationQuery.__module__,
-            **fields,
+            },
         )

--- a/scinoephile/llms/ocr_fusion/manager.py
+++ b/scinoephile/llms/ocr_fusion/manager.py
@@ -5,12 +5,15 @@
 from __future__ import annotations
 
 from functools import cache
-from typing import Any, ClassVar
+from typing import ClassVar
 
-from pydantic import Field, create_model
-
-from scinoephile.core.llms import Answer, Manager, Query, TestCase
-from scinoephile.core.llms.models import get_model_name
+from scinoephile.core.llms import (
+    Answer,
+    Manager,
+    PromptModelField,
+    Query,
+    TestCase,
+)
 
 from .models import OcrFusionAnswer, OcrFusionQuery, OcrFusionTestCase
 from .prompt import OcrFusionPrompt
@@ -23,7 +26,7 @@ class OcrFusionManager(Manager):
 
     operation: ClassVar[str] = "ocr-fusion"
     """Stable operation identifier used in persistence and CLIs."""
-    base_prompt: ClassVar[OcrFusionPrompt] = OcrFusionPrompt()
+    base_prompt: ClassVar[OcrFusionPrompt] = OcrFusionTestCase.prompt
     """Base prompt defining persisted test-case field names."""
     test_case_base_cls: ClassVar[type[TestCase]] = OcrFusionTestCase
     """Static test-case model defining OCR fusion's semantic shape."""
@@ -38,26 +41,22 @@ class OcrFusionManager(Manager):
         Returns:
             answer model class
         """
-        name = get_model_name(Answer.__name__, prompt.name)
-        fields: dict[str, Any] = {
-            "output": (
-                str,
-                Field(..., alias=prompt.output, description=prompt.output_desc),
-            ),
-            "note": (
-                str,
-                Field(..., alias=prompt.note, description=prompt.note_desc),
-            ),
-        }
-
-        model = create_model(
-            name,
-            __base__=OcrFusionAnswer,
-            __module__=Answer.__module__,
-            **fields,
+        return cls.create_prompt_model(
+            OcrFusionAnswer,
+            prompt,
+            {
+                "output": PromptModelField(
+                    alias=prompt.output,
+                    description=prompt.output_desc,
+                ),
+                "note": PromptModelField(
+                    alias=prompt.note,
+                    description=prompt.note_desc,
+                ),
+            },
+            module=Answer.__module__,
+            name=Answer.__name__,
         )
-        model.prompt = prompt
-        return model
 
     @classmethod
     @cache
@@ -69,23 +68,19 @@ class OcrFusionManager(Manager):
         Returns:
             query model class
         """
-        name = get_model_name(Query.__name__, prompt.name)
-        fields: dict[str, Any] = {
-            "source_one": (
-                str,
-                Field(..., alias=prompt.src_1, description=prompt.src_1_desc),
-            ),
-            "source_two": (
-                str,
-                Field(..., alias=prompt.src_2, description=prompt.src_2_desc),
-            ),
-        }
-
-        model = create_model(
-            name,
-            __base__=OcrFusionQuery,
-            __module__=Query.__module__,
-            **fields,
+        return cls.create_prompt_model(
+            OcrFusionQuery,
+            prompt,
+            {
+                "source_one": PromptModelField(
+                    alias=prompt.src_1,
+                    description=prompt.src_1_desc,
+                ),
+                "source_two": PromptModelField(
+                    alias=prompt.src_2,
+                    description=prompt.src_2_desc,
+                ),
+            },
+            module=Query.__module__,
+            name=Query.__name__,
         )
-        model.prompt = prompt
-        return model

--- a/scinoephile/llms/pairwise_review/manager.py
+++ b/scinoephile/llms/pairwise_review/manager.py
@@ -5,18 +5,17 @@
 from __future__ import annotations
 
 from functools import cache
-from typing import Any, ClassVar
+from typing import ClassVar
 
-from pydantic import Field, create_model
-
-from scinoephile.core.llms import Answer, Manager, Query, TestCase
-from scinoephile.core.llms.models import get_model_name
-
-from .models import (
-    PairwiseReviewAnswer,
-    PairwiseReviewQuery,
-    PairwiseReviewTestCase,
+from scinoephile.core.llms import (
+    Answer,
+    Manager,
+    PromptModelField,
+    Query,
+    TestCase,
 )
+
+from .models import PairwiseReviewAnswer, PairwiseReviewQuery, PairwiseReviewTestCase
 from .prompt import PairwiseReviewPrompt
 
 __all__ = ["PairwiseReviewManager"]
@@ -27,7 +26,7 @@ class PairwiseReviewManager(Manager):
 
     operation: ClassVar[str] = "pairwise-review"
     """Stable operation identifier used in persistence and CLIs."""
-    base_prompt: ClassVar[PairwiseReviewPrompt] = PairwiseReviewPrompt()
+    base_prompt: ClassVar[PairwiseReviewPrompt] = PairwiseReviewTestCase.prompt
     """Base prompt defining persisted test-case field names."""
     test_case_base_cls: ClassVar[type[TestCase]] = PairwiseReviewTestCase
     """Static test-case model defining pairwise review's semantic shape."""
@@ -45,34 +44,20 @@ class PairwiseReviewManager(Manager):
         Returns:
             answer model class
         """
-        fields: dict[str, Any] = {
-            "output": (
-                str,
-                Field(
-                    "",
+        return cls.create_prompt_model(
+            PairwiseReviewAnswer,
+            prompt,
+            {
+                "output": PromptModelField(
                     alias=prompt.output,
                     description=prompt.output_desc,
-                    max_length=1000,
                 ),
-            ),
-            "note": (
-                str,
-                Field(
-                    "",
+                "note": PromptModelField(
                     alias=prompt.note,
                     description=prompt.note_desc,
-                    max_length=1000,
                 ),
-            ),
-        }
-        model = create_model(
-            get_model_name("PairwiseReviewAnswer", prompt.name),
-            __base__=PairwiseReviewAnswer,
-            __module__=PairwiseReviewAnswer.__module__,
-            **fields,
+            },
         )
-        model.prompt = prompt
-        return model
 
     @classmethod
     @cache
@@ -87,31 +72,17 @@ class PairwiseReviewManager(Manager):
         Returns:
             query model class
         """
-        fields: dict[str, Any] = {
-            "target": (
-                str,
-                Field(
-                    ...,
+        return cls.create_prompt_model(
+            PairwiseReviewQuery,
+            prompt,
+            {
+                "target": PromptModelField(
                     alias=prompt.target,
                     description=prompt.target_desc,
-                    max_length=1000,
                 ),
-            ),
-            "reference": (
-                str,
-                Field(
-                    ...,
+                "reference": PromptModelField(
                     alias=prompt.reference,
                     description=prompt.reference_desc,
-                    max_length=1000,
                 ),
-            ),
-        }
-        model = create_model(
-            get_model_name("PairwiseReviewQuery", prompt.name),
-            __base__=PairwiseReviewQuery,
-            __module__=PairwiseReviewQuery.__module__,
-            **fields,
+            },
         )
-        model.prompt = prompt
-        return model

--- a/scinoephile/llms/punctuation/manager.py
+++ b/scinoephile/llms/punctuation/manager.py
@@ -5,12 +5,15 @@
 from __future__ import annotations
 
 from functools import cache
-from typing import Any, ClassVar
+from typing import ClassVar
 
-from pydantic import Field, create_model
-
-from scinoephile.core.llms import Answer, Manager, Query, TestCase
-from scinoephile.core.llms.models import get_model_name
+from scinoephile.core.llms import (
+    Answer,
+    Manager,
+    PromptModelField,
+    Query,
+    TestCase,
+)
 
 from .models import PunctuationAnswer, PunctuationQuery, PunctuationTestCase
 from .prompt import PunctuationPrompt
@@ -23,7 +26,7 @@ class PunctuationManager(Manager):
 
     operation: ClassVar[str] = "punctuation"
     """Stable operation identifier used in persistence and CLIs."""
-    base_prompt: ClassVar[PunctuationPrompt] = PunctuationPrompt()
+    base_prompt: ClassVar[PunctuationPrompt] = PunctuationTestCase.prompt
     """Base prompt defining persisted test-case field names."""
     test_case_base_cls: ClassVar[type[TestCase]] = PunctuationTestCase
     """Static test-case model defining punctuation's semantic shape."""
@@ -41,24 +44,16 @@ class PunctuationManager(Manager):
         Returns:
             answer model class
         """
-        fields: dict[str, Any] = {
-            "output": (
-                str,
-                Field(
-                    ...,
+        return cls.create_prompt_model(
+            PunctuationAnswer,
+            prompt,
+            {
+                "output": PromptModelField(
                     alias=prompt.output,
                     description=prompt.output_desc,
                 ),
-            ),
-        }
-        model = create_model(
-            get_model_name("PunctuationAnswer", prompt.name),
-            __base__=PunctuationAnswer,
-            __module__=PunctuationAnswer.__module__,
-            **fields,
+            },
         )
-        model.prompt = prompt
-        return model
 
     @classmethod
     @cache
@@ -73,29 +68,17 @@ class PunctuationManager(Manager):
         Returns:
             query model class
         """
-        fields: dict[str, Any] = {
-            "subtitles": (
-                list[str],
-                Field(
-                    ...,
+        return cls.create_prompt_model(
+            PunctuationQuery,
+            prompt,
+            {
+                "subtitles": PromptModelField(
                     alias=prompt.src_1,
                     description=prompt.src_1_desc,
                 ),
-            ),
-            "guide": (
-                str,
-                Field(
-                    ...,
+                "guide": PromptModelField(
                     alias=prompt.src_2,
                     description=prompt.src_2_desc,
                 ),
-            ),
-        }
-        model = create_model(
-            get_model_name("PunctuationQuery", prompt.name),
-            __base__=PunctuationQuery,
-            __module__=PunctuationQuery.__module__,
-            **fields,
+            },
         )
-        model.prompt = prompt
-        return model

--- a/scinoephile/llms/review/manager.py
+++ b/scinoephile/llms/review/manager.py
@@ -5,25 +5,19 @@
 from __future__ import annotations
 
 from functools import cache
-from typing import Any, ClassVar
-
-from pydantic import Field, create_model
+from typing import ClassVar
 
 from scinoephile.core.llms import (
     AnnotatedTestCaseSubtitle,
     Answer,
     Manager,
+    PromptModelField,
     Query,
     TestCase,
     TestCaseSubtitle,
 )
-from scinoephile.core.llms.models import get_model_name
 
-from .models import (
-    ReviewAnswer,
-    ReviewQuery,
-    ReviewTestCase,
-)
+from .models import ReviewAnswer, ReviewQuery, ReviewTestCase
 from .prompt import ReviewPrompt
 
 __all__ = ["ReviewManager"]
@@ -34,7 +28,7 @@ class ReviewManager(Manager):
 
     operation: ClassVar[str] = "review"
     """Stable operation identifier used in persistence and CLIs."""
-    base_prompt: ClassVar[ReviewPrompt] = ReviewPrompt()
+    base_prompt: ClassVar[ReviewPrompt] = ReviewTestCase.prompt
     """Base prompt defining persisted test-case field names."""
     test_case_base_cls: ClassVar[type[TestCase]] = ReviewTestCase
     """Static test-case model defining review's semantic shape."""
@@ -50,24 +44,17 @@ class ReviewManager(Manager):
             answer model class
         """
         revision_cls = cls.get_revision_cls(prompt)
-        fields: dict[str, Any] = {
-            "revisions": (
-                list[revision_cls],  # ty: ignore[invalid-type-form]
-                Field(
-                    ...,
+        return cls.create_prompt_model(
+            ReviewAnswer,
+            prompt,
+            {
+                "revisions": PromptModelField(
                     alias=prompt.revisions,
+                    annotation=list[revision_cls],  # ty: ignore[invalid-type-form]
                     description=prompt.revisions_desc,
                 ),
-            ),
-        }
-        model = create_model(
-            get_model_name("ReviewAnswer", prompt.name),
-            __base__=ReviewAnswer,
-            __module__=ReviewAnswer.__module__,
-            **fields,
+            },
         )
-        model.prompt = prompt
-        return model
 
     @classmethod
     @cache
@@ -80,25 +67,17 @@ class ReviewManager(Manager):
             query model class
         """
         subtitle_cls = cls.get_subtitle_cls(prompt)
-        fields: dict[str, Any] = {
-            "subtitles": (
-                list[subtitle_cls],  # ty: ignore[invalid-type-form]
-                Field(
-                    ...,
+        return cls.create_prompt_model(
+            ReviewQuery,
+            prompt,
+            {
+                "subtitles": PromptModelField(
                     alias=prompt.subtitles,
+                    annotation=list[subtitle_cls],  # ty: ignore[invalid-type-form]
                     description=prompt.subtitles_desc,
-                    min_length=1,
                 ),
-            ),
-        }
-        model = create_model(
-            get_model_name("ReviewQuery", prompt.name),
-            __base__=ReviewQuery,
-            __module__=ReviewQuery.__module__,
-            **fields,
+            },
         )
-        model.prompt = prompt
-        return model
 
     @classmethod
     @cache
@@ -113,42 +92,25 @@ class ReviewManager(Manager):
         Returns:
             revision model class
         """
-        fields: dict[str, Any] = {
-            "index": (
-                int,
-                Field(
-                    ...,
+        return cls.create_prompt_model(
+            AnnotatedTestCaseSubtitle,
+            prompt,
+            {
+                "index": PromptModelField(
                     alias=prompt.index,
                     description=prompt.index_desc,
-                    ge=1,
                 ),
-            ),
-            "text": (
-                str,
-                Field(
-                    ...,
+                "text": PromptModelField(
                     alias=prompt.text,
                     description=prompt.revision_text_desc,
-                    min_length=1,
-                    max_length=1000,
                 ),
-            ),
-            "note": (
-                str,
-                Field(
-                    ...,
+                "note": PromptModelField(
                     alias=prompt.note,
                     description=prompt.note_desc,
-                    min_length=1,
-                    max_length=1000,
                 ),
-            ),
-        }
-        return create_model(
-            get_model_name("ReviewRevision", prompt.name),
-            __base__=AnnotatedTestCaseSubtitle,
-            __module__=ReviewAnswer.__module__,
-            **fields,
+            },
+            module=ReviewAnswer.__module__,
+            name="ReviewRevision",
         )
 
     @classmethod
@@ -161,29 +123,19 @@ class ReviewManager(Manager):
         Returns:
             subtitle model class
         """
-        fields: dict[str, Any] = {
-            "index": (
-                int,
-                Field(
-                    ...,
+        return cls.create_prompt_model(
+            TestCaseSubtitle,
+            prompt,
+            {
+                "index": PromptModelField(
                     alias=prompt.index,
                     description=prompt.index_desc,
-                    ge=1,
                 ),
-            ),
-            "text": (
-                str,
-                Field(
-                    ...,
+                "text": PromptModelField(
                     alias=prompt.text,
                     description=prompt.subtitle_text_desc,
-                    max_length=1000,
                 ),
-            ),
-        }
-        return create_model(
-            get_model_name("ReviewSubtitle", prompt.name),
-            __base__=TestCaseSubtitle,
-            __module__=ReviewQuery.__module__,
-            **fields,
+            },
+            module=ReviewQuery.__module__,
+            name="ReviewSubtitle",
         )

--- a/scinoephile/llms/translation/manager.py
+++ b/scinoephile/llms/translation/manager.py
@@ -5,18 +5,16 @@
 from __future__ import annotations
 
 from functools import cache
-from typing import Any, ClassVar
-
-from pydantic import Field, create_model
+from typing import ClassVar
 
 from scinoephile.core.llms import (
     Answer,
     Manager,
+    PromptModelField,
     Query,
     TestCase,
     TestCaseSubtitle,
 )
-from scinoephile.core.llms.models import get_model_name
 
 from .models import (
     TranslationAnswer,
@@ -34,7 +32,7 @@ class TranslationManager(Manager):
 
     operation: ClassVar[str] = "translation"
     """Stable operation identifier used in persistence and CLIs."""
-    base_prompt: ClassVar[TranslationPrompt] = TranslationPrompt()
+    base_prompt: ClassVar[TranslationPrompt] = TranslationTestCase.prompt
     """Base prompt defining persisted test-case field names."""
     test_case_base_cls: ClassVar[type[TestCase]] = TranslationTestCase
     """Static test-case model defining translation's semantic shape."""
@@ -50,25 +48,17 @@ class TranslationManager(Manager):
             answer model class
         """
         output_cls = cls.get_output_cls(prompt)
-        fields: dict[str, Any] = {
-            "outputs": (
-                list[output_cls],  # ty: ignore[invalid-type-form]
-                Field(
-                    ...,
+        return cls.create_prompt_model(
+            TranslationAnswer,
+            prompt,
+            {
+                "outputs": PromptModelField(
                     alias=prompt.outputs,
+                    annotation=list[output_cls],  # ty: ignore[invalid-type-form]
                     description=prompt.outputs_desc,
-                    min_length=1,
                 ),
-            ),
-        }
-        model = create_model(
-            get_model_name("TranslationAnswer", prompt.name),
-            __base__=TranslationAnswer,
-            __module__=TranslationAnswer.__module__,
-            **fields,
+            },
         )
-        model.prompt = prompt
-        return model
 
     @classmethod
     @cache
@@ -80,30 +70,19 @@ class TranslationManager(Manager):
         Returns:
             output model class
         """
-        fields: dict[str, Any] = {
-            "index": (
-                int,
-                Field(
-                    ...,
+        return cls.create_prompt_model(
+            TranslationOutput,
+            prompt,
+            {
+                "index": PromptModelField(
                     alias=prompt.index,
                     description=prompt.index_desc,
-                    ge=1,
                 ),
-            ),
-            "text": (
-                str,
-                Field(
-                    ...,
+                "text": PromptModelField(
                     alias=prompt.text,
                     description=prompt.output_text_desc,
                 ),
-            ),
-        }
-        return create_model(
-            get_model_name("TranslationOutput", prompt.name),
-            __base__=TranslationOutput,
-            __module__=TranslationAnswer.__module__,
-            **fields,
+            },
         )
 
     @classmethod
@@ -117,25 +96,17 @@ class TranslationManager(Manager):
             query model class
         """
         subtitle_cls = cls.get_subtitle_cls(prompt)
-        fields: dict[str, Any] = {
-            "subtitles": (
-                list[subtitle_cls],  # ty: ignore[invalid-type-form]
-                Field(
-                    ...,
+        return cls.create_prompt_model(
+            TranslationQuery,
+            prompt,
+            {
+                "subtitles": PromptModelField(
                     alias=prompt.subtitles,
+                    annotation=list[subtitle_cls],  # ty: ignore[invalid-type-form]
                     description=prompt.subtitles_desc,
-                    min_length=1,
                 ),
-            ),
-        }
-        model = create_model(
-            get_model_name("TranslationQuery", prompt.name),
-            __base__=TranslationQuery,
-            __module__=TranslationQuery.__module__,
-            **fields,
+            },
         )
-        model.prompt = prompt
-        return model
 
     @classmethod
     @cache
@@ -147,29 +118,19 @@ class TranslationManager(Manager):
         Returns:
             subtitle model class
         """
-        fields: dict[str, Any] = {
-            "index": (
-                int,
-                Field(
-                    ...,
+        return cls.create_prompt_model(
+            TestCaseSubtitle,
+            prompt,
+            {
+                "index": PromptModelField(
                     alias=prompt.index,
                     description=prompt.index_desc,
-                    ge=1,
                 ),
-            ),
-            "text": (
-                str,
-                Field(
-                    ...,
+                "text": PromptModelField(
                     alias=prompt.text,
                     description=prompt.subtitle_text_desc,
-                    max_length=1000,
                 ),
-            ),
-        }
-        return create_model(
-            get_model_name("TranslationSubtitle", prompt.name),
-            __base__=TestCaseSubtitle,
-            __module__=TranslationQuery.__module__,
-            **fields,
+            },
+            module=TranslationQuery.__module__,
+            name="TranslationSubtitle",
         )

--- a/test/core/llms/test_manager.py
+++ b/test/core/llms/test_manager.py
@@ -4,18 +4,25 @@
 
 from __future__ import annotations
 
-from pytest import raises
+from pytest import mark, raises
 
+from scinoephile.core.llms import Manager
+from scinoephile.llms.delineation import DelineationManager
+from scinoephile.llms.gap_translation import GapTranslationManager
+from scinoephile.llms.guided_review import GuidedReviewManager
 from scinoephile.llms.guided_translation import (
     GuidedTranslationManager,
     GuidedTranslationPrompt,
 )
+from scinoephile.llms.ocr_fusion import OcrFusionManager
+from scinoephile.llms.pairwise_review import PairwiseReviewManager
 from scinoephile.llms.punctuation import (
     PunctuationManager,
     PunctuationPrompt,
     PunctuationTestCase,
 )
 from scinoephile.llms.review import ReviewManager, ReviewPrompt, ReviewTestCase
+from scinoephile.llms.translation import TranslationManager
 
 _LOCALIZED_REVIEW_PROMPT = ReviewPrompt(
     subtitles="zimu",
@@ -41,6 +48,25 @@ _LOCALIZED_PUNCTUATION_PROMPT = PunctuationPrompt(
     output="result",
 )
 """Punctuation prompt using non-default correspondence field names."""
+
+_MANAGER_CLASSES: list[type[Manager]] = [
+    DelineationManager,
+    GapTranslationManager,
+    GuidedReviewManager,
+    GuidedTranslationManager,
+    OcrFusionManager,
+    PairwiseReviewManager,
+    PunctuationManager,
+    ReviewManager,
+    TranslationManager,
+]
+"""Manager classes for every LLM correspondence shape."""
+
+
+@mark.parametrize("manager_cls", _MANAGER_CLASSES)
+def test_manager_reuses_static_test_case_prompt(manager_cls: type[Manager]):
+    """Each manager should reuse its semantic test-case model's prompt."""
+    assert manager_cls.base_prompt is manager_cls.test_case_base_cls.prompt
 
 
 def test_static_shape_factory_caches_and_isolates_prompt_aliases():


### PR DESCRIPTION
## Summary

- add one shared factory that copies Pydantic field defaults, constraints, and metadata from semantic base models
- let managers specify only prompt aliases, localized descriptions, replacement nested annotations, and exceptional compatibility names
- route all nine LLM managers through the shared factory
- derive every manager base prompt from its static test-case model instead of constructing a second equal prompt
- remove the single-use test-case field helper

## Why

The nine managers previously contained 31 independent `create_model()` calls. Each repeated field types, defaults, constraints, aliases, descriptions, generated class metadata, and prompt binding. That duplicated the semantic model schemas and allowed the generated correspondence schemas to drift from them.

The shared factory now copies each semantic `FieldInfo` before applying only the prompt-specific changes. Alias uniqueness remains enforced by the shared LLM model hook introduced in the preceding PR.

## Impact

The refactor reduces the manager implementation by 254 net lines and leaves runtime behavior unchanged. A direct comparison against the parent commit confirmed identical generated class identities and JSON schemas for all nine operations using both base and localized prompts.

## Validation

- Ruff format and check on all 12 changed Python files
- `ty check` on all 12 changed Python files
- focused manager and operation suite: 142 passed
- generated-schema comparison: 18 of 18 base and localized schema sets identical
- full suite: 1,730 passed, 9 skipped