### PR TITLE
Streamline architecture documentation

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,189 +1,72 @@
 # Architecture
 
-This document describes Scinoephile’s package boundaries, dependency direction,
-and how the command-line interface maps onto the core implementation.
+This document describes Scinoephile's stable package boundaries and dependency
+policy. It intentionally avoids duplicating source-controlled inventories such
+as hierarchy order, CLI commands, and persistence schemas.
 
-## Package layering (dependency direction)
+## Package hierarchy
 
-Scinoephile documents the intended package hierarchy in
-`scinoephile/__init__.py`. Modules may import from packages listed above them in
-that hierarchy. The hierarchy block in that file is authoritative; the list
-below describes package responsibilities in the same order:
+The hierarchy block in
+[`scinoephile/__init__.py`](../scinoephile/__init__.py) is the source of truth
+for dependencies between top-level packages. Each package's `__init__.py` is the
+source of truth for dependencies between its direct children.
 
-- `scinoephile.common`: general-purpose utilities; may not import from other
-  Scinoephile packages
-- `scinoephile.core`: core subtitle-domain logic; may import from `common`
-- `analysis`, `image`, and `llms`: domain packages that may import from `common`
-  and `core`
-- `scinoephile.media`: media tooling built on the lower layers
-- `scinoephile.lang`: language-specific subtitle operations that may import from
-  the packages above
-- `audio`, `dictionaries`, and `web`: audio, dictionary, and web UI packages
-  that may import from the packages above
-- `multilang`: cross-language operations that may import from the packages above
-- `optimization`: prompt optimization infrastructure that may import from the
-  packages above
-- `workflows`: reusable workflow orchestration that may import from the packages
-  above, including `optimization`
-- `scinoephile.cli`: user-facing command-line wrappers that may import from any
-  package listed above it
+Every direct child appears exactly once in its package's hierarchy. Each bullet
+is a dependency level: entries separated by `/` are independent peers, and a
+child may import only from children on earlier bullets. Sibling import cycles are
+prohibited.
 
-This layering is enforced automatically by `test/test_module_hierarchy.py` and
-through code review. It is intended to keep dependencies flowing toward earlier
-layers:
+Declared levels express architectural policy, not a compact description of the
+imports that happen to exist today. Removing an import does not require moving a
+child earlier, and adding an import does not authorize moving it later. Hierarchy
+changes are deliberate architectural changes and should be explained explicitly
+during review.
 
-- **`common`**: utilities shared everywhere; should remain dependency-free
-  within the `scinoephile` package.
-- **`core`**: stable, domain-oriented primitives (series loading/saving, timing,
-  synchronization, shared CLI helpers); may import `common` but should avoid
-  importing mid-layer domain packages.
-- **`analysis`, `image`, and `llms`**: specialized functionality that builds on
-  `core`:
-  - **`analysis`**: metrics and comparisons (for example CER and diffing).
-  - **`image`**: image/OCR representations and helpers.
-  - **`llms`**: prompt definitions, providers, and model-facing processing
-    utilities.
-- **`media`**: media-file probing, subtitle extraction helpers, subtitle cache
-  analysis, and visual offset estimation.
-- **`lang`**: language-specific subtitle operations (English, standard Chinese,
-  written Cantonese, etc.).
-- **`audio`, `dictionaries`, and `web`**: audio representation and transcription
-  tooling, dictionary lookup/build logic, and web interfaces.
-- **`multilang`**: pair-specific cross-language operations.
-- **`optimization`**: prompt optimization operations and prompt and test-case
-  persistence built on the preceding domain packages.
-- **`workflows`**: reusable end-to-end orchestration that coordinates multiple
-  domain packages, including `multilang` and `optimization`.
-- **`cli`**: thin wrappers around lower layers; argument parsing, validation,
-  and user-facing orchestration.
+[`test/test_module_hierarchy.py`](../test/test_module_hierarchy.py) verifies that
+declarations are complete, rejects duplicate or unknown children, and enforces
+dependency direction and import style. Detailed import syntax belongs in the
+[`STYLE.md`](STYLE.md) guide rather than being repeated here.
 
