### PR TITLE
Remove Chinese conversion from transcription

### DIFF
--- a/scinoephile/audio/transcription/__init__.py
+++ b/scinoephile/audio/transcription/__init__.py
@@ -10,13 +10,7 @@ Package hierarchy (modules may import from any above):
 
 from __future__ import annotations
 
-from copy import deepcopy
 from logging import getLogger
-
-from scinoephile.lang.zho.script.conversion import (
-    OpenCCConfig,
-    get_zho_text_converted,
-)
 
 from .demucs_separator import DemucsSeparator
 from .transcribed_segment import TranscribedSegment
@@ -31,39 +25,9 @@ __all__ = [
     "get_segment_merged",
     "get_segment_split_at_idx",
     "get_segment_split_on_whitespace",
-    "get_segment_zho_converted",
 ]
 
 logger = getLogger(__name__)
-
-
-def get_segment_zho_converted(
-    segment: TranscribedSegment,
-    config: OpenCCConfig = OpenCCConfig.t2s,
-    apply_exclusions: bool = True,
-) -> TranscribedSegment:
-    """Convert standard Chinese between character sets.
-
-    Arguments:
-        segment: transcribed segment to convert
-        config: OpenCC configuration for conversion
-        apply_exclusions: whether to apply character exclusions during conversion
-    Returns:
-        transcribed segment with converted standard Chinese text
-    """
-    converted_segment = deepcopy(segment)
-    converted_segment.text = get_zho_text_converted(
-        converted_segment.text, config, apply_exclusions
-    )
-
-    if converted_segment.words:
-        i = 0
-        for word in converted_segment.words:
-            word_length = len(word.text)
-            word.text = converted_segment.text[i : i + word_length]
-            i += word_length
-
-    return converted_segment
 
 
 def get_segment_merged(segments: list[TranscribedSegment]) -> TranscribedSegment:

--- a/scinoephile/cli/yue/yue_transcribe_vs_zho_cli.py
+++ b/scinoephile/cli/yue/yue_transcribe_vs_zho_cli.py
@@ -8,10 +8,6 @@ from argparse import ArgumentParser
 from pathlib import Path
 
 from scinoephile.audio.subtitles import AudioSeries
-from scinoephile.cli.helpers.conversion import (
-    CONVERSION_LOCALIZATIONS,
-    add_opencc_convert_argument,
-)
 from scinoephile.cli.helpers.io import read_series, write_series
 from scinoephile.cli.helpers.llms import (
     LLM_LOCALIZATIONS,
@@ -32,7 +28,6 @@ from scinoephile.common.file import get_temp_file_path
 from scinoephile.core.cli import ScinoephileCliBase
 from scinoephile.core.cli.localization import merge_localizations
 from scinoephile.core.exceptions import ScinoephileError
-from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.llms.delineation import DelineationPrompt
 from scinoephile.llms.providers.registry import get_provider
 from scinoephile.llms.punctuation import PunctuationPrompt
@@ -131,7 +126,6 @@ class YueTranscribeVsZhoCli(ScinoephileCliBase):
     """Transcribe subtitles from audio and revise using standard Chinese text."""
 
     localizations = merge_localizations(
-        CONVERSION_LOCALIZATIONS,
         LLM_LOCALIZATIONS,
         YUE_TRANSCRIBE_VS_ZHO_LOCALIZATIONS,
     )
@@ -205,9 +199,6 @@ class YueTranscribeVsZhoCli(ScinoephileCliBase):
                 "Whisper model identifier used for transcription (default: %(default)s)"
             ),
         )
-        add_opencc_convert_argument(
-            arg_groups["operation arguments"], arg_groups["additional help"]
-        )
         add_llm_provider_args(
             arg_groups["llm arguments"], arg_groups["additional help"]
         )
@@ -267,7 +258,6 @@ class YueTranscribeVsZhoCli(ScinoephileCliBase):
         zho_infile_path: Path | str,
         stream_index: int | None,
         script: str,
-        convert: OpenCCConfig | None,
         llm_args: LlmArguments,
         demucs: DemucsMode,
         vad: VADMode,
@@ -330,7 +320,6 @@ class YueTranscribeVsZhoCli(ScinoephileCliBase):
             demucs_mode=demucs,
             vad_mode=vad,
             provider=provider,
-            convert=convert,
             delineation_prompt=delineation_prompt,
             punctuation_prompt=punctuation_prompt,
             additional_context=additional_context,

