### PR TITLE
Protect ImageSeries directory contents

### DIFF
--- a/scinoephile/image/subtitles/series.py
+++ b/scinoephile/image/subtitles/series.py
@@ -10,6 +10,7 @@ from html import escape, unescape
 from logging import getLogger
 from os import PathLike
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Any, Self, override
 
 import numpy as np
@@ -332,25 +333,35 @@ class ImageSeries(Series):
             encoding: output file encoding
             errors: encoding error handling
         """
-        # Prepare empty directory, deleting existing files if needed
-        if dir_path.exists() and dir_path.is_dir():
-            for file in dir_path.iterdir():
-                file.unlink()
-            logger.info(f"Deleted {dir_path}")
-        else:
-            dir_path.mkdir(parents=True)
-            logger.info(f"Created directory {dir_path}")
+        # Stage the complete managed output before changing the destination
+        with TemporaryDirectory(
+            dir=dir_path.parent,
+            prefix=f".{dir_path.name}.",
+        ) as staging_dir_name:
+            staging_dir_path = Path(staging_dir_name)
+            image_paths = []
+            for i, event in enumerate(self, 1):
+                image_path = staging_dir_path / f"{i:04d}.png"
+                event.img.save(image_path)
+                image_paths.append(image_path)
+            self.save_html_index(
+                staging_dir_path,
+                encoding=encoding,
+                errors=errors,
+            )
 
-        # Save images
-        image_paths = []
-        for i, event in enumerate(self, 1):
-            outfile_path = dir_path / f"{i:04d}.png"
-            event.img.save(outfile_path)
-            image_paths.append(outfile_path)
-        logger.info(f"Saved images to {dir_path}")
+            # Reject conflicting directories before replacing any managed files
+            staged_paths = [*image_paths, staging_dir_path / "index.html"]
+            for staged_path in staged_paths:
+                output_path = dir_path / staged_path.name
+                if output_path.is_dir():
+                    raise IsADirectoryError(f"{output_path} is a directory")
 
-        # Save HTML index
-        self.save_html_index(dir_path, encoding=encoding, errors=errors)
+            # Replace images first and the index last, preserving unrelated entries
+            for image_path in image_paths:
+                image_path.replace(dir_path / image_path.name)
+            (staging_dir_path / "index.html").replace(dir_path / "index.html")
+        logger.info(f"Saved images and HTML to {dir_path}")
 
     @classmethod
     def _load_html(

--- a/test/image/subtitles/test_image_series.py
+++ b/test/image/subtitles/test_image_series.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
 from PIL import Image
 from pytest import FixtureRequest, param, raises
@@ -193,6 +194,66 @@ def test_save_html(tiny_image_series: ImageSeries):
 
         png_files = sorted(output_path.glob("*.png"))
         assert len(png_files) == len(tiny_image_series)
+
+
+def test_save_html_preserves_unrelated_directory_contents(
+    tiny_image_series: ImageSeries,
+    tmp_path: Path,
+):
+    """Test saving HTML preserves unrelated files and nested directories.
+
+    Arguments:
+        tiny_image_series: small image subtitle series
+        tmp_path: pytest temporary directory path
+    """
+    output_dir_path = tmp_path / "image_subtitles"
+    nested_dir_path = output_dir_path / "notes"
+    nested_dir_path.mkdir(parents=True)
+    note_path = nested_dir_path / "readme.txt"
+    note_path.write_text("keep me", encoding="utf-8")
+    metadata_path = output_dir_path / "metadata.json"
+    metadata_path.write_text("{}", encoding="utf-8")
+
+    tiny_image_series.save(output_dir_path)
+
+    assert note_path.read_text(encoding="utf-8") == "keep me"
+    assert metadata_path.read_text(encoding="utf-8") == "{}"
+    assert (output_dir_path / "index.html").exists()
+    assert len(list(output_dir_path.glob("*.png"))) == len(tiny_image_series)
+
+
+def test_save_html_preserves_existing_output_when_staging_fails(
+    tiny_image_series: ImageSeries,
+    tmp_path: Path,
+):
+    """Test a staging failure leaves existing managed output unchanged.
+
+    Arguments:
+        tiny_image_series: small image subtitle series
+        tmp_path: pytest temporary directory path
+    """
+    output_dir_path = tmp_path / "image_subtitles"
+    output_dir_path.mkdir()
+    index_path = output_dir_path / "index.html"
+    first_image_path = output_dir_path / "0001.png"
+    second_image_path = output_dir_path / "0002.png"
+    index_path.write_text("old index", encoding="utf-8")
+    first_image_path.write_bytes(b"old first image")
+    second_image_path.write_bytes(b"old second image")
+
+    with (
+        patch.object(
+            tiny_image_series.events[1].img,
+            "save",
+            side_effect=OSError("image write failed"),
+        ),
+        raises(ScinoephileError, match="image write failed"),
+    ):
+        tiny_image_series.save(output_dir_path)
+
+    assert index_path.read_text(encoding="utf-8") == "old index"
+    assert first_image_path.read_bytes() == b"old first image"
+    assert second_image_path.read_bytes() == b"old second image"
 
 
 def test_load_html_accepts_subtitle_number_anchor(tiny_image_series: ImageSeries):


### PR DESCRIPTION
## What changed

- Render the complete ImageSeries output into a sibling staging directory before touching the destination.
- Replace only generated PNG filenames and publish `index.html` last.
- Preserve unrelated files and nested directories in an existing output directory.
- Preflight managed-name directory conflicts before replacing any files.

## Why

`ImageSeries._save_html()` previously unlinked every child in an existing suffixless output directory before rendering. That could destroy unrelated data, fail on nested directories after partial deletion, and leave an existing series erased when a later image write failed.

## Impact

Saving an ImageSeries no longer treats the entire destination directory as disposable. Rendering failures occur in staging and leave existing managed output unchanged.

## Validation

- Merged current `master` after #1090.
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/image/subtitles/series.py test/image/subtitles/test_image_series.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/image/subtitles/series.py test/image/subtitles/test_image_series.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/image/subtitles/series.py test/image/subtitles/test_image_series.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest image/subtitles/test_image_series.py` — 17 passed
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` — 1,762 passed, 9 skipped
