### PR TITLE
Accept unknown ffprobe packet counts

### DIFF
--- a/scinoephile/media/probe.py
+++ b/scinoephile/media/probe.py
@@ -127,7 +127,10 @@ def _from_ffprobe_subtitle_stream(
 
     subtitle_count = stream.get("nb_read_packets")
     if isinstance(subtitle_count, int | str):
-        subtitle_count = int(subtitle_count)
+        try:
+            subtitle_count = int(subtitle_count)
+        except ValueError:
+            subtitle_count = None
     else:
         subtitle_count = None
 

--- a/test/media/test_probe.py
+++ b/test/media/test_probe.py
@@ -44,6 +44,34 @@ def test_get_subtitle_streams(tmp_path: Path):
     assert stream.subtitle_count == 123
 
 
+def test_get_subtitle_streams_accepts_unknown_packet_count(tmp_path: Path):
+    """Test ffprobe's N/A packet count is treated as unknown.
+
+    Arguments:
+        tmp_path: pytest temporary directory path
+    """
+    infile_path = tmp_path / "video.mkv"
+    infile_path.touch()
+
+    with patch(
+        "scinoephile.media.probe.ffmpeg.probe",
+        return_value={
+            "streams": [
+                {
+                    "index": 2,
+                    "codec_type": "subtitle",
+                    "codec_name": "subrip",
+                    "nb_read_packets": "N/A",
+                },
+            ],
+        },
+    ):
+        streams = get_subtitle_streams(infile_path)
+
+    assert len(streams) == 1
+    assert streams[0].subtitle_count is None
+
+
 def test_get_streams_returns_all_typed_streams(tmp_path: Path):
     """Test media stream probing returns all typed stream models."""
     infile_path = tmp_path / "video.mkv"


### PR DESCRIPTION
## Summary
- treat nonnumeric ffprobe `nb_read_packets` values such as `N/A` as unknown
- preserve numeric integer and string packet-count parsing
- add regression coverage for ffprobe's sentinel

## Testing
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest test/media/test_probe.py test/cli/media/test_media_probe_cli.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/media/probe.py test/media/test_probe.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/media/probe.py test/media/test_probe.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/media/probe.py test/media/test_probe.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` (1766 passed, 9 skipped)