### PR TITLE
Publish subtitle cache entries atomically

### DIFF
--- a/scinoephile/media/subtitles/cache.py
+++ b/scinoephile/media/subtitles/cache.py
@@ -6,8 +6,10 @@ from __future__ import annotations
 
 import hashlib
 import json
+from contextlib import ExitStack
 from logging import getLogger
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import ffmpeg
 
@@ -59,31 +61,49 @@ def cache_subtitles(
     # Extract subtitle streams
     if missing:
         input_stream = ffmpeg.input(str(infile_path))
-        output_streams = []
-        for stream, stream_path in missing:
-            if not stream_path.parent.exists():
-                stream_path.parent.mkdir(parents=True)
-                logger.info(f"Created cache directory: {stream_path.parent}")
-            output_streams.append(
-                input_stream.output(
-                    str(stream_path),
-                    **{
-                        "map": f"0:{stream.index}",
-                        "c:s": stream.output_codec,
-                    },
+        with ExitStack() as stack:
+            staged_paths: list[tuple[Path, Path]] = []
+            output_streams = []
+            for stream, stream_path in missing:
+                if not stream_path.parent.exists():
+                    stream_path.parent.mkdir(parents=True)
+                    logger.info(f"Created cache directory: {stream_path.parent}")
+                staging_dir_path = Path(
+                    stack.enter_context(
+                        TemporaryDirectory(
+                            dir=stream_path.parent,
+                            prefix=f".{stream_path.name}-",
+                        )
+                    )
                 )
-            )
-        try:
-            ffmpeg.merge_outputs(*output_streams).run(
-                quiet=False,
-                overwrite_output=True,
-            )
-        except ffmpeg.Error as exc:
-            raise ScinoephileError(
-                f"Could not cache subtitle streams from {infile_path}"
-            ) from exc
-        for _, stream_path in missing:
-            logger.info(f"Saved subtitle stream to cache: {stream_path}")
+                staging_path = staging_dir_path / stream_path.name
+                staged_paths.append((staging_path, stream_path))
+                output_streams.append(
+                    input_stream.output(
+                        str(staging_path),
+                        **{
+                            "map": f"0:{stream.index}",
+                            "c:s": stream.output_codec,
+                        },
+                    )
+                )
+            try:
+                ffmpeg.merge_outputs(*output_streams).run(
+                    quiet=False,
+                    overwrite_output=True,
+                )
+            except ffmpeg.Error as exc:
+                raise ScinoephileError(
+                    f"Could not cache subtitle streams from {infile_path}"
+                ) from exc
+
+            if any(not staging_path.is_file() for staging_path, _ in staged_paths):
+                raise ScinoephileError(
+                    f"Could not cache subtitle streams from {infile_path}"
+                )
+            for staging_path, stream_path in staged_paths:
+                staging_path.replace(stream_path)
+                logger.info(f"Saved subtitle stream to cache: {stream_path}")
 
     # Render cached SUP subtitle streams to image directories when requested
     if render_images:

--- a/test/media/subtitles/test_cache.py
+++ b/test/media/subtitles/test_cache.py
@@ -86,9 +86,20 @@ def test_cache_subtitles_wraps_ffmpeg_extraction_errors(tmp_path: Path):
     infile_path.write_bytes(b"video")
     stream = SubtitleStream(index=2, language="zho", codec_name="subrip")
     input_stream = Mock()
-    input_stream.output.return_value = Mock()
+
+    def write_partial_output(outfile_path: str, **_: object) -> Mock:
+        """Write a partial ffmpeg output before extraction fails."""
+        Path(outfile_path).write_bytes(b"partial")
+        return Mock()
+
+    input_stream.output.side_effect = write_partial_output
     merged_stream = Mock()
     merged_stream.run.side_effect = ffmpeg.Error("ffmpeg", b"", b"failed")
+    stream_path = get_subtitle_cache_path(
+        infile_path,
+        stream,
+        cache_dir_path=tmp_path / "cache",
+    )
 
     with (
         patch(
@@ -106,6 +117,9 @@ def test_cache_subtitles_wraps_ffmpeg_extraction_errors(tmp_path: Path):
             [stream],
             cache_dir_path=tmp_path / "cache",
         )
+
+    assert not stream_path.exists()
+    assert list(stream_path.parent.glob(f".{stream_path.name}-*")) == []
 
 
 def test_cache_subtitles_builds_image_cache_for_sup_stream(tmp_path: Path):
@@ -186,7 +200,7 @@ def test_cache_subtitle_streams_extracts_missing_streams(tmp_path: Path):
     input_stream = _RecordingFfmpegInput()
     merged_streams: list[_RecordingMergedFfmpegStream] = []
 
-    def merge_outputs(*outputs: object) -> _RecordingMergedFfmpegStream:
+    def merge_outputs(*outputs: Path) -> _RecordingMergedFfmpegStream:
         """Record merged ffmpeg outputs."""
         merged_stream = _RecordingMergedFfmpegStream(list(outputs))
         merged_streams.append(merged_stream)
@@ -218,15 +232,23 @@ def test_cache_subtitle_streams_extracts_missing_streams(tmp_path: Path):
         streams[1],
         cache_dir_path=tmp_path / "cache",
     )
-    assert set(input_stream.output_calls) == {
-        (str(first_stream_path), "0:2", "subrip"),
-        (str(second_stream_path), "0:3", "subrip"),
+    assert {
+        (Path(path).name, mapping, codec)
+        for path, mapping, codec in input_stream.output_calls
+    } == {
+        (first_stream_path.name, "0:2", "subrip"),
+        (second_stream_path.name, "0:3", "subrip"),
+    }
+    assert {Path(path).parent.parent for path, _, _ in input_stream.output_calls} == {
+        first_stream_path.parent,
+        second_stream_path.parent,
     }
     assert len(merged_streams) == 1
     assert len(merged_streams[0].outputs) == 2
     assert merged_streams[0].run_count == 1
-    assert first_stream_path.parent.exists()
-    assert second_stream_path.parent.exists()
+    assert first_stream_path.read_bytes() == b"cached"
+    assert second_stream_path.read_bytes() == b"cached"
+    assert all(not Path(path).exists() for path, _, _ in input_stream.output_calls)
 
 
 class _RecordingFfmpegInput:
@@ -236,7 +258,7 @@ class _RecordingFfmpegInput:
         """Initialize."""
         self.output_calls: list[tuple[str, str, str]] = []
 
-    def output(self, outfile_path: str, **kwargs: object) -> object:
+    def output(self, outfile_path: str, **kwargs: object) -> Path:
         """Record an ffmpeg output stream.
 
         Arguments:
@@ -246,13 +268,13 @@ class _RecordingFfmpegInput:
             fake output stream
         """
         self.output_calls.append((outfile_path, str(kwargs["map"]), str(kwargs["c:s"])))
-        return object()
+        return Path(outfile_path)
 
 
 class _RecordingMergedFfmpegStream:
     """Recording fake for merged ffmpeg output streams."""
 
-    def __init__(self, outputs: list[object]):
+    def __init__(self, outputs: list[Path]):
         """Initialize.
 
         Arguments:
@@ -269,3 +291,5 @@ class _RecordingMergedFfmpegStream:
         """
         _ = kwargs
         self.run_count += 1
+        for output in self.outputs:
+            output.write_bytes(b"cached")


### PR DESCRIPTION
## Summary
- extract missing subtitle streams into temporary directories beside their final cache paths
- verify every staged output exists before publishing any cache entry
- clean up partial ffmpeg output after extraction failures

## Testing
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest test/media/subtitles/test_cache.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/media/subtitles/cache.py test/media/subtitles/test_cache.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/media/subtitles/cache.py test/media/subtitles/test_cache.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/media/subtitles/cache.py test/media/subtitles/test_cache.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` (1764 passed, 9 skipped)