### PR TITLE
Require review notes in the reviewed language

### DIFF
--- a/scinoephile/lang/eng/review.py
+++ b/scinoephile/lang/eng/review.py
@@ -31,7 +31,8 @@ GuidedReviewPromptEng = GuidedReviewPrompt(
         Do not improve style, grammar, tone, or phrasing unless the target is clearly
         erroneous. Include a revision only when a target subtitle requires a change.
         Each revision must include the target's index, its full revised text, and a
-        short note. If no revisions are needed, return an empty revisions list."""),
+        short English note. If no revisions are needed, return an empty revisions
+        list."""),
     targets="english",
     targets_desc="English target subtitles to review, in order.",
     guides="references",
@@ -43,7 +44,7 @@ GuidedReviewPromptEng = GuidedReviewPrompt(
     target_text_desc="English target subtitle text to review.",
     guide_text_desc="Reference subtitle text.",
     revision_text_desc="Full revised English target subtitle text.",
-    note_desc="Note explaining the English target subtitle revision.",
+    note_desc="English note explaining the target subtitle revision.",
 )
 """LLM correspondence text for guided review of English subtitles."""
 
@@ -55,14 +56,15 @@ PairwiseReviewPromptEng = PairwiseReviewPrompt(
         which may be in another language. Correct only clear transcription, spelling,
         or name errors supported by the reference. Do not translate the reference or
         rewrite correct English to mirror its wording. If a revision is necessary,
-        return the full revised English subtitle and a short note. If no revision is
-        necessary, return empty strings. Return "�" only when the English subtitle has
-        no corresponding content and should be removed."""),
+        return the full revised English subtitle and a short English note. If no
+        revision is necessary, return empty strings. Return "�" only when the English
+        subtitle has no corresponding content and should be removed."""),
     target="english",
     target_desc="English subtitle to review",
     reference="reference",
     reference_desc="Corresponding reference subtitle",
     output="revised_english",
+    note_desc="English note explaining the revision, or an empty string",
 )
 """LLM correspondence text for pairwise review of English subtitles."""
 
@@ -72,8 +74,9 @@ ReviewPromptEng = ReviewPrompt(
     base_system_prompt=dedent_and_compact("""
         You are responsible for proofreading English subtitles.
         Return a revision only for a subtitle that requires changes. Each revision must
-        include the subtitle's index, its full revised text, and a note describing the
-        changes made. If no revisions are needed, return an empty revisions list.
+        include the subtitle's index, its full revised text, and an English note
+        describing the changes made. If no revisions are needed, return an empty
+        revisions list.
         Make changes only when necessary to correct typographical errors.
 
         Do not add stylistic changes or improve phrasing.
@@ -91,6 +94,6 @@ ReviewPromptEng = ReviewPrompt(
     ),
     subtitle_text_desc="English subtitle text to review.",
     revision_text_desc="Full revised English subtitle text.",
-    note_desc="Note explaining the English subtitle revision.",
+    note_desc="English note explaining the subtitle revision.",
 )
 """LLM correspondence text for English review."""

--- a/scinoephile/lang/yue/review.py
+++ b/scinoephile/lang/yue/review.py
@@ -35,7 +35,7 @@ GuidedReviewPromptYueHant = GuidedReviewPrompt(
         唔好翻譯參考字幕，亦唔好為咗貼近參考字幕而改寫本來正確嘅粵文。
         唔好潤色或者改動語氣、文法、助詞、量詞同措辭。
         只有確實需要修改嘅粵文字幕先加入修改列表。每項修改必須包含字幕序號、
-        完整修訂後文本同英文備註。如果全部字幕都唔需要修改，請返回空嘅修改列表。"""),
+        完整修訂後文本同粵文備註。如果全部字幕都唔需要修改，請返回空嘅修改列表。"""),
     targets="yuewen",
     targets_desc="按順序排列、需要審核嘅粵文字幕",
     guides="cankao",
@@ -49,7 +49,7 @@ GuidedReviewPromptYueHant = GuidedReviewPrompt(
     guide_text_desc="參考字幕文本",
     revision_text_desc="修改後嘅完整粵文字幕文本",
     note="beizhu",
-    note_desc="關於粵文字幕修改嘅英文備註",
+    note_desc="關於粵文字幕修改嘅粵文備註",
     target_indices_err="查詢目標字幕序號必須由 1 開始、連續並按順序排列。",
     guide_indices_err="查詢參考字幕序號必須由 1 開始、連續並按順序排列。",
     revision_indices_err="答案修改序號必須唯一並按升序排列。",
@@ -73,7 +73,7 @@ PairwiseReviewPromptYueHant = PairwiseReviewPrompt(
         將一條粵文字幕同一條對應嘅參考字幕作比較校對；參考字幕可以係另一種語言。
         只修正參考字幕足以證實嘅明顯聽錯字、寫錯字或者名稱錯誤。
         唔好翻譯參考字幕，亦唔好改寫本來正確嘅粵文去配合參考字幕嘅措辭。
-        如果需要修改，回傳完整修訂後粵文同英文備註；如果唔需要修改，兩者都回傳空字串。
+        如果需要修改，回傳完整修訂後粵文同粵文備註；如果唔需要修改，兩者都回傳空字串。
         只有當粵文完全冇對應內容而且應該刪除時，先回傳 "�"。"""),
     target="yuewen",
     target_desc="要校對嘅粵文字幕",
