### PR TITLE
Contain metadata-derived child paths

### DIFF
--- a/scinoephile/audio/subtitles/series.py
+++ b/scinoephile/audio/subtitles/series.py
@@ -122,7 +122,7 @@ class AudioSeries(Series):
     @override
     def save(
         self,
-        path: str | PathLike[Any],
+        path: str | PathLike[str],
         encoding: str = "utf-8",
         format_: str | None = None,
         fps: float | None = None,
@@ -186,7 +186,7 @@ class AudioSeries(Series):
     @override
     def load(
         cls,
-        path: str | PathLike[Any],
+        path: str | PathLike[str],
         encoding: str = "utf-8",
         format_: str | None = None,
         fps: float | None = None,

--- a/scinoephile/common/validation.py
+++ b/scinoephile/common/validation.py
@@ -8,7 +8,7 @@ from collections.abc import Collection, Iterable
 from logging import getLogger
 from os import PathLike
 from os.path import defpath, expanduser, expandvars
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from platform import system
 from shutil import which
 from typing import Any, TypeAliasType, get_args, overload
@@ -22,6 +22,7 @@ from .exceptions import (
 )
 
 __all__ = [
+    "val_child_path",
     "val_executable",
     "val_float",
     "val_input_dir_path",
@@ -35,6 +36,49 @@ __all__ = [
 ]
 
 logger = getLogger(__name__)
+
+
+def val_child_path(
+    parent_dir_path: Path | str | PathLike[Any],
+    child_name: str,
+) -> Path:
+    """Validate that a child name resolves within a parent directory.
+
+    Arguments:
+        parent_dir_path: parent directory path
+        child_name: proposed child name
+    Returns:
+        resolved child path
+    Raises:
+        ValueError: If the name is not a single contained filename
+    """
+    posix_path = PurePosixPath(child_name)
+    windows_path = PureWindowsPath(child_name)
+    if (
+        not child_name
+        or child_name in {".", ".."}
+        or posix_path.name != child_name
+        or windows_path.name != child_name
+    ):
+        raise ValueError(
+            f"Child name must be a single contained filename: {child_name!r}"
+        )
+
+    try:
+        resolved_parent_dir_path = Path(
+            expandvars(expanduser(str(parent_dir_path)))
+        ).resolve()
+        child_path = (resolved_parent_dir_path / child_name).resolve()
+        child_path.relative_to(resolved_parent_dir_path)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise ValueError(
+            f"Child name must be a single contained filename: {child_name!r}"
+        ) from exc
+    if child_path == resolved_parent_dir_path:
+        raise ValueError(
+            f"Child name must be a single contained filename: {child_name!r}"
+        )
+    return child_path
 
 
 def val_executable(

--- a/scinoephile/common/validation.py
+++ b/scinoephile/common/validation.py
@@ -6,12 +6,12 @@ from __future__ import annotations
 
 from collections.abc import Collection, Iterable
 from logging import getLogger
-from os import PathLike
+from os import PathLike, fspath
 from os.path import defpath, expanduser, expandvars
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from platform import system
 from shutil import which
-from typing import Any, TypeAliasType, get_args, overload
+from typing import Any, TypeAliasType, cast, get_args, overload
 
 from .exceptions import (
     ArgumentConflictError,
@@ -39,7 +39,7 @@ logger = getLogger(__name__)
 
 
 def val_child_path(
-    parent_dir_path: Path | str | PathLike[Any],
+    parent_dir_path: str | PathLike[str],
     child_name: str,
 ) -> Path:
     """Validate that a child name resolves within a parent directory.
@@ -66,7 +66,7 @@ def val_child_path(
 
     try:
         resolved_parent_dir_path = Path(
-            expandvars(expanduser(str(parent_dir_path)))
+            expandvars(expanduser(fspath(parent_dir_path)))
         ).resolve()
         child_path = (resolved_parent_dir_path / child_name).resolve()
         child_path.relative_to(resolved_parent_dir_path)
@@ -196,15 +196,15 @@ def val_float(
 
 
 @overload
-def val_input_dir_path(value: Path | str | PathLike[Any]) -> Path: ...
+def val_input_dir_path(value: str | PathLike[str]) -> Path: ...
 
 
 @overload
-def val_input_dir_path(value: Iterable[Path | str | PathLike[Any]]) -> list[Path]: ...
+def val_input_dir_path(value: Iterable[str | PathLike[str]]) -> list[Path]: ...
 
 
 def val_input_dir_path(
-    value: Path | str | PathLike[Any] | Iterable[Path | str | PathLike[Any]],
+    value: str | PathLike[str] | Iterable[str | PathLike[str]],
 ) -> Path | list[Path]:
     """Validate input directory path(s) and make them absolute.
 
@@ -218,7 +218,7 @@ def val_input_dir_path(
         TypeError: If any value cannot be cast to Path
     """
 
-    def _val_input_dir(value_to_validate: Path | str | PathLike[Any]) -> Path:
+    def _val_input_dir(value_to_validate: str | PathLike[str]) -> Path:
         """Validate a path.
 
         Arguments:
@@ -232,7 +232,7 @@ def val_input_dir_path(
         """
         try:
             validated_value = Path(
-                expandvars(expanduser(str(value_to_validate)))
+                expandvars(expanduser(fspath(value_to_validate)))
             ).resolve()
         except ValueError as exc:
             raise TypeError(
@@ -250,25 +250,25 @@ def val_input_dir_path(
         return validated_value
 
     # Handle non-iterables and iterables we don't want to iterate over
-    if isinstance(value, Path | str | PathLike) or not isinstance(value, Iterable):
-        return _val_input_dir(value)
+    if isinstance(value, str | PathLike) or not isinstance(value, Iterable):
+        return _val_input_dir(cast(str | PathLike[str], value))
 
     # Handle iterables
     return [_val_input_dir(value_to_validate) for value_to_validate in value]
 
 
 @overload
-def val_input_file_or_dir_path(value: Path | str | PathLike[Any]) -> Path: ...
+def val_input_file_or_dir_path(value: str | PathLike[str]) -> Path: ...
 
 
 @overload
 def val_input_file_or_dir_path(
-    value: Iterable[Path | str | PathLike[Any]],
+    value: Iterable[str | PathLike[str]],
 ) -> list[Path]: ...
 
 
 def val_input_file_or_dir_path(
-    value: Path | str | PathLike[Any] | Iterable[Path | str | PathLike[Any]],
+    value: str | PathLike[str] | Iterable[str | PathLike[str]],
 ) -> Path | list[Path]:
     """Validate input file or directory path(s) and make them absolute.
 
@@ -283,7 +283,7 @@ def val_input_file_or_dir_path(
     """
 
     def _val_input_file_or_dir_path(
-        value_to_validate: Path | str | PathLike[Any],
+        value_to_validate: str | PathLike[str],
     ) -> Path:
         """Validate a path.
 
@@ -298,7 +298,7 @@ def val_input_file_or_dir_path(
         """
         try:
             validated_value = Path(
-                expandvars(expanduser(str(value_to_validate)))
+                expandvars(expanduser(fspath(value_to_validate)))
             ).resolve()
         except ValueError as exc:
             raise TypeError(
@@ -314,8 +314,8 @@ def val_input_file_or_dir_path(
         return validated_value
 
     # Handle non-iterables and iterables we don't want to iterate over
-    if isinstance(value, Path | str | PathLike) or not isinstance(value, Iterable):
-        return _val_input_file_or_dir_path(value)
+    if isinstance(value, str | PathLike) or not isinstance(value, Iterable):
+        return _val_input_file_or_dir_path(cast(str | PathLike[str], value))
 
     # Handle iterables
     return [
@@ -324,15 +324,15 @@ def val_input_file_or_dir_path(
 
 
 @overload
-def val_input_path(value: Path | str | PathLike[Any]) -> Path: ...
+def val_input_path(value: str | PathLike[str]) -> Path: ...
 
 
 @overload
-def val_input_path(value: Iterable[Path | str | PathLike[Any]]) -> list[Path]: ...
+def val_input_path(value: Iterable[str | PathLike[str]]) -> list[Path]: ...
 
 
 def val_input_path(
-    value: Path | str | PathLike[Any] | Iterable[Path | str | PathLike[Any]],
+    value: str | PathLike[str] | Iterable[str | PathLike[str]],
 ) -> Path | list[Path]:
     """Validate input file path(s) and make them absolute.
 
@@ -346,7 +346,7 @@ def val_input_path(
         TypeError: If any value cannot be cast to Path
     """
 
-    def _val_input_path(value_to_validate: Path | str | PathLike[Any]) -> Path:
+    def _val_input_path(value_to_validate: str | PathLike[str]) -> Path:
         """Validate a path.
 
         Arguments:
@@ -360,7 +360,7 @@ def val_input_path(
         """
         try:
             validated_value = Path(
-                expandvars(expanduser(str(value_to_validate)))
+                expandvars(expanduser(fspath(value_to_validate)))
             ).resolve()
         except ValueError as exc:
             raise TypeError(
@@ -374,8 +374,8 @@ def val_input_path(
         return validated_value
 
     # Handle non-iterables and iterables we don't want to iterate over
-    if isinstance(value, Path | str | PathLike) or not isinstance(value, Iterable):
-        return _val_input_path(value)
+    if isinstance(value, str | PathLike) or not isinstance(value, Iterable):
+        return _val_input_path(cast(str | PathLike[str], value))
 
     # Handle iterables
     return [_val_input_path(value_to_validate) for value_to_validate in value]
@@ -471,19 +471,17 @@ def val_int(
 
 
 @overload
-def val_output_dir_path(
-    value: Path | str | PathLike[Any], create: bool = True
-) -> Path: ...
+def val_output_dir_path(value: str | PathLike[str], create: bool = True) -> Path: ...
 
 
 @overload
 def val_output_dir_path(
-    value: Iterable[Path | str | PathLike[Any]], create: bool = True
+    value: Iterable[str | PathLike[str]], create: bool = True
 ) -> list[Path]: ...
 
 
 def val_output_dir_path(
-    value: Path | str | PathLike[Any] | Iterable[Path | str | PathLike[Any]],
+    value: str | PathLike[str] | Iterable[str | PathLike[str]],
     create: bool = True,
 ) -> Path | list[Path]:
     """Validate output directory path(s), make them absolute, and create them if needed.
@@ -517,7 +515,7 @@ def val_output_dir_path(
             current_path = current_path.parent
         return current_path
 
-    def _val_output_dir_path(value_to_validate: Path | str | PathLike[Any]) -> Path:
+    def _val_output_dir_path(value_to_validate: str | PathLike[str]) -> Path:
         """Validate a path.
 
         Arguments:
@@ -531,7 +529,7 @@ def val_output_dir_path(
         """
         try:
             validated_value = Path(
-                expandvars(expanduser(str(value_to_validate)))
+                expandvars(expanduser(fspath(value_to_validate)))
             ).resolve()
         except ValueError as exc:
             raise TypeError(
@@ -555,8 +553,8 @@ def val_output_dir_path(
         return validated_value
 
     # Handle non-iterables and iterables we don't want to iterate over
-    if isinstance(value, Path | str | PathLike) or not isinstance(value, Iterable):
-        return _val_output_dir_path(value)
+    if isinstance(value, str | PathLike) or not isinstance(value, Iterable):
+        return _val_output_dir_path(cast(str | PathLike[str], value))
 
     # Handle iterables
     return [_val_output_dir_path(v) for v in value]
@@ -564,7 +562,7 @@ def val_output_dir_path(
 
 @overload
 def val_output_path(
-    value: Path | str | PathLike[Any],
+    value: str | PathLike[str],
     exist_ok: bool = False,
     create: bool = True,
 ) -> Path: ...
@@ -572,14 +570,14 @@ def val_output_path(
 
 @overload
 def val_output_path(
-    value: Iterable[Path | str | PathLike[Any]],
+    value: Iterable[str | PathLike[str]],
     exist_ok: bool = False,
     create: bool = True,
 ) -> list[Path]: ...
 
 
 def val_output_path(
-    value: Path | str | PathLike[Any] | Iterable[Path | str | PathLike[Any]],
+    value: str | PathLike[str] | Iterable[str | PathLike[str]],
     exist_ok: bool = False,
     create: bool = True,
 ) -> Path | list[Path]:
@@ -597,7 +595,7 @@ def val_output_path(
         TypeError: If any value cannot be cast to a Path
     """
 
-    def _val_output_path(value_to_validate: Path | str | PathLike[Any]) -> Path:
+    def _val_output_path(value_to_validate: str | PathLike[str]) -> Path:
         """Validate a path.
 
         Arguments:
@@ -611,7 +609,7 @@ def val_output_path(
         """
         try:
             validated_value = Path(
-                expandvars(expanduser(str(value_to_validate)))
+                expandvars(expanduser(fspath(value_to_validate)))
             ).resolve()
         except ValueError as exc:
             raise TypeError(
@@ -629,8 +627,8 @@ def val_output_path(
         return validated_value
 
     # Handle non-iterables and iterables we don't want to iterate over
-    if isinstance(value, Path | str | PathLike) or not isinstance(value, Iterable):
-        return _val_output_path(value)
+    if isinstance(value, str | PathLike) or not isinstance(value, Iterable):
+        return _val_output_path(cast(str | PathLike[str], value))
 
     # Handle iterables
     return [_val_output_path(value_to_validate) for value_to_validate in value]

--- a/scinoephile/core/subtitles/series.py
+++ b/scinoephile/core/subtitles/series.py
@@ -136,7 +136,7 @@ class Series(SSAFile):
     @override
     def save(
         self,
-        path: str | PathLike[Any],
+        path: str | PathLike[str],
         encoding: str = "utf-8",
         format_: str | None = None,
         fps: float | None = None,
@@ -276,7 +276,7 @@ class Series(SSAFile):
     @override
     def load(
         cls,
-        path: str | PathLike[Any],
+        path: str | PathLike[str],
         encoding: str = "utf-8",
         format_: str | None = None,
         fps: float | None = None,

--- a/scinoephile/image/subtitles/series.py
+++ b/scinoephile/image/subtitles/series.py
@@ -142,7 +142,7 @@ class ImageSeries(Series):
 
     def save_html_index(
         self,
-        dir_path: str | PathLike[Any],
+        dir_path: str | PathLike[str],
         encoding: str = "utf-8",
         errors: str | None = None,
     ):
@@ -181,7 +181,7 @@ class ImageSeries(Series):
     @override
     def save(
         self,
-        path: str | PathLike[Any],
+        path: str | PathLike[str],
         encoding: str = "utf-8",
         format_: str | None = None,
         fps: float | None = None,
@@ -233,7 +233,7 @@ class ImageSeries(Series):
     @override
     def load(
         cls,
-        path: str | PathLike[Any],
+        path: str | PathLike[str],
         encoding: str = "utf-8",
         format_: str | None = None,
         fps: float | None = None,

--- a/scinoephile/image/subtitles/series.py
+++ b/scinoephile/image/subtitles/series.py
@@ -16,6 +16,7 @@ import numpy as np
 from PIL import Image
 
 from scinoephile.common.validation import (
+    val_child_path,
     val_input_dir_path,
     val_input_file_or_dir_path,
     val_output_dir_path,
@@ -469,7 +470,7 @@ class ImageSeries(Series):
                     f"Subtitle anchor index {anchor_index} does not match {index}."
                 )
             image_name = match.group("img")
-            image_path = dir_path / image_name
+            image_path = val_child_path(dir_path, image_name)
             raw_text = match.group("text") or ""
             text = unescape(raw_text.replace("<br />", "\n")).replace("\n", "\\N")
             events.append(

--- a/scinoephile/workflows/subtitle_extraction.py
+++ b/scinoephile/workflows/subtitle_extraction.py
@@ -7,10 +7,11 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from logging import getLogger
-from pathlib import Path, PurePosixPath, PureWindowsPath
+from pathlib import Path
 from shutil import copy2
 
 from scinoephile.common.described_enum import DescribedEnum
+from scinoephile.common.validation import val_child_path
 from scinoephile.core import ScinoephileError
 from scinoephile.core.media import SubtitleStream
 from scinoephile.image.subtitles import ImageSeries
@@ -133,7 +134,7 @@ def extract_subtitles(
     outputs = []
     streams_to_extract = []
     for stream in streams:
-        outfile_path = _get_output_path(
+        outfile_path = _get_subtitle_output_path(
             output_dir_path,
             stream.outfile_filename,
         )
@@ -321,7 +322,7 @@ def _extract_sup_file(
     outfile_name = infile_path.name
     if stream.language is not None and "-" in stream.language:
         outfile_name = f"{stream.language}{infile_path.suffix}"
-    outfile_path = _get_output_path(output_dir_path, outfile_name)
+    outfile_path = _get_subtitle_output_path(output_dir_path, outfile_name)
 
     # Copy the SUP file and report its output status
     status = _copy_sup_file(
@@ -381,7 +382,7 @@ def _copy_sup_file(
     return SubtitleExtractionOutputStatus.CREATED
 
 
-def _get_output_path(output_dir_path: Path, outfile_name: str) -> Path:
+def _get_subtitle_output_path(output_dir_path: Path, outfile_name: str) -> Path:
     """Build a contained subtitle output path.
 
     Arguments:
@@ -392,21 +393,12 @@ def _get_output_path(output_dir_path: Path, outfile_name: str) -> Path:
     Raises:
         ScinoephileError: if the filename could escape the output directory
     """
-    posix_name = PurePosixPath(outfile_name)
-    windows_name = PureWindowsPath(outfile_name)
-    if posix_name.name != outfile_name or windows_name.name != outfile_name:
-        raise ScinoephileError(
-            f"Unsafe subtitle output filename from stream metadata: {outfile_name!r}"
-        )
-
-    outfile_path = output_dir_path / outfile_name
     try:
-        outfile_path.resolve().relative_to(output_dir_path.resolve())
-    except (OSError, RuntimeError, ValueError) as exc:
+        return val_child_path(output_dir_path, outfile_name)
+    except ValueError as exc:
         raise ScinoephileError(
             f"Unsafe subtitle output filename from stream metadata: {outfile_name!r}"
         ) from exc
-    return outfile_path
 
 
 def _extract_sup_image_series(

--- a/scinoephile/workflows/subtitle_extraction.py
+++ b/scinoephile/workflows/subtitle_extraction.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from logging import getLogger
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from shutil import copy2
 
 from scinoephile.common.described_enum import DescribedEnum
@@ -133,7 +133,10 @@ def extract_subtitles(
     outputs = []
     streams_to_extract = []
     for stream in streams:
-        outfile_path = output_dir_path / stream.outfile_filename
+        outfile_path = _get_output_path(
+            output_dir_path,
+            stream.outfile_filename,
+        )
         status = _get_stream_file_status(outfile_path, overwrite=overwrite)
         outputs.append(
             SubtitleExtractionOutput(
@@ -318,7 +321,7 @@ def _extract_sup_file(
     outfile_name = infile_path.name
     if stream.language is not None and "-" in stream.language:
         outfile_name = f"{stream.language}{infile_path.suffix}"
-    outfile_path = output_dir_path / outfile_name
+    outfile_path = _get_output_path(output_dir_path, outfile_name)
 
     # Copy the SUP file and report its output status
     status = _copy_sup_file(
@@ -376,6 +379,34 @@ def _copy_sup_file(
     if not outfile_is_infile:
         copy2(infile_path, outfile_path)
     return SubtitleExtractionOutputStatus.CREATED
+
+
+def _get_output_path(output_dir_path: Path, outfile_name: str) -> Path:
+    """Build a contained subtitle output path.
+
+    Arguments:
+        output_dir_path: subtitle output directory
+        outfile_name: proposed subtitle output filename
+    Returns:
+        contained subtitle output path
+    Raises:
+        ScinoephileError: if the filename could escape the output directory
+    """
+    posix_name = PurePosixPath(outfile_name)
+    windows_name = PureWindowsPath(outfile_name)
+    if posix_name.name != outfile_name or windows_name.name != outfile_name:
+        raise ScinoephileError(
+            f"Unsafe subtitle output filename from stream metadata: {outfile_name!r}"
+        )
+
+    outfile_path = output_dir_path / outfile_name
+    try:
+        outfile_path.resolve().relative_to(output_dir_path.resolve())
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise ScinoephileError(
+            f"Unsafe subtitle output filename from stream metadata: {outfile_name!r}"
+        ) from exc
+    return outfile_path
 
 
 def _extract_sup_image_series(

--- a/test/common/validation/test_pathlike_values.py
+++ b/test/common/validation/test_pathlike_values.py
@@ -1,0 +1,61 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests of custom string path-like values in common validation."""
+
+from __future__ import annotations
+
+from os import PathLike
+from pathlib import Path
+
+from scinoephile.common.validation import (
+    val_child_path,
+    val_input_dir_path,
+    val_input_file_or_dir_path,
+    val_input_path,
+    val_output_dir_path,
+    val_output_path,
+)
+
+
+class _CustomPath(PathLike[str]):
+    """Custom string path-like value used to exercise the public contract."""
+
+    def __init__(self, path: Path):
+        """Initialize.
+
+        Arguments:
+            path: path represented by this value
+        """
+        self.path = path
+
+    def __fspath__(self) -> str:
+        """Return the filesystem representation.
+
+        Returns:
+            string filesystem path
+        """
+        return str(self.path)
+
+
+def test_path_validators_accept_custom_string_pathlike(tmp_path: Path):
+    """Test path validators accept custom string path-like values.
+
+    Arguments:
+        tmp_path: pytest temporary directory path
+    """
+    input_path = tmp_path / "input.txt"
+    input_path.touch()
+    output_dir_path = tmp_path / "output"
+    output_path = tmp_path / "nested" / "output.txt"
+
+    assert (
+        val_child_path(_CustomPath(tmp_path), "child.txt")
+        == (tmp_path / "child.txt").resolve()
+    )
+    assert val_input_dir_path(_CustomPath(tmp_path)) == tmp_path.resolve()
+    assert val_input_file_or_dir_path(_CustomPath(input_path)) == input_path.resolve()
+    assert val_input_path(_CustomPath(input_path)) == input_path.resolve()
+    assert (
+        val_output_dir_path(_CustomPath(output_dir_path)) == output_dir_path.resolve()
+    )
+    assert val_output_path(_CustomPath(output_path)) == output_path.resolve()

--- a/test/common/validation/test_val_child_path.py
+++ b/test/common/validation/test_val_child_path.py
@@ -1,0 +1,72 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests of common.validation.val_child_path."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pytest import param, raises
+
+from scinoephile.common.validation import val_child_path
+from test.helpers import create_symlink_or_skip, parametrize
+
+
+def test_val_child_path_accepts_contained_filename(tmp_path: Path):
+    """Test child path validation accepts a contained filename.
+
+    Arguments:
+        tmp_path: pytest temporary directory path
+    """
+    parent_dir_path = tmp_path / "parent"
+    parent_dir_path.mkdir()
+
+    assert (
+        val_child_path(parent_dir_path, "eng-2.srt")
+        == (parent_dir_path / "eng-2.srt").resolve()
+    )
+
+
+@parametrize(
+    "child_name",
+    [
+        param("", id="empty"),
+        param(".", id="current-directory"),
+        param("..", id="parent-directory"),
+        param("../outside.srt", id="posix-parent"),
+        param("nested/outside.srt", id="posix-nested"),
+        param("/outside.srt", id="posix-absolute"),
+        param(r"..\outside.srt", id="windows-parent"),
+        param(r"nested\outside.srt", id="windows-nested"),
+        param(r"C:\outside.srt", id="windows-absolute"),
+    ],
+)
+def test_val_child_path_rejects_non_filename_components(
+    child_name: str,
+    tmp_path: Path,
+):
+    """Test child path validation rejects paths and special components.
+
+    Arguments:
+        child_name: proposed child name
+        tmp_path: pytest temporary directory path
+    """
+    with raises(ValueError, match="single contained filename"):
+        val_child_path(tmp_path, child_name)
+
+
+def test_val_child_path_rejects_symlink_outside_parent(tmp_path: Path):
+    """Test child path validation rejects symlinks outside the parent.
+
+    Arguments:
+        tmp_path: pytest temporary directory path
+    """
+    parent_dir_path = tmp_path / "parent"
+    parent_dir_path.mkdir()
+    outside_path = tmp_path / "outside.srt"
+    outside_path.touch()
+    symlink_path = parent_dir_path / "linked.srt"
+    create_symlink_or_skip(symlink_path, outside_path)
+
+    with raises(ValueError, match="single contained filename"):
+        val_child_path(parent_dir_path, symlink_path.name)

--- a/test/image/subtitles/test_image_series.py
+++ b/test/image/subtitles/test_image_series.py
@@ -92,6 +92,32 @@ def test_load_html(
         assert event.img.size[1] > 0
 
 
+def test_load_html_rejects_image_path_outside_directory(tmp_path: Path):
+    """Test HTML image paths cannot escape the subtitle directory.
+
+    Arguments:
+        tmp_path: pytest temporary directory path
+    """
+    input_dir_path = tmp_path / "subtitles"
+    input_dir_path.mkdir()
+    outside_path = tmp_path / "outside.png"
+    Image.new("RGBA", (2, 2), (255, 255, 255, 255)).save(outside_path)
+    html_text = ImageSeries.format_html_entry(
+        index=1,
+        start=0,
+        end=1000,
+        image_name="../outside.png",
+        text="",
+    )
+    (input_dir_path / "index.html").write_text(html_text, encoding="utf-8")
+
+    with raises(
+        ScinoephileError,
+        match="Unable to load ImageSeries.*single contained filename",
+    ):
+        ImageSeries.load(input_dir_path)
+
+
 def test_load_rejects_unsupported_input_file(tmp_path: Path):
     """Test unsupported image subtitle input files raise user-facing errors.
 

--- a/test/workflows/test_subtitle_extraction.py
+++ b/test/workflows/test_subtitle_extraction.py
@@ -233,6 +233,42 @@ def test_extract_subtitles_reports_overwritten_outputs(tmp_path: Path):
     assert outfile_path.read_text(encoding="utf-8") == "replacement"
 
 
+def test_extract_subtitles_rejects_unsafe_stream_language(tmp_path: Path):
+    """Test stream metadata cannot escape the subtitle output directory.
+
+    Arguments:
+        tmp_path: temporary directory provided by pytest
+    """
+    infile_path = tmp_path / "video.mkv"
+    infile_path.touch()
+    output_dir_path = tmp_path / "subtitles"
+
+    with (
+        patch(
+            "scinoephile.workflows.subtitle_extraction.get_subtitle_streams",
+            return_value=[
+                SubtitleStream(
+                    index=2,
+                    language="eng-../../../escaped",
+                    codec_name="subrip",
+                ),
+            ],
+        ),
+        patch(
+            "scinoephile.workflows.subtitle_extraction.cache_subtitles"
+        ) as cache_subtitles,
+        raises(ScinoephileError, match="Unsafe subtitle output filename"),
+    ):
+        extract_subtitles(
+            infile_path=infile_path,
+            languages=["eng"],
+            output_dir_path=output_dir_path,
+        )
+
+    cache_subtitles.assert_not_called()
+    assert not (tmp_path / "escaped-2.srt").exists()
+
+
 def test_extract_subtitles_extracts_sup_streams_to_image_dirs(tmp_path: Path):
     """Test subtitle extraction workflow converts SUP streams to image directories.
 
@@ -471,6 +507,38 @@ def test_extract_subtitles_skips_sup_file_with_nonmatching_language(tmp_path: Pa
         )
 
     assert result.outputs == []
+
+
+def test_extract_subtitles_rejects_unsafe_sup_language(tmp_path: Path):
+    """Test SUP stream metadata cannot escape the subtitle output directory.
+
+    Arguments:
+        tmp_path: temporary directory provided by pytest
+    """
+    infile_path = tmp_path / "source.sup"
+    infile_path.touch()
+    output_dir_path = tmp_path / "subtitles"
+
+    with (
+        patch(
+            "scinoephile.workflows.subtitle_extraction.get_subtitle_streams",
+            return_value=[
+                SubtitleStream(
+                    index=0,
+                    language="eng-../../../escaped",
+                    codec_name="hdmv_pgs_subtitle",
+                ),
+            ],
+        ),
+        raises(ScinoephileError, match="Unsafe subtitle output filename"),
+    ):
+        extract_subtitles(
+            infile_path=infile_path,
+            languages=["eng"],
+            output_dir_path=output_dir_path,
+        )
+
+    assert not (tmp_path / "escaped.sup").exists()
 
 
 def test_extract_subtitles_rejects_sup_file_without_subtitle_streams(tmp_path: Path):


### PR DESCRIPTION
## Summary

- add `common.validation.val_child_path` for explicit, cross-platform containment of untrusted child names
- use the shared validator for subtitle extraction output filenames while preserving workflow-level `ScinoephileError` reporting
- validate HTML subtitle image references before opening or rewriting image files
- normalize all repository `PathLike[Any]` annotations to `str | PathLike[str]`, removing redundant `Path` union members
- use `os.fspath` so custom string path-like objects satisfy the runtime contract as well as the type annotation

## Root cause

Metadata-derived filenames were joined directly to trusted directories without enforcing that they were single contained components. The existing path annotations also admitted byte-oriented path-like values and redundantly listed `Path`, while the implementation used `str(...)` instead of the filesystem path protocol.

## Testing

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format` on changed Python files
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix` on changed Python files
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check` on changed Python files
- targeted common/core/image/audio validation tests — 98 passed
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` — 1,760 passed, 9 skipped
