### PR TITLE
Localize runtime LLM correspondence

### DIFF
--- a/scinoephile/core/llms/manager.py
+++ b/scinoephile/core/llms/manager.py
@@ -128,7 +128,15 @@ class Manager(ABC):
             prompt: text for LLM correspondence
         Returns:
             test case model class
+        Raises:
+            TypeError: prompt type does not match this manager
         """
+        expected_prompt_cls = type(cls.base_prompt)
+        if not isinstance(prompt, expected_prompt_cls):
+            raise TypeError(
+                f"{cls.__name__} requires {expected_prompt_cls.__name__}; "
+                f"got {type(prompt).__name__}."
+            )
         query_cls = cls.get_query_cls(prompt)
         answer_cls = cls.get_answer_cls(prompt)
         model = cls.create_prompt_model(

--- a/scinoephile/core/llms/models.py
+++ b/scinoephile/core/llms/models.py
@@ -9,6 +9,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, ValidationInfo, model_validator
+from pydantic_core import PydanticCustomError
 
 __all__ = [
     "LLMModel",
@@ -86,7 +87,11 @@ class LLMModel(BaseModel):
                 f"{field_name!r} (use {alias!r})"
                 for field_name, alias in noncanonical_fields
             )
-            raise ValueError(f"JSON input must use field aliases: {replacements}.")
+            raise PydanticCustomError(
+                "llm_alias_only",
+                "JSON input must use field aliases: {replacements}.",
+                {"replacements": replacements},
+            )
 
         return value
 

--- a/scinoephile/core/llms/prompt.py
+++ b/scinoephile/core/llms/prompt.py
@@ -28,9 +28,9 @@ class PromptLocalizationFields(TypedDict):
     few_shot_answer_intro: str
     """Text preceding each few-shot expected answer."""
     answer_invalid_pre: str
-    """Text preceding answer validation errors."""
+    """Text introducing an invalid-answer retry."""
     answer_invalid_post: str
-    """Text following answer validation errors."""
+    """Text concluding an invalid-answer retry."""
     test_case_invalid_pre: str
     """Text preceding test case validation errors."""
     test_case_invalid_post: str
@@ -56,9 +56,9 @@ class Prompt:
 
     # Answer validation errors
     answer_invalid_pre: str = ""
-    """Text preceding answer validation errors."""
+    """Text introducing an invalid-answer retry."""
     answer_invalid_post: str = ""
-    """Text following answer validation errors."""
+    """Text concluding an invalid-answer retry."""
 
     # Test case validation errors
     test_case_invalid_pre: str = ""

--- a/scinoephile/core/llms/queryer.py
+++ b/scinoephile/core/llms/queryer.py
@@ -87,7 +87,7 @@ class Queryer[TTestCase: TestCase]:
         self.system_prompt = self.prompt.base_system_prompt
         """System prompt shared by all queries executed by this instance."""
         if self.additional_context:
-            self.system_prompt += f"\n\nAdditional context:\n{self.additional_context}"
+            self.system_prompt += f"\n\n{self.additional_context}"
         self.system_prompt += self.get_few_shot_test_cases_str()
 
     def __call__(self, test_case: TestCase) -> TTestCase:
@@ -150,14 +150,17 @@ class Queryer[TTestCase: TestCase]:
                 )
                 if attempt == self.max_attempts:
                     raise
+                validation_errors = self._get_prompt_validation_errors(exc)
                 messages.append({"role": "assistant", "content": content})
                 messages.append(
                     {
                         "role": "user",
-                        "content": (
-                            f"{self.prompt.answer_invalid_pre}\n"
-                            f"{'\n'.join(e['msg'] for e in exc.errors())}\n"
-                            f"{self.prompt.answer_invalid_post}"
+                        "content": "\n".join(
+                            (
+                                self.prompt.answer_invalid_pre,
+                                *validation_errors,
+                                self.prompt.answer_invalid_post,
+                            )
                         ),
                     }
                 )
@@ -183,14 +186,17 @@ class Queryer[TTestCase: TestCase]:
                 )
                 if attempt == self.max_attempts:
                     raise
+                validation_errors = self._get_prompt_validation_errors(exc)
                 messages.append({"role": "assistant", "content": content})
                 messages.append(
                     {
                         "role": "user",
-                        "content": (
-                            f"{self.prompt.test_case_invalid_pre}\n"
-                            f"{'\n'.join(e['msg'] for e in exc.errors())}\n"
-                            f"{self.prompt.test_case_invalid_post}"
+                        "content": "\n".join(
+                            (
+                                self.prompt.test_case_invalid_pre,
+                                *validation_errors,
+                                self.prompt.test_case_invalid_post,
+                            )
                         ),
                     }
                 )
@@ -388,3 +394,22 @@ class Queryer[TTestCase: TestCase]:
             message = str(error.get("msg"))
             lines.append(f"{location}: {message}" if location else message)
         return "\n".join(lines)
+
+    @staticmethod
+    def _get_prompt_validation_errors(exc: ValidationError) -> list[str]:
+        """Get prompt-authored validation errors suitable for LLM correspondence.
+
+        Arguments:
+            exc: validation error
+        Returns:
+            prompt-authored validation error messages
+        """
+        validation_errors: list[str] = []
+        for error in exc.errors():
+            context = error.get("ctx")
+            if context is None:
+                continue
+            cause = context.get("error")
+            if isinstance(cause, ValueError):
+                validation_errors.append(str(cause))
+        return validation_errors

--- a/scinoephile/lang/eng/prompts.py
+++ b/scinoephile/lang/eng/prompts.py
@@ -17,7 +17,7 @@ ENG_PROMPT_FIELDS: Final[PromptLocalizationFields] = {
     "few_shot_answer_intro": "Expected answer:",
     "answer_invalid_pre": (
         "Your previous response was not valid JSON or did not match the expected "
-        "schema. Error details:"
+        "schema."
     ),
     "answer_invalid_post": (
         "Please try again and respond only with a valid JSON object matching the "

--- a/scinoephile/lang/yue/prompts.py
+++ b/scinoephile/lang/yue/prompts.py
@@ -15,9 +15,7 @@ YUE_HANT_PROMPT_FIELDS: Final[PromptLocalizationFields] = {
     "few_shot_intro": "下面係一啲查詢同埋佢哋預期答案嘅例子：",
     "few_shot_query_intro": "例子查詢：",
     "few_shot_answer_intro": "預期答案：",
-    "answer_invalid_pre": (
-        "你之前嘅回覆唔係有效嘅 JSON，或者未符合預期嘅模式要求。錯誤詳情："
-    ),
+    "answer_invalid_pre": "你之前嘅回覆唔係有效嘅 JSON，或者未符合預期嘅模式要求。",
     "answer_invalid_post": (
         "請你再試一次，並且淨係返返一個符合該模式要求嘅有效 JSON 物件。"
     ),

--- a/scinoephile/lang/zho/prompts.py
+++ b/scinoephile/lang/zho/prompts.py
@@ -15,9 +15,7 @@ ZHO_HANT_PROMPT_FIELDS: Final[PromptLocalizationFields] = {
     "few_shot_intro": "下面是一些查詢及其預期答案的示例：",
     "few_shot_query_intro": "示例查詢：",
     "few_shot_answer_intro": "預期答案：",
-    "answer_invalid_pre": (
-        "你之前的回覆不是有效的 JSON，或未符合預期的模式要求。錯誤詳情："
-    ),
+    "answer_invalid_pre": "你之前的回覆不是有效的 JSON，或未符合預期的模式要求。",
     "answer_invalid_post": "請重新嘗試，並僅返回一個符合該模式要求的有效 JSON 對象。",
     "test_case_invalid_pre": (
         "你之前的回覆是符合答案模式的有效 JSON，但不適用於當前的特定查詢。錯誤詳情："

--- a/test/core/llms/test_manager.py
+++ b/test/core/llms/test_manager.py
@@ -22,7 +22,7 @@ from scinoephile.llms.punctuation import (
     PunctuationTestCase,
 )
 from scinoephile.llms.review import ReviewManager, ReviewPrompt, ReviewTestCase
-from scinoephile.llms.translation import TranslationManager
+from scinoephile.llms.translation import TranslationManager, TranslationPrompt
 
 _LOCALIZED_REVIEW_PROMPT = ReviewPrompt(
     subtitles="zimu",
@@ -67,6 +67,15 @@ _MANAGER_CLASSES: list[type[Manager]] = [
 def test_manager_reuses_static_test_case_prompt(manager_cls: type[Manager]):
     """Each manager should reuse its semantic test-case model's prompt."""
     assert manager_cls.base_prompt is manager_cls.test_case_base_cls.prompt