-### `__init__.py` files document local hierarchy
+## Package responsibilities
 
-In addition to the top-level hierarchy in `scinoephile/__init__.py`, each
-package’s `__init__.py` is the source of truth for its **internal hierarchy**.
-Every package containing child modules or packages must list each child exactly
-once. Each bullet is a dependency level: entries separated by `/` are independent
-peers, and a child may import only from children on earlier bullets. Sibling import
-cycles are prohibited.
+This table is alphabetical and does not encode dependency order; consult the
+authoritative hierarchy declaration above for ordering.
 
-Declared levels express architectural policy rather than a compact description of
-the imports that happen to exist today. A child may remain on a later level even
-when it does not currently import from an earlier level. Removing an import does
-not require rearranging the hierarchy, and adding an import does not authorize
-rearranging it. Hierarchy changes are deliberate architectural changes and should
-be explained explicitly during review.
+| Package | Responsibility |
+| --- | --- |
+| `analysis` | Subtitle metrics, comparisons, alignment, and review auditing |
+| `audio` | Audio representations, transcription, and audio-derived subtitles |
+| `cli` | Argument parsing, localization, validation, and user-facing adapters |
+| `common` | General-purpose utilities with no dependencies on other Scinoephile packages |
+| `core` | Stable subtitle-domain primitives, timing, synchronization, caching, and shared CLI support |
+| `dictionaries` | Dictionary lookup, parsing, and cache construction |
+| `image` | Image subtitle representations, drawing, OCR, and OCR validation |
+| `lang` | Language-specific subtitle operations |
+| `llms` | Prompt types, providers, structured correspondence, and model-facing processing |
+| `media` | Media probing, subtitle extraction, cache analysis, and visual offset estimation |
+| `multilang` | Cross-language and language-pair operations |
+| `optimization` | Prompt optimization composition and persistence |
+| `web` | Web interfaces for interactive operations |
+| `workflows` | Reusable end-to-end orchestration across domain packages |
 
-`test/test_module_hierarchy.py` verifies that declarations are complete, rejects
-duplicate or unknown children, and rejects imports that violate the declared
-direction. It also enforces import forms that keep those dependencies visible:
-imports rooted in a module's containing package use single-dot relative imports,
-imports that climb out of it use absolute concrete paths, package-facade imports
-name public exports, and modules do not reach internal siblings through their own
-ancestor package facades. The declarations serve two purposes:
+## Public APIs and internal dependencies
 
-- **Documentation**: a fast, local reference for where new code should live.
-- **Dependency hygiene**: an enforced boundary that prevents sibling dependency
-  cycles and upward imports.
+Package `__init__.py` files may expose deliberate public facades through
+`__all__`. External consumers may use those facades. Internal imports must keep
+the concrete dependency visible according to the rules in `STYLE.md`, allowing
+the hierarchy test to evaluate the real dependency graph.
 
-### Immutable prompt values
+## Command-line interface
 
-Operation-specific prompt types in `scinoephile.llms` are frozen, keyword-only
-dataclasses defining behavior and named correspondence fields for review,
-translation, OCR fusion, and the other LLM shapes. Authored and localized
-prompts construct those types directly with a `Language` and string fields. LLM
-managers, processors, queryers, and workflows pass these values directly.
-Authored prompts may reuse typed language-specific field dictionaries while
-keeping their language and operation-specific fields explicit.
+The console entry point is declared in [`pyproject.toml`](../pyproject.toml).
+`ScinoephileCli` dispatches to `argparse`-based command classes under
+`scinoephile/cli/`; those classes define the authoritative command tree and help
+text. CLI classes should parse and validate inputs, translate domain failures
+for users, and delegate substantive work to lower packages.
 
-Operation-specific Pydantic query, answer, and test-case models define stable
-structural fields. When JSON field names are part of LLM correspondence, managers
-generate and cache prompt-specific subclasses whose aliases and descriptions come
-from the immutable prompt value. List-shaped operations represent variable
-cardinality in model data, such as indexed subtitle lists, rather than in generated
-class fields. The prompt's stable content-addressed name is used in generated model
-names.
+## Focused design documents
 
