### PR TITLE
Rebuild dictionary databases atomically

### DIFF
--- a/scinoephile/core/dictionaries/sqlite_store.py
+++ b/scinoephile/core/dictionaries/sqlite_store.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from logging import getLogger
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 from sqlalchemy import (
     Boolean,
@@ -24,7 +25,7 @@ from sqlalchemy import (
     text,
 )
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
-from sqlalchemy.engine import URL, Connection, RowMapping
+from sqlalchemy.engine import URL, Connection, Engine, RowMapping
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.pool import NullPool
 from sqlalchemy.sql import Select
@@ -208,11 +209,7 @@ class DictionarySqliteStore:
             database_path: SQLite database path
         """
         self.database_path = val_output_path(database_path, exist_ok=True)
-        self.engine = create_engine(
-            URL.create("sqlite", database=str(self.database_path)),
-            future=True,
-            poolclass=NullPool,
-        )
+        self.engine = self._create_engine(self.database_path)
 
     def lookup_by_jyutping(self, query: str, limit: int) -> list[DictionaryEntry]:
         """Lookup entries by Jyutping.
@@ -323,22 +320,35 @@ class DictionarySqliteStore:
         """
         source, entries = source_data
         self.database_path.parent.mkdir(parents=True, exist_ok=True)
-        if self.database_path.exists():
-            logger.info(f"Deleting existing SQLite database: {self.database_path}")
-            self.database_path.unlink()
+        with TemporaryDirectory(
+            dir=self.database_path.parent,
+            prefix=f".{self.database_path.name}.",
+        ) as temporary_dir_name:
+            temporary_database_path = Path(temporary_dir_name) / self.database_path.name
+            temporary_engine = self._create_engine(temporary_database_path)
+            try:
+                with temporary_engine.begin() as connection:
+                    self._write_database_version(connection)
+                    self._create_tables(connection)
 
-        with self.engine.begin() as connection:
-            self._write_database_version(connection)
-            self._drop_tables(connection)
-            self._create_tables(connection)
+                    source_id = self._insert_source(connection, source)
+                    for entry in entries:
+                        entry_id = self._insert_entry(connection, entry)
+                        for definition in entry.definitions:
+                            self._insert_definition(
+                                connection,
+                                definition,
+                                entry_id,
+                                source_id,
+                            )
 
-            source_id = self._insert_source(connection, source)
-            for entry in entries:
-                entry_id = self._insert_entry(connection, entry)
-                for definition in entry.definitions:
-                    self._insert_definition(connection, definition, entry_id, source_id)
+                    self._generate_indices(connection)
+                self._validate_database(temporary_engine)
+            finally:
+                temporary_engine.dispose()
 
-            self._generate_indices(connection)
+            temporary_database_path.replace(self.database_path)
+            logger.info(f"Rebuilt SQLite database: {self.database_path}")
 
         return self.database_path
 
@@ -439,26 +449,19 @@ class DictionarySqliteStore:
                 raise
 
     @staticmethod
-    def _drop_tables(connection: Connection):
-        """Drop dictionary tables.
+    def _create_engine(database_path: Path) -> Engine:
+        """Create a SQLite engine for a database path.
 
         Arguments:
-            connection: SQLAlchemy connection
+            database_path: SQLite database path
+        Returns:
+            SQLite engine
         """
-        connection.execute(text("DROP TABLE IF EXISTS entries_fts"))
-        connection.execute(text("DROP TABLE IF EXISTS definitions_fts"))
-        connection.execute(text("DROP INDEX IF EXISTS fk_entry_id_index"))
-
-        connection.execute(
-            text("DROP TABLE IF EXISTS definitions_chinese_sentences_links")
+        return create_engine(
+            URL.create("sqlite", database=str(database_path)),
+            future=True,
+            poolclass=NullPool,
         )
-        connection.execute(text("DROP TABLE IF EXISTS sentence_links"))
-        connection.execute(text("DROP TABLE IF EXISTS definitions"))
-        connection.execute(text("DROP TABLE IF EXISTS entries"))
-        connection.execute(text("DROP TABLE IF EXISTS sources"))
-
-        connection.execute(text("DROP TABLE IF EXISTS chinese_sentences"))
-        connection.execute(text("DROP TABLE IF EXISTS nonchinese_sentences"))
 
     def _fetch_entries(
         self,
@@ -678,6 +681,32 @@ class DictionarySqliteStore:
         with self.engine.connect() as connection:
             rows = connection.execute(statement).scalars().all()
         return [int(row) for row in rows]
+
+    @classmethod
+    def _validate_database(cls, engine: Engine):
+        """Validate a rebuilt SQLite database before publication.
+
+        Arguments:
+            engine: SQLite engine connected to the rebuilt database
+        Raises:
+            RuntimeError: If database integrity or schema version is invalid
+        """
+        with engine.connect() as connection:
+            integrity_result = connection.execute(
+                text("PRAGMA quick_check")
+            ).scalar_one()
+            if integrity_result != "ok":
+                raise RuntimeError(
+                    f"SQLite database integrity check failed: {integrity_result}"
+                )
+            schema_version = connection.execute(
+                text("PRAGMA user_version")
+            ).scalar_one()
+            if schema_version != cls.schema_version:
+                raise RuntimeError(
+                    "SQLite database schema version mismatch: "
+                    f"{schema_version} != {cls.schema_version}"
+                )
 
     def _write_database_version(self, connection: Connection):
         """Write schema version.

--- a/test/core/dictionaries/test_sqlite_store.py
+++ b/test/core/dictionaries/test_sqlite_store.py
@@ -7,8 +7,9 @@ from __future__ import annotations
 import sqlite3
 from contextlib import closing
 from pathlib import Path
+from unittest.mock import patch
 
-from pytest import fixture
+from pytest import fixture, raises
 
 from scinoephile.core.dictionaries import (
     DictionaryDefinition,
@@ -151,6 +152,31 @@ def test_sqlite_store_literal_like_lookups(
     assert store.lookup_by_jyutping("%", limit=5) == [entries[0]]
     assert store.lookup_by_jyutping("_", limit=5) == [entries[1]]
     assert store.lookup_by_jyutping("\\", limit=5) == [entries[2]]
+
+
+def test_sqlite_store_preserves_existing_database_when_rebuild_fails(
+    database_path: Path,
+    sample_entries: list[DictionaryEntry],
+    sample_source: DictionarySource,
+):
+    """Test a failed rebuild leaves the existing database unchanged."""
+    store = DictionarySqliteStore(database_path=database_path)
+    store.persist((sample_source, sample_entries))
+    original_database = database_path.read_bytes()
+
+    with (
+        patch.object(
+            store,
+            "_generate_indices",
+            side_effect=RuntimeError("index generation failed"),
+        ),
+        raises(RuntimeError, match="index generation failed"),
+    ):
+        store.persist((sample_source, sample_entries[:1]))
+
+    assert database_path.read_bytes() == original_database
+    assert store.lookup_by_traditional("山坑水", limit=5) == [sample_entries[1]]
+    assert list(database_path.parent.glob(f".{database_path.name}.*")) == []
 
 
 def test_sqlite_store_collapses_duplicate_entries_and_definitions(


### PR DESCRIPTION
## What changed

- Build each dictionary SQLite database in a sibling temporary directory.
- Run SQLite `quick_check` and verify the schema version before publication.
- Dispose the temporary engine and atomically replace the live database only after a successful build.
- Remove the obsolete destructive table-drop path.

## Why

Dictionary rebuilds previously deleted the live database before insertion and index generation completed. Any failure could permanently discard a working database and leave an incomplete replacement.

## Impact

Failed dictionary rebuilds now leave the prior database untouched, while successful rebuilds publish the validated replacement atomically.

## Validation

- Ruff format and check passed on changed files.
- `ty check` passed on changed files.
- `test/core/dictionaries/test_sqlite_store.py` — 5 passed.
- Full suite — 1,765 passed, 9 skipped.
