### PR TITLE
Make LLM response validation strict and retriable

### DIFF
--- a/scinoephile/core/llms/openai_provider_base.py
+++ b/scinoephile/core/llms/openai_provider_base.py
@@ -12,7 +12,7 @@ from typing import Any, Unpack, cast
 
 from openai import OpenAI, OpenAIError
 from openai.types.chat import ChatCompletionMessageFunctionToolCall
-from pydantic import JsonValue
+from pydantic import JsonValue, ValidationError
 
 from scinoephile.core import ScinoephileError
 
@@ -184,6 +184,11 @@ class OpenAIProviderBase(LLMProvider):
             raise ScinoephileError(
                 f"OpenAI-compatible API error ({exc_code=}, {exc_type=} {exc_param=}): "
                 f"{exc}"
+            ) from exc
+        except ValidationError as exc:
+            raise ScinoephileError(
+                "OpenAI-compatible API returned content that failed structured "
+                "response validation."
             ) from exc
 
     def _build_openai_tools(self, tool_box: ToolBox) -> list[dict[str, object]]:

--- a/scinoephile/core/llms/queryer.py
+++ b/scinoephile/core/llms/queryer.py
@@ -138,6 +138,7 @@ class Queryer[TTestCase: TestCase]:
                     content,
                     by_alias=True,
                     by_name=False,
+                    strict=True,
                     extra="forbid",
                     context={"alias_only": True},
                 )

--- a/test/core/llms/test_openai_provider_base.py
+++ b/test/core/llms/test_openai_provider_base.py
@@ -8,10 +8,13 @@ import json
 from collections.abc import Callable
 from types import SimpleNamespace
 from typing import Any, cast
+from unittest.mock import Mock
 
 from openai import OpenAI
+from pydantic import ValidationError
 from pytest import raises
 
+from scinoephile.core import ScinoephileError
 from scinoephile.core.llms import Answer, OpenAIProviderBase
 from scinoephile.core.llms.tool import Tool
 from scinoephile.core.llms.tool_box import ToolBox
@@ -216,6 +219,21 @@ def test_model_override_updates_provider_model():
     )
 
     assert cast(str, client.calls[0]["model"]) == "override-model"
+
+
+def test_structured_response_validation_error_is_wrapped():
+    """Test client-side structured validation failures become domain errors."""
+    client = Mock()
+    with raises(ValidationError) as exc_info:
+        _Answer.model_validate({})
+    client.beta.chat.completions.parse.side_effect = exc_info.value
+    provider = _DummyProvider(client=cast(OpenAI, client))
+
+    with raises(ScinoephileError, match="failed structured response validation"):
+        provider.chat_completion(
+            messages=[{"role": "user", "content": "hi"}],
+            response_format=_Answer,
+        )
 
 
 def test_cache_identity_contains_nonsecret_effective_configuration():

--- a/test/core/llms/test_provider_injection.py
+++ b/test/core/llms/test_provider_injection.py
@@ -14,7 +14,7 @@ from weakref import ref
 from pydantic import JsonValue, ValidationError
 from pytest import raises
 
-from scinoephile.core import Language
+from scinoephile.core import Language, ScinoephileError
 from scinoephile.core.llms import (
     Answer,
     LLMProvider,
@@ -197,6 +197,21 @@ def test_queryer_uses_injected_provider():
     assert len(provider.calls) == 1
     assert provider.response_formats == [_Answer]
     assert queryer.system_prompt == _PROMPT.base_system_prompt
+
+
+def test_queryer_retries_provider_errors():
+    """Test transient provider errors use the configured attempt count."""
+    provider = Mock(spec=LLMProvider)
+    provider.chat_completion.side_effect = [
+        ScinoephileError("invalid structured content"),
+        '{"output":"done"}',
+    ]
+    queryer = Queryer(_TestCase, provider=provider, max_attempts=2)
+
+    result = queryer(_TestCase(query=_Query(text="input")))
+
+    assert result.answer == _Answer(output="done")
+    assert provider.chat_completion.call_count == 2
 
 
 def test_queryer_requires_injected_provider():

--- a/test/llms/test_review.py
+++ b/test/llms/test_review.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import cast
 from unittest.mock import Mock
 
 from pydantic import ValidationError
@@ -16,6 +17,7 @@ from scinoephile.core.llms import LLMProvider, Queryer
 from scinoephile.core.llms.utils import save_test_cases_to_json
 from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.llms.review import (
+    ReviewAnswer,
     ReviewManager,
     ReviewProcessor,
     ReviewPrompt,
@@ -89,6 +91,27 @@ def test_queryer_corresponds_using_prompt_aliases():
     assert json.loads(messages[1]["content"]) == {
         "zimu": [{"xuhao": 1, "wenben": "原文"}]
     }
+
+
+def test_queryer_rejects_type_coercion_at_llm_boundary():
+    """Queryer should retry answers whose values require type coercion."""
+    test_case_cls = ReviewManager.get_test_case_cls(_LOCALIZED_PROMPT)
+    test_case = test_case_cls.model_validate(
+        {"query": {"subtitles": [{"index": 1, "text": "原文"}]}}
+    )
+    provider = Mock(spec=LLMProvider)
+    provider.chat_completion.side_effect = [
+        '{"xiugai": [{"xuhao": "1", "wenben": "修改", "beizhu": "修正"}]}',
+        '{"xiugai": [{"xuhao": 1, "wenben": "修改", "beizhu": "修正"}]}',
+    ]
+    queryer = Queryer(test_case_cls, provider=provider, max_attempts=2)
+
+    result = queryer(test_case)
+
+    assert result.answer is not None
+    answer = cast(ReviewAnswer, result.answer)
+    assert answer.revisions[0].index == 1
+    assert provider.chat_completion.call_count == 2
 
 
 def test_partial_processing_preserves_unencountered_test_cases(tmp_path: Path):


### PR DESCRIPTION
## Summary

- reject live LLM answer values that require Pydantic type coercion
- convert SDK-side structured response validation failures into `ScinoephileError`
- ensure those provider failures use Queryer's configured retry count
- add regression coverage for localized indexed responses such as `"xuhao": "1"`

## Root cause

The OpenAI SDK's structured parse helper can raise `pydantic.ValidationError` before returning raw content. That exception was not an `OpenAIError`, so it bypassed the provider wrapper and Queryer's retry path. Separately, Queryer's alias-only answer validation did not pass `strict=True`, allowing values such as numeric strings to be coerced.

## Testing

- Ruff format and check on changed Python files
- ty check on changed Python files
- focused LLM tests: 44 passed
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto`: 1735 passed, 9 skipped
