### PR TITLE
Derive transcription prompts from runtime registry

### DIFF
--- a/docs/PROMPT_OPTIMIZATION.md
+++ b/docs/PROMPT_OPTIMIZATION.md
@@ -17,8 +17,8 @@ content-addressed name.
 
 ## Catalog composition
 
-Prompt-owning modules in `lang` expose their defaults through read-only
-`DEFAULT_PROMPTS` mappings. The application catalog in
+Prompt-owning modules in `lang` expose their defaults through read-only prompt or
+operation-specification mappings. The application catalog in
 `workflows.prompt_catalog` assigns stable aliases and pairs each prompt with the
 manager defining its operation. It rejects duplicate aliases during composition.
 

--- a/docs/PROMPT_OPTIMIZATION.md
+++ b/docs/PROMPT_OPTIMIZATION.md
@@ -17,8 +17,8 @@ content-addressed name.
 
 ## Catalog composition
 
-Prompt-owning modules in `lang` expose their defaults through read-only prompt or
-operation-specification mappings. The application catalog in
+Prompt-owning modules in `lang` expose their defaults through read-only
+`DEFAULT_PROMPTS` or `DEFAULT_SPECS` mappings. The application catalog in
 `workflows.prompt_catalog` assigns stable aliases and pairs each prompt with the
 manager defining its operation. It rejects duplicate aliases during composition.
 

--- a/scinoephile/lang/transcription/__init__.py
+++ b/scinoephile/lang/transcription/__init__.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from .aligner import TranscriptionAligner
 from .alignment import TranscriptionAlignment
