### PR TITLE
Normalize LLM processor stopping behavior

### DIFF
--- a/scinoephile/llms/gap_translation/processor.py
+++ b/scinoephile/llms/gap_translation/processor.py
@@ -34,7 +34,7 @@ class GapTranslationProcessor(Processor):
     manager_cls = GapTranslationManager
     """Manager class used to construct test case models."""
 
-    def process(
+    def process(  # noqa: PLR0912, PLR0915
         self,
         source_one: Series,
         source_two: Series,
@@ -51,8 +51,11 @@ class GapTranslationProcessor(Processor):
         """
         block_pairs = get_block_pairs_by_pause(source_one, source_two)
         output_series_to_concatenate: list[Series | None] = [None] * len(block_pairs)
-        stop_at_idx = stop_at_idx or len(block_pairs)
-        for blk_idx, (one_blk, two_blk) in enumerate(block_pairs[:stop_at_idx]):
+        if stop_at_idx is None:
+            stop_at_idx = len(block_pairs)
+        elif stop_at_idx < 0:
+            raise ValueError("stop_at_idx must be greater than or equal to 0")
+        for blk_idx, (one_blk, two_blk) in enumerate(block_pairs):
             if blk_idx >= stop_at_idx:
                 break
 
@@ -118,8 +121,12 @@ class GapTranslationProcessor(Processor):
 
         self.save_test_cases()
 
-        output_series = get_concatenated_series(
-            [s for s in output_series_to_concatenate if s is not None]
-        )
+        output_series_blocks = [
+            series for series in output_series_to_concatenate if series is not None
+        ]
+        if output_series_blocks:
+            output_series = get_concatenated_series(output_series_blocks)
+        else:
+            output_series = Series()
         logger.info(f"Concatenated Series:\n{output_series.to_simple_string()}")
         return output_series

--- a/scinoephile/llms/ocr_fusion/processor.py
+++ b/scinoephile/llms/ocr_fusion/processor.py
@@ -51,7 +51,10 @@ class OcrFusionProcessor(Processor):
 
         # Process subtitles
         output_subtitles = []
-        stop_at_idx = stop_at_idx or len(source_one)
+        if stop_at_idx is None:
+            stop_at_idx = len(source_one)
+        elif stop_at_idx < 0:
+            raise ValueError("stop_at_idx must be greater than or equal to 0")
         for sub_idx, (sub_one, sub_two) in enumerate(
             zip(source_one.events, source_two.events)
         ):

--- a/scinoephile/llms/translation/processor.py
+++ b/scinoephile/llms/translation/processor.py
@@ -41,7 +41,10 @@ class TranslationProcessor(Processor):
         """
         # Process subtitles
         output_series_to_concatenate: list[Series | None] = [None] * len(series.blocks)
-        stop_at_idx = stop_at_idx or len(series.blocks)
+        if stop_at_idx is None:
+            stop_at_idx = len(series.blocks)
+        elif stop_at_idx < 0:
+            raise ValueError("stop_at_idx must be greater than or equal to 0")
 
         # Track indices for logging
         current_idx = 0

--- a/test/llms/test_gap_translation.py
+++ b/test/llms/test_gap_translation.py
@@ -375,6 +375,39 @@ def test_processor_maps_targets_and_outputs_by_index():
     provider.chat_completion.assert_not_called()
 
 
+def test_processor_honors_zero_stop_index():
+    """A zero stop index should process no gap-translation blocks."""
+    provider = Mock(spec=LLMProvider)
+    processor = GapTranslationProcessor(
+        GapTranslationManager.base_prompt,
+        provider=provider,
+    )
+    source_one = Series(events=[Subtitle(start=0, end=100, text="existing one")])
+    source_two = Series(
+        events=[
+            Subtitle(start=0, end=100, text="guide one"),
+            Subtitle(start=100, end=200, text="guide two"),
+        ]
+    )
+
+    output = processor.process(source_one, source_two, stop_at_idx=0)
+
+    assert len(output) == 0
+    provider.chat_completion.assert_not_called()
+
+
+def test_processor_rejects_negative_stop_index():
+    """A negative stop index should be rejected."""
+    processor = GapTranslationProcessor(
+        GapTranslationManager.base_prompt,
+        provider=Mock(spec=LLMProvider),
+    )
+    source = Series(events=[Subtitle(start=0, end=100, text="subtitle")])
+
+    with raises(ValueError, match="greater than or equal to 0"):
+        processor.process(source, source, stop_at_idx=-1)
+
+
 def test_repository_json_fixtures_load():
     """All repository gap-translation fixtures should use the canonical list shape."""
     fixture_paths = sorted(

--- a/test/llms/test_ocr_fusion_models.py
+++ b/test/llms/test_ocr_fusion_models.py
@@ -266,6 +266,31 @@ def test_processor_uses_semantic_fields_at_runtime():
     }
 
 
+def test_processor_honors_zero_stop_index():
+    """A zero stop index should process no OCR-fusion subtitles."""
+    provider = Mock(spec=LLMProvider)
+    processor = OcrFusionProcessor(_LOCALIZED_PROMPT, provider=provider)
+    source_one = Series([Subtitle(start=0, end=1000, text="來源一")])
+    source_two = Series([Subtitle(start=0, end=1000, text="來源二")])
+
+    output = processor.process(source_one, source_two, stop_at_idx=0)
+
+    assert len(output) == 0
+    provider.chat_completion.assert_not_called()
+
+
+def test_processor_rejects_negative_stop_index():
+    """A negative stop index should be rejected."""
+    processor = OcrFusionProcessor(
+        _LOCALIZED_PROMPT,
+        provider=Mock(spec=LLMProvider),
+    )
+    source = Series([Subtitle(start=0, end=1000, text="subtitle")])
+
+    with raises(ValueError, match="greater than or equal to 0"):
+        processor.process(source, source, stop_at_idx=-1)
+
+
 def test_json_persistence_uses_base_prompt_aliases(tmp_path: Path):
     """JSON should retain base one/two fields across localized round trips."""
     test_case_cls = OcrFusionManager.get_test_case_cls(_LOCALIZED_PROMPT)

--- a/test/llms/test_translation.py
+++ b/test/llms/test_translation.py
@@ -239,3 +239,28 @@ def test_processor_uses_indexed_subtitles_and_outputs():
         "translated two",
     ]
     provider.chat_completion.assert_not_called()
+
+
+def test_processor_honors_zero_stop_index():
+    """A zero stop index should process no translation blocks."""
+    provider = Mock(spec=LLMProvider)
+    processor = TranslationProcessor(_LOCALIZED_PROMPT, provider=provider)
+    block = Series([Subtitle(start=0, end=1000, text="original")])
+    series = Series(list(block.events))
+    series.blocks = [block]
+
+    output = processor.process(series, stop_at_idx=0)
+
+    assert len(output) == 0
+    provider.chat_completion.assert_not_called()
+
+
+def test_processor_rejects_negative_stop_index():
+    """A negative stop index should be rejected."""
+    processor = TranslationProcessor(
+        _LOCALIZED_PROMPT,
+        provider=Mock(spec=LLMProvider),
+    )
+
+    with raises(ValueError, match="greater than or equal to 0"):
+        processor.process(Series(), stop_at_idx=-1)


### PR DESCRIPTION
## Summary

- make `stop_at_idx=0` process no work in gap translation, OCR fusion, and translation
- reject negative stop indexes consistently with the other LLM processors
- return an empty series when gap translation stops before processing any blocks
- add focused regression coverage for zero and negative stop indexes in all three processors

## Root cause

These processors used `stop_at_idx = stop_at_idx or length`, which treated zero as false and replaced it with the full input length. Negative values also passed through without validation, and gap translation assumed at least one block would always be processed before concatenation.

## Impact

All seven LLM processors now share the same stop-index semantics: `None` processes all work, zero processes nothing, positive values are exclusive upper bounds, and negative values raise `ValueError`.

## Testing

- Ruff format and check on the six changed Python files
- ty check on the six changed Python files
- focused LLM processor/model tests: 54 passed
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto`: 1,745 passed, 9 skipped
