### PR TITLE
Use ISO Chinese script subtags

### DIFF
--- a/scinoephile/cli/ocr/ocr_fuse_cli.py
+++ b/scinoephile/cli/ocr/ocr_fuse_cli.py
@@ -216,7 +216,7 @@ class OcrFuseCli(ScinoephileCliBase):
         if isinstance(convert, OpenCCConfig):
             resolved_convert = convert
         elif convert:
-            if language.script == "simplified":
+            if language.script == "Hans":
                 resolved_convert = OpenCCConfig.s2t
             else:
                 resolved_convert = OpenCCConfig.t2s

--- a/scinoephile/cli/process_cli.py
+++ b/scinoephile/cli/process_cli.py
@@ -209,7 +209,7 @@ class ProcessCli(ScinoephileCliBase):
         if isinstance(convert, OpenCCConfig):
             resolved_convert = convert
         elif convert:
-            if resolved_language.script == "simplified":
+            if resolved_language.script == "Hans":
                 resolved_convert = OpenCCConfig.s2t
             else:
                 resolved_convert = OpenCCConfig.t2s

--- a/scinoephile/core/language.py
+++ b/scinoephile/core/language.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+from typing import cast
+
 from scinoephile.common.described_enum import DescribedEnum
 
 from .text import ChineseScript
@@ -95,9 +97,8 @@ class Language(DescribedEnum):
 
     @property
     def script(self) -> ChineseScript | None:
-        """Chinese script implied by this language, if any."""
-        if self in (Language.yue_hans, Language.zho_hans):
-            return "simplified"
-        if self in (Language.yue_hant, Language.zho_hant):
-            return "traditional"
+        """Chinese script subtag from the complete code, if any."""
+        script = self.code.partition("-")[2]
+        if script in ("Hans", "Hant"):
+            return cast(ChineseScript, script)
         return None

--- a/scinoephile/core/text.py
+++ b/scinoephile/core/text.py
@@ -43,7 +43,7 @@ __all__ = [
 ]
 
 
-type ChineseScript = Literal["simplified", "traditional"]
+type ChineseScript = Literal["Hans", "Hant"]
 """Chinese script supported by text processing helpers."""
 
 

--- a/test/core/test_core_language.py
+++ b/test/core/test_core_language.py
@@ -24,7 +24,7 @@ def test_language_enum_exposes_simplified_chinese_metadata():
     """Test simplified Chinese language enum metadata."""
     assert Language.zho_hans.code == "zho-Hans"
     assert Language.zho_hans.language == "zho"
-    assert Language.zho_hans.script == "simplified"
+    assert Language.zho_hans.script == "Hans"
     assert Language.zho_hans.is_chinese
 
 
@@ -32,7 +32,7 @@ def test_language_enum_exposes_simplified_cantonese_metadata():
     """Test simplified Cantonese language enum metadata."""
     assert Language.yue_hans.code == "yue-Hans"
     assert Language.yue_hans.language == "yue"
-    assert Language.yue_hans.script == "simplified"
+    assert Language.yue_hans.script == "Hans"
     assert Language.yue_hans.is_chinese
 
 
@@ -40,7 +40,7 @@ def test_language_enum_exposes_traditional_chinese_metadata():
     """Test traditional Chinese language enum metadata."""
     assert Language.zho_hant.code == "zho-Hant"
     assert Language.zho_hant.language == "zho"
-    assert Language.zho_hant.script == "traditional"
+    assert Language.zho_hant.script == "Hant"
     assert Language.zho_hant.is_chinese
 
 
@@ -48,7 +48,7 @@ def test_language_enum_exposes_traditional_cantonese_metadata():
     """Test traditional Cantonese language enum metadata."""
     assert Language.yue_hant.code == "yue-Hant"
     assert Language.yue_hant.language == "yue"
-    assert Language.yue_hant.script == "traditional"
+    assert Language.yue_hant.script == "Hant"
     assert Language.yue_hant.is_chinese
 
 

--- a/test/data/ocr.py
+++ b/test/data/ocr.py
@@ -82,12 +82,12 @@ def process_ocr(
     flatten_path = output_dir_path / "fuse_clean_validate_review_flatten.srt"
     flatten = _flatten(flatten_path, language, review, overwrite)
 
-    if language.script == "simplified":
+    if language.script == "Hans":
         romanize_path = (
             output_dir_path / "fuse_clean_validate_review_flatten_romanize.srt"
         )
         _romanize(romanize_path, language, flatten, overwrite)
-    elif language.script == "traditional":
+    elif language.script == "Hant":
         simplify_path = (
             output_dir_path / "fuse_clean_validate_review_flatten_simplify.srt"
         )


### PR DESCRIPTION
## Summary

- define `ChineseScript` as the ISO `Hans` and `Hant` subtags
- derive `Language.script` directly from the complete language code
- update conversion and test-data consumers to use the ISO values
- update language metadata tests

## Stack

C2 of 4. C1 (#1120) has merged into `master`; this PR is now restacked directly on `master` and contains only C2. C3 (#1122) remains based on this branch.

## Testing

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format <6 changed Python files>`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix <6 changed Python files>`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check <6 changed Python files>`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` (1823 passed, 9 skipped after restacking)