### PR TITLE
Configure Whisper decoding options

### DIFF
--- a/scinoephile/audio/transcription/whisper_transcriber.py
+++ b/scinoephile/audio/transcription/whisper_transcriber.py
@@ -41,7 +41,7 @@ class WhisperTranscriber:
         cache_dir_path: Path | None = None,
         use_demucs: bool = False,
         use_vad: bool = True,
-        temperature: float | tuple[float, ...] = 0.0,
+        temperature: float | Sequence[float] = 0.0,
         condition_on_previous_text: bool = True,
     ):
         """Initialize.
@@ -366,7 +366,7 @@ class WhisperTranscriber:
             f"vad-{'on' if self.use_vad else 'off'}"
         )
         if self.temperature != 0.0 or not self.condition_on_previous_text:
-            if isinstance(self.temperature, tuple):
+            if isinstance(self.temperature, Sequence):
                 temperature_key = ",".join(
                     f"{temperature:g}" for temperature in self.temperature
                 )

--- a/scinoephile/audio/transcription/whisper_transcriber.py
+++ b/scinoephile/audio/transcription/whisper_transcriber.py
@@ -41,6 +41,8 @@ class WhisperTranscriber:
         cache_dir_path: Path | None = None,
         use_demucs: bool = False,
         use_vad: bool = True,
+        temperature: float | tuple[float, ...] = 0.0,
+        condition_on_previous_text: bool = True,
     ):
         """Initialize.
 
@@ -50,12 +52,17 @@ class WhisperTranscriber:
             cache_dir_path: directory in which to cache
             use_demucs: whether Demucs preprocessing was applied
             use_vad: whether to enable Whisper VAD
