### PR TITLE
Normalize the Language code API

### DIFF
--- a/scinoephile/cli/audit/audit_review_cli.py
+++ b/scinoephile/cli/audit/audit_review_cli.py
@@ -132,7 +132,7 @@ class AuditReviewCli(AuditWorkflowCliBase):
         }
         if len(detected_languages) > 1:
             languages = ", ".join(
-                sorted(language.tag for language in detected_languages)
+                sorted(language.code for language in detected_languages)
             )
             parser.error(f"Subtitle inputs have conflicting languages: {languages}")
         if not detected_languages:

--- a/scinoephile/core/language.py
+++ b/scinoephile/core/language.py
@@ -89,6 +89,11 @@ class Language(DescribedEnum):
         )
 
     @property
+    def language(self) -> str:
+        """Language component of the complete code."""
+        return self.code.partition("-")[0]
+
+    @property
     def script(self) -> ChineseScript | None:
         """Chinese script implied by this language, if any."""
         if self in (Language.yue_hans, Language.zho_hans):
@@ -96,8 +101,3 @@ class Language(DescribedEnum):
         if self in (Language.yue_hant, Language.zho_hant):
             return "traditional"
         return None
-
-    @property
-    def tag(self) -> str:
-        """Language tag."""
-        return self.value

--- a/scinoephile/core/llms/prompt.py
+++ b/scinoephile/core/llms/prompt.py
@@ -77,7 +77,7 @@ class Prompt:
         payload_json = json.dumps(
             {
                 "fields": prompt_fields,
-                "language": self.language.tag,
+                "language": self.language.code,
                 "type": type(self).__name__,
             },
             ensure_ascii=False,
@@ -85,7 +85,7 @@ class Prompt:
             sort_keys=True,
         )
         digest = hashlib.sha256(payload_json.encode()).hexdigest()[:12]
-        language_name = self.language.tag.replace("-", "_")
+        language_name = self.language.code.replace("-", "_")
         return f"{type(self).__name__}_{language_name}_{digest}"
 
     def transformed(self, language: Language, transform: Callable[[str], str]) -> Self:

