### PR TITLE
Refresh subtitle blocks after in-place mutations

### DIFF
--- a/scinoephile/audio/subtitles/series.py
+++ b/scinoephile/audio/subtitles/series.py
@@ -104,8 +104,10 @@ class AudioSeries(Series):
 
         The buffering provides context audio around subtitle boundaries.
         """
-        if self._blocks is None:
+        signature = self._get_blocks_signature()
+        if self._blocks is None or self._blocks_signature != signature:
             self._init_blocks()
+            self._blocks_signature = signature
         assert self._blocks is not None
         return self._blocks
 
@@ -118,6 +120,7 @@ class AudioSeries(Series):
             blocks: List of blocks in the series
         """
         self._blocks = blocks
+        self._blocks_signature = self._get_blocks_signature()
 
     @override
     def save(

--- a/scinoephile/core/subtitles/series.py
+++ b/scinoephile/core/subtitles/series.py
@@ -43,6 +43,7 @@ class Series(SSAFile):
         if events is not None:
             self.events = events
         self._blocks: list[Series] | None = None
+        self._blocks_signature: tuple[tuple[int, str], ...] | None = None
 
     def __eq__(self, other: object) -> bool:
         """Whether this series is equal to another.
@@ -115,12 +116,15 @@ class Series(SSAFile):
         super().__setattr__(name, value)
         if name == "events" and hasattr(self, "_blocks"):
             self._blocks = None
+            self._blocks_signature = None
 
     @property
     def blocks(self) -> list[Series]:
         """List of blocks in the series."""
-        if self._blocks is None:
+        signature = self._get_blocks_signature()
+        if self._blocks is None or self._blocks_signature != signature:
             self._init_blocks()
+            self._blocks_signature = signature
         assert self._blocks is not None
         return self._blocks
 
@@ -132,6 +136,7 @@ class Series(SSAFile):
             blocks: List of blocks in the series
         """
         self._blocks = blocks
+        self._blocks_signature = self._get_blocks_signature()
 
     @override
     def save(
@@ -342,6 +347,10 @@ class Series(SSAFile):
         block_indexes.append((start, len(series)))
 
         return block_indexes
+
+    def _get_blocks_signature(self) -> tuple[tuple[int, str], ...]:
+        """Get event identity and SSA state used to detect block mutations."""
+        return tuple((id(event), repr(event.as_dict())) for event in self.events)
 
     def _init_blocks(self):
         """Initialize blocks."""

--- a/scinoephile/image/subtitles/series.py
+++ b/scinoephile/image/subtitles/series.py
@@ -113,8 +113,10 @@ class ImageSeries(Series):
     @override
     def blocks(self) -> list[ImageSeries]:
         """List of blocks in the series."""
-        if self._blocks is None:
+        signature = self._get_blocks_signature()
+        if self._blocks is None or self._blocks_signature != signature:
             self._init_blocks()
+            self._blocks_signature = signature
         assert self._blocks is not None
         return self._blocks
 
@@ -127,6 +129,7 @@ class ImageSeries(Series):
             blocks: List of blocks in the series
         """
         self._blocks = blocks
+        self._blocks_signature = self._get_blocks_signature()
 
     def copy_text_from(self, source: Series):
         """Copy subtitle text from a source series into this image series.

--- a/test/core/subtitles/test_series.py
+++ b/test/core/subtitles/test_series.py
@@ -26,6 +26,42 @@ def test_series_round_trips_srt():
     assert_series_equal(output, series)
 
 
+def test_series_blocks_refresh_after_event_list_mutation():
+    """Test cached blocks refresh after inherited list mutations."""
+    series = Series(events=[Subtitle(start=0, end=1000, text="First")])
+    initial_blocks = series.blocks
+
+    series.append(Subtitle(start=5000, end=6000, text="Second"))
+    refreshed_blocks = series.blocks
+
+    assert refreshed_blocks is not initial_blocks
+    assert len(refreshed_blocks) == 2
+    assert [block.events[0].text for block in refreshed_blocks] == [
+        "First",
+        "Second",
+    ]
+
+
+def test_series_blocks_refresh_after_direct_event_mutation():
+    """Test cached blocks refresh after direct event field mutations."""
+    series = Series(
+        events=[
+            Subtitle(start=0, end=1000, text="First"),
+            Subtitle(start=5000, end=6000, text="Second"),
+        ]
+    )
+    initial_blocks = series.blocks
+
+    series.events[1].start = 1500
+    series.events[1].end = 2500
+    series.events[1].text = "Changed"
+    refreshed_blocks = series.blocks
+
+    assert refreshed_blocks is not initial_blocks
+    assert len(refreshed_blocks) == 1
+    assert [event.text for event in refreshed_blocks[0]] == ["First", "Changed"]
+
+
 def test_series_load_wraps_input_path_errors(tmp_path: Path):
     """Test subtitle loading path errors are user-facing.
 


### PR DESCRIPTION
## Summary
- record an event identity and SSA-state signature whenever subtitle blocks are built or assigned
- rebuild cached blocks when inherited list operations, reordering, replacement, or direct event-field edits change that signature
- apply the same validation to base, audio, and image series block accessors

## Testing
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest test/core/subtitles/test_series.py test/audio/subtitles/test_audio_series.py test/image/subtitles/test_image_series.py test/llms/test_translation.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/core/subtitles/series.py scinoephile/audio/subtitles/series.py scinoephile/image/subtitles/series.py test/core/subtitles/test_series.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/core/subtitles/series.py scinoephile/audio/subtitles/series.py scinoephile/image/subtitles/series.py test/core/subtitles/test_series.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/core/subtitles/series.py scinoephile/audio/subtitles/series.py scinoephile/image/subtitles/series.py test/core/subtitles/test_series.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` (1767 passed, 9 skipped)