### PR TITLE
Make module hierarchy declarations authoritative

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,8 +21,10 @@ below describes package responsibilities in the same order:
 - `audio`, `dictionaries`, and `web`: audio, dictionary, and web UI packages
   that may import from the packages above
 - `multilang`: cross-language operations that may import from the packages above
-- `optimization` and `workflows`: prompt optimization infrastructure and reusable
-  workflow orchestration that may import from the packages above
+- `optimization`: prompt optimization infrastructure that may import from the
+  packages above
+- `workflows`: reusable workflow orchestration that may import from the packages
+  above, including `optimization`
 - `scinoephile.cli`: user-facing command-line wrappers that may import from any
   package listed above it
 
@@ -43,15 +45,15 @@ layers:
     utilities.
 - **`media`**: media-file probing, subtitle extraction helpers, subtitle cache
   analysis, and visual offset estimation.
-- **`optimization`**: prompt optimization operations and prompt and test-case
-  persistence built on `core` and `llms`.
 - **`lang`**: language-specific subtitle operations (English, standard Chinese,
   written Cantonese, etc.).
 - **`audio`, `dictionaries`, and `web`**: audio representation and transcription
   tooling, dictionary lookup/build logic, and web interfaces.
 - **`multilang`**: pair-specific cross-language operations.
+- **`optimization`**: prompt optimization operations and prompt and test-case
+  persistence built on the preceding domain packages.
 - **`workflows`**: reusable end-to-end orchestration that coordinates multiple
-  domain packages, including `multilang`.
+  domain packages, including `multilang` and `optimization`.
 - **`cli`**: thin wrappers around lower layers; argument parsing, validation,
   and user-facing orchestration.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,27 +7,28 @@ and how the command-line interface maps onto the core implementation.
 
 Scinoephile documents the intended package hierarchy in
 `scinoephile/__init__.py`. Modules may import from packages listed above them in
-that hierarchy:
+that hierarchy. The hierarchy block in that file is authoritative; the list
+below describes package responsibilities in the same order:
 
 - `scinoephile.common`: general-purpose utilities; may not import from other
   Scinoephile packages
 - `scinoephile.core`: core subtitle-domain logic; may import from `common`
 - `analysis`, `image`, and `llms`: domain packages that may import from `common`
   and `core`
-- `scinoephile.media` and `scinoephile.optimization`: media tooling and prompt
-  optimization infrastructure built on the lower layers
+- `scinoephile.media`: media tooling built on the lower layers
 - `scinoephile.lang`: language-specific subtitle operations that may import from
   the packages above
 - `audio`, `dictionaries`, and `web`: audio, dictionary, and web UI packages
   that may import from the packages above
 - `multilang`: cross-language operations that may import from the packages above
-- `scinoephile.workflows`: reusable workflow orchestration that may import from
-  the packages above
+- `optimization` and `workflows`: prompt optimization infrastructure and reusable
+  workflow orchestration that may import from the packages above
 - `scinoephile.cli`: user-facing command-line wrappers that may import from any
   package listed above it
 
-This layering is enforced socially (by convention and code review) and is
-intended to keep dependencies flowing toward earlier layers:
+This layering is enforced automatically by `test/test_module_hierarchy.py` and
+through code review. It is intended to keep dependencies flowing toward earlier
+layers:
 
 - **`common`**: utilities shared everywhere; should remain dependency-free
   within the `scinoephile` package.
@@ -57,13 +58,26 @@ intended to keep dependencies flowing toward earlier layers:
 ### `__init__.py` files document local hierarchy
 
 In addition to the top-level hierarchy in `scinoephile/__init__.py`, each
