### PR TITLE
Use structured answer schemas for LLM correspondence

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -83,6 +83,10 @@ cardinality in model data, such as indexed subtitle lists, rather than in genera
 class fields. The prompt's stable content-addressed name is used in generated model
 names.
 
+LLM providers require a structured answer model for every completion. The provider's
+structured response format is the authoritative answer schema; system prompts do not
+duplicate that schema as text.
+
 Optimization persistence stores each prompt alias with its content-addressed
 identifier, language, and complete set of string fields. Prompt and test-case
 SQLite stores own and create their tables independently. Model persistence uses

--- a/scinoephile/core/llms/llm_provider.py
+++ b/scinoephile/core/llms/llm_provider.py
@@ -62,7 +62,7 @@ class LLMProvider(ABC):
     def chat_completion(
         self,
         messages: list[dict[str, Any]],
-        response_format: type[Answer] | None = None,
+        response_format: type[Answer],
         tool_box: ToolBox | None = None,
         **kwargs: Unpack[ChatCompletionKwargs],
     ) -> str:
@@ -70,7 +70,7 @@ class LLMProvider(ABC):
 
         Arguments:
             messages: messages to send
-            response_format: response format
+            response_format: structured response format
             tool_box: available tools
             **kwargs: provider-specific keyword arguments
         Returns:

--- a/scinoephile/core/llms/openai_provider_base.py
+++ b/scinoephile/core/llms/openai_provider_base.py
@@ -111,7 +111,7 @@ class OpenAIProviderBase(LLMProvider):
     def chat_completion(
         self,
         messages: list[dict[str, Any]],
-        response_format: type[Answer] | None = None,
+        response_format: type[Answer],
         tool_box: ToolBox | None = None,
         **kwargs: Unpack[ChatCompletionKwargs],
     ) -> str:
@@ -119,7 +119,7 @@ class OpenAIProviderBase(LLMProvider):
 
         Arguments:
             messages: messages to send
-            response_format: response format
+            response_format: structured response format
             tool_box: available tools and handlers
             **kwargs: additional keyword arguments
         Returns:
@@ -140,7 +140,7 @@ class OpenAIProviderBase(LLMProvider):
             max_tool_rounds = 8
             for _ in range(max_tool_rounds):
                 # Query provider
