### PR TITLE
Validate Whisper candidates and retry defensively

### DIFF
--- a/scinoephile/audio/transcription/whisper_transcriber.py
+++ b/scinoephile/audio/transcription/whisper_transcriber.py
@@ -68,17 +68,26 @@ class WhisperTranscriber:
             self.cache_dir_path = val_output_dir_path(cache_dir_path)
 
     def __call__(
-        self, audio: AudioSegment, *, cache_audio: AudioSegment | None = None
+        self,
+        audio: AudioSegment,
+        *,
+        cache_audio: AudioSegment | None = None,
+        use_cache: bool = True,
     ) -> list[TranscribedSegment]:
         """Transcribe audio.
 
         Arguments:
             audio: audio to transcribe
             cache_audio: optional audio used for cache-key generation
+            use_cache: whether to return a cached transcription when available
         Returns:
             transcription, split into segments
         """
-        return self.transcribe(audio, cache_audio=cache_audio)
+        return self.transcribe(
+            audio,
+            cache_audio=cache_audio,
+            use_cache=use_cache,
+        )
 
     @property
     def model(self) -> Any:
@@ -133,18 +142,26 @@ class WhisperTranscriber:
         return segments
 
     def transcribe(
-        self, audio: AudioSegment, *, cache_audio: AudioSegment | None = None
+        self,
+        audio: AudioSegment,
+        *,
+        cache_audio: AudioSegment | None = None,
+        use_cache: bool = True,
     ) -> list[TranscribedSegment]:
         """Transcribe audio.
 
         Arguments:
             audio: audio to transcribe
             cache_audio: optional audio used for cache-key generation
+            use_cache: whether to return a cached transcription when available
         Returns:
             transcription, split into segments
         """
         cache_audio = cache_audio or audio
-        if (segments := self.get_cached_transcription(cache_audio)) is not None:
+        if (
+            use_cache
+            and (segments := self.get_cached_transcription(cache_audio)) is not None
+        ):
             return segments
 
         # Transcribe using Whisper

--- a/scinoephile/lang/transcription/processor.py
+++ b/scinoephile/lang/transcription/processor.py
@@ -347,7 +347,12 @@ class GuidedTranscriptionProcessor:
             usable transcribed segments, if produced
         """
         try:
-            segments = transcriber(audio, cache_audio=cache_audio)
+            # Cached candidates were validated before preprocessing
+            segments = transcriber(
+                audio,
+                cache_audio=cache_audio,
+                use_cache=False,
+            )
         except AssertionError as exc:
             logger.warning(
                 f"Whisper transcription candidate failed with an assertion: {exc}"

--- a/scinoephile/lang/transcription/processor.py
+++ b/scinoephile/lang/transcription/processor.py
@@ -38,6 +38,15 @@ TranscribedSegmentSplitter = Callable[
 
 logger = getLogger(__name__)
 
+_AUDIO_END_TOLERANCE_SECONDS = 1.0
+"""Maximum accepted Whisper timestamp extension beyond the source audio."""
+
+_MAX_COMPRESSION_RATIO = 2.4
+"""Maximum Whisper compression ratio accepted for guided alignment."""
+
+_RECOVERY_TEMPERATURES = (0.0, 0.2, 0.4, 0.6, 0.8, 1.0)
+"""Whisper temperature schedule used after standard decoding fails."""
+
 
 class DemucsMode(StrEnum):
     """Demucs preprocessing modes for transcription."""
@@ -102,10 +111,24 @@ class GuidedTranscriptionProcessor:
             )
         self.vad_transcriber = None
         if vad_mode in (VADMode.AUTO, VADMode.ON):
-            self.vad_transcriber = self._get_whisper_transcriber(use_vad=True)
+            self.vad_transcriber = self._get_whisper_transcriber(
+                use_demucs=demucs_mode == DemucsMode.ON,
+                use_vad=True,
+            )
         self.no_vad_transcriber = None
         if vad_mode in (VADMode.AUTO, VADMode.OFF):
-            self.no_vad_transcriber = self._get_whisper_transcriber(use_vad=False)
+            self.no_vad_transcriber = self._get_whisper_transcriber(
+                use_demucs=demucs_mode == DemucsMode.ON,
+                use_vad=False,
+            )
+
+        recovery_uses_vad = vad_mode == VADMode.ON
+        self.recovery_transcriber = self._get_whisper_transcriber(
+            use_demucs=demucs_mode == DemucsMode.ON,
+            use_vad=recovery_uses_vad,
+            temperature=_RECOVERY_TEMPERATURES,
+            condition_on_previous_text=False,
+        )
 
     def process(
         self,
@@ -192,41 +215,58 @@ class GuidedTranscriptionProcessor:
         return alignment.transcription
 
     def _get_cached_block_transcription(
-        self, cache_audio: AudioSegment
+        self,
+        cache_audio: AudioSegment,
+        *,
+        audio_duration: float,
     ) -> list[TranscribedSegment] | None:
         """Get cached block transcription before expensive preprocessing.
 
         Arguments:
             cache_audio: original block audio used for cache-key generation