-package’s `__init__.py` documents its **internal hierarchy** using the same rule
-of thumb: modules may import from modules listed “above” them in that package’s
-hierarchy comment. This serves two purposes:
+package’s `__init__.py` is the source of truth for its **internal hierarchy**.
+Every package containing child modules or packages must list each child exactly
+once. Each bullet is a dependency level: entries separated by `/` are independent
+peers, and a child may import only from children on earlier bullets. Sibling import
+cycles are prohibited.
+
+Declared levels express architectural policy rather than a compact description of
+the imports that happen to exist today. A child may remain on a later level even
+when it does not currently import from an earlier level. Removing an import does
+not require rearranging the hierarchy, and adding an import does not authorize
+rearranging it. Hierarchy changes are deliberate architectural changes and should
+be explained explicitly during review.
+
+`test/test_module_hierarchy.py` verifies that declarations are complete, rejects
+duplicate or unknown children, and rejects imports that violate the declared
+direction. The declarations serve two purposes:
 
 - **Documentation**: a fast, local reference for where new code should live.
-- **Dependency hygiene**: a place to notice and resolve sibling dependency
-  cycles (cycles should be called out explicitly and grouped together).
+- **Dependency hygiene**: an enforced boundary that prevents sibling dependency
+  cycles and upward imports.
 
 ### Immutable prompt values
 

--- a/scinoephile/__init__.py
+++ b/scinoephile/__init__.py
@@ -10,6 +10,7 @@ Module hierarchy (modules may import from any above):
 * lang
 * audio / dictionaries / web
 * multilang
-* optimization / workflows
+* optimization
+* workflows
 * cli
 """

--- a/scinoephile/image/ocr/lens/__init__.py
+++ b/scinoephile/image/ocr/lens/__init__.py
@@ -1,6 +1,10 @@
 #  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
-"""Google Lens OCR support for image subtitles."""
+"""Google Lens OCR support for image subtitles.
+
+Package hierarchy (modules may import from any above):
+* lens_recognizer
+"""
 
 from __future__ import annotations
 

--- a/scinoephile/lang/cmn/__init__.py
+++ b/scinoephile/lang/cmn/__init__.py
@@ -1,3 +1,7 @@
 #  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
-"""Code related to Mandarin Chinese (cmn) text."""
+"""Code related to Mandarin Chinese (cmn) text.
+
+Package hierarchy (modules may import from any above):
+* romanization
+"""

--- a/scinoephile/media/offset/__init__.py
+++ b/scinoephile/media/offset/__init__.py
@@ -1,3 +1,7 @@
 #  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
-"""Media offset detection."""
+"""Media offset detection.
+
+Package hierarchy (modules may import from any above):
+* video
+"""

--- a/scinoephile/web/__init__.py
+++ b/scinoephile/web/__init__.py
@@ -1,3 +1,7 @@
 #  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
-"""Web applications for Scinoephile."""
+"""Web applications for Scinoephile.
+
+Package hierarchy (modules may import from any above):
+* ocr_validation
+"""

--- a/test/test_module_hierarchy.py
+++ b/test/test_module_hierarchy.py
@@ -5,69 +5,47 @@
 from __future__ import annotations
 
 import ast
-from collections import defaultdict
-from functools import cache
 from pathlib import Path
 
 from scinoephile.common import package_root
 
 
-def test_module_hierarchy_docs_match_imports():
-    """Test package hierarchy docs match the compact import hierarchy."""
+def test_declared_module_hierarchy_may_be_stricter_than_import_graph(tmp_path: Path):
+    """Test declared hierarchy need not be compacted to current imports."""
+    package_dir_path = tmp_path / "example"
+    package_dir_path.mkdir()
+    init_path = package_dir_path / "__init__.py"
+    init_path.write_text(
+        '"""Example package.\n\n'
+        "Package hierarchy (modules may import from any above):\n"
+        "* foundation\n"
+        "* feature\n"
+        '"""\n',
+        encoding="utf-8",
+    )
+    (package_dir_path / "feature.py").write_text(
+        '"""Feature module with no current dependency on foundation."""\n',
+        encoding="utf-8",
+    )
+    (package_dir_path / "foundation.py").write_text(
+        '"""Foundation module."""\n',
+        encoding="utf-8",
+    )
+
+    assert (
+        get_module_hierarchy_violations(
+            init_path,
+            package_parent_path=tmp_path,
+        )
+        == []
+    )
+
+
+def test_module_hierarchy_docs_are_authoritative():
+    """Test package imports comply with declared module hierarchies."""
     violations: list[str] = []
     for init_path in sorted(package_root.rglob("__init__.py")):