-from .guided import GuidedTranscriptionSpec
+from .guided import GuidedTranscriptionSpec, TranscriptionLanguageSpec
 from .processor import DemucsMode, GuidedTranscriptionProcessor, VADMode
 
 __all__ = [
@@ -22,5 +22,6 @@ __all__ = [
     "GuidedTranscriptionSpec",
     "TranscriptionAligner",
     "TranscriptionAlignment",
+    "TranscriptionLanguageSpec",
     "VADMode",
 ]

--- a/scinoephile/lang/transcription/guided.py
+++ b/scinoephile/lang/transcription/guided.py
@@ -33,7 +33,6 @@ from .processor import (
 )
 
 __all__ = [
-    "DEFAULT_LANGUAGE_SPECS",
     "DEFAULT_SPECS",
     "GuidedTranscriptionSpec",
     "TranscriptionLanguageSpec",
@@ -86,19 +85,12 @@ _YUE_LANGUAGE_SPEC = TranscriptionLanguageSpec(
 """Transcription-language specification for written Cantonese."""
 
 
-DEFAULT_LANGUAGE_SPECS: Mapping[Language, TranscriptionLanguageSpec] = MappingProxyType(
-    {
-        Language.yue_hans: _YUE_LANGUAGE_SPEC,
-        Language.yue_hant: _YUE_LANGUAGE_SPEC,
-    }
-)
-"""Transcription-language specifications keyed by output language."""
-
-
 @dataclass(frozen=True, slots=True, kw_only=True)
 class GuidedTranscriptionSpec:
     """Configuration for one transcription/reference language pair."""
 
+    language_spec: TranscriptionLanguageSpec
+    """Configuration for the transcription language."""
     delineation_prompt: DelineationPrompt
     """Prompt for moving transcription text between reference subtitles."""
     punctuation_prompt: PunctuationPrompt
@@ -112,6 +104,7 @@ class GuidedTranscriptionSpec:
 
 
 _YUE_HANS_SPEC = GuidedTranscriptionSpec(
+    language_spec=_YUE_LANGUAGE_SPEC,
     delineation_prompt=YueZhoDelineationPromptYueHans,
     punctuation_prompt=YueZhoPunctuationPromptYueHans,
     test_case_dir_path=Path("lang/yue_zho/transcription"),
@@ -121,6 +114,7 @@ _YUE_HANS_SPEC = GuidedTranscriptionSpec(
 """Guided transcription specification for simplified written Cantonese."""
 
 _YUE_HANT_SPEC = GuidedTranscriptionSpec(
+    language_spec=_YUE_LANGUAGE_SPEC,
     delineation_prompt=YueZhoDelineationPromptYueHant,
     punctuation_prompt=YueZhoPunctuationPromptYueHant,
     test_case_dir_path=Path("lang/yue_zho/transcription"),
@@ -198,7 +192,7 @@ def get_guided_transcriber(
             f"{language.tag} <- {reference_language.tag}"
         )
     spec = DEFAULT_SPECS[key]
-    language_spec = DEFAULT_LANGUAGE_SPECS[language]
+    language_spec = spec.language_spec
 
     if model_name is None:
         model_name = language_spec.model_name

--- a/scinoephile/lang/transcription/guided.py
+++ b/scinoephile/lang/transcription/guided.py
@@ -14,7 +14,6 @@ from scinoephile.core import Language, ScinoephileError
 from scinoephile.core.llms import LLMProvider, Queryer, TestCase
 from scinoephile.core.paths import get_runtime_cache_dir_path
 from scinoephile.lang.yue_zho.transcription import (
-    DEFAULT_YUE_WHISPER_MODEL_NAME,
     YueZhoDelineationPromptYueHans,
     YueZhoDelineationPromptYueHant,
     YueZhoPunctuationPromptYueHans,
@@ -34,8 +33,10 @@ from .processor import (
 )
 
 __all__ = [
+    "DEFAULT_LANGUAGE_SPECS",
     "DEFAULT_SPECS",
     "GuidedTranscriptionSpec",
+    "TranscriptionLanguageSpec",
     "get_guided_transcriber",
 ]
 
@@ -66,13 +67,38 @@ _YUE_ZHO_PUNCTUATION_JSON_PATHS = (
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
-class GuidedTranscriptionSpec:
-    """Configuration for one transcription/reference language pair."""
+class TranscriptionLanguageSpec:
+    """Configuration for one transcription language."""
 
     model_name: str
     """Default Whisper model name."""
     whisper_language: str
     """Language code passed to Whisper."""
+    segment_splitter: TranscribedSegmentSplitter | None = None
+    """Strategy for splitting raw Whisper segments."""
+
+
+_YUE_LANGUAGE_SPEC = TranscriptionLanguageSpec(
+    model_name="khleeloo/whisper-large-v3-cantonese",
+    whisper_language="yue",
+    segment_splitter=get_segment_split_on_whitespace,
+)
+"""Transcription-language specification for written Cantonese."""
+
+
+DEFAULT_LANGUAGE_SPECS: Mapping[Language, TranscriptionLanguageSpec] = MappingProxyType(
+    {
+        Language.yue_hans: _YUE_LANGUAGE_SPEC,
+        Language.yue_hant: _YUE_LANGUAGE_SPEC,
+    }
+)
+"""Transcription-language specifications keyed by output language."""
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class GuidedTranscriptionSpec:
+    """Configuration for one transcription/reference language pair."""
+
     delineation_prompt: DelineationPrompt
     """Prompt for moving transcription text between reference subtitles."""
     punctuation_prompt: PunctuationPrompt
@@ -83,31 +109,23 @@ class GuidedTranscriptionSpec:
     """Bundled delineation test-case JSON paths."""
     punctuation_json_paths: tuple[Path, ...] = ()
     """Bundled punctuation test-case JSON paths."""
-    segment_splitter: TranscribedSegmentSplitter | None = None
-    """Strategy for splitting raw Whisper segments."""
 
 
 _YUE_HANS_SPEC = GuidedTranscriptionSpec(
-    model_name=DEFAULT_YUE_WHISPER_MODEL_NAME,
-    whisper_language="yue",
     delineation_prompt=YueZhoDelineationPromptYueHans,
     punctuation_prompt=YueZhoPunctuationPromptYueHans,
     test_case_dir_path=Path("lang/yue_zho/transcription"),
     delineation_json_paths=_YUE_ZHO_DELINEATION_JSON_PATHS,
     punctuation_json_paths=_YUE_ZHO_PUNCTUATION_JSON_PATHS,
-    segment_splitter=get_segment_split_on_whitespace,
 )
 """Guided transcription specification for simplified written Cantonese."""
 
 _YUE_HANT_SPEC = GuidedTranscriptionSpec(
-    model_name=DEFAULT_YUE_WHISPER_MODEL_NAME,
-    whisper_language="yue",
     delineation_prompt=YueZhoDelineationPromptYueHant,
     punctuation_prompt=YueZhoPunctuationPromptYueHant,
     test_case_dir_path=Path("lang/yue_zho/transcription"),
     delineation_json_paths=_YUE_ZHO_DELINEATION_JSON_PATHS,
     punctuation_json_paths=_YUE_ZHO_PUNCTUATION_JSON_PATHS,
-    segment_splitter=get_segment_split_on_whitespace,
 )
 """Guided transcription specification for traditional written Cantonese."""
 
@@ -180,9 +198,10 @@ def get_guided_transcriber(
             f"{language.tag} <- {reference_language.tag}"
         )
     spec = DEFAULT_SPECS[key]
+    language_spec = DEFAULT_LANGUAGE_SPECS[language]
 
     if model_name is None:
-        model_name = spec.model_name
+        model_name = language_spec.model_name
     if delineation_prompt is None:
         delineation_prompt = spec.delineation_prompt
     if punctuation_prompt is None:
@@ -239,9 +258,9 @@ def get_guided_transcriber(
         language=language,
         reference_language=reference_language,
         model_name=model_name,
-        whisper_language=spec.whisper_language,
+        whisper_language=language_spec.whisper_language,
         aligner=aligner,
         demucs_mode=demucs_mode,
         vad_mode=vad_mode,
-        segment_splitter=spec.segment_splitter,
+        segment_splitter=language_spec.segment_splitter,
     )

--- a/scinoephile/lang/yue_zho/transcription.py
+++ b/scinoephile/lang/yue_zho/transcription.py
@@ -15,17 +15,11 @@ from scinoephile.llms.delineation import DelineationPrompt
 from scinoephile.llms.punctuation import PunctuationPrompt
 
 __all__ = [
-    "DEFAULT_YUE_WHISPER_MODEL_NAME",
     "YueZhoDelineationPromptYueHans",
     "YueZhoDelineationPromptYueHant",
     "YueZhoPunctuationPromptYueHans",
     "YueZhoPunctuationPromptYueHant",
 ]
-
-
-DEFAULT_YUE_WHISPER_MODEL_NAME = "khleeloo/whisper-large-v3-cantonese"
-"""Default Whisper model name for written Cantonese transcription."""
-
 
 YueZhoDelineationPromptYueHant = DelineationPrompt(
     language=Language.yue_hant,

--- a/scinoephile/workflows/prompt_catalog.py
+++ b/scinoephile/workflows/prompt_catalog.py
@@ -10,18 +10,13 @@ from types import MappingProxyType
 import scinoephile.lang.review.guided as guided_review
 import scinoephile.lang.review.pairwise as pairwise_review
 import scinoephile.lang.review.standard as review
+import scinoephile.lang.transcription.guided as guided_transcription
 import scinoephile.lang.translation.gap as gap_translation
 import scinoephile.lang.translation.guided as guided_translation
 import scinoephile.lang.translation.standard as translation
 from scinoephile.core import Language
 from scinoephile.core.llms import Manager, Prompt
 from scinoephile.lang import ocr_fusion
-from scinoephile.lang.yue_zho.transcription import (
-    YueZhoDelineationPromptYueHans,
-    YueZhoDelineationPromptYueHant,
-    YueZhoPunctuationPromptYueHans,
-    YueZhoPunctuationPromptYueHant,
-)
 from scinoephile.llms.delineation import DelineationManager
 from scinoephile.llms.gap_translation import GapTranslationManager
 from scinoephile.llms.guided_review import GuidedReviewManager
@@ -70,24 +65,7 @@ def _build_prompt_specs() -> Mapping[str, PromptSpec]:
             guided_translation.DEFAULT_PROMPTS,
             separator="to",
         ),
-        {
-            "delineation-yue-hans-vs-zho": PromptSpec(
-                manager_cls=DelineationManager,
-                prompt=YueZhoDelineationPromptYueHans,
-            ),
-            "delineation-yue-hant-vs-zho": PromptSpec(
-                manager_cls=DelineationManager,
-                prompt=YueZhoDelineationPromptYueHant,
-            ),
-            "punctuation-yue-hans-vs-zho": PromptSpec(
-                manager_cls=PunctuationManager,
-                prompt=YueZhoPunctuationPromptYueHans,
-            ),
-            "punctuation-yue-hant-vs-zho": PromptSpec(
-                manager_cls=PunctuationManager,
-                prompt=YueZhoPunctuationPromptYueHant,
-            ),
-        },
+        _build_transcription_prompt_specs(guided_transcription.DEFAULT_SPECS),
     )
 
     prompt_specs: dict[str, PromptSpec] = {}
@@ -146,6 +124,48 @@ def _build_pair_prompt_specs(
         )
         for (first_language, second_language), prompt in prompts.items()
     }
+
+
+def _build_transcription_prompt_specs(
+    specs: Mapping[
+        tuple[Language, Language],
+        guided_transcription.GuidedTranscriptionSpec,
+    ],
+) -> dict[str, PromptSpec]:
+    """Build prompt specifications for guided transcription.
+
+    Reference-script variants that share a prompt use one stable language-code alias.
+
+    Arguments:
+        specs: guided transcription specifications keyed by language pair
+    Returns:
+        prompt specifications keyed by stable alias
+    Raises:
+        ValueError: if one alias resolves to conflicting prompts
+    """
+    prompt_specs: dict[str, PromptSpec] = {}
+    for (language, reference_language), spec in specs.items():
+        reference_code = reference_language.tag.partition("-")[0].lower()
+        entries = (
+            (
+                f"{DelineationManager.operation}-{language.tag.lower()}-"
+                f"vs-{reference_code}",
+                PromptSpec(DelineationManager, spec.delineation_prompt),
+            ),
+            (
+                f"{PunctuationManager.operation}-{language.tag.lower()}-"
+                f"vs-{reference_code}",
+                PromptSpec(PunctuationManager, spec.punctuation_prompt),
+            ),
+        )
+        for alias, prompt_spec in entries:
+            existing_prompt_spec = prompt_specs.get(alias)
+            if existing_prompt_spec is not None and existing_prompt_spec != prompt_spec:
+                raise ValueError(
+                    f"Conflicting guided transcription prompt alias: {alias}"
+                )
+            prompt_specs[alias] = prompt_spec
+    return prompt_specs
 
 
 PROMPT_SPECS: Mapping[str, PromptSpec] = _build_prompt_specs()

--- a/scinoephile/workflows/prompt_catalog.py
+++ b/scinoephile/workflows/prompt_catalog.py
@@ -146,21 +146,15 @@ def _build_transcription_prompt_specs(
     prompt_specs: dict[str, PromptSpec] = {}
     for (language, reference_language), spec in specs.items():
         reference_code = reference_language.tag.partition("-")[0].lower()
-        entries = (
-            (
-                f"{DelineationManager.operation}-{language.tag.lower()}-"
-                f"vs-{reference_code}",
-                PromptSpec(DelineationManager, spec.delineation_prompt),
-            ),
-            (
-                f"{PunctuationManager.operation}-{language.tag.lower()}-"
-                f"vs-{reference_code}",
-                PromptSpec(PunctuationManager, spec.punctuation_prompt),
-            ),
-        )
-        for alias, prompt_spec in entries:
-            existing_prompt_spec = prompt_specs.get(alias)
-            if existing_prompt_spec is not None and existing_prompt_spec != prompt_spec:
+        for manager_cls, prompt in (
+            (DelineationManager, spec.delineation_prompt),
+            (PunctuationManager, spec.punctuation_prompt),
+        ):
+            alias = (
+                f"{manager_cls.operation}-{language.tag.lower()}-vs-{reference_code}"
+            )
+            prompt_spec = PromptSpec(manager_cls=manager_cls, prompt=prompt)
+            if alias in prompt_specs and prompt_specs[alias] != prompt_spec:
                 raise ValueError(
                     f"Conflicting guided transcription prompt alias: {alias}"
                 )

--- a/test/lang/transcription/test_guided.py
+++ b/test/lang/transcription/test_guided.py
@@ -12,7 +12,6 @@ from pytest import raises
 from scinoephile.core import Language, ScinoephileError
 from scinoephile.core.llms import LLMProvider
 from scinoephile.lang.transcription.guided import (
-    DEFAULT_LANGUAGE_SPECS,
     DEFAULT_SPECS,
     get_guided_transcriber,
 )
@@ -24,18 +23,12 @@ from scinoephile.lang.yue_zho.transcription import (
 
 def test_default_specs_are_read_only_and_cover_yue_zho_scripts():
     """Test default specs cover both scripts for target and reference Chinese."""
-    assert set(DEFAULT_LANGUAGE_SPECS) == {Language.yue_hans, Language.yue_hant}
-    assert (
-        DEFAULT_LANGUAGE_SPECS[Language.yue_hans]
-        is DEFAULT_LANGUAGE_SPECS[Language.yue_hant]
-    )
     assert set(DEFAULT_SPECS) == {
         (Language.yue_hans, Language.zho_hans),
         (Language.yue_hans, Language.zho_hant),
         (Language.yue_hant, Language.zho_hans),
         (Language.yue_hant, Language.zho_hant),
     }
-    assert {language for language, _ in DEFAULT_SPECS} <= DEFAULT_LANGUAGE_SPECS.keys()
     assert (
         DEFAULT_SPECS[(Language.yue_hans, Language.zho_hans)]
         is DEFAULT_SPECS[(Language.yue_hans, Language.zho_hant)]
@@ -44,14 +37,15 @@ def test_default_specs_are_read_only_and_cover_yue_zho_scripts():
         DEFAULT_SPECS[(Language.yue_hant, Language.zho_hans)]
         is DEFAULT_SPECS[(Language.yue_hant, Language.zho_hant)]
     )
+    assert (
+        DEFAULT_SPECS[(Language.yue_hans, Language.zho_hans)].language_spec
+        is DEFAULT_SPECS[(Language.yue_hant, Language.zho_hans)].language_spec
+    )
     mutable_specs = cast(dict, DEFAULT_SPECS)
     with raises(TypeError):
         mutable_specs[(Language.eng, Language.zho_hans)] = DEFAULT_SPECS[
             (Language.yue_hans, Language.zho_hans)
         ]
-    mutable_language_specs = cast(dict, DEFAULT_LANGUAGE_SPECS)
-    with raises(TypeError):
-        mutable_language_specs[Language.eng] = DEFAULT_LANGUAGE_SPECS[Language.yue_hans]
 
 
 def test_get_guided_transcriber_uses_registered_language_configuration(tmp_path):

--- a/test/lang/transcription/test_guided.py
+++ b/test/lang/transcription/test_guided.py
@@ -12,6 +12,7 @@ from pytest import raises
 from scinoephile.core import Language, ScinoephileError
 from scinoephile.core.llms import LLMProvider
 from scinoephile.lang.transcription.guided import (
+    DEFAULT_LANGUAGE_SPECS,
     DEFAULT_SPECS,
     get_guided_transcriber,
 )
@@ -23,12 +24,18 @@ from scinoephile.lang.yue_zho.transcription import (
 
 def test_default_specs_are_read_only_and_cover_yue_zho_scripts():
     """Test default specs cover both scripts for target and reference Chinese."""
+    assert set(DEFAULT_LANGUAGE_SPECS) == {Language.yue_hans, Language.yue_hant}
+    assert (
+        DEFAULT_LANGUAGE_SPECS[Language.yue_hans]
+        is DEFAULT_LANGUAGE_SPECS[Language.yue_hant]
+    )
     assert set(DEFAULT_SPECS) == {
         (Language.yue_hans, Language.zho_hans),
         (Language.yue_hans, Language.zho_hant),
         (Language.yue_hant, Language.zho_hans),
         (Language.yue_hant, Language.zho_hant),
     }
+    assert {language for language, _ in DEFAULT_SPECS} <= DEFAULT_LANGUAGE_SPECS.keys()
     assert (
         DEFAULT_SPECS[(Language.yue_hans, Language.zho_hans)]
         is DEFAULT_SPECS[(Language.yue_hans, Language.zho_hant)]
@@ -42,6 +49,9 @@ def test_default_specs_are_read_only_and_cover_yue_zho_scripts():
         mutable_specs[(Language.eng, Language.zho_hans)] = DEFAULT_SPECS[
             (Language.yue_hans, Language.zho_hans)
         ]
+    mutable_language_specs = cast(dict, DEFAULT_LANGUAGE_SPECS)
+    with raises(TypeError):
+        mutable_language_specs[Language.eng] = DEFAULT_LANGUAGE_SPECS[Language.yue_hans]
 
 
 def test_get_guided_transcriber_uses_registered_language_configuration(tmp_path):

--- a/test/workflows/test_prompt_catalog.py
+++ b/test/workflows/test_prompt_catalog.py
@@ -10,6 +10,7 @@ from types import MappingProxyType
 import scinoephile.lang.review.guided as guided_review
 import scinoephile.lang.review.pairwise as pairwise_review
 import scinoephile.lang.review.standard as review
+import scinoephile.lang.transcription.guided as guided_transcription
 import scinoephile.lang.translation.gap as gap_translation
 import scinoephile.lang.translation.guided as guided_translation
 import scinoephile.lang.translation.standard as translation
@@ -35,6 +36,8 @@ def test_prompt_catalog_and_domain_mappings_are_read_only():
         translation.DEFAULT_PROMPTS,
         ocr_fusion.DEFAULT_PROMPTS,
         review.DEFAULT_PROMPTS,
+        guided_transcription.DEFAULT_LANGUAGE_SPECS,
+        guided_transcription.DEFAULT_SPECS,
     )
 
     assert all(isinstance(mapping, MappingProxyType) for mapping in mappings)
@@ -50,6 +53,19 @@ def test_prompt_catalog_is_stable_and_manager_compatible():
             prompt_spec.manager_cls,
         )
         assert isinstance(persisted.language, Language)
+
+
+def test_prompt_catalog_contains_registered_transcription_prompts():
+    """Each guided transcription spec should contribute its prompts to the catalog."""
+    for (
+        language,
+        reference_language,
+    ), spec in guided_transcription.DEFAULT_SPECS.items():
+        reference_code = reference_language.tag.partition("-")[0].lower()
+        delineation_alias = f"delineation-{language.tag.lower()}-vs-{reference_code}"
+        punctuation_alias = f"punctuation-{language.tag.lower()}-vs-{reference_code}"
+        assert PROMPT_SPECS[delineation_alias].prompt is spec.delineation_prompt
+        assert PROMPT_SPECS[punctuation_alias].prompt is spec.punctuation_prompt
 
 
 def test_prompt_catalog_synchronizes(tmp_path: Path):

--- a/test/workflows/test_prompt_catalog.py
+++ b/test/workflows/test_prompt_catalog.py
@@ -36,7 +36,6 @@ def test_prompt_catalog_and_domain_mappings_are_read_only():
         translation.DEFAULT_PROMPTS,
         ocr_fusion.DEFAULT_PROMPTS,
         review.DEFAULT_PROMPTS,
-        guided_transcription.DEFAULT_LANGUAGE_SPECS,
         guided_transcription.DEFAULT_SPECS,
     )
 


### PR DESCRIPTION
## Summary

- model reusable transcription-language backend settings separately and compose them into each guided language-pair specification
- derive delineation and punctuation optimization prompts from the single guided transcription registry
- preserve the existing stable prompt aliases while collapsing shared reference-script variants
- update registry documentation and coverage

## Why

The runtime transcription registry and optimization prompt catalog previously registered the same prompts independently. A newly supported transcription pair could therefore work at runtime without appearing in prompt optimization. The default Whisper model also lived in the Yue/Zho pair module even though it is a transcription-language setting.

## Impact

The guided transcription registry is now the sole runtime registry and the source of truth for optimization catalog composition. Reusable language settings are embedded in its pair specifications rather than maintained in a second mapping. Existing prompt aliases and behavior are unchanged.

## Validation

- `uv run ruff format` on changed Python files
- `uv run ruff check --fix` on changed Python files
- `uv run ty check` on changed Python files
- focused transcription, prompt-catalog, and architecture tests (15 passed)
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` (1,799 passed, 9 skipped)