+            audio_duration: original block audio duration in seconds
         Returns:
             cached transcription, if present
         """
-        if self.vad_mode == VADMode.ON:
-            assert self.vad_transcriber is not None
-            return self.vad_transcriber.get_cached_transcription(cache_audio)
-        if self.vad_mode == VADMode.OFF:
-            assert self.no_vad_transcriber is not None
-            return self.no_vad_transcriber.get_cached_transcription(cache_audio)
-
-        assert self.vad_transcriber is not None
-        cached_segments = self.vad_transcriber.get_cached_transcription(cache_audio)
-        if cached_segments is not None and self._segments_are_usable(cached_segments):
-            return cached_segments
-        if self.no_vad_transcriber is not None:
-            cached_segments = self.no_vad_transcriber.get_cached_transcription(
-                cache_audio
-            )
+        transcribers = [*self._get_standard_transcribers(), self.recovery_transcriber]
+        for transcriber in transcribers:
+            cached_segments = transcriber.get_cached_transcription(cache_audio)
             if cached_segments is not None and self._segments_are_usable(
-                cached_segments
+                cached_segments,
+                audio_duration=audio_duration,
             ):
                 return cached_segments
         return None
 
-    def _get_whisper_transcriber(self, use_vad: bool) -> WhisperTranscriber:
+    def _get_standard_transcribers(self) -> tuple[WhisperTranscriber, ...]:
+        """Get standard transcribers in configured retry order.
+
+        Returns:
+            configured standard transcribers
+        """
+        transcribers = []
+        if self.vad_transcriber is not None:
+            transcribers.append(self.vad_transcriber)
+        if self.no_vad_transcriber is not None:
+            transcribers.append(self.no_vad_transcriber)
+        return tuple(transcribers)
+
+    def _get_whisper_transcriber(
+        self,
+        *,
+        use_demucs: bool,
+        use_vad: bool,
+        temperature: float | tuple[float, ...] = 0.0,
+        condition_on_previous_text: bool = True,
+    ) -> WhisperTranscriber:
         """Build a Whisper transcriber for the requested VAD setting.
 
         Arguments:
+            use_demucs: whether Demucs preprocessing is applied
             use_vad: whether Whisper VAD is enabled
+            temperature: decoding temperature or fallback schedule
+            condition_on_previous_text: whether to condition each decoding window on
+                the preceding window
         Returns:
             configured Whisper transcriber
         """
@@ -234,8 +274,10 @@ class GuidedTranscriptionProcessor:
             model_name=self.model_name,
             language=self.whisper_language,
             cache_dir_path=get_runtime_cache_dir_path("whisper"),
-            use_demucs=self.demucs_mode == DemucsMode.ON,
+            use_demucs=use_demucs,
             use_vad=use_vad,
+            temperature=temperature,
+            condition_on_previous_text=condition_on_previous_text,
         )
 
     def _transcribe_block_audio(self, audio: AudioSegment) -> list[TranscribedSegment]:
@@ -245,54 +287,124 @@ class GuidedTranscriptionProcessor:
             audio: block audio to transcribe
         Returns:
             transcribed segments
+        Raises:
+            ScinoephileError: if all configured Whisper attempts are unusable
         """
         cache_audio = audio
-        cached_segments = self._get_cached_block_transcription(cache_audio)
-        if cached_segments is not None:
-            return cached_segments
+        audio_duration = len(cache_audio) / 1000
+        segments = self._get_cached_block_transcription(
+            cache_audio,
+            audio_duration=audio_duration,
+        )
+        if segments is not None:
+            return segments
 
         if self.demucs_mode == DemucsMode.ON:
             assert self.demucs_separator is not None
             logger.info("Applying Demucs vocal separation before transcription")
             audio = self.demucs_separator(audio)
 