-        package_dir_path = init_path.parent
-        child_names = get_child_names(package_dir_path)
-        if len(child_names) < 2:
-            continue
-
-        package_dotted = get_package_dotted(package_dir_path)
-        documented_levels = get_documented_levels(init_path)
-        if documented_levels is None:
-            violations.append(
-                f"{init_path.relative_to(package_root.parent)}: missing hierarchy block"
-            )
-            continue
-
-        documented_violations = get_documented_level_violations(
-            init_path=init_path,
-            child_names=child_names,
-            documented_levels=documented_levels,
-        )
-        violations.extend(documented_violations)
-        if documented_violations:
-            continue
-
-        edges = get_sibling_import_edges(
-            package_dir_path=package_dir_path,
-            package_dotted=package_dotted,
-            child_names=child_names,
-        )
-        documented_level_by_child = {
-            child_name: level
-            for level, level_child_names in documented_levels.items()
-            for child_name in level_child_names
-        }
-        violations.extend(
-            get_import_order_violations(
-                init_path=init_path,
-                documented_level_by_child=documented_level_by_child,
-                edges=edges,
-            )
-        )
-        cycle_violations = get_cycle_violations(init_path=init_path, edges=edges)
-        violations.extend(cycle_violations)
-        if cycle_violations:
-            continue
-
-        expected_levels = get_compact_levels(edges)
-        if documented_levels != expected_levels:
-            violations.append(
-                f"{init_path.relative_to(package_root.parent)}: "
-                "hierarchy is not compact\n"
-                f"  documented: {format_levels(documented_levels)}\n"
-                f"  expected:   {format_levels(expected_levels)}"
-            )
+        violations.extend(get_module_hierarchy_violations(init_path))
 
     assert not violations, "\n\n".join(violations)
 
@@ -107,6 +85,23 @@ def test_resolve_import_from_modules_includes_relative_package_aliases():
     ]
 
 
+def test_single_child_package_requires_hierarchy(tmp_path: Path):
+    """Test packages with one child still require a hierarchy declaration."""
+    package_dir_path = tmp_path / "example"
+    package_dir_path.mkdir()
+    init_path = package_dir_path / "__init__.py"
+    init_path.write_text('"""Example package."""\n', encoding="utf-8")
+    (package_dir_path / "child.py").write_text(
+        '"""Child module."""\n',
+        encoding="utf-8",
+    )
+
+    assert get_module_hierarchy_violations(
+        init_path,
+        package_parent_path=tmp_path,
+    ) == ["example/__init__.py: missing hierarchy block"]
+
+
 def get_child_names(package_dir_path: Path) -> list[str]:
     """Get direct child module and package names.
 
@@ -126,15 +121,20 @@ def get_child_names(package_dir_path: Path) -> list[str]:
     return sorted(child_names)
 
 
-def get_package_dotted(package_dir_path: Path) -> str:
+def get_package_dotted(
+    package_dir_path: Path,
+    *,
+    package_parent_path: Path = package_root.parent,
+) -> str:
     """Get dotted package name for a package directory.
 
     Arguments:
         package_dir_path: package directory path