--- a/scinoephile/lang/ocr_fusion.py
+++ b/scinoephile/lang/ocr_fusion.py
@@ -107,7 +107,7 @@ def get_ocr_fuser(
         ScinoephileError: if OCR fusion does not support the language
     """
     if language not in DEFAULT_PROMPTS:
-        raise ScinoephileError(f"OCR fusion does not support language {language.tag}")
+        raise ScinoephileError(f"OCR fusion does not support language {language.code}")
 
     if prompt is None:
         prompt = DEFAULT_PROMPTS[language]

--- a/scinoephile/lang/review/guided.py
+++ b/scinoephile/lang/review/guided.py
@@ -111,7 +111,7 @@ def get_guided_reviewer(
     if key not in DEFAULT_PROMPTS:
         raise ScinoephileError(
             "Guided review does not support language pair "
-            f"{language.tag} <- {guide_language.tag}"
+            f"{language.code} <- {guide_language.code}"
         )
     if prompt is None:
         prompt = DEFAULT_PROMPTS[key]

--- a/scinoephile/lang/review/pairwise.py
+++ b/scinoephile/lang/review/pairwise.py
@@ -120,7 +120,7 @@ def get_pairwise_reviewer(
     if key not in DEFAULT_PROMPTS:
         raise ScinoephileError(
             "Pairwise review does not support language pair "
-            f"{language.tag} <- {reference_language.tag}"
+            f"{language.code} <- {reference_language.code}"
         )
     if prompt is None:
         prompt = DEFAULT_PROMPTS[key]

--- a/scinoephile/lang/review/standard.py
+++ b/scinoephile/lang/review/standard.py
@@ -105,7 +105,7 @@ def get_reviewer(
         ScinoephileError: if review does not support the language
     """
     if language not in DEFAULT_PROMPTS:
-        raise ScinoephileError(f"Review does not support language {language.tag}")
+        raise ScinoephileError(f"Review does not support language {language.code}")
 
     if prompt is None:
         prompt = DEFAULT_PROMPTS[language]

--- a/scinoephile/lang/transcription/guided.py
+++ b/scinoephile/lang/transcription/guided.py
@@ -189,7 +189,7 @@ def get_guided_transcriber(
     if key not in DEFAULT_SPECS:
         raise ScinoephileError(
             "Guided transcription does not support language pair "
-            f"{language.tag} <- {reference_language.tag}"
+            f"{language.code} <- {reference_language.code}"
         )
     spec = DEFAULT_SPECS[key]
     language_spec = spec.language_spec

--- a/scinoephile/lang/transcription/processor.py
+++ b/scinoephile/lang/transcription/processor.py
@@ -146,9 +146,9 @@ class GuidedTranscriptionProcessor:
             output_block = self.process_block(audio_block, reference_block)
             logger.info(
                 f"BLOCK {block_idx + 1}:\n"
-                f"REFERENCE ({self.reference_language.tag}):\n"
+                f"REFERENCE ({self.reference_language.code}):\n"
                 f"{reference_block.to_simple_string()}\n"
-                f"TRANSCRIPTION ({self.language.tag}):\n"
+                f"TRANSCRIPTION ({self.language.code}):\n"
                 f"{output_block.to_simple_string()}"
             )
             output_events.extend(output_block.events)

--- a/scinoephile/lang/translation/gap.py
+++ b/scinoephile/lang/translation/gap.py
@@ -139,7 +139,7 @@ def get_gap_translator(
     if key not in DEFAULT_PROMPTS:
         raise ScinoephileError(
             "Gap translation does not support language pair "
-            f"{source_language.tag} -> {target_language.tag}"
+            f"{source_language.code} -> {target_language.code}"
         )
 
     if prompt is None:

--- a/scinoephile/lang/translation/guided.py
+++ b/scinoephile/lang/translation/guided.py
@@ -159,7 +159,7 @@ def get_guided_translator(
     if key not in DEFAULT_PROMPTS:
         raise ScinoephileError(
             "Guided translation does not support language pair "
-            f"{source_language.tag} -> {target_language.tag}"
+            f"{source_language.code} -> {target_language.code}"
         )
 
     if prompt is None:

--- a/scinoephile/lang/translation/standard.py
+++ b/scinoephile/lang/translation/standard.py
@@ -131,7 +131,7 @@ def get_translator(
     if key not in DEFAULT_PROMPTS:
         raise ScinoephileError(
             "Translation does not support language pair "
-            f"{source_language.tag} -> {target_language.tag}"
+            f"{source_language.code} -> {target_language.code}"
         )
 
     if prompt is None:

--- a/scinoephile/lang/zho/subtitles/analysis.py
+++ b/scinoephile/lang/zho/subtitles/analysis.py
@@ -172,7 +172,7 @@ def _get_image_subtitle_sample_analysis(
         traditional_count=reference_analysis.traditional_count,
         shared_count=reference_analysis.shared_count,
         sample_indexes=tuple(sample_indexes),
-        ocr_languages=tuple(language.tag for language in _ZHO_SUBTITLE_OCR_LANGUAGES),
+        ocr_languages=tuple(language.code for language in _ZHO_SUBTITLE_OCR_LANGUAGES),
         failure_reason=failure_reason,
     )
 
@@ -206,7 +206,7 @@ def _get_subtitle_analysis_cache_path(
         "codec_name": stream.codec_name,
         "sample_size": sample_size,
         "ocr_languages": tuple(
-            language.tag for language in _ZHO_SUBTITLE_OCR_LANGUAGES
+            language.code for language in _ZHO_SUBTITLE_OCR_LANGUAGES
         ),
     }
     encoded_payload = json.dumps(payload, sort_keys=True).encode("utf-8")

--- a/scinoephile/optimization/persistence/prompts/id.py
+++ b/scinoephile/optimization/persistence/prompts/id.py
@@ -30,7 +30,7 @@ def get_prompt_id(
     payload_json = json.dumps(
         {
             "attributes": dict(attributes),
-            "language": language.tag,
+            "language": language.code,
             "operation": operation,
         },
         ensure_ascii=False,

--- a/scinoephile/optimization/persistence/prompts/sqlite_store.py
+++ b/scinoephile/optimization/persistence/prompts/sqlite_store.py
@@ -122,7 +122,7 @@ class PromptSqliteStore(OptimizationSqliteStore):
                     alias=alias,
                     prompt_id=prompt.prompt_id,
                     operation=prompt.operation,
-                    language=prompt.language.tag,
+                    language=prompt.language.code,
                     attributes_json=serialize_json(dict(prompt.attributes)),
                 )
                 connection.execute(

--- a/scinoephile/workflows/helpers.py
+++ b/scinoephile/workflows/helpers.py
@@ -30,9 +30,9 @@ def resolve_language(series: Series, explicit_language: Language | None) -> Lang
     if explicit_language is not None:
         if detected_language is not None and detected_language is not explicit_language:
             logger.warning(
-                f"Explicit language {explicit_language.tag} does not "
-                f"match detected language {detected_language.tag}; "
-                f"using {explicit_language.tag}"
+                f"Explicit language {explicit_language.code} does not "
+                f"match detected language {detected_language.code}; "
+                f"using {explicit_language.code}"
             )
         return explicit_language
     if detected_language is None:

--- a/scinoephile/workflows/prompt_catalog.py
+++ b/scinoephile/workflows/prompt_catalog.py
@@ -91,7 +91,7 @@ def _build_monolingual_prompt_specs(
         prompt specifications keyed by stable alias
     """
     return {
-        f"{manager_cls.operation}-{language.tag.lower()}": PromptSpec(
+        f"{manager_cls.operation}-{language.code.lower()}": PromptSpec(
             manager_cls=manager_cls,
             prompt=prompt,
         )
@@ -116,8 +116,8 @@ def _build_pair_prompt_specs(
     """
     return {
         (
-            f"{manager_cls.operation}-{first_language.tag.lower()}-"
-            f"{separator}-{second_language.tag.lower()}"
+            f"{manager_cls.operation}-{first_language.code.lower()}-"
+            f"{separator}-{second_language.code.lower()}"
         ): PromptSpec(
             manager_cls=manager_cls,
             prompt=prompt,
@@ -145,13 +145,13 @@ def _build_transcription_prompt_specs(
     """
     prompt_specs: dict[str, PromptSpec] = {}
     for (language, reference_language), spec in specs.items():
-        reference_code = reference_language.tag.partition("-")[0].lower()
+        reference_code = reference_language.language.lower()
         for manager_cls, prompt in (
             (DelineationManager, spec.delineation_prompt),
             (PunctuationManager, spec.punctuation_prompt),
         ):
             alias = (
-                f"{manager_cls.operation}-{language.tag.lower()}-vs-{reference_code}"
+                f"{manager_cls.operation}-{language.code.lower()}-vs-{reference_code}"
             )
             prompt_spec = PromptSpec(manager_cls=manager_cls, prompt=prompt)
             if alias in prompt_specs and prompt_specs[alias] != prompt_spec:

--- a/scinoephile/workflows/romanization.py
+++ b/scinoephile/workflows/romanization.py
@@ -42,7 +42,7 @@ def romanize_series(
         romanize_text = get_cmn_text_romanized
     else:
         raise ScinoephileError(
-            f"Romanization does not support language {resolved_language.tag}"
+            f"Romanization does not support language {resolved_language.code}"
         )
 
     romanized_series = deepcopy(series)

--- a/test/core/test_core_language.py
+++ b/test/core/test_core_language.py
@@ -12,7 +12,9 @@ from scinoephile.core.language import is_chinese_language_tag, normalize_languag
 
 def test_language_enum_exposes_english_metadata():
     """Test English language enum metadata."""
-    assert Language.eng.tag == "eng"
+    assert Language.eng.code == "eng"
+    assert Language.eng.language == "eng"
+    assert not hasattr(Language.eng, "tag")
     assert Language.eng.script is None
     assert not Language.eng.is_chinese
     assert str(Language.eng) == "eng"
@@ -20,28 +22,32 @@ def test_language_enum_exposes_english_metadata():
 
 def test_language_enum_exposes_simplified_chinese_metadata():
     """Test simplified Chinese language enum metadata."""
-    assert Language.zho_hans.tag == "zho-Hans"
+    assert Language.zho_hans.code == "zho-Hans"
+    assert Language.zho_hans.language == "zho"
     assert Language.zho_hans.script == "simplified"
     assert Language.zho_hans.is_chinese
 
 
 def test_language_enum_exposes_simplified_cantonese_metadata():
     """Test simplified Cantonese language enum metadata."""
-    assert Language.yue_hans.tag == "yue-Hans"
+    assert Language.yue_hans.code == "yue-Hans"
+    assert Language.yue_hans.language == "yue"
     assert Language.yue_hans.script == "simplified"
     assert Language.yue_hans.is_chinese
 
 
 def test_language_enum_exposes_traditional_chinese_metadata():
     """Test traditional Chinese language enum metadata."""
-    assert Language.zho_hant.tag == "zho-Hant"
+    assert Language.zho_hant.code == "zho-Hant"
+    assert Language.zho_hant.language == "zho"
     assert Language.zho_hant.script == "traditional"
     assert Language.zho_hant.is_chinese
 
 
 def test_language_enum_exposes_traditional_cantonese_metadata():
     """Test traditional Cantonese language enum metadata."""
-    assert Language.yue_hant.tag == "yue-Hant"
+    assert Language.yue_hant.code == "yue-Hant"
+    assert Language.yue_hant.language == "yue"
     assert Language.yue_hant.script == "traditional"
     assert Language.yue_hant.is_chinese
 

--- a/test/data/ocr.py
+++ b/test/data/ocr.py
@@ -57,8 +57,8 @@ def process_ocr(
         processed series
     """
     # Validate and configure
-    input_dir_path = title_root_path / "input" / f"{language.tag}_ocr"
-    output_dir_path = title_root_path / "output" / f"{language.tag}_ocr"
+    input_dir_path = title_root_path / "input" / f"{language.code}_ocr"
+    output_dir_path = title_root_path / "output" / f"{language.code}_ocr"
     overwrite = overwrite or overwrite_srt or overwrite_img or force_validation
 
     # Load, OCR, and validate series
@@ -101,7 +101,7 @@ def process_ocr(
         else:
             simplify_reviewer_kw["prompt"] = ReviewPromptZhoHans
         simplify_reviewer_kw["test_case_path"] = (
-            output_dir_path / "lang" / language.tag[:3] / "simplify_review.json"
+            output_dir_path / "lang" / language.language / "simplify_review.json"
         )
         simplify_review = _review(
             review_path,
@@ -183,7 +183,7 @@ def _ocr(
     fuser_kw = dict(fuser_kw or {})
     fuser_kw.setdefault(
         "test_case_path",
-        output_dir_path / "lang" / language.tag[:3] / "ocr_fusion.json",
+        output_dir_path / "lang" / language.language / "ocr_fusion.json",
     )
     fuser_kw.setdefault("auto_verify", True)
     workflow_kw: dict[str, Any] = {
@@ -239,7 +239,7 @@ def _review(
     reviewer_kw = dict(reviewer_kw or {})
     reviewer_kw.setdefault(
         "test_case_path",
-        path.parent / "lang" / language.tag[:3] / "review.json",
+        path.parent / "lang" / language.language / "review.json",
     )
     reviewer_kw.setdefault("auto_verify", True)
 

--- a/test/data/srt.py
+++ b/test/data/srt.py
@@ -39,8 +39,8 @@ def process_srt(
         title_root_path: title root directory
         language: source text SRT language
         reference_path: anchor subtitle path for timewarping
-        infile_path: source SRT path; defaults to `input/{language.tag}.srt`
-        output_dir_path: output directory; defaults to `output/{language.tag}`
+        infile_path: source SRT path; defaults to `input/{language.code}.srt`
+        output_dir_path: output directory; defaults to `output/{language.code}`
         one_start_idx: 1-based start index in the anchor series
         one_end_idx: 1-based end index in the anchor series
         two_start_idx: 1-based start index in the source series
@@ -53,9 +53,9 @@ def process_srt(
         processed series
     """
     if infile_path is None:
-        infile_path = title_root_path / "input" / f"{language.tag}.srt"
+        infile_path = title_root_path / "input" / f"{language.code}.srt"
     if output_dir_path is None:
-        output_dir_path = title_root_path / "output" / language.tag
+        output_dir_path = title_root_path / "output" / language.code
 
     result = SrtProcessingWorkflow(
         infile_path,

--- a/test/image/ocr/lens/test_lens_series.py
+++ b/test/image/ocr/lens/test_lens_series.py
@@ -108,7 +108,7 @@ def test_ocr_image_series_with_lens_uses_runtime_cache(
         tmp_path: temporary path fixture
     """
     cache_dir_path = tmp_path / "cache"
-    RecordingOcrRecognizer.reset(Language.zho_hans.tag)
+    RecordingOcrRecognizer.reset(Language.zho_hans.code)
 
     monkeypatch.setattr(
         "scinoephile.image.ocr.lens.get_runtime_cache_dir_path",

--- a/test/image/ocr/paddle/test_paddle_series.py
+++ b/test/image/ocr/paddle/test_paddle_series.py
@@ -108,7 +108,7 @@ def test_ocr_image_series_with_paddle_uses_runtime_cache(
         tmp_path: temporary path fixture
     """
     cache_dir_path = tmp_path / "cache"
-    RecordingOcrRecognizer.reset(Language.zho_hans.tag)
+    RecordingOcrRecognizer.reset(Language.zho_hans.code)
 
     monkeypatch.setattr(
         "scinoephile.image.ocr.paddle.get_runtime_cache_dir_path",

--- a/test/image/ocr/tesseract/test_tesseract_series.py
+++ b/test/image/ocr/tesseract/test_tesseract_series.py
@@ -113,7 +113,7 @@ def test_ocr_image_series_with_tesseract_uses_runtime_cache(
     tessdata_dir_path = tmp_path / "tessdata"
     observed_cache_dir_paths = []
     observed_cache_namespaces = []
-    RecordingOcrRecognizer.reset(Language.eng.tag)
+    RecordingOcrRecognizer.reset(Language.eng.code)
 
     monkeypatch.setattr(
         "scinoephile.image.ocr.tesseract.get_runtime_cache_dir_path",

--- a/test/llms/test_prompt_metadata.py
+++ b/test/llms/test_prompt_metadata.py
@@ -144,7 +144,7 @@ def _get_legacy_prompt_name(prompt: Prompt) -> str:
     payload_json = json.dumps(
         {
             "fields": prompt_fields,
-            "language": prompt.language.tag,
+            "language": prompt.language.code,
             "type": type(prompt).__name__,
         },
         ensure_ascii=False,
@@ -152,7 +152,7 @@ def _get_legacy_prompt_name(prompt: Prompt) -> str:
         sort_keys=True,
     )
     digest = hashlib.sha256(payload_json.encode()).hexdigest()[:12]
-    language_name = prompt.language.tag.replace("-", "_")
+    language_name = prompt.language.code.replace("-", "_")
     return f"{type(prompt).__name__}_{language_name}_{digest}"
 
 

--- a/test/workflows/test_prompt_catalog.py
+++ b/test/workflows/test_prompt_catalog.py
@@ -60,9 +60,9 @@ def test_prompt_catalog_contains_registered_transcription_prompts():
         language,
         reference_language,
     ), spec in guided_transcription.DEFAULT_SPECS.items():
-        reference_code = reference_language.tag.partition("-")[0].lower()
-        delineation_alias = f"delineation-{language.tag.lower()}-vs-{reference_code}"
-        punctuation_alias = f"punctuation-{language.tag.lower()}-vs-{reference_code}"
+        reference_code = reference_language.language.lower()
+        delineation_alias = f"delineation-{language.code.lower()}-vs-{reference_code}"
+        punctuation_alias = f"punctuation-{language.code.lower()}-vs-{reference_code}"
         assert PROMPT_SPECS[delineation_alias].prompt is spec.delineation_prompt
         assert PROMPT_SPECS[punctuation_alias].prompt is spec.punctuation_prompt
 


### PR DESCRIPTION
## Summary

- use inherited `Language.code` as the complete language code API
- add `Language.language` for the base language component
- remove the redundant `Language.tag` property
- migrate production and test callers without changing script semantics

## Stack

C1 of 4. This PR is based on `master`; C2 will target this branch.

## Testing

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format <26 changed Python files>`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix <26 changed Python files>`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check <26 changed Python files>`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` (1820 passed, 9 skipped)