-        if self.vad_mode == VADMode.ON:
-            assert self.vad_transcriber is not None
-            return self.vad_transcriber(audio, cache_audio=cache_audio)
-        if self.vad_mode == VADMode.OFF:
-            assert self.no_vad_transcriber is not None
-            return self.no_vad_transcriber(audio, cache_audio=cache_audio)
+        for transcriber in self._get_standard_transcribers():
+            segments = self._transcribe_with_candidate(
+                transcriber,
+                audio,
+                cache_audio=cache_audio,
+                audio_duration=audio_duration,
+            )
+            if segments is not None:
+                return segments
 
-        assert self.vad_transcriber is not None
+        logger.info("Retrying block transcription with defensive Whisper decoding")
+        segments = self._transcribe_with_candidate(
+            self.recovery_transcriber,
+            audio,
+            cache_audio=cache_audio,
+            audio_duration=audio_duration,
+        )
+        if segments is None:
+            raise ScinoephileError(
+                "Whisper produced no usable transcription after all configured "
+                "recovery attempts."
+            )
+        return segments
+
+    def _transcribe_with_candidate(
+        self,
+        transcriber: WhisperTranscriber,
+        audio: AudioSegment,
+        *,
+        cache_audio: AudioSegment,
+        audio_duration: float,
+    ) -> list[TranscribedSegment] | None:
+        """Run and validate one Whisper transcription candidate.
+
+        Arguments:
+            transcriber: configured Whisper transcriber
+            audio: audio to transcribe
+            cache_audio: original audio used for cache-key generation
+            audio_duration: original block audio duration in seconds
+        Returns:
+            usable transcribed segments, if produced
+        """
         try:
-            segments = self.vad_transcriber(audio, cache_audio=cache_audio)
+            segments = transcriber(audio, cache_audio=cache_audio)
         except AssertionError as exc:
             logger.warning(
-                f"Retrying block transcription without VAD after Whisper assertion: "
-                f"{exc}"
+                f"Whisper transcription candidate failed with an assertion: {exc}"
             )
-            assert self.no_vad_transcriber is not None
-            return self.no_vad_transcriber(audio, cache_audio=cache_audio)
-        if self._segments_are_usable(segments):
+            return None
+        if self._segments_are_usable(
+            segments,
+            audio_duration=audio_duration,
+        ):
             return segments
-
-        logger.info(
-            "Retrying block transcription without VAD after unusable VAD result"
-        )
-        assert self.no_vad_transcriber is not None
-        return self.no_vad_transcriber(audio, cache_audio=cache_audio)
+        return None
 
     @staticmethod
-    def _segments_are_usable(segments: list[TranscribedSegment]) -> bool:
+    def _segments_are_usable(
+        segments: list[TranscribedSegment],
+        *,
+        audio_duration: float | None = None,
+    ) -> bool:
         """Determine whether transcribed segments are usable for alignment.
 
         Arguments:
             segments: transcribed segments to inspect
+            audio_duration: original block audio duration in seconds
         Returns:
-            whether the segments contain nonempty text with word timings
+            whether the segments contain plausible nonempty text with word timings
         """
-        if not any(segment.text.strip() for segment in segments):
+        has_text = False
+        for segment in segments:
+            if not segment.text.strip():
+                continue
+            has_text = True
+            if not segment.words:
+                logger.warning(
+                    f"Rejecting Whisper segment {segment.id} without word timings"
+                )
+                return False
+            if (
+                segment.compression_ratio is not None
+                and segment.compression_ratio > _MAX_COMPRESSION_RATIO
+            ):
+                logger.warning(
+                    f"Rejecting repetitive Whisper segment {segment.id} with "
+                    f"compression ratio {segment.compression_ratio:.2f} "
+                    f"(maximum {_MAX_COMPRESSION_RATIO:.2f})"
+                )
+                return False
+            if (
+                audio_duration is not None
+                and segment.end > audio_duration + _AUDIO_END_TOLERANCE_SECONDS
+            ):
+                logger.warning(
+                    f"Rejecting Whisper segment {segment.id} ending at "
+                    f"{segment.end:.2f}s beyond {audio_duration:.2f}s source audio"
+                )
+                return False
+
+        if not has_text:
+            logger.warning("Rejecting empty Whisper transcription")
             return False