@@ -81,6 +81,7 @@ PairwiseReviewPromptYueHant = PairwiseReviewPrompt(
     reference_desc="對應嘅參考字幕",
     output="xiugai",
     note="beizhu",
+    note_desc="改動説明（粵文）；如果唔需要修改請回傳空字串",
 )
 """LLM correspondence text for pairwise review of traditional Cantonese."""
 
@@ -99,7 +100,7 @@ ReviewPromptYueHant = ReviewPrompt(
         唔好潤色、改寫、改動語氣或用詞，亦唔好根據上下文改劇情。
         如果原句本身已經係合理嘅粵語講法，請保持原文不變。
         只有喺字幕需要修改時先加入一項修改。每項修改必須包含字幕序號、
-        修訂後嘅完整文本，同埋說明修改內容嘅備註。
+        修訂後嘅完整文本，同埋說明修改內容嘅粵文備註。
         如果全部字幕都唔需要修改，請返回空嘅修改列表。"""),
     subtitles="zimu",
     subtitles_desc="按順序排列、需要校對嘅粵文字幕",
@@ -111,7 +112,7 @@ ReviewPromptYueHant = ReviewPrompt(
     subtitle_text_desc="需要校對嘅粵文字幕文本",
     revision_text_desc="修改後嘅完整粵文字幕文本",
     note="beizhu",
-    note_desc="關於粵文字幕修改嘅備註說明",
+    note_desc="關於粵文字幕修改嘅粵文備註說明",
     subtitle_indices_err="查詢字幕序號必須由 1 開始、連續並按順序排列。",
     revision_indices_err="答案修改序號必須唯一並按升序排列。",
     revision_index_missing_err_tpl="答案修改序號 {idx} 喺查詢字幕中不存在。",

--- a/scinoephile/lang/yue_zho/review.py
+++ b/scinoephile/lang/yue_zho/review.py
@@ -33,7 +33,7 @@ YueZhoGuidedReviewPromptYueHant = GuidedReviewPrompt(
         唔好評審文風、文法、語氣或者措辭；如果原句本身已經係合理嘅粵語講法，就唔好改。
         中文字幕只係參考，唔需要同粵文逐字對應。
         只有當一條粵文字幕確實需要修改時，先將佢加入修改列表。
-        每項修改必須包含字幕序號、修訂後嘅完整粵文字幕，同埋一段英文備註説明改動。
+        每項修改必須包含字幕序號、修訂後嘅完整粵文字幕，同埋一段粵文備註説明改動。
         如果全部粵文字幕都唔需要修改，請回傳空嘅修改列表。"""),
     targets="yuewen",
     targets_desc="按順序排列、需要審核嘅粵文字幕轉寫",