+        package_parent_path: parent path from which the package name begins
     Returns:
         dotted package name
     """
-    return ".".join(package_dir_path.relative_to(package_root.parent).parts)
+    return ".".join(package_dir_path.relative_to(package_parent_path).parts)
 
 
 def get_documented_levels(init_path: Path) -> dict[int, list[str]] | None:
@@ -310,6 +310,62 @@ def get_imported_modules(file_path: Path, root_package_parts: list[str]) -> list
     return imported_modules
 
 
+def get_module_hierarchy_violations(
+    init_path: Path,
+    *,
+    package_parent_path: Path = package_root.parent,
+) -> list[str]:
+    """Get violations of one package's declared module hierarchy.
+
+    Arguments:
+        init_path: package `__init__.py` path
+        package_parent_path: parent path from which the package name begins
+    Returns:
+        violation descriptions
+    """
+    package_dir_path = init_path.parent
+    child_names = get_child_names(package_dir_path)
+    if not child_names:
+        return []
+
+    documented_levels = get_documented_levels(init_path)
+    if documented_levels is None:
+        return [
+            f"{init_path.relative_to(package_parent_path)}: missing hierarchy block"
+        ]
+
+    violations = get_documented_level_violations(
+        init_path=init_path,
+        child_names=child_names,
+        documented_levels=documented_levels,
+    )
+    if violations:
+        return violations
+
+    edges = get_sibling_import_edges(
+        package_dir_path=package_dir_path,
+        package_dotted=get_package_dotted(
+            package_dir_path,
+            package_parent_path=package_parent_path,
+        ),
+        child_names=child_names,
+    )
+    documented_level_by_child = {
+        child_name: level
+        for level, level_child_names in documented_levels.items()
+        for child_name in level_child_names
+    }
+    violations.extend(
+        get_import_order_violations(
+            init_path=init_path,
+            documented_level_by_child=documented_level_by_child,
+            edges=edges,
+        )
+    )
+    violations.extend(get_cycle_violations(init_path=init_path, edges=edges))
+    return violations
+
+
 def resolve_import_from_modules(
     file_path: Path,
     node: ast.ImportFrom,
@@ -432,50 +488,3 @@ def get_cycle_violations(init_path: Path, edges: dict[str, set[str]]) -> list[st
         f"import cycle: {' -> '.join(cycle)}"
         for cycle in sorted(cycles)
     ]
-
-
-def get_compact_levels(edges: dict[str, set[str]]) -> dict[int, list[str]]:
-    """Get the compact hierarchy levels for an acyclic import graph.
-
-    Arguments:
-        edges: sibling import edges
-    Returns:
-        compact dependency levels
-    """
-
-    @cache
-    def get_level(child_name: str) -> int:
-        """Get compact dependency level for one child.
-
-        Arguments:
-            child_name: child module or package name
-        Returns:
-            compact dependency level
-        """
-        imported_names = edges[child_name]
-        if imported_names:
-            level = 1 + max(
-                get_level(imported_name) for imported_name in imported_names
-            )
-        else:
-            level = 1
-        return level
-
-    levels: dict[int, list[str]] = defaultdict(list)
-    for child_name in sorted(edges):
-        levels[get_level(child_name)].append(child_name)
-    return dict(sorted(levels.items()))
-
-
-def format_levels(levels: dict[int, list[str]]) -> str:
-    """Format hierarchy levels for assertion output.
-
-    Arguments:
-        levels: hierarchy levels
-    Returns:
-        formatted hierarchy levels
-    """
-    return "; ".join(
-        f"L{level}: {' / '.join(child_names)}"
-        for level, child_names in sorted(levels.items())
-    )


### PR DESCRIPTION
## Summary
- treat hierarchy declarations in package `__init__.py` files as architectural policy rather than a compact rendering of current imports
- continue enforcing complete declarations, strict dependency direction, and cycle prevention
- require hierarchy declarations for single-child packages and document the four previously implicit packages
- place `optimization` above `workflows`, allowing workflows to consume optimization infrastructure while prohibiting the reverse dependency
- clarify the authoritative hierarchy semantics in the architecture guide
- preserve every other existing hierarchy ordering

## Root cause
The hierarchy test recomputed a compact graph from current imports and required declarations to match it. That made implementation dependencies partially authoritative and forced hierarchy movement when imports were removed, even if the declared layering remained intentional.

## Testing
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest test/test_module_hierarchy.py -q` (5 passed)
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/__init__.py scinoephile/image/ocr/lens/__init__.py scinoephile/lang/cmn/__init__.py scinoephile/media/offset/__init__.py scinoephile/web/__init__.py test/test_module_hierarchy.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/__init__.py scinoephile/image/ocr/lens/__init__.py scinoephile/lang/cmn/__init__.py scinoephile/media/offset/__init__.py scinoephile/web/__init__.py test/test_module_hierarchy.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/__init__.py scinoephile/image/ocr/lens/__init__.py scinoephile/lang/cmn/__init__.py scinoephile/media/offset/__init__.py scinoephile/web/__init__.py test/test_module_hierarchy.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto -q` (1783 passed, 9 skipped)