### PR TITLE
Validate timewarp index ranges

### DIFF
--- a/scinoephile/core/timing.py
+++ b/scinoephile/core/timing.py
@@ -55,15 +55,21 @@ def get_series_timewarped(
     if not source_two.events:
         raise ScinoephileError("Source two has no subtitle events to timewarp")
 
-    one_start_idx = one_start_idx or 1
-    one_end_idx = one_end_idx or len(source_one)
-    two_start_idx = two_start_idx or 1
-    two_end_idx = two_end_idx or len(source_two)
+    if one_start_idx is None:
+        one_start_idx = 1
+    if one_end_idx is None:
+        one_end_idx = len(source_one)
+    if two_start_idx is None:
+        two_start_idx = 1
+    if two_end_idx is None:
+        two_end_idx = len(source_two)
 
     _validate_idx(one_start_idx, source_one, "source one start")
     _validate_idx(one_end_idx, source_one, "source one end")
     _validate_idx(two_start_idx, source_two, "source two start")
     _validate_idx(two_end_idx, source_two, "source two end")
+    _validate_range(one_start_idx, one_end_idx, "source one")
+    _validate_range(two_start_idx, two_end_idx, "source two")
 
     one_start_event = source_one.events[one_start_idx - 1]
     one_end_event = source_one.events[one_end_idx - 1]
@@ -111,4 +117,21 @@ def _validate_idx(idx: int, source: Series, label: str):
     if idx > len(source):
         raise ScinoephileError(
             f"Invalid {label} index {idx}; series has {len(source)} subtitles"
+        )
+
+
+def _validate_range(start_idx: int, end_idx: int, label: str):
+    """Validate the ordering of a 1-based timewarp index range.
+
+    Arguments:
+        start_idx: 1-based start index
+        end_idx: 1-based end index
+        label: label for error messages
+    Raises:
+        ScinoephileError: If the range is reversed
+    """
+    if start_idx > end_idx:
+        raise ScinoephileError(
+            f"Invalid {label} range {start_idx}-{end_idx}; "
+            "start index must not exceed end index"
         )

--- a/test/core/timing/test_get_series_timewarped.py
+++ b/test/core/timing/test_get_series_timewarped.py
@@ -4,9 +4,10 @@
 
 from __future__ import annotations
 
-from pytest import FixtureRequest, param
+from pytest import FixtureRequest, param, raises
 
-from scinoephile.core.subtitles import Series
+from scinoephile.core import ScinoephileError
+from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.core.timing import get_series_timewarped
 from test.helpers import assert_series_equal, parametrize
 
@@ -76,3 +77,77 @@ def test_get_series_timewarped(
         two_end_idx=two_end_idx,
     )
     assert_series_equal(output, expected)
+
+
+@parametrize(
+    "kwargs, label",
+    [
+        param({"one_start_idx": 0}, "source one start", id="source-one-start"),
+        param({"one_end_idx": 0}, "source one end", id="source-one-end"),
+        param({"two_start_idx": 0}, "source two start", id="source-two-start"),
+        param({"two_end_idx": 0}, "source two end", id="source-two-end"),
+    ],
+)
+def test_get_series_timewarped_rejects_zero_indexes(
+    kwargs: dict[str, int],
+    label: str,
+):
+    """Test explicit zero indexes are rejected instead of defaulted.
+
+    Arguments:
+        kwargs: timewarp index override
+        label: expected index label in the error message
+    """
+    source_one = _get_series()
+    source_two = _get_series()
+
+    with raises(
+        ScinoephileError,
+        match=f"Invalid {label} index 0",
+    ):
+        get_series_timewarped(source_one, source_two, **kwargs)
+
+
+@parametrize(
+    "kwargs, label",
+    [
+        param(
+            {"one_start_idx": 2, "one_end_idx": 1},
+            "source one",
+            id="source-one",
+        ),
+        param(
+            {"two_start_idx": 2, "two_end_idx": 1},
+            "source two",
+            id="source-two",
+        ),
+    ],
+)
+def test_get_series_timewarped_rejects_reversed_ranges(
+    kwargs: dict[str, int],
+    label: str,
+):
+    """Test timewarp anchor ranges must be ordered from start to end.
+
+    Arguments:
+        kwargs: timewarp index overrides
+        label: expected range label in the error message
+    """
+    source_one = _get_series()
+    source_two = _get_series()
+
+    with raises(
+        ScinoephileError,
+        match=f"Invalid {label} range 2-1",
+    ):
+        get_series_timewarped(source_one, source_two, **kwargs)
+
+
+def _get_series() -> Series:
+    """Get a small series for timewarp validation tests."""
+    return Series(
+        events=[
+            Subtitle(start=0, end=1000, text="First"),
+            Subtitle(start=2000, end=3000, text="Second"),
+        ]
+    )


### PR DESCRIPTION
## Summary
- apply timewarp defaults only when optional indexes are `None`
- reject explicit zero indexes through the existing 1-based validation
- reject reversed anchor ranges before selecting anchor events
- cover all four zero-index inputs and both reversed ranges

## Testing
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest test/core/timing/test_get_series_timewarped.py test/cli/multi/test_multi_timewarp_cli.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/core/timing.py test/core/timing/test_get_series_timewarped.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/core/timing.py test/core/timing/test_get_series_timewarped.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/core/timing.py test/core/timing/test_get_series_timewarped.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` (1771 passed, 9 skipped)