### PR TITLE
Preserve canonical CLI argument group order

### DIFF
--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -124,10 +124,17 @@
 ## Command Line Interface
 * In CLI modules, group arguments using the repository's standard
   `get_arg_groups_by_name(...)` helper when one is available.
-  * Standard group names are:
-    * `input arguments`
-    * `operation arguments`
-    * `output arguments`
+  * Populated groups appear in this order:
+    1. `positional arguments`
+    2. `input arguments`
+    3. `operation arguments`
+    4. `llm arguments`
+    5. `web arguments`
+    6. `output arguments`
+    7. `additional arguments`
+    8. `additional help`
+  * Omit groups that do not apply without changing the relative order of the
+    remaining groups.
   * Rename the default optional group to `additional arguments` via
     `optional_arguments_name="additional arguments"`.
 * Define CLI implementation methods with explicit keyword-only `_main`

--- a/scinoephile/cli/dictionary/build/dictionary_build_cli_base.py
+++ b/scinoephile/cli/dictionary/build/dictionary_build_cli_base.py
@@ -66,6 +66,8 @@ class DictionaryBuildCliBase(ScinoephileCliBase, ABC):
         """
         arg_groups = get_arg_groups_by_name(
             parser,
+            "input arguments",
+            "operation arguments",
             "output arguments",
             optional_arguments_name="additional arguments",
         )

--- a/scinoephile/common/argument_parsing.py
+++ b/scinoephile/common/argument_parsing.py
@@ -178,11 +178,19 @@ def get_arg_groups_by_name(
 
     action_groups = parser._action_groups  # noqa pylint: disable=protected-access
     additional_groups = {}
-    while len(action_groups) > 0:
-        ag = action_groups.pop()
+    optional_groups = {}
+    additional_help_groups = {}
+    remaining_groups = action_groups[:]
+    action_groups.clear()
+    for ag in remaining_groups:
         if ag.title in ["options", "optional arguments"]:
             ag.title = optional_arguments_name
+            optional_groups[ag.title] = ag
+            continue
         if ag.title == "positional arguments" and not ag._group_actions:
+            continue
+        if ag.title == "additional help":
+            additional_help_groups[ag.title] = ag
             continue
         if ag.title:
             additional_groups[ag.title] = ag
@@ -200,9 +208,16 @@ def get_arg_groups_by_name(
 
     action_groups.extend(leading_groups.values())
     action_groups.extend(additional_groups.values())
+    action_groups.extend(optional_groups.values())
+    action_groups.extend(additional_help_groups.values())
     action_groups.extend(trailing_groups.values())
 
-    return {**specified_groups, **additional_groups}
+    return {
+        **specified_groups,
+        **additional_groups,
+        **optional_groups,
+        **additional_help_groups,
+    }
 
 
 def get_validator[T](function: Callable[..., T], **kwargs: Any) -> Callable[[Any], T]:

--- a/test/cli/test_argument_group_order.py
+++ b/test/cli/test_argument_group_order.py
@@ -1,0 +1,61 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests for consistent argument-group order across the CLI tree."""
+
+from __future__ import annotations
+
+from argparse import ArgumentParser, _SubParsersAction  # noqa: PLC2701
+from collections.abc import Iterator
+from typing import cast
+
+from scinoephile.cli.scinoephile_cli import ScinoephileCli
+
+_GROUP_ORDER = (
+    "positional arguments",
+    "input arguments",
+    "operation arguments",
+    "llm arguments",
+    "web arguments",
+    "output arguments",
+    "additional arguments",
+    "additional help",
+)
+"""Canonical display order for populated CLI argument groups."""
+
+
+def test_cli_argument_groups_follow_canonical_order():
+    """Test every command's populated argument groups use canonical order."""
+    for path, parser in _iter_parsers(
+        ScinoephileCli.argparser(),
+        ("scinoephile",),
+    ):
+        titles = [
+            group.title
+            for group in parser._action_groups  # noqa: SLF001
+            if group._group_actions  # noqa: SLF001
+        ]
+        expected = sorted(titles, key=_GROUP_ORDER.index)
+        assert titles == expected, f"{' '.join(path)}: {titles}"
+
+
+def _iter_parsers(
+    parser: ArgumentParser,
+    path: tuple[str, ...],
+) -> Iterator[tuple[tuple[str, ...], ArgumentParser]]:
+    """Iterate over a parser and all of its subcommand parsers.
+
+    Arguments:
+        parser: current argument parser
+        path: command path corresponding to current parser
+    Yields:
+        command path and corresponding parser
+    """
+    yield path, parser
+    for action in parser._actions:  # noqa: SLF001
+        if not isinstance(action, _SubParsersAction):
+            continue
+        for name, subparser in sorted(action.choices.items()):
+            yield from _iter_parsers(
+                cast(ArgumentParser, subparser),
+                (*path, name),
+            )

--- a/test/common/argument_parsing/test_arg_groups.py
+++ b/test/common/argument_parsing/test_arg_groups.py
@@ -89,6 +89,27 @@ def test_get_arg_groups_by_name_order():
     assert first_idx < second_idx < third_idx < optional_idx
 
 
+def test_get_arg_groups_by_name_preserves_unspecified_group_order():
+    """Test unspecified argument groups retain their relative order."""
+    parser = ArgumentParser()
+    parser.add_argument_group("operation arguments")
+    parser.add_argument_group("output arguments")
+
+    get_arg_groups_by_name(
+        parser,
+        "input arguments",
+        optional_arguments_name="additional arguments",
+    )
+
+    group_titles = [ag.title for ag in parser._action_groups]
+    assert group_titles == [
+        "input arguments",
+        "operation arguments",
+        "output arguments",
+        "additional arguments",
+    ]
+
+
 def test_get_arg_groups_by_name_rename_optional():
     """Test renaming optional arguments group."""
     parser = ArgumentParser()


### PR DESCRIPTION
## What

- Preserve the relative order of argparse groups that are not explicitly requested through `get_arg_groups_by_name`.
- Keep the renamed optional-arguments group and the additional-help group in their canonical trailing positions.
- Document the canonical order for populated CLI argument groups.
- Make dictionary-build subcommands declare the earlier standard groups needed for tree-wide conformance.
- Add focused helper coverage and a recursive test of every parser in the CLI tree.

## Why

CLI help should present the same categories in the same relative order across every command and subcommand. Stable group placement makes help output easier to scan and prevents base-class and subclass parser construction order from changing the user-facing layout.

## Impact

This changes only the ordering of argument groups in generated CLI help. Argument names, parsing behavior, defaults, and command execution are unchanged. The CLI-tree test will catch future order regressions.

## Root cause

`get_arg_groups_by_name` previously removed unspecified groups by repeatedly popping from argparse's action-group list. That LIFO traversal reversed their relative order. It also treated optional and additional-help groups like ordinary unspecified groups, so their final positions depended on which parser layer called the helper.

## Checks

- `UV_CACHE_DIR=/tmp/uv-cache uv run --active ruff format` on the four changed Python files
- `UV_CACHE_DIR=/tmp/uv-cache uv run --active ruff check --fix` on the four changed Python files
- `UV_CACHE_DIR=/tmp/uv-cache uv run --active ty check` on the four changed Python files
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run --active pytest -n auto common/argument_parsing/test_arg_groups.py cli/test_argument_group_order.py` (11 passed)
- Focused dictionary-build CLI regression tests (4 passed)