-        return not any(
-            segment.text.strip() and not segment.words for segment in segments
-        )
+        return True

--- a/test/audio/transcription/test_whisper_transcriber.py
+++ b/test/audio/transcription/test_whisper_transcriber.py
@@ -133,6 +133,26 @@ def test_transcribe_forwards_recovery_decoding_options(monkeypatch: MonkeyPatch)
     assert whisper.transcribe.call_args.kwargs["condition_on_previous_text"] is False
 
 
+def test_transcribe_bypasses_cache_when_requested(monkeypatch: MonkeyPatch):
+    """Test an explicit uncached transcription does not reload rejected output."""
+    whisper = Mock()
+    whisper.transcribe.return_value = {"segments": []}
+    transcriber = WhisperTranscriber(model_name="custom/model")
+    transcriber._model = Mock()
+    monkeypatch.setattr(transcriber, "_get_whisper_module", Mock(return_value=whisper))
+    get_cached_transcription = Mock()
+    monkeypatch.setattr(
+        transcriber,
+        "get_cached_transcription",
+        get_cached_transcription,
+    )
+    audio = AudioSegment.silent(duration=1000)
+
+    assert transcriber(audio, use_cache=False) == []
+    get_cached_transcription.assert_not_called()
+    whisper.transcribe.assert_called_once()
+
+
 @parametrize(
     ("model_name", "expected"),
     [

--- a/test/lang/transcription/test_processor.py
+++ b/test/lang/transcription/test_processor.py
@@ -11,7 +11,7 @@ from pydub import AudioSegment
 from pytest import LogCaptureFixture, raises
 
 from scinoephile.audio.subtitles import AudioSeries, AudioSubtitle
-from scinoephile.audio.transcription import TranscribedSegment
+from scinoephile.audio.transcription import TranscribedSegment, TranscribedWord
 from scinoephile.core import Language, ScinoephileError
 from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.lang.transcription.aligner import TranscriptionAligner
@@ -22,9 +22,14 @@ from scinoephile.lang.transcription.processor import (
 )
 
 
-def _get_processor() -> tuple[GuidedTranscriptionProcessor, Mock]:
+def _get_processor(
+    *,
+    vad_mode: VADMode = VADMode.OFF,
+) -> tuple[GuidedTranscriptionProcessor, Mock]:
     """Get a processor with a passthrough alignment mock.
 
+    Arguments:
+        vad_mode: Whisper VAD mode
     Returns:
         processor and alignment mock
     """
@@ -37,7 +42,7 @@ def _get_processor() -> tuple[GuidedTranscriptionProcessor, Mock]:
             model_name="test/model",
             whisper_language="en",
             aligner=aligner,
-            vad_mode=VADMode.OFF,
+            vad_mode=vad_mode,
         ),
         aligner,
     )
@@ -49,6 +54,8 @@ def _get_segment(
     start: float = 0.1,
     end: float = 0.2,
     text: str = "hello",
+    compression_ratio: float | None = None,
+    with_words: bool = False,
 ) -> TranscribedSegment:
     """Get a minimal transcribed segment.
 
@@ -57,16 +64,135 @@ def _get_segment(
         start: segment start in seconds
         end: segment end in seconds
         text: segment text
+        compression_ratio: gzip compression ratio reported by Whisper
+        with_words: whether to include word-level timings
     Returns:
         transcribed segment
     """
+    words = None
+    if with_words:
+        words = [TranscribedWord(text=text, start=start, end=end, confidence=1.0)]
     return TranscribedSegment(
         id=segment_id,
         seek=0,
         start=start,
         end=end,
         text=text,
+        compression_ratio=compression_ratio,
+        words=words,
     )
