### PR TITLE
Make subtitle series slicing subtype-safe

### DIFF
--- a/scinoephile/audio/subtitles/series.py
+++ b/scinoephile/audio/subtitles/series.py
@@ -5,6 +5,8 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Sequence
+from copy import deepcopy
 from logging import getLogger
 from os import PathLike
 from pathlib import Path
@@ -23,7 +25,7 @@ from scinoephile.common.validation import (
 )
 from scinoephile.core import ScinoephileError
 from scinoephile.core.media import AudioStream
-from scinoephile.core.subtitles import Series
+from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.media.probe import get_streams
 
 from .subtitle import AudioSubtitle
@@ -164,21 +166,6 @@ class AudioSeries(Series):
                 f"Unable to save {type(self).__name__} to {path}: {exc}"
             ) from exc
         logger.info(f"Saved series to {validated_output_path}")
-
-    @override
-    def slice(self, start: int, end: int) -> Self:
-        """Slice series.
-
-        Arguments:
-            start: start index
-            end: end index
-        Returns:
-            new sliced series
-        """
-        audio = self.audio[self.events[start].start : self.events[end - 1].end]
-        sliced = self._copy_with_events(self.events[start:end])
-        sliced.audio = audio
-        return sliced
 
     @classmethod
     @override
@@ -386,6 +373,29 @@ class AudioSeries(Series):
                 f"Could not extract audio stream {audio_track} from "
                 f"{video_input_path} to {audio_output_path}"
             ) from exc
+
+    @override
+    def _copy_with_events(self, events: Sequence[Subtitle]) -> Self:
+        """Copy this audio series with a selected collection of events.
+
+        Arguments:
+            events: events to include in the copied series
+        Returns:
+            copied audio series
+        """
+        audio_events: list[AudioSubtitle] = []
+        for event in events:
+            if not isinstance(event, AudioSubtitle):
+                raise TypeError("AudioSeries events must be AudioSubtitle instances")
+            audio_events.append(deepcopy(event))
+
+        if events:
+            audio = self.audio[events[0].start : events[-1].end]
+        else:
+            audio = self.audio[0:0]
+        copied = type(self)(audio=audio, events=audio_events)
+        self._copy_metadata_to(copied)
+        return copied
 
     @staticmethod
     def _get_audio_stream(media_path: Path, stream_index: int | None) -> AudioStream:

--- a/scinoephile/audio/subtitles/series.py
+++ b/scinoephile/audio/subtitles/series.py
@@ -176,10 +176,8 @@ class AudioSeries(Series):
             new sliced series
         """
         audio = self.audio[self.events[start].start : self.events[end - 1].end]
-        sliced = type(self)(audio=audio)
-        sliced.events = [
-            self.event_class(**event.as_dict()) for event in self.events[start:end]
-        ]
+        sliced = self._copy_with_events(self.events[start:end])
+        sliced.audio = audio
         return sliced
 
     @classmethod

--- a/scinoephile/core/subtitles/series.py
+++ b/scinoephile/core/subtitles/series.py
@@ -4,7 +4,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
+from copy import copy, deepcopy
 from logging import getLogger
 from os import PathLike
 from typing import Any, Self, cast, override
@@ -179,11 +180,7 @@ class Series(SSAFile):
         Returns:
             sliced series
         """
