### PR TITLE
Add percentages to CER reports

### DIFF
--- a/scinoephile/analysis/character_error_rate/line_cer.py
+++ b/scinoephile/analysis/character_error_rate/line_cer.py
@@ -86,12 +86,24 @@ class LineCER:
         Returns:
             formatted character error rate summary
         """
+        if self.reference_length == 0:
+            correct_percentage = "N/A"
+            substitutions_percentage = "N/A"
+            insertions_percentage = "N/A"
+            deletions_percentage = "N/A"
+        else:
+            correct_percentage = f"{self.correct / self.reference_length:.2%}"
+            substitutions_percentage = (
+                f"{self.substitutions / self.reference_length:.2%}"
+            )
+            insertions_percentage = f"{self.insertions / self.reference_length:.2%}"
+            deletions_percentage = f"{self.deletions / self.reference_length:.2%}"
         return (
             f"CER: {self.cer}\n"
-            f"Correct: {self.correct}\n"
-            f"Substitutions: {self.substitutions}\n"
-            f"Insertions: {self.insertions}\n"
-            f"Deletions: {self.deletions}\n"
+            f"Correct: {self.correct} ({correct_percentage})\n"
+            f"Substitutions: {self.substitutions} ({substitutions_percentage})\n"
+            f"Insertions: {self.insertions} ({insertions_percentage})\n"
+            f"Deletions: {self.deletions} ({deletions_percentage})\n"
             f"Reference length: {self.reference_length}"
         )
 

--- a/scinoephile/analysis/character_error_rate/series_cer.py
+++ b/scinoephile/analysis/character_error_rate/series_cer.py
@@ -49,12 +49,24 @@ class SeriesCER:
         Returns:
             formatted character error rate summary
         """
+        if self.reference_length == 0:
+            correct_percentage = "N/A"
+            substitutions_percentage = "N/A"
+            insertions_percentage = "N/A"
+            deletions_percentage = "N/A"
+        else:
+            correct_percentage = f"{self.correct / self.reference_length:.2%}"
+            substitutions_percentage = (
+                f"{self.substitutions / self.reference_length:.2%}"
+            )
+            insertions_percentage = f"{self.insertions / self.reference_length:.2%}"
+            deletions_percentage = f"{self.deletions / self.reference_length:.2%}"
         return (
             f"CER: {self.cer}\n"
-            f"Correct: {self.correct}\n"
-            f"Substitutions: {self.substitutions}\n"
-            f"Insertions: {self.insertions}\n"
-            f"Deletions: {self.deletions}\n"
+            f"Correct: {self.correct} ({correct_percentage})\n"
+            f"Substitutions: {self.substitutions} ({substitutions_percentage})\n"
+            f"Insertions: {self.insertions} ({insertions_percentage})\n"
+            f"Deletions: {self.deletions} ({deletions_percentage})\n"
             f"Reference length: {self.reference_length}"
         )
 

--- a/test/analysis/character_error_rate/test_character_error_rate.py
+++ b/test/analysis/character_error_rate/test_character_error_rate.py
@@ -145,6 +145,34 @@ def test_line_cer(reference: str, candidate: str, expected: SeriesCERResult):
     assert result.reference_length == expected.reference_length
 
 
+def test_line_cer_string_includes_percentages():
+    """Test line-level CER output includes percentages of reference length."""
+    result = LineCER("abc", "axc")
+
+    assert str(result) == (
+        "CER: 0.3333333333333333\n"
+        "Correct: 2 (66.67%)\n"
+        "Substitutions: 1 (33.33%)\n"
+        "Insertions: 0 (0.00%)\n"
+        "Deletions: 0 (0.00%)\n"
+        "Reference length: 3"
+    )
+
+
+def test_line_cer_string_uses_na_for_empty_reference():
+    """Test line-level CER component percentages require a reference."""
+    result = LineCER("", "abc")
+
+    assert str(result) == (
+        "CER: inf\n"
+        "Correct: 0 (N/A)\n"
+        "Substitutions: 0 (N/A)\n"
+        "Insertions: 3 (N/A)\n"
+        "Deletions: 0 (N/A)\n"
+        "Reference length: 0"
+    )
+
+
 @parametrize(
     ("reference", "candidate"),
     [
@@ -163,6 +191,34 @@ def test_series_cer_ignores_separator_only_line_wrapping(
     assert result.substitutions == 0
     assert result.insertions == 0
     assert result.deletions == 0
+
+
+def test_series_cer_string_includes_percentages():
+    """Test series-level CER output includes percentages of reference length."""
+    result = SeriesCER(get_text_series("abc"), get_text_series("axc"))
+
+    assert str(result) == (
+        "CER: 0.3333333333333333\n"
+        "Correct: 2 (66.67%)\n"
+        "Substitutions: 1 (33.33%)\n"
+        "Insertions: 0 (0.00%)\n"
+        "Deletions: 0 (0.00%)\n"
+        "Reference length: 3"
+    )
+
+
+def test_series_cer_string_uses_na_for_empty_reference():
+    """Test series-level CER component percentages require a reference."""
+    result = SeriesCER(get_text_series(), get_text_series("abc"))
+
+    assert str(result) == (
+        "CER: inf\n"
+        "Correct: 0 (N/A)\n"
+        "Substitutions: 0 (N/A)\n"
+        "Insertions: 3 (N/A)\n"
+        "Deletions: 0 (N/A)\n"
+        "Reference length: 0"
+    )
 
 
 @parametrize(


### PR DESCRIPTION
## What changed

- Include reference-relative percentages for correct characters, substitutions, insertions, and deletions in `LineCER` and `SeriesCER` string reports.
- Display `N/A` for each component percentage when the normalized reference is empty.
- Add focused line- and series-level tests for populated and empty references.

## Why

Raw edit counts are difficult to interpret without the reference length. Showing percentages alongside counts makes CER reports easier to compare at a glance.

## Impact

CLI and diagnostic output that renders these CER objects now includes percentages while retaining the existing counts, aggregate CER, and reference length. Empty-reference reports remain valid and avoid division by zero by marking component percentages as unavailable.

## Root cause

The report format exposed only raw component counts even though their common denominator, the normalized reference length, was already available. Empty references require explicit handling because no meaningful reference-relative percentage exists.

## Checks

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/analysis/character_error_rate/line_cer.py scinoephile/analysis/character_error_rate/series_cer.py test/analysis/character_error_rate/test_character_error_rate.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/analysis/character_error_rate/line_cer.py scinoephile/analysis/character_error_rate/series_cer.py test/analysis/character_error_rate/test_character_error_rate.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/analysis/character_error_rate/line_cer.py scinoephile/analysis/character_error_rate/series_cer.py test/analysis/character_error_rate/test_character_error_rate.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto analysis/character_error_rate/test_character_error_rate.py` (17 passed)