-                completion = self._query(messages, response_format, request_kwargs)
+                completion = self._query(messages, request_kwargs)
                 message = completion.choices[0].message
                 tool_calls = cast(
                     list[ChatCompletionMessageFunctionToolCall],
@@ -210,29 +210,21 @@ class OpenAIProviderBase(LLMProvider):
     def _query(
         self,
         messages: list[dict[str, Any]],
-        response_format: type[Answer] | None,
         request_kwargs: dict[str, Any],
     ) -> Any:
         """Query provider for completion.
 
         Arguments:
             messages: messages to send
-            response_format: structured response format, if any
             request_kwargs: OpenAI SDK request keyword arguments
         Returns:
             completion response object
         """
-        if response_format:
-            return self.sync_client.beta.chat.completions.parse(
-                messages=messages,  # ty:ignore[invalid-argument-type]
-                model=self.model,
-                **request_kwargs,
-            )
-        return self.sync_client.chat.completions.create(
-            messages=messages,
+        return self.sync_client.beta.chat.completions.parse(
+            messages=messages,  # ty:ignore[invalid-argument-type]
             model=self.model,
             **request_kwargs,
-        )  # ty:ignore[no-matching-overload]
+        )
 
     @staticmethod
     def _call_tool(
@@ -286,7 +278,7 @@ class OpenAIProviderBase(LLMProvider):
 
     @staticmethod
     def _build_request_kwargs(
-        response_format: type[Answer] | None,
+        response_format: type[Answer],
         openai_tools: list[dict[str, object]] | None,
         kwargs: Mapping[str, Any],
     ) -> dict[str, Any]:
@@ -300,8 +292,7 @@ class OpenAIProviderBase(LLMProvider):
             request kwargs for the OpenAI SDK call
         """
         request_kwargs: dict[str, Any] = dict(kwargs)
-        if response_format:
-            request_kwargs["response_format"] = response_format
+        request_kwargs["response_format"] = response_format
         if openai_tools is not None:
             request_kwargs.setdefault("tool_choice", "auto")
             request_kwargs.setdefault("parallel_tool_calls", False)

--- a/scinoephile/core/llms/prompt.py
+++ b/scinoephile/core/llms/prompt.py
@@ -21,8 +21,6 @@ __all__ = [
 class PromptLocalizationFields(TypedDict):
     """Shared localization fields accepted by all prompt types."""
 
-    schema_intro: str
-    """Text preceding schema description."""
     few_shot_intro: str
     """Text preceding few-shot examples."""
     few_shot_query_intro: str
@@ -49,8 +47,6 @@ class Prompt:
     # Prompt
     base_system_prompt: str = ""
     """Base system prompt."""
-    schema_intro: str = ""
-    """Text preceding schema description."""
     few_shot_intro: str = ""
     """Text preceding few-shot examples."""
     few_shot_query_intro: str = ""

--- a/scinoephile/core/llms/queryer.py
+++ b/scinoephile/core/llms/queryer.py
@@ -84,8 +84,11 @@ class Queryer[TTestCase: TestCase]:
         """Automatically verify test cases if they meet selected criteria."""
         self.tool_box = tool_box or ToolBox()
         """Available tools and handlers."""
-        self.system_prompt = self._build_system_prompt()
+        self.system_prompt = self.prompt.base_system_prompt
         """System prompt shared by all queries executed by this instance."""
+        if self.additional_context:
+            self.system_prompt += f"\n\nAdditional context:\n{self.additional_context}"
+        self.system_prompt += self.get_few_shot_test_cases_str()
 
     def __call__(self, test_case: TestCase) -> TTestCase:
         """Query LLM.
@@ -243,23 +246,6 @@ class Queryer[TTestCase: TestCase]:
         normalized.verified |= key in self.verified_test_cases
         self.encountered_test_cases[key] = normalized
         logger.debug(f"Logged test case: {normalized.query.key_str}")
-
-    def _build_system_prompt(self) -> str:
-        """Build the system prompt for the bound answer class.
-
-        Returns:
-            system prompt for the bound answer class
-        """
-        schema = self.test_case_cls.answer_cls.model_json_schema(by_alias=True)
-        schema_json = json.dumps(schema, indent=4, ensure_ascii=False)
-
-        system_prompt = self.prompt.base_system_prompt
-        if self.additional_context:
-            system_prompt += f"\n\nAdditional context:\n{self.additional_context}"
-        system_prompt += self.get_few_shot_test_cases_str()
-        system_prompt += f"\n\n{self.prompt.schema_intro}\n{schema_json}\n"
-
-        return system_prompt
 
     def _get_cache_path(
         self, system_prompt: str, tools_json: str, query_json: str

--- a/scinoephile/lang/eng/prompts.py
+++ b/scinoephile/lang/eng/prompts.py
@@ -12,7 +12,6 @@ __all__ = ["ENG_PROMPT_FIELDS"]
 
 
 ENG_PROMPT_FIELDS: Final[PromptLocalizationFields] = {
-    "schema_intro": "Your response must be a JSON object with the following structure:",
     "few_shot_intro": "Here are some examples of queries and expected answers:",
     "few_shot_query_intro": "Example query:",
     "few_shot_answer_intro": "Expected answer:",

--- a/scinoephile/lang/yue/prompts.py
+++ b/scinoephile/lang/yue/prompts.py
@@ -12,7 +12,6 @@ __all__ = ["YUE_HANT_PROMPT_FIELDS"]
 
 
 YUE_HANT_PROMPT_FIELDS: Final[PromptLocalizationFields] = {
-    "schema_intro": "你嘅回覆一定要係一個有以下結構嘅 JSON 物件：",
     "few_shot_intro": "下面係一啲查詢同埋佢哋預期答案嘅例子：",
     "few_shot_query_intro": "例子查詢：",
     "few_shot_answer_intro": "預期答案：",

--- a/scinoephile/lang/zho/prompts.py
+++ b/scinoephile/lang/zho/prompts.py
@@ -12,7 +12,6 @@ __all__ = ["ZHO_HANT_PROMPT_FIELDS"]
 
 
 ZHO_HANT_PROMPT_FIELDS: Final[PromptLocalizationFields] = {
-    "schema_intro": "你的回覆必須是一個具有以下結構的 JSON 對象：",
     "few_shot_intro": "下面是一些查詢及其預期答案的示例：",
     "few_shot_query_intro": "示例查詢：",
     "few_shot_answer_intro": "預期答案：",

--- a/test/core/llms/test_openai_provider_base.py
+++ b/test/core/llms/test_openai_provider_base.py
@@ -12,7 +12,7 @@ from typing import Any, cast
 from openai import OpenAI
 from pytest import raises
 
-from scinoephile.core.llms import OpenAIProviderBase
+from scinoephile.core.llms import Answer, OpenAIProviderBase
 from scinoephile.core.llms.tool import Tool
 from scinoephile.core.llms.tool_box import ToolBox
 
@@ -22,6 +22,13 @@ class _DummyProvider(OpenAIProviderBase):
 
     model = "dummy-model"
     """Dummy model name."""
+
+
+class _Answer(Answer):
+    """Structured answer fixture."""
+
+    output: str
+    """Answer output."""
 
 
 class _ToolCallFunction:
@@ -92,6 +99,7 @@ class _DummyClient:
     def __init__(self):
         """Initialize dummy client state and completion surface."""
         self.calls: list[dict[str, object]] = []
+        self.parse_calls = 0
         self._round = 0
 
         def create(
@@ -121,9 +129,27 @@ class _DummyClient:
                 )
             return _Completion(_Message(content="done", tool_calls=[]))
 
+        def parse(
+            *,
+            messages: list[dict[str, object]],
+            model: str,
+            **kwargs: Any,
+        ) -> _Completion:
+            """Parse one structured dummy chat completion.
+
+            Arguments:
+                messages: OpenAI chat messages
+                model: model name
+                **kwargs: additional completion keyword arguments
+            Returns:
+                dummy completion
+            """
+            self.parse_calls += 1
+            return create(messages=messages, model=model, **kwargs)
+
         self.chat = SimpleNamespace(completions=SimpleNamespace(create=create))
         self.beta = SimpleNamespace(
-            chat=SimpleNamespace(completions=SimpleNamespace(parse=None))
+            chat=SimpleNamespace(completions=SimpleNamespace(parse=parse))
         )
 
 
@@ -163,11 +189,15 @@ def test_tool_call_loop_runs_handler_and_returns_final_text():
 
     result = provider.chat_completion(
         messages=[{"role": "user", "content": "hi"}],
+        response_format=_Answer,
         tool_box=_get_tool_box(handler),
     )
 
     assert result == "done"
+    assert client.parse_calls == 2
     assert len(client.calls) == 2
+    first_call_kwargs = cast(dict[str, object], client.calls[0]["kwargs"])
+    assert first_call_kwargs["response_format"] is _Answer
     second_call_messages = cast(list[dict[str, object]], client.calls[1]["messages"])
     assert second_call_messages[1]["reasoning_content"] == (
         "Need tool output before answering."
@@ -181,6 +211,7 @@ def test_model_override_updates_provider_model():
 
     provider.chat_completion(
         messages=[{"role": "user", "content": "hi"}],
+        response_format=_Answer,
         tool_box=_get_tool_box(lambda args: args),
     )
 

--- a/test/core/llms/test_provider_injection.py
+++ b/test/core/llms/test_provider_injection.py
@@ -31,7 +31,6 @@ from scinoephile.core.llms.tool_box import ToolBox
 _PROMPT = Prompt(
     language=Language.eng,
     base_system_prompt="System prompt",
-    schema_intro="Schema",
     few_shot_intro="Few shot",
     few_shot_query_intro="Query",
     few_shot_answer_intro="Answer",
@@ -153,6 +152,7 @@ class _RecordingProvider(LLMProvider):
             base_url: base URL identity for cache namespacing
         """
         self.calls: list[list[dict[str, Any]]] = []
+        self.response_formats: list[type[Answer]] = []
         self.response = response
         self.model = model
         self.base_url = base_url
@@ -169,13 +169,14 @@ class _RecordingProvider(LLMProvider):
     def chat_completion(
         self,
         messages: list[dict[str, Any]],
-        response_format: type[Answer] | None = None,
+        response_format: type[Answer],
         tool_box: ToolBox | None = None,
         **kwargs: Unpack[ChatCompletionKwargs],
     ) -> str:
         """Record messages and return a fixed completion response."""
-        _ = (response_format, tool_box, kwargs)
+        _ = (tool_box, kwargs)
         self.calls.append(messages)
+        self.response_formats.append(response_format)
         return self.response
 
 
@@ -194,6 +195,8 @@ def test_queryer_uses_injected_provider():
     assert output_test_case.answer is not None
     assert output_test_case.answer.output == "done"
     assert len(provider.calls) == 1
+    assert provider.response_formats == [_Answer]
+    assert queryer.system_prompt == _PROMPT.base_system_prompt
 
 
 def test_queryer_requires_injected_provider():

--- a/test/llms/providers/test_registry.py
+++ b/test/llms/providers/test_registry.py
@@ -10,7 +10,7 @@ from unittest.mock import Mock
 from pytest import fixture, raises
 
 from scinoephile.core import ScinoephileError
-from scinoephile.core.llms import Answer, LLMProvider
+from scinoephile.core.llms import Answer, LLMProvider, OpenAIProviderBase
 from scinoephile.core.llms.llm_provider import ChatCompletionKwargs
 from scinoephile.core.llms.tool_box import ToolBox
 from scinoephile.llms.providers import registry as provider_registry
@@ -123,6 +123,12 @@ def test_get_provider_names_returns_registered_provider_names():
     assert "openai" in provider_names
 
 
+def test_built_in_providers_use_structured_openai_base():
+    """Test built-in providers share the structured completion implementation."""
+    assert isinstance(get_provider("deepseek"), OpenAIProviderBase)
+    assert isinstance(get_provider("openai"), OpenAIProviderBase)
+
+
 def test_get_provider_raises_for_unknown_provider():
     """Test provider lookup fails for unknown provider names."""
     with raises(ScinoephileError):
@@ -149,7 +155,7 @@ class _DummyProvider(LLMProvider):
     def chat_completion(
         self,
         messages: list[dict[str, Any]],
-        response_format: type[Answer] | None = None,
+        response_format: type[Answer],
         tool_box: ToolBox | None = None,
         **kwargs: Unpack[ChatCompletionKwargs],
     ) -> str:

--- a/test/llms/test_delineation.py
+++ b/test/llms/test_delineation.py
@@ -148,15 +148,14 @@ def test_queryer_corresponds_using_prompt_aliases():
         "output_one": "甲乙",
         "output_two": "",
     }
-    messages = provider.chat_completion.call_args.args[0]
+    messages, answer_cls, _ = provider.chat_completion.call_args.args
+    assert answer_cls is test_case_cls.answer_cls
     assert json.loads(messages[1]["content"]) == {
         "cankao_yi": "參考一",
         "cankao_er": "參考二",
         "mubiao_yi": "甲",
         "mubiao_er": "乙",
     }
-    assert '"shuchu_yi"' in messages[0]["content"]
-    assert '"shuchu_er"' in messages[0]["content"]
 
 
 @mark.parametrize(

--- a/test/llms/test_gap_translation.py
+++ b/test/llms/test_gap_translation.py
@@ -105,7 +105,8 @@ def test_queryer_corresponds_using_prompt_aliases():
     result = queryer(test_case)
 
     assert result.answer is not None
-    messages = provider.chat_completion.call_args.args[0]
+    messages, answer_cls, _ = provider.chat_completion.call_args.args
+    assert answer_cls is test_case_cls.answer_cls
     assert json.loads(messages[1]["content"]) == {
         "mubiao": [{"xuhao": 1, "wenben": "現有"}],
         "cankao": [
@@ -113,9 +114,6 @@ def test_queryer_corresponds_using_prompt_aliases():
             {"xuhao": 2, "wenben": "參考二"},
         ],
     }
-    assert '"shuchu"' in messages[0]["content"]
-    assert '"xuhao"' in messages[0]["content"]
-    assert '"wenben"' in messages[0]["content"]
 
 
 def test_query_requires_nonempty_consecutive_guides():

--- a/test/llms/test_guided_review_models.py
+++ b/test/llms/test_guided_review_models.py
@@ -98,15 +98,12 @@ def test_queryer_corresponds_using_prompt_aliases():
     result = queryer(test_case)
 
     assert result.answer is not None
-    messages = provider.chat_completion.call_args.args[0]
+    messages, answer_cls, _ = provider.chat_completion.call_args.args
+    assert answer_cls is test_case_cls.answer_cls
     assert json.loads(messages[1]["content"]) == {
         "mubiao": [{"xuhao": 1, "wenben": "原文"}],
         "zhinan": [{"xuhao": 1, "wenben": "參考"}],
     }
-    assert '"xiugai"' in messages[0]["content"]
-    assert '"xuhao"' in messages[0]["content"]
-    assert '"wenben"' in messages[0]["content"]
-    assert '"beizhu"' in messages[0]["content"]
 
 
 def test_query_lists_require_items_and_consecutive_ordered_indexes():

--- a/test/llms/test_guided_translation.py
+++ b/test/llms/test_guided_translation.py
@@ -164,7 +164,8 @@ def test_processor_maps_indexed_outputs_to_subtitle_timing():
             Subtitle(start=1000, end=2000, text="譯文二"),
         ]
     )
-    messages = provider.chat_completion.call_args.args[0]
+    messages, answer_cls, _ = provider.chat_completion.call_args.args
+    assert answer_cls is processor.queryer.test_case_cls.answer_cls
     assert json.loads(messages[1]["content"]) == {
         "zimu": [
             {"xuhao": 1, "wenben": "原文一"},
@@ -172,9 +173,6 @@ def test_processor_maps_indexed_outputs_to_subtitle_timing():
         ],
         "cankao": [{"xuhao": 1, "wenben": "參考"}],
     }
-    assert '"shuchu"' in messages[0]["content"]
-    assert '"xuhao"' in messages[0]["content"]
-    assert '"wenben"' in messages[0]["content"]
 
 
 def test_persistence_uses_base_prompt_field_names(tmp_path: Path):

--- a/test/llms/test_ocr_fusion_models.py
+++ b/test/llms/test_ocr_fusion_models.py
@@ -237,13 +237,12 @@ def test_queryer_corresponds_using_prompt_aliases():
         "output": "來源一",
         "note": "採用來源一",
     }
-    messages = provider.chat_completion.call_args.args[0]
+    messages, answer_cls, _ = provider.chat_completion.call_args.args
+    assert answer_cls is test_case_cls.answer_cls
     assert json.loads(messages[1]["content"]) == {
         "yilai": "來源一",
         "erlai": "來源二",
     }
-    assert '"jieguo"' in messages[0]["content"]
-    assert '"shuoming"' in messages[0]["content"]
 
 
 def test_processor_uses_semantic_fields_at_runtime():

--- a/test/llms/test_pairwise_review_models.py
+++ b/test/llms/test_pairwise_review_models.py
@@ -173,9 +173,6 @@ def test_queryer_corresponds_using_prompt_aliases():
         "mubiao": "原文",
         "cankao": "參考",
     }
-    assert f'"title": "{answer_cls.__name__}"' in messages[0]["content"]
-    assert '"shuchu"' in messages[0]["content"]
-    assert '"beizhu"' in messages[0]["content"]
 
 
 @mark.parametrize(

--- a/test/llms/test_prompt_metadata.py
+++ b/test/llms/test_prompt_metadata.py
@@ -29,7 +29,7 @@ _LEGACY_TEST_CASE_PROMPT_FIELDS: Final = {
 def test_registered_prompt_model_and_cache_identities_change_once(
     tmp_path: Path,
 ):
-    """Removing metadata should change prompt, model, system, and cache identities."""
+    """Removing metadata should change prompt, model, and cache identities."""
     provider = Mock(spec=LLMProvider)
     provider.cache_identity = {"implementation": "test.provider"}
 
@@ -50,17 +50,10 @@ def test_registered_prompt_model_and_cache_identities_change_once(
 
         queryer = Queryer(test_case_cls, provider=provider)
         legacy_queryer = Queryer(legacy_test_case_cls, provider=provider)
-        answer_schema = test_case_cls.answer_cls.model_json_schema(by_alias=True)
-        legacy_answer_schema = legacy_test_case_cls.answer_cls.model_json_schema(
-            by_alias=True
-        )
         system_prompt = queryer.system_prompt
         legacy_system_prompt = legacy_queryer.system_prompt
 
-        assert system_prompt != legacy_system_prompt
-        assert _get_system_prompt_prefix(system_prompt, answer_schema) == (
-            _get_system_prompt_prefix(legacy_system_prompt, legacy_answer_schema)
-        )
+        assert system_prompt == legacy_system_prompt
 
         queryer.cache_dir_path = tmp_path
         legacy_queryer.cache_dir_path = tmp_path
@@ -177,23 +170,6 @@ def _get_registered_prompts() -> list[tuple[type[Manager], Prompt]]:
         prompt_pairs,
         key=lambda pair: (pair[0].operation, pair[1].name),
     )
-
-
-def _get_system_prompt_prefix(
-    system_prompt: str,
-    answer_schema: dict[str, Any],
-) -> str:
-    """Get system prompt text preceding its answer schema.
-
-    Arguments:
-        system_prompt: full system prompt
-        answer_schema: answer schema appended to the system prompt
-    Returns:
-        system prompt text preceding the schema
-    """
-    schema_suffix = f"{json.dumps(answer_schema, indent=4, ensure_ascii=False)}\n"
-    assert system_prompt.endswith(schema_suffix)
-    return system_prompt.removesuffix(schema_suffix)
 
 
 def _normalize_schema_identifiers(schema: dict[str, Any]) -> dict[str, Any]:

--- a/test/llms/test_punctuation.py
+++ b/test/llms/test_punctuation.py
@@ -97,12 +97,12 @@ def test_queryer_corresponds_using_prompt_aliases():
 
     assert result.answer is not None
     assert result.answer.model_dump() == {"output": "原文"}
-    messages = provider.chat_completion.call_args.args[0]
+    messages, answer_cls, _ = provider.chat_completion.call_args.args
+    assert answer_cls is test_case_cls.answer_cls
     assert json.loads(messages[1]["content"]) == {
         "zimu": ["原文"],
         "cankao": "參考",
     }
-    assert '"jieguo"' in messages[0]["content"]
 
 
 def test_query_and_answer_require_nonempty_fields():

--- a/test/llms/test_review.py
+++ b/test/llms/test_review.py
@@ -84,14 +84,11 @@ def test_queryer_corresponds_using_prompt_aliases():
     result = queryer(test_case)
 
     assert result.answer is not None
-    messages = provider.chat_completion.call_args.args[0]
+    messages, answer_cls, _ = provider.chat_completion.call_args.args
+    assert answer_cls is test_case_cls.answer_cls
     assert json.loads(messages[1]["content"]) == {
         "zimu": [{"xuhao": 1, "wenben": "原文"}]
     }
-    assert '"xiugai"' in messages[0]["content"]
-    assert '"xuhao"' in messages[0]["content"]
-    assert '"wenben"' in messages[0]["content"]
-    assert '"beizhu"' in messages[0]["content"]
 
 
 def test_partial_processing_preserves_unencountered_test_cases(tmp_path: Path):

--- a/test/llms/test_translation.py
+++ b/test/llms/test_translation.py
@@ -87,13 +87,11 @@ def test_queryer_corresponds_using_prompt_aliases():
     result = queryer(test_case)
 
     assert result.answer is not None
-    messages = provider.chat_completion.call_args.args[0]
+    messages, answer_cls, _ = provider.chat_completion.call_args.args
+    assert answer_cls is test_case_cls.answer_cls
     assert json.loads(messages[1]["content"]) == {
         "zimu": [{"xuhao": 1, "wenben": "原文"}]
     }
-    assert '"fanyi"' in messages[0]["content"]
-    assert '"xuhao"' in messages[0]["content"]
-    assert '"wenben"' in messages[0]["content"]
 
 
 def test_query_and_answer_require_nonempty_consecutive_indexes():


### PR DESCRIPTION
## Summary

- require every LLM completion to supply a structured answer model
- make the OpenAI-compatible structured parse path authoritative, including tool-call rounds
- remove duplicated textual answer schemas and their localized prompt introductions
- update localized correspondence tests to verify the generated answer class passed to the provider
- document the provider/schema boundary

Removing `schema_intro` changes prompt-derived model and cache identities once. Repository test-case JSON remains base-prompt serialized and does not require migration for this change.

## Testing

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format <changed Python files>`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix <changed Python files>`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check <changed Python files>`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` (1732 passed, 9 skipped)