-        sliced = type(self)()
-        sliced.events = [
-            self.event_class(**event.as_dict()) for event in self.events[start:end]
-        ]
-        return sliced
+        return self._copy_with_events(self.events[start:end])
 
     def to_simple_string(
         self, start: int | None = None, duration: int | None = None
@@ -342,6 +339,24 @@ class Series(SSAFile):
         block_indexes.append((start, len(series)))
 
         return block_indexes
+
+    def _copy_with_events(self, events: Sequence[Subtitle]) -> Self:
+        """Copy this series with a selected collection of events.
+
+        Arguments:
+            events: events to include in the copied series
+        Returns:
+            copied series
+        """
+        copied = copy(self)
+        copied.__dict__ = {
+            name: deepcopy(value)
+            for name, value in self.__dict__.items()
+            if name not in {"events", "_blocks"}
+        }
+        copied.events = [deepcopy(event) for event in events]
+        copied._blocks = None
+        return copied
 
     def _init_blocks(self):
         """Initialize blocks."""

--- a/scinoephile/core/subtitles/series.py
+++ b/scinoephile/core/subtitles/series.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator, Sequence
-from copy import copy, deepcopy
+from copy import deepcopy
 from logging import getLogger
 from os import PathLike
 from typing import Any, Self, cast, override
@@ -340,6 +340,20 @@ class Series(SSAFile):
 
         return block_indexes
 
+    def _copy_metadata_to(self, copied: Series):
+        """Copy pysubs2 series metadata to another series.
+
+        Arguments:
+            copied: series to receive the copied metadata
+        """
+        copied.styles = deepcopy(self.styles)
+        copied.info = deepcopy(self.info)
+        copied.aegisub_project = deepcopy(self.aegisub_project)
+        copied.fonts_opaque = deepcopy(self.fonts_opaque)
+        copied.graphics_opaque = deepcopy(self.graphics_opaque)
+        copied.fps = self.fps
+        copied.format = self.format
+
     def _copy_with_events(self, events: Sequence[Subtitle]) -> Self:
         """Copy this series with a selected collection of events.
 
@@ -348,14 +362,12 @@ class Series(SSAFile):
         Returns:
             copied series
         """
-        copied = copy(self)
-        copied.__dict__ = {
-            name: deepcopy(value)
-            for name, value in self.__dict__.items()
-            if name not in {"events", "_blocks"}
-        }
-        copied.events = [deepcopy(event) for event in events]
-        copied._blocks = None
+        if type(self) is not Series:
+            raise NotImplementedError(
+                f"{type(self).__name__} must implement _copy_with_events()"
+            )
+        copied = Series(events=[deepcopy(event) for event in events])
+        self._copy_metadata_to(copied)
         return copied
 
     def _init_blocks(self):

--- a/scinoephile/image/subtitles/series.py
+++ b/scinoephile/image/subtitles/series.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 import re
 from collections import Counter
+from collections.abc import Sequence
+from copy import deepcopy
 from html import escape, unescape
 from logging import getLogger
 from os import PathLike
@@ -24,7 +26,7 @@ from scinoephile.common.validation import (
     val_output_path,
 )
 from scinoephile.core import ScinoephileError
-from scinoephile.core.subtitles import Series
+from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.image.bboxes import get_bboxes
 from scinoephile.image.colors import get_fill_and_outline_colors_from_hist
 from scinoephile.image.drawing import convert_rgba_img_to_la
@@ -271,6 +273,25 @@ class ImageSeries(Series):
             f"{cls.__name__}'s path must be path to a directory containing one "
             "index.html file and N png files, or a .sup file."
         )
+
+    @override
+    def _copy_with_events(self, events: Sequence[Subtitle]) -> Self:
+        """Copy this image series with a selected collection of events.
+
+        Arguments:
+            events: events to include in the copied series
+        Returns:
+            copied image series
+        """
+        image_events: list[ImageSubtitle] = []
+        for event in events:
+            if not isinstance(event, ImageSubtitle):
+                raise TypeError("ImageSeries events must be ImageSubtitle instances")
+            image_events.append(deepcopy(event))
+
+        copied = type(self)(events=image_events)
+        self._copy_metadata_to(copied)
+        return copied
 
     @override
     def _init_blocks(self):

--- a/test/audio/subtitles/test_audio_series.py
+++ b/test/audio/subtitles/test_audio_series.py
@@ -11,7 +11,7 @@ from pydub import AudioSegment
 from pydub.exceptions import CouldntDecodeError
 from pytest import raises
 