+
+
+def test_segments_are_usable_rejects_repetitive_whisper_output():
+    """Test highly compressible Whisper loops are unusable for alignment."""
+    segments = [
+        _get_segment(
+            compression_ratio=16.24,
+            with_words=True,
+        )
+    ]
+
+    assert not GuidedTranscriptionProcessor._segments_are_usable(segments)
+
+
+def test_segments_are_usable_rejects_timestamp_beyond_audio():
+    """Test Whisper timestamps extending beyond source audio are unusable."""
+    segments = [
+        _get_segment(
+            end=12.0,
+            compression_ratio=1.0,
+            with_words=True,
+        )
+    ]
+
+    assert not GuidedTranscriptionProcessor._segments_are_usable(
+        segments,
+        audio_duration=10.0,
+    )
+
+
+def test_segments_are_usable_accepts_partial_guided_tail():
+    """Test guide coverage does not determine transcription validity."""
+    segments = [
+        _get_segment(
+            end=4.0,
+            compression_ratio=1.0,
+            with_words=True,
+        )
+    ]
+
+    assert GuidedTranscriptionProcessor._segments_are_usable(
+        segments,
+        audio_duration=10.0,
+    )
+
+
+def test_auto_vad_uses_cached_non_vad_result_after_repetitive_vad_result():
+    """Test automatic VAD skips a repetitive cached result."""
+    processor, _ = _get_processor(vad_mode=VADMode.AUTO)
+    repetitive_segments = [_get_segment(compression_ratio=16.24, with_words=True)]
+    usable_segments = [_get_segment(compression_ratio=1.0, with_words=True)]
+    processor.vad_transcriber = Mock()
+    processor.vad_transcriber.get_cached_transcription.return_value = (
+        repetitive_segments
+    )
+    processor.no_vad_transcriber = Mock()
+    processor.no_vad_transcriber.get_cached_transcription.return_value = usable_segments
+
+    output = processor._transcribe_block_audio(AudioSegment.silent(duration=1000))
+
+    assert output == usable_segments
+    processor.vad_transcriber.assert_not_called()
+    processor.no_vad_transcriber.assert_not_called()
+
+
+def test_auto_vad_retries_without_vad_after_repetitive_new_result():
+    """Test automatic VAD retries without VAD after a repetitive new result."""
+    processor, _ = _get_processor(vad_mode=VADMode.AUTO)
+    repetitive_segments = [_get_segment(compression_ratio=16.24, with_words=True)]
+    usable_segments = [_get_segment(compression_ratio=1.0, with_words=True)]
+    processor.vad_transcriber = Mock(return_value=repetitive_segments)
+    processor.vad_transcriber.get_cached_transcription.return_value = None
+    processor.no_vad_transcriber = Mock(return_value=usable_segments)
+    processor.no_vad_transcriber.get_cached_transcription.return_value = None
+    audio = AudioSegment.silent(duration=1000)
+
+    output = processor._transcribe_block_audio(audio)
+
+    assert output == usable_segments
+    processor.vad_transcriber.assert_called_once_with(audio, cache_audio=audio)
+    processor.no_vad_transcriber.assert_called_once_with(audio, cache_audio=audio)
+
+
+def test_unusable_no_vad_result_uses_defensive_recovery():
+    """Test unusable non-VAD output is validated before defensive recovery."""
+    processor, _ = _get_processor(vad_mode=VADMode.OFF)
+    repetitive_segments = [_get_segment(compression_ratio=16.24, with_words=True)]
+    usable_segments = [_get_segment(compression_ratio=1.0, with_words=True)]
+    processor.no_vad_transcriber = Mock(return_value=repetitive_segments)
+    processor.no_vad_transcriber.get_cached_transcription.return_value = None
+    processor.recovery_transcriber = Mock(return_value=usable_segments)
+    processor.recovery_transcriber.get_cached_transcription.return_value = None
+    audio = AudioSegment.silent(duration=1000)
+
+    output = processor._transcribe_block_audio(audio)
+
+    assert output == usable_segments
+    processor.no_vad_transcriber.assert_called_once_with(audio, cache_audio=audio)
+    processor.recovery_transcriber.assert_called_once_with(audio, cache_audio=audio)
+
+
+def test_all_unusable_candidates_fail_before_alignment():
+    """Test unusable recovery output raises a transcription-domain error."""
+    processor, _ = _get_processor(vad_mode=VADMode.OFF)
+    repetitive_segments = [_get_segment(compression_ratio=16.24, with_words=True)]
+    processor.no_vad_transcriber = Mock(return_value=repetitive_segments)
+    processor.no_vad_transcriber.get_cached_transcription.return_value = None
+    processor.recovery_transcriber = Mock(return_value=repetitive_segments)
+    processor.recovery_transcriber.get_cached_transcription.return_value = None
+
+    with raises(ScinoephileError, match="no usable transcription"):
+        processor._transcribe_block_audio(AudioSegment.silent(duration=1000))
 
 
 def test_process_block_preserves_raw_segments_and_uses_buffered_offset():