-LLM providers require a structured answer model for every completion. The provider's
-structured response format is the authoritative answer schema; system prompts do not
-duplicate that schema as text.
+Subsystem-specific design belongs in focused documents so this overview remains
+stable:
 
-Optimization persistence stores each prompt alias with its content-addressed
-identifier, language, and complete set of string fields. Prompt and test-case
-SQLite stores own and create their tables independently. Model persistence uses
-immutable, content-addressed rows containing the provider, resolved model name,
-effective base URL, and non-secret inference settings. Credentials and provider
-client state are excluded. All table groups may coexist in one SQLite file
-without a global schema version or migration contract.
-
-## Command Line Interface
-
-The entrypoint configured in `pyproject.toml` is:
-
-- `scinoephile = scinoephile.cli.scinoephile_cli:ScinoephileCli.main`
-
-`ScinoephileCli` is an `argparse`-based top-level dispatcher that selects a
-subcommand and forwards arguments to the corresponding CLI class.
-
-### Full CLI surface
-
-The CLI is organized as a tree of `argparse` subparsers. The complete command
-surface (commands and subcommands) is:
-
-- `scinoephile`
-  - `audit`: audit subtitle review workflows
-    - `review`: audit one review with automatic language and script detection
-    - `review-trad`: audit traditional review followed by review of its
-      simplified form
-    - `review-dual`: audit parallel simplified and traditional-to-simplified
-      review paths and their final discrepancy
-  - `dictionary`
-    - `build`
-      - `cuhk`: build CUHK dictionary cache
-      - `gzzj`: build GZZJ dictionary cache
-      - `kaifangcidian`: build Kaifangcidian dictionary cache
-      - `unihan`: build Unihan dictionary cache
-      - `wiktionary`: build Wiktionary dictionary cache
-    - `search`: search one or more configured dictionaries
-  - `media`
-    - `extract-subs`: extract matching subtitle streams from a video file
-    - `offset`: estimate visual offset between two media files
-    - `probe`: list media streams in a media file
-  - `multi`
-    - `cer`: calculate character error rate (CER) for one series relative to
-      another
-    - `diff`: calculate the diff between two series
-    - `stack`: stack two series into top and bottom subtitle lines
-    - `sync`: estimate subtitle offset and shift a mobile series to an anchor
-      series
-    - `timewarp`: shift/stretch timings of one series to match another
-  - `ocr`
-    - `fuse`: fuse OCR output for a selected language
-    - `lens`: recognize image subtitles with Google Lens
-    - `paddle`: recognize image subtitles with PaddleOCR
-    - `process`: process image subtitle OCR and fuse output for a selected
-      language
-    - `tesseract`: recognize image subtitles with Tesseract OCR
-    - `validate`: validate OCR text against subtitle images
-  - `process`: process subtitles (clean/convert/flatten/romanize/offset)
-  - `proofread`: review one subtitle series, review it pairwise against a
-    reference series, or review it in blocks using a guide series
-  - `utility`
-    - `cache`
-      - `clear`: remove cached files
-      - `list`: list cached files
-      - `prune`: remove stale cached files
-      - `stats`: inspect cache size and entry counts
-    - `optimization`
-      - `sync-prompts`: synchronize registered prompts
-      - `sync-test-cases`: synchronize persisted prompt-optimization test cases
-  - `translate`: translate subtitles between supported languages
-  - `yue`
-    - `transcribe-vs-zho`: transcribe from media audio using standard Chinese
-      as reference
-
-Each subcommand lives under `scinoephile/cli/` and is responsible for:
-
-- Defining its argument parser
-- Validating inputs and outputs
-- Calling into the appropriate `core` and domain-layer modules to do the real
-  work
+- [Prompt optimization and persistence](PROMPT_OPTIMIZATION.md)

