### PR TITLE
Document language-pair package naming

### DIFF
--- a/scinoephile/lang/__init__.py
+++ b/scinoephile/lang/__init__.py
@@ -7,4 +7,7 @@ Package hierarchy (modules may import from any above):
 * yue
 * eng_yue / eng_zho / id / ocr_fusion / yue_eng / yue_zho / zho_eng / zho_yue
 * review / transcription / translation
+
+Directional language-pair package names put the primary or result language first and
+the source, guide, or reference language second.
 """


### PR DESCRIPTION
## Summary

- document the ordering convention for directional language-pair package names in `lang/__init__.py`
- keep the convention beside the authoritative `lang` hierarchy

## Why

Names such as `eng_yue` consistently put the primary or result language first and the source, guide, or reference language second, but that convention was implicit. Documenting it reduces ambiguity for future package additions without expanding the architecture overview.

## Impact

Documentation only; no imports, APIs, or runtime behavior change.

## Validation

- `uv run ruff format scinoephile/lang/__init__.py`
- `uv run ruff check --fix scinoephile/lang/__init__.py`
- `uv run ty check scinoephile/lang/__init__.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest test_module_hierarchy.py -q` (8 passed)