+            temperature: decoding temperature or fallback schedule
+            condition_on_previous_text: whether to condition each decoding window on
+                the preceding window
         """
         self.model_name = model_name
         self._model: Any | None = None
         self.language = language
         self.use_demucs = use_demucs
         self.use_vad = use_vad
+        self.temperature = temperature
+        self.condition_on_previous_text = condition_on_previous_text
         self.cache_dir_path = None
         if cache_dir_path is not None:
             self.cache_dir_path = val_output_dir_path(cache_dir_path)
@@ -150,6 +157,8 @@ class WhisperTranscriber:
                 str(temp_audio_path),
                 language=self.language,
                 vad=self.use_vad,
+                temperature=self.temperature,
+                condition_on_previous_text=self.condition_on_previous_text,
             )
         segments = [TranscribedSegment(**s) for s in result["segments"]]
         segments = self._normalize_transcription_segments(
@@ -356,5 +365,17 @@ class WhisperTranscriber:
             f"demucs-{'on' if self.use_demucs else 'off'}_"
             f"vad-{'on' if self.use_vad else 'off'}"
         )
+        if self.temperature != 0.0 or not self.condition_on_previous_text:
+            if isinstance(self.temperature, tuple):
+                temperature_key = ",".join(
+                    f"{temperature:g}" for temperature in self.temperature
+                )
+            else:
+                temperature_key = f"{self.temperature:g}"
+            cache_key += (
+                f"_temperature-{temperature_key}_"
+                "condition-on-previous-text-"
+                f"{'on' if self.condition_on_previous_text else 'off'}"
+            )
         cache_sha256 = hashlib.sha256(cache_key.encode("utf-8")).hexdigest()
         return self.cache_dir_path / f"{cache_sha256}.json"

--- a/test/audio/transcription/test_whisper_transcriber.py
+++ b/test/audio/transcription/test_whisper_transcriber.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import builtins
+import hashlib
 import os
 import sys
 from collections.abc import Mapping, Sequence
@@ -12,6 +13,7 @@ from pathlib import Path
 from textwrap import dedent
 from unittest.mock import Mock
 
+from pydub import AudioSegment
 from pytest import MonkeyPatch, importorskip, raises
 
 from scinoephile.audio.transcription import get_segment_split_at_idx
@@ -39,6 +41,8 @@ _OPTIONAL_TRANSCRIPTION_MODULES = (
         ("use_vad", True, False),
         ("model_name", "model/one", "model/two"),
         ("use_demucs", True, False),
+        ("temperature", 0.0, (0.0, 0.2, 0.4)),
+        ("condition_on_previous_text", True, False),
     ],
 )
 def test_get_cache_path_separates_configuration(
@@ -74,6 +78,40 @@ def test_get_cache_path_separates_configuration(
     assert first_cache_path.parent == tmp_path
     assert second_cache_path.parent == tmp_path
     assert first_cache_path != second_cache_path
+
+
+def test_get_cache_path_preserves_default_decoding_identity(tmp_path: Path):
+    """Test default decoding continues to use legacy Whisper cache keys."""
+    audio = Mock(raw_data=b"audio")
+    transcriber = WhisperTranscriber(
+        cache_dir_path=tmp_path,
+        model_name="custom/model",
+    )
+    audio_sha256 = hashlib.sha256(audio.raw_data).hexdigest()
+    cache_key = f"{audio_sha256}_custom/model_yue_demucs-off_vad-on"
+    expected_sha256 = hashlib.sha256(cache_key.encode("utf-8")).hexdigest()
+
+    assert transcriber._get_cache_path(audio) == tmp_path / f"{expected_sha256}.json"
+
+
+def test_transcribe_forwards_recovery_decoding_options(monkeypatch: MonkeyPatch):
+    """Test Whisper receives configured defensive decoding options."""
+    whisper = Mock()
+    whisper.transcribe.return_value = {"segments": []}
+    temperatures = (0.0, 0.2, 0.4)
+    transcriber = WhisperTranscriber(
+        model_name="custom/model",
+        temperature=temperatures,
+        condition_on_previous_text=False,
+    )
+    transcriber._model = Mock()
+    monkeypatch.setattr(transcriber, "_get_whisper_module", Mock(return_value=whisper))
+    audio = AudioSegment.silent(duration=1000)
+
+    assert transcriber(audio) == []
+    whisper.transcribe.assert_called_once()
+    assert whisper.transcribe.call_args.kwargs["temperature"] == temperatures
+    assert whisper.transcribe.call_args.kwargs["condition_on_previous_text"] is False
 
 
 @parametrize(

--- a/test/audio/transcription/test_whisper_transcriber.py
+++ b/test/audio/transcription/test_whisper_transcriber.py
@@ -94,6 +94,25 @@ def test_get_cache_path_preserves_default_decoding_identity(tmp_path: Path):
     assert transcriber._get_cache_path(audio) == tmp_path / f"{expected_sha256}.json"
 
 
+def test_get_cache_path_accepts_list_temperature_schedule(tmp_path: Path):
+    """Test list and tuple temperature schedules use the same cache key."""
+    audio = Mock(raw_data=b"audio")
+    list_transcriber = WhisperTranscriber(
+        cache_dir_path=tmp_path,
+        model_name="custom/model",
+        temperature=[0.0, 0.2, 0.4],
+    )
+    tuple_transcriber = WhisperTranscriber(
+        cache_dir_path=tmp_path,
+        model_name="custom/model",
+        temperature=(0.0, 0.2, 0.4),
+    )
+
+    assert list_transcriber._get_cache_path(audio) == tuple_transcriber._get_cache_path(
+        audio
+    )
+
+
 def test_transcribe_forwards_recovery_decoding_options(monkeypatch: MonkeyPatch):
     """Test Whisper receives configured defensive decoding options."""
     whisper = Mock()


### PR DESCRIPTION
## Summary

- make Whisper decoding temperature schedules configurable
- make conditioning on previous text configurable
- forward both options to `whisper_timestamped.transcribe`
- separate caches for non-default decoding configurations while preserving the legacy default cache identity

## Testing

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/audio/transcription/whisper_transcriber.py test/audio/transcription/test_whisper_transcriber.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/audio/transcription/whisper_transcriber.py test/audio/transcription/test_whisper_transcriber.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/audio/transcription/whisper_transcriber.py test/audio/transcription/test_whisper_transcriber.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto audio/transcription/test_whisper_transcriber.py`