--- a/docs/PROMPT_OPTIMIZATION.md
+++ b/docs/PROMPT_OPTIMIZATION.md
@@ -1,0 +1,40 @@
+# Prompt optimization and persistence
+
+This document records the data-model and persistence decisions used by prompt
+optimization without expanding the high-level architecture overview.
+
+## Prompt values
+
+Operation-specific prompt types in `scinoephile.llms` are frozen, keyword-only
+dataclasses. They define behavior and named correspondence fields for review,
+translation, OCR fusion, and other LLM operations. Authored and localized prompts
+construct these types directly with a language and explicit string fields. LLM
+managers, processors, queryers, and workflows pass the immutable values directly.
+
+Authored prompts may reuse typed language-specific field dictionaries while
+keeping language and operation-specific fields explicit. Each prompt has a stable
+content-addressed name.
+
+## Structured models
+
+Operation-specific Pydantic query, answer, and test-case models define stable
+structural fields. When JSON field names are part of LLM correspondence, managers
+generate and cache prompt-specific subclasses whose aliases and descriptions come
+from the prompt value. List-shaped operations represent variable cardinality in
+model data rather than generated class fields. Generated model names include the
+prompt's content-addressed name.
+
+LLM providers require a structured answer model for every completion. The
+provider's structured response format is the authoritative answer schema; system
+prompts do not duplicate that schema as text.
+
+## Persistence
+
+Optimization persistence stores each prompt alias with its content-addressed
+identifier, language, and complete set of string fields. Prompt and test-case
+SQLite stores own and create their tables independently.
+
+Model persistence uses immutable, content-addressed rows containing the provider,
+resolved model name, effective base URL, and non-secret inference settings.
+Credentials and provider client state are excluded. All table groups may coexist
+in one SQLite file without a global schema version or migration contract.

--- a/scinoephile/__init__.py
+++ b/scinoephile/__init__.py
@@ -2,7 +2,7 @@
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
 """Code for scinoephile.
 
-Module hierarchy (modules may import from any above):
+Package hierarchy (modules may import from any above):
 * common
 * core
 * analysis / image / llms

--- a/scinoephile/analysis/__init__.py
+++ b/scinoephile/analysis/__init__.py
@@ -2,9 +2,7 @@
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
 """Analysis code for comparing subtitle series.
 
-This module may import from: common, core
-
-Hierarchy within module (lower may import from higher):
+Package hierarchy (modules may import from any above):
 * line_alignment / review_audit
 * diff
 * character_error_rate

--- a/scinoephile/audio/__init__.py
+++ b/scinoephile/audio/__init__.py
@@ -2,9 +2,7 @@
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
 """Code related to audio.
 
-This module may import from: common, core, lang
-
-Hierarchy within module (lower may import from higher)::
+Package hierarchy (modules may import from any above):
 * transcription
 * subtitles
 """

--- a/scinoephile/core/__init__.py
+++ b/scinoephile/core/__init__.py
@@ -2,9 +2,7 @@
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
 """Core code.
 
-This module may import from: common
-
-Hierarchy within module (lower may import from higher):
+Package hierarchy (modules may import from any above):
 * dictionaries / exceptions / ml / paths
 * cache / subtitles / text
 * language / pairs / romanization / timing

--- a/scinoephile/image/__init__.py
+++ b/scinoephile/image/__init__.py
@@ -2,9 +2,7 @@
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
 """Code related to images.
 
-This module may import from: common, core
-
-Hierarchy within module (lower may import from higher):
+Package hierarchy (modules may import from any above):
 * bbox / colors
 * bboxes / drawing
 * subtitles

--- a/scinoephile/lang/__init__.py
+++ b/scinoephile/lang/__init__.py
@@ -2,9 +2,7 @@
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
 """Language-specific code for scinoephile.
 
-This module may import from: common, core, image, llms
-
-Hierarchy within module (lower may import from higher)::
+Package hierarchy (modules may import from any above):
 * cmn / eng / zho
 * yue
 * id / ocr_fusion / review

--- a/scinoephile/llms/__init__.py
+++ b/scinoephile/llms/__init__.py
@@ -2,9 +2,7 @@
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
 """Code related to interactions with LLMs.
 
