### PR TITLE
Localize Yue-Hant transcription retries

### DIFF
--- a/scinoephile/lang/yue_zho/transcription.py
+++ b/scinoephile/lang/yue_zho/transcription.py
@@ -8,7 +8,6 @@ from functools import partial
 
 from scinoephile.core import Language
 from scinoephile.core.text import dedent_and_compact
-from scinoephile.lang.eng.prompts import ENG_PROMPT_FIELDS
 from scinoephile.lang.yue.prompts import YUE_HANT_PROMPT_FIELDS
 from scinoephile.lang.zho.script.conversion import OpenCCConfig, get_zho_text_converted
 from scinoephile.llms.delineation import DelineationPrompt
@@ -23,7 +22,7 @@ __all__ = [
 
 YueZhoDelineationPromptYueHant = DelineationPrompt(
     language=Language.yue_hant,
-    **ENG_PROMPT_FIELDS,
+    **YUE_HANT_PROMPT_FIELDS,
     base_system_prompt=dedent_and_compact("""
         你負責將廣東話口語嘅粵文字幕同對應嘅中文字幕對齊。
         你會收到一條中文字幕 (zhongwen_1) 同一條初步粵文字幕 (yuewen_1)，
@@ -89,10 +88,10 @@ YueZhoPunctuationPromptYueHant = PunctuationPrompt(
     output_desc="整理同加標點後嘅粵文字幕",
     output_missing_err="答案必須包含整理同加標點後嘅粵文字幕。",
     src_1_chars_changed_err_tpl=(
-        "Answer's written Cantonese subtitle stripped of punctuation and whitespace "
-        "does not match query's written Cantonese subtitle concatenated:\n"
-        "Expected: {expected}\n"
-        "Received: {received}"
+        "回答嘅 yuewen_punctuated 移除標點同空格後，同查詢入面拼埋嘅 "
+        "yuewen_to_punctuate 唔一致：\n"
+        "期望: {expected}\n"
+        "收到: {received}"
     ),
 )
 """Text for traditional written Cantonese/standard Chinese punctuation."""

--- a/test/lang/transcription/test_guided.py
+++ b/test/lang/transcription/test_guided.py
@@ -15,6 +15,7 @@ from scinoephile.lang.transcription.guided import (
     DEFAULT_SPECS,
     get_guided_transcriber,
 )
+from scinoephile.lang.yue.prompts import YUE_HANT_PROMPT_FIELDS
 from scinoephile.lang.yue_zho.transcription import (
     YueZhoDelineationPromptYueHant,
     YueZhoPunctuationPromptYueHant,
@@ -81,3 +82,13 @@ def test_get_guided_transcriber_rejects_unsupported_language_pair():
     """Test factory rejects language pairs absent from the registry."""
     with raises(ScinoephileError, match="eng <- zho-Hans"):
         get_guided_transcriber(Language.eng, Language.zho_hans)
+
+
+def test_transcription_prompts_use_yue_hant_correspondence_fields():
+    """Test Yue-Hant transcription prompts use Yue-Hant shared text."""
+    for prompt in (
+        YueZhoDelineationPromptYueHant,
+        YueZhoPunctuationPromptYueHant,
+    ):
+        for field_name, expected in YUE_HANT_PROMPT_FIELDS.items():
+            assert getattr(prompt, field_name) == expected

--- a/test/llms/test_punctuation.py
+++ b/test/llms/test_punctuation.py
@@ -19,6 +19,7 @@ from scinoephile.core.llms.utils import (
 )
 from scinoephile.lang.yue_zho.transcription import (
     YueZhoPunctuationPromptYueHans,
+    YueZhoPunctuationPromptYueHant,
 )
 from scinoephile.llms.punctuation import (
     PunctuationManager,
@@ -102,6 +103,41 @@ def test_queryer_corresponds_using_prompt_aliases():
     }
 
 
+def test_queryer_localizes_test_case_validation_retry():
+    """Test punctuation retries use the prompt's Yue-Hant validation text."""
+    prompt = YueZhoPunctuationPromptYueHant
+    test_case_cls = PunctuationManager.get_test_case_cls(prompt)
+    subtitles = ["係", "洋文嚟嘅", "蝦即係有鬥心噉解"]
+    test_case = test_case_cls.model_validate(
+        {
+            "query": {
+                "subtitles": subtitles,
+                "guide": "是洋文！即是有鬥心",
+            }
+        }
+    )
+    provider = Mock(spec=LLMProvider)
+    provider.chat_completion.side_effect = [
+        '{"yuewen_punctuated": "係洋文嚟嘅！蝦即係有鬥心"}',
+        '{"yuewen_punctuated": "係，洋文嚟嘅！蝦即係有鬥心噉解"}',
+    ]
+    queryer = Queryer(test_case_cls, provider=provider, max_attempts=2)
+
+    queryer(test_case)
+
+    messages = provider.chat_completion.call_args_list[1].args[0]
+    assert messages[-1]["content"] == "\n".join(
+        (
+            prompt.test_case_invalid_pre,
+            prompt.src_1_chars_changed_err(
+                "".join(subtitles),
+                "係洋文嚟嘅蝦即係有鬥心",
+            ),
+            prompt.test_case_invalid_post,
+        )
+    )
+
+
 def test_query_and_answer_require_nonempty_fields():
     """Punctuation queries and answers should reject empty required fields."""
     query_cls = PunctuationManager.get_query_cls(_LOCALIZED_PROMPT)
@@ -147,7 +183,7 @@ def test_validation_and_minimum_difficulty_are_static():
     assert matching_punctuation.difficulty == 1
     assert different_punctuation.difficulty == 2
     assert direct.difficulty == 2
-    with raises(ValidationError, match="does not match"):
+    with raises(ValidationError, match="唔一致"):
         test_case_cls.model_validate(
             {
                 "query": {"subtitles": ["你好"], "guide": "你好"},


### PR DESCRIPTION
## Summary

- use shared Yue-Hant correspondence text for delineation retry messages
- localize punctuation character-mismatch errors into written Cantonese
- verify both transcription prompts use the Yue-Hant correspondence fields
- cover the full validation-retry message sent back to the provider

## Testing

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/lang/yue_zho/transcription.py test/lang/transcription/test_guided.py test/llms/test_punctuation.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/lang/yue_zho/transcription.py test/lang/transcription/test_guided.py test/llms/test_punctuation.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/lang/yue_zho/transcription.py test/lang/transcription/test_guided.py test/llms/test_punctuation.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto lang/transcription/test_guided.py llms/test_punctuation.py`

## Notes

This intentionally changes content-addressed prompt and cache identities for the affected transcription prompts.