--- a/scinoephile/multilang/yue_zho/transcription/__init__.py
+++ b/scinoephile/multilang/yue_zho/transcription/__init__.py
@@ -18,7 +18,6 @@ from scinoephile.audio.subtitles import AudioSeries
 from scinoephile.core.llms import LLMProvider, TestCase
 from scinoephile.core.paths import get_runtime_cache_dir_path
 from scinoephile.core.subtitles import Series
-from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.llms import load_default_test_cases
 from scinoephile.llms.delineation import DelineationManager, DelineationPrompt
 from scinoephile.llms.providers.registry import get_provider
@@ -90,8 +89,6 @@ class YueZhoTranscriberKwargs(TypedDict, total=False):
     """Whisper VAD mode for transcription."""
     provider: LLMProvider | None
     """provider to use for queries."""
-    convert: OpenCCConfig | None
-    """OpenCC configuration used for transcribed text conversion."""
     delineation_prompt: DelineationPrompt
     """prompt used for alignment delineation."""
     punctuation_prompt: PunctuationPrompt
@@ -108,7 +105,6 @@ def get_yue_transcribed_vs_zho(
     yuewen: AudioSeries,
     zhongwen: Series,
     transcriber: YueTranscriber | None = None,
-    convert: OpenCCConfig | None = None,
     **kwargs: Unpack[YueZhoTranscriptionKwargs],
 ) -> AudioSeries:
     """Get initial written Cantonese transcription aligned to standard Chinese.
@@ -117,13 +113,12 @@ def get_yue_transcribed_vs_zho(
         yuewen: nascent written Cantonese audio subtitle series
         zhongwen: standard Chinese subtitle series
         transcriber: transcriber to use
-        convert: OpenCC configuration used for transcribed text conversion
         **kwargs: additional keyword arguments for YueTranscriber.process_all_blocks
     Returns:
         transcribed written Cantonese subtitle series
     """
     if transcriber is None:
-        transcriber = get_yue_vs_zho_transcriber(convert=convert)
+        transcriber = get_yue_vs_zho_transcriber()
     return transcriber.process_all_blocks(yuewen, zhongwen, **kwargs)
 
 