@@ -48,7 +48,7 @@ YueZhoGuidedReviewPromptYueHant = GuidedReviewPrompt(
     guide_text_desc="中文字幕指引文本",
     revision_text_desc="修改後嘅完整粵文字幕文本",
     note="beizhu",
-    note_desc="關於粵文字幕修改嘅英文備註",
+    note_desc="關於粵文字幕修改嘅粵文備註",
     target_indices_err="查詢粵文字幕序號必須由 1 開始、連續並按順序排列。",
     guide_indices_err="查詢中文字幕序號必須由 1 開始、連續並按順序排列。",
     revision_indices_err="答案修改序號必須唯一並按升序排列。",
@@ -76,7 +76,7 @@ YueZhoPairwiseReviewPromptYueHant = PairwiseReviewPrompt(
         唔好調整語氣、語法、助詞、量詞或者措辭，除非嗰啲地方本身就係轉寫錯誤。
         只有當你認為原句明顯有誤時，先作修改。
         如果發現粵文同中文字幕完全對唔上，請回傳字符 "�"，並喺備註説明無對應。
-        如果需要修改，回傳完整嘅修訂後粵文，並用英文一句話説明改動。
+        如果需要修改，回傳完整嘅修訂後粵文，並用粵文一句話説明改動。
         如果冇修改，修訂後粵文同備註都回傳空字串。"""),
     target="yuewen",
     target_desc="要校對嘅粵文字幕轉寫",
@@ -85,7 +85,7 @@ YueZhoPairwiseReviewPromptYueHant = PairwiseReviewPrompt(
     output="xiugai",
     output_desc='修訂後嘅粵文字幕；如果冇修改請回傳 ""，如需刪掉請回傳 "�"',
     note="beizhu",
-    note_desc="改動説明（英文）；如果冇修改請回傳空字串",
+    note_desc="改動説明（粵文）；如果冇修改請回傳空字串",
     note_missing_err="修訂後嘅粵文有改動，但答案冇提供改動説明。",
     output_missing_err="修訂後嘅粵文冇改動，但答案提供咗改動説明。",
 )

--- a/scinoephile/lang/zho/review.py
+++ b/scinoephile/lang/zho/review.py
@@ -35,7 +35,7 @@ GuidedReviewPromptZhoHant = GuidedReviewPrompt(
         不要翻譯參考字幕，也不要為了貼近參考字幕而改寫原本正確的中文。
         不要潤色或改動語氣、文法與措辭。
         只有確實需要修改的中文字幕才加入修改列表。每項修改必須包含字幕序號、
-        完整修訂後文本與簡短備註。如果全部字幕都不需要修改，請返回空的修改列表。"""),
+        完整修訂後文本與簡短中文備註。如果全部字幕都不需要修改，請返回空的修改列表。"""),
     targets="zhongwen",
     targets_desc="按順序排列、需要審核的中文字幕",
     guides="cankao",
@@ -49,7 +49,7 @@ GuidedReviewPromptZhoHant = GuidedReviewPrompt(
     guide_text_desc="參考字幕文本",
     revision_text_desc="修改後的完整中文字幕文本",
     note="beizhu",
-    note_desc="關於中文字幕修改的簡短備註",
+    note_desc="關於中文字幕修改的簡短中文備註",
     target_indices_err="查詢目標字幕序號必須從 1 開始、連續並按順序排列。",
     guide_indices_err="查詢參考字幕序號必須從 1 開始、連續並按順序排列。",
     revision_indices_err="答案修改序號必須唯一並按升序排列。",
@@ -73,7 +73,7 @@ PairwiseReviewPromptZhoHant = PairwiseReviewPrompt(
         將一條中文字幕與一條對應的參考字幕逐條比較校對；參考字幕可以使用另一種語言。
         僅修正參考字幕足以證實的明顯聽寫、用字或名稱錯誤。
         不要翻譯參考字幕，也不要改寫原本正確的中文來配合參考字幕的措辭。
-        如需修改，返回完整修訂後中文字幕與簡短備註；如無需修改，兩者均返回空字符串。
+        如需修改，返回完整修訂後中文字幕與簡短中文備註；如無需修改，兩者均返回空字符串。
         只有當中文字幕完全沒有對應內容且應刪除時，才返回 "�"。"""),
     target="zhongwen",
     target_desc="要校對的中文字幕",
@@ -81,6 +81,7 @@ PairwiseReviewPromptZhoHant = PairwiseReviewPrompt(
     reference_desc="對應的參考字幕",
     output="xiugai",
     note="beizhu",
+    note_desc="修改說明（中文）；如無需修改則返回空字符串",
 )
 """LLM correspondence text for pairwise review of traditional Chinese."""
 