-This module may import from: common, core
-
-Hierarchy within module, where lower entries may import from higher entries:
+Package hierarchy (modules may import from any above):
 * delineation / gap_translation / guided_review / guided_translation / ocr_fusion
   / pairwise_review / providers / punctuation / review / translation
 

--- a/scinoephile/multilang/__init__.py
+++ b/scinoephile/multilang/__init__.py
@@ -2,9 +2,7 @@
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
 """Code that involves multiple languages.
 
-This module may import from: common, core, dictionaries, lang, audio, llms
-
-Hierarchy within module (lower may import from higher):
+Package hierarchy (modules may import from any above):
 * eng_yue / eng_zho / yue_eng / yue_zho / zho_eng / zho_yue
 * review / translation
 """

--- a/scinoephile/optimization/__init__.py
+++ b/scinoephile/optimization/__init__.py
@@ -2,14 +2,6 @@
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
 """Prompt optimization and related persistence.
 
-This module may import from:
-- common
-- core
-- analysis / image / llms
-- lang
-- audio / dictionaries
-- multilang
-
 Package hierarchy (modules may import from any above):
 * operations / prompt_specs
 * persistence

--- a/test/test_module_hierarchy.py
+++ b/test/test_module_hierarchy.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 from scinoephile.common import package_root
 
+_HIERARCHY_HEADER = "Package hierarchy (modules may import from any above):"
+
 
 def test_declared_module_hierarchy_may_be_stricter_than_import_graph(tmp_path: Path):
     """Test declared hierarchy need not be compacted to current imports."""
@@ -39,6 +41,26 @@ def test_declared_module_hierarchy_may_be_stricter_than_import_graph(tmp_path: P
         )
         == []
     )
+
+
+def test_hierarchy_declarations_require_standard_heading(tmp_path: Path):
+    """Test incidental hierarchy prose is not parsed as a declaration."""
+    package_dir_path = tmp_path / "example"
+    package_dir_path.mkdir()
+    init_path = package_dir_path / "__init__.py"
+    init_path.write_text(
+        '"""Example package.\n\nHierarchy notes:\n* child\n"""\n',
+        encoding="utf-8",
+    )
+    (package_dir_path / "child.py").write_text(
+        '"""Child module."""\n',
+        encoding="utf-8",
+    )
+
+    assert get_module_hierarchy_violations(
+        init_path,
+        package_parent_path=tmp_path,
+    ) == ["example/__init__.py: missing hierarchy block"]
 
 
 def test_module_hierarchy_docs_are_authoritative():
@@ -291,7 +313,7 @@ def get_documented_levels(init_path: Path) -> dict[int, list[str]] | None:
     for line in docstring.splitlines():
         stripped_line = line.strip()
         if not hierarchy_seen:
-            if "hierarchy" in stripped_line.lower():
+            if stripped_line == _HIERARCHY_HEADER:
                 hierarchy_seen = True
             continue
 


### PR DESCRIPTION
## Summary

- make package `__init__.py` hierarchy declarations the only documentation that encodes dependency order
- standardize the hierarchy declaration heading and reject incidental hierarchy prose in the architecture test
- replace duplicated layer descriptions with an alphabetical package-responsibility map
- remove the volatile CLI command inventory and point to the command classes and generated help as authoritative
- move prompt and optimization persistence details into a focused design document
- remove stale cross-package dependency lists from package docstrings

## Root cause

Dependency order was repeated in `ARCHITECTURE.md` and several package docstrings in addition to the authoritative hierarchy declarations. Those copies had already drifted, including incomplete dependency lists in `audio` and `lang`. The architecture overview also mixed stable package boundaries with a full CLI inventory and subsystem-specific persistence details, making it long and costly to keep current.

## Developer impact

Hierarchy ordering is now documented only in package `__init__.py` files and enforced by `test_module_hierarchy.py`. `ARCHITECTURE.md` is reduced from 189 lines to 72 and remains focused on stable responsibilities and boundaries. No hierarchy ordering or runtime behavior changes.

## Testing

- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest test/test_module_hierarchy.py -q` (8 passed)
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format <changed Python files>`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix <changed Python files>`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check <changed Python files>`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` (1,787 passed, 9 skipped)