### PR TITLE
Keep image series loading read-only

### DIFF
--- a/scinoephile/image/drawing.py
+++ b/scinoephile/image/drawing.py
@@ -25,20 +25,20 @@ __all__ = [
 ]
 
 
-def convert_rgba_img_to_la(img: Image.Image) -> tuple[Image.Image, bool]:
+def convert_rgba_img_to_la(img: Image.Image) -> Image.Image:
     """Convert RGBA images with grayscale color channels to LA.
 
     Arguments:
         img: Image to convert
     Returns:
-        Image and whether it was converted
+        converted image, or the original image when conversion is not applicable
     """
     if img.mode != "RGBA":
-        return img, False
+        return img
     arr = np.array(img)
     if np.all(arr[:, :, 0] == arr[:, :, 1]) and np.all(arr[:, :, 1] == arr[:, :, 2]):
-        return img.convert("LA"), True
-    return img, False
+        return img.convert("LA")
+    return img
 
 
 def get_img_with_bboxes(

--- a/scinoephile/image/subtitles/series.py
+++ b/scinoephile/image/subtitles/series.py
@@ -392,7 +392,7 @@ class ImageSeries(Series):
         for html_event in html_events:
             with Image.open(html_event["path"]) as opened:
                 img = opened.copy()
-            img, _ = convert_rgba_img_to_la(img)
+            img = convert_rgba_img_to_la(img)
             events.append(
                 cls.event_class(
                     start=html_event["start"],
@@ -424,7 +424,7 @@ class ImageSeries(Series):
         events = []
         for start, end, image in zip(starts, ends, images):
             img = Image.fromarray(image, "RGBA")
-            img, _ = convert_rgba_img_to_la(img)
+            img = convert_rgba_img_to_la(img)
             events.append(
                 cls.event_class(
                     start=int(round(start * 1000)),

--- a/scinoephile/image/subtitles/series.py
+++ b/scinoephile/image/subtitles/series.py
@@ -392,10 +392,7 @@ class ImageSeries(Series):
         for html_event in html_events:
             with Image.open(html_event["path"]) as opened:
                 img = opened.copy()
-            img, converted = convert_rgba_img_to_la(img)
-            if converted:
-                img.save(html_event["path"])
-                logger.info(f"Converted {html_event['path']} to LA and resaved")
+            img, _ = convert_rgba_img_to_la(img)
             events.append(
                 cls.event_class(
                     start=html_event["start"],

--- a/test/image/subtitles/test_image_series.py
+++ b/test/image/subtitles/test_image_series.py
@@ -93,6 +93,34 @@ def test_load_html(
         assert event.img.size[1] > 0
 
 
+def test_load_html_does_not_modify_source_images(tmp_path: Path):
+    """Test loading normalizes images in memory without rewriting input files.
+
+    Arguments:
+        tmp_path: pytest temporary directory path
+    """
+    input_dir_path = tmp_path / "subtitles"
+    input_dir_path.mkdir()
+    image_path = input_dir_path / "0001.png"
+    Image.new("RGBA", (2, 2), (64, 64, 64, 128)).save(image_path)
+    original_image_bytes = image_path.read_bytes()
+    html_text = ImageSeries.format_html_entry(
+        index=1,
+        start=0,
+        end=1000,
+        image_name=image_path.name,
+        text="Text",
+    )
+    (input_dir_path / "index.html").write_text(html_text, encoding="utf-8")
+
+    series = ImageSeries.load(input_dir_path)
+
+    assert series.events[0].img.mode == "LA"
+    assert image_path.read_bytes() == original_image_bytes
+    with Image.open(image_path) as source_image:
+        assert source_image.mode == "RGBA"
+
+
 def test_load_html_rejects_image_path_outside_directory(tmp_path: Path):
     """Test HTML image paths cannot escape the subtitle directory.
 

--- a/test/image/test_drawing.py
+++ b/test/image/test_drawing.py
@@ -7,7 +7,26 @@ from __future__ import annotations
 from PIL import Image
 
 from scinoephile.image.bbox import Bbox
-from scinoephile.image.drawing import get_img_with_bboxes
+from scinoephile.image.drawing import convert_rgba_img_to_la, get_img_with_bboxes
+
+
+def test_convert_rgba_img_to_la_converts_grayscale_rgba_image():
+    """Test grayscale RGBA images are returned in LA mode."""
+    img = Image.new("RGBA", (2, 2), (64, 64, 64, 128))
+
+    result = convert_rgba_img_to_la(img)
+
+    assert result.mode == "LA"
+    assert result.getpixel((0, 0)) == (64, 128)
+
+
+def test_convert_rgba_img_to_la_preserves_color_rgba_image():
+    """Test color RGBA images are returned unchanged."""
+    img = Image.new("RGBA", (2, 2), (64, 32, 16, 128))
+
+    result = convert_rgba_img_to_la(img)
+
+    assert result is img
 
 
 def test_get_img_with_bboxes_draws_second_outline_pixel_outside():


### PR DESCRIPTION
## Summary
- normalize grayscale RGBA subtitle images to LA only in memory during HTML loading
- stop rewriting caller-owned PNG files as a side effect of `ImageSeries.load`
- simplify `convert_rgba_img_to_la` to return only the resulting image
- verify conversion behavior directly and confirm source image mode and bytes remain unchanged during loading

## Testing
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest test/image/test_drawing.py test/image/subtitles/test_image_series.py test/image/subtitles/test_sup.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/image/drawing.py scinoephile/image/subtitles/series.py test/image/test_drawing.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/image/drawing.py scinoephile/image/subtitles/series.py test/image/test_drawing.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/image/drawing.py scinoephile/image/subtitles/series.py test/image/test_drawing.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` (1768 passed, 9 skipped)