@@ -99,7 +100,7 @@ ReviewPromptZhoHant = ReviewPrompt(
         不要潤色、改寫、改動語氣或用詞，也不要根據上下文改劇情。
         如果沒有明顯的錯別字或排版錯誤，請保持原文不變。
         只有在字幕需要修改時才加入一項修改。每項修改必須包含字幕序號、
-        修訂後的完整文本，以及說明修改內容的備註。
+        修訂後的完整文本，以及說明修改內容的中文備註。
         如果全部字幕都不需要修改，請返回空的修改列表。"""),
     subtitles="zimu",
     subtitles_desc="按順序排列、需要校對的中文字幕",
@@ -111,7 +112,7 @@ ReviewPromptZhoHant = ReviewPrompt(
     subtitle_text_desc="需要校對的中文字幕文本",
     revision_text_desc="修改後的完整中文字幕文本",
     note="beizhu",
-    note_desc="關於中文字幕修改的備註說明",
+    note_desc="關於中文字幕修改的中文備註說明",
     subtitle_indices_err="查詢字幕序號必須從 1 開始、連續並按順序排列。",
     revision_indices_err="答案修改序號必須唯一並按升序排列。",
     revision_index_missing_err_tpl="答案修改序號 {idx} 在查詢字幕中不存在。",

--- a/test/llms/test_prompt_metadata.py
+++ b/test/llms/test_prompt_metadata.py
@@ -11,7 +11,11 @@ from pathlib import Path
 from typing import Any, Final, cast
 from unittest.mock import Mock
 
+from scinoephile.core import Language
 from scinoephile.core.llms import LLMProvider, Manager, Prompt, Queryer
+from scinoephile.llms.guided_review import GuidedReviewManager, GuidedReviewPrompt
+from scinoephile.llms.pairwise_review import PairwiseReviewManager, PairwiseReviewPrompt
+from scinoephile.llms.review import ReviewManager, ReviewPrompt
 from scinoephile.workflows.prompt_catalog import PROMPT_SPECS
 
 _LEGACY_TEST_CASE_PROMPT_FIELDS: Final = {
@@ -99,6 +103,33 @@ def test_registered_query_and_answer_schemas_change_only_model_identifiers():
                 ensure_ascii=False,
                 separators=(",", ":"),
             )
+
+
+def test_registered_review_prompts_specify_note_language():
+    """Review prompts should request notes in the reviewed subtitle language."""
+    note_language_markers = {
+        Language.eng: "English",
+        Language.yue_hans: "粤文",
+        Language.yue_hant: "粵文",
+        Language.zho_hans: "中文",
+        Language.zho_hant: "中文",
+    }
+    review_manager_classes = {
+        GuidedReviewManager,
+        PairwiseReviewManager,
+        ReviewManager,
+    }
+
+    for alias, prompt_spec in PROMPT_SPECS.items():
+        if prompt_spec.manager_cls not in review_manager_classes:
+            continue
+        review_prompt = cast(
+            "GuidedReviewPrompt | PairwiseReviewPrompt | ReviewPrompt",
+            prompt_spec.prompt,
+        )
+        note_language = note_language_markers[review_prompt.language]
+        assert note_language in review_prompt.base_system_prompt, alias
+        assert note_language in review_prompt.note_desc, alias
 
 
 def _get_legacy_prompt(prompt: Prompt) -> Prompt:


### PR DESCRIPTION
## Summary

- require English review prompts to return English notes
- require written Cantonese review prompts to return Cantonese notes
- require standard Chinese review prompts to return Chinese notes
- cover every registered review prompt with a registry-wide metadata test

## Testing

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/lang/eng/review.py scinoephile/lang/yue/review.py scinoephile/lang/yue_zho/review.py scinoephile/lang/zho/review.py test/llms/test_prompt_metadata.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/lang/eng/review.py scinoephile/lang/yue/review.py scinoephile/lang/yue_zho/review.py scinoephile/lang/zho/review.py test/llms/test_prompt_metadata.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/lang/eng/review.py scinoephile/lang/yue/review.py scinoephile/lang/yue_zho/review.py scinoephile/lang/zho/review.py test/llms/test_prompt_metadata.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto llms/test_prompt_metadata.py`

## Notes

This intentionally changes content-addressed prompt and cache identities for the affected review prompts.