-from scinoephile.audio.subtitles import AudioSeries
+from scinoephile.audio.subtitles import AudioSeries, AudioSubtitle
 from scinoephile.core import ScinoephileError
 
 
@@ -75,3 +75,26 @@ def test_audio_series_save_wraps_output_path_errors(tmp_path: Path):
         series.save(output_path)
 
     assert isinstance(excinfo.value.__cause__, OSError)
+
+
+def test_audio_series_slice_preserves_audio_subtitle_payloads():
+    """Test audio series slicing retains series and subtitle audio."""
+    event_audio = AudioSegment.silent(duration=1000)
+    series = AudioSeries(
+        audio=AudioSegment.silent(duration=4000),
+        events=[
+            AudioSubtitle(
+                start=1000,
+                end=2000,
+                text="Text",
+                audio=event_audio,
+            )
+        ],
+    )
+
+    sliced = series.slice(0, 1)
+
+    assert type(sliced) is AudioSeries
+    assert len(sliced.audio) == 1000
+    assert sliced.events[0] is not series.events[0]
+    assert len(sliced.events[0].audio) == len(event_audio)

--- a/test/audio/subtitles/test_audio_series.py
+++ b/test/audio/subtitles/test_audio_series.py
@@ -91,6 +91,7 @@ def test_audio_series_slice_preserves_audio_subtitle_payloads():
             )
         ],
     )
+    series.info["Title"] = "Example"
 
     sliced = series.slice(0, 1)
 
@@ -98,3 +99,16 @@ def test_audio_series_slice_preserves_audio_subtitle_payloads():
     assert len(sliced.audio) == 1000
     assert sliced.events[0] is not series.events[0]
     assert len(sliced.events[0].audio) == len(event_audio)
+    assert sliced.info == series.info
+    assert sliced.info is not series.info
+
+
+def test_audio_series_slice_supports_empty_ranges():
+    """Test audio series slicing can produce an empty series."""
+    series = AudioSeries(audio=AudioSegment.silent(duration=1000))
+
+    sliced = series.slice(0, 0)
+
+    assert type(sliced) is AudioSeries
+    assert len(sliced) == 0
+    assert len(sliced.audio) == 0

--- a/test/core/subtitles/test_series.py
+++ b/test/core/subtitles/test_series.py
@@ -69,6 +69,37 @@ def test_series_save_wraps_output_path_errors(tmp_path: Path):
     assert isinstance(excinfo.value.__cause__, OSError)
 
 
+def test_series_slice_preserves_metadata_and_copies_events():
+    """Test slicing preserves series metadata and independently copies events."""
+    series = Series(
+        events=[
+            Subtitle(start=1000, end=2000, text="First"),
+            Subtitle(start=3000, end=4000, text="Second"),
+        ]
+    )
+    series.info["Title"] = "Example"
+    series.format = "ass"
+    series.fps = 23.976
+    series.fonts_opaque["font.ttf"] = ["encoded font"]
+
+    sliced = series.slice(1, 2)
+
+    assert type(sliced) is Series
+    assert sliced.events == [series.events[1]]
+    assert sliced.events[0] is not series.events[1]
+    assert sliced.styles == series.styles
+    assert sliced.styles is not series.styles
+    assert sliced.info == series.info
+    assert sliced.info is not series.info
+    assert sliced.format == series.format
+    assert sliced.fps == series.fps
+    assert sliced.fonts_opaque == series.fonts_opaque
+    assert sliced.fonts_opaque is not series.fonts_opaque
+
+    sliced.events[0].text = "Changed"
+    assert series.events[1].text == "Second"
+
+
 def test_series_to_string_wraps_serializer_errors():
     """Test subtitle string serialization errors are user-facing."""
     series = Series(events=[Subtitle(start=1000, end=2000, text="Text")])

--- a/test/image/subtitles/test_image_series.py
+++ b/test/image/subtitles/test_image_series.py
@@ -207,6 +207,7 @@ def test_image_series_blocks_preserve_image_subtitle_payloads():
         bboxes=[Bbox(1, 2, 3, 4)],
     )
     series = ImageSeries(events=[first, second])
