### PR TITLE
Add automatic Demucs fallback

### DIFF
--- a/scinoephile/cli/transcribe_cli.py
+++ b/scinoephile/cli/transcribe_cli.py
@@ -59,8 +59,8 @@ TRANSCRIBE_LOCALIZATIONS: dict[str, dict[str, str]] = {
         "reference language tag (detected from infile if omitted)": (
             "参考语言标签（省略时从输入文件检测）"
         ),
-        "Demucs vocal-separation mode (options: on, off; default: off)": (
-            "Demucs 人声分离模式（选项：on、off；默认：off）"
+        "Demucs vocal-separation mode (options: auto, on, off; default: auto)": (
+            "Demucs 人声分离模式（选项：auto、on、off；默认：auto）"
         ),
         (
             "Whisper voice activity detection mode "
@@ -91,8 +91,8 @@ TRANSCRIBE_LOCALIZATIONS: dict[str, dict[str, str]] = {
         "reference language tag (detected from infile if omitted)": (
             "參考語言標籤（省略時從輸入檔偵測）"
         ),
-        "Demucs vocal-separation mode (options: on, off; default: off)": (
-            "Demucs 人聲分離模式（選項：on、off；預設：off）"
+        "Demucs vocal-separation mode (options: auto, on, off; default: auto)": (
+            "Demucs 人聲分離模式（選項：auto、on、off；預設：auto）"
         ),
         (
             "Whisper voice activity detection mode "
@@ -173,11 +173,13 @@ class TranscribeCli(ScinoephileCliBase):
         )
         arg_groups["operation arguments"].add_argument(
             "--demucs",
-            default=DemucsMode.OFF,
+            default=DemucsMode.AUTO,
             dest="demucs_mode",
-            metavar="{on,off}",
+            metavar="{auto,on,off}",
             type=enum_arg(DemucsMode),
-            help="Demucs vocal-separation mode (options: on, off; default: off)",
+            help=(
+                "Demucs vocal-separation mode (options: auto, on, off; default: auto)"
+            ),
         )
         arg_groups["operation arguments"].add_argument(
             "--vad",

--- a/scinoephile/lang/transcription/guided.py
+++ b/scinoephile/lang/transcription/guided.py
@@ -155,7 +155,7 @@ def get_guided_transcriber(
     reference_language: Language,
     *,
     model_name: str | None = None,
-    demucs_mode: DemucsMode = DemucsMode.OFF,
+    demucs_mode: DemucsMode = DemucsMode.AUTO,
     vad_mode: VADMode = VADMode.AUTO,
     provider: LLMProvider | None = None,
     additional_context: str | None = None,

--- a/scinoephile/lang/transcription/processor.py
+++ b/scinoephile/lang/transcription/processor.py
@@ -346,6 +346,33 @@ class GuidedTranscriptionProcessor:
             condition_on_previous_text=condition_on_previous_text,
         )
 
+    def _get_primary_transcription_audio(
+        self,
+        audio: AudioSegment,
+    ) -> AudioSegment | None:
+        """Apply configured Demucs preprocessing.
+
+        Arguments:
+            audio: original block audio
+        Returns:
+            primary transcription audio, or None after automatic separation failure
+        """
+        if self.demucs_mode == DemucsMode.OFF:
+            return audio
+
+        assert self.demucs_separator is not None
+        logger.info("Applying Demucs vocal separation before transcription")
+        try:
+            return self.demucs_separator(audio)
+        except ScinoephileError as exc:
+            if self.demucs_mode == DemucsMode.ON:
+                raise
+            logger.warning(
+                f"Demucs separation failed in automatic mode; falling back "
+                f"to original audio: {exc}"
+            )
+            return None
+
     def _transcribe_block_audio(
         self,
         audio: AudioSegment,
@@ -369,27 +396,24 @@ class GuidedTranscriptionProcessor:
             audio_duration=audio_duration,
         )
         if segments is None:
-            primary_audio = audio
-            if self.demucs_mode in (DemucsMode.AUTO, DemucsMode.ON):
-                assert self.demucs_separator is not None
-                logger.info("Applying Demucs vocal separation before transcription")
-                primary_audio = self.demucs_separator(audio)
-
-            for transcriber in self._get_standard_transcribers():
-                segments = self._transcribe_with_candidate(
-                    transcriber,
-                    primary_audio,
-                    cache_audio=cache_audio,
-                    audio_duration=audio_duration,
-                )
-                if segments is not None:
-                    break
+            primary_audio = self._get_primary_transcription_audio(audio)
+            if primary_audio is not None:
+                for transcriber in self._get_standard_transcribers():
+                    segments = self._transcribe_with_candidate(
+                        transcriber,
+                        primary_audio,
+                        cache_audio=cache_audio,
+                        audio_duration=audio_duration,
+                    )
+                    if segments is not None:
+                        break
 
             if segments is None and self.demucs_mode == DemucsMode.AUTO:
-                logger.info(
-                    "Retrying block transcription with original audio after unusable "
-                    "Demucs result"
-                )
+                if primary_audio is not None:
+                    logger.info(
+                        "Retrying block transcription with original audio after "
+                        "unusable Demucs result"
+                    )
                 for transcriber in self._get_standard_transcribers(unseparated=True):
                     segments = self._transcribe_with_candidate(
                         transcriber,
@@ -406,6 +430,7 @@ class GuidedTranscriptionProcessor:
                 )
                 recovery_audio = audio
                 if self.demucs_mode == DemucsMode.ON:
+                    assert primary_audio is not None
                     recovery_audio = primary_audio
                 segments = self._transcribe_with_candidate(
                     self.recovery_transcriber,

--- a/scinoephile/lang/transcription/processor.py
+++ b/scinoephile/lang/transcription/processor.py
@@ -67,6 +67,8 @@ _TAIL_RECOVERY_MAX_SECONDS_PER_CHARACTER = 1.5
 class DemucsMode(StrEnum):
     """Demucs preprocessing modes for transcription."""
 
+    AUTO = "auto"
+    """Run Demucs first and retry the original audio when needed."""
     ON = "on"
     """Run Demucs preprocessing."""
     OFF = "off"
@@ -121,20 +123,40 @@ class GuidedTranscriptionProcessor:
         self.segment_splitter = segment_splitter
 
         self.demucs_separator = None
-        if demucs_mode == DemucsMode.ON:
+        if demucs_mode in (DemucsMode.AUTO, DemucsMode.ON):
             self.demucs_separator = DemucsSeparator(
                 cache_dir_path=get_runtime_cache_dir_path("demucs")
             )
+        primary_uses_demucs = demucs_mode in (DemucsMode.AUTO, DemucsMode.ON)
         self.vad_transcriber = None
         if vad_mode in (VADMode.AUTO, VADMode.ON):
             self.vad_transcriber = self._get_whisper_transcriber(
-                use_demucs=demucs_mode == DemucsMode.ON,
+                use_demucs=primary_uses_demucs,
                 use_vad=True,
             )
         self.no_vad_transcriber = None
         if vad_mode in (VADMode.AUTO, VADMode.OFF):
             self.no_vad_transcriber = self._get_whisper_transcriber(
-                use_demucs=demucs_mode == DemucsMode.ON,
+                use_demucs=primary_uses_demucs,
+                use_vad=False,
+            )
+
+        self.unseparated_vad_transcriber = None
+        if demucs_mode == DemucsMode.AUTO and vad_mode in (
+            VADMode.AUTO,
+            VADMode.ON,
+        ):
+            self.unseparated_vad_transcriber = self._get_whisper_transcriber(
+                use_demucs=False,
+                use_vad=True,
+            )
+        self.unseparated_no_vad_transcriber = None
+        if demucs_mode == DemucsMode.AUTO and vad_mode in (
+            VADMode.AUTO,
+            VADMode.OFF,
+        ):
+            self.unseparated_no_vad_transcriber = self._get_whisper_transcriber(
+                use_demucs=False,
                 use_vad=False,
             )
 
@@ -256,7 +278,10 @@ class GuidedTranscriptionProcessor:
         Returns:
             cached transcription, if present
         """
-        transcribers = [*self._get_standard_transcribers(), self.recovery_transcriber]
+        transcribers = list(self._get_standard_transcribers())
+        if self.demucs_mode == DemucsMode.AUTO:
+            transcribers.extend(self._get_standard_transcribers(unseparated=True))
+        transcribers.append(self.recovery_transcriber)
         for transcriber in transcribers:
             cached_segments = transcriber.get_cached_transcription(cache_audio)
             if cached_segments is not None and self._segments_are_usable(
@@ -266,17 +291,30 @@ class GuidedTranscriptionProcessor:
                 return cached_segments
         return None
 
-    def _get_standard_transcribers(self) -> tuple[WhisperTranscriber, ...]:
+    def _get_standard_transcribers(
+        self,
+        *,
+        unseparated: bool = False,
+    ) -> tuple[WhisperTranscriber, ...]:
         """Get standard transcribers in configured retry order.
 
+        Arguments:
+            unseparated: whether to return original-audio fallback transcribers
         Returns:
             configured standard transcribers
         """
+        if unseparated:
+            vad_transcriber = self.unseparated_vad_transcriber
+            no_vad_transcriber = self.unseparated_no_vad_transcriber
+        else:
+            vad_transcriber = self.vad_transcriber
+            no_vad_transcriber = self.no_vad_transcriber
+
         transcribers = []
-        if self.vad_transcriber is not None:
-            transcribers.append(self.vad_transcriber)
-        if self.no_vad_transcriber is not None:
-            transcribers.append(self.no_vad_transcriber)
+        if vad_transcriber is not None:
+            transcribers.append(vad_transcriber)
+        if no_vad_transcriber is not None:
+            transcribers.append(no_vad_transcriber)
         return tuple(transcribers)
 
     def _get_whisper_transcriber(
@@ -331,28 +369,47 @@ class GuidedTranscriptionProcessor:
             audio_duration=audio_duration,
         )
         if segments is None:
-            if self.demucs_mode == DemucsMode.ON:
+            primary_audio = audio
+            if self.demucs_mode in (DemucsMode.AUTO, DemucsMode.ON):
                 assert self.demucs_separator is not None
                 logger.info("Applying Demucs vocal separation before transcription")
-                audio = self.demucs_separator(audio)
+                primary_audio = self.demucs_separator(audio)
 
             for transcriber in self._get_standard_transcribers():
                 segments = self._transcribe_with_candidate(
                     transcriber,
-                    audio,
+                    primary_audio,
                     cache_audio=cache_audio,
                     audio_duration=audio_duration,
                 )
                 if segments is not None:
                     break
 
+            if segments is None and self.demucs_mode == DemucsMode.AUTO:
+                logger.info(
+                    "Retrying block transcription with original audio after unusable "
+                    "Demucs result"
+                )
+                for transcriber in self._get_standard_transcribers(unseparated=True):
+                    segments = self._transcribe_with_candidate(
+                        transcriber,
+                        audio,
+                        cache_audio=cache_audio,
+                        audio_duration=audio_duration,
+                    )
+                    if segments is not None:
+                        break
+
             if segments is None:
                 logger.info(
                     "Retrying block transcription with defensive Whisper decoding"
                 )
+                recovery_audio = audio
+                if self.demucs_mode == DemucsMode.ON:
+                    recovery_audio = primary_audio
                 segments = self._transcribe_with_candidate(
                     self.recovery_transcriber,
-                    audio,
+                    recovery_audio,
                     cache_audio=cache_audio,
                     audio_duration=audio_duration,
                 )

--- a/scinoephile/workflows/transcription.py
+++ b/scinoephile/workflows/transcription.py
@@ -31,7 +31,7 @@ def transcribe_series_guided(
     language: Language,
     reference_language: Language | None = None,
     model_name: str | None = None,
-    demucs_mode: DemucsMode = DemucsMode.OFF,
+    demucs_mode: DemucsMode = DemucsMode.AUTO,
     vad_mode: VADMode = VADMode.AUTO,
     provider: LLMProvider | None = None,
     additional_context: str | None = None,

--- a/test/cli/test_transcribe_cli.py
+++ b/test/cli/test_transcribe_cli.py
@@ -65,7 +65,7 @@ def test_transcribe_help_lists_generic_options():
     assert "--reference-language" in help_text
     assert "--script" not in normalized_help_text
     assert "--convert" not in normalized_help_text
-    assert "--demucs {on,off}" in help_text
+    assert "--demucs {auto,on,off}" in help_text
     assert "--vad {auto,on,off}" in help_text
     assert "--whisper-model MODEL_NAME" in help_text
     assert "uses language-pair default if omitted" in normalized_help_text
@@ -81,6 +81,24 @@ def test_transcribe_cli_defers_whisper_model_default_to_registry():
     )
 
     assert whisper_model_action.default is None
+
+
+def test_transcribe_cli_defaults_audio_preprocessing_to_auto():
+    """Test transcription CLI defaults Demucs and VAD to automatic modes."""
+    parser = TranscribeCli.argparser()
+    demucs_action = next(
+        action
+        for action in parser._actions  # noqa: SLF001
+        if "--demucs" in action.option_strings
+    )
+    vad_action = next(
+        action
+        for action in parser._actions  # noqa: SLF001
+        if "--vad" in action.option_strings
+    )
+
+    assert demucs_action.default is DemucsMode.AUTO
+    assert vad_action.default is VADMode.AUTO
 
 
 def test_transcribe_cli_writes_file(

--- a/test/lang/transcription/test_guided.py
+++ b/test/lang/transcription/test_guided.py
@@ -15,6 +15,7 @@ from scinoephile.lang.transcription.guided import (
     DEFAULT_SPECS,
     get_guided_transcriber,
 )
+from scinoephile.lang.transcription.processor import DemucsMode, VADMode
 from scinoephile.lang.yue.prompts import YUE_HANT_PROMPT_FIELDS
 from scinoephile.lang.yue_zho.transcription import (
     YueZhoDelineationPromptYueHant,
@@ -62,6 +63,8 @@ def test_get_guided_transcriber_uses_registered_language_configuration(tmp_path)
 
     assert transcriber.language is Language.yue_hant
     assert transcriber.reference_language is Language.zho_hans
+    assert transcriber.demucs_mode is DemucsMode.AUTO
+    assert transcriber.vad_mode is VADMode.AUTO
     assert transcriber.whisper_language == "yue"
     assert transcriber.segment_splitter is not None
     assert transcriber.aligner.delineation_queryer.prompt is (

--- a/test/lang/transcription/test_processor.py
+++ b/test/lang/transcription/test_processor.py
@@ -387,6 +387,62 @@ def test_auto_demucs_retries_unseparated_audio_after_unusable_result():
     processor.recovery_transcriber.assert_not_called()
 
 
+def test_auto_demucs_uses_original_audio_after_separation_failure():
+    """Test automatic Demucs recovers when vocal separation fails."""
+    processor, _ = _get_processor(
+        demucs_mode=DemucsMode.AUTO,
+        vad_mode=VADMode.OFF,
+    )
+    usable_segments = [_get_segment(compression_ratio=1.0, with_words=True)]
+    processor.no_vad_transcriber = Mock()
+    processor.no_vad_transcriber.get_cached_transcription.return_value = None
+    processor.unseparated_no_vad_transcriber = Mock(return_value=usable_segments)
+    processor.unseparated_no_vad_transcriber.get_cached_transcription.return_value = (
+        None
+    )
+    processor.recovery_transcriber = Mock()
+    processor.recovery_transcriber.get_cached_transcription.return_value = None
+    original_audio = AudioSegment.silent(duration=1000)
+    processor.demucs_separator = Mock(
+        side_effect=ScinoephileError("Demucs separation failed.")
+    )
+
+    output = processor._transcribe_block_audio(original_audio)
+
+    assert output == usable_segments
+    processor.demucs_separator.assert_called_once_with(original_audio)
+    processor.no_vad_transcriber.assert_not_called()
+    processor.unseparated_no_vad_transcriber.assert_called_once_with(
+        original_audio,
+        cache_audio=original_audio,
+        use_cache=False,
+    )
+    processor.recovery_transcriber.assert_not_called()
+
+
+def test_forced_demucs_surfaces_separation_failure():
+    """Test forced Demucs does not hide vocal-separation failures."""
+    processor, _ = _get_processor(
+        demucs_mode=DemucsMode.ON,
+        vad_mode=VADMode.OFF,
+    )
+    processor.no_vad_transcriber = Mock()
+    processor.no_vad_transcriber.get_cached_transcription.return_value = None
+    processor.recovery_transcriber = Mock()
+    processor.recovery_transcriber.get_cached_transcription.return_value = None
+    original_audio = AudioSegment.silent(duration=1000)
+    processor.demucs_separator = Mock(
+        side_effect=ScinoephileError("Demucs separation failed.")
+    )
+
+    with raises(ScinoephileError, match="Demucs separation failed"):
+        processor._transcribe_block_audio(original_audio)
+
+    processor.demucs_separator.assert_called_once_with(original_audio)
+    processor.no_vad_transcriber.assert_not_called()
+    processor.recovery_transcriber.assert_not_called()
+
+
 def test_process_block_preserves_raw_segments_and_uses_buffered_offset():
     """Test generic processing preserves segments and anchors buffered audio."""
     processor, aligner = _get_processor()

--- a/test/lang/transcription/test_processor.py
+++ b/test/lang/transcription/test_processor.py
@@ -18,6 +18,7 @@ from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.lang.transcription.aligner import TranscriptionAligner
 from scinoephile.lang.transcription.alignment import TranscriptionAlignment
 from scinoephile.lang.transcription.processor import (
+    DemucsMode,
     GuidedTranscriptionProcessor,
     VADMode,
 )
@@ -25,11 +26,13 @@ from scinoephile.lang.transcription.processor import (
 
 def _get_processor(
     *,
+    demucs_mode: DemucsMode = DemucsMode.OFF,
     vad_mode: VADMode = VADMode.OFF,
 ) -> tuple[GuidedTranscriptionProcessor, Mock]:
     """Get a processor with a passthrough alignment mock.
 
     Arguments:
+        demucs_mode: Demucs preprocessing mode
         vad_mode: Whisper VAD mode
     Returns:
         processor and alignment mock
@@ -43,6 +46,7 @@ def _get_processor(
             model_name="test/model",
             whisper_language="en",
             aligner=aligner,
+            demucs_mode=demucs_mode,
             vad_mode=vad_mode,
         ),
         aligner,
@@ -344,6 +348,43 @@ def test_all_unusable_candidates_fail_before_alignment():
 
     with raises(ScinoephileError, match="no usable transcription"):
         processor._transcribe_block_audio(AudioSegment.silent(duration=1000))
+
+
+def test_auto_demucs_retries_unseparated_audio_after_unusable_result():
+    """Test automatic Demucs retries the original audio before recovery decoding."""
+    processor, _ = _get_processor(
+        demucs_mode=DemucsMode.AUTO,
+        vad_mode=VADMode.OFF,
+    )
+    repetitive_segments = [_get_segment(compression_ratio=16.24, with_words=True)]
+    usable_segments = [_get_segment(compression_ratio=1.0, with_words=True)]
+    processor.no_vad_transcriber = Mock(return_value=repetitive_segments)
+    processor.no_vad_transcriber.get_cached_transcription.return_value = None
+    processor.unseparated_no_vad_transcriber = Mock(return_value=usable_segments)
+    processor.unseparated_no_vad_transcriber.get_cached_transcription.return_value = (
+        None
+    )
+    processor.recovery_transcriber = Mock()
+    processor.recovery_transcriber.get_cached_transcription.return_value = None
+    original_audio = AudioSegment.silent(duration=1000)
+    separated_audio = AudioSegment.silent(duration=900)
+    processor.demucs_separator = Mock(return_value=separated_audio)
+
+    output = processor._transcribe_block_audio(original_audio)
+
+    assert output == usable_segments
+    processor.demucs_separator.assert_called_once_with(original_audio)
+    processor.no_vad_transcriber.assert_called_once_with(
+        separated_audio,
+        cache_audio=original_audio,
+        use_cache=False,
+    )
+    processor.unseparated_no_vad_transcriber.assert_called_once_with(
+        original_audio,
+        cache_audio=original_audio,
+        use_cache=False,
+    )
+    processor.recovery_transcriber.assert_not_called()
 
 
 def test_process_block_preserves_raw_segments_and_uses_buffered_offset():

--- a/test/workflows/test_transcription.py
+++ b/test/workflows/test_transcription.py
@@ -11,7 +11,11 @@ from pydub import AudioSegment
 from scinoephile.audio.subtitles import AudioSeries
 from scinoephile.core import Language
 from scinoephile.core.subtitles import Series, Subtitle
-from scinoephile.lang.transcription.processor import GuidedTranscriptionProcessor
+from scinoephile.lang.transcription.processor import (
+    DemucsMode,
+    GuidedTranscriptionProcessor,
+    VADMode,
+)
 from scinoephile.workflows.transcription import transcribe_series_guided
 
 
@@ -40,6 +44,8 @@ def test_transcribe_series_guided_constructs_processor_for_language_pair():
         Language.yue_hant,
         Language.zho_hans,
     )
+    assert get_transcriber.call_args.kwargs["demucs_mode"] is DemucsMode.AUTO
+    assert get_transcriber.call_args.kwargs["vad_mode"] is VADMode.AUTO
     transcriber.process.assert_called_once_with(
         audio_series,
         reference_series,


### PR DESCRIPTION
## Summary

- add an automatic Demucs mode that transcribes separated vocals first
- retry the original audio with matching VAD settings when separated candidates are unusable
- fall back to original audio when Demucs separation fails in automatic mode
- continue surfacing Demucs separation failures when separation is explicitly forced on
- use original audio for defensive decoding in automatic mode while preserving forced-on behavior
- make automatic Demucs processing the CLI, guided factory, and workflow default
- update localized CLI help and focused coverage for fallback ordering and defaults

## Why

Demucs vocal separation often improves transcription, but it can also remove or distort useful speech. Automatic mode keeps the separated-audio-first behavior while recovering transparently from unusable results by retrying the original audio.

Automatic mode must also remain usable when Demucs cannot load or separate a block. Domain-level separation failures now skip Demucs-tagged candidates and proceed directly to original-audio transcription, while forced mode still raises the error.

## Stack

T3 of 3. T1, #1124, and T2, #1125, have merged; this PR now targets `master`.

## Testing

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format` on the changed processor and test files
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix` on the changed processor and test files
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check` on the changed processor and test files
- focused processor tests: 19 passed
- full suite: 1840 passed, 9 skipped