--- a/test/lang/transcription/test_processor.py
+++ b/test/lang/transcription/test_processor.py
@@ -146,6 +146,29 @@ def test_auto_vad_uses_cached_non_vad_result_after_repetitive_vad_result():
     processor.no_vad_transcriber.assert_not_called()
 
 
+def test_rejected_cached_result_is_bypassed_for_fresh_retry():
+    """Test a rejected cache entry does not prevent a fresh Whisper attempt."""
+    processor, _ = _get_processor(vad_mode=VADMode.OFF)
+    repetitive_segments = [_get_segment(compression_ratio=16.24, with_words=True)]
+    usable_segments = [_get_segment(compression_ratio=1.0, with_words=True)]
+    processor.no_vad_transcriber = Mock(return_value=usable_segments)
+    processor.no_vad_transcriber.get_cached_transcription.return_value = (
+        repetitive_segments
+    )
+    processor.recovery_transcriber = Mock()
+    processor.recovery_transcriber.get_cached_transcription.return_value = None
+    audio = AudioSegment.silent(duration=1000)
+
+    output = processor._transcribe_block_audio(audio)
+
+    assert output == usable_segments
+    processor.no_vad_transcriber.assert_called_once_with(
+        audio,
+        cache_audio=audio,
+        use_cache=False,
+    )
+
+
 def test_auto_vad_retries_without_vad_after_repetitive_new_result():
     """Test automatic VAD retries without VAD after a repetitive new result."""
     processor, _ = _get_processor(vad_mode=VADMode.AUTO)
@@ -160,8 +183,16 @@ def test_auto_vad_retries_without_vad_after_repetitive_new_result():
     output = processor._transcribe_block_audio(audio)
 
     assert output == usable_segments
-    processor.vad_transcriber.assert_called_once_with(audio, cache_audio=audio)
-    processor.no_vad_transcriber.assert_called_once_with(audio, cache_audio=audio)
+    processor.vad_transcriber.assert_called_once_with(
+        audio,
+        cache_audio=audio,
+        use_cache=False,
+    )
+    processor.no_vad_transcriber.assert_called_once_with(
+        audio,
+        cache_audio=audio,
+        use_cache=False,
+    )
 
 
 def test_unusable_no_vad_result_uses_defensive_recovery():
@@ -178,8 +209,16 @@ def test_unusable_no_vad_result_uses_defensive_recovery():
     output = processor._transcribe_block_audio(audio)
 
     assert output == usable_segments
-    processor.no_vad_transcriber.assert_called_once_with(audio, cache_audio=audio)
-    processor.recovery_transcriber.assert_called_once_with(audio, cache_audio=audio)
+    processor.no_vad_transcriber.assert_called_once_with(
+        audio,
+        cache_audio=audio,
+        use_cache=False,
+    )
+    processor.recovery_transcriber.assert_called_once_with(
+        audio,
+        cache_audio=audio,
+        use_cache=False,
+    )
 
 
 def test_all_unusable_candidates_fail_before_alignment():


### PR DESCRIPTION
## Summary

- validate both cached and newly generated Whisper candidates before alignment
- reject empty, wordless, repetitive, and out-of-range output
- try configured VAD/no-VAD candidates in order, then use a defensive temperature schedule with previous-text conditioning disabled
- bypass rejected cache entries during fresh retries so Whisper can replace stale unusable output
- convert unusable candidates and Whisper assertion failures into retries, raising a domain error only after every attempt fails

## Why

Whisper can return structurally valid but unusable output, including repetition loops and timestamps beyond the source audio. Passing those candidates directly to guided alignment produces misleading or broken results instead of trying another decoding strategy.

Rejected cache entries also need to be bypassed during a retry. Otherwise the transcriber reloads the same unusable JSON internally and can remain stuck until the cache is manually deleted.

## Stack

T1 of 3, based on `master`. T2 targets this branch.

## Testing

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format` on the 4 changed Python files
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix` on the 4 changed Python files
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check` on the 4 changed Python files
- focused processor and Whisper transcriber tests: 26 passed, 5 skipped
- full suite: 1833 passed, 9 skipped