+    series.info["Title"] = "Example"
 
     blocks = series.blocks
 
@@ -215,6 +216,8 @@ def test_image_series_blocks_preserve_image_subtitle_payloads():
     assert blocks[0].events[0] is not first
     assert blocks[0].events[0].img.tobytes() == first.img.tobytes()
     assert blocks[0].events[0].bboxes == first.bboxes
+    assert blocks[0].info == series.info
+    assert blocks[0].info is not series.info
     assert blocks[1].events[0] is not second
     assert blocks[1].events[0].img.tobytes() == second.img.tobytes()
     assert blocks[1].events[0].bboxes == second.bboxes

--- a/test/image/subtitles/test_image_series.py
+++ b/test/image/subtitles/test_image_series.py
@@ -192,6 +192,34 @@ def test_copy_text_from_rejects_length_mismatch():
         image_series.copy_text_from(text_series)
 
 
+def test_image_series_blocks_preserve_image_subtitle_payloads():
+    """Test image series blocks retain images and bounding boxes."""
+    first = ImageSubtitle(
+        start=0,
+        end=1000,
+        img=Image.new("LA", (2, 2), (0, 255)),
+        bboxes=[Bbox(0, 1, 2, 3)],
+    )
+    second = ImageSubtitle(
+        start=5000,
+        end=6000,
+        img=Image.new("LA", (3, 3), (128, 255)),
+        bboxes=[Bbox(1, 2, 3, 4)],
+    )
+    series = ImageSeries(events=[first, second])
+
+    blocks = series.blocks
+
+    assert len(blocks) == 2
+    assert all(type(block) is ImageSeries for block in blocks)
+    assert blocks[0].events[0] is not first
+    assert blocks[0].events[0].img.tobytes() == first.img.tobytes()
+    assert blocks[0].events[0].bboxes == first.bboxes
+    assert blocks[1].events[0] is not second
+    assert blocks[1].events[0].img.tobytes() == second.img.tobytes()
+    assert blocks[1].events[0].bboxes == second.bboxes
+
+
 def test_save_html(tiny_image_series: ImageSeries):
     """Test saving HTML image subtitles.
 


### PR DESCRIPTION
## Summary
- keep `Series.slice()` generic and delegate construction to a polymorphic `_copy_with_events()` contract
- copy pysubs2 styles, info, format, fps, and attachments explicitly in the base class
- reconstruct `ImageSeries` through its constructor while preserving copied image and bounding-box payloads
- reconstruct `AudioSeries` through its constructor with the selected audio span, allowing it to inherit `Series.slice()`
- define empty audio slices as empty `AudioSeries` instances
- merge current `master` while preserving its mutation-aware block cache signatures

## Testing
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest test/core/subtitles/test_series.py test/audio/subtitles/test_audio_series.py test/image/subtitles/test_image_series.py test/core/timing/test_get_series_timewarped.py test/media/test_probe.py` (45 passed)
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/audio/subtitles/series.py scinoephile/core/subtitles/series.py scinoephile/core/timing.py scinoephile/image/subtitles/series.py scinoephile/media/probe.py test/core/subtitles/test_series.py test/core/timing/test_get_series_timewarped.py test/media/test_probe.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/audio/subtitles/series.py scinoephile/core/subtitles/series.py scinoephile/core/timing.py scinoephile/image/subtitles/series.py scinoephile/media/probe.py test/core/subtitles/test_series.py test/core/timing/test_get_series_timewarped.py test/media/test_probe.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/audio/subtitles/series.py scinoephile/core/subtitles/series.py scinoephile/core/timing.py scinoephile/image/subtitles/series.py scinoephile/media/probe.py test/core/subtitles/test_series.py test/core/timing/test_get_series_timewarped.py test/media/test_probe.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` (1778 passed, 9 skipped)