+
+
+def test_manager_rejects_incompatible_prompt_type():
+    """Managers should reject prompts belonging to another operation."""
+    with raises(
+        TypeError,
+        match="ReviewManager requires ReviewPrompt; got TranslationPrompt",
+    ):
+        ReviewManager.get_test_case_cls(TranslationPrompt())
 
 
 def test_static_shape_factory_caches_and_isolates_prompt_aliases():

--- a/test/core/llms/test_provider_injection.py
+++ b/test/core/llms/test_provider_injection.py
@@ -244,8 +244,9 @@ def test_queryer_includes_additional_context_before_few_shot_prompt():
     messages = provider.calls[0]
     system_message = messages[0]["content"]
     assert system_message == queryer.system_prompt
-    assert "Additional context:\nUse canonical names." in system_message
-    assert system_message.index("Additional context:") < system_message.index(
+    assert "Additional context:" not in system_message
+    assert "\n\nUse canonical names." in system_message
+    assert system_message.index("Use canonical names.") < system_message.index(
         _PROMPT.few_shot_intro
     )
 

--- a/test/llms/test_review.py
+++ b/test/llms/test_review.py
@@ -16,6 +16,7 @@ from scinoephile.core import Language
 from scinoephile.core.llms import LLMProvider, Queryer
 from scinoephile.core.llms.utils import save_test_cases_to_json
 from scinoephile.core.subtitles import Series, Subtitle
+from scinoephile.lang.zho.review import ReviewPromptZhoHant
 from scinoephile.llms.review import (
     ReviewAnswer,
     ReviewManager,
@@ -112,6 +113,90 @@ def test_queryer_rejects_type_coercion_at_llm_boundary():
     answer = cast(ReviewAnswer, result.answer)
     assert answer.revisions[0].index == 1
     assert provider.chat_completion.call_count == 2
+
+
+def test_queryer_localizes_answer_validation_retry():
+    """Structural answer retries should not include English validation text."""
+    test_case_cls = ReviewManager.get_test_case_cls(ReviewPromptZhoHant)
+    test_case = test_case_cls.model_validate(
+        {"query": {"subtitles": [{"index": 1, "text": "原文"}]}}
+    )
+    provider = Mock(spec=LLMProvider)
+    provider.chat_completion.side_effect = [
+        '{"xiugai": [{"xuhao": "1", "wenben": "修改", "beizhu": "修正"}]}',
+        '{"xiugai": [{"xuhao": 1, "wenben": "修改", "beizhu": "修正"}]}',
+    ]
+    queryer = Queryer(test_case_cls, provider=provider, max_attempts=2)
+
+    queryer(test_case)
+
+    messages = provider.chat_completion.call_args_list[1].args[0]
+    assert messages[-1]["content"] == (
+        f"{ReviewPromptZhoHant.answer_invalid_pre}\n"
+        f"{ReviewPromptZhoHant.answer_invalid_post}"
+    )
+
+
+def test_queryer_includes_localized_answer_validation_details():
+    """Answer retries should retain prompt-authored validation details."""
+    test_case_cls = ReviewManager.get_test_case_cls(ReviewPromptZhoHant)
+    test_case = test_case_cls.model_validate(
+        {
+            "query": {
+                "subtitles": [
+                    {"index": 1, "text": "原文一"},
+                    {"index": 2, "text": "原文二"},
+                ]
+            }
+        }
+    )
+    provider = Mock(spec=LLMProvider)
+    provider.chat_completion.side_effect = [
+        (
+            '{"xiugai": ['
+            '{"xuhao": 2, "wenben": "修改二", "beizhu": "修正"},'
+            '{"xuhao": 1, "wenben": "修改一", "beizhu": "修正"}'
+            "]}"
+        ),
+        '{"xiugai": []}',
+    ]
+    queryer = Queryer(test_case_cls, provider=provider, max_attempts=2)
+
+    queryer(test_case)
+
+    messages = provider.chat_completion.call_args_list[1].args[0]
+    assert messages[-1]["content"] == "\n".join(
+        (
+            ReviewPromptZhoHant.answer_invalid_pre,
+            ReviewPromptZhoHant.revision_indices_err,
+            ReviewPromptZhoHant.answer_invalid_post,
+        )
+    )
+
+
+def test_queryer_localizes_test_case_validation_retry():
+    """Query-specific retries should use the prompt's localized error text."""
+    test_case_cls = ReviewManager.get_test_case_cls(ReviewPromptZhoHant)
+    test_case = test_case_cls.model_validate(
+        {"query": {"subtitles": [{"index": 1, "text": "原文"}]}}
+    )
+    provider = Mock(spec=LLMProvider)
+    provider.chat_completion.side_effect = [
+        '{"xiugai": [{"xuhao": 2, "wenben": "修改", "beizhu": "修正"}]}',
+        '{"xiugai": []}',
+    ]
+    queryer = Queryer(test_case_cls, provider=provider, max_attempts=2)
+
+    queryer(test_case)
+
+    messages = provider.chat_completion.call_args_list[1].args[0]
+    assert messages[-1]["content"] == "\n".join(
+        (
+            ReviewPromptZhoHant.test_case_invalid_pre,
+            ReviewPromptZhoHant.revision_index_missing_err(2),
+            ReviewPromptZhoHant.test_case_invalid_post,
+        )
+    )
 
 
 def test_partial_processing_preserves_unencountered_test_cases(tmp_path: Path):


### PR DESCRIPTION
## Summary

- insert caller-provided additional context verbatim instead of adding an English heading
- keep generic Pydantic validation prose in application logs rather than localized LLM retries
- retain prompt-authored answer and query-specific validation details without Pydantic's English `Value error` prefix
- classify alias-only failures separately from prompt-authored validation errors
- reject prompts belonging to a different manager with a clear `TypeError`

## Impact

The updated localized retry introductions change content-addressed IDs for registered English, written Cantonese, and Chinese prompts once. Test-case JSON remains serialized with base-prompt field names and requires no migration.

## Testing

- Ruff format and check on changed Python files
- ty check on changed Python files
- focused correspondence and persistence tests: 123 passed
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto`: 1739 passed, 9 skipped
