### PR TITLE
Log transcription blocks with one-based numbers

### DIFF
--- a/scinoephile/lang/transcription/processor.py
+++ b/scinoephile/lang/transcription/processor.py
@@ -145,7 +145,7 @@ class GuidedTranscriptionProcessor:
                 break
             output_block = self.process_block(audio_block, reference_block)
             logger.info(
-                f"BLOCK {block_idx}:\n"
+                f"BLOCK {block_idx + 1}:\n"
                 f"REFERENCE ({self.reference_language.tag}):\n"
                 f"{reference_block.to_simple_string()}\n"
                 f"TRANSCRIPTION ({self.language.tag}):\n"

--- a/test/lang/transcription/test_processor.py
+++ b/test/lang/transcription/test_processor.py
@@ -4,10 +4,11 @@
 
 from __future__ import annotations
 
+from logging import INFO
 from unittest.mock import Mock, patch
 
 from pydub import AudioSegment
-from pytest import raises
+from pytest import LogCaptureFixture, raises
 
 from scinoephile.audio.subtitles import AudioSeries, AudioSubtitle
 from scinoephile.audio.transcription import TranscribedSegment
@@ -122,9 +123,14 @@ def test_process_block_applies_configured_segment_splitter():
     assert [subtitle.text for subtitle in transcription] == ["one", "two"]
 
 
-def test_process_uses_exclusive_stop_index():
-    """Test stop_at_idx excludes the block at that index."""
+def test_process_uses_exclusive_stop_index(caplog: LogCaptureFixture):
+    """Test stop_at_idx excludes that block while logs use one-based numbers.
+
+    Arguments:
+        caplog: captured log records
+    """
     processor, _ = _get_processor()
+    caplog.set_level(INFO, logger="scinoephile.lang.transcription.processor")
     audio_series = AudioSeries(
         audio=AudioSegment.silent(duration=6000),
         events=[
@@ -149,6 +155,8 @@ def test_process_uses_exclusive_stop_index():
     assert process_block.call_count == 1
     assert len(output) == 1
     assert output[0].text == "one"
+    assert "BLOCK 1:" in caplog.text
+    assert "BLOCK 0:" not in caplog.text
 
 
 def test_process_rejects_mismatched_block_counts():


### PR DESCRIPTION
## What changed

- Display guided-transcription block numbers as one-based values in human-facing logs.
- Extend the exclusive stop-index test with focused log assertions for `BLOCK 1` and the absence of `BLOCK 0`.

## Why

Users read these labels as ordinal block numbers, while the implementation was exposing the internal zero-based loop index.

## Impact

The first processed block is now logged as `BLOCK 1`. Processing order, stop-index semantics, transcription output, and public APIs are unchanged.

## Root cause

The log message interpolated `block_idx` directly instead of converting the internal zero-based index to its human-facing one-based number.

## Checks

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/lang/transcription/processor.py test/lang/transcription/test_processor.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/lang/transcription/processor.py test/lang/transcription/test_processor.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/lang/transcription/processor.py test/lang/transcription/test_processor.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto lang/transcription/test_processor.py` (5 passed)