@@ -132,7 +127,6 @@ def get_yue_vs_zho_transcriber(
     demucs_mode: DemucsMode = DemucsMode.OFF,
     vad_mode: VADMode = VADMode.AUTO,
     provider: LLMProvider | None = None,
-    convert: OpenCCConfig | None = None,
     additional_context: str | None = None,
     delineation_prompt: DelineationPrompt = (YueDelineationVsZhoPromptYueHans),
     punctuation_prompt: PunctuationPrompt = (YuePunctuationVsZhoPromptYueHans),
@@ -147,7 +141,6 @@ def get_yue_vs_zho_transcriber(
         demucs_mode: Demucs preprocessing mode for transcription
         vad_mode: Whisper VAD mode for transcription
         provider: provider to use for queries
-        convert: OpenCC configuration used for transcribed text conversion
         additional_context: additional context to include in LLM prompts
         delineation_prompt: prompt for alignment delineation
         punctuation_prompt: prompt for transcription punctuation
@@ -182,7 +175,6 @@ def get_yue_vs_zho_transcriber(
         demucs_mode=demucs_mode,
         vad_mode=vad_mode,
         provider=provider,
-        convert=convert,
         additional_context=additional_context,
         delineation_prompt=delineation_prompt,
         punctuation_prompt=punctuation_prompt,

--- a/scinoephile/multilang/yue_zho/transcription/transcriber.py
+++ b/scinoephile/multilang/yue_zho/transcription/transcriber.py
@@ -19,13 +19,11 @@ from scinoephile.audio.transcription import (
     TranscribedSegment,
     WhisperTranscriber,
     get_segment_split_on_whitespace,
-    get_segment_zho_converted,
 )
 from scinoephile.common.validation import val_input_dir_path
 from scinoephile.core.llms import LLMProvider, Queryer, TestCase
 from scinoephile.core.paths import get_runtime_cache_dir_path
 from scinoephile.core.subtitles import Series
-from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.llms.delineation import DelineationManager, DelineationPrompt
 from scinoephile.llms.providers.registry import get_provider
 from scinoephile.llms.punctuation import PunctuationPrompt
@@ -76,7 +74,6 @@ class YueTranscriber:
         demucs_mode: DemucsMode = DemucsMode.OFF,
         vad_mode: VADMode = VADMode.AUTO,
         provider: LLMProvider | None = None,
-        convert: OpenCCConfig | None = None,
         additional_context: str | None = None,
         delineation_prompt: DelineationPrompt,
         punctuation_prompt: PunctuationPrompt,
@@ -91,7 +88,6 @@ class YueTranscriber:
             demucs_mode: Demucs preprocessing mode for transcription
             vad_mode: Whisper VAD mode for transcription
             provider: provider to use for LLM queryers
-            convert: OpenCC configuration used to convert transcribed text
             additional_context: additional context to include in LLM prompts
             delineation_prompt: prompt for block-boundary delineation
             punctuation_prompt: prompt for line punctuation
@@ -103,7 +99,6 @@ class YueTranscriber:
         self.model_name = model_name
         self.vad_mode = vad_mode
         self.demucs_mode = demucs_mode
-        self.convert = convert
         if provider is None:
             provider = get_provider()
         self.demucs_separator = None
@@ -193,17 +188,9 @@ class YueTranscriber:
         for segment in segments:
             split_segments.extend(get_segment_split_on_whitespace(segment))
 
-        # Convert transcribed text, if applicable
-        converted_segments = split_segments
-        if self.convert is not None:
-            converted_segments = [
-                get_segment_zho_converted(segment, self.convert)
-                for segment in split_segments
-            ]
-
         # Merge segments into a series
         yuewen_block_series = get_series_from_segments(
-            converted_segments,
+            split_segments,
             audio=yuewen_block.audio,
             offset=yuewen_block[0].start,
         )

--- a/test/cli/yue/test_yue_transcribe_vs_zho_cli.py
+++ b/test/cli/yue/test_yue_transcribe_vs_zho_cli.py
@@ -16,7 +16,6 @@ from scinoephile.common.file import get_temp_file_path
 from scinoephile.common.testing import run_cli_with_args
 from scinoephile.core import ScinoephileError
 from scinoephile.core.subtitles import Series
-from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.llms.delineation import DelineationPrompt
 from scinoephile.llms.punctuation import PunctuationPrompt
 from scinoephile.multilang.yue_zho.transcription import DEFAULT_YUE_WHISPER_MODEL_NAME
@@ -47,11 +46,7 @@ def test_yue_transcribe_vs_zho_help_lists_transcription_options():
     assert stderr.getvalue() == ""
     assert "--script {simplified,traditional}" in help_text
     assert "script used for transcription prompts" in help_text
-    assert "--convert CONVERT" in normalized_help_text
-    assert (
-        "convert Chinese characters with an OpenCC code such as s2t, t2s, or s2hk"
-        in normalized_help_text
-    )
+    assert "--convert" not in normalized_help_text
     assert "--demucs {on,off}" in help_text
     assert "Demucs vocal-separation mode" in help_text
     assert "options: on, off;" in help_text
@@ -144,20 +139,20 @@ def test_yue_transcribe_vs_zho_cli_writes_stdout():
     assert_series_equal(output_series, expected_series)
 
 
-def test_yue_transcribe_vs_zho_cli_rejects_bare_convert_flag():
-    """Test written Cantonese CLI requires an explicit conversion config."""
+def test_yue_transcribe_vs_zho_cli_rejects_removed_convert_flag():
+    """Test written Cantonese CLI rejects the removed conversion option."""
     zhongwen_infile_path = test_data_root / "mnt/output/zho-Hans_ocr/fuse.srt"
     media_infile_path = "/tmp/test_media.mp4"
     with raises(SystemExit, match="2"):
         run_cli_with_args(
             YueTranscribeVsZhoCli,
             f"--media-infile {media_infile_path} "
-            f"--zho-infile {zhongwen_infile_path} --convert",
+            f"--zho-infile {zhongwen_infile_path} --convert hk2s",
         )
 
 
-def test_yue_transcribe_vs_zho_cli_keeps_script_and_convert_independent():
-    """Test written Cantonese CLI keeps prompt script separate from conversion."""
+def test_yue_transcribe_vs_zho_cli_uses_selected_prompt_script():
+    """Test written Cantonese CLI uses prompts for the selected script."""
     zhongwen_infile_path = test_data_root / "mnt/output/zho-Hans_ocr/fuse.srt"
     media_infile_path = "/tmp/test_media.mp4"
     expected_series = Series.from_string(
@@ -172,17 +167,15 @@ def test_yue_transcribe_vs_zho_cli_keeps_script_and_convert_independent():
         demucs_mode: object,
         vad_mode: object,
         provider: object,
-        convert: OpenCCConfig | None,
         delineation_prompt: DelineationPrompt,
         punctuation_prompt: PunctuationPrompt,
         additional_context: str | None,
     ) -> str:
-        """Validate script and conversion options passed by the CLI."""
+        """Validate prompt script options passed by the CLI."""
         assert model_name == DEFAULT_YUE_WHISPER_MODEL_NAME
         assert demucs_mode is not None
         assert vad_mode is not None
         assert provider is not None
-        assert convert == OpenCCConfig.hk2s
         assert delineation_prompt is YueDelineationVsZhoPromptYueHant
         assert punctuation_prompt is YuePunctuationVsZhoPromptYueHant
         assert additional_context is None
@@ -204,7 +197,7 @@ def test_yue_transcribe_vs_zho_cli_keeps_script_and_convert_independent():
                     YueTranscribeVsZhoCli,
                     f"--media-infile {media_infile_path} "
                     f"--zho-infile {zhongwen_infile_path} "
-                    "--script traditional --convert hk2s",
+                    "--script traditional",
                 )
 
 

--- a/test/data/kob/create_output.py
+++ b/test/data/kob/create_output.py
@@ -11,7 +11,6 @@ from scinoephile.analysis.diff import SeriesDiff
 from scinoephile.common.logs import set_logging_verbosity
 from scinoephile.core import Language
 from scinoephile.core.subtitles import Series
-from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.multilang.yue_zho.review import (
     YueZhoGuidedReviewPromptYueHans,
     YueZhoGuidedReviewPromptYueHant,
@@ -120,7 +119,6 @@ if "yue-Hans_transcribe" in actions:
             "model_name": "khleeloo/whisper-large-v3-cantonese",
             "demucs_mode": DemucsMode.ON,
             "vad_mode": VADMode.AUTO,
-            "convert": OpenCCConfig.hk2s,
             "delineation_prompt": YueDelineationVsZhoPromptYueHans,
             "punctuation_prompt": YuePunctuationVsZhoPromptYueHans,
         },
@@ -141,7 +139,6 @@ if "yue-Hans_transcribe" in actions:
             "model_name": "khleeloo/whisper-large-v3-cantonese",
             "demucs_mode": DemucsMode.ON,
             "vad_mode": VADMode.AUTO,
-            "convert": OpenCCConfig.s2hk,
             "delineation_prompt": YueDelineationVsZhoPromptYueHant,
             "punctuation_prompt": YuePunctuationVsZhoPromptYueHant,
         },

--- a/test/data/mlamd/create_output.py
+++ b/test/data/mlamd/create_output.py
@@ -12,7 +12,6 @@ from scinoephile.common.logs import set_logging_verbosity
 from scinoephile.core import Language
 from scinoephile.core.ml import get_torch_device
 from scinoephile.core.subtitles import Series, get_series_with_subs_merged
-from scinoephile.lang.zho.script.conversion import OpenCCConfig
 from scinoephile.multilang.review.guided import get_guided_reviewer
 from scinoephile.multilang.review.pairwise import get_pairwise_reviewer
 from scinoephile.multilang.translation.gap import get_gap_translator
@@ -79,7 +78,6 @@ if "yue-Hans_transcribe" in actions:
     yue_hans = AudioSeries.load(audio_path)
     transcriber = get_yue_vs_zho_transcriber(
         vad_mode=VADMode.ON,
-        convert=OpenCCConfig.hk2s,
         test_case_directory_path=output_path
         / "yue-Hans_transcribe"
         / "multilang/yue_zho",


### PR DESCRIPTION
## Summary

- remove Chinese script conversion from audio transcription and the Yue/Zho transcriber API
- remove the transcription CLI's `--convert` option while retaining `--script` for prompt selection
- update transcription data-generation callers and CLI coverage

## Rationale

OpenCC conversion is not safe at the timed-word layer: phrase conversion can change character counts and boundaries, so redistributing converted text according to the original word lengths can corrupt the text-to-timing mapping. Script conversion remains available as an explicit downstream text-processing operation.

## Tests

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format ...`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix ...`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check ...`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` (1,788 passed, 9 skipped)