### PR TITLE
Use Unicode display width for character classification

### DIFF
--- a/scinoephile/core/text.py
+++ b/scinoephile/core/text.py
@@ -296,41 +296,17 @@ def get_char_type(char: str) -> str:
     if char in punctuation:
         return "punc"
 
-    # Check if character is full-width (CJK)
-    if any(
-        [
-            "\u4e00" <= char <= "\u9fff",  # CJK Unified Ideographs
-            "\u3400" <= char <= "\u4dbf",  # CJK Unified Ideographs Extension A
-            "\uf900" <= char <= "\ufaff",  # CJK Compatibility Ideographs
-            "\U00020000" <= char <= "\U0002a6df",  # CJK Unified Ideographs Ext B
-            "\U0002a700" <= char <= "\U0002b73f",  # CJK Unified Ideographs Ext C
-            "\U0002b740" <= char <= "\U0002b81f",  # CJK Unified Ideographs Ext D
-            "\U0002b820" <= char <= "\U0002ceaf",  # CJK Unified Ideographs Ext E
-            "\U0002ceb0" <= char <= "\U0002ebef",  # CJK Unified Ideographs Ext F
-            "\U0002ebf0" <= char <= "\U0002ee5d",  # CJK Unified Ideographs Ext I
-            "\U00030000" <= char <= "\U0003134a",  # CJK Unified Ideographs Ext G
-            "\U00031350" <= char <= "\U000323af",  # CJK Unified Ideographs Ext H
-            "\u3000" <= char <= "\u303f",  # CJK Symbols and Punctuation
-            "\uff01" <= char <= "\uff60",  # Fullwidth ASCII variants
-            "\uffe0" <= char <= "\uffe6",  # Fullwidth symbol variants
-        ]
-    ):
+    # Reject control, format, and combining characters unsupported by this model
+    if unicodedata.category(char).startswith(("C", "M")):
+        name = unicodedata.name(char, "<unnamed>")
+        raise ScinoephileError(f"Unrecognized char type for {char!r} of name {name}")
+
+    # Check Unicode characters with wide or full-width display properties
+    if unicodedata.east_asian_width(char) in {"F", "W"}:
         return "full"
 
-    # Check if character is half-width (Western)
-    if any(
-        [
-            "\u0020" <= char <= "\u007f",  # Basic Latin
-            "\u00a0" <= char <= "\u00ff",  # Latin-1 Supplement
-            "\u0100" <= char <= "\u017f",  # Latin Extended-A
-            "\u0180" <= char <= "\u024f",  # Latin Extended-B
-        ]
-    ):
-        return "half"
-
-    # Raise exception if character type is not recognized
-    name = unicodedata.name(char, "<unnamed>")
-    raise ScinoephileError(f"Unrecognized char type for {char!r} of name {name}")
+    # Treat narrow, half-width, neutral, and ambiguous characters as half-width
+    return "half"
 
 
 def is_full_width_char(char: str) -> bool:

--- a/test/analysis/diff/test_line_diff.py
+++ b/test/analysis/diff/test_line_diff.py
@@ -53,6 +53,23 @@ def test_line_diff_get_stacked_str_full_width_punctuation_placeholder():
     assert rendered.splitlines()[2] == "　"
 
 
+def test_line_diff_get_stacked_str_hiragana_placeholder():
+    """Test hiragana uses an ideographic placeholder."""
+    msg = LineDiff(
+        kind=LineDiffKind.EDIT,
+        one_lbl="one",
+        two_lbl="two",
+        one_idxs=(0,),
+        two_idxs=(0,),
+        one_texts=("で",),
+        two_texts=("",),
+    )
+
+    rendered = msg.get_stacked_str(color=False)
+
+    assert rendered.splitlines()[2] == "　"
+
+
 def test_line_diff_get_stacked_str_insert_uses_public_insert_side():
     """Test insert rendering uses the inserted side of a public `LineDiff`."""
     msg = LineDiff(

--- a/test/core/test_text.py
+++ b/test/core/test_text.py
@@ -22,10 +22,28 @@ def test_get_char_type_handles_unnamed_control_char() -> None:
         get_char_type("\x00")
 
 
+def test_get_char_type_rejects_combining_character() -> None:
+    """Combining characters cannot be represented by the two-width model."""
+    with raises(ScinoephileError, match="COMBINING ACUTE ACCENT"):
+        get_char_type("\u0301")
+
+
 @parametrize("char", ["Ｋ", "Ａ", "１", "ｋ"])
 def test_get_char_type_handles_fullwidth_latin_forms(char: str) -> None:
     """Fullwidth Latin forms are classified as full-width characters."""
     assert get_char_type(char) == "full"
+
+
+@parametrize("char", ["で", "ア"])
+def test_get_char_type_handles_japanese_wide_characters(char: str) -> None:
+    """Japanese wide characters are classified as full-width characters."""
+    assert get_char_type(char) == "full"
+
+
+@parametrize("char", ["A", "é", "Ω", "Ж", "ع", "ｱ"])
+def test_get_char_type_handles_half_width_characters(char: str) -> None:
+    """Printable non-wide characters are classified as half-width characters."""
+    assert get_char_type(char) == "half"
 
 
 @parametrize(


### PR DESCRIPTION
## What changed

- Classify printable characters with Unicode `east_asian_width`, treating `F` and `W` characters as full-width and other printable widths as half-width.
- Reject control, format, and combining characters because the existing two-width model cannot represent them.
- Add focused coverage for Japanese hiragana and katakana, half-width characters across scripts, combining characters, and line-diff placeholder rendering.

## Why

`get_char_type` used a hand-maintained list of CJK and Latin code-point ranges. That list omitted wide printable characters outside those ranges, including Japanese hiragana and katakana, so downstream rendering could choose a half-width placeholder for characters that occupy a full display cell.

## Impact

Line-diff rendering and other consumers of `get_char_type` now use Unicode display-width metadata consistently. Japanese wide characters receive ideographic placeholders, while printable narrow, half-width, neutral, and ambiguous characters remain half-width. Punctuation behavior is unchanged. This PR does not change `ChineseScript` or `Language.script`.

## Root cause

The implementation inferred display width from script-specific ranges rather than Unicode's display-width property, making the classification incomplete as additional scripts and characters were encountered.

## Checks

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/core/text.py test/core/test_text.py test/analysis/diff/test_line_diff.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/core/text.py test/core/test_text.py test/analysis/diff/test_line_diff.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/core/text.py test/core/test_text.py test/analysis/diff/test_line_diff.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto core/test_text.py analysis/diff/test_line_diff.py` (27 passed)