### PR TITLE
Use Luna as the default OpenAI model

### DIFF
--- a/scinoephile/llms/providers/openai_provider.py
+++ b/scinoephile/llms/providers/openai_provider.py
@@ -20,7 +20,7 @@ class OpenAIProvider(OpenAIProviderBase):
     }
     """Provider description translations keyed by locale."""
 
-    model = "gpt-5.4-mini"
+    model = "gpt-5.6-luna"
     """OpenAI model identifier."""
 
     api_key_env_var_name = "OPENAI_API_KEY"

--- a/test/llms/providers/test_registry.py
+++ b/test/llms/providers/test_registry.py
@@ -60,7 +60,7 @@ def test_get_provider_preserves_default_model_with_none_override():
     provider = get_provider("openai", model=None)
 
     assert isinstance(provider, OpenAIProvider)
-    assert provider.model == "gpt-5.4-mini"
+    assert provider.model == "gpt-5.6-luna"
 
 
 def test_get_provider_constructs_deepseek_provider_with_kwargs():


### PR DESCRIPTION
## Summary

- change the built-in OpenAI provider default from `gpt-5.4-mini` to `gpt-5.6-luna`
- update the provider-registry regression test to assert the new default

## Rationale and impact

The OpenAI provider now selects Luna when callers do not specify a model. Explicit model overrides are unchanged. This keeps the provider registry's default-model behavior covered by an exact assertion.

## Checks

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/llms/providers/openai_provider.py test/llms/providers/test_registry.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/llms/providers/openai_provider.py test/llms/providers/test_registry.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/llms/providers/openai_provider.py test/llms/providers/test_registry.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto llms/providers/test_registry.py` (14 passed)