### PR TITLE
Use semantic delineation prompt fields

### DIFF
--- a/scinoephile/lang/yue_zho/transcription.py
+++ b/scinoephile/lang/yue_zho/transcription.py
@@ -33,24 +33,24 @@ YueZhoDelineationPromptYueHant = DelineationPrompt(
         或者將 yuewen_2 開頭嘅字符移到 yuewen_1 末尾。
         請喺 yuewen_1_yidong 同 yuewen_2_yidong 返回調整後嘅粵文字幕。
         如果唔需要調整，請 yuewen_1_yidong 同 yuewen_2_yidong 都返回空字串。"""),
-    src_1_sub_1="zhongwen_1",
-    src_1_sub_1_desc="已知字幕1嘅中文",
-    src_1_sub_2="zhongwen_2",
-    src_1_sub_2_desc="已知字幕2嘅中文",
-    src_2_sub_1="yuewen_1",
-    src_2_sub_1_desc="初步字幕1嘅粵文",
-    src_2_sub_2="yuewen_2",
-    src_2_sub_2_desc="初步字幕2嘅粵文",
-    src_2_sub_1_sub_2_missing_err="查詢要有 yuewen_1、yuewen_2，或者兩個都有。",
-    src_2_sub_1_shifted="yuewen_1_yidong",
-    src_2_sub_1_shifted_desc="調整後字幕1嘅粵文",
-    src_2_sub_2_shifted="yuewen_2_yidong",
-    src_2_sub_2_shifted_desc="調整後字幕2嘅粵文",
-    src_2_sub_1_sub_2_unchanged_err=(
+    ref_sub_1="zhongwen_1",
+    ref_sub_1_desc="已知字幕1嘅中文",
+    ref_sub_2="zhongwen_2",
+    ref_sub_2_desc="已知字幕2嘅中文",
+    target_sub_1="yuewen_1",
+    target_sub_1_desc="初步字幕1嘅粵文",
+    target_sub_2="yuewen_2",
+    target_sub_2_desc="初步字幕2嘅粵文",
+    target_subs_missing_err="查詢要有 yuewen_1、yuewen_2，或者兩個都有。",
+    target_sub_1_shifted="yuewen_1_yidong",
+    target_sub_1_shifted_desc="調整後字幕1嘅粵文",
+    target_sub_2_shifted="yuewen_2_yidong",
+    target_sub_2_shifted_desc="調整後字幕2嘅粵文",
+    target_subs_unchanged_err=(
         "回答嘅 yuewen_1_yidong 同 yuewen_2_yidong 同查詢嘅 yuewen_1、yuewen_2 "
         "一樣；如果唔需要調整，yuewen_1_yidong 同 yuewen_2_yidong 要返空字串。"
     ),
-    src_2_chars_changed_err_tpl=(
+    target_chars_changed_err_tpl=(
         "回答裏拼埋嘅 yuewen_1_yidong 同 yuewen_2_yidong 同查詢拼埋嘅 "
         "yuewen_1 同 yuewen_2 唔一致：\n"
         "期望: {expected}\n"

--- a/scinoephile/llms/delineation/manager.py
+++ b/scinoephile/llms/delineation/manager.py
@@ -49,12 +49,12 @@ class DelineationManager(Manager):
             prompt,
             {
                 "output_one": PromptModelField(
-                    alias=prompt.src_2_sub_1_shifted,
-                    description=prompt.src_2_sub_1_shifted_desc,
+                    alias=prompt.target_sub_1_shifted,
+                    description=prompt.target_sub_1_shifted_desc,
                 ),
                 "output_two": PromptModelField(
-                    alias=prompt.src_2_sub_2_shifted,
-                    description=prompt.src_2_sub_2_shifted_desc,
+                    alias=prompt.target_sub_2_shifted,
+                    description=prompt.target_sub_2_shifted_desc,
                 ),
             },
         )
@@ -77,20 +77,20 @@ class DelineationManager(Manager):
             prompt,
             {
                 "reference_one": PromptModelField(
-                    alias=prompt.src_1_sub_1,
-                    description=prompt.src_1_sub_1_desc,
+                    alias=prompt.ref_sub_1,
+                    description=prompt.ref_sub_1_desc,
                 ),
                 "reference_two": PromptModelField(
-                    alias=prompt.src_1_sub_2,
-                    description=prompt.src_1_sub_2_desc,
+                    alias=prompt.ref_sub_2,
+                    description=prompt.ref_sub_2_desc,
                 ),
                 "target_one": PromptModelField(
-                    alias=prompt.src_2_sub_1,
-                    description=prompt.src_2_sub_1_desc,
+                    alias=prompt.target_sub_1,
+                    description=prompt.target_sub_1_desc,
                 ),
                 "target_two": PromptModelField(
-                    alias=prompt.src_2_sub_2,
-                    description=prompt.src_2_sub_2_desc,
+                    alias=prompt.target_sub_2,
+                    description=prompt.target_sub_2_desc,
                 ),
             },
         )

--- a/scinoephile/llms/delineation/models.py
+++ b/scinoephile/llms/delineation/models.py
@@ -40,7 +40,7 @@ class DelineationQuery(Query):
     def validate_target_presence(self) -> Self:
         """Ensure at least one initial target subtitle is nonempty."""
         if not self.target_one and not self.target_two:
-            raise ValueError(self.prompt.src_2_sub_1_sub_2_missing_err)
+            raise ValueError(self.prompt.target_subs_missing_err)
         return self
 
 
@@ -92,13 +92,13 @@ class DelineationTestCase(TestCase):
             self.query.target_one == self.answer.output_one
             and self.query.target_two == self.answer.output_two
         ):
-            raise ValueError(self.prompt.src_2_sub_1_sub_2_unchanged_err)
+            raise ValueError(self.prompt.target_subs_unchanged_err)
 
         if self.answer.output_one or self.answer.output_two:
             expected = self.query.target_one + self.query.target_two
             received = self.answer.output_one + self.answer.output_two
             if expected != received:
                 raise ValueError(
-                    self.prompt.src_2_chars_changed_err(expected, received)
+                    self.prompt.target_chars_changed_err(expected, received)
                 )
         return self

--- a/scinoephile/llms/delineation/prompt.py
+++ b/scinoephile/llms/delineation/prompt.py
@@ -16,74 +16,74 @@ class DelineationPrompt(Prompt):
     """Text for LLM correspondence for delineation."""
 
     # Query fields
-    src_1_sub_1: str = "src_1_sub_1"
-    """Name of source one subtitle one field in query."""
+    ref_sub_1: str = "ref_sub_1"
+    """Name of reference subtitle one field in query."""
 
-    src_1_sub_1_desc: str = "Source one subtitle one text"
-    """Description of source one subtitle one field in query."""
+    ref_sub_1_desc: str = "Reference subtitle one text"
+    """Description of reference subtitle one field in query."""
 
-    src_1_sub_2: str = "src_1_sub_2"
-    """Name of source one subtitle two field in query."""
+    ref_sub_2: str = "ref_sub_2"
+    """Name of reference subtitle two field in query."""
 
-    src_1_sub_2_desc: str = "Source one subtitle two text"
-    """Description of source one subtitle two field in query."""
+    ref_sub_2_desc: str = "Reference subtitle two text"
+    """Description of reference subtitle two field in query."""
 
-    src_2_sub_1: str = "src_2_sub_1"
-    """Name of source two subtitle one field in query."""
+    target_sub_1: str = "target_sub_1"
+    """Name of target subtitle one field in query."""
 
-    src_2_sub_1_desc: str = "Source two subtitle one text"
-    """Description of source two subtitle one field in query."""
+    target_sub_1_desc: str = "Target subtitle one text"
+    """Description of target subtitle one field in query."""
 
-    src_2_sub_2: str = "src_2_sub_2"
-    """Name of source two subtitle two field in query."""
+    target_sub_2: str = "target_sub_2"
+    """Name of target subtitle two field in query."""
 
-    src_2_sub_2_desc: str = "Source two subtitle two text"
-    """Description of source two subtitle two field in query."""
+    target_sub_2_desc: str = "Target subtitle two text"
+    """Description of target subtitle two field in query."""
 
     # Query validation errors
-    src_2_sub_1_sub_2_missing_err: str = (
-        "Query must have src_2_sub_1, src_2_sub_2, or both."
+    target_subs_missing_err: str = (
+        "Query must have target_sub_1, target_sub_2, or both."
     )
-    """Error when src_2_sub_1 and src_2_sub_2 fields are missing."""
+    """Error when target subtitle fields are missing."""
 
     # Answer fields
-    src_2_sub_1_shifted: str = "src_2_sub_1_shifted"
-    """Name of shifted source two subtitle one field in answer."""
+    target_sub_1_shifted: str = "target_sub_1_shifted"
+    """Name of shifted target subtitle one field in answer."""
 
-    src_2_sub_1_shifted_desc: str = "Shifted source two subtitle one"
-    """Description of shifted source two subtitle one field in answer."""
+    target_sub_1_shifted_desc: str = "Shifted target subtitle one"
+    """Description of shifted target subtitle one field in answer."""
 
-    src_2_sub_2_shifted: str = "src_2_sub_2_shifted"
-    """Name of shifted source two subtitle two field in answer."""
+    target_sub_2_shifted: str = "target_sub_2_shifted"
+    """Name of shifted target subtitle two field in answer."""
 
-    src_2_sub_2_shifted_desc: str = "Shifted source two subtitle two"
-    """Description of shifted source two subtitle two field in answer."""
+    target_sub_2_shifted_desc: str = "Shifted target subtitle two"
+    """Description of shifted target subtitle two field in answer."""
 
     # Test case validation errors
-    src_2_sub_1_sub_2_unchanged_err: str = (
-        "Answer's src_2_sub_1_shifted and src_2_sub_2_shifted are equal to query's "
-        "src_2_sub_1 and src_2_sub_2; if no shift is needed, src_2_sub_1_shifted and "
-        "src_2_sub_2_shifted must be empty strings."
+    target_subs_unchanged_err: str = (
+        "Answer's target_sub_1_shifted and target_sub_2_shifted are equal to query's "
+        "target_sub_1 and target_sub_2; if no shift is needed, target_sub_1_shifted "
+        "and target_sub_2_shifted must be empty strings."
     )
-    """Error when src_2_sub_1 and src_2_sub_2 are unchanged."""
+    """Error when target subtitles are unchanged."""
 
-    src_2_chars_changed_err_tpl: str = (
-        "Answer's concatenated src_2_sub_1_shifted and src_2_sub_2_shifted does not "
-        "match query's concatenated src_2_sub_1 and src_2_sub_2:\n"
+    target_chars_changed_err_tpl: str = (
+        "Answer's concatenated target_sub_1_shifted and target_sub_2_shifted does "
+        "not match query's concatenated target_sub_1 and target_sub_2:\n"
         "Expected: {expected}\n"
         "Received: {received}"
     )
-    """Error template when shifted source two characters do not match original."""
+    """Error template when shifted target characters do not match original."""
 
-    def src_2_chars_changed_err(self, expected: str, received: str) -> str:
-        """Error when shifted source two characters do not match original.
+    def target_chars_changed_err(self, expected: str, received: str) -> str:
+        """Error when shifted target characters do not match original.
 
         Arguments:
-            expected: expected concatenated source two characters
-            received: received concatenated source two characters
+            expected: expected concatenated target characters
+            received: received concatenated shifted target characters
         Returns:
             formatted error message
         """
-        return self.src_2_chars_changed_err_tpl.format(
+        return self.target_chars_changed_err_tpl.format(
             expected=expected, received=received
         )

--- a/test/core/llms/test_test_case_json_fixtures.py
+++ b/test/core/llms/test_test_case_json_fixtures.py
@@ -41,7 +41,7 @@ _TEST_CASE_FAMILIES: tuple[tuple[str, type[Manager]], ...] = (
         PairwiseReviewManager,
     ),
     (
-        "*/output/*/lang/yue_zho/transcription/delineation/*.json",
+        "mlamd/output/*/lang/yue_zho/transcription/delineation/*.json",
         DelineationManager,
     ),
     (
@@ -160,5 +160,5 @@ def test_tracked_test_case_json_inventory_is_complete():
         for input_path, _ in _TEST_CASE_FILES
     )
 
-    assert len(_TEST_CASE_FILES) == 85
-    assert test_case_count == 31_081
+    assert len(_TEST_CASE_FILES) == 83
+    assert test_case_count == 28_581

--- a/test/data/mlamd/output/yue-Hans_transcribe/lang/yue_zho/transcription/delineation/cuda.json
+++ b/test/data/mlamd/output/yue-Hans_transcribe/lang/yue_zho/transcription/delineation/cuda.json
@@ -1,71 +1,40 @@
 [
   {
     "query": {
-      "src_1_sub_1": "在麦太即将临盆的时候",
-      "src_1_sub_2": "一只胶兜在九龙上空飞过",
-      "src_2_sub_1": "就喺麦太快要临盘嘅时候",
-      "src_2_sub_2": "有一个胶兜喺九龙上空飞过"
+      "ref_sub_1": "在麦太即将临盆的时候",
+      "ref_sub_2": "一只胶兜在九龙上空飞过",
+      "target_sub_1": "就喺麦太快要临盘嘅时候",
+      "target_sub_2": "有一个胶兜喺九龙上空飞过"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "一只胶兜在九龙上空飞过",
-      "src_1_sub_2": "沿荔枝角道直出大角咀道",
-      "src_2_sub_1": "有一个胶兜喺九龙上空飞过",
-      "src_2_sub_2": "沿住荔枝角度直出大角咀度"
+      "ref_sub_1": "一只胶兜在九龙上空飞过",
+      "ref_sub_2": "沿荔枝角道直出大角咀道",
+      "target_sub_1": "有一个胶兜喺九龙上空飞过",
+      "target_sub_2": "沿住荔枝角度直出大角咀度"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "沿荔枝角道直出大角咀道",
-      "src_1_sub_2": "经好彩酒家左转花园街乐园牛丸王⋯",
-      "src_2_sub_1": "沿住荔枝角度直出大角咀度",
-      "src_2_sub_2": "经过好彩走家再左转返出花园街乐园牛园望对上"
+      "ref_sub_1": "沿荔枝角道直出大角咀道",
+      "ref_sub_2": "经好彩酒家左转花园街乐园牛丸王⋯",
+      "target_sub_1": "沿住荔枝角度直出大角咀度",
+      "target_sub_2": "经过好彩走家再左转返出花园街乐园牛园望对上"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "经好彩酒家左转花园街乐园牛丸王⋯",
-      "src_1_sub_2": "更正一下：",
-      "src_2_sub_1": "经过好彩走家再左转返出花园街乐园牛园望对上",
-      "src_2_sub_2": "都系唔好"
-    },
-    "answer": {},
-    "few_shot": true,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "更正一下：",
-      "src_1_sub_2": "先到街市大楼妹记鱼腩粥外边",
-      "src_2_sub_1": "都系唔好",
-      "src_2_sub_2": "先去街市大楼嗰间妹记鱼腩粥嗰度"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "先到街市大楼妹记鱼腩粥外边",
-      "src_1_sub_2": "转呀，转⋯再更正一下：",
-      "src_2_sub_1": "先去街市大楼嗰间妹记鱼腩粥嗰度",
-      "src_2_sub_2": "转下转下都系唔好"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "转呀，转⋯再更正一下：",
-      "src_1_sub_2": "直出亚皆老街跨过火车桥右转太平道",
-      "src_2_sub_1": "转下转下都系唔好",
-      "src_2_sub_2": "都系出返去阿街路街飞过火车桥右转入太平道"
+      "ref_sub_1": "经好彩酒家左转花园街乐园牛丸王⋯",
+      "ref_sub_2": "更正一下：",
+      "target_sub_1": "经过好彩走家再左转返出花园街乐园牛园望对上",
+      "target_sub_2": "都系唔好"
     },
     "answer": {},
     "few_shot": true,
@@ -73,151 +42,30 @@
   },
   {
     "query": {
-      "src_1_sub_1": "直出亚皆老街跨过火车桥右转太平道",
-      "src_1_sub_2": "再右拐窝打老道向女人街方向飞⋯",
-      "src_2_sub_1": "都系出返去阿街路街飞过火车桥右转入太平道",
-      "src_2_sub_2": "再右转抹返出去窝打炉道向女人街方向飞下下"
+      "ref_sub_1": "更正一下：",
+      "ref_sub_2": "先到街市大楼妹记鱼腩粥外边",
+      "target_sub_1": "都系唔好",
+      "target_sub_2": "先去街市大楼嗰间妹记鱼腩粥嗰度"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "再右拐窝打老道向女人街方向飞⋯",
-      "src_1_sub_2": "飞呀，飞⋯",
-      "src_2_sub_1": "再右转抹返出去窝打炉道向女人街方向飞下下",
-      "src_2_sub_2": "飞下飞下"
-    },
-    "answer": {},
-    "few_shot": true,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "飞呀，飞⋯",
-      "src_1_sub_2": "胶兜最后飞进广华医院候产房",
-      "src_2_sub_1": "飞下飞下",
-      "src_2_sub_2": "最后胶兜飞咗入广华医院嘅后产房"
+      "ref_sub_1": "先到街市大楼妹记鱼腩粥外边",
+      "ref_sub_2": "转呀，转⋯再更正一下：",
+      "target_sub_1": "先去街市大楼嗰间妹记鱼腩粥嗰度",
+      "target_sub_2": "转下转下都系唔好"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "胶兜最后飞进广华医院候产房",
-      "src_1_sub_2": "也就是在麦太右边额角上⋯",
-      "src_2_sub_1": "最后胶兜飞咗入广华医院嘅后产房",
-      "src_2_sub_2": "亦即系麦太右边云晶对上"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "也就是在麦太右边额角上⋯",
-      "src_1_sub_2": "更正：左边额角上⋯",
-      "src_2_sub_1": "亦即系麦太右边云晶对上",
-      "src_2_sub_2": "都系唔好左边云晶对上"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "更正：左边额角上⋯",
-      "src_1_sub_2": "转呀，转⋯",
-      "src_2_sub_1": "都系唔好左边云晶对上",
-      "src_2_sub_2": "转下转下转下噉"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "转呀，转⋯",
-      "src_1_sub_2": "麦太认定这是异像",
-      "src_2_sub_1": "转下转下转下噉",
-      "src_2_sub_2": "麦太认定呢个系异象"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "麦太认定这是异像",
-      "src_1_sub_2": "于是向额角上的胶兜许愿",
-      "src_2_sub_1": "麦太认定呢个系异象",
-      "src_2_sub_2": "于是向云晶对上嘅胶兜许愿"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "于是向额角上的胶兜许愿",
-      "src_1_sub_2": "脑海中同时出现即将诞生的儿子容貌⋯",
-      "src_2_sub_1": "于是向云晶对上嘅胶兜许愿",
-      "src_2_sub_2": "而脑入面亦即时出现咗快要出世个仔嘅样"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "脑海中同时出现即将诞生的儿子容貌⋯",
-      "src_1_sub_2": "希望他好聪明，读书好叻！",
-      "src_2_sub_1": "而脑入面亦即时出现咗快要出世个仔嘅样",
-      "src_2_sub_2": "希望佢好聪明读书好叻"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "希望他好聪明，读书好叻！",
-      "src_1_sub_2": "胶兜对麦太的愿望似乎没有反应",
-      "src_2_sub_1": "希望佢好聪明读书好叻",
-      "src_2_sub_2": "胶兜对麦太嘅愿望似乎冇咩表示"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "胶兜对麦太的愿望似乎没有反应",
-      "src_1_sub_2": "于是她向胶兜补充说：",
-      "src_2_sub_1": "胶兜对麦太嘅愿望似乎冇咩表示",
-      "src_2_sub_2": "于是佢对住胶兜补充噉话"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "于是她向胶兜补充说：",
-      "src_1_sub_2": "或者读书唔叻，工作叻呢？",
-      "src_2_sub_1": "于是佢对住胶兜补充噉话",
-      "src_2_sub_2": "或者读书唔叻出嚟做嘢叻啦"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "或者读书唔叻，工作叻呢？",
-      "src_1_sub_2": "又或者⋯",
-      "src_2_sub_1": "或者读书唔叻出嚟做嘢叻啦",
-      "src_2_sub_2": "又或者呢"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "又或者⋯",
-      "src_1_sub_2": "又或者好靓仔，好靓仔",
-      "src_2_sub_1": "又或者呢",
-      "src_2_sub_2": "又或者系好靓仔好靓仔"
+      "ref_sub_1": "转呀，转⋯再更正一下：",
+      "ref_sub_2": "直出亚皆老街跨过火车桥右转太平道",
+      "target_sub_1": "转下转下都系唔好",
+      "target_sub_2": "都系出返去阿街路街飞过火车桥右转入太平道"
     },
     "answer": {},
     "few_shot": true,
@@ -225,234 +73,386 @@
   },
   {
     "query": {
-      "src_1_sub_1": "又或者好靓仔，好靓仔",
-      "src_1_sub_2": "跟周润发，梁朝伟那么靓仔！",
-      "src_2_sub_1": "又或者系好靓仔好靓仔",
-      "src_2_sub_2": "好似周润发同埋梁朝伟咁靓仔"
+      "ref_sub_1": "直出亚皆老街跨过火车桥右转太平道",
+      "ref_sub_2": "再右拐窝打老道向女人街方向飞⋯",
+      "target_sub_1": "都系出返去阿街路街飞过火车桥右转入太平道",
+      "target_sub_2": "再右转抹返出去窝打炉道向女人街方向飞下下"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "跟周润发，梁朝伟那么靓仔！",
-      "src_1_sub_2": "胶兜仍然在转，毫无点头迹象",
-      "src_2_sub_1": "好似周润发同埋梁朝伟咁靓仔",
-      "src_2_sub_2": "胶兜依然系噉喺度转好似一啲应承嘅迹象都冇"
+      "ref_sub_1": "再右拐窝打老道向女人街方向飞⋯",
+      "ref_sub_2": "飞呀，飞⋯",
+      "target_sub_1": "再右转抹返出去窝打炉道向女人街方向飞下下",
+      "target_sub_2": "飞下飞下"
+    },
+    "answer": {},
+    "few_shot": true,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "飞呀，飞⋯",
+      "ref_sub_2": "胶兜最后飞进广华医院候产房",
+      "target_sub_1": "飞下飞下",
+      "target_sub_2": "最后胶兜飞咗入广华医院嘅后产房"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "胶兜仍然在转，毫无点头迹象",
-      "src_1_sub_2": "麦太一时心虚",
-      "src_2_sub_1": "胶兜依然系噉喺度转好似一啲应承嘅迹象都冇",
-      "src_2_sub_2": "麦太一时心虚"
+      "ref_sub_1": "胶兜最后飞进广华医院候产房",
+      "ref_sub_2": "也就是在麦太右边额角上⋯",
+      "target_sub_1": "最后胶兜飞咗入广华医院嘅后产房",
+      "target_sub_2": "亦即系麦太右边云晶对上"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "麦太一时心虚",
-      "src_1_sub_2": "赶忙趁胶兜落地前另许一个愿望：",
-      "src_2_sub_1": "麦太一时心虚",
-      "src_2_sub_2": "嗱嗱嗱喺胶兜未落地之前起过另外一个愿望"
+      "ref_sub_1": "也就是在麦太右边额角上⋯",
+      "ref_sub_2": "更正：左边额角上⋯",
+      "target_sub_1": "亦即系麦太右边云晶对上",
+      "target_sub_2": "都系唔好左边云晶对上"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "赶忙趁胶兜落地前另许一个愿望：",
-      "src_1_sub_2": "唔聪明唔靓仔也算了，只要福星高照",
-      "src_2_sub_1": "嗱嗱嗱喺胶兜未落地之前起过另外一个愿望",
-      "src_2_sub_2": "就算唔系咁聪明同咁靓仔只要复星高照"
+      "ref_sub_1": "更正：左边额角上⋯",
+      "ref_sub_2": "转呀，转⋯",
+      "target_sub_1": "都系唔好左边云晶对上",
+      "target_sub_2": "转下转下转下噉"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "唔聪明唔靓仔也算了，只要福星高照",
-      "src_1_sub_2": "一世够运，逢凶化吉！",
-      "src_2_sub_1": "就算唔系咁聪明同咁靓仔只要复星高照",
-      "src_2_sub_2": "一世救运乜嘢事都逢凶化㗎喇"
+      "ref_sub_1": "转呀，转⋯",
+      "ref_sub_2": "麦太认定这是异像",
+      "target_sub_1": "转下转下转下噉",
+      "target_sub_2": "麦太认定呢个系异象"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "一世够运，逢凶化吉！",
-      "src_1_sub_2": "靠自己能力解决事情当然最好",
-      "src_2_sub_1": "一世救运乜嘢事都逢凶化㗎喇",
-      "src_2_sub_2": "佢靠自己有料解决啲嘢就梗系好啦"
+      "ref_sub_1": "麦太认定这是异像",
+      "ref_sub_2": "于是向额角上的胶兜许愿",
+      "target_sub_1": "麦太认定呢个系异象",
+      "target_sub_2": "于是向云晶对上嘅胶兜许愿"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "靠自己能力解决事情当然最好",
-      "src_1_sub_2": "不过运气还是很重要的",
-      "src_2_sub_1": "佢靠自己有料解决啲嘢就梗系好啦",
-      "src_2_sub_2": "不过运气都好紧要㖞"
+      "ref_sub_1": "于是向额角上的胶兜许愿",
+      "ref_sub_2": "脑海中同时出现即将诞生的儿子容貌⋯",
+      "target_sub_1": "于是向云晶对上嘅胶兜许愿",
+      "target_sub_2": "而脑入面亦即时出现咗快要出世个仔嘅样"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "不过运气还是很重要的",
-      "src_1_sub_2": "虽是说像梁朝伟周润发也行运定了",
-      "src_2_sub_1": "不过运气都好紧要㖞",
-      "src_2_sub_2": "虽然似梁朝伟周润发都唔返去冒运行"
+      "ref_sub_1": "脑海中同时出现即将诞生的儿子容貌⋯",
+      "ref_sub_2": "希望他好聪明，读书好叻！",
+      "target_sub_1": "而脑入面亦即时出现咗快要出世个仔嘅样",
+      "target_sub_2": "希望佢好聪明读书好叻"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "虽是说像梁朝伟周润发也行运定了",
-      "src_1_sub_2": "但总得要叻仔呀！",
-      "src_2_sub_1": "虽然似梁朝伟周润发都唔返去冒运行",
-      "src_2_sub_2": "但系都要叻仔先得㗎"
+      "ref_sub_1": "希望他好聪明，读书好叻！",
+      "ref_sub_2": "胶兜对麦太的愿望似乎没有反应",
+      "target_sub_1": "希望佢好聪明读书好叻",
+      "target_sub_2": "胶兜对麦太嘅愿望似乎冇咩表示"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "最后，胶兜「嘀督」一声落地",
-      "src_1_sub_2": "嘀督？嘀督，就是答应了",
-      "src_2_sub_1": "最后胶兜滴嘟一声咁落地",
-      "src_2_sub_2": "滴嘟滴嘟㖞即系应承啦"
+      "ref_sub_1": "胶兜对麦太的愿望似乎没有反应",
+      "ref_sub_2": "于是她向胶兜补充说：",
+      "target_sub_1": "胶兜对麦太嘅愿望似乎冇咩表示",
+      "target_sub_2": "于是佢对住胶兜补充噉话"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "嘀督？嘀督，就是答应了",
-      "src_1_sub_2": "麦太想，这次走运了！",
-      "src_2_sub_1": "滴嘟滴嘟㖞即系应承啦",
-      "src_2_sub_2": "麦太心谂今次冇死喇"
+      "ref_sub_1": "于是她向胶兜补充说：",
+      "ref_sub_2": "或者读书唔叻，工作叻呢？",
+      "target_sub_1": "于是佢对住胶兜补充噉话",
+      "target_sub_2": "或者读书唔叻出嚟做嘢叻啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "麦太想，这次走运了！",
-      "src_1_sub_2": "可是答应了些什么呢？",
-      "src_2_sub_1": "麦太心谂今次冇死喇",
-      "src_2_sub_2": "但你应承咗啲咩呢"
+      "ref_sub_1": "或者读书唔叻，工作叻呢？",
+      "ref_sub_2": "又或者⋯",
+      "target_sub_1": "或者读书唔叻出嚟做嘢叻啦",
+      "target_sub_2": "又或者呢"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "可是答应了些什么呢？",
-      "src_1_sub_2": "叻仔？好运？",
-      "src_2_sub_1": "但你应承咗啲咩呢",
-      "src_2_sub_2": "叻仔好运"
+      "ref_sub_1": "又或者⋯",
+      "ref_sub_2": "又或者好靓仔，好靓仔",
+      "target_sub_1": "又或者呢",
+      "target_sub_2": "又或者系好靓仔好靓仔"
+    },
+    "answer": {},
+    "few_shot": true,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "又或者好靓仔，好靓仔",
+      "ref_sub_2": "跟周润发，梁朝伟那么靓仔！",
+      "target_sub_1": "又或者系好靓仔好靓仔",
+      "target_sub_2": "好似周润发同埋梁朝伟咁靓仔"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "叻仔？好运？",
-      "src_1_sub_2": "还是似周润发？",
-      "src_2_sub_1": "叻仔好运",
-      "src_2_sub_2": "定系话自周人烦啊"
+      "ref_sub_1": "跟周润发，梁朝伟那么靓仔！",
+      "ref_sub_2": "胶兜仍然在转，毫无点头迹象",
+      "target_sub_1": "好似周润发同埋梁朝伟咁靓仔",
+      "target_sub_2": "胶兜依然系噉喺度转好似一啲应承嘅迹象都冇"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "还是似周润发？",
-      "src_1_sub_2": "为了纪念这赐福的胶兜",
-      "src_2_sub_1": "定系话自周人烦啊",
-      "src_2_sub_2": "为咗纪念呢个赤幅嘅胶兜"
+      "ref_sub_1": "胶兜仍然在转，毫无点头迹象",
+      "ref_sub_2": "麦太一时心虚",
+      "target_sub_1": "胶兜依然系噉喺度转好似一啲应承嘅迹象都冇",
+      "target_sub_2": "麦太一时心虚"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "为了纪念这赐福的胶兜",
-      "src_1_sub_2": "麦太决定把儿子命名麦胶",
-      "src_2_sub_1": "为咗纪念呢个赤幅嘅胶兜",
-      "src_2_sub_2": "麦太决定将个仔嘅名叫做麦胶"
+      "ref_sub_1": "麦太一时心虚",
+      "ref_sub_2": "赶忙趁胶兜落地前另许一个愿望：",
+      "target_sub_1": "麦太一时心虚",
+      "target_sub_2": "嗱嗱嗱喺胶兜未落地之前起过另外一个愿望"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "麦太决定把儿子命名麦胶",
-      "src_1_sub_2": "不行，胶胶声，多难听！",
-      "src_2_sub_1": "麦太决定将个仔嘅名叫做麦胶",
-      "src_2_sub_2": "都系唔好胶胶声咁难听"
+      "ref_sub_1": "赶忙趁胶兜落地前另许一个愿望：",
+      "ref_sub_2": "唔聪明唔靓仔也算了，只要福星高照",
+      "target_sub_1": "嗱嗱嗱喺胶兜未落地之前起过另外一个愿望",
+      "target_sub_2": "就算唔系咁聪明同咁靓仔只要复星高照"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "不行，胶胶声，多难听！",
-      "src_1_sub_2": "还是唤他麦兜！",
-      "src_2_sub_1": "都系唔好胶胶声咁难听",
-      "src_2_sub_2": "不如叫麦兜啦"
+      "ref_sub_1": "唔聪明唔靓仔也算了，只要福星高照",
+      "ref_sub_2": "一世够运，逢凶化吉！",
+      "target_sub_1": "就算唔系咁聪明同咁靓仔只要复星高照",
+      "target_sub_2": "一世救运乜嘢事都逢凶化㗎喇"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "还是唤他麦兜！",
-      "src_1_sub_2": "各位⋯",
-      "src_2_sub_1": "不如叫麦兜啦",
-      "src_2_sub_2": "各位"
+      "ref_sub_1": "一世够运，逢凶化吉！",
+      "ref_sub_2": "靠自己能力解决事情当然最好",
+      "target_sub_1": "一世救运乜嘢事都逢凶化㗎喇",
+      "target_sub_2": "佢靠自己有料解决啲嘢就梗系好啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "各位⋯",
-      "src_1_sub_2": "我就是险些给定名麦胶的小朋友⋯",
-      "src_2_sub_1": "各位",
-      "src_2_sub_2": "我就系呢个差少少就叫做麦胶嘅小朋友"
+      "ref_sub_1": "靠自己能力解决事情当然最好",
+      "ref_sub_2": "不过运气还是很重要的",
+      "target_sub_1": "佢靠自己有料解决啲嘢就梗系好啦",
+      "target_sub_2": "不过运气都好紧要㖞"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我就是险些给定名麦胶的小朋友⋯",
-      "src_1_sub_2": "麦兜！",
-      "src_2_sub_1": "我就系呢个差少少就叫做麦胶嘅小朋友",
-      "src_2_sub_2": "麦兜"
+      "ref_sub_1": "不过运气还是很重要的",
+      "ref_sub_2": "虽是说像梁朝伟周润发也行运定了",
+      "target_sub_1": "不过运气都好紧要㖞",
+      "target_sub_2": "虽然似梁朝伟周润发都唔返去冒运行"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "麦太，没见面一阵",
-      "src_1_sub_2": "怎么小腿粗起来了？",
-      "src_2_sub_1": "咦麦太",
-      "src_2_sub_2": "咩唔见你一排个脚刮囊粗咗咁多呀"
+      "ref_sub_1": "虽是说像梁朝伟周润发也行运定了",
+      "ref_sub_2": "但总得要叻仔呀！",
+      "target_sub_1": "虽然似梁朝伟周润发都唔返去冒运行",
+      "target_sub_2": "但系都要叻仔先得㗎"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "最后，胶兜「嘀督」一声落地",
+      "ref_sub_2": "嘀督？嘀督，就是答应了",
+      "target_sub_1": "最后胶兜滴嘟一声咁落地",
+      "target_sub_2": "滴嘟滴嘟㖞即系应承啦"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "嘀督？嘀督，就是答应了",
+      "ref_sub_2": "麦太想，这次走运了！",
+      "target_sub_1": "滴嘟滴嘟㖞即系应承啦",
+      "target_sub_2": "麦太心谂今次冇死喇"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "麦太想，这次走运了！",
+      "ref_sub_2": "可是答应了些什么呢？",
+      "target_sub_1": "麦太心谂今次冇死喇",
+      "target_sub_2": "但你应承咗啲咩呢"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "可是答应了些什么呢？",
+      "ref_sub_2": "叻仔？好运？",
+      "target_sub_1": "但你应承咗啲咩呢",
+      "target_sub_2": "叻仔好运"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "叻仔？好运？",
+      "ref_sub_2": "还是似周润发？",
+      "target_sub_1": "叻仔好运",
+      "target_sub_2": "定系话自周人烦啊"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "还是似周润发？",
+      "ref_sub_2": "为了纪念这赐福的胶兜",
+      "target_sub_1": "定系话自周人烦啊",
+      "target_sub_2": "为咗纪念呢个赤幅嘅胶兜"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "为了纪念这赐福的胶兜",
+      "ref_sub_2": "麦太决定把儿子命名麦胶",
+      "target_sub_1": "为咗纪念呢个赤幅嘅胶兜",
+      "target_sub_2": "麦太决定将个仔嘅名叫做麦胶"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "麦太决定把儿子命名麦胶",
+      "ref_sub_2": "不行，胶胶声，多难听！",
+      "target_sub_1": "麦太决定将个仔嘅名叫做麦胶",
+      "target_sub_2": "都系唔好胶胶声咁难听"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "不行，胶胶声，多难听！",
+      "ref_sub_2": "还是唤他麦兜！",
+      "target_sub_1": "都系唔好胶胶声咁难听",
+      "target_sub_2": "不如叫麦兜啦"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "还是唤他麦兜！",
+      "ref_sub_2": "各位⋯",
+      "target_sub_1": "不如叫麦兜啦",
+      "target_sub_2": "各位"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "各位⋯",
+      "ref_sub_2": "我就是险些给定名麦胶的小朋友⋯",
+      "target_sub_1": "各位",
+      "target_sub_2": "我就系呢个差少少就叫做麦胶嘅小朋友"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我就是险些给定名麦胶的小朋友⋯",
+      "ref_sub_2": "麦兜！",
+      "target_sub_1": "我就系呢个差少少就叫做麦胶嘅小朋友",
+      "target_sub_2": "麦兜"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "麦太，没见面一阵",
+      "ref_sub_2": "怎么小腿粗起来了？",
+      "target_sub_1": "咦麦太",
+      "target_sub_2": "咩唔见你一排个脚刮囊粗咗咁多呀"
     },
     "answer": {
-      "src_2_sub_1_shifted": "咦麦太咩唔见你一排",
-      "src_2_sub_2_shifted": "个脚刮囊粗咗咁多呀"
+      "target_sub_1_shifted": "咦麦太咩唔见你一排",
+      "target_sub_2_shifted": "个脚刮囊粗咗咁多呀"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -460,10 +460,10 @@
   },
   {
     "query": {
-      "src_1_sub_1": "怎么小腿粗起来了？",
-      "src_1_sub_2": "可怜呀，每天扑来扑去⋯",
-      "src_2_sub_1": "个脚刮囊粗咗咁多呀",
-      "src_2_sub_2": "鬼咩"
+      "ref_sub_1": "怎么小腿粗起来了？",
+      "ref_sub_2": "可怜呀，每天扑来扑去⋯",
+      "target_sub_1": "个脚刮囊粗咗咁多呀",
+      "target_sub_2": "鬼咩"
     },
     "answer": {},
     "few_shot": true,
@@ -471,14 +471,14 @@
   },
   {
     "query": {
-      "src_1_sub_1": "可怜呀，每天扑来扑去⋯",
-      "src_1_sub_2": "替儿子找幼稚园！",
-      "src_2_sub_1": "鬼咩",
-      "src_2_sub_2": "日日扑嚟扑去同我仔揾幼稚园吖嘛"
+      "ref_sub_1": "可怜呀，每天扑来扑去⋯",
+      "ref_sub_2": "替儿子找幼稚园！",
+      "target_sub_1": "鬼咩",
+      "target_sub_2": "日日扑嚟扑去同我仔揾幼稚园吖嘛"
     },
     "answer": {
-      "src_2_sub_1_shifted": "鬼咩日日扑嚟扑去",
-      "src_2_sub_2_shifted": "同我仔揾幼稚园吖嘛"
+      "target_sub_1_shifted": "鬼咩日日扑嚟扑去",
+      "target_sub_2_shifted": "同我仔揾幼稚园吖嘛"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -486,52 +486,52 @@
   },
   {
     "query": {
-      "src_1_sub_1": "替儿子找幼稚园！",
-      "src_1_sub_2": "怎么不试一试好彩酒楼对面",
-      "src_2_sub_1": "同我仔揾幼稚园吖嘛",
-      "src_2_sub_2": "点解唔试下好彩走楼斜对面"
+      "ref_sub_1": "替儿子找幼稚园！",
+      "ref_sub_2": "怎么不试一试好彩酒楼对面",
+      "target_sub_1": "同我仔揾幼稚园吖嘛",
+      "target_sub_2": "点解唔试下好彩走楼斜对面"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "怎么不试一试好彩酒楼对面",
-      "src_1_sub_2": "旧中侨国货楼上的⋯",
-      "src_2_sub_1": "点解唔试下好彩走楼斜对面"
+      "ref_sub_1": "怎么不试一试好彩酒楼对面",
+      "ref_sub_2": "旧中侨国货楼上的⋯",
+      "target_sub_1": "点解唔试下好彩走楼斜对面"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "旧中侨国货楼上的⋯",
-      "src_1_sub_2": "春田花花幼稚园？",
-      "src_2_sub_2": "旧中桥百货公司楼上嗰间春田花花幼稚园呢"
+      "ref_sub_1": "旧中侨国货楼上的⋯",
+      "ref_sub_2": "春田花花幼稚园？",
+      "target_sub_2": "旧中桥百货公司楼上嗰间春田花花幼稚园呢"
     },
     "answer": {
-      "src_2_sub_1_shifted": "旧中桥百货公司楼上嗰间",
-      "src_2_sub_2_shifted": "春田花花幼稚园呢"
+      "target_sub_1_shifted": "旧中桥百货公司楼上嗰间",
+      "target_sub_2_shifted": "春田花花幼稚园呢"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "怎么不试一试好彩酒楼对面",
-      "src_1_sub_2": "旧中侨国货楼上的⋯",
-      "src_2_sub_1": "点解唔试下好彩走楼斜对面",
-      "src_2_sub_2": "旧中桥百货公司楼上嗰间"
+      "ref_sub_1": "怎么不试一试好彩酒楼对面",
+      "ref_sub_2": "旧中侨国货楼上的⋯",
+      "target_sub_1": "点解唔试下好彩走楼斜对面",
+      "target_sub_2": "旧中桥百货公司楼上嗰间"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "旧中侨国货楼上的⋯",
-      "src_1_sub_2": "春田花花幼稚园？",
-      "src_2_sub_1": "旧中桥百货公司楼上嗰间",
-      "src_2_sub_2": "春田花花幼稚园呢"
+      "ref_sub_1": "旧中侨国货楼上的⋯",
+      "ref_sub_2": "春田花花幼稚园？",
+      "target_sub_1": "旧中桥百货公司楼上嗰间",
+      "target_sub_2": "春田花花幼稚园呢"
     },
     "answer": {},
     "few_shot": true,
@@ -539,32 +539,32 @@
   },
   {
     "query": {
-      "src_1_sub_1": "春田花花幼稚园？",
-      "src_1_sub_2": "就是座落界限街南昌街交界⋯",
-      "src_2_sub_1": "春田花花幼稚园呢",
-      "src_2_sub_2": "就系坐落喺界限街同南昌街交界"
+      "ref_sub_1": "春田花花幼稚园？",
+      "ref_sub_2": "就是座落界限街南昌街交界⋯",
+      "target_sub_1": "春田花花幼稚园呢",
+      "target_sub_2": "就系坐落喺界限街同南昌街交界"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "就是座落界限街南昌街交界⋯",
-      "src_1_sub_2": "银城美食广场附近的⋯",
-      "src_2_sub_1": "就系坐落喺界限街同南昌街交界"
+      "ref_sub_1": "就是座落界限街南昌街交界⋯",
+      "ref_sub_2": "银城美食广场附近的⋯",
+      "target_sub_1": "就系坐落喺界限街同南昌街交界"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "银城美食广场附近的⋯",
-      "src_1_sub_2": "春田花花幼稚园？",
-      "src_2_sub_2": "银城美食广场附近嗰间春田花花幼稚园呀"
+      "ref_sub_1": "银城美食广场附近的⋯",
+      "ref_sub_2": "春田花花幼稚园？",
+      "target_sub_2": "银城美食广场附近嗰间春田花花幼稚园呀"
     },
     "answer": {
-      "src_2_sub_1_shifted": "银城美食广场附近嗰间",
-      "src_2_sub_2_shifted": "春田花花幼稚园呀"
+      "target_sub_1_shifted": "银城美食广场附近嗰间",
+      "target_sub_2_shifted": "春田花花幼稚园呀"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -572,70 +572,70 @@
   },
   {
     "query": {
-      "src_1_sub_1": "春田花花幼稚园？",
-      "src_1_sub_2": "对！深水埗地铁站步行不用10分钟！",
-      "src_2_sub_1": "春田花花幼稚园呀",
-      "src_2_sub_2": "系呀深水埗地铁站口行过去唔使十分钟呀"
+      "ref_sub_1": "春田花花幼稚园？",
+      "ref_sub_2": "对！深水埗地铁站步行不用10分钟！",
+      "target_sub_1": "春田花花幼稚园呀",
+      "target_sub_2": "系呀深水埗地铁站口行过去唔使十分钟呀"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "对！深水埗地铁站步行不用10分钟！",
-      "src_1_sub_2": "春田花花幼稚园，师资优良⋯",
-      "src_2_sub_1": "系呀深水埗地铁站口行过去唔使十分钟呀",
-      "src_2_sub_2": "春田花花幼稚园"
+      "ref_sub_1": "对！深水埗地铁站步行不用10分钟！",
+      "ref_sub_2": "春田花花幼稚园，师资优良⋯",
+      "target_sub_1": "系呀深水埗地铁站口行过去唔使十分钟呀",
+      "target_sub_2": "春田花花幼稚园"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "春田花花幼稚园，师资优良⋯",
-      "src_1_sub_2": "而且还有西人教英文！",
-      "src_2_sub_1": "春田花花幼稚园",
-      "src_2_sub_2": "诗诗优良仲系西人教英文添㗎"
+      "ref_sub_1": "春田花花幼稚园，师资优良⋯",
+      "ref_sub_2": "而且还有西人教英文！",
+      "target_sub_1": "春田花花幼稚园",
+      "target_sub_2": "诗诗优良仲系西人教英文添㗎"
     },
     "answer": {
-      "src_2_sub_1_shifted": "春田花花幼稚园诗诗优良",
-      "src_2_sub_2_shifted": "仲系西人教英文添㗎"
+      "target_sub_1_shifted": "春田花花幼稚园诗诗优良",
+      "target_sub_2_shifted": "仲系西人教英文添㗎"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "而且还有西人教英文！",
-      "src_1_sub_2": "西人教英文？",
-      "src_2_sub_1": "仲系西人教英文添㗎",
-      "src_2_sub_2": "咦"
+      "ref_sub_1": "而且还有西人教英文！",
+      "ref_sub_2": "西人教英文？",
+      "target_sub_1": "仲系西人教英文添㗎",
+      "target_sub_2": "咦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "西人教英文？",
-      "src_1_sub_2": "是呀！",
-      "src_2_sub_1": "咦",
-      "src_2_sub_2": "西人教英文"
+      "ref_sub_1": "西人教英文？",
+      "ref_sub_2": "是呀！",
+      "target_sub_1": "咦",
+      "target_sub_2": "西人教英文"
     },
     "answer": {
-      "src_2_sub_1_shifted": "咦西人教英文"
+      "target_sub_1_shifted": "咦西人教英文"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "是呀！",
-      "src_1_sub_2": "春田花花，确有好多西人呀！",
-      "src_2_sub_2": "系呀春田花花真系好多西人㗎"
+      "ref_sub_1": "是呀！",
+      "ref_sub_2": "春田花花，确有好多西人呀！",
+      "target_sub_2": "系呀春田花花真系好多西人㗎"
     },
     "answer": {
-      "src_2_sub_1_shifted": "系呀",
-      "src_2_sub_2_shifted": "春田花花真系好多西人㗎"
+      "target_sub_1_shifted": "系呀",
+      "target_sub_2_shifted": "春田花花真系好多西人㗎"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -643,9 +643,9 @@
   },
   {
     "query": {
-      "src_1_sub_1": "〝鹅闷是春天滴化！〞",
-      "src_1_sub_2": "这个猪样白兔小朋友⋯",
-      "src_2_sub_2": "呢个扮紧白兔猪样嘅小朋友"
+      "ref_sub_1": "〝鹅闷是春天滴化！〞",
+      "ref_sub_2": "这个猪样白兔小朋友⋯",
+      "target_sub_2": "呢个扮紧白兔猪样嘅小朋友"
     },
     "answer": {},
     "few_shot": true,
@@ -653,84 +653,84 @@
   },
   {
     "query": {
-      "src_1_sub_1": "这个猪样白兔小朋友⋯",
-      "src_1_sub_2": "横看竖看也不像发哥伟仔的一个⋯",
-      "src_2_sub_1": "呢个扮紧白兔猪样嘅小朋友",
-      "src_2_sub_2": "即系横睇掂睇都唔似发哥或者"
+      "ref_sub_1": "这个猪样白兔小朋友⋯",
+      "ref_sub_2": "横看竖看也不像发哥伟仔的一个⋯",
+      "target_sub_1": "呢个扮紧白兔猪样嘅小朋友",
+      "target_sub_2": "即系横睇掂睇都唔似发哥或者"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "横看竖看也不像发哥伟仔的一个⋯",
-      "src_1_sub_2": "就是我，麦兜",
-      "src_2_sub_1": "即系横睇掂睇都唔似发哥或者",
-      "src_2_sub_2": "位仔嗰个呢就系我麦兜"
+      "ref_sub_1": "横看竖看也不像发哥伟仔的一个⋯",
+      "ref_sub_2": "就是我，麦兜",
+      "target_sub_1": "即系横睇掂睇都唔似发哥或者",
+      "target_sub_2": "位仔嗰个呢就系我麦兜"
     },
     "answer": {
-      "src_2_sub_1_shifted": "即系横睇掂睇都唔似发哥或者位仔嗰个呢",
-      "src_2_sub_2_shifted": "就系我麦兜"
+      "target_sub_1_shifted": "即系横睇掂睇都唔似发哥或者位仔嗰个呢",
+      "target_sub_2_shifted": "就系我麦兜"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "就是我，麦兜",
-      "src_1_sub_2": "这是我就读的幼稚园",
-      "src_2_sub_1": "就系我麦兜",
-      "src_2_sub_2": "呢间就系我读嘅幼稚园"
+      "ref_sub_1": "就是我，麦兜",
+      "ref_sub_2": "这是我就读的幼稚园",
+      "target_sub_1": "就系我麦兜",
+      "target_sub_2": "呢间就系我读嘅幼稚园"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "这是我就读的幼稚园",
-      "src_1_sub_2": "校长是潮州人",
-      "src_2_sub_1": "呢间就系我读嘅幼稚园",
-      "src_2_sub_2": "校长系潮州人"
+      "ref_sub_1": "这是我就读的幼稚园",
+      "ref_sub_2": "校长是潮州人",
+      "target_sub_1": "呢间就系我读嘅幼稚园",
+      "target_sub_2": "校长系潮州人"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "校长是潮州人",
-      "src_1_sub_2": "可能是潮州口音的关系",
-      "src_2_sub_1": "校长系潮州人",
-      "src_2_sub_2": "可能仲系讲紧潮州话嘅"
+      "ref_sub_1": "校长是潮州人",
+      "ref_sub_2": "可能是潮州口音的关系",
+      "target_sub_1": "校长系潮州人",
+      "target_sub_2": "可能仲系讲紧潮州话嘅"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "可能是潮州口音的关系",
-      "src_1_sub_2": "这么多年来⋯",
-      "src_2_sub_1": "可能仲系讲紧潮州话嘅",
-      "src_2_sub_2": "所以咁多年嚟"
+      "ref_sub_1": "可能是潮州口音的关系",
+      "ref_sub_2": "这么多年来⋯",
+      "target_sub_1": "可能仲系讲紧潮州话嘅",
+      "target_sub_2": "所以咁多年嚟"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "这么多年来⋯",
-      "src_1_sub_2": "我其实不大明白他的说话",
-      "src_2_sub_1": "所以咁多年嚟",
-      "src_2_sub_2": "我其实唔系好知佢噏文"
+      "ref_sub_1": "这么多年来⋯",
+      "ref_sub_2": "我其实不大明白他的说话",
+      "target_sub_1": "所以咁多年嚟",
+      "target_sub_2": "我其实唔系好知佢噏文"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我其实不大明白他的说话",
-      "src_1_sub_2": "蛋挞！　　蛋挞！",
-      "src_2_sub_1": "我其实唔系好知佢噏文",
-      "src_2_sub_2": "大湖荒岩宅"
+      "ref_sub_1": "我其实不大明白他的说话",
+      "ref_sub_2": "蛋挞！　　蛋挞！",
+      "target_sub_1": "我其实唔系好知佢噏文",
+      "target_sub_2": "大湖荒岩宅"
     },
     "answer": {},
     "difficulty": 3,
@@ -738,10 +738,10 @@
   },
   {
     "query": {
-      "src_1_sub_1": "蛋挞！　　蛋挞！",
-      "src_1_sub_2": "荔芋火鸭札！　　荔芋火鸭札！",
-      "src_2_sub_1": "大湖荒岩宅",
-      "src_2_sub_2": "湾吉校坟交涉设"
+      "ref_sub_1": "蛋挞！　　蛋挞！",
+      "ref_sub_2": "荔芋火鸭札！　　荔芋火鸭札！",
+      "target_sub_1": "大湖荒岩宅",
+      "target_sub_2": "湾吉校坟交涉设"
     },
     "answer": {},
     "difficulty": 3,
@@ -749,9 +749,9 @@
   },
   {
     "query": {
-      "src_1_sub_1": "荔芋火鸭札！　　荔芋火鸭札！",
-      "src_1_sub_2": "忘记校训九十七⋯　　忘记校训九十七⋯",
-      "src_2_sub_1": "湾吉校坟交涉设"
+      "ref_sub_1": "荔芋火鸭札！　　荔芋火鸭札！",
+      "ref_sub_2": "忘记校训九十七⋯　　忘记校训九十七⋯",
+      "target_sub_1": "湾吉校坟交涉设"
     },
     "answer": {},
     "difficulty": 3,
@@ -759,9 +759,9 @@
   },
   {
     "query": {
-      "src_1_sub_1": "忘记校训九十七⋯　　忘记校训九十七⋯",
-      "src_1_sub_2": "也不能忘记校训九十八！",
-      "src_2_sub_2": "都唔好湾吉校坟交涉白"
+      "ref_sub_1": "忘记校训九十七⋯　　忘记校训九十七⋯",
+      "ref_sub_2": "也不能忘记校训九十八！",
+      "target_sub_2": "都唔好湾吉校坟交涉白"
     },
     "answer": {},
     "difficulty": 3,
@@ -769,18 +769,18 @@
   },
   {
     "query": {
-      "src_1_sub_1": "也不能忘记校训九十八！",
-      "src_1_sub_2": "也不能忘记校训九十八！",
-      "src_2_sub_1": "都唔好湾吉校坟交涉白"
+      "ref_sub_1": "也不能忘记校训九十八！",
+      "ref_sub_2": "也不能忘记校训九十八！",
+      "target_sub_1": "都唔好湾吉校坟交涉白"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "也不能忘记校训九十八！",
-      "src_1_sub_2": "好！各位同学⋯",
-      "src_2_sub_2": "嗰个位同学"
+      "ref_sub_1": "也不能忘记校训九十八！",
+      "ref_sub_2": "好！各位同学⋯",
+      "target_sub_2": "嗰个位同学"
     },
     "answer": {},
     "few_shot": true,
@@ -788,62 +788,62 @@
   },
   {
     "query": {
-      "src_1_sub_1": "好！各位同学⋯",
-      "src_1_sub_2": "今天的早会主要是跟大家分享",
-      "src_2_sub_1": "嗰个位同学"
+      "ref_sub_1": "好！各位同学⋯",
+      "ref_sub_2": "今天的早会主要是跟大家分享",
+      "target_sub_1": "嗰个位同学"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "今天的早会主要是跟大家分享",
-      "src_1_sub_2": "一个重要主题：",
-      "src_2_sub_2": "今次座会系要同大家分享一个可重要嘅主题"
+      "ref_sub_1": "今天的早会主要是跟大家分享",
+      "ref_sub_2": "一个重要主题：",
+      "target_sub_2": "今次座会系要同大家分享一个可重要嘅主题"
     },
     "answer": {
-      "src_2_sub_1_shifted": "今次座会系要同大家分享",
-      "src_2_sub_2_shifted": "一个可重要嘅主题"
+      "target_sub_1_shifted": "今次座会系要同大家分享",
+      "target_sub_2_shifted": "一个可重要嘅主题"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "好！各位同学⋯",
-      "src_1_sub_2": "今天的早会主要是跟大家分享",
-      "src_2_sub_1": "嗰个位同学",
-      "src_2_sub_2": "今次座会系要同大家分享"
+      "ref_sub_1": "好！各位同学⋯",
+      "ref_sub_2": "今天的早会主要是跟大家分享",
+      "target_sub_1": "嗰个位同学",
+      "target_sub_2": "今次座会系要同大家分享"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "今天的早会主要是跟大家分享",
-      "src_1_sub_2": "一个重要主题：",
-      "src_2_sub_1": "今次座会系要同大家分享",
-      "src_2_sub_2": "一个可重要嘅主题"
+      "ref_sub_1": "今天的早会主要是跟大家分享",
+      "ref_sub_2": "一个重要主题：",
+      "target_sub_1": "今次座会系要同大家分享",
+      "target_sub_2": "一个可重要嘅主题"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "一个重要主题：",
-      "src_1_sub_2": "小朋友，这个月你们交过学费没有？",
-      "src_2_sub_1": "一个可重要嘅主题",
-      "src_2_sub_2": "小朋友你哋今个月交咗学费咩呀"
+      "ref_sub_1": "一个重要主题：",
+      "ref_sub_2": "小朋友，这个月你们交过学费没有？",
+      "target_sub_1": "一个可重要嘅主题",
+      "target_sub_2": "小朋友你哋今个月交咗学费咩呀"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "小朋友，这个月你们交过学费没有？",
-      "src_1_sub_2": "交过了！",
-      "src_2_sub_1": "小朋友你哋今个月交咗学费咩呀",
-      "src_2_sub_2": "交"
+      "ref_sub_1": "小朋友，这个月你们交过学费没有？",
+      "ref_sub_2": "交过了！",
+      "target_sub_1": "小朋友你哋今个月交咗学费咩呀",
+      "target_sub_2": "交"
     },
     "answer": {},
     "few_shot": true,
@@ -851,230 +851,230 @@
   },
   {
     "query": {
-      "src_1_sub_1": "交过了！",
-      "src_1_sub_2": "太好了！大家去上堂吧",
-      "src_2_sub_1": "交",
-      "src_2_sub_2": "哎好在噉大家可以返去上堂喇"
+      "ref_sub_1": "交过了！",
+      "ref_sub_2": "太好了！大家去上堂吧",
+      "target_sub_1": "交",
+      "target_sub_2": "哎好在噉大家可以返去上堂喇"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "你们可能觉得这间幼稚园很烂",
-      "src_1_sub_2": "可是，对我和我一班同学",
-      "src_2_sub_1": "你哋可能觉得呢间幼稚园好逗利",
-      "src_2_sub_2": "但系对于我同埋我班同学仔嚟讲"
+      "ref_sub_1": "你们可能觉得这间幼稚园很烂",
+      "ref_sub_2": "可是，对我和我一班同学",
+      "target_sub_1": "你哋可能觉得呢间幼稚园好逗利",
+      "target_sub_2": "但系对于我同埋我班同学仔嚟讲"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "可是，对我和我一班同学",
-      "src_1_sub_2": "这儿是我们最快乐，最美丽的乐园⋯",
-      "src_2_sub_1": "但系对于我同埋我班同学仔嚟讲",
-      "src_2_sub_2": "呢度系我哋最快乐最美丽嘅乐园"
+      "ref_sub_1": "可是，对我和我一班同学",
+      "ref_sub_2": "这儿是我们最快乐，最美丽的乐园⋯",
+      "target_sub_1": "但系对于我同埋我班同学仔嚟讲",
+      "target_sub_2": "呢度系我哋最快乐最美丽嘅乐园"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "这儿是我们最快乐，最美丽的乐园⋯",
-      "src_1_sub_2": "⋯还有一个很疼我们",
-      "src_2_sub_1": "呢度系我哋最快乐最美丽嘅乐园",
-      "src_2_sub_2": "仲有一个好疼我哋"
+      "ref_sub_1": "这儿是我们最快乐，最美丽的乐园⋯",
+      "ref_sub_2": "⋯还有一个很疼我们",
+      "target_sub_1": "呢度系我哋最快乐最美丽嘅乐园",
+      "target_sub_2": "仲有一个好疼我哋"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "⋯还有一个很疼我们",
-      "src_1_sub_2": "就是有点游魂的Miss Chan",
-      "src_2_sub_1": "仲有一个好疼我哋",
-      "src_2_sub_2": "不过就有少少失魂嘅班主有MissChan"
+      "ref_sub_1": "⋯还有一个很疼我们",
+      "ref_sub_2": "就是有点游魂的Miss Chan",
+      "target_sub_1": "仲有一个好疼我哋",
+      "target_sub_2": "不过就有少少失魂嘅班主有MissChan"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "就是有点游魂的Miss Chan",
-      "src_1_sub_2": "她的志愿是做第二个王菲",
-      "src_2_sub_1": "不过就有少少失魂嘅班主有MissChan",
-      "src_2_sub_2": "佢嘅志愿系做下一个王妃"
+      "ref_sub_1": "就是有点游魂的Miss Chan",
+      "ref_sub_2": "她的志愿是做第二个王菲",
+      "target_sub_1": "不过就有少少失魂嘅班主有MissChan",
+      "target_sub_2": "佢嘅志愿系做下一个王妃"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "她的志愿是做第二个王菲",
-      "src_1_sub_2": "做第二个陈慧琳也可以",
-      "src_2_sub_1": "佢嘅志愿系做下一个王妃",
-      "src_2_sub_2": "或者系做下一个陈维林都得"
+      "ref_sub_1": "她的志愿是做第二个王菲",
+      "ref_sub_2": "做第二个陈慧琳也可以",
+      "target_sub_1": "佢嘅志愿系做下一个王妃",
+      "target_sub_2": "或者系做下一个陈维林都得"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "做第二个陈慧琳也可以",
-      "src_1_sub_2": "我们现在开始点名",
-      "src_2_sub_1": "或者系做下一个陈维林都得",
-      "src_2_sub_2": "好喇我哋而家开始点名"
+      "ref_sub_1": "做第二个陈慧琳也可以",
+      "ref_sub_2": "我们现在开始点名",
+      "target_sub_1": "或者系做下一个陈维林都得",
+      "target_sub_2": "好喇我哋而家开始点名"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我们现在开始点名",
-      "src_1_sub_2": "麦唛同学！　　到！",
-      "src_2_sub_1": "好喇我哋而家开始点名",
-      "src_2_sub_2": "麦麦同学"
+      "ref_sub_1": "我们现在开始点名",
+      "ref_sub_2": "麦唛同学！　　到！",
+      "target_sub_1": "好喇我哋而家开始点名",
+      "target_sub_2": "麦麦同学"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "麦唛同学！　　到！",
-      "src_1_sub_2": "亚辉同学！　　到！",
-      "src_2_sub_1": "麦麦同学",
-      "src_2_sub_2": "到阿辉同学"
+      "ref_sub_1": "麦唛同学！　　到！",
+      "ref_sub_2": "亚辉同学！　　到！",
+      "target_sub_1": "麦麦同学",
+      "target_sub_2": "到阿辉同学"
     },
     "answer": {
-      "src_2_sub_1_shifted": "麦麦同学到",
-      "src_2_sub_2_shifted": "阿辉同学"
+      "target_sub_1_shifted": "麦麦同学到",
+      "target_sub_2_shifted": "阿辉同学"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "亚辉同学！　　到！",
-      "src_1_sub_2": "菇时同学！　　到！",
-      "src_2_sub_1": "阿辉同学",
-      "src_2_sub_2": "到Boosie同学"
+      "ref_sub_1": "亚辉同学！　　到！",
+      "ref_sub_2": "菇时同学！　　到！",
+      "target_sub_1": "阿辉同学",
+      "target_sub_2": "到Boosie同学"
     },
     "answer": {
-      "src_2_sub_1_shifted": "阿辉同学到",
-      "src_2_sub_2_shifted": "Boosie同学"
+      "target_sub_1_shifted": "阿辉同学到",
+      "target_sub_2_shifted": "Boosie同学"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "菇时同学！　　到！",
-      "src_1_sub_2": "得巴同学！　　到！",
-      "src_2_sub_1": "Boosie同学",
-      "src_2_sub_2": "到德巴同学"
+      "ref_sub_1": "菇时同学！　　到！",
+      "ref_sub_2": "得巴同学！　　到！",
+      "target_sub_1": "Boosie同学",
+      "target_sub_2": "到德巴同学"
     },
     "answer": {
-      "src_2_sub_1_shifted": "Boosie同学到",
-      "src_2_sub_2_shifted": "德巴同学"
+      "target_sub_1_shifted": "Boosie同学到",
+      "target_sub_2_shifted": "德巴同学"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "得巴同学！　　到！",
-      "src_1_sub_2": "阿May同学！　　到！",
-      "src_2_sub_1": "德巴同学",
-      "src_2_sub_2": "到阿May同学到"
+      "ref_sub_1": "得巴同学！　　到！",
+      "ref_sub_2": "阿May同学！　　到！",
+      "target_sub_1": "德巴同学",
+      "target_sub_2": "到阿May同学到"
     },
     "answer": {
-      "src_2_sub_1_shifted": "德巴同学到",
-      "src_2_sub_2_shifted": "阿May同学到"
+      "target_sub_1_shifted": "德巴同学到",
+      "target_sub_2_shifted": "阿May同学到"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "阿May同学！　　到！",
-      "src_1_sub_2": "阿June同学！　　到！",
-      "src_2_sub_1": "阿May同学到",
-      "src_2_sub_2": "阿June同学"
+      "ref_sub_1": "阿May同学！　　到！",
+      "ref_sub_2": "阿June同学！　　到！",
+      "target_sub_1": "阿May同学到",
+      "target_sub_2": "阿June同学"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "阿June同学！　　到！",
-      "src_1_sub_2": "阿May同学！　　到！",
-      "src_2_sub_1": "阿June同学",
-      "src_2_sub_2": "到阿May同学到"
+      "ref_sub_1": "阿June同学！　　到！",
+      "ref_sub_2": "阿May同学！　　到！",
+      "target_sub_1": "阿June同学",
+      "target_sub_2": "到阿May同学到"
     },
     "answer": {
-      "src_2_sub_1_shifted": "阿June同学到",
-      "src_2_sub_2_shifted": "阿May同学到"
+      "target_sub_1_shifted": "阿June同学到",
+      "target_sub_2_shifted": "阿May同学到"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "阿May同学！　　到！",
-      "src_1_sub_2": "麦唛同学！　　到！",
-      "src_2_sub_1": "阿May同学到",
-      "src_2_sub_2": "麦麦同学到"
+      "ref_sub_1": "阿May同学！　　到！",
+      "ref_sub_2": "麦唛同学！　　到！",
+      "target_sub_1": "阿May同学到",
+      "target_sub_2": "麦麦同学到"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "麦唛同学！　　到！",
-      "src_1_sub_2": "阿May同学！",
-      "src_2_sub_1": "麦麦同学到"
+      "ref_sub_1": "麦唛同学！　　到！",
+      "ref_sub_2": "阿May同学！",
+      "target_sub_1": "麦麦同学到"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "阿May同学！",
-      "src_1_sub_2": "Miss Chan，我点过两次了！",
-      "src_2_sub_2": "阿May同学MissChan你点咗我两次喇"
+      "ref_sub_1": "阿May同学！",
+      "ref_sub_2": "Miss Chan，我点过两次了！",
+      "target_sub_2": "阿May同学MissChan你点咗我两次喇"
     },
     "answer": {
-      "src_2_sub_1_shifted": "阿May同学",
-      "src_2_sub_2_shifted": "MissChan你点咗我两次喇"
+      "target_sub_1_shifted": "阿May同学",
+      "target_sub_2_shifted": "MissChan你点咗我两次喇"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "Miss Chan，我点过两次了！",
-      "src_1_sub_2": "呀，真的吗？",
-      "src_2_sub_1": "MissChan你点咗我两次喇",
-      "src_2_sub_2": "啊系咩"
+      "ref_sub_1": "Miss Chan，我点过两次了！",
+      "ref_sub_2": "呀，真的吗？",
+      "target_sub_1": "MissChan你点咗我两次喇",
+      "target_sub_2": "啊系咩"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "呀，真的吗？",
-      "src_1_sub_2": "校长早晨！",
-      "src_2_sub_1": "啊系咩"
+      "ref_sub_1": "呀，真的吗？",
+      "ref_sub_2": "校长早晨！",
+      "target_sub_1": "啊系咩"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "校长再见！",
-      "src_1_sub_2": "我们现在继续点名",
-      "src_2_sub_2": "好我哋而家继续点名"
+      "ref_sub_1": "校长再见！",
+      "ref_sub_2": "我们现在继续点名",
+      "target_sub_2": "好我哋而家继续点名"
     },
     "answer": {},
     "few_shot": true,
@@ -1082,106 +1082,106 @@
   },
   {
     "query": {
-      "src_1_sub_1": "我们现在继续点名",
-      "src_1_sub_2": "阿June同学！　　到！",
-      "src_2_sub_1": "好我哋而家继续点名",
-      "src_2_sub_2": "阿June同学"
+      "ref_sub_1": "我们现在继续点名",
+      "ref_sub_2": "阿June同学！　　到！",
+      "target_sub_1": "好我哋而家继续点名",
+      "target_sub_2": "阿June同学"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "阿June同学！　　到！",
-      "src_1_sub_2": "亚辉同学！　　到！",
-      "src_2_sub_1": "阿June同学",
-      "src_2_sub_2": "到阿辉同学"
+      "ref_sub_1": "阿June同学！　　到！",
+      "ref_sub_2": "亚辉同学！　　到！",
+      "target_sub_1": "阿June同学",
+      "target_sub_2": "到阿辉同学"
     },
     "answer": {
-      "src_2_sub_1_shifted": "阿June同学到",
-      "src_2_sub_2_shifted": "阿辉同学"
+      "target_sub_1_shifted": "阿June同学到",
+      "target_sub_2_shifted": "阿辉同学"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "亚辉同学！　　到！",
-      "src_1_sub_2": "得巴同学！　　到！",
-      "src_2_sub_1": "阿辉同学",
-      "src_2_sub_2": "到德巴同学到"
+      "ref_sub_1": "亚辉同学！　　到！",
+      "ref_sub_2": "得巴同学！　　到！",
+      "target_sub_1": "阿辉同学",
+      "target_sub_2": "到德巴同学到"
     },
     "answer": {
-      "src_2_sub_1_shifted": "阿辉同学到",
-      "src_2_sub_2_shifted": "德巴同学到"
+      "target_sub_1_shifted": "阿辉同学到",
+      "target_sub_2_shifted": "德巴同学到"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "得巴同学！　　到！",
-      "src_1_sub_2": "阿May同学！　　到！",
-      "src_2_sub_1": "德巴同学到",
-      "src_2_sub_2": "阿May同学"
+      "ref_sub_1": "得巴同学！　　到！",
+      "ref_sub_2": "阿May同学！　　到！",
+      "target_sub_1": "德巴同学到",
+      "target_sub_2": "阿May同学"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "阿May同学！　　到！",
-      "src_1_sub_2": "麦唛同学！　　到！",
-      "src_2_sub_1": "阿May同学",
-      "src_2_sub_2": "到麦麦同学到"
+      "ref_sub_1": "阿May同学！　　到！",
+      "ref_sub_2": "麦唛同学！　　到！",
+      "target_sub_1": "阿May同学",
+      "target_sub_2": "到麦麦同学到"
     },
     "answer": {
-      "src_2_sub_1_shifted": "阿May同学到",
-      "src_2_sub_2_shifted": "麦麦同学到"
+      "target_sub_1_shifted": "阿May同学到",
+      "target_sub_2_shifted": "麦麦同学到"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "麦唛同学！　　到！",
-      "src_1_sub_2": "菇时同学！　　到！",
-      "src_2_sub_1": "麦麦同学到",
-      "src_2_sub_2": "Boosie同学到"
+      "ref_sub_1": "麦唛同学！　　到！",
+      "ref_sub_2": "菇时同学！　　到！",
+      "target_sub_1": "麦麦同学到",
+      "target_sub_2": "Boosie同学到"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "菇时同学！　　到！",
-      "src_1_sub_2": "菇时同学！　　到！",
-      "src_2_sub_1": "Boosie同学到",
-      "src_2_sub_2": "川明同学"
+      "ref_sub_1": "菇时同学！　　到！",
+      "ref_sub_2": "菇时同学！　　到！",
+      "target_sub_1": "Boosie同学到",
+      "target_sub_2": "川明同学"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "菇时同学！　　到！",
-      "src_1_sub_2": "还有谁没点过吗？",
-      "src_2_sub_1": "川明同学",
-      "src_2_sub_2": "到好仲有边个未点"
+      "ref_sub_1": "菇时同学！　　到！",
+      "ref_sub_2": "还有谁没点过吗？",
+      "target_sub_1": "川明同学",
+      "target_sub_2": "到好仲有边个未点"
     },
     "answer": {
-      "src_2_sub_1_shifted": "川明同学到",
-      "src_2_sub_2_shifted": "好仲有边个未点"
+      "target_sub_1_shifted": "川明同学到",
+      "target_sub_2_shifted": "好仲有边个未点"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "还有谁没点过吗？",
-      "src_1_sub_2": "麦兜！",
-      "src_2_sub_1": "好仲有边个未点",
-      "src_2_sub_2": "猫"
+      "ref_sub_1": "还有谁没点过吗？",
+      "ref_sub_2": "麦兜！",
+      "target_sub_1": "好仲有边个未点",
+      "target_sub_2": "猫"
     },
     "answer": {},
     "difficulty": 3,
@@ -1189,198 +1189,198 @@
   },
   {
     "query": {
-      "src_1_sub_1": "麦兜！",
-      "src_1_sub_2": "麦兜同学！",
-      "src_2_sub_1": "猫",
-      "src_2_sub_2": "噢麦兜同学"
+      "ref_sub_1": "麦兜！",
+      "ref_sub_2": "麦兜同学！",
+      "target_sub_1": "猫",
+      "target_sub_2": "噢麦兜同学"
     },
     "answer": {
-      "src_2_sub_1_shifted": "猫噢",
-      "src_2_sub_2_shifted": "麦兜同学"
+      "target_sub_1_shifted": "猫噢",
+      "target_sub_2_shifted": "麦兜同学"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "麦兜同学！",
-      "src_1_sub_2": "麦兜同学！",
-      "src_2_sub_1": "麦兜同学",
-      "src_2_sub_2": "麦兜同学"
+      "ref_sub_1": "麦兜同学！",
+      "ref_sub_2": "麦兜同学！",
+      "target_sub_1": "麦兜同学",
+      "target_sub_2": "麦兜同学"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "麦兜同学！",
-      "src_1_sub_2": "麦唛呀，即是呢⋯",
-      "src_2_sub_1": "麦兜同学",
-      "src_2_sub_2": "妈妈啊麦兜同学"
+      "ref_sub_1": "麦兜同学！",
+      "ref_sub_2": "麦唛呀，即是呢⋯",
+      "target_sub_1": "麦兜同学",
+      "target_sub_2": "妈妈啊麦兜同学"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "麦唛呀，即是呢⋯",
-      "src_1_sub_2": "我好像觉得呢⋯",
-      "src_2_sub_1": "妈妈啊麦兜同学",
-      "src_2_sub_2": "即系呢"
+      "ref_sub_1": "麦唛呀，即是呢⋯",
+      "ref_sub_2": "我好像觉得呢⋯",
+      "target_sub_1": "妈妈啊麦兜同学",
+      "target_sub_2": "即系呢"
     },
     "answer": {
-      "src_2_sub_1_shifted": "妈妈啊麦兜同学即系呢"
+      "target_sub_1_shifted": "妈妈啊麦兜同学即系呢"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我好像觉得呢⋯",
-      "src_1_sub_2": "有什么人在喊我似的",
-      "src_2_sub_2": "我个心总系仁住仁住好似有人嗌紧我个名噉嘅"
+      "ref_sub_1": "我好像觉得呢⋯",
+      "ref_sub_2": "有什么人在喊我似的",
+      "target_sub_2": "我个心总系仁住仁住好似有人嗌紧我个名噉嘅"
     },
     "answer": {
-      "src_2_sub_1_shifted": "我个心总系仁住仁住",
-      "src_2_sub_2_shifted": "好似有人嗌紧我个名噉嘅"
+      "target_sub_1_shifted": "我个心总系仁住仁住",
+      "target_sub_2_shifted": "好似有人嗌紧我个名噉嘅"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "有什么人在喊我似的",
-      "src_1_sub_2": "你们不要以为我心散",
-      "src_2_sub_1": "好似有人嗌紧我个名噉嘅",
-      "src_2_sub_2": "你哋唔好以为我心散啊"
+      "ref_sub_1": "有什么人在喊我似的",
+      "ref_sub_2": "你们不要以为我心散",
+      "target_sub_1": "好似有人嗌紧我个名噉嘅",
+      "target_sub_2": "你哋唔好以为我心散啊"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "你们不要以为我心散",
-      "src_1_sub_2": "其实我正在思考一个学术问题：",
-      "src_2_sub_1": "你哋唔好以为我心散啊",
-      "src_2_sub_2": "其实我系喺度思考紧一啲学术性嘅问题"
+      "ref_sub_1": "你们不要以为我心散",
+      "ref_sub_2": "其实我正在思考一个学术问题：",
+      "target_sub_1": "你哋唔好以为我心散啊",
+      "target_sub_2": "其实我系喺度思考紧一啲学术性嘅问题"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "其实我正在思考一个学术问题：",
-      "src_1_sub_2": "橙，为什么会是「屙－烂－煮」呢？",
-      "src_2_sub_1": "其实我系喺度思考紧一啲学术性嘅问题",
-      "src_2_sub_2": "点解橙叫Orange呢"
+      "ref_sub_1": "其实我正在思考一个学术问题：",
+      "ref_sub_2": "橙，为什么会是「屙－烂－煮」呢？",
+      "target_sub_1": "其实我系喺度思考紧一啲学术性嘅问题",
+      "target_sub_2": "点解橙叫Orange呢"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "橙，为什么会是「屙－烂－煮」呢？",
-      "src_1_sub_2": "妈妈说吃橙可通大便",
-      "src_2_sub_1": "点解橙叫Orange呢",
-      "src_2_sub_2": "妈妈话食橙会通大"
+      "ref_sub_1": "橙，为什么会是「屙－烂－煮」呢？",
+      "ref_sub_2": "妈妈说吃橙可通大便",
+      "target_sub_1": "点解橙叫Orange呢",
+      "target_sub_2": "妈妈话食橙会通大"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈说吃橙可通大便",
-      "src_1_sub_2": "「屙」这个我明白，可是「烂－煮」呢？",
-      "src_2_sub_1": "妈妈话食橙会通大",
-      "src_2_sub_2": "变噢呢个我明白但系橙呢"
+      "ref_sub_1": "妈妈说吃橙可通大便",
+      "ref_sub_2": "「屙」这个我明白，可是「烂－煮」呢？",
+      "target_sub_1": "妈妈话食橙会通大",
+      "target_sub_2": "变噢呢个我明白但系橙呢"
     },
     "answer": {
-      "src_2_sub_1_shifted": "妈妈话食橙会通大变",
-      "src_2_sub_2_shifted": "噢呢个我明白但系橙呢"
+      "target_sub_1_shifted": "妈妈话食橙会通大变",
+      "target_sub_2_shifted": "噢呢个我明白但系橙呢"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「屙」这个我明白，可是「烂－煮」呢？",
-      "src_1_sub_2": "还有这个「芭－娜－哪」香蕉",
-      "src_2_sub_1": "噢呢个我明白但系橙呢",
-      "src_2_sub_2": "仲有呢个啊芭拉娜啊"
+      "ref_sub_1": "「屙」这个我明白，可是「烂－煮」呢？",
+      "ref_sub_2": "还有这个「芭－娜－哪」香蕉",
+      "target_sub_1": "噢呢个我明白但系橙呢",
+      "target_sub_2": "仲有呢个啊芭拉娜啊"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "还有这个「芭－娜－哪」香蕉",
-      "src_1_sub_2": "为什么雨伞又会是「暗－芭－娜－哪」呢？",
-      "src_2_sub_1": "仲有呢个啊芭拉娜啊",
-      "src_2_sub_2": "香蕉啊点解雨姐会叫做暗芭拉娜呢"
+      "ref_sub_1": "还有这个「芭－娜－哪」香蕉",
+      "ref_sub_2": "为什么雨伞又会是「暗－芭－娜－哪」呢？",
+      "target_sub_1": "仲有呢个啊芭拉娜啊",
+      "target_sub_2": "香蕉啊点解雨姐会叫做暗芭拉娜呢"
     },
     "answer": {
-      "src_2_sub_1_shifted": "仲有呢个啊芭拉娜啊香蕉啊",
-      "src_2_sub_2_shifted": "点解雨姐会叫做暗芭拉娜呢"
+      "target_sub_1_shifted": "仲有呢个啊芭拉娜啊香蕉啊",
+      "target_sub_2_shifted": "点解雨姐会叫做暗芭拉娜呢"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "为什么雨伞又会是「暗－芭－娜－哪」呢？",
-      "src_1_sub_2": "我「暗」的「暗」掉一条蕉",
-      "src_2_sub_1": "点解雨姐会叫做暗芭拉娜呢",
-      "src_2_sub_2": "嗱我暗啦噉我暗嗰条香蕉"
+      "ref_sub_1": "为什么雨伞又会是「暗－芭－娜－哪」呢？",
+      "ref_sub_2": "我「暗」的「暗」掉一条蕉",
+      "target_sub_1": "点解雨姐会叫做暗芭拉娜呢",
+      "target_sub_2": "嗱我暗啦噉我暗嗰条香蕉"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我「暗」的「暗」掉一条蕉",
-      "src_1_sub_2": "至多是屙烂煮，怎么会下起雨来呢？",
-      "src_2_sub_1": "嗱我暗啦噉我暗嗰条香蕉",
-      "src_2_sub_2": "至多会Orange啫点解会搞到落雨呢"
+      "ref_sub_1": "我「暗」的「暗」掉一条蕉",
+      "ref_sub_2": "至多是屙烂煮，怎么会下起雨来呢？",
+      "target_sub_1": "嗱我暗啦噉我暗嗰条香蕉",
+      "target_sub_2": "至多会Orange啫点解会搞到落雨呢"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "至多是屙烂煮，怎么会下起雨来呢？",
-      "src_1_sub_2": "这世界还有很多事情我弄不明白",
-      "src_2_sub_1": "至多会Orange啫点解会搞到落雨呢",
-      "src_2_sub_2": "呢个世界仲有好多嘢我谂唔明"
+      "ref_sub_1": "至多是屙烂煮，怎么会下起雨来呢？",
+      "ref_sub_2": "这世界还有很多事情我弄不明白",
+      "target_sub_1": "至多会Orange啫点解会搞到落雨呢",
+      "target_sub_2": "呢个世界仲有好多嘢我谂唔明"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "这世界还有很多事情我弄不明白",
-      "src_1_sub_2": "但我不害怕",
-      "src_2_sub_1": "呢个世界仲有好多嘢我谂唔明",
-      "src_2_sub_2": "不过我唔怕"
+      "ref_sub_1": "这世界还有很多事情我弄不明白",
+      "ref_sub_2": "但我不害怕",
+      "target_sub_1": "呢个世界仲有好多嘢我谂唔明",
+      "target_sub_2": "不过我唔怕"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "但我不害怕",
-      "src_1_sub_2": "我想，有天我念完幼稚园",
-      "src_2_sub_1": "不过我唔怕",
-      "src_2_sub_2": "我谂到我读完幼稚园"
+      "ref_sub_1": "但我不害怕",
+      "ref_sub_2": "我想，有天我念完幼稚园",
+      "target_sub_1": "不过我唔怕",
+      "target_sub_2": "我谂到我读完幼稚园"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我想，有天我念完幼稚园",
-      "src_1_sub_2": "升小学，上中学",
-      "src_2_sub_1": "我谂到我读完幼稚园",
-      "src_2_sub_2": "识埋小学上到中学"
+      "ref_sub_1": "我想，有天我念完幼稚园",
+      "ref_sub_2": "升小学，上中学",
+      "target_sub_1": "我谂到我读完幼稚园",
+      "target_sub_2": "识埋小学上到中学"
     },
     "answer": {},
     "few_shot": true,
@@ -1388,385 +1388,385 @@
   },
   {
     "query": {
-      "src_1_sub_1": "升小学，上中学",
-      "src_1_sub_2": "再念大学⋯",
-      "src_2_sub_1": "识埋小学上到中学",
-      "src_2_sub_2": "再入埋大学"
+      "ref_sub_1": "升小学，上中学",
+      "ref_sub_2": "再念大学⋯",
+      "target_sub_1": "识埋小学上到中学",
+      "target_sub_2": "再入埋大学"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "再念大学⋯",
-      "src_1_sub_2": "当我大学毕业的时候",
-      "src_2_sub_1": "再入埋大学",
-      "src_2_sub_2": "等我大学毕业嗰阵"
+      "ref_sub_1": "再念大学⋯",
+      "ref_sub_2": "当我大学毕业的时候",
+      "target_sub_1": "再入埋大学",
+      "target_sub_2": "等我大学毕业嗰阵"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "当我大学毕业的时候",
-      "src_1_sub_2": "我知道我会明白一切！",
-      "src_2_sub_1": "等我大学毕业嗰阵",
-      "src_2_sub_2": "我谂我乜都会明白晒"
+      "ref_sub_1": "当我大学毕业的时候",
+      "ref_sub_2": "我知道我会明白一切！",
+      "target_sub_1": "等我大学毕业嗰阵",
+      "target_sub_2": "我谂我乜都会明白晒"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我知道我会明白一切！",
-      "src_1_sub_2": "那时候⋯",
-      "src_2_sub_1": "我谂我乜都会明白晒",
-      "src_2_sub_2": "到嗰阵"
+      "ref_sub_1": "我知道我会明白一切！",
+      "ref_sub_2": "那时候⋯",
+      "target_sub_1": "我谂我乜都会明白晒",
+      "target_sub_2": "到嗰阵"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "那时候⋯",
-      "src_1_sub_2": "我买所房子给妈妈！",
-      "src_2_sub_1": "到嗰阵",
-      "src_2_sub_2": "我买层楼畀我妈妈"
+      "ref_sub_1": "那时候⋯",
+      "ref_sub_2": "我买所房子给妈妈！",
+      "target_sub_1": "到嗰阵",
+      "target_sub_2": "我买层楼畀我妈妈"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "幼稚园楼下，由校长兼营的茶餐厅",
-      "src_1_sub_2": "我们一班同学下课后经常光顾",
-      "src_2_sub_1": "喺幼稚园楼下校长兼营嘅间茶餐厅",
-      "src_2_sub_2": "我哋一班同学仔放咗学都经常系傍陈"
+      "ref_sub_1": "幼稚园楼下，由校长兼营的茶餐厅",
+      "ref_sub_2": "我们一班同学下课后经常光顾",
+      "target_sub_1": "喺幼稚园楼下校长兼营嘅间茶餐厅",
+      "target_sub_2": "我哋一班同学仔放咗学都经常系傍陈"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我们一班同学下课后经常光顾",
-      "src_1_sub_2": "鱼蛋粗面，麻烦你　　粗面买光了",
-      "src_2_sub_1": "我哋一班同学仔放咗学都经常系傍陈",
-      "src_2_sub_2": "唔该鱼蛋粗啊"
+      "ref_sub_1": "我们一班同学下课后经常光顾",
+      "ref_sub_2": "鱼蛋粗面，麻烦你　　粗面买光了",
+      "target_sub_1": "我哋一班同学仔放咗学都经常系傍陈",
+      "target_sub_2": "唔该鱼蛋粗啊"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "鱼蛋粗面，麻烦你　　粗面买光了",
-      "src_1_sub_2": "那样子⋯来碗鱼蛋河粉吧　　鱼蛋买光了",
-      "src_2_sub_1": "唔该鱼蛋粗啊",
-      "src_2_sub_2": "冇粗面噃噉啊要碗鱼蛋好啊冇鱼蛋噃"
+      "ref_sub_1": "鱼蛋粗面，麻烦你　　粗面买光了",
+      "ref_sub_2": "那样子⋯来碗鱼蛋河粉吧　　鱼蛋买光了",
+      "target_sub_1": "唔该鱼蛋粗啊",
+      "target_sub_2": "冇粗面噃噉啊要碗鱼蛋好啊冇鱼蛋噃"
     },
     "answer": {
-      "src_2_sub_1_shifted": "唔该鱼蛋粗啊冇粗面噃",
-      "src_2_sub_2_shifted": "噉啊要碗鱼蛋好啊冇鱼蛋噃"
+      "target_sub_1_shifted": "唔该鱼蛋粗啊冇粗面噃",
+      "target_sub_2_shifted": "噉啊要碗鱼蛋好啊冇鱼蛋噃"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "那样子⋯来碗鱼蛋河粉吧　　鱼蛋买光了",
-      "src_1_sub_2": "那么⋯金钱肚粗面好了　　粗面买光了",
-      "src_2_sub_1": "噉啊要碗鱼蛋好啊冇鱼蛋噃",
-      "src_2_sub_2": "噉啊要金钱透粗啊冇粗面噃"
+      "ref_sub_1": "那样子⋯来碗鱼蛋河粉吧　　鱼蛋买光了",
+      "ref_sub_2": "那么⋯金钱肚粗面好了　　粗面买光了",
+      "target_sub_1": "噉啊要碗鱼蛋好啊冇鱼蛋噃",
+      "target_sub_2": "噉啊要金钱透粗啊冇粗面噃"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "那么⋯金钱肚粗面好了　　粗面买光了",
-      "src_1_sub_2": "那么要鱼蛋油面吧　　鱼蛋买光了",
-      "src_2_sub_1": "噉啊要金钱透粗啊冇粗面噃",
-      "src_2_sub_2": "噉啊咁要鱼蛋油面啊"
+      "ref_sub_1": "那么⋯金钱肚粗面好了　　粗面买光了",
+      "ref_sub_2": "那么要鱼蛋油面吧　　鱼蛋买光了",
+      "target_sub_1": "噉啊要金钱透粗啊冇粗面噃",
+      "target_sub_2": "噉啊咁要鱼蛋油面啊"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "那么要鱼蛋油面吧　　鱼蛋买光了",
-      "src_1_sub_2": "怎么都买光了？",
-      "src_2_sub_1": "噉啊咁要鱼蛋油面啊",
-      "src_2_sub_2": "冇鱼蛋噃乜样样都冇嘅"
+      "ref_sub_1": "那么要鱼蛋油面吧　　鱼蛋买光了",
+      "ref_sub_2": "怎么都买光了？",
+      "target_sub_1": "噉啊咁要鱼蛋油面啊",
+      "target_sub_2": "冇鱼蛋噃乜样样都冇嘅"
     },
     "answer": {
-      "src_2_sub_1_shifted": "噉啊咁要鱼蛋油面啊冇鱼蛋噃",
-      "src_2_sub_2_shifted": "乜样样都冇嘅"
+      "target_sub_1_shifted": "噉啊咁要鱼蛋油面啊冇鱼蛋噃",
+      "target_sub_2_shifted": "乜样样都冇嘅"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "怎么都买光了？",
-      "src_1_sub_2": "来个墨鱼丸粗面吧　　粗面买光了",
-      "src_2_sub_1": "乜样样都冇嘅",
-      "src_2_sub_2": "噉要蜜丸粗啊"
+      "ref_sub_1": "怎么都买光了？",
+      "ref_sub_2": "来个墨鱼丸粗面吧　　粗面买光了",
+      "target_sub_1": "乜样样都冇嘅",
+      "target_sub_2": "噉要蜜丸粗啊"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "来个墨鱼丸粗面吧　　粗面买光了",
-      "src_1_sub_2": "又买光了？",
-      "src_2_sub_1": "噉要蜜丸粗啊",
-      "src_2_sub_2": "冇粗面噃又冇啊"
+      "ref_sub_1": "来个墨鱼丸粗面吧　　粗面买光了",
+      "ref_sub_2": "又买光了？",
+      "target_sub_1": "噉要蜜丸粗啊",
+      "target_sub_2": "冇粗面噃又冇啊"
     },
     "answer": {
-      "src_2_sub_1_shifted": "噉要蜜丸粗啊冇粗面噃",
-      "src_2_sub_2_shifted": "又冇啊"
+      "target_sub_1_shifted": "噉要蜜丸粗啊冇粗面噃",
+      "target_sub_2_shifted": "又冇啊"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "又买光了？",
-      "src_1_sub_2": "麻烦来碗鱼蛋濑吧　　鱼蛋买光了",
-      "src_2_sub_1": "又冇啊",
-      "src_2_sub_2": "噉唔该畀碗鱼蛋奶啊"
+      "ref_sub_1": "又买光了？",
+      "ref_sub_2": "麻烦来碗鱼蛋濑吧　　鱼蛋买光了",
+      "target_sub_1": "又冇啊",
+      "target_sub_2": "噉唔该畀碗鱼蛋奶啊"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "麻烦来碗鱼蛋濑吧　　鱼蛋买光了",
-      "src_1_sub_2": "麦兜呀，鱼蛋跟粗面都买光了",
-      "src_2_sub_1": "噉唔该畀碗鱼蛋奶啊",
-      "src_2_sub_2": "冇鱼蛋噃麦兜啊佢哋啲鱼蛋同粗面卖晒㗎啦"
+      "ref_sub_1": "麻烦来碗鱼蛋濑吧　　鱼蛋买光了",
+      "ref_sub_2": "麦兜呀，鱼蛋跟粗面都买光了",
+      "target_sub_1": "噉唔该畀碗鱼蛋奶啊",
+      "target_sub_2": "冇鱼蛋噃麦兜啊佢哋啲鱼蛋同粗面卖晒㗎啦"
     },
     "answer": {
-      "src_2_sub_1_shifted": "噉唔该畀碗鱼蛋奶啊冇鱼蛋噃",
-      "src_2_sub_2_shifted": "麦兜啊佢哋啲鱼蛋同粗面卖晒㗎啦"
+      "target_sub_1_shifted": "噉唔该畀碗鱼蛋奶啊冇鱼蛋噃",
+      "target_sub_2_shifted": "麦兜啊佢哋啲鱼蛋同粗面卖晒㗎啦"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "麦兜呀，鱼蛋跟粗面都买光了",
-      "src_1_sub_2": "即是所有鱼蛋跟粗面的配搭都没了",
-      "src_2_sub_1": "麦兜啊佢哋啲鱼蛋同粗面卖晒㗎啦",
-      "src_2_sub_2": "即系所有要鱼蛋或者粗面嘅配搭都冇㗎啦"
+      "ref_sub_1": "麦兜呀，鱼蛋跟粗面都买光了",
+      "ref_sub_2": "即是所有鱼蛋跟粗面的配搭都没了",
+      "target_sub_1": "麦兜啊佢哋啲鱼蛋同粗面卖晒㗎啦",
+      "target_sub_2": "即系所有要鱼蛋或者粗面嘅配搭都冇㗎啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "即是所有鱼蛋跟粗面的配搭都没了",
-      "src_1_sub_2": "没有那些配搭吗？",
-      "src_2_sub_1": "即系所有要鱼蛋或者粗面嘅配搭都冇㗎啦",
-      "src_2_sub_2": "噢冇嗰啲配搭啊"
+      "ref_sub_1": "即是所有鱼蛋跟粗面的配搭都没了",
+      "ref_sub_2": "没有那些配搭吗？",
+      "target_sub_1": "即系所有要鱼蛋或者粗面嘅配搭都冇㗎啦",
+      "target_sub_2": "噢冇嗰啲配搭啊"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "没有那些配搭吗？",
-      "src_1_sub_2": "麻烦你，净要鱼蛋吧　　鱼蛋买光了",
-      "src_2_sub_1": "噢冇嗰啲配搭啊",
-      "src_2_sub_2": "噉唔该净鱼蛋啊"
+      "ref_sub_1": "没有那些配搭吗？",
+      "ref_sub_2": "麻烦你，净要鱼蛋吧　　鱼蛋买光了",
+      "target_sub_1": "噢冇嗰啲配搭啊",
+      "target_sub_2": "噉唔该净鱼蛋啊"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "麻烦你，净要鱼蛋吧　　鱼蛋买光了",
-      "src_1_sub_2": "那么净要粗面呢？　　粗面买光了",
-      "src_2_sub_1": "噉唔该净鱼蛋啊",
-      "src_2_sub_2": "冇鱼蛋噃净粗面呢冇粗面噃"
+      "ref_sub_1": "麻烦你，净要鱼蛋吧　　鱼蛋买光了",
+      "ref_sub_2": "那么净要粗面呢？　　粗面买光了",
+      "target_sub_1": "噉唔该净鱼蛋啊",
+      "target_sub_2": "冇鱼蛋噃净粗面呢冇粗面噃"
     },
     "answer": {
-      "src_2_sub_1_shifted": "噉唔该净鱼蛋啊冇鱼蛋噃",
-      "src_2_sub_2_shifted": "净粗面呢冇粗面噃"
+      "target_sub_1_shifted": "噉唔该净鱼蛋啊冇鱼蛋噃",
+      "target_sub_2_shifted": "净粗面呢冇粗面噃"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "那么净要粗面呢？　　粗面买光了",
-      "src_1_sub_2": "看到这里⋯",
-      "src_2_sub_1": "净粗面呢冇粗面噃",
-      "src_2_sub_2": "睇到呢度"
+      "ref_sub_1": "那么净要粗面呢？　　粗面买光了",
+      "ref_sub_2": "看到这里⋯",
+      "target_sub_1": "净粗面呢冇粗面噃",
+      "target_sub_2": "睇到呢度"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "看到这里⋯",
-      "src_1_sub_2": "大家大概都知道我是个怎么样的叻仔",
-      "src_2_sub_1": "睇到呢度",
-      "src_2_sub_2": "大家大概都知道我有几叻仔嘞"
+      "ref_sub_1": "看到这里⋯",
+      "ref_sub_2": "大家大概都知道我是个怎么样的叻仔",
+      "target_sub_1": "睇到呢度",
+      "target_sub_2": "大家大概都知道我有几叻仔嘞"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "大家大概都知道我是个怎么样的叻仔",
-      "src_1_sub_2": "那时候我无忧无虑，万事无所谓－－",
-      "src_2_sub_1": "大家大概都知道我有几叻仔嘞",
-      "src_2_sub_2": "果只我无忧无虑冇乜所谓"
+      "ref_sub_1": "大家大概都知道我是个怎么样的叻仔",
+      "ref_sub_2": "那时候我无忧无虑，万事无所谓－－",
+      "target_sub_1": "大家大概都知道我有几叻仔嘞",
+      "target_sub_2": "果只我无忧无虑冇乜所谓"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "那时候我无忧无虑，万事无所谓－－",
-      "src_1_sub_2": "鱼蛋买光了？那么粗面吧",
-      "src_2_sub_1": "果只我无忧无虑冇乜所谓",
-      "src_2_sub_2": "冇鱼蛋咩粗面都好啊"
+      "ref_sub_1": "那时候我无忧无虑，万事无所谓－－",
+      "ref_sub_2": "鱼蛋买光了？那么粗面吧",
+      "target_sub_1": "果只我无忧无虑冇乜所谓",
+      "target_sub_2": "冇鱼蛋咩粗面都好啊"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "鱼蛋买光了？那么粗面吧",
-      "src_1_sub_2": "麦兜，射呀！",
-      "src_2_sub_1": "冇鱼蛋咩粗面都好啊",
-      "src_2_sub_2": "麦兜转身食啊"
+      "ref_sub_1": "鱼蛋买光了？那么粗面吧",
+      "ref_sub_2": "麦兜，射呀！",
+      "target_sub_1": "冇鱼蛋咩粗面都好啊",
+      "target_sub_2": "麦兜转身食啊"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "看著自己每天屙烂煮⋯",
-      "src_1_sub_2": "每天长肉⋯",
-      "src_2_sub_1": "睇住自己日日柯能处",
-      "src_2_sub_2": "日日掌肉"
+      "ref_sub_1": "看著自己每天屙烂煮⋯",
+      "ref_sub_2": "每天长肉⋯",
+      "target_sub_1": "睇住自己日日柯能处",
+      "target_sub_2": "日日掌肉"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "每天长肉⋯",
-      "src_1_sub_2": "我感到充满力量！",
-      "src_2_sub_1": "日日掌肉",
-      "src_2_sub_2": "感到充满力量"
+      "ref_sub_1": "每天长肉⋯",
+      "ref_sub_2": "我感到充满力量！",
+      "target_sub_1": "日日掌肉",
+      "target_sub_2": "感到充满力量"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我感到充满力量！",
-      "src_1_sub_2": "世界好美丽！",
-      "src_2_sub_1": "感到充满力量",
-      "src_2_sub_2": "世界好美丽"
+      "ref_sub_1": "我感到充满力量！",
+      "ref_sub_2": "世界好美丽！",
+      "target_sub_1": "感到充满力量",
+      "target_sub_2": "世界好美丽"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "有一首歌，Miss Chan唱的好听",
-      "src_1_sub_2": "我时常想著学习",
-      "src_2_sub_1": "有一首歌麦词春唱得好好听呀",
-      "src_2_sub_2": "我成日想学习"
+      "ref_sub_1": "有一首歌，Miss Chan唱的好听",
+      "ref_sub_2": "我时常想著学习",
+      "target_sub_1": "有一首歌麦词春唱得好好听呀",
+      "target_sub_2": "我成日想学习"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我时常想著学习",
-      "src_1_sub_2": "可每次我总唱成「屙」什么什么的⋯",
-      "src_2_sub_1": "我成日想学习",
-      "src_2_sub_2": "但系唱嚟唱去都系阿伦厨"
+      "ref_sub_1": "我时常想著学习",
+      "ref_sub_2": "可每次我总唱成「屙」什么什么的⋯",
+      "target_sub_1": "我成日想学习",
+      "target_sub_2": "但系唱嚟唱去都系阿伦厨"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "可每次我总唱成「屙」什么什么的⋯",
-      "src_1_sub_2": "是All Things Bright and Beautiful吧？",
-      "src_2_sub_1": "但系唱嚟唱去都系阿伦厨",
-      "src_2_sub_2": "咁Ballana噉系唔系AllThingsBrightandBeautiful呀"
+      "ref_sub_1": "可每次我总唱成「屙」什么什么的⋯",
+      "ref_sub_2": "是All Things Bright and Beautiful吧？",
+      "target_sub_1": "但系唱嚟唱去都系阿伦厨",
+      "target_sub_2": "咁Ballana噉系唔系AllThingsBrightandBeautiful呀"
     },
     "answer": {
-      "src_2_sub_1_shifted": "但系唱嚟唱去都系阿伦厨咁Ballana噉",
-      "src_2_sub_2_shifted": "系唔系AllThingsBrightandBeautiful呀"
+      "target_sub_1_shifted": "但系唱嚟唱去都系阿伦厨咁Ballana噉",
+      "target_sub_2_shifted": "系唔系AllThingsBrightandBeautiful呀"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "是All Things Bright and Beautiful吧？",
-      "src_1_sub_2": "是的，一切都好！",
-      "src_2_sub_1": "系唔系AllThingsBrightandBeautiful呀",
-      "src_2_sub_2": "系呀"
+      "ref_sub_1": "是All Things Bright and Beautiful吧？",
+      "ref_sub_2": "是的，一切都好！",
+      "target_sub_1": "系唔系AllThingsBrightandBeautiful呀",
+      "target_sub_2": "系呀"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "是的，一切都好！",
-      "src_1_sub_2": "世上一切，一切一切⋯",
-      "src_2_sub_1": "系呀",
-      "src_2_sub_2": "所有嘢都几好喇"
+      "ref_sub_1": "是的，一切都好！",
+      "ref_sub_2": "世上一切，一切一切⋯",
+      "target_sub_1": "系呀",
+      "target_sub_2": "所有嘢都几好喇"
     },
     "answer": {
-      "src_2_sub_1_shifted": "系呀所有嘢都几好喇"
+      "target_sub_1_shifted": "系呀所有嘢都几好喇"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "世上一切，一切一切⋯",
-      "src_1_sub_2": "所有那些，都好！",
-      "src_2_sub_2": "世上一切所有嗰啲嘢都几好AllThingsBrightandBeautiful"
+      "ref_sub_1": "世上一切，一切一切⋯",
+      "ref_sub_2": "所有那些，都好！",
+      "target_sub_2": "世上一切所有嗰啲嘢都几好AllThingsBrightandBeautiful"
     },
     "answer": {
-      "src_2_sub_1_shifted": "世上一切",
-      "src_2_sub_2_shifted": "所有嗰啲嘢都几好AllThingsBrightandBeautiful"
+      "target_sub_1_shifted": "世上一切",
+      "target_sub_2_shifted": "所有嗰啲嘢都几好AllThingsBrightandBeautiful"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "一、二、三、四、五、六、七⋯",
-      "src_1_sub_2": "多劳多得！",
-      "src_2_sub_2": "1234567多喽多得"
+      "ref_sub_1": "一、二、三、四、五、六、七⋯",
+      "ref_sub_2": "多劳多得！",
+      "target_sub_2": "1234567多喽多得"
     },
     "answer": {
-      "src_2_sub_1_shifted": "1234567",
-      "src_2_sub_2_shifted": "多喽多得"
+      "target_sub_1_shifted": "1234567",
+      "target_sub_2_shifted": "多喽多得"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "一、二、三、四、五、六、七⋯",
-      "src_1_sub_2": "多劳多得！",
-      "src_2_sub_2": "1234567"
+      "ref_sub_1": "一、二、三、四、五、六、七⋯",
+      "ref_sub_2": "多劳多得！",
+      "target_sub_2": "1234567"
     },
     "answer": {
-      "src_2_sub_1_shifted": "1234567"
+      "target_sub_1_shifted": "1234567"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -1774,317 +1774,317 @@
   },
   {
     "query": {
-      "src_1_sub_1": "多劳多得！",
-      "src_1_sub_2": "星期一至星期七⋯多劳多得！",
-      "src_2_sub_2": "多喽多得星期一至星期七多喽多得"
+      "ref_sub_1": "多劳多得！",
+      "ref_sub_2": "星期一至星期七⋯多劳多得！",
+      "target_sub_2": "多喽多得星期一至星期七多喽多得"
     },
     "answer": {
-      "src_2_sub_1_shifted": "多喽多得",
-      "src_2_sub_2_shifted": "星期一至星期七多喽多得"
+      "target_sub_1_shifted": "多喽多得",
+      "target_sub_2_shifted": "星期一至星期七多喽多得"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "星期一至星期七⋯多劳多得！",
-      "src_1_sub_2": "这位喊得特劲的中年母猪",
-      "src_2_sub_1": "星期一至星期七多喽多得"
+      "ref_sub_1": "星期一至星期七⋯多劳多得！",
+      "ref_sub_2": "这位喊得特劲的中年母猪",
+      "target_sub_1": "星期一至星期七多喽多得"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "这位喊得特劲的中年母猪",
-      "src_1_sub_2": "就是我妈妈麦太",
-      "src_2_sub_2": "呢个嗌得特别劲嘅中年母猪就系我妈妈麦太"
+      "ref_sub_1": "这位喊得特劲的中年母猪",
+      "ref_sub_2": "就是我妈妈麦太",
+      "target_sub_2": "呢个嗌得特别劲嘅中年母猪就系我妈妈麦太"
     },
     "answer": {
-      "src_2_sub_1_shifted": "呢个嗌得特别劲嘅中年母猪",
-      "src_2_sub_2_shifted": "就系我妈妈麦太"
+      "target_sub_1_shifted": "呢个嗌得特别劲嘅中年母猪",
+      "target_sub_2_shifted": "就系我妈妈麦太"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "星期一至星期七⋯多劳多得！",
-      "src_1_sub_2": "这位喊得特劲的中年母猪",
-      "src_2_sub_1": "星期一至星期七多喽多得",
-      "src_2_sub_2": "呢个嗌得特别劲嘅中年母猪"
+      "ref_sub_1": "星期一至星期七⋯多劳多得！",
+      "ref_sub_2": "这位喊得特劲的中年母猪",
+      "target_sub_1": "星期一至星期七多喽多得",
+      "target_sub_2": "呢个嗌得特别劲嘅中年母猪"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "这位喊得特劲的中年母猪",
-      "src_1_sub_2": "就是我妈妈麦太",
-      "src_2_sub_1": "呢个嗌得特别劲嘅中年母猪",
-      "src_2_sub_2": "就系我妈妈麦太"
+      "ref_sub_1": "这位喊得特劲的中年母猪",
+      "ref_sub_2": "就是我妈妈麦太",
+      "target_sub_1": "呢个嗌得特别劲嘅中年母猪",
+      "target_sub_2": "就系我妈妈麦太"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "就是我妈妈麦太",
-      "src_1_sub_2": "我妈妈真的很劲",
-      "src_2_sub_1": "就系我妈妈麦太",
-      "src_2_sub_2": "我妈妈真系好劲呀"
+      "ref_sub_1": "就是我妈妈麦太",
+      "ref_sub_2": "我妈妈真的很劲",
+      "target_sub_1": "就系我妈妈麦太",
+      "target_sub_2": "我妈妈真系好劲呀"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我妈妈真的很劲",
-      "src_1_sub_2": "一个女人背起整个世界！",
-      "src_2_sub_1": "我妈妈真系好劲呀",
-      "src_2_sub_2": "一个女人揹起成个世界"
+      "ref_sub_1": "我妈妈真的很劲",
+      "ref_sub_2": "一个女人背起整个世界！",
+      "target_sub_1": "我妈妈真系好劲呀",
+      "target_sub_2": "一个女人揹起成个世界"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "是的，我妈妈真的很厉害",
-      "src_1_sub_2": "除了兼任保险，地产经纪及trading⋯",
-      "src_2_sub_1": "系呀我妈妈真系好犀利㗎",
-      "src_2_sub_2": "除咗做保险地产经纪同埋trading之外"
+      "ref_sub_1": "是的，我妈妈真的很厉害",
+      "ref_sub_2": "除了兼任保险，地产经纪及trading⋯",
+      "target_sub_1": "系呀我妈妈真系好犀利㗎",
+      "target_sub_2": "除咗做保险地产经纪同埋trading之外"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "除了兼任保险，地产经纪及trading⋯",
-      "src_1_sub_2": "她还趁高科技热潮搞了个烹饪网站⋯",
-      "src_2_sub_1": "除咗做保险地产经纪同埋trading之外",
-      "src_2_sub_2": "佢仲趁住高科技热潮搞咗个煮𩠌嘅网站"
+      "ref_sub_1": "除了兼任保险，地产经纪及trading⋯",
+      "ref_sub_2": "她还趁高科技热潮搞了个烹饪网站⋯",
+      "target_sub_1": "除咗做保险地产经纪同埋trading之外",
+      "target_sub_2": "佢仲趁住高科技热潮搞咗个煮𩠌嘅网站"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "她还趁高科技热潮搞了个烹饪网站⋯",
-      "src_1_sub_2": "www．麦太世界．com",
-      "src_2_sub_1": "佢仲趁住高科技热潮搞咗个煮𩠌嘅网站",
-      "src_2_sub_2": "www.mcticege.com"
+      "ref_sub_1": "她还趁高科技热潮搞了个烹饪网站⋯",
+      "ref_sub_2": "www．麦太世界．com",
+      "target_sub_1": "佢仲趁住高科技热潮搞咗个煮𩠌嘅网站",
+      "target_sub_2": "www.mcticege.com"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "www．麦太世界．com",
-      "src_1_sub_2": "她做的菜，同样厉害",
-      "src_2_sub_1": "www.mcticege.com",
-      "src_2_sub_2": "佢煮嘅𩠌一样咁犀利"
+      "ref_sub_1": "www．麦太世界．com",
+      "ref_sub_2": "她做的菜，同样厉害",
+      "target_sub_1": "www.mcticege.com",
+      "target_sub_2": "佢煮嘅𩠌一样咁犀利"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "她做的菜，同样厉害",
-      "src_1_sub_2": "欢迎大家收看＜麦太世界＞",
-      "src_2_sub_1": "佢煮嘅𩠌一样咁犀利",
-      "src_2_sub_2": "欢迎大家收睇麦太世界"
+      "ref_sub_1": "她做的菜，同样厉害",
+      "ref_sub_2": "欢迎大家收看＜麦太世界＞",
+      "target_sub_1": "佢煮嘅𩠌一样咁犀利",
+      "target_sub_2": "欢迎大家收睇麦太世界"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "欢迎大家收看＜麦太世界＞",
-      "src_1_sub_2": "今日为大家介绍一个⋯",
-      "src_2_sub_1": "欢迎大家收睇麦太世界"
+      "ref_sub_1": "欢迎大家收看＜麦太世界＞",
+      "ref_sub_2": "今日为大家介绍一个⋯",
+      "target_sub_1": "欢迎大家收睇麦太世界"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "今日为大家介绍一个⋯",
-      "src_1_sub_2": "简单别致的小菜纸包鸡",
-      "src_2_sub_2": "今日我为大家介绍个简单又别致嘅小菜自包鸡"
+      "ref_sub_1": "今日为大家介绍一个⋯",
+      "ref_sub_2": "简单别致的小菜纸包鸡",
+      "target_sub_2": "今日我为大家介绍个简单又别致嘅小菜自包鸡"
     },
     "answer": {
-      "src_2_sub_1_shifted": "今日我为大家介绍个",
-      "src_2_sub_2_shifted": "简单又别致嘅小菜自包鸡"
+      "target_sub_1_shifted": "今日我为大家介绍个",
+      "target_sub_2_shifted": "简单又别致嘅小菜自包鸡"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "简单别致的小菜纸包鸡",
-      "src_1_sub_2": "家中小朋友一定好喜欢",
-      "src_2_sub_1": "简单又别致嘅小菜自包鸡",
-      "src_2_sub_2": "家里头嘅小朋友一定好喜欢㗎"
+      "ref_sub_1": "简单别致的小菜纸包鸡",
+      "ref_sub_2": "家中小朋友一定好喜欢",
+      "target_sub_1": "简单又别致嘅小菜自包鸡",
+      "target_sub_2": "家里头嘅小朋友一定好喜欢㗎"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "家中小朋友一定好喜欢",
-      "src_1_sub_2": "材料很简单：一个鸡包",
-      "src_2_sub_1": "家里头嘅小朋友一定好喜欢㗎",
-      "src_2_sub_2": "材料系好简单我哋只需要一个鸡包"
+      "ref_sub_1": "家中小朋友一定好喜欢",
+      "ref_sub_2": "材料很简单：一个鸡包",
+      "target_sub_1": "家里头嘅小朋友一定好喜欢㗎",
+      "target_sub_2": "材料系好简单我哋只需要一个鸡包"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "材料很简单：一个鸡包",
-      "src_1_sub_2": "将鸡包底部的纸撕下来⋯慢慢地撕",
-      "src_2_sub_1": "材料系好简单我哋只需要一个鸡包",
-      "src_2_sub_2": "我哋将黐喺鸡包底嘅纸撕出嚟慢慢撕"
+      "ref_sub_1": "材料很简单：一个鸡包",
+      "ref_sub_2": "将鸡包底部的纸撕下来⋯慢慢地撕",
+      "target_sub_1": "材料系好简单我哋只需要一个鸡包",
+      "target_sub_2": "我哋将黐喺鸡包底嘅纸撕出嚟慢慢撕"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "将鸡包底部的纸撕下来⋯慢慢地撕",
-      "src_1_sub_2": "就会得到一张鸡包纸",
-      "src_2_sub_1": "我哋将黐喺鸡包底嘅纸撕出嚟慢慢撕",
-      "src_2_sub_2": "咁就会得到一张鸡包纸喇"
+      "ref_sub_1": "将鸡包底部的纸撕下来⋯慢慢地撕",
+      "ref_sub_2": "就会得到一张鸡包纸",
+      "target_sub_1": "我哋将黐喺鸡包底嘅纸撕出嚟慢慢撕",
+      "target_sub_2": "咁就会得到一张鸡包纸喇"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "就会得到一张鸡包纸",
-      "src_1_sub_2": "把鸡包纸一反反转",
-      "src_2_sub_1": "咁就会得到一张鸡包纸喇",
-      "src_2_sub_2": "然后将鸡包纸一反反转"
+      "ref_sub_1": "就会得到一张鸡包纸",
+      "ref_sub_2": "把鸡包纸一反反转",
+      "target_sub_1": "咁就会得到一张鸡包纸喇",
+      "target_sub_2": "然后将鸡包纸一反反转"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "把鸡包纸一反反转",
-      "src_1_sub_2": "这一味纸包鸡就完成了，很容易是吧？",
-      "src_2_sub_1": "然后将鸡包纸一反反转",
-      "src_2_sub_2": "呢味自包鸡就完成喇系咪好易整啦"
+      "ref_sub_1": "把鸡包纸一反反转",
+      "ref_sub_2": "这一味纸包鸡就完成了，很容易是吧？",
+      "target_sub_1": "然后将鸡包纸一反反转",
+      "target_sub_2": "呢味自包鸡就完成喇系咪好易整啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "这一味纸包鸡就完成了，很容易是吧？",
-      "src_1_sub_2": "多谢大家收看",
-      "src_2_sub_1": "呢味自包鸡就完成喇系咪好易整啦",
-      "src_2_sub_2": "多谢大家收睇"
+      "ref_sub_1": "这一味纸包鸡就完成了，很容易是吧？",
+      "ref_sub_2": "多谢大家收看",
+      "target_sub_1": "呢味自包鸡就完成喇系咪好易整啦",
+      "target_sub_2": "多谢大家收睇"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "好高兴这么快又跟大家见面",
-      "src_1_sub_2": "接下来我会教大家整一味纸鸡包",
-      "src_2_sub_1": "好高兴咁快又同大家见面",
-      "src_2_sub_2": "跟住落嚟我会教大家整一味纸鸡包"
+      "ref_sub_1": "好高兴这么快又跟大家见面",
+      "ref_sub_2": "接下来我会教大家整一味纸鸡包",
+      "target_sub_1": "好高兴咁快又同大家见面",
+      "target_sub_2": "跟住落嚟我会教大家整一味纸鸡包"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "接下来我会教大家整一味纸鸡包",
-      "src_1_sub_2": "材料也很简单，只需要白纸一张",
-      "src_2_sub_1": "跟住落嚟我会教大家整一味纸鸡包",
-      "src_2_sub_2": "材料都好简单只需要白纸一张"
+      "ref_sub_1": "接下来我会教大家整一味纸鸡包",
+      "ref_sub_2": "材料也很简单，只需要白纸一张",
+      "target_sub_1": "跟住落嚟我会教大家整一味纸鸡包",
+      "target_sub_2": "材料都好简单只需要白纸一张"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "材料也很简单，只需要白纸一张",
-      "src_1_sub_2": "只要把这纸这样子⋯",
-      "src_2_sub_1": "材料都好简单只需要白纸一张",
-      "src_2_sub_2": "我哋只需要张张纸咁样"
+      "ref_sub_1": "材料也很简单，只需要白纸一张",
+      "ref_sub_2": "只要把这纸这样子⋯",
+      "target_sub_1": "材料都好简单只需要白纸一张",
+      "target_sub_2": "我哋只需要张张纸咁样"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "只要把这纸这样子⋯",
-      "src_1_sub_2": "一个纸鸡包就这样完成了",
-      "src_2_sub_1": "我哋只需要张张纸咁样",
-      "src_2_sub_2": "一个纸鸡包就咁完成咗喇"
+      "ref_sub_1": "只要把这纸这样子⋯",
+      "ref_sub_2": "一个纸鸡包就这样完成了",
+      "target_sub_1": "我哋只需要张张纸咁样",
+      "target_sub_2": "一个纸鸡包就咁完成咗喇"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "一个纸鸡包就这样完成了",
-      "src_1_sub_2": "各位小朋友，像鸡包不像呀？",
-      "src_2_sub_1": "一个纸鸡包就咁完成咗喇",
-      "src_2_sub_2": "各位小朋友你哋话似唔似鸡包啊"
+      "ref_sub_1": "一个纸鸡包就这样完成了",
+      "ref_sub_2": "各位小朋友，像鸡包不像呀？",
+      "target_sub_1": "一个纸鸡包就咁完成咗喇",
+      "target_sub_2": "各位小朋友你哋话似唔似鸡包啊"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "现在要教大家一味别致小菜－",
-      "src_1_sub_2": "包鸡纸包鸡包纸包鸡",
-      "src_2_sub_1": "间阵要教大家一味几别节嘅小菜",
-      "src_2_sub_2": "包鸡子包鸡包子包鸡"
+      "ref_sub_1": "现在要教大家一味别致小菜－",
+      "ref_sub_2": "包鸡纸包鸡包纸包鸡",
+      "target_sub_1": "间阵要教大家一味几别节嘅小菜",
+      "target_sub_2": "包鸡子包鸡包子包鸡"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "包鸡纸包鸡包纸包鸡",
-      "src_1_sub_2": "首先将纸包鸡小心撕开",
-      "src_2_sub_1": "包鸡子包鸡包子包鸡",
-      "src_2_sub_2": "首先将子包鸡小心噉撕开"
+      "ref_sub_1": "包鸡纸包鸡包纸包鸡",
+      "ref_sub_2": "首先将纸包鸡小心撕开",
+      "target_sub_1": "包鸡子包鸡包子包鸡",
+      "target_sub_2": "首先将子包鸡小心噉撕开"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "首先将纸包鸡小心撕开",
-      "src_1_sub_2": "大家就会有一张纸包鸡及一块鸡",
-      "src_2_sub_1": "首先将子包鸡小心噉撕开",
-      "src_2_sub_2": "大家就会有一张包鸡子同埋一嚿鸡啦"
+      "ref_sub_1": "首先将纸包鸡小心撕开",
+      "ref_sub_2": "大家就会有一张纸包鸡及一块鸡",
+      "target_sub_1": "首先将子包鸡小心噉撕开",
+      "target_sub_2": "大家就会有一张包鸡子同埋一嚿鸡啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "大家就会有一张纸包鸡及一块鸡",
-      "src_1_sub_2": "接著把鸡包纸这样子包起那块鸡",
-      "src_2_sub_1": "大家就会有一张包鸡子同埋一嚿鸡啦",
-      "src_2_sub_2": "跟住将鸡包子好似我噉包住牛鸡"
+      "ref_sub_1": "大家就会有一张纸包鸡及一块鸡",
+      "ref_sub_2": "接著把鸡包纸这样子包起那块鸡",
+      "target_sub_1": "大家就会有一张包鸡子同埋一嚿鸡啦",
+      "target_sub_2": "跟住将鸡包子好似我噉包住牛鸡"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "接著把鸡包纸这样子包起那块鸡",
-      "src_1_sub_2": "再依照这样子用包鸡纸把它包起",
-      "src_2_sub_1": "跟住将鸡包子好似我噉包住牛鸡",
-      "src_2_sub_2": "然后再好似噉样将包鸡子包包包包包包住佢"
+      "ref_sub_1": "接著把鸡包纸这样子包起那块鸡",
+      "ref_sub_2": "再依照这样子用包鸡纸把它包起",
+      "target_sub_1": "跟住将鸡包子好似我噉包住牛鸡",
+      "target_sub_2": "然后再好似噉样将包鸡子包包包包包包住佢"
     },
     "answer": {},
     "difficulty": 3,
@@ -2092,124 +2092,124 @@
   },
   {
     "query": {
-      "src_1_sub_1": "再依照这样子用包鸡纸把它包起",
-      "src_1_sub_2": "一味「包鸡纸包鸡包纸包鸡」完成了！",
-      "src_2_sub_1": "然后再好似噉样将包鸡子包包包包包包住佢",
-      "src_2_sub_2": "咁一味包鸡子包鸡包子包鸡就完成喇"
+      "ref_sub_1": "再依照这样子用包鸡纸把它包起",
+      "ref_sub_2": "一味「包鸡纸包鸡包纸包鸡」完成了！",
+      "target_sub_1": "然后再好似噉样将包鸡子包包包包包包住佢",
+      "target_sub_2": "咁一味包鸡子包鸡包子包鸡就完成喇"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "一味「包鸡纸包鸡包纸包鸡」完成了！",
-      "src_1_sub_2": "真的很简单吧？",
-      "src_2_sub_1": "咁一味包鸡子包鸡包子包鸡就完成喇",
-      "src_2_sub_2": "系咪好简单呢"
+      "ref_sub_1": "一味「包鸡纸包鸡包纸包鸡」完成了！",
+      "ref_sub_2": "真的很简单吧？",
+      "target_sub_1": "咁一味包鸡子包鸡包子包鸡就完成喇",
+      "target_sub_2": "系咪好简单呢"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "真的很简单吧？",
-      "src_1_sub_2": "还真有一块鸡吃呢！",
-      "src_2_sub_1": "系咪好简单呢",
-      "src_2_sub_2": "仲真系有嚿鸡食添"
+      "ref_sub_1": "真的很简单吧？",
+      "ref_sub_2": "还真有一块鸡吃呢！",
+      "target_sub_1": "系咪好简单呢",
+      "target_sub_2": "仲真系有嚿鸡食添"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "今日为大家介绍一味⋯",
-      "src_1_sub_2": "小朋友一定喜欢的⋯",
-      "src_2_sub_1": "今日要同大家介绍一味",
-      "src_2_sub_2": "小朋友一定喜欢嘅"
+      "ref_sub_1": "今日为大家介绍一味⋯",
+      "ref_sub_2": "小朋友一定喜欢的⋯",
+      "target_sub_1": "今日要同大家介绍一味",
+      "target_sub_2": "小朋友一定喜欢嘅"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "小朋友一定喜欢的⋯",
-      "src_1_sub_2": "鸡包包鸡包包鸡包纸包纸⋯",
-      "src_2_sub_1": "小朋友一定喜欢嘅",
-      "src_2_sub_2": "鸡包包鸡包包鸡包纸包"
+      "ref_sub_1": "小朋友一定喜欢的⋯",
+      "ref_sub_2": "鸡包包鸡包包鸡包纸包纸⋯",
+      "target_sub_1": "小朋友一定喜欢嘅",
+      "target_sub_2": "鸡包包鸡包包鸡包纸包"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "鸡包包鸡包包鸡包纸包纸⋯",
-      "src_1_sub_2": "包鸡包鸡包纸包鸡",
-      "src_2_sub_1": "鸡包包鸡包包鸡包纸包",
-      "src_2_sub_2": "纸包鸡包包鸡纸包鸡包纸包鸡"
+      "ref_sub_1": "鸡包包鸡包包鸡包纸包纸⋯",
+      "ref_sub_2": "包鸡包鸡包纸包鸡",
+      "target_sub_1": "鸡包包鸡包包鸡包纸包",
+      "target_sub_2": "纸包鸡包包鸡纸包鸡包纸包鸡"
     },
     "answer": {
-      "src_2_sub_1_shifted": "鸡包包鸡包包鸡包纸包纸包鸡包包鸡",
-      "src_2_sub_2_shifted": "纸包鸡包纸包鸡"
+      "target_sub_1_shifted": "鸡包包鸡包包鸡包纸包纸包鸡包包鸡",
+      "target_sub_2_shifted": "纸包鸡包纸包鸡"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "包鸡包鸡包纸包鸡",
-      "src_1_sub_2": "做法亦很简单",
-      "src_2_sub_1": "纸包鸡包纸包鸡",
-      "src_2_sub_2": "做法都好简单"
+      "ref_sub_1": "包鸡包鸡包纸包鸡",
+      "ref_sub_2": "做法亦很简单",
+      "target_sub_1": "纸包鸡包纸包鸡",
+      "target_sub_2": "做法都好简单"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "做法亦很简单",
-      "src_1_sub_2": "只要将鸡包包住个鸡包",
-      "src_2_sub_1": "做法都好简单",
-      "src_2_sub_2": "我哋先将鸡包包住个鸡包"
+      "ref_sub_1": "做法亦很简单",
+      "ref_sub_2": "只要将鸡包包住个鸡包",
+      "target_sub_1": "做法都好简单",
+      "target_sub_2": "我哋先将鸡包包住个鸡包"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "只要将鸡包包住个鸡包",
-      "src_1_sub_2": "再包住个鸡包⋯",
-      "src_2_sub_1": "我哋先将鸡包包住个鸡包",
-      "src_2_sub_2": "再包住个鸡包"
+      "ref_sub_1": "只要将鸡包包住个鸡包",
+      "ref_sub_2": "再包住个鸡包⋯",
+      "target_sub_1": "我哋先将鸡包包住个鸡包",
+      "target_sub_2": "再包住个鸡包"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "再包住个鸡包⋯",
-      "src_1_sub_2": "包住张鸡包纸",
-      "src_2_sub_1": "再包住个鸡包",
-      "src_2_sub_2": "包住张鸡包纸"
+      "ref_sub_1": "再包住个鸡包⋯",
+      "ref_sub_2": "包住张鸡包纸",
+      "target_sub_1": "再包住个鸡包",
+      "target_sub_2": "包住张鸡包纸"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "包住张鸡包纸",
-      "src_1_sub_2": "再包包包包包住个纸鸡包",
-      "src_2_sub_1": "包住张鸡包纸",
-      "src_2_sub_2": "再包包包包包住个纸包鸡"
+      "ref_sub_1": "包住张鸡包纸",
+      "ref_sub_2": "再包包包包包住个纸鸡包",
+      "target_sub_1": "包住张鸡包纸",
+      "target_sub_2": "再包包包包包住个纸包鸡"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "再包包包包包住个纸鸡包",
-      "src_1_sub_2": "再包包包，纸纸纸",
-      "src_2_sub_1": "再包包包包包住个纸包鸡",
-      "src_2_sub_2": "再包包包包包鸡包纸包纸纸纸纸纸"
+      "ref_sub_1": "再包包包包包住个纸鸡包",
+      "ref_sub_2": "再包包包，纸纸纸",
+      "target_sub_1": "再包包包包包住个纸包鸡",
+      "target_sub_2": "再包包包包包鸡包纸包纸纸纸纸纸"
     },
     "answer": {},
     "difficulty": 3,
@@ -2217,58 +2217,58 @@
   },
   {
     "query": {
-      "src_1_sub_1": "再包包包，纸纸纸",
-      "src_1_sub_2": "纸包纸，纸包鸡，鸡包纸，纸包鸡⋯",
-      "src_2_sub_1": "再包包包包包鸡包纸包纸纸纸纸纸",
-      "src_2_sub_2": "纸包纸纸包鸡包鸡纸纸包鸡鸡鸡鸡纸纸纸再包鸡鸡"
+      "ref_sub_1": "再包包包，纸纸纸",
+      "ref_sub_2": "纸包纸，纸包鸡，鸡包纸，纸包鸡⋯",
+      "target_sub_1": "再包包包包包鸡包纸包纸纸纸纸纸",
+      "target_sub_2": "纸包纸纸包鸡包鸡纸纸包鸡鸡鸡鸡纸纸纸再包鸡鸡"
     },
     "answer": {
-      "src_2_sub_1_shifted": "再包包包包包鸡包纸包纸纸纸纸纸纸包纸",
-      "src_2_sub_2_shifted": "纸包鸡包鸡纸纸包鸡鸡鸡鸡纸纸纸再包鸡鸡"
+      "target_sub_1_shifted": "再包包包包包鸡包纸包纸纸纸纸纸纸包纸",
+      "target_sub_2_shifted": "纸包鸡包鸡纸纸包鸡鸡鸡鸡纸纸纸再包鸡鸡"
     },
     "difficulty": 3,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "纸包纸，纸包鸡，鸡包纸，纸包鸡⋯",
-      "src_1_sub_2": "可我妈妈也有她温柔的一面",
-      "src_2_sub_1": "纸包鸡包鸡纸纸包鸡鸡鸡鸡纸纸纸再包鸡鸡",
-      "src_2_sub_2": "不过我妈妈都有佢温柔嘅一面"
+      "ref_sub_1": "纸包纸，纸包鸡，鸡包纸，纸包鸡⋯",
+      "ref_sub_2": "可我妈妈也有她温柔的一面",
+      "target_sub_1": "纸包鸡包鸡纸纸包鸡鸡鸡鸡纸纸纸再包鸡鸡",
+      "target_sub_2": "不过我妈妈都有佢温柔嘅一面"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "可我妈妈也有她温柔的一面",
-      "src_1_sub_2": "例如每晚睡觉前，她都会说故事给我听",
-      "src_2_sub_1": "不过我妈妈都有佢温柔嘅一面",
-      "src_2_sub_2": "例如每晚临睡前佢都会讲故事畀我听"
+      "ref_sub_1": "可我妈妈也有她温柔的一面",
+      "ref_sub_2": "例如每晚睡觉前，她都会说故事给我听",
+      "target_sub_1": "不过我妈妈都有佢温柔嘅一面",
+      "target_sub_2": "例如每晚临睡前佢都会讲故事畀我听"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "例如每晚睡觉前，她都会说故事给我听",
-      "src_1_sub_2": "从前，有个小朋友撒谎；有一天⋯",
-      "src_2_sub_1": "例如每晚临睡前佢都会讲故事畀我听",
-      "src_2_sub_2": "从前有个小朋友讲大话"
+      "ref_sub_1": "例如每晚睡觉前，她都会说故事给我听",
+      "ref_sub_2": "从前，有个小朋友撒谎；有一天⋯",
+      "target_sub_1": "例如每晚临睡前佢都会讲故事畀我听",
+      "target_sub_2": "从前有个小朋友讲大话"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "从前，有个小朋友撒谎；有一天⋯",
-      "src_1_sub_2": "他死了！",
-      "src_2_sub_1": "从前有个小朋友讲大话",
-      "src_2_sub_2": "有一日佢死咗"
+      "ref_sub_1": "从前，有个小朋友撒谎；有一天⋯",
+      "ref_sub_2": "他死了！",
+      "target_sub_1": "从前有个小朋友讲大话",
+      "target_sub_2": "有一日佢死咗"
     },
     "answer": {
-      "src_2_sub_1_shifted": "从前有个小朋友讲大话有一日",
-      "src_2_sub_2_shifted": "佢死咗"
+      "target_sub_1_shifted": "从前有个小朋友讲大话有一日",
+      "target_sub_2_shifted": "佢死咗"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -2276,622 +2276,622 @@
   },
   {
     "query": {
-      "src_1_sub_1": "他死了！",
-      "src_1_sub_2": "从前，有个小朋友很勤力念书⋯",
-      "src_2_sub_1": "佢死咗",
-      "src_2_sub_2": "从前有个小朋友好勤力读书"
+      "ref_sub_1": "他死了！",
+      "ref_sub_2": "从前，有个小朋友很勤力念书⋯",
+      "target_sub_1": "佢死咗",
+      "target_sub_2": "从前有个小朋友好勤力读书"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "从前，有个小朋友很勤力念书⋯",
-      "src_1_sub_2": "他长大后，发财了！",
-      "src_2_sub_1": "从前有个小朋友好勤力读书",
-      "src_2_sub_2": "佢长大发咗"
+      "ref_sub_1": "从前，有个小朋友很勤力念书⋯",
+      "ref_sub_2": "他长大后，发财了！",
+      "target_sub_1": "从前有个小朋友好勤力读书",
+      "target_sub_2": "佢长大发咗"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "他长大后，发财了！",
-      "src_1_sub_2": "从前，有个小朋友不孝，有天⋯",
-      "src_2_sub_1": "佢长大发咗",
-      "src_2_sub_2": "从前有个小朋友唔孝顺"
+      "ref_sub_1": "他长大后，发财了！",
+      "ref_sub_2": "从前，有个小朋友不孝，有天⋯",
+      "target_sub_1": "佢长大发咗",
+      "target_sub_2": "从前有个小朋友唔孝顺"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "从前，有个小朋友不孝，有天⋯",
-      "src_1_sub_2": "他扭了脚骹！",
-      "src_2_sub_1": "从前有个小朋友唔孝顺",
-      "src_2_sub_2": "有一日佢屈亲个脚脚"
+      "ref_sub_1": "从前，有个小朋友不孝，有天⋯",
+      "ref_sub_2": "他扭了脚骹！",
+      "target_sub_1": "从前有个小朋友唔孝顺",
+      "target_sub_2": "有一日佢屈亲个脚脚"
     },
     "answer": {
-      "src_2_sub_1_shifted": "从前有个小朋友唔孝顺有一日",
-      "src_2_sub_2_shifted": "佢屈亲个脚脚"
+      "target_sub_1_shifted": "从前有个小朋友唔孝顺有一日",
+      "target_sub_2_shifted": "佢屈亲个脚脚"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "他扭了脚骹！",
-      "src_1_sub_2": "妈妈，我想睡觉",
-      "src_2_sub_1": "佢屈亲个脚脚",
-      "src_2_sub_2": "妈我想瞓啦"
+      "ref_sub_1": "他扭了脚骹！",
+      "ref_sub_2": "妈妈，我想睡觉",
+      "target_sub_1": "佢屈亲个脚脚",
+      "target_sub_2": "妈我想瞓啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "从前，有个小朋友早睡晚起；第二天⋯",
-      "src_1_sub_2": "他死了！",
-      "src_2_sub_1": "从前有个小朋友早睡晚起第二朝社群提供",
-      "src_2_sub_2": "佢死咗"
+      "ref_sub_1": "从前，有个小朋友早睡晚起；第二天⋯",
+      "ref_sub_2": "他死了！",
+      "target_sub_1": "从前有个小朋友早睡晚起第二朝社群提供",
+      "target_sub_2": "佢死咗"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "他死了！",
-      "src_1_sub_2": "我妈妈就是这样子，一切都那么直接",
-      "src_2_sub_1": "佢死咗",
-      "src_2_sub_2": "我妈妈就系噉一切都咁直接"
+      "ref_sub_1": "他死了！",
+      "ref_sub_2": "我妈妈就是这样子，一切都那么直接",
+      "target_sub_1": "佢死咗",
+      "target_sub_2": "我妈妈就系噉一切都咁直接"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我妈妈就是这样子，一切都那么直接",
-      "src_1_sub_2": "她爱得我直接⋯",
-      "src_2_sub_1": "我妈妈就系噉一切都咁直接",
-      "src_2_sub_2": "佢爱得我直接"
+      "ref_sub_1": "我妈妈就是这样子，一切都那么直接",
+      "ref_sub_2": "她爱得我直接⋯",
+      "target_sub_1": "我妈妈就系噉一切都咁直接",
+      "target_sub_2": "佢爱得我直接"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "她爱得我直接⋯",
-      "src_1_sub_2": "对我的期望直接",
-      "src_2_sub_1": "佢爱得我直接",
-      "src_2_sub_2": "对我嘅期望直接"
+      "ref_sub_1": "她爱得我直接⋯",
+      "ref_sub_2": "对我的期望直接",
+      "target_sub_1": "佢爱得我直接",
+      "target_sub_2": "对我嘅期望直接"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "对我的期望直接",
-      "src_1_sub_2": "对她，一、二、三、四、五、六、七",
-      "src_2_sub_1": "对我嘅期望直接"
+      "ref_sub_1": "对我的期望直接",
+      "ref_sub_2": "对她，一、二、三、四、五、六、七",
+      "target_sub_1": "对我嘅期望直接"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "对她，一、二、三、四、五、六、七",
-      "src_1_sub_2": "没有不成的事",
-      "src_2_sub_2": "佢一二三四五六七唔得都要得字幕由Amara.org"
+      "ref_sub_1": "对她，一、二、三、四、五、六、七",
+      "ref_sub_2": "没有不成的事",
+      "target_sub_2": "佢一二三四五六七唔得都要得字幕由Amara.org"
     },
     "answer": {
-      "src_2_sub_1_shifted": "佢一二三四五六七",
-      "src_2_sub_2_shifted": "唔得都要得字幕由Amara.org"
+      "target_sub_1_shifted": "佢一二三四五六七",
+      "target_sub_2_shifted": "唔得都要得字幕由Amara.org"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "对我的期望直接",
-      "src_1_sub_2": "对她，一、二、三、四、五、六、七",
-      "src_2_sub_1": "对我嘅期望直接",
-      "src_2_sub_2": "佢一二三四五六七"
+      "ref_sub_1": "对我的期望直接",
+      "ref_sub_2": "对她，一、二、三、四、五、六、七",
+      "target_sub_1": "对我嘅期望直接",
+      "target_sub_2": "佢一二三四五六七"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "对她，一、二、三、四、五、六、七",
-      "src_1_sub_2": "没有不成的事",
-      "src_2_sub_1": "佢一二三四五六七",
-      "src_2_sub_2": "唔得都要得字幕由Amara.org"
+      "ref_sub_1": "对她，一、二、三、四、五、六、七",
+      "ref_sub_2": "没有不成的事",
+      "target_sub_1": "佢一二三四五六七",
+      "target_sub_2": "唔得都要得字幕由Amara.org"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "可有些事情，要是真的不成呢？",
-      "src_1_sub_2": "日子一天一天的过",
-      "src_2_sub_1": "但系如果有啲嘢真系真系唔得呢",
-      "src_2_sub_2": "日子一日一日咁过"
+      "ref_sub_1": "可有些事情，要是真的不成呢？",
+      "ref_sub_2": "日子一天一天的过",
+      "target_sub_1": "但系如果有啲嘢真系真系唔得呢",
+      "target_sub_2": "日子一日一日咁过"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "日子一天一天的过",
-      "src_1_sub_2": "首先是周润发事件⋯",
-      "src_2_sub_1": "日子一日一日咁过",
-      "src_2_sub_2": "首先周润发嗰单嘢"
+      "ref_sub_1": "日子一天一天的过",
+      "ref_sub_2": "首先是周润发事件⋯",
+      "target_sub_1": "日子一日一日咁过",
+      "target_sub_2": "首先周润发嗰单嘢"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "首先是周润发事件⋯",
-      "src_1_sub_2": "拜托不要再提了！",
-      "src_2_sub_1": "首先周润发嗰单嘢",
-      "src_2_sub_2": "大家都唔好再提"
+      "ref_sub_1": "首先是周润发事件⋯",
+      "ref_sub_2": "拜托不要再提了！",
+      "target_sub_1": "首先周润发嗰单嘢",
+      "target_sub_2": "大家都唔好再提"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "拜托不要再提了！",
-      "src_1_sub_2": "至于好运⋯",
-      "src_2_sub_1": "大家都唔好再提"
+      "ref_sub_1": "拜托不要再提了！",
+      "ref_sub_2": "至于好运⋯",
+      "target_sub_1": "大家都唔好再提"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "至于好运⋯",
-      "src_1_sub_2": "我用一双童子手替妈妈抽的六合彩号码",
-      "src_2_sub_2": "至于好运我用我嘅同事手帮妈妈抽嘅六合彩number"
+      "ref_sub_1": "至于好运⋯",
+      "ref_sub_2": "我用一双童子手替妈妈抽的六合彩号码",
+      "target_sub_2": "至于好运我用我嘅同事手帮妈妈抽嘅六合彩number"
     },
     "answer": {
-      "src_2_sub_1_shifted": "至于好运",
-      "src_2_sub_2_shifted": "我用我嘅同事手帮妈妈抽嘅六合彩number"
+      "target_sub_1_shifted": "至于好运",
+      "target_sub_2_shifted": "我用我嘅同事手帮妈妈抽嘅六合彩number"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我用一双童子手替妈妈抽的六合彩号码",
-      "src_1_sub_2": "奇迹般似的一个号码也没中过！",
-      "src_2_sub_1": "我用我嘅同事手帮妈妈抽嘅六合彩number",
-      "src_2_sub_2": "竟然奇迹一样一个都未中过"
+      "ref_sub_1": "我用一双童子手替妈妈抽的六合彩号码",
+      "ref_sub_2": "奇迹般似的一个号码也没中过！",
+      "target_sub_1": "我用我嘅同事手帮妈妈抽嘅六合彩number",
+      "target_sub_2": "竟然奇迹一样一个都未中过"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "奇迹般似的一个号码也没中过！",
-      "src_1_sub_2": "叻仔？",
-      "src_2_sub_1": "竟然奇迹一样一个都未中过",
-      "src_2_sub_2": "叻仔"
+      "ref_sub_1": "奇迹般似的一个号码也没中过！",
+      "ref_sub_2": "叻仔？",
+      "target_sub_1": "竟然奇迹一样一个都未中过",
+      "target_sub_2": "叻仔"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "叻仔？",
-      "src_1_sub_2": "我也试过努力念书，可是⋯",
-      "src_2_sub_1": "叻仔",
-      "src_2_sub_2": "我试过好努力咁读书但系"
+      "ref_sub_1": "叻仔？",
+      "ref_sub_2": "我也试过努力念书，可是⋯",
+      "target_sub_1": "叻仔",
+      "target_sub_2": "我试过好努力咁读书但系"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我也试过努力念书，可是⋯",
-      "src_1_sub_2": "可是⋯我仍然有梦",
-      "src_2_sub_1": "我试过好努力咁读书但系",
-      "src_2_sub_2": "但系我仲可以发梦"
+      "ref_sub_1": "我也试过努力念书，可是⋯",
+      "ref_sub_2": "可是⋯我仍然有梦",
+      "target_sub_1": "我试过好努力咁读书但系",
+      "target_sub_2": "但系我仲可以发梦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "马尔代夫，座落于印度洋的世外桃源",
-      "src_1_sub_2": "蓝天白云，椰林树影，水清沙幼",
-      "src_2_sub_1": "马尔代夫坐落于印度洋嘅世外桃源",
-      "src_2_sub_2": "蓝天白云椰林树影水清沙游"
+      "ref_sub_1": "马尔代夫，座落于印度洋的世外桃源",
+      "ref_sub_2": "蓝天白云，椰林树影，水清沙幼",
+      "target_sub_1": "马尔代夫坐落于印度洋嘅世外桃源",
+      "target_sub_2": "蓝天白云椰林树影水清沙游"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "蓝天白云，椰林树影，水清沙幼",
-      "src_1_sub_2": "七彩缤纷的珊瑚，目不暇给的热带鱼",
-      "src_2_sub_1": "蓝天白云椰林树影水清沙游",
-      "src_2_sub_2": "七彩缤纷嘅珊瑚目不下级嘅热带鱼群"
+      "ref_sub_1": "蓝天白云，椰林树影，水清沙幼",
+      "ref_sub_2": "七彩缤纷的珊瑚，目不暇给的热带鱼",
+      "target_sub_1": "蓝天白云椰林树影水清沙游",
+      "target_sub_2": "七彩缤纷嘅珊瑚目不下级嘅热带鱼群"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "七彩缤纷的珊瑚，目不暇给的热带鱼",
-      "src_1_sub_2": "充满赤道活力的原始海洋，脱离繁嚣",
-      "src_2_sub_1": "七彩缤纷嘅珊瑚目不下级嘅热带鱼群",
-      "src_2_sub_2": "充满住赤道热力嘅原始海洋远离凡嚣"
+      "ref_sub_1": "七彩缤纷的珊瑚，目不暇给的热带鱼",
+      "ref_sub_2": "充满赤道活力的原始海洋，脱离繁嚣",
+      "target_sub_1": "七彩缤纷嘅珊瑚目不下级嘅热带鱼群",
+      "target_sub_2": "充满住赤道热力嘅原始海洋远离凡嚣"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "充满赤道活力的原始海洋，脱离繁嚣",
-      "src_1_sub_2": "体验热情如火的风土人情",
-      "src_2_sub_1": "充满住赤道热力嘅原始海洋远离凡嚣",
-      "src_2_sub_2": "体验热情如火嘅风土人情"
+      "ref_sub_1": "充满赤道活力的原始海洋，脱离繁嚣",
+      "ref_sub_2": "体验热情如火的风土人情",
+      "target_sub_1": "充满住赤道热力嘅原始海洋远离凡嚣",
+      "target_sub_2": "体验热情如火嘅风土人情"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "体验热情如火的风土人情",
-      "src_1_sub_2": "享受一个脱俗出尘的梦幻之旅",
-      "src_2_sub_1": "体验热情如火嘅风土人情",
-      "src_2_sub_2": "享受一个脱轴出尘嘅梦幻之旅"
+      "ref_sub_1": "体验热情如火的风土人情",
+      "ref_sub_2": "享受一个脱俗出尘的梦幻之旅",
+      "target_sub_1": "体验热情如火嘅风土人情",
+      "target_sub_2": "享受一个脱轴出尘嘅梦幻之旅"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "享受一个脱俗出尘的梦幻之旅",
-      "src_1_sub_2": "犀利旅行社，旅行社牌照号码350999",
-      "src_2_sub_1": "享受一个脱轴出尘嘅梦幻之旅",
-      "src_2_sub_2": "犀利旅行社旅行社牌照号码350999"
+      "ref_sub_1": "享受一个脱俗出尘的梦幻之旅",
+      "ref_sub_2": "犀利旅行社，旅行社牌照号码350999",
+      "target_sub_1": "享受一个脱轴出尘嘅梦幻之旅",
+      "target_sub_2": "犀利旅行社旅行社牌照号码350999"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "犀利旅行社，旅行社牌照号码350999",
-      "src_1_sub_2": "妈妈你知道马尔代夫在哪儿吗？",
-      "src_2_sub_1": "犀利旅行社旅行社牌照号码350999",
-      "src_2_sub_2": "妈妈你知唔知到马尔代夫系边㗎"
+      "ref_sub_1": "犀利旅行社，旅行社牌照号码350999",
+      "ref_sub_2": "妈妈你知道马尔代夫在哪儿吗？",
+      "target_sub_1": "犀利旅行社旅行社牌照号码350999",
+      "target_sub_2": "妈妈你知唔知到马尔代夫系边㗎"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈你知道马尔代夫在哪儿吗？",
-      "src_1_sub_2": "很远的",
-      "src_2_sub_1": "妈妈你知唔知到马尔代夫系边㗎"
+      "ref_sub_1": "妈妈你知道马尔代夫在哪儿吗？",
+      "ref_sub_2": "很远的",
+      "target_sub_1": "妈妈你知唔知到马尔代夫系边㗎"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "很远的",
-      "src_1_sub_2": "有多远？",
-      "src_2_sub_2": "啊好远㗎点远发呀"
+      "ref_sub_1": "很远的",
+      "ref_sub_2": "有多远？",
+      "target_sub_2": "啊好远㗎点远发呀"
     },
     "answer": {
-      "src_2_sub_1_shifted": "啊好远㗎",
-      "src_2_sub_2_shifted": "点远发呀"
+      "target_sub_1_shifted": "啊好远㗎",
+      "target_sub_2_shifted": "点远发呀"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "有多远？",
-      "src_1_sub_2": "得搭飞机",
-      "src_2_sub_1": "点远发呀",
-      "src_2_sub_2": "搭飞机至到啰"
+      "ref_sub_1": "有多远？",
+      "ref_sub_2": "得搭飞机",
+      "target_sub_1": "点远发呀",
+      "target_sub_2": "搭飞机至到啰"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "得搭飞机",
-      "src_1_sub_2": "妈妈你会带我去吗？",
-      "src_2_sub_1": "搭飞机至到啰",
-      "src_2_sub_2": "咁妈妈你会唔会走落去㗎"
+      "ref_sub_1": "得搭飞机",
+      "ref_sub_2": "妈妈你会带我去吗？",
+      "target_sub_1": "搭飞机至到啰",
+      "target_sub_2": "咁妈妈你会唔会走落去㗎"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈你会带我去吗？",
-      "src_1_sub_2": "会！发财了再说吧",
-      "src_2_sub_1": "咁妈妈你会唔会走落去㗎",
-      "src_2_sub_2": "会得学发咗先啦"
+      "ref_sub_1": "妈妈你会带我去吗？",
+      "ref_sub_2": "会！发财了再说吧",
+      "target_sub_1": "咁妈妈你会唔会走落去㗎",
+      "target_sub_2": "会得学发咗先啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "会！发财了再说吧",
-      "src_1_sub_2": "那么妈妈你什么时候发？",
-      "src_2_sub_1": "会得学发咗先啦",
-      "src_2_sub_2": "咁妈妈你几时发得呀"
+      "ref_sub_1": "会！发财了再说吧",
+      "ref_sub_2": "那么妈妈你什么时候发？",
+      "target_sub_1": "会得学发咗先啦",
+      "target_sub_2": "咁妈妈你几时发得呀"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "那么妈妈你什么时候发？",
-      "src_1_sub_2": "快了⋯",
-      "src_2_sub_1": "咁妈妈你几时发得呀",
-      "src_2_sub_2": "呃就快啦"
+      "ref_sub_1": "那么妈妈你什么时候发？",
+      "ref_sub_2": "快了⋯",
+      "target_sub_1": "咁妈妈你几时发得呀",
+      "target_sub_2": "呃就快啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "快了⋯",
-      "src_1_sub_2": "发梦呀！",
-      "src_2_sub_1": "呃就快啦",
-      "src_2_sub_2": "发梦吖嘛"
+      "ref_sub_1": "快了⋯",
+      "ref_sub_2": "发梦呀！",
+      "target_sub_1": "呃就快啦",
+      "target_sub_2": "发梦吖嘛"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "校长早晨！",
-      "src_1_sub_2": "校长再见！",
-      "src_2_sub_1": "嗨"
+      "ref_sub_1": "校长早晨！",
+      "ref_sub_2": "校长再见！",
+      "target_sub_1": "嗨"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "校长再见！",
-      "src_1_sub_2": "你最喜爱的地方是哪儿？",
-      "src_2_sub_2": "你最喜爱嘅地方喺边度呀"
+      "ref_sub_1": "校长再见！",
+      "ref_sub_2": "你最喜爱的地方是哪儿？",
+      "target_sub_2": "你最喜爱嘅地方喺边度呀"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "你最喜爱的地方是哪儿？",
-      "src_1_sub_2": "我最喜爱的地方是日本",
-      "src_2_sub_1": "你最喜爱嘅地方喺边度呀",
-      "src_2_sub_2": "我最喜爱嘅地方呢就系日本喇"
+      "ref_sub_1": "你最喜爱的地方是哪儿？",
+      "ref_sub_2": "我最喜爱的地方是日本",
+      "target_sub_1": "你最喜爱嘅地方喺边度呀",
+      "target_sub_2": "我最喜爱嘅地方呢就系日本喇"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我最喜爱的地方是日本",
-      "src_1_sub_2": "那儿有 Disneyland 和 Hello Kitty Land",
-      "src_2_sub_1": "我最喜爱嘅地方呢就系日本喇",
-      "src_2_sub_2": "嗰度好迪士尼呢同埋HelloTT呢"
+      "ref_sub_1": "我最喜爱的地方是日本",
+      "ref_sub_2": "那儿有 Disneyland 和 Hello Kitty Land",
+      "target_sub_1": "我最喜爱嘅地方呢就系日本喇",
+      "target_sub_2": "嗰度好迪士尼呢同埋HelloTT呢"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "那儿有 Disneyland 和 Hello Kitty Land",
-      "src_1_sub_2": "我这个发夹也是在那儿买的",
-      "src_2_sub_1": "嗰度好迪士尼呢同埋HelloTT呢",
-      "src_2_sub_2": "我而家打紧个发卷都系嗰边买嘅"
+      "ref_sub_1": "那儿有 Disneyland 和 Hello Kitty Land",
+      "ref_sub_2": "我这个发夹也是在那儿买的",
+      "target_sub_1": "嗰度好迪士尼呢同埋HelloTT呢",
+      "target_sub_2": "我而家打紧个发卷都系嗰边买嘅"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我这个发夹也是在那儿买的",
-      "src_1_sub_2": "我最喜爱的地方是加拿大",
-      "src_2_sub_1": "我而家打紧个发卷都系嗰边买嘅",
-      "src_2_sub_2": "我最钟意嘅地方就系加拿大"
+      "ref_sub_1": "我这个发夹也是在那儿买的",
+      "ref_sub_2": "我最喜爱的地方是加拿大",
+      "target_sub_1": "我而家打紧个发卷都系嗰边买嘅",
+      "target_sub_2": "我最钟意嘅地方就系加拿大"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我最喜爱的地方是加拿大",
-      "src_1_sub_2": "婆婆跟舅父他们都在加拿大",
-      "src_2_sub_1": "我最钟意嘅地方就系加拿大",
-      "src_2_sub_2": "婆婆同埋舅父呀佢哋都系加拿大㗎"
+      "ref_sub_1": "我最喜爱的地方是加拿大",
+      "ref_sub_2": "婆婆跟舅父他们都在加拿大",
+      "target_sub_1": "我最钟意嘅地方就系加拿大",
+      "target_sub_2": "婆婆同埋舅父呀佢哋都系加拿大㗎"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "婆婆跟舅父他们都在加拿大",
-      "src_1_sub_2": "我最喜爱的地方是泰国",
-      "src_2_sub_1": "婆婆同埋舅父呀佢哋都系加拿大㗎",
-      "src_2_sub_2": "我最钟意去嘅地方就系泰国喇"
+      "ref_sub_1": "婆婆跟舅父他们都在加拿大",
+      "ref_sub_2": "我最喜爱的地方是泰国",
+      "target_sub_1": "婆婆同埋舅父呀佢哋都系加拿大㗎",
+      "target_sub_2": "我最钟意去嘅地方就系泰国喇"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我最喜爱的地方是泰国",
-      "src_1_sub_2": "那儿有很好多水上活动，还有鱼翅吃",
-      "src_2_sub_1": "我最钟意去嘅地方就系泰国喇",
-      "src_2_sub_2": "嗰度有好多水晶活动㗎仲有一次食添㖞"
+      "ref_sub_1": "我最喜爱的地方是泰国",
+      "ref_sub_2": "那儿有很好多水上活动，还有鱼翅吃",
+      "target_sub_1": "我最钟意去嘅地方就系泰国喇",
+      "target_sub_2": "嗰度有好多水晶活动㗎仲有一次食添㖞"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "那儿有很好多水上活动，还有鱼翅吃",
-      "src_1_sub_2": "我最喜爱的地方⋯",
-      "src_2_sub_1": "嗰度有好多水晶活动㗎仲有一次食添㖞",
-      "src_2_sub_2": "呃我最喜爱嘅地方呢"
+      "ref_sub_1": "那儿有很好多水上活动，还有鱼翅吃",
+      "ref_sub_2": "我最喜爱的地方⋯",
+      "target_sub_1": "嗰度有好多水晶活动㗎仲有一次食添㖞",
+      "target_sub_2": "呃我最喜爱嘅地方呢"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我最喜爱的地方⋯",
-      "src_1_sub_2": "就是那间什么！",
-      "src_2_sub_1": "呃我最喜爱嘅地方呢",
-      "src_2_sub_2": "就系嗰间咩嚟啰"
+      "ref_sub_1": "我最喜爱的地方⋯",
+      "ref_sub_2": "就是那间什么！",
+      "target_sub_1": "呃我最喜爱嘅地方呢",
+      "target_sub_2": "就系嗰间咩嚟啰"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "就是那间什么！",
-      "src_1_sub_2": "那儿有欢乐天地，还有美食广场",
-      "src_2_sub_1": "就系嗰间咩嚟啰",
-      "src_2_sub_2": "嗰度有欢乐天地啦仲有米食广场啦"
+      "ref_sub_1": "就是那间什么！",
+      "ref_sub_2": "那儿有欢乐天地，还有美食广场",
+      "target_sub_1": "就系嗰间咩嚟啰",
+      "target_sub_2": "嗰度有欢乐天地啦仲有米食广场啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "那儿有欢乐天地，还有美食广场",
-      "src_1_sub_2": "那儿的海南鸡饭很大碟的",
-      "src_2_sub_1": "嗰度有欢乐天地啦仲有米食广场啦",
-      "src_2_sub_2": "嗰度啲可能几份好大碟㗎"
+      "ref_sub_1": "那儿有欢乐天地，还有美食广场",
+      "ref_sub_2": "那儿的海南鸡饭很大碟的",
+      "target_sub_1": "嗰度有欢乐天地啦仲有米食广场啦",
+      "target_sub_2": "嗰度啲可能几份好大碟㗎"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "那儿的海南鸡饭很大碟的",
-      "src_1_sub_2": "对了，那地方叫银城中心",
-      "src_2_sub_1": "嗰度啲可能几份好大碟㗎",
-      "src_2_sub_2": "系喇系喇嗰间叫做银城中心"
+      "ref_sub_1": "那儿的海南鸡饭很大碟的",
+      "ref_sub_2": "对了，那地方叫银城中心",
+      "target_sub_1": "嗰度啲可能几份好大碟㗎",
+      "target_sub_2": "系喇系喇嗰间叫做银城中心"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "对了，那地方叫银城中心",
-      "src_1_sub_2": "那店子的饭很多，很大碟的！",
-      "src_2_sub_1": "系喇系喇嗰间叫做银城中心",
-      "src_2_sub_2": "嗰间嘢啲饭好多人好大碟㗎"
+      "ref_sub_1": "对了，那地方叫银城中心",
+      "ref_sub_2": "那店子的饭很多，很大碟的！",
+      "target_sub_1": "系喇系喇嗰间叫做银城中心",
+      "target_sub_2": "嗰间嘢啲饭好多人好大碟㗎"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "那店子的饭很多，很大碟的！",
-      "src_1_sub_2": "不过说到我最想去的地方，那可厉害了",
-      "src_2_sub_1": "嗰间嘢啲饭好多人好大碟㗎",
-      "src_2_sub_2": "不过讲到我最想去嘅地方呢嗰度细嚟啰"
+      "ref_sub_1": "那店子的饭很多，很大碟的！",
+      "ref_sub_2": "不过说到我最想去的地方，那可厉害了",
+      "target_sub_1": "嗰间嘢啲饭好多人好大碟㗎",
+      "target_sub_2": "不过讲到我最想去嘅地方呢嗰度细嚟啰"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "不过说到我最想去的地方，那可厉害了",
-      "src_1_sub_2": "那儿蓝天白云，椰林树影，水清沙幼",
-      "src_2_sub_1": "不过讲到我最想去嘅地方呢嗰度细嚟啰",
-      "src_2_sub_2": "嗰度南天白云夜临树影水清沙幽"
+      "ref_sub_1": "不过说到我最想去的地方，那可厉害了",
+      "ref_sub_2": "那儿蓝天白云，椰林树影，水清沙幼",
+      "target_sub_1": "不过讲到我最想去嘅地方呢嗰度细嚟啰",
+      "target_sub_2": "嗰度南天白云夜临树影水清沙幽"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "那儿蓝天白云，椰林树影，水清沙幼",
-      "src_1_sub_2": "座落于印度洋的世外桃源",
-      "src_2_sub_1": "嗰度南天白云夜临树影水清沙幽",
-      "src_2_sub_2": "独来鱼印度洋嘅世外桃源"
+      "ref_sub_1": "那儿蓝天白云，椰林树影，水清沙幼",
+      "ref_sub_2": "座落于印度洋的世外桃源",
+      "target_sub_1": "嗰度南天白云夜临树影水清沙幽",
+      "target_sub_2": "独来鱼印度洋嘅世外桃源"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "衰仔，快点起床上学",
-      "src_1_sub_2": "咦？",
-      "src_2_sub_1": "喂衰仔啊快啲起身返学喇",
-      "src_2_sub_2": "咦"
+      "ref_sub_1": "衰仔，快点起床上学",
+      "ref_sub_2": "咦？",
+      "target_sub_1": "喂衰仔啊快啲起身返学喇",
+      "target_sub_2": "咦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "咦？",
-      "src_1_sub_2": "妈妈！",
-      "src_2_sub_1": "咦",
-      "src_2_sub_2": "妈妈"
+      "ref_sub_1": "咦？",
+      "ref_sub_2": "妈妈！",
+      "target_sub_1": "咦",
+      "target_sub_2": "妈妈"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "开点药给他吃就没事了",
-      "src_1_sub_2": "医生，吃了药会不会有那个什么的？",
-      "src_2_sub_1": "开啲药过佢食就冇事㗎喇",
-      "src_2_sub_2": "医生啊"
+      "ref_sub_1": "开点药给他吃就没事了",
+      "ref_sub_2": "医生，吃了药会不会有那个什么的？",
+      "target_sub_1": "开啲药过佢食就冇事㗎喇",
+      "target_sub_2": "医生啊"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "医生，吃了药会不会有那个什么的？",
-      "src_1_sub_2": "不会！",
-      "src_2_sub_1": "医生啊",
-      "src_2_sub_2": "啲药食咗会唔会有嗰啲咩㗎唔会"
+      "ref_sub_1": "医生，吃了药会不会有那个什么的？",
+      "ref_sub_2": "不会！",
+      "target_sub_1": "医生啊",
+      "target_sub_2": "啲药食咗会唔会有嗰啲咩㗎唔会"
     },
     "answer": {
-      "src_2_sub_1_shifted": "医生啊啲药食咗会唔会有嗰啲咩㗎",
-      "src_2_sub_2_shifted": "唔会"
+      "target_sub_1_shifted": "医生啊啲药食咗会唔会有嗰啲咩㗎",
+      "target_sub_2_shifted": "唔会"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "不会！",
-      "src_1_sub_2": "那么吃药用不用那个什么的？",
-      "src_2_sub_1": "唔会",
-      "src_2_sub_2": "噉佢食药使唔使咩啊"
+      "ref_sub_1": "不会！",
+      "ref_sub_2": "那么吃药用不用那个什么的？",
+      "target_sub_1": "唔会",
+      "target_sub_2": "噉佢食药使唔使咩啊"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "那么吃药用不用那个什么的？",
-      "src_1_sub_2": "不用！给他打口针吧！",
-      "src_2_sub_1": "噉佢食药使唔使咩啊",
-      "src_2_sub_2": "唔使同佢打多支针添呢"
+      "ref_sub_1": "那么吃药用不用那个什么的？",
+      "ref_sub_2": "不用！给他打口针吧！",
+      "target_sub_1": "噉佢食药使唔使咩啊",
+      "target_sub_2": "唔使同佢打多支针添呢"
     },
     "answer": {},
     "few_shot": true,
@@ -2899,124 +2899,124 @@
   },
   {
     "query": {
-      "src_1_sub_1": "不用！给他打口针吧！",
-      "src_1_sub_2": "怎么？得打针？",
-      "src_2_sub_1": "唔使同佢打多支针添呢",
-      "src_2_sub_2": "吓要打针啊"
+      "ref_sub_1": "不用！给他打口针吧！",
+      "ref_sub_2": "怎么？得打针？",
+      "target_sub_1": "唔使同佢打多支针添呢",
+      "target_sub_2": "吓要打针啊"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "怎么？得打针？",
-      "src_1_sub_2": "他最怕打针的了",
-      "src_2_sub_1": "吓要打针啊",
-      "src_2_sub_2": "佢好怕打针㗎㖞"
+      "ref_sub_1": "怎么？得打针？",
+      "ref_sub_2": "他最怕打针的了",
+      "target_sub_1": "吓要打针啊",
+      "target_sub_2": "佢好怕打针㗎㖞"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "他最怕打针的了",
-      "src_1_sub_2": "那么他怕不怕死？",
-      "src_2_sub_1": "佢好怕打针㗎㖞",
-      "src_2_sub_2": "噉佢怕唔怕死呀"
+      "ref_sub_1": "他最怕打针的了",
+      "ref_sub_2": "那么他怕不怕死？",
+      "target_sub_1": "佢好怕打针㗎㖞",
+      "target_sub_2": "噉佢怕唔怕死呀"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "没事吧？快点先把药水喝掉！",
-      "src_1_sub_2": "妈妈我不想喝药水",
-      "src_2_sub_1": "冇嘢吖嘛快啲食埋啲药水佢先啦",
-      "src_2_sub_2": "妈妈我唔想食药水呀"
+      "ref_sub_1": "没事吧？快点先把药水喝掉！",
+      "ref_sub_2": "妈妈我不想喝药水",
+      "target_sub_1": "冇嘢吖嘛快啲食埋啲药水佢先啦",
+      "target_sub_2": "妈妈我唔想食药水呀"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈我不想喝药水",
-      "src_1_sub_2": "不要呀妈妈，我不喝呀",
-      "src_2_sub_1": "妈妈我唔想食药水呀",
-      "src_2_sub_2": "唔好捞妈妈我唔食呀"
+      "ref_sub_1": "妈妈我不想喝药水",
+      "ref_sub_2": "不要呀妈妈，我不喝呀",
+      "target_sub_1": "妈妈我唔想食药水呀",
+      "target_sub_2": "唔好捞妈妈我唔食呀"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "不要呀妈妈，我不喝呀",
-      "src_1_sub_2": "我不喝士多啤梨药水呀！",
-      "src_2_sub_1": "唔好捞妈妈我唔食呀",
-      "src_2_sub_2": "我唔食士多啤梨药水呀"
+      "ref_sub_1": "不要呀妈妈，我不喝呀",
+      "ref_sub_2": "我不喝士多啤梨药水呀！",
+      "target_sub_1": "唔好捞妈妈我唔食呀",
+      "target_sub_2": "我唔食士多啤梨药水呀"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我不喝士多啤梨药水呀！",
-      "src_1_sub_2": "别哭了，不喝药水病不会好的",
-      "src_2_sub_1": "我唔食士多啤梨药水呀",
-      "src_2_sub_2": "唔好喊啦唔食药唔会好㗎"
+      "ref_sub_1": "我不喝士多啤梨药水呀！",
+      "ref_sub_2": "别哭了，不喝药水病不会好的",
+      "target_sub_1": "我唔食士多啤梨药水呀",
+      "target_sub_2": "唔好喊啦唔食药唔会好㗎"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "别哭了，不喝药水病不会好的",
-      "src_1_sub_2": "乖乖，病好了妈妈带你去马尔代夫",
-      "src_2_sub_1": "唔好喊啦唔食药唔会好㗎",
-      "src_2_sub_2": "乖乖啲病好咗妈妈大理马尔代夫"
+      "ref_sub_1": "别哭了，不喝药水病不会好的",
+      "ref_sub_2": "乖乖，病好了妈妈带你去马尔代夫",
+      "target_sub_1": "唔好喊啦唔食药唔会好㗎",
+      "target_sub_2": "乖乖啲病好咗妈妈大理马尔代夫"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "乖乖，病好了妈妈带你去马尔代夫",
-      "src_1_sub_2": "真的吗？",
-      "src_2_sub_1": "乖乖啲病好咗妈妈大理马尔代夫",
-      "src_2_sub_2": "真嘅"
+      "ref_sub_1": "乖乖，病好了妈妈带你去马尔代夫",
+      "ref_sub_2": "真的吗？",
+      "target_sub_1": "乖乖啲病好咗妈妈大理马尔代夫",
+      "target_sub_2": "真嘅"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "真的吗？",
-      "src_1_sub_2": "妈妈什么时候骗过你？",
-      "src_2_sub_1": "真嘅",
-      "src_2_sub_2": "妈妈几时呃过你呀"
+      "ref_sub_1": "真的吗？",
+      "ref_sub_2": "妈妈什么时候骗过你？",
+      "target_sub_1": "真嘅",
+      "target_sub_2": "妈妈几时呃过你呀"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈什么时候骗过你？",
-      "src_1_sub_2": "乖，先把药水喝掉",
-      "src_2_sub_1": "妈妈几时呃过你呀",
-      "src_2_sub_2": "乖食埋啲药水先啦"
+      "ref_sub_1": "妈妈什么时候骗过你？",
+      "ref_sub_2": "乖，先把药水喝掉",
+      "target_sub_1": "妈妈几时呃过你呀",
+      "target_sub_2": "乖食埋啲药水先啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "好呀，马尔代夫！",
-      "src_1_sub_2": "马尔代夫！",
-      "src_2_sub_1": "嘻嘻好嘢",
-      "src_2_sub_2": "买二代夫买二代夫"
+      "ref_sub_1": "好呀，马尔代夫！",
+      "ref_sub_2": "马尔代夫！",
+      "target_sub_1": "嘻嘻好嘢",
+      "target_sub_2": "买二代夫买二代夫"
     },
     "answer": {
-      "src_2_sub_1_shifted": "嘻嘻好嘢买二代夫",
-      "src_2_sub_2_shifted": "买二代夫"
+      "target_sub_1_shifted": "嘻嘻好嘢买二代夫",
+      "target_sub_2_shifted": "买二代夫"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -3024,61 +3024,61 @@
   },
   {
     "query": {
-      "src_1_sub_1": "马尔代夫！",
-      "src_1_sub_2": "马尔代夫！",
-      "src_2_sub_1": "买二代夫"
+      "ref_sub_1": "马尔代夫！",
+      "ref_sub_2": "马尔代夫！",
+      "target_sub_1": "买二代夫"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "马尔代夫！",
-      "src_1_sub_2": "马尔代夫！",
-      "src_2_sub_2": "买二代夫买二代夫"
+      "ref_sub_1": "马尔代夫！",
+      "ref_sub_2": "马尔代夫！",
+      "target_sub_2": "买二代夫买二代夫"
     },
     "answer": {
-      "src_2_sub_1_shifted": "买二代夫",
-      "src_2_sub_2_shifted": "买二代夫"
+      "target_sub_1_shifted": "买二代夫",
+      "target_sub_2_shifted": "买二代夫"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "马尔代夫！",
-      "src_1_sub_2": "妈妈，那么我们什么时候去？",
-      "src_2_sub_1": "买二代夫",
-      "src_2_sub_2": "妈妈咁我哋几时去呀"
+      "ref_sub_1": "马尔代夫！",
+      "ref_sub_2": "妈妈，那么我们什么时候去？",
+      "target_sub_1": "买二代夫",
+      "target_sub_2": "妈妈咁我哋几时去呀"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈，那么我们什么时候去？",
-      "src_1_sub_2": "你先把药水喝掉，病好了我就去订机票",
-      "src_2_sub_1": "妈妈咁我哋几时去呀",
-      "src_2_sub_2": "嗯你乖乖哋食埋啲药好返晒啦我即刻订机票"
+      "ref_sub_1": "妈妈，那么我们什么时候去？",
+      "ref_sub_2": "你先把药水喝掉，病好了我就去订机票",
+      "target_sub_1": "妈妈咁我哋几时去呀",
+      "target_sub_2": "嗯你乖乖哋食埋啲药好返晒啦我即刻订机票"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "你先把药水喝掉，病好了我就去订机票",
-      "src_1_sub_2": "来，多喝一点！",
-      "src_2_sub_1": "嗯你乖乖哋食埋啲药好返晒啦我即刻订机票",
-      "src_2_sub_2": "嚟啦食多更"
+      "ref_sub_1": "你先把药水喝掉，病好了我就去订机票",
+      "ref_sub_2": "来，多喝一点！",
+      "target_sub_1": "嗯你乖乖哋食埋啲药好返晒啦我即刻订机票",
+      "target_sub_2": "嚟啦食多更"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈，你看！",
-      "src_1_sub_2": "妈妈你看，我病好了！",
-      "src_2_sub_2": "妈妈你睇我好返喇"
+      "ref_sub_1": "妈妈，你看！",
+      "ref_sub_2": "妈妈你看，我病好了！",
+      "target_sub_2": "妈妈你睇我好返喇"
     },
     "answer": {},
     "difficulty": 3,
@@ -3086,176 +3086,176 @@
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈你看，我病好了！",
-      "src_1_sub_2": "我把药都吃光了",
-      "src_2_sub_1": "妈妈你睇我好返喇",
-      "src_2_sub_2": "啲嘢所以我全部食晒喇"
+      "ref_sub_1": "妈妈你看，我病好了！",
+      "ref_sub_2": "我把药都吃光了",
+      "target_sub_1": "妈妈你睇我好返喇",
+      "target_sub_2": "啲嘢所以我全部食晒喇"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我把药都吃光了",
-      "src_1_sub_2": "家中的东西有什么没给你吃光的？",
-      "src_2_sub_1": "啲嘢所以我全部食晒喇",
-      "src_2_sub_2": "即系间屋有乜嘢唔系畀你食晒㗎"
+      "ref_sub_1": "我把药都吃光了",
+      "ref_sub_2": "家中的东西有什么没给你吃光的？",
+      "target_sub_1": "啲嘢所以我全部食晒喇",
+      "target_sub_2": "即系间屋有乜嘢唔系畀你食晒㗎"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "家中的东西有什么没给你吃光的？",
-      "src_1_sub_2": "这次不同呀，原来这么一大樽的",
-      "src_2_sub_1": "即系间屋有乜嘢唔系畀你食晒㗎",
-      "src_2_sub_2": "妈妈呢次唔同㗎本来咁大樽嘅"
+      "ref_sub_1": "家中的东西有什么没给你吃光的？",
+      "ref_sub_2": "这次不同呀，原来这么一大樽的",
+      "target_sub_1": "即系间屋有乜嘢唔系畀你食晒㗎",
+      "target_sub_2": "妈妈呢次唔同㗎本来咁大樽嘅"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "这次不同呀，原来这么一大樽的",
-      "src_1_sub_2": "我喝一格，又喝一格，又喝一格⋯",
-      "src_2_sub_1": "妈妈呢次唔同㗎本来咁大樽嘅",
-      "src_2_sub_2": "我饮下一格又一格又一格"
+      "ref_sub_1": "这次不同呀，原来这么一大樽的",
+      "ref_sub_2": "我喝一格，又喝一格，又喝一格⋯",
+      "target_sub_1": "妈妈呢次唔同㗎本来咁大樽嘅",
+      "target_sub_2": "我饮下一格又一格又一格"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我喝一格，又喝一格，又喝一格⋯",
-      "src_1_sub_2": "就给我喝光了！",
-      "src_2_sub_1": "我饮下一格又一格又一格",
-      "src_2_sub_2": "吓咪我饮晒㖞"
+      "ref_sub_1": "我喝一格，又喝一格，又喝一格⋯",
+      "ref_sub_2": "就给我喝光了！",
+      "target_sub_1": "我饮下一格又一格又一格",
+      "target_sub_2": "吓咪我饮晒㖞"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "喝光了就叻仔了！",
-      "src_1_sub_2": "喝光了就病好了！",
-      "src_2_sub_1": "饮实就叻仔啦",
-      "src_2_sub_2": "饮实就好返实啦"
+      "ref_sub_1": "喝光了就叻仔了！",
+      "ref_sub_2": "喝光了就病好了！",
+      "target_sub_1": "饮实就叻仔啦",
+      "target_sub_2": "饮实就好返实啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "喝光了就病好了！",
-      "src_1_sub_2": "妈妈呀⋯",
-      "src_2_sub_1": "饮实就好返实啦"
+      "ref_sub_1": "喝光了就病好了！",
+      "ref_sub_2": "妈妈呀⋯",
+      "target_sub_1": "饮实就好返实啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈呀⋯",
-      "src_1_sub_2": "什么事？",
-      "src_2_sub_2": "妈妈乜嘢啊"
+      "ref_sub_1": "妈妈呀⋯",
+      "ref_sub_2": "什么事？",
+      "target_sub_2": "妈妈乜嘢啊"
     },
     "answer": {
-      "src_2_sub_1_shifted": "妈妈",
-      "src_2_sub_2_shifted": "乜嘢啊"
+      "target_sub_1_shifted": "妈妈",
+      "target_sub_2_shifted": "乜嘢啊"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "什么事？",
-      "src_1_sub_2": "我们什么时候去马尔代夫？",
-      "src_2_sub_1": "乜嘢啊",
-      "src_2_sub_2": "阿哋几时去马尔代夫啊"
+      "ref_sub_1": "什么事？",
+      "ref_sub_2": "我们什么时候去马尔代夫？",
+      "target_sub_1": "乜嘢啊",
+      "target_sub_2": "阿哋几时去马尔代夫啊"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我们什么时候去马尔代夫？",
-      "src_1_sub_2": "什么马尔代夫？",
-      "src_2_sub_1": "阿哋几时去马尔代夫啊",
-      "src_2_sub_2": "乜嘢马尔代夫啊"
+      "ref_sub_1": "我们什么时候去马尔代夫？",
+      "ref_sub_2": "什么马尔代夫？",
+      "target_sub_1": "阿哋几时去马尔代夫啊",
+      "target_sub_2": "乜嘢马尔代夫啊"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "什么马尔代夫？",
-      "src_1_sub_2": "你说我病好带我去马尔代夫的呀！",
-      "src_2_sub_1": "乜嘢马尔代夫啊",
-      "src_2_sub_2": "呢你话我返就同我去马尔代夫㗎嘛"
+      "ref_sub_1": "什么马尔代夫？",
+      "ref_sub_2": "你说我病好带我去马尔代夫的呀！",
+      "target_sub_1": "乜嘢马尔代夫啊",
+      "target_sub_2": "呢你话我返就同我去马尔代夫㗎嘛"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "你说我病好带我去马尔代夫的呀！",
-      "src_1_sub_2": "马尔代夫，椰林树影，水清沙幼⋯",
-      "src_2_sub_1": "呢你话我返就同我去马尔代夫㗎嘛",
-      "src_2_sub_2": "马尔代夫呢耶南树影"
+      "ref_sub_1": "你说我病好带我去马尔代夫的呀！",
+      "ref_sub_2": "马尔代夫，椰林树影，水清沙幼⋯",
+      "target_sub_1": "呢你话我返就同我去马尔代夫㗎嘛",
+      "target_sub_2": "马尔代夫呢耶南树影"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "马尔代夫，椰林树影，水清沙幼⋯",
-      "src_1_sub_2": "座落于印度洋的世外桃源呀！",
-      "src_2_sub_1": "马尔代夫呢耶南树影",
-      "src_2_sub_2": "水清沙游助流于印度园嘅世外导演啦"
+      "ref_sub_1": "马尔代夫，椰林树影，水清沙幼⋯",
+      "ref_sub_2": "座落于印度洋的世外桃源呀！",
+      "target_sub_1": "马尔代夫呢耶南树影",
+      "target_sub_2": "水清沙游助流于印度园嘅世外导演啦"
     },
     "answer": {
-      "src_2_sub_1_shifted": "马尔代夫呢耶南树影水清沙游",
-      "src_2_sub_2_shifted": "助流于印度园嘅世外导演啦"
+      "target_sub_1_shifted": "马尔代夫呢耶南树影水清沙游",
+      "target_sub_2_shifted": "助流于印度园嘅世外导演啦"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "座落于印度洋的世外桃源呀！",
-      "src_1_sub_2": "想不到你还有点文采",
-      "src_2_sub_1": "助流于印度园嘅世外导演啦",
-      "src_2_sub_2": "啊估唔到你几好文采㗎噃"
+      "ref_sub_1": "座落于印度洋的世外桃源呀！",
+      "ref_sub_2": "想不到你还有点文采",
+      "target_sub_1": "助流于印度园嘅世外导演啦",
+      "target_sub_2": "啊估唔到你几好文采㗎噃"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "想不到你还有点文采",
-      "src_1_sub_2": "说得不错呀！",
-      "src_2_sub_1": "啊估唔到你几好文采㗎噃",
-      "src_2_sub_2": "讲得几好听啊"
+      "ref_sub_1": "想不到你还有点文采",
+      "ref_sub_2": "说得不错呀！",
+      "target_sub_1": "啊估唔到你几好文采㗎噃",
+      "target_sub_2": "讲得几好听啊"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "说得不错呀！",
-      "src_1_sub_2": "我不是光说的呀，妈妈你说过⋯",
-      "src_2_sub_1": "讲得几好听啊",
-      "src_2_sub_2": "妈妈我唔系讲喇㗎又系你话嘅"
+      "ref_sub_1": "说得不错呀！",
+      "ref_sub_2": "我不是光说的呀，妈妈你说过⋯",
+      "target_sub_1": "讲得几好听啊",
+      "target_sub_2": "妈妈我唔系讲喇㗎又系你话嘅"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我不是光说的呀，妈妈你说过⋯",
-      "src_1_sub_2": "我病好了带我去马尔代夫的！",
-      "src_2_sub_1": "妈妈我唔系讲喇㗎又系你话嘅",
-      "src_2_sub_2": "你话我病好咗之日就同我去马尔代夫㗎你讲过㗎"
+      "ref_sub_1": "我不是光说的呀，妈妈你说过⋯",
+      "ref_sub_2": "我病好了带我去马尔代夫的！",
+      "target_sub_1": "妈妈我唔系讲喇㗎又系你话嘅",
+      "target_sub_2": "你话我病好咗之日就同我去马尔代夫㗎你讲过㗎"
     },
     "answer": {},
     "few_shot": true,
@@ -3263,5873 +3263,5873 @@
   },
   {
     "query": {
-      "src_1_sub_1": "我病好了带我去马尔代夫的！",
-      "src_1_sub_2": "我是说发了财就带你去",
-      "src_2_sub_1": "你话我病好咗之日就同我去马尔代夫㗎你讲过㗎",
-      "src_2_sub_2": "我话发咗先至同你去㗎"
+      "ref_sub_1": "我病好了带我去马尔代夫的！",
+      "ref_sub_2": "我是说发了财就带你去",
+      "target_sub_1": "你话我病好咗之日就同我去马尔代夫㗎你讲过㗎",
+      "target_sub_2": "我话发咗先至同你去㗎"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我是说发了财就带你去",
-      "src_1_sub_2": "不是的，妈妈你说我病好了就去的",
-      "src_2_sub_1": "我话发咗先至同你去㗎",
-      "src_2_sub_2": "唔系㖞妈妈你话好咗就同我去㗎㖞"
+      "ref_sub_1": "我是说发了财就带你去",
+      "ref_sub_2": "不是的，妈妈你说我病好了就去的",
+      "target_sub_1": "我话发咗先至同你去㗎",
+      "target_sub_2": "唔系㖞妈妈你话好咗就同我去㗎㖞"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "不是的，妈妈你说我病好了就去的",
-      "src_1_sub_2": "你分明讲过病好了就去马尔代夫的",
-      "src_2_sub_1": "唔系㖞妈妈你话好咗就同我去㗎㖞",
-      "src_2_sub_2": "你明明讲过好返就同你去马尔代夫㗎㖞"
+      "ref_sub_1": "不是的，妈妈你说我病好了就去的",
+      "ref_sub_2": "你分明讲过病好了就去马尔代夫的",
+      "target_sub_1": "唔系㖞妈妈你话好咗就同我去㗎㖞",
+      "target_sub_2": "你明明讲过好返就同你去马尔代夫㗎㖞"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "你分明讲过病好了就去马尔代夫的",
-      "src_1_sub_2": "你讲过的！",
-      "src_2_sub_1": "你明明讲过好返就同你去马尔代夫㗎㖞",
-      "src_2_sub_2": "你讲过㗎"
+      "ref_sub_1": "你分明讲过病好了就去马尔代夫的",
+      "ref_sub_2": "你讲过的！",
+      "target_sub_1": "你明明讲过好返就同你去马尔代夫㗎㖞",
+      "target_sub_2": "你讲过㗎"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "你讲过的！",
-      "src_1_sub_2": "好了，别哭了",
-      "src_2_sub_1": "你讲过㗎",
-      "src_2_sub_2": "得啦得啦唔好喊啦"
+      "ref_sub_1": "你讲过的！",
+      "ref_sub_2": "好了，别哭了",
+      "target_sub_1": "你讲过㗎",
+      "target_sub_2": "得啦得啦唔好喊啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "好了，别哭了",
-      "src_1_sub_2": "带你去马尔代夫好了",
-      "src_2_sub_1": "得啦得啦唔好喊啦",
-      "src_2_sub_2": "同你去马尔代夫啦"
+      "ref_sub_1": "好了，别哭了",
+      "ref_sub_2": "带你去马尔代夫好了",
+      "target_sub_1": "得啦得啦唔好喊啦",
+      "target_sub_2": "同你去马尔代夫啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "带你去马尔代夫好了",
-      "src_1_sub_2": "真的吗？　　对",
-      "src_2_sub_1": "同你去马尔代夫啦",
-      "src_2_sub_2": "真嘅系啊"
+      "ref_sub_1": "带你去马尔代夫好了",
+      "ref_sub_2": "真的吗？　　对",
+      "target_sub_1": "同你去马尔代夫啦",
+      "target_sub_2": "真嘅系啊"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "真的吗？　　对",
-      "src_1_sub_2": "什么时候去？",
-      "src_2_sub_1": "真嘅系啊",
-      "src_2_sub_2": "咁几时去啊"
+      "ref_sub_1": "真的吗？　　对",
+      "ref_sub_2": "什么时候去？",
+      "target_sub_1": "真嘅系啊",
+      "target_sub_2": "咁几时去啊"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "什么时候去？",
-      "src_1_sub_2": "发财再说",
-      "src_2_sub_1": "咁几时去啊",
-      "src_2_sub_2": "等我发咗先啰"
+      "ref_sub_1": "什么时候去？",
+      "ref_sub_2": "发财再说",
+      "target_sub_1": "咁几时去啊",
+      "target_sub_2": "等我发咗先啰"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "发财再说",
-      "src_1_sub_2": "你早发财了⋯",
-      "src_2_sub_1": "等我发咗先啰",
-      "src_2_sub_2": "你发咗㗎喇"
+      "ref_sub_1": "发财再说",
+      "ref_sub_2": "你早发财了⋯",
+      "target_sub_1": "等我发咗先啰",
+      "target_sub_2": "你发咗㗎喇"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "你早发财了⋯",
-      "src_1_sub_2": "好了好了，发财了",
-      "src_2_sub_1": "你发咗㗎喇",
-      "src_2_sub_2": "你发咗㗎喇系喇系喇系喇发咗喇"
+      "ref_sub_1": "你早发财了⋯",
+      "ref_sub_2": "好了好了，发财了",
+      "target_sub_1": "你发咗㗎喇",
+      "target_sub_2": "你发咗㗎喇系喇系喇系喇发咗喇"
     },
     "answer": {
-      "src_2_sub_1_shifted": "你发咗㗎喇你发咗㗎喇",
-      "src_2_sub_2_shifted": "系喇系喇系喇发咗喇"
-    },
-    "difficulty": 3,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "好了好了，发财了",
-      "src_1_sub_2": "我们下个星期去，好了吧？",
-      "src_2_sub_1": "系喇系喇系喇发咗喇",
-      "src_2_sub_2": "下个礼拜同你去啦"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我们下个星期去，好了吧？",
-      "src_1_sub_2": "太好了！",
-      "src_2_sub_1": "下个礼拜同你去啦",
-      "src_2_sub_2": "得未啊好嘢"
-    },
-    "answer": {
-      "src_2_sub_1_shifted": "下个礼拜同你去啦得未啊",
-      "src_2_sub_2_shifted": "好嘢"
-    },
-    "difficulty": 1,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "麦唛，我是麦兜呀",
-      "src_1_sub_2": "是这样子的，我明天就飞了",
-      "src_2_sub_1": "喂麦麦啊麦豆啊我系",
-      "src_2_sub_2": "即系呢我明日就要飞喇"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "是这样子的，我明天就飞了",
-      "src_1_sub_2": "对　　⋯是吗？",
-      "src_2_sub_1": "即系呢我明日就要飞喇",
-      "src_2_sub_2": "系啊系咩"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "对　　⋯是吗？",
-      "src_1_sub_2": "飞机餐很难吃的吗？",
-      "src_2_sub_1": "系啊系咩",
-      "src_2_sub_2": "飞机真好难食㗎"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "飞机餐很难吃的吗？",
-      "src_1_sub_2": "也得吃呀！",
-      "src_2_sub_1": "飞机真好难食㗎",
-      "src_2_sub_2": "但点都要食㗎啦"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "也得吃呀！",
-      "src_1_sub_2": "难道自己带东西上去吃吗？",
-      "src_2_sub_1": "但点都要食㗎啦",
-      "src_2_sub_2": "唔通自己带嘢上去食咩"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "难道自己带东西上去吃吗？",
-      "src_1_sub_2": "还在讲？",
-      "src_2_sub_1": "唔通自己带嘢上去食咩",
-      "src_2_sub_2": "仲讲"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "还在讲？",
-      "src_1_sub_2": "快点帮手执行李",
-      "src_2_sub_1": "仲讲",
-      "src_2_sub_2": "哦快啲嚟执埋啲行李先啦"
-    },
-    "answer": {
-      "src_2_sub_1_shifted": "仲讲哦",
-      "src_2_sub_2_shifted": "快啲嚟执埋啲行李先啦"
-    },
-    "difficulty": 1,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "快点帮手执行李",
-      "src_1_sub_2": "跟我向他们说，我明天去马尔代夫了",
-      "src_2_sub_1": "快啲嚟执埋啲行李先啦",
-      "src_2_sub_2": "哦你帮我话畀佢哋知我明日去买热带裤薄"
-    },
-    "answer": {
-      "src_2_sub_1_shifted": "快啲嚟执埋啲行李先啦哦",
-      "src_2_sub_2_shifted": "你帮我话畀佢哋知我明日去买热带裤薄"
-    },
-    "difficulty": 1,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "跟我向他们说，我明天去马尔代夫了",
-      "src_1_sub_2": "那边蓝天白云，椰林树影⋯",
-      "src_2_sub_1": "你帮我话畀佢哋知我明日去买热带裤薄",
-      "src_2_sub_2": "嗰度蓝天五百云夜临雪"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "那边蓝天白云，椰林树影⋯",
-      "src_1_sub_2": "还在讲！",
-      "src_2_sub_1": "嗰度蓝天五百云夜临雪",
-      "src_2_sub_2": "水清净沙有"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "还在讲！",
-      "src_1_sub_2": "来了！",
-      "src_2_sub_1": "水清净沙有",
-      "src_2_sub_2": "我嚟紧㗎喇"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "来了！",
-      "src_1_sub_2": "要执行李了，回来再跟你说吧",
-      "src_2_sub_1": "我嚟紧㗎喇",
-      "src_2_sub_2": "我要执行你喇返嚟先再同你倾过啦"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "要执行李了，回来再跟你说吧",
-      "src_1_sub_2": "再见！",
-      "src_2_sub_1": "我要执行你喇返嚟先再同你倾过啦",
-      "src_2_sub_2": "拜拜"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "妈妈，我得把出世纸带著吗？",
-      "src_1_sub_2": "也要的",
-      "src_2_sub_1": "哎哟妈妈我系咪要带埋出世纸去㗎"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "也要的",
-      "src_1_sub_2": "那么成绩表呢？",
-      "src_2_sub_2": "都要㗎"
-    },
-    "answer": {
-      "src_2_sub_1_shifted": "都要㗎"
-    },
-    "difficulty": 1,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "那么成绩表呢？",
-      "src_1_sub_2": "成绩表就不用了",
-      "src_2_sub_2": "咁成绩表呢成绩表又唔使"
-    },
-    "answer": {
-      "src_2_sub_1_shifted": "咁成绩表呢",
-      "src_2_sub_2_shifted": "成绩表又唔使"
-    },
-    "difficulty": 1,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "成绩表就不用了",
-      "src_1_sub_2": "太好了！吓得我！",
-      "src_2_sub_1": "成绩表又唔使",
-      "src_2_sub_2": "好嘢吓得我啊咁都好啲"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "找到了！",
-      "src_1_sub_2": "出世纸给我找到了！",
-      "src_2_sub_1": "揾到喇"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "出世纸给我找到了！",
-      "src_1_sub_2": "妈妈你替我收好它别抛掉",
-      "src_2_sub_2": "竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然"
-    },
-    "answer": {
-      "src_2_sub_1_shifted": "竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然"
+      "target_sub_1_shifted": "你发咗㗎喇你发咗㗎喇",
+      "target_sub_2_shifted": "系喇系喇系喇发咗喇"
     },
     "difficulty": 3,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "早机去，晚机返",
-      "src_1_sub_2": "妈妈说这样才够精明",
-      "src_2_sub_1": "早机去晚机返",
-      "src_2_sub_2": "妈妈话噉先最著数"
+      "ref_sub_1": "好了好了，发财了",
+      "ref_sub_2": "我们下个星期去，好了吧？",
+      "target_sub_1": "系喇系喇系喇发咗喇",
+      "target_sub_2": "下个礼拜同你去啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈说这样才够精明",
-      "src_1_sub_2": "就这样⋯",
-      "src_2_sub_1": "妈妈话噉先最著数",
-      "src_2_sub_2": "就系噉样"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "就这样⋯",
-      "src_1_sub_2": "我过了我小时候最精明⋯",
-      "src_2_sub_1": "就系噉样",
-      "src_2_sub_2": "我过咗我小时候最著数"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我过了我小时候最精明⋯",
-      "src_1_sub_2": "最美丽的一天",
-      "src_2_sub_1": "我过咗我小时候最著数",
-      "src_2_sub_2": "最完美嘅一日"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "最美丽的一天",
-      "src_1_sub_2": "依你说，纸是否可以包著鸡呢？",
-      "src_2_sub_1": "最完美嘅一日",
-      "src_2_sub_2": "噉你话纸包唔包得绝鸡呢"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "依你说，纸是否可以包著鸡呢？",
-      "src_1_sub_2": "也可以的⋯",
-      "src_2_sub_1": "噉你话纸包唔包得绝鸡呢",
-      "src_2_sub_2": "都得嘅"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "也可以的⋯",
-      "src_1_sub_2": "特别是小小一块的",
-      "src_2_sub_1": "都得嘅",
-      "src_2_sub_2": "尤其系细细旧嗰啲"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "最新消息",
-      "src_1_sub_2": "奥运滑浪风帆选手李丽珊五场四胜",
-      "src_2_sub_1": "啱啱收到消息"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "奥运滑浪风帆选手李丽珊五场四胜",
-      "src_1_sub_2": "夺得香港历史上第一面奥运金牌！",
-      "src_2_sub_2": "奥运滑浪风帆选手李丽珊以五场四胜嘅结果夺取香港历史上第一面奥运金牌"
+      "ref_sub_1": "我们下个星期去，好了吧？",
+      "ref_sub_2": "太好了！",
+      "target_sub_1": "下个礼拜同你去啦",
+      "target_sub_2": "得未啊好嘢"
     },
     "answer": {
-      "src_2_sub_1_shifted": "奥运滑浪风帆选手李丽珊以五场四胜嘅结果",
-      "src_2_sub_2_shifted": "夺取香港历史上第一面奥运金牌"
+      "target_sub_1_shifted": "下个礼拜同你去啦得未啊",
+      "target_sub_2_shifted": "好嘢"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "最新消息",
-      "src_1_sub_2": "奥运滑浪风帆选手李丽珊五场四胜",
-      "src_2_sub_1": "啱啱收到消息",
-      "src_2_sub_2": "奥运滑浪风帆选手李丽珊以五场四胜嘅结果"
+      "ref_sub_1": "麦唛，我是麦兜呀",
+      "ref_sub_2": "是这样子的，我明天就飞了",
+      "target_sub_1": "喂麦麦啊麦豆啊我系",
+      "target_sub_2": "即系呢我明日就要飞喇"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "奥运滑浪风帆选手李丽珊五场四胜",
-      "src_1_sub_2": "夺得香港历史上第一面奥运金牌！",
-      "src_2_sub_1": "奥运滑浪风帆选手李丽珊以五场四胜嘅结果",
-      "src_2_sub_2": "夺取香港历史上第一面奥运金牌"
+      "ref_sub_1": "是这样子的，我明天就飞了",
+      "ref_sub_2": "对　　⋯是吗？",
+      "target_sub_1": "即系呢我明日就要飞喇",
+      "target_sub_2": "系啊系咩"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "夺得香港历史上第一面奥运金牌！",
-      "src_1_sub_2": "消息说当李丽珊获悉自己稳夺金牌后",
-      "src_2_sub_1": "夺取香港历史上第一面奥运金牌"
+      "ref_sub_1": "对　　⋯是吗？",
+      "ref_sub_2": "飞机餐很难吃的吗？",
+      "target_sub_1": "系啊系咩",
+      "target_sub_2": "飞机真好难食㗎"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "消息说当李丽珊获悉自己稳夺金牌后",
-      "src_1_sub_2": "激动地对在场记者表示她今次的成绩⋯",
-      "src_2_sub_2": "消息话李丽珊喺知道自己稳夺奥运金牌之后好激动噉同在场嘅记者讲"
+      "ref_sub_1": "飞机餐很难吃的吗？",
+      "ref_sub_2": "也得吃呀！",
+      "target_sub_1": "飞机真好难食㗎",
+      "target_sub_2": "但点都要食㗎啦"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "也得吃呀！",
+      "ref_sub_2": "难道自己带东西上去吃吗？",
+      "target_sub_1": "但点都要食㗎啦",
+      "target_sub_2": "唔通自己带嘢上去食咩"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "难道自己带东西上去吃吗？",
+      "ref_sub_2": "还在讲？",
+      "target_sub_1": "唔通自己带嘢上去食咩",
+      "target_sub_2": "仲讲"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "还在讲？",
+      "ref_sub_2": "快点帮手执行李",
+      "target_sub_1": "仲讲",
+      "target_sub_2": "哦快啲嚟执埋啲行李先啦"
     },
     "answer": {
-      "src_2_sub_1_shifted": "消息话李丽珊喺知道自己稳夺奥运金牌之后",
-      "src_2_sub_2_shifted": "好激动噉同在场嘅记者讲"
+      "target_sub_1_shifted": "仲讲哦",
+      "target_sub_2_shifted": "快啲嚟执埋啲行李先啦"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "夺得香港历史上第一面奥运金牌！",
-      "src_1_sub_2": "消息说当李丽珊获悉自己稳夺金牌后",
-      "src_2_sub_1": "夺取香港历史上第一面奥运金牌",
-      "src_2_sub_2": "消息话李丽珊喺知道自己稳夺奥运金牌之后"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "消息说当李丽珊获悉自己稳夺金牌后",
-      "src_1_sub_2": "激动地对在场记者表示她今次的成绩⋯",
-      "src_2_sub_1": "消息话李丽珊喺知道自己稳夺奥运金牌之后",
-      "src_2_sub_2": "好激动噉同在场嘅记者讲"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "激动地对在场记者表示她今次的成绩⋯",
-      "src_1_sub_2": "足以证明香港运动员不是腊鸭！",
-      "src_2_sub_1": "好激动噉同在场嘅记者讲",
-      "src_2_sub_2": "今次佢嘅成绩可以证明到香港嘅运动员唔系𫚭鸭"
+      "ref_sub_1": "快点帮手执行李",
+      "ref_sub_2": "跟我向他们说，我明天去马尔代夫了",
+      "target_sub_1": "快啲嚟执埋啲行李先啦",
+      "target_sub_2": "哦你帮我话畀佢哋知我明日去买热带裤薄"
     },
     "answer": {
-      "src_2_sub_1_shifted": "好激动噉同在场嘅记者讲今次佢嘅成绩",
-      "src_2_sub_2_shifted": "可以证明到香港嘅运动员唔系𫚭鸭"
+      "target_sub_1_shifted": "快啲嚟执埋啲行李先啦哦",
+      "target_sub_2_shifted": "你帮我话畀佢哋知我明日去买热带裤薄"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "足以证明香港运动员不是腊鸭！",
-      "src_1_sub_2": "对不起，应该　　是垃圾，不是腊鸭！",
-      "src_2_sub_1": "可以证明到香港嘅运动员唔系𫚭鸭",
-      "src_2_sub_2": "各位对唔住应该系垃圾唔系𫚭鸭"
+      "ref_sub_1": "跟我向他们说，我明天去马尔代夫了",
+      "ref_sub_2": "那边蓝天白云，椰林树影⋯",
+      "target_sub_1": "你帮我话畀佢哋知我明日去买热带裤薄",
+      "target_sub_2": "嗰度蓝天五百云夜临雪"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "对不起，应该　　是垃圾，不是腊鸭！",
-      "src_1_sub_2": "对不起，应该　　不是垃圾，也不是腊鸭！",
-      "src_2_sub_1": "各位对唔住应该系垃圾唔系𫚭鸭",
-      "src_2_sub_2": "对唔住应该系唔系垃圾亦都唔系𫚭鸭"
+      "ref_sub_1": "那边蓝天白云，椰林树影⋯",
+      "ref_sub_2": "还在讲！",
+      "target_sub_1": "嗰度蓝天五百云夜临雪",
+      "target_sub_2": "水清净沙有"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "对不起，应该　　不是垃圾，也不是腊鸭！",
-      "src_1_sub_2": "特别报告完毕",
-      "src_2_sub_1": "对唔住应该系唔系垃圾亦都唔系𫚭鸭",
-      "src_2_sub_2": "特别报个原不"
+      "ref_sub_1": "还在讲！",
+      "ref_sub_2": "来了！",
+      "target_sub_1": "水清净沙有",
+      "target_sub_2": "我嚟紧㗎喇"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈好像又有计了",
-      "src_1_sub_2": "靓仔，好运，叻仔⋯",
-      "src_2_sub_1": "咦妈妈好似又有计噉噃",
-      "src_2_sub_2": "靓仔好运"
+      "ref_sub_1": "来了！",
+      "ref_sub_2": "要执行李了，回来再跟你说吧",
+      "target_sub_1": "我嚟紧㗎喇",
+      "target_sub_2": "我要执行你喇返嚟先再同你倾过啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "靓仔，好运，叻仔⋯",
-      "src_1_sub_2": "好像都没希望了",
-      "src_2_sub_1": "靓仔好运",
-      "src_2_sub_2": "叻仔呀睇嚟都唔多靠得住"
+      "ref_sub_1": "要执行李了，回来再跟你说吧",
+      "ref_sub_2": "再见！",
+      "target_sub_1": "我要执行你喇返嚟先再同你倾过啦",
+      "target_sub_2": "拜拜"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "妈妈，我得把出世纸带著吗？",
+      "ref_sub_2": "也要的",
+      "target_sub_1": "哎哟妈妈我系咪要带埋出世纸去㗎"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "也要的",
+      "ref_sub_2": "那么成绩表呢？",
+      "target_sub_2": "都要㗎"
     },
     "answer": {
-      "src_2_sub_1_shifted": "靓仔好运叻仔呀",
-      "src_2_sub_2_shifted": "睇嚟都唔多靠得住"
+      "target_sub_1_shifted": "都要㗎"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "好像都没希望了",
-      "src_1_sub_2": "是不是可以靠手瓜呢？",
-      "src_2_sub_1": "睇嚟都唔多靠得住",
-      "src_2_sub_2": "哗好唔好靠下个手瓜噉呢"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "是不是可以靠手瓜呢？",
-      "src_1_sub_2": "于是，一个梦还没醒⋯",
-      "src_2_sub_1": "哗好唔好靠下个手瓜噉呢",
-      "src_2_sub_2": "于是一个梦都未醒"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "于是，一个梦还没醒⋯",
-      "src_1_sub_2": "我又得到另一个梦",
-      "src_2_sub_1": "于是一个梦都未醒",
-      "src_2_sub_2": "我又得到另外一个梦"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我又得到另一个梦",
-      "src_1_sub_2": "应该是脚瓜",
-      "src_2_sub_1": "我又得到另外一个梦",
-      "src_2_sub_2": "系咪应该系脚瓜之争"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "应该是脚瓜",
-      "src_1_sub_2": "我知道一点也不容易",
-      "src_2_sub_1": "系咪应该系脚瓜之争",
-      "src_2_sub_2": "我知道一啲都唔容易"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我知道一点也不容易",
-      "src_1_sub_2": "我知道要找到黎根绝对不容易",
-      "src_2_sub_1": "我知道一啲都唔容易",
-      "src_2_sub_2": "我知道要揾到励根绝对唔容易"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我知道要找到黎根绝对不容易",
-      "src_1_sub_2": "我知道要他收我做徒弟更加不容易",
-      "src_2_sub_1": "我知道要揾到励根绝对唔容易",
-      "src_2_sub_2": "我知道要佢收我做徒弟更加唔容易"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "但无论多不容易，我都要试一试",
-      "src_1_sub_2": "我要黎根收我做徒弟！",
-      "src_2_sub_1": "但无论几唔容易我都要试一试",
-      "src_2_sub_2": "我要来紧收我度徒弟"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我要黎根收我做徒弟！",
-      "src_1_sub_2": "无论几辛苦，我一定要得到奥运金牌！",
-      "src_2_sub_1": "我要来紧收我度徒弟",
-      "src_2_sub_2": "无论几辛苦我一定要捞到奥运金牌"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "你孕育了珊珊！你也会孕育我！",
-      "src_1_sub_2": "当我站在奥运会颁奖台上",
-      "src_2_sub_2": "三张堂上面"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "当我站在奥运会颁奖台上",
-      "src_1_sub_2": "我会举起金牌跟全世界说：",
-      "src_2_sub_1": "三张堂上面",
-      "src_2_sub_2": "系今排同全世界讲"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我会举起金牌跟全世界说：",
-      "src_1_sub_2": "香港运动员不是垃圾！",
-      "src_2_sub_1": "系今排同全世界讲"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "小朋友，这儿是南丫岛呀！",
-      "src_1_sub_2": "南丫岛？它也孕育了周润发！",
-      "src_2_sub_1": "小朋友呀呢度系南丫岛噃",
-      "src_2_sub_2": "南丫岛都引用咗周润发噃"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "想不到我黎根避进南丫岛也给你发现",
-      "src_1_sub_2": "小朋友，你知道什么是狗仔队吧？",
-      "src_2_sub_1": "制估唔到我嚟跟你入嚟南丫岛都畀你揾到",
-      "src_2_sub_2": "小朋友我谂你都知道乜嘢叫做狗仔队嘞"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "小朋友，你知道什么是狗仔队吧？",
-      "src_1_sub_2": "加上总有小朋友及家长来说要拜我为师",
-      "src_2_sub_1": "小朋友我谂你都知道乜嘢叫做狗仔队嘞",
-      "src_2_sub_2": "再加上不时有啲小朋友同埋家长嚟揾我话要拜我为师"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "加上总有小朋友及家长来说要拜我为师",
-      "src_1_sub_2": "我才过来南丫岛避一避",
-      "src_2_sub_1": "再加上不时有啲小朋友同埋家长嚟揾我话要拜我为师",
-      "src_2_sub_2": "所以我咪过嚟南丫岛避一避"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我才过来南丫岛避一避",
-      "src_1_sub_2": "至于拜师的事⋯",
-      "src_2_sub_1": "所以我咪过嚟南丫岛避一避",
-      "src_2_sub_2": "至于拜师嘅嘢"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "至于拜师的事⋯",
-      "src_1_sub_2": "拜你个头！",
-      "src_2_sub_1": "至于拜师嘅嘢",
-      "src_2_sub_2": "拜你个头嘅"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "拜你个头！",
-      "src_1_sub_2": "你们这些住香港岛的小朋友骄生惯养",
-      "src_2_sub_1": "拜你个头嘅",
-      "src_2_sub_2": "你哋呢班住喺香港岛嘅小朋友娇生惯养边挨得苦㗎"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "你们这些住香港岛的小朋友骄生惯养",
-      "src_1_sub_2": "怎么吃得苦？",
-      "src_2_sub_1": "你哋呢班住喺香港岛嘅小朋友娇生惯养边挨得苦㗎"
+      "ref_sub_1": "那么成绩表呢？",
+      "ref_sub_2": "成绩表就不用了",
+      "target_sub_2": "咁成绩表呢成绩表又唔使"
     },
     "answer": {
-      "src_2_sub_1_shifted": "你哋呢班住喺香港岛嘅小朋友娇生惯养",
-      "src_2_sub_2_shifted": "边挨得苦㗎"
+      "target_sub_1_shifted": "咁成绩表呢",
+      "target_sub_2_shifted": "成绩表又唔使"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "拜你个头！",
-      "src_1_sub_2": "你们这些住香港岛的小朋友骄生惯养",
-      "src_2_sub_1": "拜你个头嘅",
-      "src_2_sub_2": "你哋呢班住喺香港岛嘅小朋友娇生惯养"
+      "ref_sub_1": "成绩表就不用了",
+      "ref_sub_2": "太好了！吓得我！",
+      "target_sub_1": "成绩表又唔使",
+      "target_sub_2": "好嘢吓得我啊咁都好啲"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "你们这些住香港岛的小朋友骄生惯养",
-      "src_1_sub_2": "怎么吃得苦？",
-      "src_2_sub_1": "你哋呢班住喺香港岛嘅小朋友娇生惯养",
-      "src_2_sub_2": "边挨得苦㗎"
+      "ref_sub_1": "找到了！",
+      "ref_sub_2": "出世纸给我找到了！",
+      "target_sub_1": "揾到喇"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "怎么吃得苦？",
-      "src_1_sub_2": "想跟珊珊般得奥运金牌？",
-      "src_2_sub_1": "边挨得苦㗎"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "想跟珊珊般得奥运金牌？",
-      "src_1_sub_2": "别作梦了！",
-      "src_2_sub_2": "想学山伞攞奥运金牌食母你嘢"
+      "ref_sub_1": "出世纸给我找到了！",
+      "ref_sub_2": "妈妈你替我收好它别抛掉",
+      "target_sub_2": "竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然"
     },
     "answer": {
-      "src_2_sub_1_shifted": "想学山伞攞奥运金牌",
-      "src_2_sub_2_shifted": "食母你嘢"
+      "target_sub_1_shifted": "竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然"
+    },
+    "difficulty": 3,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "早机去，晚机返",
+      "ref_sub_2": "妈妈说这样才够精明",
+      "target_sub_1": "早机去晚机返",
+      "target_sub_2": "妈妈话噉先最著数"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "妈妈说这样才够精明",
+      "ref_sub_2": "就这样⋯",
+      "target_sub_1": "妈妈话噉先最著数",
+      "target_sub_2": "就系噉样"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "就这样⋯",
+      "ref_sub_2": "我过了我小时候最精明⋯",
+      "target_sub_1": "就系噉样",
+      "target_sub_2": "我过咗我小时候最著数"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我过了我小时候最精明⋯",
+      "ref_sub_2": "最美丽的一天",
+      "target_sub_1": "我过咗我小时候最著数",
+      "target_sub_2": "最完美嘅一日"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "最美丽的一天",
+      "ref_sub_2": "依你说，纸是否可以包著鸡呢？",
+      "target_sub_1": "最完美嘅一日",
+      "target_sub_2": "噉你话纸包唔包得绝鸡呢"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "依你说，纸是否可以包著鸡呢？",
+      "ref_sub_2": "也可以的⋯",
+      "target_sub_1": "噉你话纸包唔包得绝鸡呢",
+      "target_sub_2": "都得嘅"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "也可以的⋯",
+      "ref_sub_2": "特别是小小一块的",
+      "target_sub_1": "都得嘅",
+      "target_sub_2": "尤其系细细旧嗰啲"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "最新消息",
+      "ref_sub_2": "奥运滑浪风帆选手李丽珊五场四胜",
+      "target_sub_1": "啱啱收到消息"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "奥运滑浪风帆选手李丽珊五场四胜",
+      "ref_sub_2": "夺得香港历史上第一面奥运金牌！",
+      "target_sub_2": "奥运滑浪风帆选手李丽珊以五场四胜嘅结果夺取香港历史上第一面奥运金牌"
+    },
+    "answer": {
+      "target_sub_1_shifted": "奥运滑浪风帆选手李丽珊以五场四胜嘅结果",
+      "target_sub_2_shifted": "夺取香港历史上第一面奥运金牌"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "怎么吃得苦？",
-      "src_1_sub_2": "想跟珊珊般得奥运金牌？",
-      "src_2_sub_1": "边挨得苦㗎",
-      "src_2_sub_2": "想学山伞攞奥运金牌"
+      "ref_sub_1": "最新消息",
+      "ref_sub_2": "奥运滑浪风帆选手李丽珊五场四胜",
+      "target_sub_1": "啱啱收到消息",
+      "target_sub_2": "奥运滑浪风帆选手李丽珊以五场四胜嘅结果"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "想跟珊珊般得奥运金牌？",
-      "src_1_sub_2": "别作梦了！",
-      "src_2_sub_1": "想学山伞攞奥运金牌",
-      "src_2_sub_2": "食母你嘢"
+      "ref_sub_1": "奥运滑浪风帆选手李丽珊五场四胜",
+      "ref_sub_2": "夺得香港历史上第一面奥运金牌！",
+      "target_sub_1": "奥运滑浪风帆选手李丽珊以五场四胜嘅结果",
+      "target_sub_2": "夺取香港历史上第一面奥运金牌"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "这个⋯",
-      "src_1_sub_2": "这脚瓜⋯好粗好大！比一节瓜还要大！",
-      "src_2_sub_1": "哗",
-      "src_2_sub_2": "呢只呢只脚瓜好粗好大呀仲大个只瓜呀"
+      "ref_sub_1": "夺得香港历史上第一面奥运金牌！",
+      "ref_sub_2": "消息说当李丽珊获悉自己稳夺金牌后",
+      "target_sub_1": "夺取香港历史上第一面奥运金牌"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "消息说当李丽珊获悉自己稳夺金牌后",
+      "ref_sub_2": "激动地对在场记者表示她今次的成绩⋯",
+      "target_sub_2": "消息话李丽珊喺知道自己稳夺奥运金牌之后好激动噉同在场嘅记者讲"
     },
     "answer": {
-      "src_2_sub_1_shifted": "哗呢只",
-      "src_2_sub_2_shifted": "呢只脚瓜好粗好大呀仲大个只瓜呀"
+      "target_sub_1_shifted": "消息话李丽珊喺知道自己稳夺奥运金牌之后",
+      "target_sub_2_shifted": "好激动噉同在场嘅记者讲"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "这脚瓜⋯好粗好大！比一节瓜还要大！",
-      "src_1_sub_2": "脚瓜的肌肉非常结实⋯",
-      "src_2_sub_1": "呢只脚瓜好粗好大呀仲大个只瓜呀",
-      "src_2_sub_2": "脚瓜啲肌肉非常结实"
+      "ref_sub_1": "夺得香港历史上第一面奥运金牌！",
+      "ref_sub_2": "消息说当李丽珊获悉自己稳夺金牌后",
+      "target_sub_1": "夺取香港历史上第一面奥运金牌",
+      "target_sub_2": "消息话李丽珊喺知道自己稳夺奥运金牌之后"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "脚瓜的肌肉非常结实⋯",
-      "src_1_sub_2": "青筋凸现，钢线似的",
-      "src_2_sub_1": "脚瓜啲肌肉非常结实",
-      "src_2_sub_2": "啲青筋凸晒出嚟好似钢线噉"
+      "ref_sub_1": "消息说当李丽珊获悉自己稳夺金牌后",
+      "ref_sub_2": "激动地对在场记者表示她今次的成绩⋯",
+      "target_sub_1": "消息话李丽珊喺知道自己稳夺奥运金牌之后",
+      "target_sub_2": "好激动噉同在场嘅记者讲"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "青筋凸现，钢线似的",
-      "src_1_sub_2": "每一条脚毛都硬似铁钉",
-      "src_2_sub_1": "啲青筋凸晒出嚟好似钢线噉",
-      "src_2_sub_2": "啲脚毛每一条好似铁钉噉硬"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "每一条脚毛都硬似铁钉",
-      "src_1_sub_2": "脚趾甲有一寸厚，究竟⋯",
-      "src_2_sub_1": "啲脚毛每一条好似铁钉噉硬",
-      "src_2_sub_2": "脚趾弓啲脚甲成吋噉厚"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "脚趾甲有一寸厚，究竟⋯",
-      "src_1_sub_2": "要行过几多座山⋯",
-      "src_2_sub_1": "脚趾弓啲脚甲成吋噉厚",
-      "src_2_sub_2": "究竟要行我几多座山"
+      "ref_sub_1": "激动地对在场记者表示她今次的成绩⋯",
+      "ref_sub_2": "足以证明香港运动员不是腊鸭！",
+      "target_sub_1": "好激动噉同在场嘅记者讲",
+      "target_sub_2": "今次佢嘅成绩可以证明到香港嘅运动员唔系𫚭鸭"
     },
     "answer": {
-      "src_2_sub_1_shifted": "脚趾弓啲脚甲成吋噉厚究竟",
-      "src_2_sub_2_shifted": "要行我几多座山"
+      "target_sub_1_shifted": "好激动噉同在场嘅记者讲今次佢嘅成绩",
+      "target_sub_2_shifted": "可以证明到香港嘅运动员唔系𫚭鸭"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "要行过几多座山⋯",
-      "src_1_sub_2": "跨过几多个海⋯",
-      "src_2_sub_1": "要行我几多座山",
-      "src_2_sub_2": "跨我几多个海"
+      "ref_sub_1": "足以证明香港运动员不是腊鸭！",
+      "ref_sub_2": "对不起，应该　　是垃圾，不是腊鸭！",
+      "target_sub_1": "可以证明到香港嘅运动员唔系𫚭鸭",
+      "target_sub_2": "各位对唔住应该系垃圾唔系𫚭鸭"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "跨过几多个海⋯",
-      "src_1_sub_2": "吃过几多苦头⋯",
-      "src_2_sub_1": "跨我几多个海"
+      "ref_sub_1": "对不起，应该　　是垃圾，不是腊鸭！",
+      "ref_sub_2": "对不起，应该　　不是垃圾，也不是腊鸭！",
+      "target_sub_1": "各位对唔住应该系垃圾唔系𫚭鸭",
+      "target_sub_2": "对唔住应该系唔系垃圾亦都唔系𫚭鸭"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "吃过几多苦头⋯",
-      "src_1_sub_2": "才可以练成这举世无双的脚瓜？",
-      "src_2_sub_2": "挨过几多苦头先至可以练成呢只举世无双嘅脚瓜"
+      "ref_sub_1": "对不起，应该　　不是垃圾，也不是腊鸭！",
+      "ref_sub_2": "特别报告完毕",
+      "target_sub_1": "对唔住应该系唔系垃圾亦都唔系𫚭鸭",
+      "target_sub_2": "特别报个原不"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "妈妈好像又有计了",
+      "ref_sub_2": "靓仔，好运，叻仔⋯",
+      "target_sub_1": "咦妈妈好似又有计噉噃",
+      "target_sub_2": "靓仔好运"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "靓仔，好运，叻仔⋯",
+      "ref_sub_2": "好像都没希望了",
+      "target_sub_1": "靓仔好运",
+      "target_sub_2": "叻仔呀睇嚟都唔多靠得住"
     },
     "answer": {
-      "src_2_sub_1_shifted": "挨过几多苦头",
-      "src_2_sub_2_shifted": "先至可以练成呢只举世无双嘅脚瓜"
+      "target_sub_1_shifted": "靓仔好运叻仔呀",
+      "target_sub_2_shifted": "睇嚟都唔多靠得住"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我⋯我一定要练成这脚瓜！",
-      "src_1_sub_2": "师傅！",
-      "src_2_sub_1": "我我一定要练成呢只脚挂",
-      "src_2_sub_2": "师父"
+      "ref_sub_1": "好像都没希望了",
+      "ref_sub_2": "是不是可以靠手瓜呢？",
+      "target_sub_1": "睇嚟都唔多靠得住",
+      "target_sub_2": "哗好唔好靠下个手瓜噉呢"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "每次唱这首歌，我都会急小便",
-      "src_1_sub_2": "现在先去，一回恐怕还是会急",
-      "src_2_sub_1": "而知点解每一字唱呢首歌都会急小便",
-      "src_2_sub_2": "仅次去定先都怕一阵会再急过"
+      "ref_sub_1": "是不是可以靠手瓜呢？",
+      "ref_sub_2": "于是，一个梦还没醒⋯",
+      "target_sub_1": "哗好唔好靠下个手瓜噉呢",
+      "target_sub_2": "于是一个梦都未醒"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "现在先去，一回恐怕还是会急",
-      "src_1_sub_2": "但是我现在一定要唱这首歌",
-      "src_2_sub_1": "仅次去定先都怕一阵会再急过",
-      "src_2_sub_2": "但系我而家一定要唱呢首歌"
+      "ref_sub_1": "于是，一个梦还没醒⋯",
+      "ref_sub_2": "我又得到另一个梦",
+      "target_sub_1": "于是一个梦都未醒",
+      "target_sub_2": "我又得到另外一个梦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "但是我现在一定要唱这首歌",
-      "src_1_sub_2": "希望可以改变黎根对我的看法",
-      "src_2_sub_1": "但系我而家一定要唱呢首歌",
-      "src_2_sub_2": "希望可以改变黎根对我嘅睇法"
+      "ref_sub_1": "我又得到另一个梦",
+      "ref_sub_2": "应该是脚瓜",
+      "target_sub_1": "我又得到另外一个梦",
+      "target_sub_2": "系咪应该系脚瓜之争"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "希望可以改变黎根对我的看法",
-      "src_1_sub_2": "我要用这歌打动黎根",
-      "src_2_sub_1": "希望可以改变黎根对我嘅睇法",
-      "src_2_sub_2": "我要用呢首歌打动黎根"
+      "ref_sub_1": "应该是脚瓜",
+      "ref_sub_2": "我知道一点也不容易",
+      "target_sub_1": "系咪应该系脚瓜之争",
+      "target_sub_2": "我知道一啲都唔容易"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我要用这歌打动黎根",
-      "src_1_sub_2": "我要黎根收我做徒弟！",
-      "src_2_sub_1": "我要用呢首歌打动黎根",
-      "src_2_sub_2": "我要黎根收我做徒弟"
+      "ref_sub_1": "我知道一点也不容易",
+      "ref_sub_2": "我知道要找到黎根绝对不容易",
+      "target_sub_1": "我知道一啲都唔容易",
+      "target_sub_2": "我知道要揾到励根绝对唔容易"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我要黎根收我做徒弟！",
-      "src_1_sub_2": "歌，是这样唱的⋯",
-      "src_2_sub_1": "我要黎根收我做徒弟",
-      "src_2_sub_2": "嗰首歌系噉唱嘅"
+      "ref_sub_1": "我知道要找到黎根绝对不容易",
+      "ref_sub_2": "我知道要他收我做徒弟更加不容易",
+      "target_sub_1": "我知道要揾到励根绝对唔容易",
+      "target_sub_2": "我知道要佢收我做徒弟更加唔容易"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "歌，是这样唱的⋯",
-      "src_1_sub_2": "「大包，整多两笼」",
-      "src_2_sub_1": "嗰首歌系噉唱嘅"
+      "ref_sub_1": "但无论多不容易，我都要试一试",
+      "ref_sub_2": "我要黎根收我做徒弟！",
+      "target_sub_1": "但无论几唔容易我都要试一试",
+      "target_sub_2": "我要来紧收我度徒弟"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "黎根听完歌以后，表情有点古怪⋯",
-      "src_1_sub_2": "我一定要好好把握这机会",
-      "src_2_sub_1": "黎今听完首歌之后啲表情有啲古怪",
-      "src_2_sub_2": "唔我一定要好好把握呢个机会"
+      "ref_sub_1": "我要黎根收我做徒弟！",
+      "ref_sub_2": "无论几辛苦，我一定要得到奥运金牌！",
+      "target_sub_1": "我要来紧收我度徒弟",
+      "target_sub_2": "无论几辛苦我一定要捞到奥运金牌"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我一定要好好把握这机会",
-      "src_1_sub_2": "师傅！你收我做徒弟吧！",
-      "src_2_sub_1": "唔我一定要好好把握呢个机会",
-      "src_2_sub_2": "师父你收我做徒弟啦"
+      "ref_sub_1": "你孕育了珊珊！你也会孕育我！",
+      "ref_sub_2": "当我站在奥运会颁奖台上",
+      "target_sub_2": "三张堂上面"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "师傅！你收我做徒弟吧！",
-      "src_1_sub_2": "你唔收我做徒弟，我一世都这么跪著！",
-      "src_2_sub_1": "师父你收我做徒弟啦",
-      "src_2_sub_2": "你收我做徒弟我呢一世都跪喺度"
+      "ref_sub_1": "当我站在奥运会颁奖台上",
+      "ref_sub_2": "我会举起金牌跟全世界说：",
+      "target_sub_1": "三张堂上面",
+      "target_sub_2": "系今排同全世界讲"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "你唔收我做徒弟，我一世都这么跪著！",
-      "src_1_sub_2": "起来呀！",
-      "src_2_sub_1": "你收我做徒弟我呢一世都跪喺度",
-      "src_2_sub_2": "起身啊"
+      "ref_sub_1": "我会举起金牌跟全世界说：",
+      "ref_sub_2": "香港运动员不是垃圾！",
+      "target_sub_1": "系今排同全世界讲"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "起来呀！",
-      "src_1_sub_2": "多谢师傅！",
-      "src_2_sub_1": "起身啊",
-      "src_2_sub_2": "多谢师父"
+      "ref_sub_1": "小朋友，这儿是南丫岛呀！",
+      "ref_sub_2": "南丫岛？它也孕育了周润发！",
+      "target_sub_1": "小朋友呀呢度系南丫岛噃",
+      "target_sub_2": "南丫岛都引用咗周润发噃"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "多谢师傅！",
-      "src_1_sub_2": "不⋯我是叫你扶我起来呀！",
-      "src_2_sub_1": "多谢师父",
-      "src_2_sub_2": "唔系啊我系叫你扶我起身啊"
+      "ref_sub_1": "想不到我黎根避进南丫岛也给你发现",
+      "ref_sub_2": "小朋友，你知道什么是狗仔队吧？",
+      "target_sub_1": "制估唔到我嚟跟你入嚟南丫岛都畀你揾到",
+      "target_sub_2": "小朋友我谂你都知道乜嘢叫做狗仔队嘞"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "不⋯我是叫你扶我起来呀！",
-      "src_1_sub_2": "不成了！我的脚瓜太痹了！",
-      "src_2_sub_1": "唔系啊我系叫你扶我起身啊",
-      "src_2_sub_2": "顶唔顺啊我个腿挂好鼻啊字幕由Amara.org社群提供"
+      "ref_sub_1": "小朋友，你知道什么是狗仔队吧？",
+      "ref_sub_2": "加上总有小朋友及家长来说要拜我为师",
+      "target_sub_1": "小朋友我谂你都知道乜嘢叫做狗仔队嘞",
+      "target_sub_2": "再加上不时有啲小朋友同埋家长嚟揾我话要拜我为师"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我将今天发生的事讲给妈妈听",
-      "src_1_sub_2": "妈妈一句话也没说",
-      "src_2_sub_1": "我将今日发生嘅嘢话晒畀妈妈听",
-      "src_2_sub_2": "妈妈佢乜嘢都冇讲到"
+      "ref_sub_1": "加上总有小朋友及家长来说要拜我为师",
+      "ref_sub_2": "我才过来南丫岛避一避",
+      "target_sub_1": "再加上不时有啲小朋友同埋家长嚟揾我话要拜我为师",
+      "target_sub_2": "所以我咪过嚟南丫岛避一避"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈一句话也没说",
-      "src_1_sub_2": "从冰箱内拿了只雪鸡出来解冻",
-      "src_2_sub_1": "妈妈佢乜嘢都冇讲到",
-      "src_2_sub_2": "净系喺冰箱度攞咗只雪鸡出嚟解冻"
+      "ref_sub_1": "我才过来南丫岛避一避",
+      "ref_sub_2": "至于拜师的事⋯",
+      "target_sub_1": "所以我咪过嚟南丫岛避一避",
+      "target_sub_2": "至于拜师嘅嘢"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "从冰箱内拿了只雪鸡出来解冻",
-      "src_1_sub_2": "晚饭时，妈妈倒了三杯米酒",
-      "src_2_sub_1": "净系喺冰箱度攞咗只雪鸡出嚟解冻",
-      "src_2_sub_2": "晚饭时候妈妈倒咗三杯米酒"
+      "ref_sub_1": "至于拜师的事⋯",
+      "ref_sub_2": "拜你个头！",
+      "target_sub_1": "至于拜师嘅嘢",
+      "target_sub_2": "拜你个头嘅"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "晚饭时，妈妈倒了三杯米酒",
-      "src_1_sub_2": "又将几只橙和蒸好的鸡放到祖先前",
-      "src_2_sub_1": "晚饭时候妈妈倒咗三杯米酒",
-      "src_2_sub_2": "再将几个铲同埋蒸熟咗嘅鸡放喺祖先前面"
+      "ref_sub_1": "拜你个头！",
+      "ref_sub_2": "你们这些住香港岛的小朋友骄生惯养",
+      "target_sub_1": "拜你个头嘅",
+      "target_sub_2": "你哋呢班住喺香港岛嘅小朋友娇生惯养边挨得苦㗎"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "又将几只橙和蒸好的鸡放到祖先前",
-      "src_1_sub_2": "妈妈叫我跪低，向祖先请请",
-      "src_2_sub_1": "再将几个铲同埋蒸熟咗嘅鸡放喺祖先前面",
-      "src_2_sub_2": "妈妈叫我跪低同祖先请请"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "妈妈叫我跪低，向祖先请请",
-      "src_1_sub_2": "妈妈跟著又念念有词的",
-      "src_2_sub_1": "妈妈叫我跪低同祖先请请",
-      "src_2_sub_2": "跟住妈妈口噏噏噉讲咗一啲嘢"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "妈妈跟著又念念有词的",
-      "src_1_sub_2": "然后我们一起向祖先再拜了几拜",
-      "src_2_sub_1": "跟住妈妈口噏噏噉讲咗一啲嘢",
-      "src_2_sub_2": "然之后我哋又一齐对住祖先拜多几拜"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "然后我们一起向祖先再拜了几拜",
-      "src_1_sub_2": "妈妈蹲低把酒洒到地上",
-      "src_2_sub_1": "然之后我哋又一齐对住祖先拜多几拜",
-      "src_2_sub_2": "妈妈虎低身将啲酒倒喺地上面"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "妈妈蹲低把酒洒到地上",
-      "src_1_sub_2": "庄重而温柔地跟我说：",
-      "src_2_sub_1": "妈妈虎低身将啲酒倒喺地上面",
-      "src_2_sub_2": "庄重又温柔紧同我讲"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "庄重而温柔地跟我说：",
-      "src_1_sub_2": "以后生生性性",
-      "src_2_sub_1": "庄重又温柔紧同我讲",
-      "src_2_sub_2": "以后要生生性性"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "以后生生性性",
-      "src_1_sub_2": "跟师傅学习，光宗耀祖！",
-      "src_2_sub_1": "以后要生生性性",
-      "src_2_sub_2": "跟师父学嘢当中要祖"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "妈妈在长洲找了间酒楼摆拜师宴",
-      "src_1_sub_2": "因为我是师傅最后一个入室弟子",
-      "src_2_sub_1": "妈妈喺长洲揾咗间酒楼摆咗几回白丝宴",
-      "src_2_sub_2": "因为我系师父最后一个入室弟子"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "因为我是师傅最后一个入室弟子",
-      "src_1_sub_2": "到贺的乡绅父老特别多",
-      "src_2_sub_1": "因为我系师父最后一个入室弟子",
-      "src_2_sub_2": "所以到学嘅乡亲父老特别多"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "到贺的乡绅父老特别多",
-      "src_1_sub_2": "想不到黄德森也来了",
-      "src_2_sub_1": "所以到学嘅乡亲父老特别多",
-      "src_2_sub_2": "估唔到黄德森都有嚟饮"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "想不到黄德森也来了",
-      "src_1_sub_2": "还赞我背上的肉厚",
-      "src_2_sub_1": "估唔到黄德森都有嚟饮",
-      "src_2_sub_2": "仲赞我背著啲肉口添"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "还赞我背上的肉厚",
-      "src_1_sub_2": "珊珊因为去了集训，没来",
-      "src_2_sub_1": "仲赞我背著啲肉口添",
-      "src_2_sub_2": "但系山神就去咗集训冇嚟到"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "珊珊因为去了集训，没来",
-      "src_1_sub_2": "麦唛，菇时跟得巴都来了",
-      "src_2_sub_1": "但系山神就去咗集训冇嚟到",
-      "src_2_sub_2": "默默姑侍同德巴都嚟咗"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "麦唛，菇时跟得巴都来了",
-      "src_1_sub_2": "还带著成绩表，奖牌和大包",
-      "src_2_sub_1": "默默姑侍同德巴都嚟咗",
-      "src_2_sub_2": "仲带埋成绩表奖牌同大包嚟添"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "还带著成绩表，奖牌和大包",
-      "src_1_sub_2": "他们都希望黎根也可以收他们做徒弟",
-      "src_2_sub_1": "仲带埋成绩表奖牌同大包嚟添",
-      "src_2_sub_2": "佢哋都希望嚟今可以收埋佢哋做徒弟"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "他们都希望黎根也可以收他们做徒弟",
-      "src_1_sub_2": "吃过鸡丝翅，就是拜师仪式",
-      "src_2_sub_1": "佢哋都希望嚟今可以收埋佢哋做徒弟",
-      "src_2_sub_2": "食完鸡丝翅就到咗拜师仪式"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "吃过鸡丝翅，就是拜师仪式",
-      "src_1_sub_2": "妈妈倒了杯茶给我，让我给师傅喝",
-      "src_2_sub_1": "食完鸡丝翅就到咗拜师仪式",
-      "src_2_sub_2": "妈妈针咗杯热茶畀我叫我弟畀师父饮"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "妈妈倒了杯茶给我，让我给师傅喝",
-      "src_1_sub_2": "我千辛万苦来长洲找黎根⋯",
-      "src_2_sub_1": "妈妈针咗杯热茶畀我叫我弟畀师父饮",
-      "src_2_sub_2": "哦我前三万苦嚟到长洲揾嚟近"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我千辛万苦来长洲找黎根⋯",
-      "src_1_sub_2": "我终于可以跟珊珊一起练滑浪风帆了！",
-      "src_2_sub_1": "哦我前三万苦嚟到长洲揾嚟近",
-      "src_2_sub_2": "哦我终于可以同山神一齐练习玩弄风范啊"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我终于可以跟珊珊一起练滑浪风帆了！",
-      "src_1_sub_2": "我将茶递给黎根，黎根他⋯",
-      "src_2_sub_1": "哦我终于可以同山神一齐练习玩弄风范啊",
-      "src_2_sub_2": "我将杯茶递咗畀嚟跟嚟跟佢"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我将茶递给黎根，黎根他⋯",
-      "src_1_sub_2": "师傅他把茶喝了，正式收我做徒弟",
-      "src_2_sub_1": "我将杯茶递咗畀嚟跟嚟跟佢",
-      "src_2_sub_2": "亦唔系师父佢饮咗杯茶正式收咗我做徒弟嘞"
+      "ref_sub_1": "你们这些住香港岛的小朋友骄生惯养",
+      "ref_sub_2": "怎么吃得苦？",
+      "target_sub_1": "你哋呢班住喺香港岛嘅小朋友娇生惯养边挨得苦㗎"
     },
     "answer": {
-      "src_2_sub_1_shifted": "我将杯茶递咗畀嚟跟嚟跟佢亦唔系",
-      "src_2_sub_2_shifted": "师父佢饮咗杯茶正式收咗我做徒弟嘞"
+      "target_sub_1_shifted": "你哋呢班住喺香港岛嘅小朋友娇生惯养",
+      "target_sub_2_shifted": "边挨得苦㗎"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "师傅他把茶喝了，正式收我做徒弟",
-      "src_1_sub_2": "宾客们好像都很高兴",
-      "src_2_sub_1": "师父佢饮咗杯茶正式收咗我做徒弟嘞",
-      "src_2_sub_2": "啲来宾睇嚟好高气"
+      "ref_sub_1": "拜你个头！",
+      "ref_sub_2": "你们这些住香港岛的小朋友骄生惯养",
+      "target_sub_1": "拜你个头嘅",
+      "target_sub_2": "你哋呢班住喺香港岛嘅小朋友娇生惯养"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "宾客们好像都很高兴",
-      "src_1_sub_2": "长洲的乡绅父老拍掌拍得特别落力",
-      "src_2_sub_1": "啲来宾睇嚟好高气",
-      "src_2_sub_2": "特别系长洲啲乡亲父老拍奖拍得特别落力"
+      "ref_sub_1": "你们这些住香港岛的小朋友骄生惯养",
+      "ref_sub_2": "怎么吃得苦？",
+      "target_sub_1": "你哋呢班住喺香港岛嘅小朋友娇生惯养",
+      "target_sub_2": "边挨得苦㗎"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "长洲的乡绅父老拍掌拍得特别落力",
-      "src_1_sub_2": "多谢各位赏面！多谢各位！",
-      "src_2_sub_1": "特别系长洲啲乡亲父老拍奖拍得特别落力",
-      "src_2_sub_2": "多谢各位上面多谢各位"
+      "ref_sub_1": "怎么吃得苦？",
+      "ref_sub_2": "想跟珊珊般得奥运金牌？",
+      "target_sub_1": "边挨得苦㗎"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "多谢各位赏面！多谢各位！",
-      "src_1_sub_2": "在下平生有两项称得上得意的绝技",
-      "src_2_sub_1": "多谢各位上面多谢各位",
-      "src_2_sub_2": "在下评生有两项称得上得意嘅绝技"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "在下平生有两项称得上得意的绝技",
-      "src_1_sub_2": "第一项，是滑浪风帆！",
-      "src_2_sub_1": "在下评生有两项称得上得意嘅绝技",
-      "src_2_sub_2": "第一样系滑浪风范"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "第一项，是滑浪风帆！",
-      "src_1_sub_2": "我把它传给外甥女珊珊了",
-      "src_2_sub_1": "第一样系滑浪风范",
-      "src_2_sub_2": "呢样早已传咗畀我外甥女山神啊"
+      "ref_sub_1": "想跟珊珊般得奥运金牌？",
+      "ref_sub_2": "别作梦了！",
+      "target_sub_2": "想学山伞攞奥运金牌食母你嘢"
     },
     "answer": {
-      "src_2_sub_1_shifted": "第一样系滑浪风范呢样早已",
-      "src_2_sub_2_shifted": "传咗畀我外甥女山神啊"
+      "target_sub_1_shifted": "想学山伞攞奥运金牌",
+      "target_sub_2_shifted": "食母你嘢"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我把它传给外甥女珊珊了",
-      "src_1_sub_2": "另一项绝技，我打算传给这个新徒弟⋯",
-      "src_2_sub_1": "传咗畀我外甥女山神啊",
-      "src_2_sub_2": "另一项绝技我打算传畀呢个新修嘅徒弟"
+      "ref_sub_1": "怎么吃得苦？",
+      "ref_sub_2": "想跟珊珊般得奥运金牌？",
+      "target_sub_1": "边挨得苦㗎",
+      "target_sub_2": "想学山伞攞奥运金牌"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "另一项绝技，我打算传给这个新徒弟⋯",
-      "src_1_sub_2": "希望他把长洲人世世代代的绝技",
-      "src_2_sub_1": "另一项绝技我打算传畀呢个新修嘅徒弟",
-      "src_2_sub_2": "希望我可以将我哋长洲人世世代代嘅传统发扬光大"
+      "ref_sub_1": "想跟珊珊般得奥运金牌？",
+      "ref_sub_2": "别作梦了！",
+      "target_sub_1": "想学山伞攞奥运金牌",
+      "target_sub_2": "食母你嘢"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "希望他把长洲人世世代代的绝技",
-      "src_1_sub_2": "发扬光大！",
-      "src_2_sub_1": "希望我可以将我哋长洲人世世代代嘅传统发扬光大"
+      "ref_sub_1": "这个⋯",
+      "ref_sub_2": "这脚瓜⋯好粗好大！比一节瓜还要大！",
+      "target_sub_1": "哗",
+      "target_sub_2": "呢只呢只脚瓜好粗好大呀仲大个只瓜呀"
     },
     "answer": {
-      "src_2_sub_1_shifted": "希望我可以将我哋长洲人世世代代嘅传统",
-      "src_2_sub_2_shifted": "发扬光大"
+      "target_sub_1_shifted": "哗呢只",
+      "target_sub_2_shifted": "呢只脚瓜好粗好大呀仲大个只瓜呀"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "另一项绝技，我打算传给这个新徒弟⋯",
-      "src_1_sub_2": "希望他把长洲人世世代代的绝技",
-      "src_2_sub_1": "另一项绝技我打算传畀呢个新修嘅徒弟",
-      "src_2_sub_2": "希望我可以将我哋长洲人世世代代嘅传统"
+      "ref_sub_1": "这脚瓜⋯好粗好大！比一节瓜还要大！",
+      "ref_sub_2": "脚瓜的肌肉非常结实⋯",
+      "target_sub_1": "呢只脚瓜好粗好大呀仲大个只瓜呀",
+      "target_sub_2": "脚瓜啲肌肉非常结实"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "希望他把长洲人世世代代的绝技",
-      "src_1_sub_2": "发扬光大！",
-      "src_2_sub_1": "希望我可以将我哋长洲人世世代代嘅传统",
-      "src_2_sub_2": "发扬光大"
+      "ref_sub_1": "脚瓜的肌肉非常结实⋯",
+      "ref_sub_2": "青筋凸现，钢线似的",
+      "target_sub_1": "脚瓜啲肌肉非常结实",
+      "target_sub_2": "啲青筋凸晒出嚟好似钢线噉"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "发扬光大！",
-      "src_1_sub_2": "请问那是什么绝技呢？",
-      "src_2_sub_1": "发扬光大",
-      "src_2_sub_2": "噉请问嗰样绝技系乜嘢啊"
+      "ref_sub_1": "青筋凸现，钢线似的",
+      "ref_sub_2": "每一条脚毛都硬似铁钉",
+      "target_sub_1": "啲青筋凸晒出嚟好似钢线噉",
+      "target_sub_2": "啲脚毛每一条好似铁钉噉硬"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "第二项绝技，就是⋯",
-      "src_1_sub_2": "抢包山！",
-      "src_2_sub_1": "第二样绝技就系抢爆山"
+      "ref_sub_1": "每一条脚毛都硬似铁钉",
+      "ref_sub_2": "脚趾甲有一寸厚，究竟⋯",
+      "target_sub_1": "啲脚毛每一条好似铁钉噉硬",
+      "target_sub_2": "脚趾弓啲脚甲成吋噉厚"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "脚趾甲有一寸厚，究竟⋯",
+      "ref_sub_2": "要行过几多座山⋯",
+      "target_sub_1": "脚趾弓啲脚甲成吋噉厚",
+      "target_sub_2": "究竟要行我几多座山"
     },
     "answer": {
-      "src_2_sub_1_shifted": "第二样绝技就系",
-      "src_2_sub_2_shifted": "抢爆山"
+      "target_sub_1_shifted": "脚趾弓啲脚甲成吋噉厚究竟",
+      "target_sub_2_shifted": "要行我几多座山"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "第二项绝技，就是⋯",
-      "src_1_sub_2": "抢包山！",
-      "src_2_sub_1": "第二样绝技就系",
-      "src_2_sub_2": "抢爆山"
+      "ref_sub_1": "要行过几多座山⋯",
+      "ref_sub_2": "跨过几多个海⋯",
+      "target_sub_1": "要行我几多座山",
+      "target_sub_2": "跨我几多个海"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "抢包山？",
-      "src_1_sub_2": "年轻观众可能不知「抢包山」何物",
-      "src_2_sub_1": "抢包山?",
-      "src_2_sub_2": "年轻嘅观众可能唔知乜嘢系抢包山呀"
+      "ref_sub_1": "跨过几多个海⋯",
+      "ref_sub_2": "吃过几多苦头⋯",
+      "target_sub_1": "跨我几多个海"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "年轻观众可能不知「抢包山」何物",
-      "src_1_sub_2": "抢包山乃长洲独有传统节日",
-      "src_2_sub_1": "年轻嘅观众可能唔知乜嘢系抢包山呀",
-      "src_2_sub_2": "抢包山系长洲独有嘅传统节日"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "抢包山乃长洲独有传统节日",
-      "src_1_sub_2": "每年农历四月",
-      "src_2_sub_1": "抢包山系长洲独有嘅传统节日",
-      "src_2_sub_2": "每年农历四月"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "每年农历四月",
-      "src_1_sub_2": "长洲居民均举办太平清醮",
-      "src_2_sub_1": "每年农历四月",
-      "src_2_sub_2": "长洲嘅居民都会举办太平清朝"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "长洲居民均举办太平清醮",
-      "src_1_sub_2": "于北帝庙前搭起三座包山",
-      "src_2_sub_1": "长洲嘅居民都会举办太平清朝",
-      "src_2_sub_2": "喺北帝庙前搭起三座包山"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "于北帝庙前搭起三座包山",
-      "src_1_sub_2": "什么是包山呢？",
-      "src_2_sub_1": "喺北帝庙前搭起三座包山",
-      "src_2_sub_2": "噉乜嘢系包山呢?"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "什么是包山呢？",
-      "src_1_sub_2": "顾名思义⋯",
-      "src_2_sub_1": "噉乜嘢系包山呢?",
-      "src_2_sub_2": "顾名思义"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "顾名思义⋯",
-      "src_1_sub_2": "包山就是一座由好多好多包砌起的山！",
-      "src_2_sub_1": "顾名思义",
-      "src_2_sub_2": "包山就系一座由好多好多好多包砌起嘅山"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "包山就是一座由好多好多包砌起的山！",
-      "src_1_sub_2": "一座包山，起码六、七层楼高⋯",
-      "src_2_sub_1": "包山就系一座由好多好多好多包砌起嘅山",
-      "src_2_sub_2": "一座包山起码六七层楼高"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "一座包山，起码六、七层楼高⋯",
-      "src_1_sub_2": "你可以想像一下包山有多高了吧？",
-      "src_2_sub_1": "一座包山起码六七层楼高",
-      "src_2_sub_2": "噉你可以想像一下嗰度有几多包喇"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "你可以想像一下包山有多高了吧？",
-      "src_1_sub_2": "抢包山，就是要把包山上的包抢到手！",
-      "src_2_sub_1": "噉你可以想像一下嗰度有几多包喇",
-      "src_2_sub_2": "噉抢包山自然就系要将包山嘅包抢到手"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "抢包山，就是要把包山上的包抢到手！",
-      "src_1_sub_2": "锣鼓响起",
-      "src_2_sub_1": "噉抢包山自然就系要将包山嘅包抢到手",
-      "src_2_sub_2": "罗古响起"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "锣鼓响起",
-      "src_1_sub_2": "数以百计的青年一涌而上抢包",
-      "src_2_sub_1": "罗古响起",
-      "src_2_sub_2": "数以百计嘅青年就会一涌而上去抢包"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "数以百计的青年一涌而上抢包",
-      "src_1_sub_2": "抢得位置愈高的包，就是愈大的祝福",
-      "src_2_sub_1": "数以百计嘅青年就会一涌而上去抢包",
-      "src_2_sub_2": "抢到位置越高嘅包就代表越大嘅祝福"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "抢得位置愈高的包，就是愈大的祝福",
-      "src_1_sub_2": "更可以表现自己的不凡身手",
-      "src_2_sub_1": "抢到位置越高嘅包就代表越大嘅祝福",
-      "src_2_sub_2": "更加可以表现自己不凡嘅身手"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "更可以表现自己的不凡身手",
-      "src_1_sub_2": "在1978年两座包山忽然倒下，多人重伤",
-      "src_2_sub_1": "更加可以表现自己不凡嘅身手",
-      "src_2_sub_2": "但喺1978年两座包山突然塌咗都去抢包山"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "在1978年两座包山忽然倒下，多人重伤",
-      "src_1_sub_2": "「抢包山」从此被禁！",
-      "src_2_sub_1": "但喺1978年两座包山突然塌咗都去抢包山",
-      "src_2_sub_2": "而长洲特有嘅传统亦占备为榜"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "「抢包山」从此被禁！",
-      "src_1_sub_2": "而长洲独有的传统，亦渐被遗忘",
-      "src_2_sub_1": "而长洲特有嘅传统亦占备为榜",
-      "src_2_sub_2": "长洲特有嘅传统亦占备为榜"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "奥运金牌⋯这一世是没有机会的了",
-      "src_1_sub_2": "每个星期六我都搭船过长洲",
-      "src_2_sub_1": "奥运金牌我谂呢一世都唔会攞到",
-      "src_2_sub_2": "每个礼拜六我都会搭船过长洲"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "每个星期六我都搭船过长洲",
-      "src_1_sub_2": "去学抢包山⋯",
-      "src_2_sub_1": "每个礼拜六我都会搭船过长洲",
-      "src_2_sub_2": "去学抢包山"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "去学抢包山⋯",
-      "src_1_sub_2": "一项没有奖牌，没有对手，没有比赛⋯",
-      "src_2_sub_1": "去学抢包山",
-      "src_2_sub_2": "一日冇奖牌冇对手冇比赛"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "一项没有奖牌，没有对手，没有比赛⋯",
-      "src_1_sub_2": "甚至没有人知道是运动的运动",
-      "src_2_sub_1": "一日冇奖牌冇对手冇比赛",
-      "src_2_sub_2": "甚至乎冇人知对佢系运动嘅运动"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "甚至没有人知道是运动的运动",
-      "src_1_sub_2": "更坏的是，连包山也没有！",
-      "src_2_sub_1": "甚至乎冇人知对佢系运动嘅运动",
-      "src_2_sub_2": "更衰嘅系连包山都冇"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "更坏的是，连包山也没有！",
-      "src_1_sub_2": "师傅只是叫我去他的家⋯",
-      "src_2_sub_1": "更衰嘅系连包山都冇",
-      "src_2_sub_2": "师傅净系叫我去佢屋企"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "师傅只是叫我去他的家⋯",
-      "src_1_sub_2": "在组合柜爬来爬去",
-      "src_2_sub_1": "师傅净系叫我去佢屋企",
-      "src_2_sub_2": "喺个组合柜度爬嚟爬去"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "在组合柜爬来爬去",
-      "src_1_sub_2": "碰！三番！",
-      "src_2_sub_1": "喺个组合柜度爬嚟爬去",
-      "src_2_sub_2": "通三番"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "碰！三番！",
-      "src_1_sub_2": "别躲懒！继续练！",
-      "src_2_sub_1": "通三番",
-      "src_2_sub_2": "冇偷懒继续练"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "别躲懒！继续练！",
-      "src_1_sub_2": "一天，珊珊到了师传家！",
-      "src_2_sub_1": "冇偷懒继续练",
-      "src_2_sub_2": "有一日山伞嚟咗师傅屋企"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "一天，珊珊到了师传家！",
-      "src_1_sub_2": "珊珊！我的师姐珊珊！",
-      "src_2_sub_1": "有一日山伞嚟咗师傅屋企",
-      "src_2_sub_2": "山伞我个师仔山伞啊"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "珊珊！我的师姐珊珊！",
-      "src_1_sub_2": "可以看见珊珊⋯",
-      "src_2_sub_1": "山伞我个师仔山伞啊",
-      "src_2_sub_2": "可以见到山伞"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "可以看见珊珊⋯",
-      "src_1_sub_2": "这几个星期爬得再辛苦也是值得的！",
-      "src_2_sub_1": "可以见到山伞",
-      "src_2_sub_2": "爬得咁辛苦都系值得㗎"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "这几个星期爬得再辛苦也是值得的！",
-      "src_1_sub_2": "珊珊！",
-      "src_2_sub_1": "爬得咁辛苦都系值得㗎",
-      "src_2_sub_2": "山伞"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "珊珊！",
-      "src_1_sub_2": "珊你个头！继续练习！",
-      "src_2_sub_1": "山伞",
-      "src_2_sub_2": "伞你个头啊继续练习"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "还不去？",
-      "src_1_sub_2": "珊珊没看见我这个师弟",
-      "src_2_sub_1": "仲唔系",
-      "src_2_sub_2": "山神佢见唔到我呢个师弟"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "珊珊没看见我这个师弟",
-      "src_1_sub_2": "我只有死死气再爬上组合柜",
-      "src_2_sub_1": "山神佢见唔到我呢个师弟",
-      "src_2_sub_2": "我唯有死死气爬返上个组合柜"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我只有死死气再爬上组合柜",
-      "src_1_sub_2": "我咁大个仔，什么「头」也给骂过⋯",
-      "src_2_sub_1": "我唯有死死气爬返上个组合柜",
-      "src_2_sub_2": "我咁大个仔乜嘢头都畀人闹过"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我咁大个仔，什么「头」也给骂过⋯",
-      "src_1_sub_2": "不知道为什么「珊你个头」却特别刺耳",
-      "src_2_sub_1": "我咁大个仔乜嘢头都畀人闹过",
-      "src_2_sub_2": "但系山呢个头唔知点解特别瘾"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "不知道为什么「珊你个头」却特别刺耳",
-      "src_1_sub_2": "我⋯我⋯",
-      "src_2_sub_1": "但系山呢个头唔知点解特别瘾",
-      "src_2_sub_2": "我我"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我⋯我⋯",
-      "src_1_sub_2": "我唔学抢包山了！",
-      "src_2_sub_1": "我我",
-      "src_2_sub_2": "我唔好抢包纱嘞字幕由纱友提供"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "其实今天是我第一次近距离见黎根",
-      "src_1_sub_2": "他恐怕都有五十岁了",
-      "src_2_sub_1": "其实今日系我第一次咁近距离同丽根见面",
-      "src_2_sub_2": "睇怕佢都有五十岁啦"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "他恐怕都有五十岁了",
-      "src_1_sub_2": "却还是一副孩子脸",
-      "src_2_sub_1": "睇怕佢都有五十岁啦",
-      "src_2_sub_2": "但系仲有一副孩子脸"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "却还是一副孩子脸",
-      "src_1_sub_2": "鸡尾包！新鲜出炉！",
-      "src_2_sub_1": "但系仲有一副孩子脸",
-      "src_2_sub_2": "鸡尾包啱啱出炉嘅"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "其实鸡尾包呢⋯",
-      "src_1_sub_2": "你说这似不似鸡尾？",
-      "src_2_sub_1": "其实鸡尾爆呢",
-      "src_2_sub_2": "吓你话噉样似唔似鸡尾呀哈哈哈哈"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "麦兜他学东西⋯还可以",
-      "src_1_sub_2": "黎根接著说了一大堆话⋯",
-      "src_2_sub_1": "麦兜嘅学嘢呢都仲可以",
-      "src_2_sub_2": "跟住黎根讲咗一大堆说话"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "黎根接著说了一大堆话⋯",
-      "src_1_sub_2": "他的抱负，他对麦兜的期望",
-      "src_2_sub_1": "跟住黎根讲咗一大堆说话",
-      "src_2_sub_2": "讲下佢嘅抱负佢对麦兜嘅期望"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "他的抱负，他对麦兜的期望",
-      "src_1_sub_2": "他说他会把他所识的毫不保留教给麦兜",
-      "src_2_sub_1": "讲下佢嘅抱负佢对麦兜嘅期望",
-      "src_2_sub_2": "佢话会将佢识嘅嘢毫无保留噉教晒畀麦兜"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "他说他会把他所识的毫不保留教给麦兜",
-      "src_1_sub_2": "黎根越说越兴奋，直到双眼发光",
-      "src_2_sub_1": "佢话会将佢识嘅嘢毫无保留噉教晒畀麦兜",
-      "src_2_sub_2": "黎根越讲越兴奋"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "黎根越说越兴奋，直到双眼发光",
-      "src_1_sub_2": "他又说滑浪风帆并不是他最犀利的项目",
-      "src_2_sub_1": "黎根越讲越兴奋",
-      "src_2_sub_2": "佢话滑浪风帆都唔系佢最犀利嗰样"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "他又说滑浪风帆并不是他最犀利的项目",
-      "src_1_sub_2": "他最大强项是抢包山",
-      "src_2_sub_1": "佢话滑浪风帆都唔系佢最犀利嗰样",
-      "src_2_sub_2": "佢最劲嘅就系抢包山"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "他最大强项是抢包山",
-      "src_1_sub_2": "他说抢包山结合了南拳",
-      "src_2_sub_1": "佢最劲嘅就系抢包山",
-      "src_2_sub_2": "佢话抢包山结合咗南拳"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "他说抢包山结合了南拳",
-      "src_1_sub_2": "神功戏和现代器械操",
-      "src_2_sub_1": "佢话抢包山结合咗南拳",
-      "src_2_sub_2": "神功气现代气蟹粗"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "神功戏和现代器械操",
-      "src_1_sub_2": "他说抢包山才是他一生最大成就",
-      "src_2_sub_1": "神功气现代气蟹粗",
-      "src_2_sub_2": "佢话抢包山先至系佢呢世人最大嘅成就"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "他说抢包山才是他一生最大成就",
-      "src_1_sub_2": "缩脚，唔该！",
-      "src_2_sub_1": "佢话抢包山先至系佢呢世人最大嘅成就",
-      "src_2_sub_2": "缩嗰只脚唔该"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "缩脚，唔该！",
-      "src_1_sub_2": "你看！",
-      "src_2_sub_1": "缩嗰只脚唔该",
-      "src_2_sub_2": "你睇下"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "你看！",
-      "src_1_sub_2": "这脚瓜⋯好粗好大！比一节瓜还要大！",
-      "src_2_sub_1": "你睇下",
-      "src_2_sub_2": "哗呢节呢节脚瓜好粗好大呀仲大过节瓜"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "这脚瓜⋯好粗好大！比一节瓜还要大！",
-      "src_1_sub_2": "脚瓜的肌肉非常结实⋯",
-      "src_2_sub_1": "哗呢节呢节脚瓜好粗好大呀仲大过节瓜",
-      "src_2_sub_2": "脚瓜嘅肌肉非常结实"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "脚瓜的肌肉非常结实⋯",
-      "src_1_sub_2": "青筋凸现，钢线似的",
-      "src_2_sub_1": "脚瓜嘅肌肉非常结实",
-      "src_2_sub_2": "啲青筋凸晒出嚟好似钢线噉"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "青筋凸现，钢线似的",
-      "src_1_sub_2": "每一条脚毛都硬似铁钉",
-      "src_2_sub_1": "啲青筋凸晒出嚟好似钢线噉",
-      "src_2_sub_2": "啲脚毛每一条都好似铁钉咁硬"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "每一条脚毛都硬似铁钉",
-      "src_1_sub_2": "脚趾甲有一寸厚，究竟⋯",
-      "src_2_sub_1": "啲脚毛每一条都好似铁钉咁硬",
-      "src_2_sub_2": "脚趾弓啲脚夹成串咁厚"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "脚趾甲有一寸厚，究竟⋯",
-      "src_1_sub_2": "要走过几多座山",
-      "src_2_sub_1": "脚趾弓啲脚夹成串咁厚",
-      "src_2_sub_2": "究竟要行个几度呢?"
+      "ref_sub_1": "吃过几多苦头⋯",
+      "ref_sub_2": "才可以练成这举世无双的脚瓜？",
+      "target_sub_2": "挨过几多苦头先至可以练成呢只举世无双嘅脚瓜"
     },
     "answer": {
-      "src_2_sub_1_shifted": "脚趾弓啲脚夹成串咁厚究竟",
-      "src_2_sub_2_shifted": "要行个几度呢?"
+      "target_sub_1_shifted": "挨过几多苦头",
+      "target_sub_2_shifted": "先至可以练成呢只举世无双嘅脚瓜"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "要走过几多座山",
-      "src_1_sub_2": "跨过几多个海",
-      "src_2_sub_1": "要行个几度呢?",
-      "src_2_sub_2": "几多座山挂过几多个海"
+      "ref_sub_1": "我⋯我一定要练成这脚瓜！",
+      "ref_sub_2": "师傅！",
+      "target_sub_1": "我我一定要练成呢只脚挂",
+      "target_sub_2": "师父"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "每次唱这首歌，我都会急小便",
+      "ref_sub_2": "现在先去，一回恐怕还是会急",
+      "target_sub_1": "而知点解每一字唱呢首歌都会急小便",
+      "target_sub_2": "仅次去定先都怕一阵会再急过"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "现在先去，一回恐怕还是会急",
+      "ref_sub_2": "但是我现在一定要唱这首歌",
+      "target_sub_1": "仅次去定先都怕一阵会再急过",
+      "target_sub_2": "但系我而家一定要唱呢首歌"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "但是我现在一定要唱这首歌",
+      "ref_sub_2": "希望可以改变黎根对我的看法",
+      "target_sub_1": "但系我而家一定要唱呢首歌",
+      "target_sub_2": "希望可以改变黎根对我嘅睇法"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "希望可以改变黎根对我的看法",
+      "ref_sub_2": "我要用这歌打动黎根",
+      "target_sub_1": "希望可以改变黎根对我嘅睇法",
+      "target_sub_2": "我要用呢首歌打动黎根"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我要用这歌打动黎根",
+      "ref_sub_2": "我要黎根收我做徒弟！",
+      "target_sub_1": "我要用呢首歌打动黎根",
+      "target_sub_2": "我要黎根收我做徒弟"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我要黎根收我做徒弟！",
+      "ref_sub_2": "歌，是这样唱的⋯",
+      "target_sub_1": "我要黎根收我做徒弟",
+      "target_sub_2": "嗰首歌系噉唱嘅"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "歌，是这样唱的⋯",
+      "ref_sub_2": "「大包，整多两笼」",
+      "target_sub_1": "嗰首歌系噉唱嘅"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "黎根听完歌以后，表情有点古怪⋯",
+      "ref_sub_2": "我一定要好好把握这机会",
+      "target_sub_1": "黎今听完首歌之后啲表情有啲古怪",
+      "target_sub_2": "唔我一定要好好把握呢个机会"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我一定要好好把握这机会",
+      "ref_sub_2": "师傅！你收我做徒弟吧！",
+      "target_sub_1": "唔我一定要好好把握呢个机会",
+      "target_sub_2": "师父你收我做徒弟啦"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "师傅！你收我做徒弟吧！",
+      "ref_sub_2": "你唔收我做徒弟，我一世都这么跪著！",
+      "target_sub_1": "师父你收我做徒弟啦",
+      "target_sub_2": "你收我做徒弟我呢一世都跪喺度"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "你唔收我做徒弟，我一世都这么跪著！",
+      "ref_sub_2": "起来呀！",
+      "target_sub_1": "你收我做徒弟我呢一世都跪喺度",
+      "target_sub_2": "起身啊"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "起来呀！",
+      "ref_sub_2": "多谢师傅！",
+      "target_sub_1": "起身啊",
+      "target_sub_2": "多谢师父"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "多谢师傅！",
+      "ref_sub_2": "不⋯我是叫你扶我起来呀！",
+      "target_sub_1": "多谢师父",
+      "target_sub_2": "唔系啊我系叫你扶我起身啊"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "不⋯我是叫你扶我起来呀！",
+      "ref_sub_2": "不成了！我的脚瓜太痹了！",
+      "target_sub_1": "唔系啊我系叫你扶我起身啊",
+      "target_sub_2": "顶唔顺啊我个腿挂好鼻啊字幕由Amara.org社群提供"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我将今天发生的事讲给妈妈听",
+      "ref_sub_2": "妈妈一句话也没说",
+      "target_sub_1": "我将今日发生嘅嘢话晒畀妈妈听",
+      "target_sub_2": "妈妈佢乜嘢都冇讲到"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "妈妈一句话也没说",
+      "ref_sub_2": "从冰箱内拿了只雪鸡出来解冻",
+      "target_sub_1": "妈妈佢乜嘢都冇讲到",
+      "target_sub_2": "净系喺冰箱度攞咗只雪鸡出嚟解冻"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "从冰箱内拿了只雪鸡出来解冻",
+      "ref_sub_2": "晚饭时，妈妈倒了三杯米酒",
+      "target_sub_1": "净系喺冰箱度攞咗只雪鸡出嚟解冻",
+      "target_sub_2": "晚饭时候妈妈倒咗三杯米酒"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "晚饭时，妈妈倒了三杯米酒",
+      "ref_sub_2": "又将几只橙和蒸好的鸡放到祖先前",
+      "target_sub_1": "晚饭时候妈妈倒咗三杯米酒",
+      "target_sub_2": "再将几个铲同埋蒸熟咗嘅鸡放喺祖先前面"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "又将几只橙和蒸好的鸡放到祖先前",
+      "ref_sub_2": "妈妈叫我跪低，向祖先请请",
+      "target_sub_1": "再将几个铲同埋蒸熟咗嘅鸡放喺祖先前面",
+      "target_sub_2": "妈妈叫我跪低同祖先请请"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "妈妈叫我跪低，向祖先请请",
+      "ref_sub_2": "妈妈跟著又念念有词的",
+      "target_sub_1": "妈妈叫我跪低同祖先请请",
+      "target_sub_2": "跟住妈妈口噏噏噉讲咗一啲嘢"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "妈妈跟著又念念有词的",
+      "ref_sub_2": "然后我们一起向祖先再拜了几拜",
+      "target_sub_1": "跟住妈妈口噏噏噉讲咗一啲嘢",
+      "target_sub_2": "然之后我哋又一齐对住祖先拜多几拜"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "然后我们一起向祖先再拜了几拜",
+      "ref_sub_2": "妈妈蹲低把酒洒到地上",
+      "target_sub_1": "然之后我哋又一齐对住祖先拜多几拜",
+      "target_sub_2": "妈妈虎低身将啲酒倒喺地上面"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "妈妈蹲低把酒洒到地上",
+      "ref_sub_2": "庄重而温柔地跟我说：",
+      "target_sub_1": "妈妈虎低身将啲酒倒喺地上面",
+      "target_sub_2": "庄重又温柔紧同我讲"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "庄重而温柔地跟我说：",
+      "ref_sub_2": "以后生生性性",
+      "target_sub_1": "庄重又温柔紧同我讲",
+      "target_sub_2": "以后要生生性性"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "以后生生性性",
+      "ref_sub_2": "跟师傅学习，光宗耀祖！",
+      "target_sub_1": "以后要生生性性",
+      "target_sub_2": "跟师父学嘢当中要祖"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "妈妈在长洲找了间酒楼摆拜师宴",
+      "ref_sub_2": "因为我是师傅最后一个入室弟子",
+      "target_sub_1": "妈妈喺长洲揾咗间酒楼摆咗几回白丝宴",
+      "target_sub_2": "因为我系师父最后一个入室弟子"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "因为我是师傅最后一个入室弟子",
+      "ref_sub_2": "到贺的乡绅父老特别多",
+      "target_sub_1": "因为我系师父最后一个入室弟子",
+      "target_sub_2": "所以到学嘅乡亲父老特别多"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "到贺的乡绅父老特别多",
+      "ref_sub_2": "想不到黄德森也来了",
+      "target_sub_1": "所以到学嘅乡亲父老特别多",
+      "target_sub_2": "估唔到黄德森都有嚟饮"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "想不到黄德森也来了",
+      "ref_sub_2": "还赞我背上的肉厚",
+      "target_sub_1": "估唔到黄德森都有嚟饮",
+      "target_sub_2": "仲赞我背著啲肉口添"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "还赞我背上的肉厚",
+      "ref_sub_2": "珊珊因为去了集训，没来",
+      "target_sub_1": "仲赞我背著啲肉口添",
+      "target_sub_2": "但系山神就去咗集训冇嚟到"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "珊珊因为去了集训，没来",
+      "ref_sub_2": "麦唛，菇时跟得巴都来了",
+      "target_sub_1": "但系山神就去咗集训冇嚟到",
+      "target_sub_2": "默默姑侍同德巴都嚟咗"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "麦唛，菇时跟得巴都来了",
+      "ref_sub_2": "还带著成绩表，奖牌和大包",
+      "target_sub_1": "默默姑侍同德巴都嚟咗",
+      "target_sub_2": "仲带埋成绩表奖牌同大包嚟添"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "还带著成绩表，奖牌和大包",
+      "ref_sub_2": "他们都希望黎根也可以收他们做徒弟",
+      "target_sub_1": "仲带埋成绩表奖牌同大包嚟添",
+      "target_sub_2": "佢哋都希望嚟今可以收埋佢哋做徒弟"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "他们都希望黎根也可以收他们做徒弟",
+      "ref_sub_2": "吃过鸡丝翅，就是拜师仪式",
+      "target_sub_1": "佢哋都希望嚟今可以收埋佢哋做徒弟",
+      "target_sub_2": "食完鸡丝翅就到咗拜师仪式"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "吃过鸡丝翅，就是拜师仪式",
+      "ref_sub_2": "妈妈倒了杯茶给我，让我给师傅喝",
+      "target_sub_1": "食完鸡丝翅就到咗拜师仪式",
+      "target_sub_2": "妈妈针咗杯热茶畀我叫我弟畀师父饮"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "妈妈倒了杯茶给我，让我给师傅喝",
+      "ref_sub_2": "我千辛万苦来长洲找黎根⋯",
+      "target_sub_1": "妈妈针咗杯热茶畀我叫我弟畀师父饮",
+      "target_sub_2": "哦我前三万苦嚟到长洲揾嚟近"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我千辛万苦来长洲找黎根⋯",
+      "ref_sub_2": "我终于可以跟珊珊一起练滑浪风帆了！",
+      "target_sub_1": "哦我前三万苦嚟到长洲揾嚟近",
+      "target_sub_2": "哦我终于可以同山神一齐练习玩弄风范啊"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我终于可以跟珊珊一起练滑浪风帆了！",
+      "ref_sub_2": "我将茶递给黎根，黎根他⋯",
+      "target_sub_1": "哦我终于可以同山神一齐练习玩弄风范啊",
+      "target_sub_2": "我将杯茶递咗畀嚟跟嚟跟佢"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我将茶递给黎根，黎根他⋯",
+      "ref_sub_2": "师傅他把茶喝了，正式收我做徒弟",
+      "target_sub_1": "我将杯茶递咗畀嚟跟嚟跟佢",
+      "target_sub_2": "亦唔系师父佢饮咗杯茶正式收咗我做徒弟嘞"
     },
     "answer": {
-      "src_2_sub_1_shifted": "要行个几度呢?几多座山",
-      "src_2_sub_2_shifted": "挂过几多个海"
+      "target_sub_1_shifted": "我将杯茶递咗畀嚟跟嚟跟佢亦唔系",
+      "target_sub_2_shifted": "师父佢饮咗杯茶正式收咗我做徒弟嘞"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "跨过几多个海",
-      "src_1_sub_2": "吃过几多苦头",
-      "src_2_sub_1": "挂过几多个海",
-      "src_2_sub_2": "挨过几多斧头"
+      "ref_sub_1": "师傅他把茶喝了，正式收我做徒弟",
+      "ref_sub_2": "宾客们好像都很高兴",
+      "target_sub_1": "师父佢饮咗杯茶正式收咗我做徒弟嘞",
+      "target_sub_2": "啲来宾睇嚟好高气"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "吃过几多苦头",
-      "src_1_sub_2": "才可以练成这举世无双的脚瓜？",
-      "src_2_sub_1": "挨过几多斧头",
-      "src_2_sub_2": "先至可以练成呢一只举细无伤嘅脚瓜"
+      "ref_sub_1": "宾客们好像都很高兴",
+      "ref_sub_2": "长洲的乡绅父老拍掌拍得特别落力",
+      "target_sub_1": "啲来宾睇嚟好高气",
+      "target_sub_2": "特别系长洲啲乡亲父老拍奖拍得特别落力"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我个仔⋯",
-      "src_1_sub_2": "你个仔，他日都会有这只大脚瓜",
-      "src_2_sub_1": "我个仔",
-      "src_2_sub_2": "你个仔第时都会有我咁大只脚瓜"
+      "ref_sub_1": "长洲的乡绅父老拍掌拍得特别落力",
+      "ref_sub_2": "多谢各位赏面！多谢各位！",
+      "target_sub_1": "特别系长洲啲乡亲父老拍奖拍得特别落力",
+      "target_sub_2": "多谢各位上面多谢各位"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "你个仔，他日都会有这只大脚瓜",
-      "src_1_sub_2": "其实我也不知道个仔要这么粗的脚瓜⋯",
-      "src_2_sub_1": "你个仔第时都会有我咁大只脚瓜",
-      "src_2_sub_2": "其实我都唔知我仔要咁粗嘅脚瓜有咩用"
+      "ref_sub_1": "多谢各位赏面！多谢各位！",
+      "ref_sub_2": "在下平生有两项称得上得意的绝技",
+      "target_sub_1": "多谢各位上面多谢各位",
+      "target_sub_2": "在下评生有两项称得上得意嘅绝技"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "其实我也不知道个仔要这么粗的脚瓜⋯",
-      "src_1_sub_2": "有什么用",
-      "src_2_sub_1": "其实我都唔知我仔要咁粗嘅脚瓜有咩用"
+      "ref_sub_1": "在下平生有两项称得上得意的绝技",
+      "ref_sub_2": "第一项，是滑浪风帆！",
+      "target_sub_1": "在下评生有两项称得上得意嘅绝技",
+      "target_sub_2": "第一样系滑浪风范"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "第一项，是滑浪风帆！",
+      "ref_sub_2": "我把它传给外甥女珊珊了",
+      "target_sub_1": "第一样系滑浪风范",
+      "target_sub_2": "呢样早已传咗畀我外甥女山神啊"
     },
     "answer": {
-      "src_2_sub_1_shifted": "其实我都唔知我仔要咁粗嘅脚瓜",
-      "src_2_sub_2_shifted": "有咩用"
+      "target_sub_1_shifted": "第一样系滑浪风范呢样早已",
+      "target_sub_2_shifted": "传咗畀我外甥女山神啊"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "你个仔，他日都会有这只大脚瓜",
-      "src_1_sub_2": "其实我也不知道个仔要这么粗的脚瓜⋯",
-      "src_2_sub_1": "你个仔第时都会有我咁大只脚瓜",
-      "src_2_sub_2": "其实我都唔知我仔要咁粗嘅脚瓜"
+      "ref_sub_1": "我把它传给外甥女珊珊了",
+      "ref_sub_2": "另一项绝技，我打算传给这个新徒弟⋯",
+      "target_sub_1": "传咗畀我外甥女山神啊",
+      "target_sub_2": "另一项绝技我打算传畀呢个新修嘅徒弟"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "其实我也不知道个仔要这么粗的脚瓜⋯",
-      "src_1_sub_2": "有什么用",
-      "src_2_sub_1": "其实我都唔知我仔要咁粗嘅脚瓜",
-      "src_2_sub_2": "有咩用"
+      "ref_sub_1": "另一项绝技，我打算传给这个新徒弟⋯",
+      "ref_sub_2": "希望他把长洲人世世代代的绝技",
+      "target_sub_1": "另一项绝技我打算传畀呢个新修嘅徒弟",
+      "target_sub_2": "希望我可以将我哋长洲人世世代代嘅传统发扬光大"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "有什么用",
-      "src_1_sub_2": "可是看见那些凸现的青筋，不知怎样⋯",
-      "src_2_sub_1": "有咩用",
-      "src_2_sub_2": "但系见到佢一条条凸起嘅青筋唔知点解"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "可是看见那些凸现的青筋，不知怎样⋯",
-      "src_1_sub_2": "我想起麦兜的爸爸，阿炳",
-      "src_2_sub_1": "但系见到佢一条条凸起嘅青筋唔知点解",
-      "src_2_sub_2": "我我谂起麦兜嘅爸爸阿炳"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我找来找去也找不到那部电子英文辞典",
-      "src_1_sub_2": "跑哪去了？",
-      "src_2_sub_1": "我揾完成间屋都揾唔到部电子英文词典",
-      "src_2_sub_2": "去咗边呢"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "跑哪去了？",
-      "src_1_sub_2": "难道⋯不会吧？",
-      "src_2_sub_1": "去咗边呢",
-      "src_2_sub_2": "唔通冇理由㗎"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "想不到真的让妈妈拿去了。吓得我！",
-      "src_1_sub_2": "妈妈怎么会写起英文信？",
-      "src_2_sub_1": "咦估唔到真系妈妈攞咗㖞吓得我啊",
-      "src_2_sub_2": "点解妈妈会用英文写信嘅"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "妈妈怎么会写起英文信？",
-      "src_1_sub_2": "信很短",
-      "src_2_sub_1": "点解妈妈会用英文写信嘅",
-      "src_2_sub_2": "封信好短"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "信很短",
-      "src_1_sub_2": "我猜是妈妈用电子辞典逐个字译成英文",
-      "src_2_sub_1": "封信好短",
-      "src_2_sub_2": "我谂妈妈佢系好辛苦用电子词典逐个逐个字译做英文"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我猜是妈妈用电子辞典逐个字译成英文",
-      "src_1_sub_2": "于是我又用电子辞典把信译回中文",
-      "src_2_sub_1": "我谂妈妈佢系好辛苦用电子词典逐个逐个字译做英文",
-      "src_2_sub_2": "于是我让返电子词典将封信译返做中文"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "于是我又用电子辞典把信译回中文",
-      "src_1_sub_2": "信，是妈妈写给奥委会主席的",
-      "src_2_sub_1": "于是我让返电子词典将封信译返做中文",
-      "src_2_sub_2": "封信原来系妈妈写畀奥委会主席㗎"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "信，是妈妈写给奥委会主席的",
-      "src_1_sub_2": "「亲爱的主席：」",
-      "src_2_sub_1": "封信原来系妈妈写畀奥委会主席㗎",
-      "src_2_sub_2": "亲爱的主席"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "「亲爱的主席：」",
-      "src_1_sub_2": "「你好吗？我很好！」",
-      "src_2_sub_1": "亲爱的主席",
-      "src_2_sub_2": "你好吗我很好"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "「你好吗？我很好！」",
-      "src_1_sub_2": "「你吃包吗？我吃包！」",
-      "src_2_sub_1": "你好吗我很好",
-      "src_2_sub_2": "你吃包吗我吃包"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "「你吃包吗？我吃包！」",
-      "src_1_sub_2": "「我们居住在香港这里的人，很爱吃包」",
-      "src_2_sub_1": "你吃包吗我吃包",
-      "src_2_sub_2": "我门居住在香港这类的人肯爱吃包"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "「我们居住在香港这里的人，很爱吃包」",
-      "src_1_sub_2": "「小笼包，上海包，广东包，莲蓉包」",
-      "src_2_sub_1": "我门居住在香港这类的人肯爱吃包",
-      "src_2_sub_2": "小笼包上海包广东包联融包"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "「小笼包，上海包，广东包，莲蓉包」",
-      "src_1_sub_2": "「好朋友，我认为",
-      "src_2_sub_1": "小笼包上海包广东包联融包",
-      "src_2_sub_2": "好朋友"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "「好朋友，我认为",
-      "src_1_sub_2": "抢劫那些包，十分重要」",
-      "src_2_sub_1": "好朋友",
-      "src_2_sub_2": "我认为抢劫嗰些包十分重要"
+      "ref_sub_1": "希望他把长洲人世世代代的绝技",
+      "ref_sub_2": "发扬光大！",
+      "target_sub_1": "希望我可以将我哋长洲人世世代代嘅传统发扬光大"
     },
     "answer": {
-      "src_2_sub_1_shifted": "好朋友我认为",
-      "src_2_sub_2_shifted": "抢劫嗰些包十分重要"
+      "target_sub_1_shifted": "希望我可以将我哋长洲人世世代代嘅传统",
+      "target_sub_2_shifted": "发扬光大"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "抢劫那些包，十分重要」",
-      "src_1_sub_2": "「也算是运动，就真！」",
-      "src_2_sub_1": "抢劫嗰些包十分重要",
-      "src_2_sub_2": "也算是运动就真"
+      "ref_sub_1": "另一项绝技，我打算传给这个新徒弟⋯",
+      "ref_sub_2": "希望他把长洲人世世代代的绝技",
+      "target_sub_1": "另一项绝技我打算传畀呢个新修嘅徒弟",
+      "target_sub_2": "希望我可以将我哋长洲人世世代代嘅传统"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「也算是运动，就真！」",
-      "src_1_sub_2": "「要大力！大吃晚上的粥，和大节瓜！」",
-      "src_2_sub_1": "也算是运动就真",
-      "src_2_sub_2": "要大力大吃吻上的粥和大字瓜"
+      "ref_sub_1": "希望他把长洲人世世代代的绝技",
+      "ref_sub_2": "发扬光大！",
+      "target_sub_1": "希望我可以将我哋长洲人世世代代嘅传统",
+      "target_sub_2": "发扬光大"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「要大力！大吃晚上的粥，和大节瓜！」",
-      "src_1_sub_2": "「按照我愚蠢的见解⋯」",
-      "src_2_sub_1": "要大力大吃吻上的粥和大字瓜",
-      "src_2_sub_2": "按照我愚蠢的见解"
+      "ref_sub_1": "发扬光大！",
+      "ref_sub_2": "请问那是什么绝技呢？",
+      "target_sub_1": "发扬光大",
+      "target_sub_2": "噉请问嗰样绝技系乜嘢啊"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「按照我愚蠢的见解⋯」",
-      "src_1_sub_2": "「抢劫那些包，是奥运会比赛」",
-      "src_2_sub_1": "按照我愚蠢的见解",
-      "src_2_sub_2": "抢劫嗰些包系奥运会比赛"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "「抢劫那些包，是奥运会比赛」",
-      "src_1_sub_2": "「让全世界的体育家，抢过！」",
-      "src_2_sub_1": "抢劫嗰些包系奥运会比赛",
-      "src_2_sub_2": "让全世界嘅体育家抢过"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "「让全世界的体育家，抢过！」",
-      "src_1_sub_2": "「世界便和平！」",
-      "src_2_sub_1": "让全世界嘅体育家抢过",
-      "src_2_sub_2": "世界变和平"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "「世界便和平！」",
-      "src_1_sub_2": "「你有孩子吗？」",
-      "src_2_sub_1": "世界变和平",
-      "src_2_sub_2": "你有孩子吗"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "「你有孩子吗？」",
-      "src_1_sub_2": "「我有一个孩子，麦兜」",
-      "src_2_sub_1": "你有孩子吗",
-      "src_2_sub_2": "我有一个孩子麦兜"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "「我有一个孩子，麦兜」",
-      "src_1_sub_2": "终于讲到我了！",
-      "src_2_sub_1": "我有一个孩子麦兜",
-      "src_2_sub_2": "终于讲到我啦"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "终于讲到我了！",
-      "src_1_sub_2": "「他是一个好男孩」",
-      "src_2_sub_1": "终于讲到我啦",
-      "src_2_sub_2": "她系一个好男孩"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "「他是一个好男孩」",
-      "src_1_sub_2": "「他非常懂得抢劫那些包」",
-      "src_2_sub_1": "她系一个好男孩",
-      "src_2_sub_2": "她非常懂得抢劫嗰些包"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "「他非常懂得抢劫那些包」",
-      "src_1_sub_2": "「有一天，我看见他，抢劫包⋯」",
-      "src_2_sub_1": "她非常懂得抢劫嗰些包",
-      "src_2_sub_2": "有一天我看见她抢劫包"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "「有一天，我看见他，抢劫包⋯」",
-      "src_1_sub_2": "「抢了一个奥运金牌」",
-      "src_2_sub_1": "有一天我看见她抢劫包",
-      "src_2_sub_2": "抢了一个奥运金牌"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "「抢了一个奥运金牌」",
-      "src_1_sub_2": "「那便是一个母亲能够有的最大的安慰」",
-      "src_2_sub_1": "抢了一个奥运金牌",
-      "src_2_sub_2": "哪便是一个母亲能够有的最好的最大的安慰"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "「那便是一个母亲能够有的最大的安慰」",
-      "src_1_sub_2": "「孩子的才干，得到了世界人类的知道」",
-      "src_2_sub_1": "哪便是一个母亲能够有的最好的最大的安慰",
-      "src_2_sub_2": "孩子的才干得到了世界人类的知道"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "「孩子的才干，得到了世界人类的知道」",
-      "src_1_sub_2": "「父母愿意做什么的东西都得」",
-      "src_2_sub_1": "孩子的才干得到了世界人类的知道",
-      "src_2_sub_2": "父母愿意做什么的东西都得"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "「父母愿意做什么的东西都得」",
-      "src_1_sub_2": "「于是我写了这忽然间的信给你」",
-      "src_2_sub_1": "父母愿意做什么的东西都得",
-      "src_2_sub_2": "于是我写了这忽然间的信给你"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "「于是我写了这忽然间的信给你」",
-      "src_1_sub_2": "「虽然你不知道我是什么微细的东西」",
-      "src_2_sub_1": "于是我写了这忽然间的信给你",
-      "src_2_sub_2": "虽然你不知道我是什么微细的东西"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "「虽然你不知道我是什么微细的东西」",
-      "src_1_sub_2": "「但我的孩子很大，很大！」",
-      "src_2_sub_1": "虽然你不知道我是什么微细的东西",
-      "src_2_sub_2": "但我的孩子很大很大"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "「但我的孩子很大，很大！」",
-      "src_1_sub_2": "「有一天，你都会知道」",
-      "src_2_sub_1": "但我的孩子很大很大",
-      "src_2_sub_2": "有一天你都会知道"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "「有一天，你都会知道」",
-      "src_1_sub_2": "「多谢合作！」",
-      "src_2_sub_1": "有一天你都会知道",
-      "src_2_sub_2": "多谢合作"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "「多谢合作！」",
-      "src_1_sub_2": "「你忠实的，麦太」",
-      "src_2_sub_1": "多谢合作",
-      "src_2_sub_2": "你忠实的麦太"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "看完妈妈的信",
-      "src_1_sub_2": "我决定回长洲继续学抢包山",
-      "src_2_sub_1": "睇完妈妈封信后",
-      "src_2_sub_2": "我决定返长洲继续抢包生"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我决定回长洲继续学抢包山",
-      "src_1_sub_2": "我不是为了见珊珊",
-      "src_2_sub_1": "我决定返长洲继续抢包生",
-      "src_2_sub_2": "我唔系为咗见到山神"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我不是为了见珊珊",
-      "src_1_sub_2": "我并不知道为什么要抢那些包",
-      "src_2_sub_1": "我唔系为咗见到山神",
-      "src_2_sub_2": "我唔知点解要抢嗰啲包"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我并不知道为什么要抢那些包",
-      "src_1_sub_2": "我也不相信抢包山会成为奥运项目",
-      "src_2_sub_1": "我唔知点解要抢嗰啲包",
-      "src_2_sub_2": "我亦唔信抢包生会成为奥运项目"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我也不相信抢包山会成为奥运项目",
-      "src_1_sub_2": "可是，我依然努力练习抢包山",
-      "src_2_sub_1": "我亦唔信抢包生会成为奥运项目",
-      "src_2_sub_2": "但系我依然努力练习抢包生"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "可是，我依然努力练习抢包山",
-      "src_1_sub_2": "因为，我爱我妈妈",
-      "src_2_sub_1": "但系我依然努力练习抢包生",
-      "src_2_sub_2": "因为我爱我妈妈"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "因为，我爱我妈妈",
-      "src_1_sub_2": "师傅说我攀爬功夫已经不错",
-      "src_2_sub_1": "因为我爱我妈妈",
-      "src_2_sub_2": "师傅话我嘅攀爬功夫已经唔错"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "师傅说我攀爬功夫已经不错",
-      "src_1_sub_2": "可以开始教我「十二路抢包手」",
-      "src_2_sub_1": "师傅话我嘅攀爬功夫已经唔错",
-      "src_2_sub_2": "可以开始教我十二路抢包手"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "可以开始教我「十二路抢包手」",
-      "src_1_sub_2": "师傅说当年师祖耍出这套",
-      "src_2_sub_1": "可以开始教我十二路抢包手",
-      "src_2_sub_2": "师傅话"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "师傅说当年师祖耍出这套",
-      "src_1_sub_2": "「十二路抢包手」⋯",
-      "src_2_sub_1": "师傅话",
-      "src_2_sub_2": "当年师祖使出呢套十二路抢包手"
+      "ref_sub_1": "第二项绝技，就是⋯",
+      "ref_sub_2": "抢包山！",
+      "target_sub_1": "第二样绝技就系抢爆山"
     },
     "answer": {
-      "src_2_sub_1_shifted": "师傅话当年师祖使出呢套",
-      "src_2_sub_2_shifted": "十二路抢包手"
+      "target_sub_1_shifted": "第二样绝技就系",
+      "target_sub_2_shifted": "抢爆山"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "可以开始教我「十二路抢包手」",
-      "src_1_sub_2": "师傅说当年师祖耍出这套",
-      "src_2_sub_1": "可以开始教我十二路抢包手",
-      "src_2_sub_2": "师傅话当年师祖使出呢套"
+      "ref_sub_1": "第二项绝技，就是⋯",
+      "ref_sub_2": "抢包山！",
+      "target_sub_1": "第二样绝技就系",
+      "target_sub_2": "抢爆山"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "师傅说当年师祖耍出这套",
-      "src_1_sub_2": "「十二路抢包手」⋯",
-      "src_2_sub_1": "师傅话当年师祖使出呢套",
-      "src_2_sub_2": "十二路抢包手"
+      "ref_sub_1": "抢包山？",
+      "ref_sub_2": "年轻观众可能不知「抢包山」何物",
+      "target_sub_1": "抢包山?",
+      "target_sub_2": "年轻嘅观众可能唔知乜嘢系抢包山呀"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「十二路抢包手」⋯",
-      "src_1_sub_2": "连林世荣也大大赞好",
-      "src_2_sub_1": "十二路抢包手",
-      "src_2_sub_2": "连林世荣睇见都大赞老爷"
+      "ref_sub_1": "年轻观众可能不知「抢包山」何物",
+      "ref_sub_2": "抢包山乃长洲独有传统节日",
+      "target_sub_1": "年轻嘅观众可能唔知乜嘢系抢包山呀",
+      "target_sub_2": "抢包山系长洲独有嘅传统节日"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "连林世荣也大大赞好",
-      "src_1_sub_2": "后来麦唛告诉我⋯",
-      "src_2_sub_1": "连林世荣睇见都大赞老爷",
-      "src_2_sub_2": "后来默默话我知"
+      "ref_sub_1": "抢包山乃长洲独有传统节日",
+      "ref_sub_2": "每年农历四月",
+      "target_sub_1": "抢包山系长洲独有嘅传统节日",
+      "target_sub_2": "每年农历四月"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "后来麦唛告诉我⋯",
-      "src_1_sub_2": "林世荣即是猪肉荣，是黄飞鸿的徒弟",
-      "src_2_sub_1": "后来默默话我知",
-      "src_2_sub_2": "林世荣即系猪肉荣系黄飞鸿嘅徒弟"
+      "ref_sub_1": "每年农历四月",
+      "ref_sub_2": "长洲居民均举办太平清醮",
+      "target_sub_1": "每年农历四月",
+      "target_sub_2": "长洲嘅居民都会举办太平清朝"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "林世荣即是猪肉荣，是黄飞鸿的徒弟",
-      "src_1_sub_2": "我不知道师傅像不像黄飞鸿",
-      "src_2_sub_1": "林世荣即系猪肉荣系黄飞鸿嘅徒弟",
-      "src_2_sub_2": "我唔知到师傅似唔似黄飞鸿"
+      "ref_sub_1": "长洲居民均举办太平清醮",
+      "ref_sub_2": "于北帝庙前搭起三座包山",
+      "target_sub_1": "长洲嘅居民都会举办太平清朝",
+      "target_sub_2": "喺北帝庙前搭起三座包山"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我不知道师傅像不像黄飞鸿",
-      "src_1_sub_2": "我却肯定像一块猪肉",
-      "src_2_sub_1": "我唔知到师傅似唔似黄飞鸿",
-      "src_2_sub_2": "但系我就肯定似旧猪肉"
+      "ref_sub_1": "于北帝庙前搭起三座包山",
+      "ref_sub_2": "什么是包山呢？",
+      "target_sub_1": "喺北帝庙前搭起三座包山",
+      "target_sub_2": "噉乜嘢系包山呢?"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我却肯定像一块猪肉",
-      "src_1_sub_2": "我是一块揸住两个包",
-      "src_2_sub_1": "但系我就肯定似旧猪肉",
-      "src_2_sub_2": "我就系一个揸住两个包"
+      "ref_sub_1": "什么是包山呢？",
+      "ref_sub_2": "顾名思义⋯",
+      "target_sub_1": "噉乜嘢系包山呢?",
+      "target_sub_2": "顾名思义"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我是一块揸住两个包",
-      "src_1_sub_2": "在长洲转来转去的猪肉",
-      "src_2_sub_1": "我就系一个揸住两个包",
-      "src_2_sub_2": "喺长洲转嚟转去嘅猪肉"
+      "ref_sub_1": "顾名思义⋯",
+      "ref_sub_2": "包山就是一座由好多好多包砌起的山！",
+      "target_sub_1": "顾名思义",
+      "target_sub_2": "包山就系一座由好多好多好多包砌起嘅山"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "在长洲转来转去的猪肉",
-      "src_1_sub_2": "我一边练习，一边胡思乱想；始终⋯",
-      "src_2_sub_1": "喺长洲转嚟转去嘅猪肉",
-      "src_2_sub_2": "我一边练习一边乱练一边谂嘢始终"
+      "ref_sub_1": "包山就是一座由好多好多包砌起的山！",
+      "ref_sub_2": "一座包山，起码六、七层楼高⋯",
+      "target_sub_1": "包山就系一座由好多好多好多包砌起嘅山",
+      "target_sub_2": "一座包山起码六七层楼高"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我一边练习，一边胡思乱想；始终⋯",
-      "src_1_sub_2": "我还是不大喜欢抢包",
-      "src_2_sub_1": "我一边练习一边乱练一边谂嘢始终",
-      "src_2_sub_2": "我都唔系咁钟意抢包"
+      "ref_sub_1": "一座包山，起码六、七层楼高⋯",
+      "ref_sub_2": "你可以想像一下包山有多高了吧？",
+      "target_sub_1": "一座包山起码六七层楼高",
+      "target_sub_2": "噉你可以想像一下嗰度有几多包喇"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我还是不大喜欢抢包",
-      "src_1_sub_2": "我只是爱我妈妈",
-      "src_2_sub_1": "我都唔系咁钟意抢包",
-      "src_2_sub_2": "我净系爱我妈妈"
+      "ref_sub_1": "你可以想像一下包山有多高了吧？",
+      "ref_sub_2": "抢包山，就是要把包山上的包抢到手！",
+      "target_sub_1": "噉你可以想像一下嗰度有几多包喇",
+      "target_sub_2": "噉抢包山自然就系要将包山嘅包抢到手"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我只是爱我妈妈",
-      "src_1_sub_2": "于是我咬实牙根⋯",
-      "src_2_sub_1": "我净系爱我妈妈",
-      "src_2_sub_2": "于是我咬细牙根"
+      "ref_sub_1": "抢包山，就是要把包山上的包抢到手！",
+      "ref_sub_2": "锣鼓响起",
+      "target_sub_1": "噉抢包山自然就系要将包山嘅包抢到手",
+      "target_sub_2": "罗古响起"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "于是我咬实牙根⋯",
-      "src_1_sub_2": "一步一步，一爪一爪⋯",
-      "src_2_sub_1": "于是我咬细牙根",
-      "src_2_sub_2": "一步一步一爪一爪"
+      "ref_sub_1": "锣鼓响起",
+      "ref_sub_2": "数以百计的青年一涌而上抢包",
+      "target_sub_1": "罗古响起",
+      "target_sub_2": "数以百计嘅青年就会一涌而上去抢包"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "一步一步，一爪一爪⋯",
-      "src_1_sub_2": "我最后终于练成「十二路抢包手」",
-      "src_2_sub_1": "一步一步一爪一爪",
-      "src_2_sub_2": "最后我终于练成十二路抢包手啦"
+      "ref_sub_1": "数以百计的青年一涌而上抢包",
+      "ref_sub_2": "抢得位置愈高的包，就是愈大的祝福",
+      "target_sub_1": "数以百计嘅青年就会一涌而上去抢包",
+      "target_sub_2": "抢到位置越高嘅包就代表越大嘅祝福"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "喂，我是麦兜",
-      "src_1_sub_2": "刚才的是小朋友麦兜，我是大个佬麦兜",
-      "src_2_sub_1": "喂我系麦兜啊",
-      "src_2_sub_2": "正话嗰个系细路仔麦兜我系大个佬麦兜"
+      "ref_sub_1": "抢得位置愈高的包，就是愈大的祝福",
+      "ref_sub_2": "更可以表现自己的不凡身手",
+      "target_sub_1": "抢到位置越高嘅包就代表越大嘅祝福",
+      "target_sub_2": "更加可以表现自己不凡嘅身手"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "刚才的是小朋友麦兜，我是大个佬麦兜",
-      "src_1_sub_2": "小朋友麦兜和大个佬麦兜除了声音不同⋯",
-      "src_2_sub_1": "正话嗰个系细路仔麦兜我系大个佬麦兜",
-      "src_2_sub_2": "细路仔麦兜同大个佬麦兜除咗把声唔同之外"
+      "ref_sub_1": "更可以表现自己的不凡身手",
+      "ref_sub_2": "在1978年两座包山忽然倒下，多人重伤",
+      "target_sub_1": "更加可以表现自己不凡嘅身手",
+      "target_sub_2": "但喺1978年两座包山突然塌咗都去抢包山"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "小朋友麦兜和大个佬麦兜除了声音不同⋯",
-      "src_1_sub_2": "小朋友麦兜的世界仍然有好多幻想",
-      "src_2_sub_1": "细路仔麦兜同大个佬麦兜除咗把声唔同之外",
-      "src_2_sub_2": "细路仔麦兜嘅世界仲有好多幻想"
+      "ref_sub_1": "在1978年两座包山忽然倒下，多人重伤",
+      "ref_sub_2": "「抢包山」从此被禁！",
+      "target_sub_1": "但喺1978年两座包山突然塌咗都去抢包山",
+      "target_sub_2": "而长洲特有嘅传统亦占备为榜"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "小朋友麦兜的世界仍然有好多幻想",
-      "src_1_sub_2": "仍然有好多希望",
-      "src_2_sub_1": "细路仔麦兜嘅世界仲有好多幻想",
-      "src_2_sub_2": "仲有好多希望"
+      "ref_sub_1": "「抢包山」从此被禁！",
+      "ref_sub_2": "而长洲独有的传统，亦渐被遗忘",
+      "target_sub_1": "而长洲特有嘅传统亦占备为榜",
+      "target_sub_2": "长洲特有嘅传统亦占备为榜"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "仍然有好多希望",
-      "src_1_sub_2": "希望⋯失望⋯",
-      "src_2_sub_1": "仲有好多希望",
-      "src_2_sub_2": "希望失望"
+      "ref_sub_1": "奥运金牌⋯这一世是没有机会的了",
+      "ref_sub_2": "每个星期六我都搭船过长洲",
+      "target_sub_1": "奥运金牌我谂呢一世都唔会攞到",
+      "target_sub_2": "每个礼拜六我都会搭船过长洲"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "希望⋯失望⋯",
-      "src_1_sub_2": "希望⋯",
-      "src_2_sub_1": "希望失望",
-      "src_2_sub_2": "希望"
+      "ref_sub_1": "每个星期六我都搭船过长洲",
+      "ref_sub_2": "去学抢包山⋯",
+      "target_sub_1": "每个礼拜六我都会搭船过长洲",
+      "target_sub_2": "去学抢包山"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "希望⋯",
-      "src_1_sub_2": "失望",
-      "src_2_sub_1": "希望",
-      "src_2_sub_2": "失望"
+      "ref_sub_1": "去学抢包山⋯",
+      "ref_sub_2": "一项没有奖牌，没有对手，没有比赛⋯",
+      "target_sub_1": "去学抢包山",
+      "target_sub_2": "一日冇奖牌冇对手冇比赛"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "失望",
-      "src_1_sub_2": "久而久之，就变成大个佬麦兜",
-      "src_2_sub_1": "失望",
-      "src_2_sub_2": "搞咗一轮就变咗大个佬麦兜"
+      "ref_sub_1": "一项没有奖牌，没有对手，没有比赛⋯",
+      "ref_sub_2": "甚至没有人知道是运动的运动",
+      "target_sub_1": "一日冇奖牌冇对手冇比赛",
+      "target_sub_2": "甚至乎冇人知对佢系运动嘅运动"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "久而久之，就变成大个佬麦兜",
-      "src_1_sub_2": "我现在还是多说点小朋友麦兜",
-      "src_2_sub_1": "搞咗一轮就变咗大个佬麦兜",
-      "src_2_sub_2": "不过而家我都系想讲返细路仔麦兜"
+      "ref_sub_1": "甚至没有人知道是运动的运动",
+      "ref_sub_2": "更坏的是，连包山也没有！",
+      "target_sub_1": "甚至乎冇人知对佢系运动嘅运动",
+      "target_sub_2": "更衰嘅系连包山都冇"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我现在还是多说点小朋友麦兜",
-      "src_1_sub_2": "小朋友麦兜仍然希望希望⋯",
-      "src_2_sub_1": "不过而家我都系想讲返细路仔麦兜",
-      "src_2_sub_2": "细路仔麦兜仲系希望希望"
+      "ref_sub_1": "更坏的是，连包山也没有！",
+      "ref_sub_2": "师傅只是叫我去他的家⋯",
+      "target_sub_1": "更衰嘅系连包山都冇",
+      "target_sub_2": "师傅净系叫我去佢屋企"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "小朋友麦兜仍然希望希望⋯",
-      "src_1_sub_2": "希望真的有圣诞老人",
-      "src_2_sub_1": "细路仔麦兜仲系希望希望",
-      "src_2_sub_2": "希望真系有圣诞老人"
+      "ref_sub_1": "师傅只是叫我去他的家⋯",
+      "ref_sub_2": "在组合柜爬来爬去",
+      "target_sub_1": "师傅净系叫我去佢屋企",
+      "target_sub_2": "喺个组合柜度爬嚟爬去"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "希望真的有圣诞老人",
-      "src_1_sub_2": "而且好想试试圣诞火鸡的滋味",
-      "src_2_sub_1": "希望真系有圣诞老人",
-      "src_2_sub_2": "仲系好想好想试下圣诞火鸡嘅滋味"
+      "ref_sub_1": "在组合柜爬来爬去",
+      "ref_sub_2": "碰！三番！",
+      "target_sub_1": "喺个组合柜度爬嚟爬去",
+      "target_sub_2": "通三番"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "而且好想试试圣诞火鸡的滋味",
-      "src_1_sub_2": "对，那时我还没吃过火鸡",
-      "src_2_sub_1": "仲系好想好想试下圣诞火鸡嘅滋味",
-      "src_2_sub_2": "系啊我嗰阵我真系仲未食过火鸡"
+      "ref_sub_1": "碰！三番！",
+      "ref_sub_2": "别躲懒！继续练！",
+      "target_sub_1": "通三番",
+      "target_sub_2": "冇偷懒继续练"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "对，那时我还没吃过火鸡",
-      "src_1_sub_2": "关于火鸡的一切⋯",
-      "src_2_sub_1": "系啊我嗰阵我真系仲未食过火鸡",
-      "src_2_sub_2": "所有关于火鸡嘅嘢"
+      "ref_sub_1": "别躲懒！继续练！",
+      "ref_sub_2": "一天，珊珊到了师传家！",
+      "target_sub_1": "冇偷懒继续练",
+      "target_sub_2": "有一日山伞嚟咗师傅屋企"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "关于火鸡的一切⋯",
-      "src_1_sub_2": "圣诞树上一闪一闪的饰物",
-      "src_2_sub_1": "所有关于火鸡嘅嘢",
-      "src_2_sub_2": "圣诞树一闪一闪嘅灯饰"
+      "ref_sub_1": "一天，珊珊到了师传家！",
+      "ref_sub_2": "珊珊！我的师姐珊珊！",
+      "target_sub_1": "有一日山伞嚟咗师傅屋企",
+      "target_sub_2": "山伞我个师仔山伞啊"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "圣诞树上一闪一闪的饰物",
-      "src_1_sub_2": "就像天上掉落的星星",
-      "src_2_sub_1": "圣诞树一闪一闪嘅灯饰",
-      "src_2_sub_2": "就好似喺天上面落嚟嘅星星噉"
+      "ref_sub_1": "珊珊！我的师姐珊珊！",
+      "ref_sub_2": "可以看见珊珊⋯",
+      "target_sub_1": "山伞我个师仔山伞啊",
+      "target_sub_2": "可以见到山伞"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "就像天上掉落的星星",
-      "src_1_sub_2": "落到火炉旁边",
-      "src_2_sub_1": "就好似喺天上面落嚟嘅星星噉",
-      "src_2_sub_2": "落喺火炉旁边"
+      "ref_sub_1": "可以看见珊珊⋯",
+      "ref_sub_2": "这几个星期爬得再辛苦也是值得的！",
+      "target_sub_1": "可以见到山伞",
+      "target_sub_2": "爬得咁辛苦都系值得㗎"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "落到火炉旁边",
-      "src_1_sub_2": "一片片比外边的雪还要白的鸡胸肉⋯",
-      "src_2_sub_1": "落喺火炉旁边",
-      "src_2_sub_2": "一片一片比窗外面嘅雪仲要白嘅鸡胸肉"
+      "ref_sub_1": "这几个星期爬得再辛苦也是值得的！",
+      "ref_sub_2": "珊珊！",
+      "target_sub_1": "爬得咁辛苦都系值得㗎",
+      "target_sub_2": "山伞"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "一片片比外边的雪还要白的鸡胸肉⋯",
-      "src_1_sub_2": "就在我们跟前",
-      "src_2_sub_1": "一片一片比窗外面嘅雪仲要白嘅鸡胸肉",
-      "src_2_sub_2": "就喺我哋面前啦"
+      "ref_sub_1": "珊珊！",
+      "ref_sub_2": "珊你个头！继续练习！",
+      "target_sub_1": "山伞",
+      "target_sub_2": "伞你个头啊继续练习"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "就在我们跟前",
-      "src_1_sub_2": "香气直入灵魂⋯",
-      "src_2_sub_1": "就喺我哋面前啦",
-      "src_2_sub_2": "香气直入灵魂"
+      "ref_sub_1": "还不去？",
+      "ref_sub_2": "珊珊没看见我这个师弟",
+      "target_sub_1": "仲唔系",
+      "target_sub_2": "山神佢见唔到我呢个师弟"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "香气直入灵魂⋯",
-      "src_1_sub_2": "连守在灵魂旁边的天使都醒过来",
-      "src_2_sub_1": "香气直入灵魂",
-      "src_2_sub_2": "就连守喺灵魂旁边嘅天使都醒咗起嚟"
+      "ref_sub_1": "珊珊没看见我这个师弟",
+      "ref_sub_2": "我只有死死气再爬上组合柜",
+      "target_sub_1": "山神佢见唔到我呢个师弟",
+      "target_sub_2": "我唯有死死气爬返上个组合柜"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "连守在灵魂旁边的天使都醒过来",
-      "src_1_sub_2": "围住这香而圣洁的肉⋯",
-      "src_2_sub_1": "就连守喺灵魂旁边嘅天使都醒咗起嚟",
-      "src_2_sub_2": "围住呢一嚿好香好香又好盛洁嘅肉"
+      "ref_sub_1": "我只有死死气再爬上组合柜",
+      "ref_sub_2": "我咁大个仔，什么「头」也给骂过⋯",
+      "target_sub_1": "我唯有死死气爬返上个组合柜",
+      "target_sub_2": "我咁大个仔乜嘢头都畀人闹过"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "围住这香而圣洁的肉⋯",
-      "src_1_sub_2": "在圣诞夜中飞呀，飞⋯",
-      "src_2_sub_1": "围住呢一嚿好香好香又好盛洁嘅肉",
-      "src_2_sub_2": "喺圣诞夜里面飞呀飞呀"
+      "ref_sub_1": "我咁大个仔，什么「头」也给骂过⋯",
+      "ref_sub_2": "不知道为什么「珊你个头」却特别刺耳",
+      "target_sub_1": "我咁大个仔乜嘢头都畀人闹过",
+      "target_sub_2": "但系山呢个头唔知点解特别瘾"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "在圣诞夜中飞呀，飞⋯",
-      "src_1_sub_2": "这关于火鸡的一切，不过是我的想像",
-      "src_2_sub_1": "喺圣诞夜里面飞呀飞呀",
-      "src_2_sub_2": "但系呢一切一切关于火鸡嘅嘢都不过系我嘅想像"
+      "ref_sub_1": "不知道为什么「珊你个头」却特别刺耳",
+      "ref_sub_2": "我⋯我⋯",
+      "target_sub_1": "但系山呢个头唔知点解特别瘾",
+      "target_sub_2": "我我"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "这关于火鸡的一切，不过是我的想像",
-      "src_1_sub_2": "我从来没吃过火鸡⋯",
-      "src_2_sub_1": "但系呢一切一切关于火鸡嘅嘢都不过系我嘅想像",
-      "src_2_sub_2": "因为我从来都未食过火鸡"
+      "ref_sub_1": "我⋯我⋯",
+      "ref_sub_2": "我唔学抢包山了！",
+      "target_sub_1": "我我",
+      "target_sub_2": "我唔好抢包纱嘞字幕由纱友提供"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我从来没吃过火鸡⋯",
-      "src_1_sub_2": "连它的气味也没嗅过",
-      "src_2_sub_1": "因为我从来都未食过火鸡",
-      "src_2_sub_2": "就连嗰阵味都未闻过"
+      "ref_sub_1": "其实今天是我第一次近距离见黎根",
+      "ref_sub_2": "他恐怕都有五十岁了",
+      "target_sub_1": "其实今日系我第一次咁近距离同丽根见面",
+      "target_sub_2": "睇怕佢都有五十岁啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "连它的气味也没嗅过",
-      "src_1_sub_2": "妈妈说火鸡太大",
-      "src_2_sub_1": "就连嗰阵味都未闻过",
-      "src_2_sub_2": "妈妈话火鸡太大"
+      "ref_sub_1": "他恐怕都有五十岁了",
+      "ref_sub_2": "却还是一副孩子脸",
+      "target_sub_1": "睇怕佢都有五十岁啦",
+      "target_sub_2": "但系仲有一副孩子脸"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈说火鸡太大",
-      "src_1_sub_2": "我们一家两口，吃不下",
-      "src_2_sub_1": "妈妈话火鸡太大",
-      "src_2_sub_2": "我哋一家两口点食都食唔晒"
+      "ref_sub_1": "却还是一副孩子脸",
+      "ref_sub_2": "鸡尾包！新鲜出炉！",
+      "target_sub_1": "但系仲有一副孩子脸",
+      "target_sub_2": "鸡尾包啱啱出炉嘅"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我们一家两口，吃不下",
-      "src_1_sub_2": "有年圣诞节妈妈买了半只烧鸭庆祝",
-      "src_2_sub_1": "我哋一家两口点食都食唔晒",
-      "src_2_sub_2": "有一年圣诞节妈妈买咗半边烧鸭庆祝"
+      "ref_sub_1": "其实鸡尾包呢⋯",
+      "ref_sub_2": "你说这似不似鸡尾？",
+      "target_sub_1": "其实鸡尾爆呢",
+      "target_sub_2": "吓你话噉样似唔似鸡尾呀哈哈哈哈"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "有年圣诞节妈妈买了半只烧鸭庆祝",
-      "src_1_sub_2": "当时的我，十分十分失望",
-      "src_2_sub_1": "有一年圣诞节妈妈买咗半边烧鸭庆祝",
-      "src_2_sub_2": "当时我真系十分十分之失望"
+      "ref_sub_1": "麦兜他学东西⋯还可以",
+      "ref_sub_2": "黎根接著说了一大堆话⋯",
+      "target_sub_1": "麦兜嘅学嘢呢都仲可以",
+      "target_sub_2": "跟住黎根讲咗一大堆说话"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "当时的我，十分十分失望",
-      "src_1_sub_2": "又有一年，一间百货公司结业",
-      "src_2_sub_1": "当时我真系十分十分之失望",
-      "src_2_sub_2": "又有一年有间大薄货公司倒闭"
+      "ref_sub_1": "黎根接著说了一大堆话⋯",
+      "ref_sub_2": "他的抱负，他对麦兜的期望",
+      "target_sub_1": "跟住黎根讲咗一大堆说话",
+      "target_sub_2": "讲下佢嘅抱负佢对麦兜嘅期望"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "又有一年，一间百货公司结业",
-      "src_1_sub_2": "妈妈以四折买了个小小焗炉",
-      "src_2_sub_1": "又有一年有间大薄货公司倒闭",
-      "src_2_sub_2": "妈妈用四折买咗个焗炉仔返屋企"
+      "ref_sub_1": "他的抱负，他对麦兜的期望",
+      "ref_sub_2": "他说他会把他所识的毫不保留教给麦兜",
+      "target_sub_1": "讲下佢嘅抱负佢对麦兜嘅期望",
+      "target_sub_2": "佢话会将佢识嘅嘢毫无保留噉教晒畀麦兜"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈以四折买了个小小焗炉",
-      "src_1_sub_2": "可能因为买了焗炉而技痒",
-      "src_2_sub_1": "妈妈用四折买咗个焗炉仔返屋企",
-      "src_2_sub_2": "可能系因为买咗焗炉嘅样"
+      "ref_sub_1": "他说他会把他所识的毫不保留教给麦兜",
+      "ref_sub_2": "黎根越说越兴奋，直到双眼发光",
+      "target_sub_1": "佢话会将佢识嘅嘢毫无保留噉教晒畀麦兜",
+      "target_sub_2": "黎根越讲越兴奋"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "可能因为买了焗炉而技痒",
-      "src_1_sub_2": "那日妈妈竟然跟我说⋯",
-      "src_2_sub_1": "可能系因为买咗焗炉嘅样",
-      "src_2_sub_2": "嗰日妈妈竟然同我讲"
+      "ref_sub_1": "黎根越说越兴奋，直到双眼发光",
+      "ref_sub_2": "他又说滑浪风帆并不是他最犀利的项目",
+      "target_sub_1": "黎根越讲越兴奋",
+      "target_sub_2": "佢话滑浪风帆都唔系佢最犀利嗰样"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "那日妈妈竟然跟我说⋯",
-      "src_1_sub_2": "让我们明天去超级市场揪火鸡",
-      "src_2_sub_1": "嗰日妈妈竟然同我讲",
-      "src_2_sub_2": "佢话明日我哋要超级市场抽火鸡"
+      "ref_sub_1": "他又说滑浪风帆并不是他最犀利的项目",
+      "ref_sub_2": "他最大强项是抢包山",
+      "target_sub_1": "佢话滑浪风帆都唔系佢最犀利嗰样",
+      "target_sub_2": "佢最劲嘅就系抢包山"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "他最大强项是抢包山",
+      "ref_sub_2": "他说抢包山结合了南拳",
+      "target_sub_1": "佢最劲嘅就系抢包山",
+      "target_sub_2": "佢话抢包山结合咗南拳"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "他说抢包山结合了南拳",
+      "ref_sub_2": "神功戏和现代器械操",
+      "target_sub_1": "佢话抢包山结合咗南拳",
+      "target_sub_2": "神功气现代气蟹粗"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "神功戏和现代器械操",
+      "ref_sub_2": "他说抢包山才是他一生最大成就",
+      "target_sub_1": "神功气现代气蟹粗",
+      "target_sub_2": "佢话抢包山先至系佢呢世人最大嘅成就"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "他说抢包山才是他一生最大成就",
+      "ref_sub_2": "缩脚，唔该！",
+      "target_sub_1": "佢话抢包山先至系佢呢世人最大嘅成就",
+      "target_sub_2": "缩嗰只脚唔该"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "缩脚，唔该！",
+      "ref_sub_2": "你看！",
+      "target_sub_1": "缩嗰只脚唔该",
+      "target_sub_2": "你睇下"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "你看！",
+      "ref_sub_2": "这脚瓜⋯好粗好大！比一节瓜还要大！",
+      "target_sub_1": "你睇下",
+      "target_sub_2": "哗呢节呢节脚瓜好粗好大呀仲大过节瓜"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "这脚瓜⋯好粗好大！比一节瓜还要大！",
+      "ref_sub_2": "脚瓜的肌肉非常结实⋯",
+      "target_sub_1": "哗呢节呢节脚瓜好粗好大呀仲大过节瓜",
+      "target_sub_2": "脚瓜嘅肌肉非常结实"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "脚瓜的肌肉非常结实⋯",
+      "ref_sub_2": "青筋凸现，钢线似的",
+      "target_sub_1": "脚瓜嘅肌肉非常结实",
+      "target_sub_2": "啲青筋凸晒出嚟好似钢线噉"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "青筋凸现，钢线似的",
+      "ref_sub_2": "每一条脚毛都硬似铁钉",
+      "target_sub_1": "啲青筋凸晒出嚟好似钢线噉",
+      "target_sub_2": "啲脚毛每一条都好似铁钉咁硬"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "每一条脚毛都硬似铁钉",
+      "ref_sub_2": "脚趾甲有一寸厚，究竟⋯",
+      "target_sub_1": "啲脚毛每一条都好似铁钉咁硬",
+      "target_sub_2": "脚趾弓啲脚夹成串咁厚"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "脚趾甲有一寸厚，究竟⋯",
+      "ref_sub_2": "要走过几多座山",
+      "target_sub_1": "脚趾弓啲脚夹成串咁厚",
+      "target_sub_2": "究竟要行个几度呢?"
     },
     "answer": {
-      "src_2_sub_1_shifted": "嗰日妈妈竟然同我讲佢话",
-      "src_2_sub_2_shifted": "明日我哋要超级市场抽火鸡"
+      "target_sub_1_shifted": "脚趾弓啲脚夹成串咁厚究竟",
+      "target_sub_2_shifted": "要行个几度呢?"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "让我们明天去超级市场揪火鸡",
-      "src_1_sub_2": "我跟妈妈把火鸡揪回家的路上⋯",
-      "src_2_sub_1": "明日我哋要超级市场抽火鸡",
-      "src_2_sub_2": "我同妈妈抽住只火鸡行返屋企嗰阵"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我跟妈妈把火鸡揪回家的路上⋯",
-      "src_1_sub_2": "是我生命中最开心的时刻",
-      "src_2_sub_1": "我同妈妈抽住只火鸡行返屋企嗰阵",
-      "src_2_sub_2": "喺嗰阵时我谂系我生命里面最开心嘅一刻"
+      "ref_sub_1": "要走过几多座山",
+      "ref_sub_2": "跨过几多个海",
+      "target_sub_1": "要行个几度呢?",
+      "target_sub_2": "几多座山挂过几多个海"
     },
     "answer": {
-      "src_2_sub_1_shifted": "我同妈妈抽住只火鸡行返屋企嗰阵喺嗰阵时",
-      "src_2_sub_2_shifted": "我谂系我生命里面最开心嘅一刻"
+      "target_sub_1_shifted": "要行个几度呢?几多座山",
+      "target_sub_2_shifted": "挂过几多个海"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "是我生命中最开心的时刻",
-      "src_1_sub_2": "火鸡终于解冻了",
-      "src_2_sub_1": "我谂系我生命里面最开心嘅一刻",
-      "src_2_sub_2": "火鸡终于解冻啦"
+      "ref_sub_1": "跨过几多个海",
+      "ref_sub_2": "吃过几多苦头",
+      "target_sub_1": "挂过几多个海",
+      "target_sub_2": "挨过几多斧头"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "火鸡终于解冻了",
-      "src_1_sub_2": "我学著妈妈，把双手涂满盐⋯",
-      "src_2_sub_1": "火鸡终于解冻啦",
-      "src_2_sub_2": "我同妈妈噉双手查满盐"
+      "ref_sub_1": "吃过几多苦头",
+      "ref_sub_2": "才可以练成这举世无双的脚瓜？",
+      "target_sub_1": "挨过几多斧头",
+      "target_sub_2": "先至可以练成呢一只举细无伤嘅脚瓜"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我学著妈妈，把双手涂满盐⋯",
-      "src_1_sub_2": "在火鸡丰厚的鸡胸上擦呀，擦",
-      "src_2_sub_1": "我同妈妈噉双手查满盐",
-      "src_2_sub_2": "喺火鸡封口嘅鸡胸度起细噉啫啫"
+      "ref_sub_1": "我个仔⋯",
+      "ref_sub_2": "你个仔，他日都会有这只大脚瓜",
+      "target_sub_1": "我个仔",
+      "target_sub_2": "你个仔第时都会有我咁大只脚瓜"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "在火鸡丰厚的鸡胸上擦呀，擦",
-      "src_1_sub_2": "联火鸡时⋯",
-      "src_2_sub_1": "喺火鸡封口嘅鸡胸度起细噉啫啫"
+      "ref_sub_1": "你个仔，他日都会有这只大脚瓜",
+      "ref_sub_2": "其实我也不知道个仔要这么粗的脚瓜⋯",
+      "target_sub_1": "你个仔第时都会有我咁大只脚瓜",
+      "target_sub_2": "其实我都唔知我仔要咁粗嘅脚瓜有咩用"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "联火鸡时⋯",
-      "src_1_sub_2": "妈妈不留神漏出了火鸡内的洋葱粒",
-      "src_2_sub_2": "联火鸡时妈妈一个唔觉意畀酿喺火鸡里面嘅火鸡内脏洋葱粒"
+      "ref_sub_1": "其实我也不知道个仔要这么粗的脚瓜⋯",
+      "ref_sub_2": "有什么用",
+      "target_sub_1": "其实我都唔知我仔要咁粗嘅脚瓜有咩用"
     },
     "answer": {
-      "src_2_sub_1_shifted": "联火鸡时",
-      "src_2_sub_2_shifted": "妈妈一个唔觉意畀酿喺火鸡里面嘅火鸡内脏洋葱粒"
+      "target_sub_1_shifted": "其实我都唔知我仔要咁粗嘅脚瓜",
+      "target_sub_2_shifted": "有咩用"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈不留神漏出了火鸡内的洋葱粒",
-      "src_1_sub_2": "红萝卜粒",
-      "src_2_sub_1": "妈妈一个唔觉意畀酿喺火鸡里面嘅火鸡内脏洋葱粒",
-      "src_2_sub_2": "红萝虾粒流嘅出嚟"
+      "ref_sub_1": "你个仔，他日都会有这只大脚瓜",
+      "ref_sub_2": "其实我也不知道个仔要这么粗的脚瓜⋯",
+      "target_sub_1": "你个仔第时都会有我咁大只脚瓜",
+      "target_sub_2": "其实我都唔知我仔要咁粗嘅脚瓜"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "红萝卜粒",
-      "src_1_sub_2": "我说：火鸡「屙烂煮」！",
-      "src_2_sub_1": "红萝虾粒流嘅出嚟",
-      "src_2_sub_2": "我话火鸡我能住呀"
+      "ref_sub_1": "其实我也不知道个仔要这么粗的脚瓜⋯",
+      "ref_sub_2": "有什么用",
+      "target_sub_1": "其实我都唔知我仔要咁粗嘅脚瓜",
+      "target_sub_2": "有咩用"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我说：火鸡「屙烂煮」！",
-      "src_1_sub_2": "好勉强把火鸡塞进焗炉内",
-      "src_2_sub_1": "我话火鸡我能住呀",
-      "src_2_sub_2": "火鸡好勉强噏咗入焗炉度"
+      "ref_sub_1": "有什么用",
+      "ref_sub_2": "可是看见那些凸现的青筋，不知怎样⋯",
+      "target_sub_1": "有咩用",
+      "target_sub_2": "但系见到佢一条条凸起嘅青筋唔知点解"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "好勉强把火鸡塞进焗炉内",
-      "src_1_sub_2": "12月24日",
-      "src_2_sub_1": "火鸡好勉强噏咗入焗炉度",
-      "src_2_sub_2": "10月24日"
+      "ref_sub_1": "可是看见那些凸现的青筋，不知怎样⋯",
+      "ref_sub_2": "我想起麦兜的爸爸，阿炳",
+      "target_sub_1": "但系见到佢一条条凸起嘅青筋唔知点解",
+      "target_sub_2": "我我谂起麦兜嘅爸爸阿炳"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "12月24日",
-      "src_1_sub_2": "上升的白烟跟奇异的焦味拨动星星",
-      "src_2_sub_1": "10月24日",
-      "src_2_sub_2": "上升嘅白烟同奇异嘅㶶味拨动声声"
+      "ref_sub_1": "我找来找去也找不到那部电子英文辞典",
+      "ref_sub_2": "跑哪去了？",
+      "target_sub_1": "我揾完成间屋都揾唔到部电子英文词典",
+      "target_sub_2": "去咗边呢"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "上升的白烟跟奇异的焦味拨动星星",
-      "src_1_sub_2": "焗炉戚戚恻恻，戚戚恻恻⋯",
-      "src_2_sub_1": "上升嘅白烟同奇异嘅㶶味拨动声声",
-      "src_2_sub_2": "个焗炉叱叱叱叱叱叱叱咁"
+      "ref_sub_1": "跑哪去了？",
+      "ref_sub_2": "难道⋯不会吧？",
+      "target_sub_1": "去咗边呢",
+      "target_sub_2": "唔通冇理由㗎"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "焗炉戚戚恻恻，戚戚恻恻⋯",
-      "src_1_sub_2": "有如天使预早送来的福音",
-      "src_2_sub_1": "个焗炉叱叱叱叱叱叱叱咁",
-      "src_2_sub_2": "就好似天赐预祖畀我哋嘅福音"
+      "ref_sub_1": "想不到真的让妈妈拿去了。吓得我！",
+      "ref_sub_2": "妈妈怎么会写起英文信？",
+      "target_sub_1": "咦估唔到真系妈妈攞咗㖞吓得我啊",
+      "target_sub_2": "点解妈妈会用英文写信嘅"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "好靓的晚上啊！",
-      "src_1_sub_2": "我和妈妈坐在尖东海傍",
-      "src_2_sub_1": "好靓嘅夜晚呀",
-      "src_2_sub_2": "我同妈妈坐喺尖东海旁"
+      "ref_sub_1": "妈妈怎么会写起英文信？",
+      "ref_sub_2": "信很短",
+      "target_sub_1": "点解妈妈会用英文写信嘅",
+      "target_sub_2": "封信好短"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我和妈妈坐在尖东海傍",
-      "src_1_sub_2": "点点灯光在海面走来走去⋯",
-      "src_2_sub_1": "我同妈妈坐喺尖东海旁",
-      "src_2_sub_2": "点点点点嘅灯光喺海上面走来走去"
+      "ref_sub_1": "信很短",
+      "ref_sub_2": "我猜是妈妈用电子辞典逐个字译成英文",
+      "target_sub_1": "封信好短",
+      "target_sub_2": "我谂妈妈佢系好辛苦用电子词典逐个逐个字译做英文"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "点点灯光在海面走来走去⋯",
-      "src_1_sub_2": "美丽又温柔",
-      "src_2_sub_1": "点点点点嘅灯光喺海上面走来走去",
-      "src_2_sub_2": "又靓又温柔"
+      "ref_sub_1": "我猜是妈妈用电子辞典逐个字译成英文",
+      "ref_sub_2": "于是我又用电子辞典把信译回中文",
+      "target_sub_1": "我谂妈妈佢系好辛苦用电子词典逐个逐个字译做英文",
+      "target_sub_2": "于是我让返电子词典将封信译返做中文"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "美丽又温柔",
-      "src_1_sub_2": "真的好靓！",
-      "src_2_sub_1": "又靓又温柔",
-      "src_2_sub_2": "真系好靓"
+      "ref_sub_1": "于是我又用电子辞典把信译回中文",
+      "ref_sub_2": "信，是妈妈写给奥委会主席的",
+      "target_sub_1": "于是我让返电子词典将封信译返做中文",
+      "target_sub_2": "封信原来系妈妈写畀奥委会主席㗎"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我从没吃过这么浓味的东西",
-      "src_1_sub_2": "甚至杯面，烧鸭的味道也没有这么浓",
-      "src_2_sub_1": "我从未食过咁浓味嘅嘢",
-      "src_2_sub_2": "连烧鸭连杯面都冇咁浓嘅味道"
+      "ref_sub_1": "信，是妈妈写给奥委会主席的",
+      "ref_sub_2": "「亲爱的主席：」",
+      "target_sub_1": "封信原来系妈妈写畀奥委会主席㗎",
+      "target_sub_2": "亲爱的主席"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "甚至杯面，烧鸭的味道也没有这么浓",
-      "src_1_sub_2": "火鸡的味道把我每一个味蕾缠住⋯",
-      "src_2_sub_1": "连烧鸭连杯面都冇咁浓嘅味道",
-      "src_2_sub_2": "火鸡嘅味道喺我嘅每一个味蕾度缠住"
+      "ref_sub_1": "「亲爱的主席：」",
+      "ref_sub_2": "「你好吗？我很好！」",
+      "target_sub_1": "亲爱的主席",
+      "target_sub_2": "你好吗我很好"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "火鸡的味道把我每一个味蕾缠住⋯",
-      "src_1_sub_2": "爆发⋯缠住⋯爆发⋯",
-      "src_2_sub_1": "火鸡嘅味道喺我嘅每一个味蕾度缠住",
-      "src_2_sub_2": "爆发缠住爆发"
+      "ref_sub_1": "「你好吗？我很好！」",
+      "ref_sub_2": "「你吃包吗？我吃包！」",
+      "target_sub_1": "你好吗我很好",
+      "target_sub_2": "你吃包吗我吃包"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "爆发⋯缠住⋯爆发⋯",
-      "src_1_sub_2": "就像今晚的一切",
-      "src_2_sub_1": "爆发缠住爆发",
-      "src_2_sub_2": "就好似今晚嘅嘢噉"
+      "ref_sub_1": "「你吃包吗？我吃包！」",
+      "ref_sub_2": "「我们居住在香港这里的人，很爱吃包」",
+      "target_sub_1": "你吃包吗我吃包",
+      "target_sub_2": "我门居住在香港这类的人肯爱吃包"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "就像今晚的一切",
-      "src_1_sub_2": "最靓最靓，最犀利，而且最温柔",
-      "src_2_sub_1": "就好似今晚嘅嘢噉",
-      "src_2_sub_2": "最靓最靓最犀利亦都系最温柔"
+      "ref_sub_1": "「我们居住在香港这里的人，很爱吃包」",
+      "ref_sub_2": "「小笼包，上海包，广东包，莲蓉包」",
+      "target_sub_1": "我门居住在香港这类的人肯爱吃包",
+      "target_sub_2": "小笼包上海包广东包联融包"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "第二天我睡得很晏⋯",
-      "src_1_sub_2": "刷过牙我还感觉到火鸡的美味",
-      "src_2_sub_1": "第二日我瞓到好硬",
-      "src_2_sub_2": "测完牙我仲感觉到火鸡嘅美味"
+      "ref_sub_1": "「小笼包，上海包，广东包，莲蓉包」",
+      "ref_sub_2": "「好朋友，我认为",
+      "target_sub_1": "小笼包上海包广东包联融包",
+      "target_sub_2": "好朋友"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "刷过牙我还感觉到火鸡的美味",
-      "src_1_sub_2": "因为早餐吃得晚⋯",
-      "src_2_sub_1": "测完牙我仲感觉到火鸡嘅美味",
-      "src_2_sub_2": "因为早餐食得硬"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "因为早餐吃得晚⋯",
-      "src_1_sub_2": "午餐时妈妈只煮了罐粟米汤",
-      "src_2_sub_1": "因为早餐食得硬",
-      "src_2_sub_2": "唔餐妈妈净系整咗罐粟米汤畀我"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "午餐时妈妈只煮了罐粟米汤",
-      "src_1_sub_2": "我用汤匙撩了两下",
-      "src_2_sub_1": "唔餐妈妈净系整咗罐粟米汤畀我",
-      "src_2_sub_2": "我系噉用匙羹撩下撩下"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我用汤匙撩了两下",
-      "src_1_sub_2": "竟然发现美味的火鸡粒",
-      "src_2_sub_1": "我系噉用匙羹撩下撩下",
-      "src_2_sub_2": "我竟然撩到一粒美味嘅火鸡肉"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "竟然发现美味的火鸡粒",
-      "src_1_sub_2": "不用说，那夜就是我渴望了⋯",
-      "src_2_sub_1": "我竟然撩到一粒美味嘅火鸡肉",
-      "src_2_sub_2": "嗰晚唔使讲"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "不用说，那夜就是我渴望了⋯",
-      "src_1_sub_2": "很久很久很久的⋯圣诞火鸡大餐！",
-      "src_2_sub_1": "嗰晚唔使讲",
-      "src_2_sub_2": "当然系食我限咗好耐好耐好耐好耐嘅圣诞火鸡大餐"
+      "ref_sub_1": "「好朋友，我认为",
+      "ref_sub_2": "抢劫那些包，十分重要」",
+      "target_sub_1": "好朋友",
+      "target_sub_2": "我认为抢劫嗰些包十分重要"
     },
     "answer": {
-      "src_2_sub_1_shifted": "嗰晚唔使讲当然系食我限咗",
-      "src_2_sub_2_shifted": "好耐好耐好耐好耐嘅圣诞火鸡大餐"
+      "target_sub_1_shifted": "好朋友我认为",
+      "target_sub_2_shifted": "抢劫嗰些包十分重要"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "竟然发现美味的火鸡粒",
-      "src_1_sub_2": "不用说，那夜就是我渴望了⋯",
-      "src_2_sub_1": "我竟然撩到一粒美味嘅火鸡肉",
-      "src_2_sub_2": "嗰晚唔使讲当然系食我限咗"
+      "ref_sub_1": "抢劫那些包，十分重要」",
+      "ref_sub_2": "「也算是运动，就真！」",
+      "target_sub_1": "抢劫嗰些包十分重要",
+      "target_sub_2": "也算是运动就真"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "不用说，那夜就是我渴望了⋯",
-      "src_1_sub_2": "很久很久很久的⋯圣诞火鸡大餐！",
-      "src_2_sub_1": "嗰晚唔使讲当然系食我限咗",
-      "src_2_sub_2": "好耐好耐好耐好耐嘅圣诞火鸡大餐"
+      "ref_sub_1": "「也算是运动，就真！」",
+      "ref_sub_2": "「要大力！大吃晚上的粥，和大节瓜！」",
+      "target_sub_1": "也算是运动就真",
+      "target_sub_2": "要大力大吃吻上的粥和大字瓜"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "很久很久很久的⋯圣诞火鸡大餐！",
-      "src_1_sub_2": "一片片的火鸡肉和伴碟的薯仔和节瓜⋯",
-      "src_2_sub_1": "好耐好耐好耐好耐嘅圣诞火鸡大餐",
-      "src_2_sub_2": "一片一片嘅火鸡肉半碟嘅有薯仔同节瓜"
+      "ref_sub_1": "「要大力！大吃晚上的粥，和大节瓜！」",
+      "ref_sub_2": "「按照我愚蠢的见解⋯」",
+      "target_sub_1": "要大力大吃吻上的粥和大字瓜",
+      "target_sub_2": "按照我愚蠢的见解"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "一片片的火鸡肉和伴碟的薯仔和节瓜⋯",
-      "src_1_sub_2": "上面淋了老抽生粉献",
-      "src_2_sub_1": "一片一片嘅火鸡肉半碟嘅有薯仔同节瓜",
-      "src_2_sub_2": "上面淋咗一层老抽生粉馅"
+      "ref_sub_1": "「按照我愚蠢的见解⋯」",
+      "ref_sub_2": "「抢劫那些包，是奥运会比赛」",
+      "target_sub_1": "按照我愚蠢的见解",
+      "target_sub_2": "抢劫嗰些包系奥运会比赛"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "上面淋了老抽生粉献",
-      "src_1_sub_2": "我们真的好兴奋，好满足",
-      "src_2_sub_1": "上面淋咗一层老抽生粉馅",
-      "src_2_sub_2": "我哋真系好兴奋好满足"
+      "ref_sub_1": "「抢劫那些包，是奥运会比赛」",
+      "ref_sub_2": "「让全世界的体育家，抢过！」",
+      "target_sub_1": "抢劫嗰些包系奥运会比赛",
+      "target_sub_2": "让全世界嘅体育家抢过"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我们真的好兴奋，好满足",
-      "src_1_sub_2": "之后，我们吃了一个星期的⋯",
-      "src_2_sub_1": "我哋真系好兴奋好满足"
+      "ref_sub_1": "「让全世界的体育家，抢过！」",
+      "ref_sub_2": "「世界便和平！」",
+      "target_sub_1": "让全世界嘅体育家抢过",
+      "target_sub_2": "世界变和平"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "之后，我们吃了一个星期的⋯",
-      "src_1_sub_2": "火鸡三文治早餐",
-      "src_2_sub_2": "之后我哋仲食咗一个礼拜嘅火鸡三文治做早餐"
+      "ref_sub_1": "「世界便和平！」",
+      "ref_sub_2": "「你有孩子吗？」",
+      "target_sub_1": "世界变和平",
+      "target_sub_2": "你有孩子吗"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "「你有孩子吗？」",
+      "ref_sub_2": "「我有一个孩子，麦兜」",
+      "target_sub_1": "你有孩子吗",
+      "target_sub_2": "我有一个孩子麦兜"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "「我有一个孩子，麦兜」",
+      "ref_sub_2": "终于讲到我了！",
+      "target_sub_1": "我有一个孩子麦兜",
+      "target_sub_2": "终于讲到我啦"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "终于讲到我了！",
+      "ref_sub_2": "「他是一个好男孩」",
+      "target_sub_1": "终于讲到我啦",
+      "target_sub_2": "她系一个好男孩"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "「他是一个好男孩」",
+      "ref_sub_2": "「他非常懂得抢劫那些包」",
+      "target_sub_1": "她系一个好男孩",
+      "target_sub_2": "她非常懂得抢劫嗰些包"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "「他非常懂得抢劫那些包」",
+      "ref_sub_2": "「有一天，我看见他，抢劫包⋯」",
+      "target_sub_1": "她非常懂得抢劫嗰些包",
+      "target_sub_2": "有一天我看见她抢劫包"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "「有一天，我看见他，抢劫包⋯」",
+      "ref_sub_2": "「抢了一个奥运金牌」",
+      "target_sub_1": "有一天我看见她抢劫包",
+      "target_sub_2": "抢了一个奥运金牌"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "「抢了一个奥运金牌」",
+      "ref_sub_2": "「那便是一个母亲能够有的最大的安慰」",
+      "target_sub_1": "抢了一个奥运金牌",
+      "target_sub_2": "哪便是一个母亲能够有的最好的最大的安慰"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "「那便是一个母亲能够有的最大的安慰」",
+      "ref_sub_2": "「孩子的才干，得到了世界人类的知道」",
+      "target_sub_1": "哪便是一个母亲能够有的最好的最大的安慰",
+      "target_sub_2": "孩子的才干得到了世界人类的知道"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "「孩子的才干，得到了世界人类的知道」",
+      "ref_sub_2": "「父母愿意做什么的东西都得」",
+      "target_sub_1": "孩子的才干得到了世界人类的知道",
+      "target_sub_2": "父母愿意做什么的东西都得"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "「父母愿意做什么的东西都得」",
+      "ref_sub_2": "「于是我写了这忽然间的信给你」",
+      "target_sub_1": "父母愿意做什么的东西都得",
+      "target_sub_2": "于是我写了这忽然间的信给你"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "「于是我写了这忽然间的信给你」",
+      "ref_sub_2": "「虽然你不知道我是什么微细的东西」",
+      "target_sub_1": "于是我写了这忽然间的信给你",
+      "target_sub_2": "虽然你不知道我是什么微细的东西"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "「虽然你不知道我是什么微细的东西」",
+      "ref_sub_2": "「但我的孩子很大，很大！」",
+      "target_sub_1": "虽然你不知道我是什么微细的东西",
+      "target_sub_2": "但我的孩子很大很大"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "「但我的孩子很大，很大！」",
+      "ref_sub_2": "「有一天，你都会知道」",
+      "target_sub_1": "但我的孩子很大很大",
+      "target_sub_2": "有一天你都会知道"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "「有一天，你都会知道」",
+      "ref_sub_2": "「多谢合作！」",
+      "target_sub_1": "有一天你都会知道",
+      "target_sub_2": "多谢合作"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "「多谢合作！」",
+      "ref_sub_2": "「你忠实的，麦太」",
+      "target_sub_1": "多谢合作",
+      "target_sub_2": "你忠实的麦太"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "看完妈妈的信",
+      "ref_sub_2": "我决定回长洲继续学抢包山",
+      "target_sub_1": "睇完妈妈封信后",
+      "target_sub_2": "我决定返长洲继续抢包生"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我决定回长洲继续学抢包山",
+      "ref_sub_2": "我不是为了见珊珊",
+      "target_sub_1": "我决定返长洲继续抢包生",
+      "target_sub_2": "我唔系为咗见到山神"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我不是为了见珊珊",
+      "ref_sub_2": "我并不知道为什么要抢那些包",
+      "target_sub_1": "我唔系为咗见到山神",
+      "target_sub_2": "我唔知点解要抢嗰啲包"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我并不知道为什么要抢那些包",
+      "ref_sub_2": "我也不相信抢包山会成为奥运项目",
+      "target_sub_1": "我唔知点解要抢嗰啲包",
+      "target_sub_2": "我亦唔信抢包生会成为奥运项目"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我也不相信抢包山会成为奥运项目",
+      "ref_sub_2": "可是，我依然努力练习抢包山",
+      "target_sub_1": "我亦唔信抢包生会成为奥运项目",
+      "target_sub_2": "但系我依然努力练习抢包生"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "可是，我依然努力练习抢包山",
+      "ref_sub_2": "因为，我爱我妈妈",
+      "target_sub_1": "但系我依然努力练习抢包生",
+      "target_sub_2": "因为我爱我妈妈"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "因为，我爱我妈妈",
+      "ref_sub_2": "师傅说我攀爬功夫已经不错",
+      "target_sub_1": "因为我爱我妈妈",
+      "target_sub_2": "师傅话我嘅攀爬功夫已经唔错"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "师傅说我攀爬功夫已经不错",
+      "ref_sub_2": "可以开始教我「十二路抢包手」",
+      "target_sub_1": "师傅话我嘅攀爬功夫已经唔错",
+      "target_sub_2": "可以开始教我十二路抢包手"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "可以开始教我「十二路抢包手」",
+      "ref_sub_2": "师傅说当年师祖耍出这套",
+      "target_sub_1": "可以开始教我十二路抢包手",
+      "target_sub_2": "师傅话"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "师傅说当年师祖耍出这套",
+      "ref_sub_2": "「十二路抢包手」⋯",
+      "target_sub_1": "师傅话",
+      "target_sub_2": "当年师祖使出呢套十二路抢包手"
     },
     "answer": {
-      "src_2_sub_1_shifted": "之后我哋仲食咗一个礼拜嘅",
-      "src_2_sub_2_shifted": "火鸡三文治做早餐"
+      "target_sub_1_shifted": "师傅话当年师祖使出呢套",
+      "target_sub_2_shifted": "十二路抢包手"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我们真的好兴奋，好满足",
-      "src_1_sub_2": "之后，我们吃了一个星期的⋯",
-      "src_2_sub_1": "我哋真系好兴奋好满足",
-      "src_2_sub_2": "之后我哋仲食咗一个礼拜嘅"
+      "ref_sub_1": "可以开始教我「十二路抢包手」",
+      "ref_sub_2": "师傅说当年师祖耍出这套",
+      "target_sub_1": "可以开始教我十二路抢包手",
+      "target_sub_2": "师傅话当年师祖使出呢套"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "之后，我们吃了一个星期的⋯",
-      "src_1_sub_2": "火鸡三文治早餐",
-      "src_2_sub_1": "之后我哋仲食咗一个礼拜嘅",
-      "src_2_sub_2": "火鸡三文治做早餐"
+      "ref_sub_1": "师傅说当年师祖耍出这套",
+      "ref_sub_2": "「十二路抢包手」⋯",
+      "target_sub_1": "师傅话当年师祖使出呢套",
+      "target_sub_2": "十二路抢包手"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "火鸡三文治早餐",
-      "src_1_sub_2": "星期天",
-      "src_2_sub_1": "火鸡三文治做早餐",
-      "src_2_sub_2": "星期日"
+      "ref_sub_1": "「十二路抢包手」⋯",
+      "ref_sub_2": "连林世荣也大大赞好",
+      "target_sub_1": "十二路抢包手",
+      "target_sub_2": "连林世荣睇见都大赞老爷"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "星期天",
-      "src_1_sub_2": "我大著胆跟妈妈说：不如去饮茶吖",
-      "src_2_sub_1": "星期日",
-      "src_2_sub_2": "我嘅记心肝同妈妈讲不如饮茶"
+      "ref_sub_1": "连林世荣也大大赞好",
+      "ref_sub_2": "后来麦唛告诉我⋯",
+      "target_sub_1": "连林世荣睇见都大赞老爷",
+      "target_sub_2": "后来默默话我知"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我大著胆跟妈妈说：不如去饮茶吖",
-      "src_1_sub_2": "妈妈骂我「冇衣食」⋯",
-      "src_2_sub_1": "我嘅记心肝同妈妈讲不如饮茶",
-      "src_2_sub_2": "妈妈闹我冇意食"
+      "ref_sub_1": "后来麦唛告诉我⋯",
+      "ref_sub_2": "林世荣即是猪肉荣，是黄飞鸿的徒弟",
+      "target_sub_1": "后来默默话我知",
+      "target_sub_2": "林世荣即系猪肉荣系黄飞鸿嘅徒弟"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈骂我「冇衣食」⋯",
-      "src_1_sub_2": "不过还是带了我去饮茶",
-      "src_2_sub_1": "妈妈闹我冇意食",
-      "src_2_sub_2": "但系都带咗我去饮茶"
+      "ref_sub_1": "林世荣即是猪肉荣，是黄飞鸿的徒弟",
+      "ref_sub_2": "我不知道师傅像不像黄飞鸿",
+      "target_sub_1": "林世荣即系猪肉荣系黄飞鸿嘅徒弟",
+      "target_sub_2": "我唔知到师傅似唔似黄飞鸿"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "不过还是带了我去饮茶",
-      "src_1_sub_2": "之后，妈妈又有计⋯",
-      "src_2_sub_1": "但系都带咗我去饮茶",
-      "src_2_sub_2": "之后妈妈又有计"
+      "ref_sub_1": "我不知道师傅像不像黄飞鸿",
+      "ref_sub_2": "我却肯定像一块猪肉",
+      "target_sub_1": "我唔知到师傅似唔似黄飞鸿",
+      "target_sub_2": "但系我就肯定似旧猪肉"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "之后，妈妈又有计⋯",
-      "src_1_sub_2": "她把冰箱内剩下来的火鸡肉撕呀撕",
-      "src_2_sub_1": "之后妈妈又有计",
-      "src_2_sub_2": "佢将雪柜净返嘅火鸡肉系噉撕系噉撕"
+      "ref_sub_1": "我却肯定像一块猪肉",
+      "ref_sub_2": "我是一块揸住两个包",
+      "target_sub_1": "但系我就肯定似旧猪肉",
+      "target_sub_2": "我就系一个揸住两个包"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "她把冰箱内剩下来的火鸡肉撕呀撕",
-      "src_1_sub_2": "有时候也叫我帮手撕",
-      "src_2_sub_1": "佢将雪柜净返嘅火鸡肉系噉撕系噉撕",
-      "src_2_sub_2": "有时都叫我帮手撕"
+      "ref_sub_1": "我是一块揸住两个包",
+      "ref_sub_2": "在长洲转来转去的猪肉",
+      "target_sub_1": "我就系一个揸住两个包",
+      "target_sub_2": "喺长洲转嚟转去嘅猪肉"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "有时候也叫我帮手撕",
-      "src_1_sub_2": "火鸡留在指甲的味道",
-      "src_2_sub_1": "有时都叫我帮手撕",
-      "src_2_sub_2": "火鸡留喺指甲嗰阵味"
+      "ref_sub_1": "在长洲转来转去的猪肉",
+      "ref_sub_2": "我一边练习，一边胡思乱想；始终⋯",
+      "target_sub_1": "喺长洲转嚟转去嘅猪肉",
+      "target_sub_2": "我一边练习一边乱练一边谂嘢始终"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "火鸡留在指甲的味道",
-      "src_1_sub_2": "原来得洗好多次",
-      "src_2_sub_1": "火鸡留喺指甲嗰阵味",
-      "src_2_sub_2": "原来洗好多次都仲喺度㗎"
+      "ref_sub_1": "我一边练习，一边胡思乱想；始终⋯",
+      "ref_sub_2": "我还是不大喜欢抢包",
+      "target_sub_1": "我一边练习一边乱练一边谂嘢始终",
+      "target_sub_2": "我都唔系咁钟意抢包"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "原来得洗好多次",
-      "src_1_sub_2": "银芽火鸡丝炒米，好味道",
-      "src_2_sub_1": "原来洗好多次都仲喺度㗎",
-      "src_2_sub_2": "银牙火鸡丝炒米好味道噉"
+      "ref_sub_1": "我还是不大喜欢抢包",
+      "ref_sub_2": "我只是爱我妈妈",
+      "target_sub_1": "我都唔系咁钟意抢包",
+      "target_sub_2": "我净系爱我妈妈"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "银芽火鸡丝炒米，好味道",
-      "src_1_sub_2": "栗子炆火鸡丝㷛",
-      "src_2_sub_1": "银牙火鸡丝炒米好味道噉",
-      "src_2_sub_2": "焯焯栗子焖火鸡丝煲"
+      "ref_sub_1": "我只是爱我妈妈",
+      "ref_sub_2": "于是我咬实牙根⋯",
+      "target_sub_1": "我净系爱我妈妈",
+      "target_sub_2": "于是我咬细牙根"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "栗子炆火鸡丝㷛",
-      "src_1_sub_2": "花生火鸡骨煲粥",
-      "src_2_sub_1": "焯焯栗子焖火鸡丝煲",
-      "src_2_sub_2": "花生火鸡骨煲粥"
+      "ref_sub_1": "于是我咬实牙根⋯",
+      "ref_sub_2": "一步一步，一爪一爪⋯",
+      "target_sub_1": "于是我咬细牙根",
+      "target_sub_2": "一步一步一爪一爪"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "花生火鸡骨煲粥",
-      "src_1_sub_2": "纸包火鸡包包纸",
-      "src_2_sub_1": "花生火鸡骨煲粥",
-      "src_2_sub_2": "纸包火鸡包包纸"
+      "ref_sub_1": "一步一步，一爪一爪⋯",
+      "ref_sub_2": "我最后终于练成「十二路抢包手」",
+      "target_sub_1": "一步一步一爪一爪",
+      "target_sub_2": "最后我终于练成十二路抢包手啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "纸包火鸡包包纸",
-      "src_1_sub_2": "包火鸡包包包火鸡包",
-      "src_2_sub_1": "纸包火鸡包包纸",
-      "src_2_sub_2": "包火鸡包包包火鸡包"
+      "ref_sub_1": "喂，我是麦兜",
+      "ref_sub_2": "刚才的是小朋友麦兜，我是大个佬麦兜",
+      "target_sub_1": "喂我系麦兜啊",
+      "target_sub_2": "正话嗰个系细路仔麦兜我系大个佬麦兜"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "包火鸡包包包火鸡包",
-      "src_1_sub_2": "酿火鸡馅搽面包",
-      "src_2_sub_1": "包火鸡包包包火鸡包",
-      "src_2_sub_2": "让火鸡馅茶面包"
+      "ref_sub_1": "刚才的是小朋友麦兜，我是大个佬麦兜",
+      "ref_sub_2": "小朋友麦兜和大个佬麦兜除了声音不同⋯",
+      "target_sub_1": "正话嗰个系细路仔麦兜我系大个佬麦兜",
+      "target_sub_2": "细路仔麦兜同大个佬麦兜除咗把声唔同之外"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "酿火鸡馅搽面包",
-      "src_1_sub_2": "唉，我好后悔讲过一句「火鸡屙烂煮」",
-      "src_2_sub_1": "让火鸡馅茶面包",
-      "src_2_sub_2": "唉我后悔讲过火鸡阿宁处呢句嘢"
+      "ref_sub_1": "小朋友麦兜和大个佬麦兜除了声音不同⋯",
+      "ref_sub_2": "小朋友麦兜的世界仍然有好多幻想",
+      "target_sub_1": "细路仔麦兜同大个佬麦兜除咗把声唔同之外",
+      "target_sub_2": "细路仔麦兜嘅世界仲有好多幻想"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "唉，我好后悔讲过一句「火鸡屙烂煮」",
-      "src_1_sub_2": "端午节，当我翻开我最喜欢吃的裹蒸粽⋯",
-      "src_2_sub_1": "唉我后悔讲过火鸡阿宁处呢句嘢",
-      "src_2_sub_2": "到端午节当我督开我最钟意食嘅果精粽嘅时候"
+      "ref_sub_1": "小朋友麦兜的世界仍然有好多幻想",
+      "ref_sub_2": "仍然有好多希望",
+      "target_sub_1": "细路仔麦兜嘅世界仲有好多幻想",
+      "target_sub_2": "仲有好多希望"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "端午节，当我翻开我最喜欢吃的裹蒸粽⋯",
-      "src_1_sub_2": "发现咸蛋旁边是一件火鸡背的时候⋯",
-      "src_2_sub_1": "到端午节当我督开我最钟意食嘅果精粽嘅时候",
-      "src_2_sub_2": "发现宿喺咸蛋旁边嘅系一件火鸡背脊"
+      "ref_sub_1": "仍然有好多希望",
+      "ref_sub_2": "希望⋯失望⋯",
+      "target_sub_1": "仲有好多希望",
+      "target_sub_2": "希望失望"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "发现咸蛋旁边是一件火鸡背的时候⋯",
-      "src_1_sub_2": "我脑部一时想唔通，哭起来",
-      "src_2_sub_1": "发现宿喺咸蛋旁边嘅系一件火鸡背脊",
-      "src_2_sub_2": "我脑部一时想唔通喊咗起上嚟"
+      "ref_sub_1": "希望⋯失望⋯",
+      "ref_sub_2": "希望⋯",
+      "target_sub_1": "希望失望",
+      "target_sub_2": "希望"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我脑部一时想唔通，哭起来",
-      "src_1_sub_2": "救命呀！",
-      "src_2_sub_1": "我脑部一时想唔通喊咗起上嚟",
-      "src_2_sub_2": "救命啊"
+      "ref_sub_1": "希望⋯",
+      "ref_sub_2": "失望",
+      "target_sub_1": "希望",
+      "target_sub_2": "失望"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "救命呀！",
-      "src_1_sub_2": "妈妈悄悄把剩下的火鸡扔掉",
-      "src_2_sub_1": "救命啊",
-      "src_2_sub_2": "妈妈净计计将净低嘅火鸡劈咗"
+      "ref_sub_1": "失望",
+      "ref_sub_2": "久而久之，就变成大个佬麦兜",
+      "target_sub_1": "失望",
+      "target_sub_2": "搞咗一轮就变咗大个佬麦兜"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈悄悄把剩下的火鸡扔掉",
-      "src_1_sub_2": "那已经是火鸡解冻后差不多半年的事",
-      "src_2_sub_1": "妈妈净计计将净低嘅火鸡劈咗",
-      "src_2_sub_2": "原来嗰阵已经系只火鸡解冻咗差唔多半年后嘅事"
+      "ref_sub_1": "久而久之，就变成大个佬麦兜",
+      "ref_sub_2": "我现在还是多说点小朋友麦兜",
+      "target_sub_1": "搞咗一轮就变咗大个佬麦兜",
+      "target_sub_2": "不过而家我都系想讲返细路仔麦兜"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "那已经是火鸡解冻后差不多半年的事",
-      "src_1_sub_2": "我的美梦跟恶梦亦同时完结",
-      "src_2_sub_1": "原来嗰阵已经系只火鸡解冻咗差唔多半年后嘅事",
-      "src_2_sub_2": "我嘅美梦同噩梦都同时完结"
+      "ref_sub_1": "我现在还是多说点小朋友麦兜",
+      "ref_sub_2": "小朋友麦兜仍然希望希望⋯",
+      "target_sub_1": "不过而家我都系想讲返细路仔麦兜",
+      "target_sub_2": "细路仔麦兜仲系希望希望"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我的美梦跟恶梦亦同时完结",
-      "src_1_sub_2": "后来我才知道⋯",
-      "src_2_sub_1": "我嘅美梦同噩梦都同时完结",
-      "src_2_sub_2": "后来我先知道"
+      "ref_sub_1": "小朋友麦兜仍然希望希望⋯",
+      "ref_sub_2": "希望真的有圣诞老人",
+      "target_sub_1": "细路仔麦兜仲系希望希望",
+      "target_sub_2": "希望真系有圣诞老人"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "后来我才知道⋯",
-      "src_1_sub_2": "一只火鸡由出世到给人宰掉",
-      "src_2_sub_1": "后来我先知道",
-      "src_2_sub_2": "一只火鸡由出世到畀人㓥"
+      "ref_sub_1": "希望真的有圣诞老人",
+      "ref_sub_2": "而且好想试试圣诞火鸡的滋味",
+      "target_sub_1": "希望真系有圣诞老人",
+      "target_sub_2": "仲系好想好想试下圣诞火鸡嘅滋味"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "一只火鸡由出世到给人宰掉",
-      "src_1_sub_2": "也不过是几个月间的事",
-      "src_2_sub_1": "一只火鸡由出世到畀人㓥",
-      "src_2_sub_2": "都不过系几个月之间嘅事"
+      "ref_sub_1": "而且好想试试圣诞火鸡的滋味",
+      "ref_sub_2": "对，那时我还没吃过火鸡",
+      "target_sub_1": "仲系好想好想试下圣诞火鸡嘅滋味",
+      "target_sub_2": "系啊我嗰阵我真系仲未食过火鸡"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "也不过是几个月间的事",
-      "src_1_sub_2": "即是说，火鸡死掉后跟我们一起的日子",
-      "src_2_sub_1": "都不过系几个月之间嘅事",
-      "src_2_sub_2": "即系话只火鸡死咗之后同我哋一齐嘅日子"
+      "ref_sub_1": "对，那时我还没吃过火鸡",
+      "ref_sub_2": "关于火鸡的一切⋯",
+      "target_sub_1": "系啊我嗰阵我真系仲未食过火鸡",
+      "target_sub_2": "所有关于火鸡嘅嘢"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "即是说，火鸡死掉后跟我们一起的日子",
-      "src_1_sub_2": "还要长过它的一生",
-      "src_2_sub_1": "即系话只火鸡死咗之后同我哋一齐嘅日子",
-      "src_2_sub_2": "仲长过佢自己本身条命"
+      "ref_sub_1": "关于火鸡的一切⋯",
+      "ref_sub_2": "圣诞树上一闪一闪的饰物",
+      "target_sub_1": "所有关于火鸡嘅嘢",
+      "target_sub_2": "圣诞树一闪一闪嘅灯饰"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "还要长过它的一生",
-      "src_1_sub_2": "我还发觉，火鸡的味道⋯",
-      "src_2_sub_1": "仲长过佢自己本身条命",
-      "src_2_sub_2": "我仲发觉到"
+      "ref_sub_1": "圣诞树上一闪一闪的饰物",
+      "ref_sub_2": "就像天上掉落的星星",
+      "target_sub_1": "圣诞树一闪一闪嘅灯饰",
+      "target_sub_2": "就好似喺天上面落嚟嘅星星噉"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我还发觉，火鸡的味道⋯",
-      "src_1_sub_2": "将吃未吃和第一口之间已经是最高峰",
-      "src_2_sub_1": "我仲发觉到",
-      "src_2_sub_2": "火鸡嘅味道味食同食第一啖之间已经系佢嘅最高峰"
+      "ref_sub_1": "就像天上掉落的星星",
+      "ref_sub_2": "落到火炉旁边",
+      "target_sub_1": "就好似喺天上面落嚟嘅星星噉",
+      "target_sub_2": "落喺火炉旁边"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "落到火炉旁边",
+      "ref_sub_2": "一片片比外边的雪还要白的鸡胸肉⋯",
+      "target_sub_1": "落喺火炉旁边",
+      "target_sub_2": "一片一片比窗外面嘅雪仲要白嘅鸡胸肉"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "一片片比外边的雪还要白的鸡胸肉⋯",
+      "ref_sub_2": "就在我们跟前",
+      "target_sub_1": "一片一片比窗外面嘅雪仲要白嘅鸡胸肉",
+      "target_sub_2": "就喺我哋面前啦"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "就在我们跟前",
+      "ref_sub_2": "香气直入灵魂⋯",
+      "target_sub_1": "就喺我哋面前啦",
+      "target_sub_2": "香气直入灵魂"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "香气直入灵魂⋯",
+      "ref_sub_2": "连守在灵魂旁边的天使都醒过来",
+      "target_sub_1": "香气直入灵魂",
+      "target_sub_2": "就连守喺灵魂旁边嘅天使都醒咗起嚟"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "连守在灵魂旁边的天使都醒过来",
+      "ref_sub_2": "围住这香而圣洁的肉⋯",
+      "target_sub_1": "就连守喺灵魂旁边嘅天使都醒咗起嚟",
+      "target_sub_2": "围住呢一嚿好香好香又好盛洁嘅肉"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "围住这香而圣洁的肉⋯",
+      "ref_sub_2": "在圣诞夜中飞呀，飞⋯",
+      "target_sub_1": "围住呢一嚿好香好香又好盛洁嘅肉",
+      "target_sub_2": "喺圣诞夜里面飞呀飞呀"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "在圣诞夜中飞呀，飞⋯",
+      "ref_sub_2": "这关于火鸡的一切，不过是我的想像",
+      "target_sub_1": "喺圣诞夜里面飞呀飞呀",
+      "target_sub_2": "但系呢一切一切关于火鸡嘅嘢都不过系我嘅想像"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "这关于火鸡的一切，不过是我的想像",
+      "ref_sub_2": "我从来没吃过火鸡⋯",
+      "target_sub_1": "但系呢一切一切关于火鸡嘅嘢都不过系我嘅想像",
+      "target_sub_2": "因为我从来都未食过火鸡"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我从来没吃过火鸡⋯",
+      "ref_sub_2": "连它的气味也没嗅过",
+      "target_sub_1": "因为我从来都未食过火鸡",
+      "target_sub_2": "就连嗰阵味都未闻过"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "连它的气味也没嗅过",
+      "ref_sub_2": "妈妈说火鸡太大",
+      "target_sub_1": "就连嗰阵味都未闻过",
+      "target_sub_2": "妈妈话火鸡太大"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "妈妈说火鸡太大",
+      "ref_sub_2": "我们一家两口，吃不下",
+      "target_sub_1": "妈妈话火鸡太大",
+      "target_sub_2": "我哋一家两口点食都食唔晒"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我们一家两口，吃不下",
+      "ref_sub_2": "有年圣诞节妈妈买了半只烧鸭庆祝",
+      "target_sub_1": "我哋一家两口点食都食唔晒",
+      "target_sub_2": "有一年圣诞节妈妈买咗半边烧鸭庆祝"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "有年圣诞节妈妈买了半只烧鸭庆祝",
+      "ref_sub_2": "当时的我，十分十分失望",
+      "target_sub_1": "有一年圣诞节妈妈买咗半边烧鸭庆祝",
+      "target_sub_2": "当时我真系十分十分之失望"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "当时的我，十分十分失望",
+      "ref_sub_2": "又有一年，一间百货公司结业",
+      "target_sub_1": "当时我真系十分十分之失望",
+      "target_sub_2": "又有一年有间大薄货公司倒闭"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "又有一年，一间百货公司结业",
+      "ref_sub_2": "妈妈以四折买了个小小焗炉",
+      "target_sub_1": "又有一年有间大薄货公司倒闭",
+      "target_sub_2": "妈妈用四折买咗个焗炉仔返屋企"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "妈妈以四折买了个小小焗炉",
+      "ref_sub_2": "可能因为买了焗炉而技痒",
+      "target_sub_1": "妈妈用四折买咗个焗炉仔返屋企",
+      "target_sub_2": "可能系因为买咗焗炉嘅样"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "可能因为买了焗炉而技痒",
+      "ref_sub_2": "那日妈妈竟然跟我说⋯",
+      "target_sub_1": "可能系因为买咗焗炉嘅样",
+      "target_sub_2": "嗰日妈妈竟然同我讲"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "那日妈妈竟然跟我说⋯",
+      "ref_sub_2": "让我们明天去超级市场揪火鸡",
+      "target_sub_1": "嗰日妈妈竟然同我讲",
+      "target_sub_2": "佢话明日我哋要超级市场抽火鸡"
     },
     "answer": {
-      "src_2_sub_1_shifted": "我仲发觉到火鸡嘅味道",
-      "src_2_sub_2_shifted": "味食同食第一啖之间已经系佢嘅最高峰"
+      "target_sub_1_shifted": "嗰日妈妈竟然同我讲佢话",
+      "target_sub_2_shifted": "明日我哋要超级市场抽火鸡"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "将吃未吃和第一口之间已经是最高峰",
-      "src_1_sub_2": "之后的，不过是开始了也就吃下去",
-      "src_2_sub_1": "味食同食第一啖之间已经系佢嘅最高峰",
-      "src_2_sub_2": "之后不过都系食开就食埋落去噉解"
+      "ref_sub_1": "让我们明天去超级市场揪火鸡",
+      "ref_sub_2": "我跟妈妈把火鸡揪回家的路上⋯",
+      "target_sub_1": "明日我哋要超级市场抽火鸡",
+      "target_sub_2": "我同妈妈抽住只火鸡行返屋企嗰阵"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "之后的，不过是开始了也就吃下去",
-      "src_1_sub_2": "我没有哲学家的头脑⋯",
-      "src_2_sub_1": "之后不过都系食开就食埋落去噉解",
-      "src_2_sub_2": "我冇知学家嘅头脑"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我没有哲学家的头脑⋯",
-      "src_1_sub_2": "不知道两件事情应该得出什么道理",
-      "src_2_sub_1": "我冇知学家嘅头脑",
-      "src_2_sub_2": "唔知呢两样嘢要得起嘅呢个得出啲咩道理"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "不知道两件事情应该得出什么道理",
-      "src_1_sub_2": "可是这些想法⋯",
-      "src_2_sub_1": "唔知呢两样嘢要得起嘅呢个得出啲咩道理",
-      "src_2_sub_2": "但系呢啲谂法"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "可是这些想法⋯",
-      "src_1_sub_2": "在我长大后⋯",
-      "src_2_sub_1": "但系呢啲谂法",
-      "src_2_sub_2": "喺我长大之后"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "在我长大后⋯",
-      "src_1_sub_2": "在一些跟圣诞节无关的日子⋯",
-      "src_2_sub_1": "喺我长大之后",
-      "src_2_sub_2": "系一啲同圣诞节无关嘅日子"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "在一些跟圣诞节无关的日子⋯",
-      "src_1_sub_2": "毫无因由的在我脑中出现过三两次",
-      "src_2_sub_1": "系一啲同圣诞节无关嘅日子",
-      "src_2_sub_2": "无端端噉喺我脑部出现过两三次"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "毫无因由的在我脑中出现过三两次",
-      "src_1_sub_2": "一次，是在我自己的婚宴上",
-      "src_2_sub_1": "无端端噉喺我脑部出现过两三次",
-      "src_2_sub_2": "一次喺我自己嘅婚宴上"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "一次，是在我自己的婚宴上",
-      "src_1_sub_2": "一次⋯",
-      "src_2_sub_1": "一次喺我自己嘅婚宴上",
-      "src_2_sub_2": "一次"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "一次⋯",
-      "src_1_sub_2": "是在我妈妈火化那天",
-      "src_2_sub_1": "一次",
-      "src_2_sub_2": "喺我妈妈火化嗰日"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "是在我妈妈火化那天",
-      "src_1_sub_2": "那天，我看著天空几缕灰色的烟",
-      "src_2_sub_1": "喺我妈妈火化嗰日",
-      "src_2_sub_2": "嗰日我望住天东几条灰色嘅烟"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "那天，我看著天空几缕灰色的烟",
-      "src_1_sub_2": "忽然间嗅到火鸡又浓又淡的气味",
-      "src_2_sub_1": "嗰日我望住天东几条灰色嘅烟",
-      "src_2_sub_2": "忽然闻到火鸡又浓又淡嘅气味"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "忽然间嗅到火鸡又浓又淡的气味",
-      "src_1_sub_2": "我好后悔要妈妈扔掉最后几件火鸡",
-      "src_2_sub_1": "忽然闻到火鸡又浓又淡嘅气味",
-      "src_2_sub_2": "我后悔要妈妈劈咗个忌廉火鸡"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "特别报告",
-      "src_1_sub_2": "奥运金牌得主李丽珊决定参加今届奥运",
-      "src_2_sub_1": "特别报道",
-      "src_2_sub_2": "奥运滑浪风帆金牌得主李丽珊决定参加今届嘅奥运"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "奥运金牌得主李丽珊决定参加今届奥运",
-      "src_1_sub_2": "向全世界人再次证明⋯",
-      "src_2_sub_1": "奥运滑浪风帆金牌得主李丽珊决定参加今届嘅奥运"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "向全世界人再次证明⋯",
-      "src_1_sub_2": "香港运动员不是腊鸭",
-      "src_2_sub_2": "向全世界人再次证明香港嘅运动员唔系腊鸭"
+      "ref_sub_1": "我跟妈妈把火鸡揪回家的路上⋯",
+      "ref_sub_2": "是我生命中最开心的时刻",
+      "target_sub_1": "我同妈妈抽住只火鸡行返屋企嗰阵",
+      "target_sub_2": "喺嗰阵时我谂系我生命里面最开心嘅一刻"
     },
     "answer": {
-      "src_2_sub_1_shifted": "向全世界人再次证明",
-      "src_2_sub_2_shifted": "香港嘅运动员唔系腊鸭"
+      "target_sub_1_shifted": "我同妈妈抽住只火鸡行返屋企嗰阵喺嗰阵时",
+      "target_sub_2_shifted": "我谂系我生命里面最开心嘅一刻"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "奥运金牌得主李丽珊决定参加今届奥运",
-      "src_1_sub_2": "向全世界人再次证明⋯",
-      "src_2_sub_1": "奥运滑浪风帆金牌得主李丽珊决定参加今届嘅奥运",
-      "src_2_sub_2": "向全世界人再次证明"
+      "ref_sub_1": "是我生命中最开心的时刻",
+      "ref_sub_2": "火鸡终于解冻了",
+      "target_sub_1": "我谂系我生命里面最开心嘅一刻",
+      "target_sub_2": "火鸡终于解冻啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "向全世界人再次证明⋯",
-      "src_1_sub_2": "香港运动员不是腊鸭",
-      "src_2_sub_1": "向全世界人再次证明",
-      "src_2_sub_2": "香港嘅运动员唔系腊鸭"
+      "ref_sub_1": "火鸡终于解冻了",
+      "ref_sub_2": "我学著妈妈，把双手涂满盐⋯",
+      "target_sub_1": "火鸡终于解冻啦",
+      "target_sub_2": "我同妈妈噉双手查满盐"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "香港运动员不是腊鸭",
-      "src_1_sub_2": "另方面⋯",
-      "src_2_sub_1": "香港嘅运动员唔系腊鸭"
+      "ref_sub_1": "我学著妈妈，把双手涂满盐⋯",
+      "ref_sub_2": "在火鸡丰厚的鸡胸上擦呀，擦",
+      "target_sub_1": "我同妈妈噉双手查满盐",
+      "target_sub_2": "喺火鸡封口嘅鸡胸度起细噉啫啫"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "另方面⋯",
-      "src_1_sub_2": "香港体运总会霍震霆⋯",
-      "src_2_sub_2": "另一方面"
+      "ref_sub_1": "在火鸡丰厚的鸡胸上擦呀，擦",
+      "ref_sub_2": "联火鸡时⋯",
+      "target_sub_1": "喺火鸡封口嘅鸡胸度起细噉啫啫"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "联火鸡时⋯",
+      "ref_sub_2": "妈妈不留神漏出了火鸡内的洋葱粒",
+      "target_sub_2": "联火鸡时妈妈一个唔觉意畀酿喺火鸡里面嘅火鸡内脏洋葱粒"
     },
     "answer": {
-      "src_2_sub_1_shifted": "另一方面"
+      "target_sub_1_shifted": "联火鸡时",
+      "target_sub_2_shifted": "妈妈一个唔觉意畀酿喺火鸡里面嘅火鸡内脏洋葱粒"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "香港体运总会霍震霆⋯",
-      "src_1_sub_2": "正式向亚运协会提出申请",
-      "src_2_sub_2": "中国香港体育协会企奥委会会长霍振庭正式向亚运协会提出申请"
+      "ref_sub_1": "妈妈不留神漏出了火鸡内的洋葱粒",
+      "ref_sub_2": "红萝卜粒",
+      "target_sub_1": "妈妈一个唔觉意畀酿喺火鸡里面嘅火鸡内脏洋葱粒",
+      "target_sub_2": "红萝虾粒流嘅出嚟"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "红萝卜粒",
+      "ref_sub_2": "我说：火鸡「屙烂煮」！",
+      "target_sub_1": "红萝虾粒流嘅出嚟",
+      "target_sub_2": "我话火鸡我能住呀"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我说：火鸡「屙烂煮」！",
+      "ref_sub_2": "好勉强把火鸡塞进焗炉内",
+      "target_sub_1": "我话火鸡我能住呀",
+      "target_sub_2": "火鸡好勉强噏咗入焗炉度"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "好勉强把火鸡塞进焗炉内",
+      "ref_sub_2": "12月24日",
+      "target_sub_1": "火鸡好勉强噏咗入焗炉度",
+      "target_sub_2": "10月24日"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "12月24日",
+      "ref_sub_2": "上升的白烟跟奇异的焦味拨动星星",
+      "target_sub_1": "10月24日",
+      "target_sub_2": "上升嘅白烟同奇异嘅㶶味拨动声声"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "上升的白烟跟奇异的焦味拨动星星",
+      "ref_sub_2": "焗炉戚戚恻恻，戚戚恻恻⋯",
+      "target_sub_1": "上升嘅白烟同奇异嘅㶶味拨动声声",
+      "target_sub_2": "个焗炉叱叱叱叱叱叱叱咁"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "焗炉戚戚恻恻，戚戚恻恻⋯",
+      "ref_sub_2": "有如天使预早送来的福音",
+      "target_sub_1": "个焗炉叱叱叱叱叱叱叱咁",
+      "target_sub_2": "就好似天赐预祖畀我哋嘅福音"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "好靓的晚上啊！",
+      "ref_sub_2": "我和妈妈坐在尖东海傍",
+      "target_sub_1": "好靓嘅夜晚呀",
+      "target_sub_2": "我同妈妈坐喺尖东海旁"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我和妈妈坐在尖东海傍",
+      "ref_sub_2": "点点灯光在海面走来走去⋯",
+      "target_sub_1": "我同妈妈坐喺尖东海旁",
+      "target_sub_2": "点点点点嘅灯光喺海上面走来走去"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "点点灯光在海面走来走去⋯",
+      "ref_sub_2": "美丽又温柔",
+      "target_sub_1": "点点点点嘅灯光喺海上面走来走去",
+      "target_sub_2": "又靓又温柔"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "美丽又温柔",
+      "ref_sub_2": "真的好靓！",
+      "target_sub_1": "又靓又温柔",
+      "target_sub_2": "真系好靓"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我从没吃过这么浓味的东西",
+      "ref_sub_2": "甚至杯面，烧鸭的味道也没有这么浓",
+      "target_sub_1": "我从未食过咁浓味嘅嘢",
+      "target_sub_2": "连烧鸭连杯面都冇咁浓嘅味道"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "甚至杯面，烧鸭的味道也没有这么浓",
+      "ref_sub_2": "火鸡的味道把我每一个味蕾缠住⋯",
+      "target_sub_1": "连烧鸭连杯面都冇咁浓嘅味道",
+      "target_sub_2": "火鸡嘅味道喺我嘅每一个味蕾度缠住"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "火鸡的味道把我每一个味蕾缠住⋯",
+      "ref_sub_2": "爆发⋯缠住⋯爆发⋯",
+      "target_sub_1": "火鸡嘅味道喺我嘅每一个味蕾度缠住",
+      "target_sub_2": "爆发缠住爆发"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "爆发⋯缠住⋯爆发⋯",
+      "ref_sub_2": "就像今晚的一切",
+      "target_sub_1": "爆发缠住爆发",
+      "target_sub_2": "就好似今晚嘅嘢噉"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "就像今晚的一切",
+      "ref_sub_2": "最靓最靓，最犀利，而且最温柔",
+      "target_sub_1": "就好似今晚嘅嘢噉",
+      "target_sub_2": "最靓最靓最犀利亦都系最温柔"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "第二天我睡得很晏⋯",
+      "ref_sub_2": "刷过牙我还感觉到火鸡的美味",
+      "target_sub_1": "第二日我瞓到好硬",
+      "target_sub_2": "测完牙我仲感觉到火鸡嘅美味"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "刷过牙我还感觉到火鸡的美味",
+      "ref_sub_2": "因为早餐吃得晚⋯",
+      "target_sub_1": "测完牙我仲感觉到火鸡嘅美味",
+      "target_sub_2": "因为早餐食得硬"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "因为早餐吃得晚⋯",
+      "ref_sub_2": "午餐时妈妈只煮了罐粟米汤",
+      "target_sub_1": "因为早餐食得硬",
+      "target_sub_2": "唔餐妈妈净系整咗罐粟米汤畀我"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "午餐时妈妈只煮了罐粟米汤",
+      "ref_sub_2": "我用汤匙撩了两下",
+      "target_sub_1": "唔餐妈妈净系整咗罐粟米汤畀我",
+      "target_sub_2": "我系噉用匙羹撩下撩下"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我用汤匙撩了两下",
+      "ref_sub_2": "竟然发现美味的火鸡粒",
+      "target_sub_1": "我系噉用匙羹撩下撩下",
+      "target_sub_2": "我竟然撩到一粒美味嘅火鸡肉"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "竟然发现美味的火鸡粒",
+      "ref_sub_2": "不用说，那夜就是我渴望了⋯",
+      "target_sub_1": "我竟然撩到一粒美味嘅火鸡肉",
+      "target_sub_2": "嗰晚唔使讲"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "不用说，那夜就是我渴望了⋯",
+      "ref_sub_2": "很久很久很久的⋯圣诞火鸡大餐！",
+      "target_sub_1": "嗰晚唔使讲",
+      "target_sub_2": "当然系食我限咗好耐好耐好耐好耐嘅圣诞火鸡大餐"
     },
     "answer": {
-      "src_2_sub_1_shifted": "中国香港体育协会企奥委会会长霍振庭",
-      "src_2_sub_2_shifted": "正式向亚运协会提出申请"
+      "target_sub_1_shifted": "嗰晚唔使讲当然系食我限咗",
+      "target_sub_2_shifted": "好耐好耐好耐好耐嘅圣诞火鸡大餐"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "另方面⋯",
-      "src_1_sub_2": "香港体运总会霍震霆⋯",
-      "src_2_sub_2": "另一方面中国香港体育协会企奥委会会长霍振庭"
+      "ref_sub_1": "竟然发现美味的火鸡粒",
+      "ref_sub_2": "不用说，那夜就是我渴望了⋯",
+      "target_sub_1": "我竟然撩到一粒美味嘅火鸡肉",
+      "target_sub_2": "嗰晚唔使讲当然系食我限咗"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "不用说，那夜就是我渴望了⋯",
+      "ref_sub_2": "很久很久很久的⋯圣诞火鸡大餐！",
+      "target_sub_1": "嗰晚唔使讲当然系食我限咗",
+      "target_sub_2": "好耐好耐好耐好耐嘅圣诞火鸡大餐"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "很久很久很久的⋯圣诞火鸡大餐！",
+      "ref_sub_2": "一片片的火鸡肉和伴碟的薯仔和节瓜⋯",
+      "target_sub_1": "好耐好耐好耐好耐嘅圣诞火鸡大餐",
+      "target_sub_2": "一片一片嘅火鸡肉半碟嘅有薯仔同节瓜"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "一片片的火鸡肉和伴碟的薯仔和节瓜⋯",
+      "ref_sub_2": "上面淋了老抽生粉献",
+      "target_sub_1": "一片一片嘅火鸡肉半碟嘅有薯仔同节瓜",
+      "target_sub_2": "上面淋咗一层老抽生粉馅"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "上面淋了老抽生粉献",
+      "ref_sub_2": "我们真的好兴奋，好满足",
+      "target_sub_1": "上面淋咗一层老抽生粉馅",
+      "target_sub_2": "我哋真系好兴奋好满足"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我们真的好兴奋，好满足",
+      "ref_sub_2": "之后，我们吃了一个星期的⋯",
+      "target_sub_1": "我哋真系好兴奋好满足"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "之后，我们吃了一个星期的⋯",
+      "ref_sub_2": "火鸡三文治早餐",
+      "target_sub_2": "之后我哋仲食咗一个礼拜嘅火鸡三文治做早餐"
     },
     "answer": {
-      "src_2_sub_1_shifted": "另一方面",
-      "src_2_sub_2_shifted": "中国香港体育协会企奥委会会长霍振庭"
+      "target_sub_1_shifted": "之后我哋仲食咗一个礼拜嘅",
+      "target_sub_2_shifted": "火鸡三文治做早餐"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "香港体运总会霍震霆⋯",
-      "src_1_sub_2": "正式向亚运协会提出申请",
-      "src_2_sub_1": "中国香港体育协会企奥委会会长霍振庭",
-      "src_2_sub_2": "正式向亚运协会提出申请"
+      "ref_sub_1": "我们真的好兴奋，好满足",
+      "ref_sub_2": "之后，我们吃了一个星期的⋯",
+      "target_sub_1": "我哋真系好兴奋好满足",
+      "target_sub_2": "之后我哋仲食咗一个礼拜嘅"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "正式向亚运协会提出申请",
-      "src_1_sub_2": "香港将争夺下届亚运会主办权",
-      "src_2_sub_1": "正式向亚运协会提出申请",
-      "src_2_sub_2": "香港将要争夺下届亚运会嘅主办权"
+      "ref_sub_1": "之后，我们吃了一个星期的⋯",
+      "ref_sub_2": "火鸡三文治早餐",
+      "target_sub_1": "之后我哋仲食咗一个礼拜嘅",
+      "target_sub_2": "火鸡三文治做早餐"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "香港将争夺下届亚运会主办权",
-      "src_1_sub_2": "多个运动团体立即表示热烈支持",
-      "src_2_sub_1": "香港将要争夺下届亚运会嘅主办权",
-      "src_2_sub_2": "多个运动团体立即表示热烈支持"
+      "ref_sub_1": "火鸡三文治早餐",
+      "ref_sub_2": "星期天",
+      "target_sub_1": "火鸡三文治做早餐",
+      "target_sub_2": "星期日"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "多个运动团体立即表示热烈支持",
-      "src_1_sub_2": "其中港九新界竹战联谊会⋯",
-      "src_2_sub_1": "多个运动团体立即表示热烈支持"
+      "ref_sub_1": "星期天",
+      "ref_sub_2": "我大著胆跟妈妈说：不如去饮茶吖",
+      "target_sub_1": "星期日",
+      "target_sub_2": "我嘅记心肝同妈妈讲不如饮茶"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "其中港九新界竹战联谊会⋯",
-      "src_1_sub_2": "更希望打麻将可以成为亚运项目",
-      "src_2_sub_2": "其中港狗新界足战联谊会更希望打麻雀可以成为亚运项目"
+      "ref_sub_1": "我大著胆跟妈妈说：不如去饮茶吖",
+      "ref_sub_2": "妈妈骂我「冇衣食」⋯",
+      "target_sub_1": "我嘅记心肝同妈妈讲不如饮茶",
+      "target_sub_2": "妈妈闹我冇意食"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "妈妈骂我「冇衣食」⋯",
+      "ref_sub_2": "不过还是带了我去饮茶",
+      "target_sub_1": "妈妈闹我冇意食",
+      "target_sub_2": "但系都带咗我去饮茶"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "不过还是带了我去饮茶",
+      "ref_sub_2": "之后，妈妈又有计⋯",
+      "target_sub_1": "但系都带咗我去饮茶",
+      "target_sub_2": "之后妈妈又有计"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "之后，妈妈又有计⋯",
+      "ref_sub_2": "她把冰箱内剩下来的火鸡肉撕呀撕",
+      "target_sub_1": "之后妈妈又有计",
+      "target_sub_2": "佢将雪柜净返嘅火鸡肉系噉撕系噉撕"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "她把冰箱内剩下来的火鸡肉撕呀撕",
+      "ref_sub_2": "有时候也叫我帮手撕",
+      "target_sub_1": "佢将雪柜净返嘅火鸡肉系噉撕系噉撕",
+      "target_sub_2": "有时都叫我帮手撕"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "有时候也叫我帮手撕",
+      "ref_sub_2": "火鸡留在指甲的味道",
+      "target_sub_1": "有时都叫我帮手撕",
+      "target_sub_2": "火鸡留喺指甲嗰阵味"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "火鸡留在指甲的味道",
+      "ref_sub_2": "原来得洗好多次",
+      "target_sub_1": "火鸡留喺指甲嗰阵味",
+      "target_sub_2": "原来洗好多次都仲喺度㗎"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "原来得洗好多次",
+      "ref_sub_2": "银芽火鸡丝炒米，好味道",
+      "target_sub_1": "原来洗好多次都仲喺度㗎",
+      "target_sub_2": "银牙火鸡丝炒米好味道噉"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "银芽火鸡丝炒米，好味道",
+      "ref_sub_2": "栗子炆火鸡丝㷛",
+      "target_sub_1": "银牙火鸡丝炒米好味道噉",
+      "target_sub_2": "焯焯栗子焖火鸡丝煲"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "栗子炆火鸡丝㷛",
+      "ref_sub_2": "花生火鸡骨煲粥",
+      "target_sub_1": "焯焯栗子焖火鸡丝煲",
+      "target_sub_2": "花生火鸡骨煲粥"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "花生火鸡骨煲粥",
+      "ref_sub_2": "纸包火鸡包包纸",
+      "target_sub_1": "花生火鸡骨煲粥",
+      "target_sub_2": "纸包火鸡包包纸"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "纸包火鸡包包纸",
+      "ref_sub_2": "包火鸡包包包火鸡包",
+      "target_sub_1": "纸包火鸡包包纸",
+      "target_sub_2": "包火鸡包包包火鸡包"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "包火鸡包包包火鸡包",
+      "ref_sub_2": "酿火鸡馅搽面包",
+      "target_sub_1": "包火鸡包包包火鸡包",
+      "target_sub_2": "让火鸡馅茶面包"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "酿火鸡馅搽面包",
+      "ref_sub_2": "唉，我好后悔讲过一句「火鸡屙烂煮」",
+      "target_sub_1": "让火鸡馅茶面包",
+      "target_sub_2": "唉我后悔讲过火鸡阿宁处呢句嘢"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "唉，我好后悔讲过一句「火鸡屙烂煮」",
+      "ref_sub_2": "端午节，当我翻开我最喜欢吃的裹蒸粽⋯",
+      "target_sub_1": "唉我后悔讲过火鸡阿宁处呢句嘢",
+      "target_sub_2": "到端午节当我督开我最钟意食嘅果精粽嘅时候"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "端午节，当我翻开我最喜欢吃的裹蒸粽⋯",
+      "ref_sub_2": "发现咸蛋旁边是一件火鸡背的时候⋯",
+      "target_sub_1": "到端午节当我督开我最钟意食嘅果精粽嘅时候",
+      "target_sub_2": "发现宿喺咸蛋旁边嘅系一件火鸡背脊"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "发现咸蛋旁边是一件火鸡背的时候⋯",
+      "ref_sub_2": "我脑部一时想唔通，哭起来",
+      "target_sub_1": "发现宿喺咸蛋旁边嘅系一件火鸡背脊",
+      "target_sub_2": "我脑部一时想唔通喊咗起上嚟"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我脑部一时想唔通，哭起来",
+      "ref_sub_2": "救命呀！",
+      "target_sub_1": "我脑部一时想唔通喊咗起上嚟",
+      "target_sub_2": "救命啊"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "救命呀！",
+      "ref_sub_2": "妈妈悄悄把剩下的火鸡扔掉",
+      "target_sub_1": "救命啊",
+      "target_sub_2": "妈妈净计计将净低嘅火鸡劈咗"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "妈妈悄悄把剩下的火鸡扔掉",
+      "ref_sub_2": "那已经是火鸡解冻后差不多半年的事",
+      "target_sub_1": "妈妈净计计将净低嘅火鸡劈咗",
+      "target_sub_2": "原来嗰阵已经系只火鸡解冻咗差唔多半年后嘅事"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "那已经是火鸡解冻后差不多半年的事",
+      "ref_sub_2": "我的美梦跟恶梦亦同时完结",
+      "target_sub_1": "原来嗰阵已经系只火鸡解冻咗差唔多半年后嘅事",
+      "target_sub_2": "我嘅美梦同噩梦都同时完结"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我的美梦跟恶梦亦同时完结",
+      "ref_sub_2": "后来我才知道⋯",
+      "target_sub_1": "我嘅美梦同噩梦都同时完结",
+      "target_sub_2": "后来我先知道"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "后来我才知道⋯",
+      "ref_sub_2": "一只火鸡由出世到给人宰掉",
+      "target_sub_1": "后来我先知道",
+      "target_sub_2": "一只火鸡由出世到畀人㓥"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "一只火鸡由出世到给人宰掉",
+      "ref_sub_2": "也不过是几个月间的事",
+      "target_sub_1": "一只火鸡由出世到畀人㓥",
+      "target_sub_2": "都不过系几个月之间嘅事"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "也不过是几个月间的事",
+      "ref_sub_2": "即是说，火鸡死掉后跟我们一起的日子",
+      "target_sub_1": "都不过系几个月之间嘅事",
+      "target_sub_2": "即系话只火鸡死咗之后同我哋一齐嘅日子"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "即是说，火鸡死掉后跟我们一起的日子",
+      "ref_sub_2": "还要长过它的一生",
+      "target_sub_1": "即系话只火鸡死咗之后同我哋一齐嘅日子",
+      "target_sub_2": "仲长过佢自己本身条命"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "还要长过它的一生",
+      "ref_sub_2": "我还发觉，火鸡的味道⋯",
+      "target_sub_1": "仲长过佢自己本身条命",
+      "target_sub_2": "我仲发觉到"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我还发觉，火鸡的味道⋯",
+      "ref_sub_2": "将吃未吃和第一口之间已经是最高峰",
+      "target_sub_1": "我仲发觉到",
+      "target_sub_2": "火鸡嘅味道味食同食第一啖之间已经系佢嘅最高峰"
     },
     "answer": {
-      "src_2_sub_1_shifted": "其中港狗新界足战联谊会",
-      "src_2_sub_2_shifted": "更希望打麻雀可以成为亚运项目"
+      "target_sub_1_shifted": "我仲发觉到火鸡嘅味道",
+      "target_sub_2_shifted": "味食同食第一啖之间已经系佢嘅最高峰"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "多个运动团体立即表示热烈支持",
-      "src_1_sub_2": "其中港九新界竹战联谊会⋯",
-      "src_2_sub_1": "多个运动团体立即表示热烈支持",
-      "src_2_sub_2": "其中港狗新界足战联谊会"
+      "ref_sub_1": "将吃未吃和第一口之间已经是最高峰",
+      "ref_sub_2": "之后的，不过是开始了也就吃下去",
+      "target_sub_1": "味食同食第一啖之间已经系佢嘅最高峰",
+      "target_sub_2": "之后不过都系食开就食埋落去噉解"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "其中港九新界竹战联谊会⋯",
-      "src_1_sub_2": "更希望打麻将可以成为亚运项目",
-      "src_2_sub_1": "其中港狗新界足战联谊会",
-      "src_2_sub_2": "更希望打麻雀可以成为亚运项目"
+      "ref_sub_1": "之后的，不过是开始了也就吃下去",
+      "ref_sub_2": "我没有哲学家的头脑⋯",
+      "target_sub_1": "之后不过都系食开就食埋落去噉解",
+      "target_sub_2": "我冇知学家嘅头脑"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "更希望打麻将可以成为亚运项目",
-      "src_1_sub_2": "另外，全港茶餐厅员工协会⋯",
-      "src_2_sub_1": "更希望打麻雀可以成为亚运项目",
-      "src_2_sub_2": "另外"
+      "ref_sub_1": "我没有哲学家的头脑⋯",
+      "ref_sub_2": "不知道两件事情应该得出什么道理",
+      "target_sub_1": "我冇知学家嘅头脑",
+      "target_sub_2": "唔知呢两样嘢要得起嘅呢个得出啲咩道理"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "另外，全港茶餐厅员工协会⋯",
-      "src_1_sub_2": "经已发动所有会员⋯",
-      "src_2_sub_1": "另外"
+      "ref_sub_1": "不知道两件事情应该得出什么道理",
+      "ref_sub_2": "可是这些想法⋯",
+      "target_sub_1": "唔知呢两样嘢要得起嘅呢个得出啲咩道理",
+      "target_sub_2": "但系呢啲谂法"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "经已发动所有会员⋯",
-      "src_1_sub_2": "争取「掷蛋挞」成为亚运比赛项目",
-      "src_2_sub_2": "全港茶餐厅联工协会经热发动所有会员争取掟蛋挞成为亚运会比赛项目"
+      "ref_sub_1": "可是这些想法⋯",
+      "ref_sub_2": "在我长大后⋯",
+      "target_sub_1": "但系呢啲谂法",
+      "target_sub_2": "喺我长大之后"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "在我长大后⋯",
+      "ref_sub_2": "在一些跟圣诞节无关的日子⋯",
+      "target_sub_1": "喺我长大之后",
+      "target_sub_2": "系一啲同圣诞节无关嘅日子"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "在一些跟圣诞节无关的日子⋯",
+      "ref_sub_2": "毫无因由的在我脑中出现过三两次",
+      "target_sub_1": "系一啲同圣诞节无关嘅日子",
+      "target_sub_2": "无端端噉喺我脑部出现过两三次"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "毫无因由的在我脑中出现过三两次",
+      "ref_sub_2": "一次，是在我自己的婚宴上",
+      "target_sub_1": "无端端噉喺我脑部出现过两三次",
+      "target_sub_2": "一次喺我自己嘅婚宴上"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "一次，是在我自己的婚宴上",
+      "ref_sub_2": "一次⋯",
+      "target_sub_1": "一次喺我自己嘅婚宴上",
+      "target_sub_2": "一次"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "一次⋯",
+      "ref_sub_2": "是在我妈妈火化那天",
+      "target_sub_1": "一次",
+      "target_sub_2": "喺我妈妈火化嗰日"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "是在我妈妈火化那天",
+      "ref_sub_2": "那天，我看著天空几缕灰色的烟",
+      "target_sub_1": "喺我妈妈火化嗰日",
+      "target_sub_2": "嗰日我望住天东几条灰色嘅烟"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "那天，我看著天空几缕灰色的烟",
+      "ref_sub_2": "忽然间嗅到火鸡又浓又淡的气味",
+      "target_sub_1": "嗰日我望住天东几条灰色嘅烟",
+      "target_sub_2": "忽然闻到火鸡又浓又淡嘅气味"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "忽然间嗅到火鸡又浓又淡的气味",
+      "ref_sub_2": "我好后悔要妈妈扔掉最后几件火鸡",
+      "target_sub_1": "忽然闻到火鸡又浓又淡嘅气味",
+      "target_sub_2": "我后悔要妈妈劈咗个忌廉火鸡"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "特别报告",
+      "ref_sub_2": "奥运金牌得主李丽珊决定参加今届奥运",
+      "target_sub_1": "特别报道",
+      "target_sub_2": "奥运滑浪风帆金牌得主李丽珊决定参加今届嘅奥运"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "奥运金牌得主李丽珊决定参加今届奥运",
+      "ref_sub_2": "向全世界人再次证明⋯",
+      "target_sub_1": "奥运滑浪风帆金牌得主李丽珊决定参加今届嘅奥运"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "向全世界人再次证明⋯",
+      "ref_sub_2": "香港运动员不是腊鸭",
+      "target_sub_2": "向全世界人再次证明香港嘅运动员唔系腊鸭"
     },
     "answer": {
-      "src_2_sub_1_shifted": "全港茶餐厅联工协会经热发动所有会员",
-      "src_2_sub_2_shifted": "争取掟蛋挞成为亚运会比赛项目"
+      "target_sub_1_shifted": "向全世界人再次证明",
+      "target_sub_2_shifted": "香港嘅运动员唔系腊鸭"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "另外，全港茶餐厅员工协会⋯",
-      "src_1_sub_2": "经已发动所有会员⋯",
-      "src_2_sub_1": "另外",
-      "src_2_sub_2": "全港茶餐厅联工协会经热发动所有会员"
+      "ref_sub_1": "奥运金牌得主李丽珊决定参加今届奥运",
+      "ref_sub_2": "向全世界人再次证明⋯",
+      "target_sub_1": "奥运滑浪风帆金牌得主李丽珊决定参加今届嘅奥运",
+      "target_sub_2": "向全世界人再次证明"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "向全世界人再次证明⋯",
+      "ref_sub_2": "香港运动员不是腊鸭",
+      "target_sub_1": "向全世界人再次证明",
+      "target_sub_2": "香港嘅运动员唔系腊鸭"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "香港运动员不是腊鸭",
+      "ref_sub_2": "另方面⋯",
+      "target_sub_1": "香港嘅运动员唔系腊鸭"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "另方面⋯",
+      "ref_sub_2": "香港体运总会霍震霆⋯",
+      "target_sub_2": "另一方面"
     },
     "answer": {
-      "src_2_sub_1_shifted": "另外全港茶餐厅联工协会",
-      "src_2_sub_2_shifted": "经热发动所有会员"
+      "target_sub_1_shifted": "另一方面"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "更希望打麻将可以成为亚运项目",
-      "src_1_sub_2": "另外，全港茶餐厅员工协会⋯",
-      "src_2_sub_1": "更希望打麻雀可以成为亚运项目",
-      "src_2_sub_2": "另外全港茶餐厅联工协会"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "另外，全港茶餐厅员工协会⋯",
-      "src_1_sub_2": "经已发动所有会员⋯",
-      "src_2_sub_1": "另外全港茶餐厅联工协会"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "经已发动所有会员⋯",
-      "src_1_sub_2": "争取「掷蛋挞」成为亚运比赛项目",
-      "src_2_sub_2": "经热发动所有会员争取掟蛋挞成为亚运会比赛项目"
+      "ref_sub_1": "香港体运总会霍震霆⋯",
+      "ref_sub_2": "正式向亚运协会提出申请",
+      "target_sub_2": "中国香港体育协会企奥委会会长霍振庭正式向亚运协会提出申请"
     },
     "answer": {
-      "src_2_sub_1_shifted": "经热发动所有会员",
-      "src_2_sub_2_shifted": "争取掟蛋挞成为亚运会比赛项目"
+      "target_sub_1_shifted": "中国香港体育协会企奥委会会长霍振庭",
+      "target_sub_2_shifted": "正式向亚运协会提出申请"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "争取「掷蛋挞」成为亚运比赛项目",
-      "src_1_sub_2": "港九烧味卤味腊味同业会",
-      "src_2_sub_1": "争取掟蛋挞成为亚运会比赛项目",
-      "src_2_sub_2": "港狗烧尾掳尾"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "港九烧味卤味腊味同业会",
-      "src_1_sub_2": "亦向霍主席当面提出⋯",
-      "src_2_sub_1": "港狗烧尾掳尾"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "亦向霍主席当面提出⋯",
-      "src_1_sub_2": "「挂腊鸭」可以成为亚运比赛项目",
-      "src_2_sub_2": "立尾同业会亦都向霍主席当面提出挂立鸭可以成为亚运比赛项目"
+      "ref_sub_1": "另方面⋯",
+      "ref_sub_2": "香港体运总会霍震霆⋯",
+      "target_sub_2": "另一方面中国香港体育协会企奥委会会长霍振庭"
     },
     "answer": {
-      "src_2_sub_1_shifted": "立尾同业会亦都向霍主席当面提出",
-      "src_2_sub_2_shifted": "挂立鸭可以成为亚运比赛项目"
+      "target_sub_1_shifted": "另一方面",
+      "target_sub_2_shifted": "中国香港体育协会企奥委会会长霍振庭"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "港九烧味卤味腊味同业会",
-      "src_1_sub_2": "亦向霍主席当面提出⋯",
-      "src_2_sub_1": "港狗烧尾掳尾",
-      "src_2_sub_2": "立尾同业会亦都向霍主席当面提出"
+      "ref_sub_1": "香港体运总会霍震霆⋯",
+      "ref_sub_2": "正式向亚运协会提出申请",
+      "target_sub_1": "中国香港体育协会企奥委会会长霍振庭",
+      "target_sub_2": "正式向亚运协会提出申请"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "正式向亚运协会提出申请",
+      "ref_sub_2": "香港将争夺下届亚运会主办权",
+      "target_sub_1": "正式向亚运协会提出申请",
+      "target_sub_2": "香港将要争夺下届亚运会嘅主办权"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "香港将争夺下届亚运会主办权",
+      "ref_sub_2": "多个运动团体立即表示热烈支持",
+      "target_sub_1": "香港将要争夺下届亚运会嘅主办权",
+      "target_sub_2": "多个运动团体立即表示热烈支持"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "多个运动团体立即表示热烈支持",
+      "ref_sub_2": "其中港九新界竹战联谊会⋯",
+      "target_sub_1": "多个运动团体立即表示热烈支持"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "其中港九新界竹战联谊会⋯",
+      "ref_sub_2": "更希望打麻将可以成为亚运项目",
+      "target_sub_2": "其中港狗新界足战联谊会更希望打麻雀可以成为亚运项目"
     },
     "answer": {
-      "src_2_sub_1_shifted": "港狗烧尾掳尾立尾同业会",
-      "src_2_sub_2_shifted": "亦都向霍主席当面提出"
+      "target_sub_1_shifted": "其中港狗新界足战联谊会",
+      "target_sub_2_shifted": "更希望打麻雀可以成为亚运项目"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "亦向霍主席当面提出⋯",
-      "src_1_sub_2": "「挂腊鸭」可以成为亚运比赛项目",
-      "src_2_sub_1": "亦都向霍主席当面提出",
-      "src_2_sub_2": "挂立鸭可以成为亚运比赛项目"
+      "ref_sub_1": "多个运动团体立即表示热烈支持",
+      "ref_sub_2": "其中港九新界竹战联谊会⋯",
+      "target_sub_1": "多个运动团体立即表示热烈支持",
+      "target_sub_2": "其中港狗新界足战联谊会"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「挂腊鸭」可以成为亚运比赛项目",
-      "src_1_sub_2": "较为特别的是，CIC保险营业员联同⋯",
-      "src_2_sub_1": "挂立鸭可以成为亚运比赛项目",
-      "src_2_sub_2": "较为特别嘅系"
+      "ref_sub_1": "其中港九新界竹战联谊会⋯",
+      "ref_sub_2": "更希望打麻将可以成为亚运项目",
+      "target_sub_1": "其中港狗新界足战联谊会",
+      "target_sub_2": "更希望打麻雀可以成为亚运项目"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "较为特别的是，CIC保险营业员联同⋯",
-      "src_1_sub_2": "大角咀春田花花幼稚园⋯",
-      "src_2_sub_1": "较为特别嘅系",
-      "src_2_sub_2": "CIC保险营业员联同大角嘴春田花花"
+      "ref_sub_1": "更希望打麻将可以成为亚运项目",
+      "ref_sub_2": "另外，全港茶餐厅员工协会⋯",
+      "target_sub_1": "更希望打麻雀可以成为亚运项目",
+      "target_sub_2": "另外"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "另外，全港茶餐厅员工协会⋯",
+      "ref_sub_2": "经已发动所有会员⋯",
+      "target_sub_1": "另外"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "经已发动所有会员⋯",
+      "ref_sub_2": "争取「掷蛋挞」成为亚运比赛项目",
+      "target_sub_2": "全港茶餐厅联工协会经热发动所有会员争取掟蛋挞成为亚运会比赛项目"
     },
     "answer": {
-      "src_2_sub_1_shifted": "较为特别嘅系CIC保险营业员联同",
-      "src_2_sub_2_shifted": "大角嘴春田花花"
+      "target_sub_1_shifted": "全港茶餐厅联工协会经热发动所有会员",
+      "target_sub_2_shifted": "争取掟蛋挞成为亚运会比赛项目"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「挂腊鸭」可以成为亚运比赛项目",
-      "src_1_sub_2": "较为特别的是，CIC保险营业员联同⋯",
-      "src_2_sub_1": "挂立鸭可以成为亚运比赛项目",
-      "src_2_sub_2": "较为特别嘅系CIC保险营业员联同"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "较为特别的是，CIC保险营业员联同⋯",
-      "src_1_sub_2": "大角咀春田花花幼稚园⋯",
-      "src_2_sub_1": "较为特别嘅系CIC保险营业员联同",
-      "src_2_sub_2": "大角嘴春田花花"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "大角咀春田花花幼稚园⋯",
-      "src_1_sub_2": "附属小学一班小朋友⋯",
-      "src_2_sub_1": "大角嘴春田花花"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "附属小学一班小朋友⋯",
-      "src_1_sub_2": "争取「抢包山」",
-      "src_2_sub_2": "幼稚园附属小学嘅一班小朋友争取抢包山"
+      "ref_sub_1": "另外，全港茶餐厅员工协会⋯",
+      "ref_sub_2": "经已发动所有会员⋯",
+      "target_sub_1": "另外",
+      "target_sub_2": "全港茶餐厅联工协会经热发动所有会员"
     },
     "answer": {
-      "src_2_sub_1_shifted": "幼稚园附属小学嘅一班小朋友",
-      "src_2_sub_2_shifted": "争取抢包山"
+      "target_sub_1_shifted": "另外全港茶餐厅联工协会",
+      "target_sub_2_shifted": "经热发动所有会员"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "大角咀春田花花幼稚园⋯",
-      "src_1_sub_2": "附属小学一班小朋友⋯",
-      "src_2_sub_1": "大角嘴春田花花",
-      "src_2_sub_2": "幼稚园附属小学嘅一班小朋友"
+      "ref_sub_1": "更希望打麻将可以成为亚运项目",
+      "ref_sub_2": "另外，全港茶餐厅员工协会⋯",
+      "target_sub_1": "更希望打麻雀可以成为亚运项目",
+      "target_sub_2": "另外全港茶餐厅联工协会"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "另外，全港茶餐厅员工协会⋯",
+      "ref_sub_2": "经已发动所有会员⋯",
+      "target_sub_1": "另外全港茶餐厅联工协会"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "经已发动所有会员⋯",
+      "ref_sub_2": "争取「掷蛋挞」成为亚运比赛项目",
+      "target_sub_2": "经热发动所有会员争取掟蛋挞成为亚运会比赛项目"
     },
     "answer": {
-      "src_2_sub_1_shifted": "大角嘴春田花花幼稚园",
-      "src_2_sub_2_shifted": "附属小学嘅一班小朋友"
+      "target_sub_1_shifted": "经热发动所有会员",
+      "target_sub_2_shifted": "争取掟蛋挞成为亚运会比赛项目"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "附属小学一班小朋友⋯",
-      "src_1_sub_2": "争取「抢包山」",
-      "src_2_sub_1": "附属小学嘅一班小朋友",
-      "src_2_sub_2": "争取抢包山"
+      "ref_sub_1": "争取「掷蛋挞」成为亚运比赛项目",
+      "ref_sub_2": "港九烧味卤味腊味同业会",
+      "target_sub_1": "争取掟蛋挞成为亚运会比赛项目",
+      "target_sub_2": "港狗烧尾掳尾"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "争取「抢包山」",
-      "src_1_sub_2": "一项几乎绝迹的运动⋯",
-      "src_2_sub_1": "争取抢包山"
+      "ref_sub_1": "港九烧味卤味腊味同业会",
+      "ref_sub_2": "亦向霍主席当面提出⋯",
+      "target_sub_1": "港狗烧尾掳尾"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "一项几乎绝迹的运动⋯",
-      "src_1_sub_2": "成为本港举办亚运的重点推介比赛项目",
-      "src_2_sub_2": "一项几乎绝迹嘅运动成为本港举办亚运重点推介嘅比赛项目"
+      "ref_sub_1": "亦向霍主席当面提出⋯",
+      "ref_sub_2": "「挂腊鸭」可以成为亚运比赛项目",
+      "target_sub_2": "立尾同业会亦都向霍主席当面提出挂立鸭可以成为亚运比赛项目"
     },
     "answer": {
-      "src_2_sub_1_shifted": "一项几乎绝迹嘅运动",
-      "src_2_sub_2_shifted": "成为本港举办亚运重点推介嘅比赛项目"
+      "target_sub_1_shifted": "立尾同业会亦都向霍主席当面提出",
+      "target_sub_2_shifted": "挂立鸭可以成为亚运比赛项目"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "争取「抢包山」",
-      "src_1_sub_2": "一项几乎绝迹的运动⋯",
-      "src_2_sub_1": "争取抢包山",
-      "src_2_sub_2": "一项几乎绝迹嘅运动"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "一项几乎绝迹的运动⋯",
-      "src_1_sub_2": "成为本港举办亚运的重点推介比赛项目",
-      "src_2_sub_1": "一项几乎绝迹嘅运动",
-      "src_2_sub_2": "成为本港举办亚运重点推介嘅比赛项目"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "最后⋯",
-      "src_1_sub_2": "最后，一切成烟",
-      "src_2_sub_1": "最后",
-      "src_2_sub_2": "最后全部都系banana"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "最后，一切成烟",
-      "src_1_sub_2": "最后，他们选了「掷蛋挞」做推介项目",
-      "src_2_sub_1": "最后全部都系banana",
-      "src_2_sub_2": "最后佢哋选咗定蛋挞做推介项目"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "最后，他们选了「掷蛋挞」做推介项目",
-      "src_1_sub_2": "至于香港争取申办亚运的口号⋯",
-      "src_2_sub_1": "最后佢哋选咗定蛋挞做推介项目",
-      "src_2_sub_2": "至于香港争取申办亚运嘅口号"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "至于香港争取申办亚运的口号⋯",
-      "src_1_sub_2": "亦顺理成章叫成「香港一蛋挞」",
-      "src_2_sub_1": "至于香港争取申办亚运嘅口号",
-      "src_2_sub_2": "亦都顺理成章噉叫做香港一蛋挞"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "亦顺理成章叫成「香港一蛋挞」",
-      "src_1_sub_2": "之后李丽珊蝉联失败⋯",
-      "src_2_sub_1": "亦都顺理成章噉叫做香港一蛋挞",
-      "src_2_sub_2": "之后李利山丧乱失败"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "之后李丽珊蝉联失败⋯",
-      "src_1_sub_2": "亚运主办权⋯",
-      "src_2_sub_1": "之后李利山丧乱失败"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "亚运主办权⋯",
-      "src_1_sub_2": "亦由一个香港人从未听过的地方夺得",
-      "src_2_sub_2": "亚运主办权亦都由一个香港人从未听过嘅地方夺得"
+      "ref_sub_1": "港九烧味卤味腊味同业会",
+      "ref_sub_2": "亦向霍主席当面提出⋯",
+      "target_sub_1": "港狗烧尾掳尾",
+      "target_sub_2": "立尾同业会亦都向霍主席当面提出"
     },
     "answer": {
-      "src_2_sub_1_shifted": "亚运主办权",
-      "src_2_sub_2_shifted": "亦都由一个香港人从未听过嘅地方夺得"
+      "target_sub_1_shifted": "港狗烧尾掳尾立尾同业会",
+      "target_sub_2_shifted": "亦都向霍主席当面提出"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "亦由一个香港人从未听过的地方夺得",
-      "src_1_sub_2": "想著转行当运动员的茶餐厅伙记⋯",
-      "src_2_sub_1": "亦都由一个香港人从未听过嘅地方夺得",
-      "src_2_sub_2": "谂住可以转行做运动员嘅茶餐厅伙计"
+      "ref_sub_1": "亦向霍主席当面提出⋯",
+      "ref_sub_2": "「挂腊鸭」可以成为亚运比赛项目",
+      "target_sub_1": "亦都向霍主席当面提出",
+      "target_sub_2": "挂立鸭可以成为亚运比赛项目"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "想著转行当运动员的茶餐厅伙记⋯",
-      "src_1_sub_2": "都回到茶餐厅继续掷他们的蛋挞",
-      "src_2_sub_1": "谂住可以转行做运动员嘅茶餐厅伙计",
-      "src_2_sub_2": "都返返去茶餐厅继续钉佢哋嘅蛋挞"
+      "ref_sub_1": "「挂腊鸭」可以成为亚运比赛项目",
+      "ref_sub_2": "较为特别的是，CIC保险营业员联同⋯",
+      "target_sub_1": "挂立鸭可以成为亚运比赛项目",
+      "target_sub_2": "较为特别嘅系"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "都回到茶餐厅继续掷他们的蛋挞",
-      "src_1_sub_2": "一切回复正常",
-      "src_2_sub_1": "都返返去茶餐厅继续钉佢哋嘅蛋挞",
-      "src_2_sub_2": "一切回复正常"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "上中学后，我再没有练习抢包手",
-      "src_1_sub_2": "有时候跟妈妈饮茶⋯",
-      "src_2_sub_1": "上个中学我已经再冇练习抢包手",
-      "src_2_sub_2": "间中同妈妈饮茶"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "有时候跟妈妈饮茶⋯",
-      "src_1_sub_2": "我都会手快快替她抢一笼大包",
-      "src_2_sub_1": "间中同妈妈饮茶",
-      "src_2_sub_2": "我都会手快快噉帮佢抢龙大包"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我都会手快快替她抢一笼大包",
-      "src_1_sub_2": "之后，茶楼再不卖大包了",
-      "src_2_sub_1": "我都会手快快噉帮佢抢龙大包",
-      "src_2_sub_2": "之后茶楼都冇埋大包"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "之后，茶楼再不卖大包了",
-      "src_1_sub_2": "点心车亦转成点心纸",
-      "src_2_sub_1": "之后茶楼都冇埋大包",
-      "src_2_sub_2": "退车仔都转咗用点心纸"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "点心车亦转成点心纸",
-      "src_1_sub_2": "一切落空",
-      "src_2_sub_1": "退车仔都转咗用点心纸",
-      "src_2_sub_2": "一切都落空"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "有时候我也会跟同学回到长洲烧烤",
-      "src_1_sub_2": "每次看见师傅⋯",
-      "src_2_sub_1": "有时我都会同班同学仔返长洲宵夜食",
-      "src_2_sub_2": "每次见到师傅"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "每次看见师傅⋯",
-      "src_1_sub_2": "他都好像老了一点",
-      "src_2_sub_1": "每次见到师傅",
-      "src_2_sub_2": "佢都好似老咗啲噉"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "因为环保⋯",
-      "src_1_sub_2": "长洲的抢包都转为塑胶",
-      "src_2_sub_1": "因为环保",
-      "src_2_sub_2": "长洲嘅厂包经已转咗用塑胶"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "长洲的抢包都转为塑胶",
-      "src_1_sub_2": "师傅说，那阵胶气，相当臭",
-      "src_2_sub_1": "长洲嘅厂包经已转咗用塑胶",
-      "src_2_sub_2": "师傅话嗰阵胶气都几丑下"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "长洲有个张保仔洞",
-      "src_1_sub_2": "听说张保仔在洞内藏了很多宝藏",
-      "src_2_sub_1": "墙后个张宝仔洞",
-      "src_2_sub_2": "听讲海盗张宝仔喺里面收埋咗好多宝藏"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "听说张保仔在洞内藏了很多宝藏",
-      "src_1_sub_2": "因为我练过抢包手，身手比较灵活⋯",
-      "src_2_sub_1": "听讲海盗张宝仔喺里面收埋咗好多宝藏",
-      "src_2_sub_2": "因为我练过抢包手身手比较灵活"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "因为我练过抢包手，身手比较灵活⋯",
-      "src_1_sub_2": "同学们叫我爬进去看看，说不定会发达",
-      "src_2_sub_1": "因为我练过抢包手身手比较灵活",
-      "src_2_sub_2": "班同我叫我爬佢睇下话唔定会发达"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "同学们叫我爬进去看看，说不定会发达",
-      "src_1_sub_2": "于是我就向著这个又黑又窄的洞⋯",
-      "src_2_sub_1": "班同我叫我爬佢睇下话唔定会发达",
-      "src_2_sub_2": "于是我就向住呢一个又黑又窄嘅洞"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "于是我就向著这个又黑又窄的洞⋯",
-      "src_1_sub_2": "一直爬",
-      "src_2_sub_1": "于是我就向住呢一个又黑又窄嘅洞",
-      "src_2_sub_2": "系噉爬爬"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "一直爬",
-      "src_1_sub_2": "洞里面什么也没有，只有一个盒",
-      "src_2_sub_1": "系噉爬爬",
-      "src_2_sub_2": "洞里面乜都冇净系有一个盒"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "洞里面什么也没有，只有一个盒",
-      "src_1_sub_2": "我小心揭开盒⋯",
-      "src_2_sub_1": "洞里面乜都冇净系有一个盒",
-      "src_2_sub_2": "我好小心揭开呢个盒"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我小心揭开盒⋯",
-      "src_1_sub_2": "发现里面一个没吃完的大包",
-      "src_2_sub_1": "我好小心揭开呢个盒",
-      "src_2_sub_2": "发现入面系一个食净咗嘅大包"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "发现里面一个没吃完的大包",
-      "src_1_sub_2": "是不是张保仔吃过的呢？",
-      "src_2_sub_1": "发现入面系一个食净咗嘅大包",
-      "src_2_sub_2": "唔知系咪张宝仔食净㗎啦"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "是不是张保仔吃过的呢？",
-      "src_1_sub_2": "「寻晚，食了六个餐包」",
-      "src_2_sub_1": "唔知系咪张宝仔食净㗎啦"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "「年晚，又培育了珊珊！可惜⋯」",
-      "src_1_sub_2": "揸住个包，我忽然明白⋯",
-      "src_2_sub_2": "揸住个包我忽然明白"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "揸住个包，我忽然明白⋯",
-      "src_1_sub_2": "原来有些事情，没有就是没有",
-      "src_2_sub_1": "揸住个包我忽然明白",
-      "src_2_sub_2": "原来有啲嘢冇就真系冇"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "原来有些事情，没有就是没有",
-      "src_1_sub_2": "唔得，就是唔得",
-      "src_2_sub_1": "原来有啲嘢冇就真系冇",
-      "src_2_sub_2": "唔得就真系唔得"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "唔得，就是唔得",
-      "src_1_sub_2": "没有鱼蛋没有粗面没去成马尔代夫⋯",
-      "src_2_sub_1": "唔得就真系唔得",
-      "src_2_sub_2": "冇鱼蛋冇粗面"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "没有鱼蛋没有粗面没去成马尔代夫⋯",
-      "src_1_sub_2": "没有奖牌没有张保仔宝藏",
-      "src_2_sub_1": "冇鱼蛋冇粗面",
-      "src_2_sub_2": "冇去买义大夫冇奖牌冇张宝仔宝藏"
+      "ref_sub_1": "较为特别的是，CIC保险营业员联同⋯",
+      "ref_sub_2": "大角咀春田花花幼稚园⋯",
+      "target_sub_1": "较为特别嘅系",
+      "target_sub_2": "CIC保险营业员联同大角嘴春田花花"
     },
     "answer": {
-      "src_2_sub_1_shifted": "冇鱼蛋冇粗面冇去买义大夫",
-      "src_2_sub_2_shifted": "冇奖牌冇张宝仔宝藏"
+      "target_sub_1_shifted": "较为特别嘅系CIC保险营业员联同",
+      "target_sub_2_shifted": "大角嘴春田花花"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "唔得，就是唔得",
-      "src_1_sub_2": "没有鱼蛋没有粗面没去成马尔代夫⋯",
-      "src_2_sub_1": "唔得就真系唔得",
-      "src_2_sub_2": "冇鱼蛋冇粗面冇去买义大夫"
+      "ref_sub_1": "「挂腊鸭」可以成为亚运比赛项目",
+      "ref_sub_2": "较为特别的是，CIC保险营业员联同⋯",
+      "target_sub_1": "挂立鸭可以成为亚运比赛项目",
+      "target_sub_2": "较为特别嘅系CIC保险营业员联同"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "没有鱼蛋没有粗面没去成马尔代夫⋯",
-      "src_1_sub_2": "没有奖牌没有张保仔宝藏",
-      "src_2_sub_1": "冇鱼蛋冇粗面冇去买义大夫",
-      "src_2_sub_2": "冇奖牌冇张宝仔宝藏"
+      "ref_sub_1": "较为特别的是，CIC保险营业员联同⋯",
+      "ref_sub_2": "大角咀春田花花幼稚园⋯",
+      "target_sub_1": "较为特别嘅系CIC保险营业员联同",
+      "target_sub_2": "大角嘴春田花花"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "没有奖牌没有张保仔宝藏",
-      "src_1_sub_2": "而张保仔，也没有咬过那个包",
-      "src_2_sub_1": "冇奖牌冇张宝仔宝藏",
-      "src_2_sub_2": "而张宝仔亦都冇咬过个包"
+      "ref_sub_1": "大角咀春田花花幼稚园⋯",
+      "ref_sub_2": "附属小学一班小朋友⋯",
+      "target_sub_1": "大角嘴春田花花"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "而张保仔，也没有咬过那个包",
-      "src_1_sub_2": "原来蠢，并不那么好笑",
-      "src_2_sub_1": "而张宝仔亦都冇咬过个包",
-      "src_2_sub_2": "原来唔系咁好笑"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "原来蠢，并不那么好笑",
-      "src_1_sub_2": "蠢会失败⋯",
-      "src_2_sub_1": "原来唔系咁好笑",
-      "src_2_sub_2": "会失败"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "蠢会失败⋯",
-      "src_1_sub_2": "会失望",
-      "src_2_sub_1": "会失败",
-      "src_2_sub_2": "会失望"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "会失望",
-      "src_1_sub_2": "失望，并不那么好笑",
-      "src_2_sub_1": "会失望",
-      "src_2_sub_2": "失望唔系咁好笑"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "失望，并不那么好笑",
-      "src_1_sub_2": "肥，都不一定好笑",
-      "src_2_sub_1": "失望唔系咁好笑",
-      "src_2_sub_2": "肥都未必好笑"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "肥，都不一定好笑",
-      "src_1_sub_2": "肥，不一定大力",
-      "src_2_sub_1": "肥都未必好笑",
-      "src_2_sub_2": "肥唔一定大力"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "肥，不一定大力",
-      "src_1_sub_2": "大力，亦不一定得",
-      "src_2_sub_1": "肥唔一定大力",
-      "src_2_sub_2": "大力亦都唔一定得"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "大力，亦不一定得",
-      "src_1_sub_2": "揸住个包，我忽然想⋯",
-      "src_2_sub_1": "大力亦都唔一定得",
-      "src_2_sub_2": "揸住个包我忽然喺度谂"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "揸住个包，我忽然想⋯",
-      "src_1_sub_2": "长大了，到我要面对这个实掘掘⋯",
-      "src_2_sub_1": "揸住个包我忽然喺度谂",
-      "src_2_sub_2": "大个咗到我要面对呢一个实角局"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "长大了，到我要面对这个实掘掘⋯",
-      "src_1_sub_2": "未必可以发梦，未必那么好笑的⋯",
-      "src_2_sub_1": "大个咗到我要面对呢一个实角局",
-      "src_2_sub_2": "未必到你发梦"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "未必可以发梦，未必那么好笑的⋯",
-      "src_1_sub_2": "世界的时候，我会怎么样？",
-      "src_2_sub_1": "未必到你发梦",
-      "src_2_sub_2": "又未必咁好笑嘅世界嘅时候我会系点㗎呢"
+      "ref_sub_1": "附属小学一班小朋友⋯",
+      "ref_sub_2": "争取「抢包山」",
+      "target_sub_2": "幼稚园附属小学嘅一班小朋友争取抢包山"
     },
     "answer": {
-      "src_2_sub_1_shifted": "未必到你发梦又未必咁好笑嘅",
-      "src_2_sub_2_shifted": "世界嘅时候我会系点㗎呢"
+      "target_sub_1_shifted": "幼稚园附属小学嘅一班小朋友",
+      "target_sub_2_shifted": "争取抢包山"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "是的，我就是大个佬麦兜",
-      "src_1_sub_2": "肥，算大力",
-      "src_2_sub_1": "系呀我就系大个佬麦豆喇",
-      "src_2_sub_2": "肥啰算大力啦"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "肥，算大力",
-      "src_1_sub_2": "麻麻地可以",
-      "src_2_sub_1": "肥啰算大力啦",
-      "src_2_sub_2": "麻麻地得咁啦"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "麻麻地可以",
-      "src_1_sub_2": "负家产",
-      "src_2_sub_1": "麻麻地得咁啦",
-      "src_2_sub_2": "富家产啰"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "负家产",
-      "src_1_sub_2": "脚瓜是真的大，比一节瓜还要大",
-      "src_2_sub_1": "富家产啰",
-      "src_2_sub_2": "脚瓜真系几大仲大过个折瓜"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "脚瓜是真的大，比一节瓜还要大",
-      "src_1_sub_2": "脚瓜上的肌肉非常结实⋯",
-      "src_2_sub_1": "脚瓜真系几大仲大过个折瓜",
-      "src_2_sub_2": "脚瓜上面个肌肉非常结实"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "脚瓜上的肌肉非常结实⋯",
-      "src_1_sub_2": "青筋一条条凸出来，似钢筋",
-      "src_2_sub_1": "脚瓜上面个肌肉非常结实",
-      "src_2_sub_2": "啲青筋一条一条凸下凸下好似钢筋"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "青筋一条条凸出来，似钢筋",
-      "src_1_sub_2": "至于脚趾甲⋯",
-      "src_2_sub_1": "啲青筋一条一条凸下凸下好似钢筋",
-      "src_2_sub_2": "至于脚趾弓啲脚甲"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "至于脚趾甲⋯",
-      "src_1_sub_2": "有次我无无聊聊真的量了一下⋯",
-      "src_2_sub_1": "至于脚趾弓啲脚甲",
-      "src_2_sub_2": "有次我无无聊聊真系走去卡下佢"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "有次我无无聊聊真的量了一下⋯",
-      "src_1_sub_2": "足有一寸厚",
-      "src_2_sub_1": "有次我无无聊聊真系走去卡下佢",
-      "src_2_sub_2": "哗粥粥成串咁厚"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "足有一寸厚",
-      "src_1_sub_2": "是的，故事讲完了",
-      "src_2_sub_1": "哗粥粥成串咁厚",
-      "src_2_sub_2": "系呀故事讲完喇"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "是的，故事讲完了",
-      "src_1_sub_2": "这是一个尝试",
-      "src_2_sub_1": "系呀故事讲完喇",
-      "src_2_sub_2": "呢个系一个尝试"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "这是一个尝试",
-      "src_1_sub_2": "失败⋯尝试⋯",
-      "src_2_sub_1": "呢个系一个尝试",
-      "src_2_sub_2": "失败尝试"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "失败⋯尝试⋯",
-      "src_1_sub_2": "好多包⋯可是没有包保成功的故事",
-      "src_2_sub_1": "失败尝试",
-      "src_2_sub_2": "好多包但系冇包补成功嘅故事"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "好多包⋯可是没有包保成功的故事",
-      "src_1_sub_2": "故事说了一轮⋯",
-      "src_2_sub_1": "好多包但系冇包补成功嘅故事",
-      "src_2_sub_2": "故事讲咗一轮"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "故事说了一轮⋯",
-      "src_1_sub_2": "什么也没有？也不是",
-      "src_2_sub_1": "故事讲咗一轮",
-      "src_2_sub_2": "乜都冇又唔系噃"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "什么也没有？也不是",
-      "src_1_sub_2": "就是大了双脚瓜",
-      "src_2_sub_1": "乜都冇又唔系噃",
-      "src_2_sub_2": "就系大咗两个脚瓜"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "就是大了双脚瓜",
-      "src_1_sub_2": "可是楝一双脚瓜站这儿⋯",
-      "src_2_sub_1": "就系大咗两个脚瓜",
-      "src_2_sub_2": "但系冻住两个脚瓜企喺度"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "可是楝一双脚瓜站这儿⋯",
-      "src_1_sub_2": "当浪打过来⋯",
-      "src_2_sub_1": "但系冻住两个脚瓜企喺度",
-      "src_2_sub_2": "当啲浪打埋嚟"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "当浪打过来⋯",
-      "src_1_sub_2": "那感觉还真不错",
-      "src_2_sub_1": "当啲浪打埋嚟",
-      "src_2_sub_2": "嗰张感觉真系好好"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "那感觉还真不错",
-      "src_1_sub_2": "你知道我麻麻地叻佬，不懂得⋯",
-      "src_2_sub_1": "嗰张感觉真系好好",
-      "src_2_sub_2": "你知我麻麻地叻佬"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "你知道我麻麻地叻佬，不懂得⋯",
-      "src_1_sub_2": "替自己的故事加点教训呀锦囊呀那些",
-      "src_2_sub_1": "你知我麻麻地叻佬",
-      "src_2_sub_2": "唔识得帮自己嘅故事加啲教训呀锦囊呀嗰啲嘢"
+      "ref_sub_1": "大角咀春田花花幼稚园⋯",
+      "ref_sub_2": "附属小学一班小朋友⋯",
+      "target_sub_1": "大角嘴春田花花",
+      "target_sub_2": "幼稚园附属小学嘅一班小朋友"
     },
     "answer": {
-      "src_2_sub_1_shifted": "你知我麻麻地叻佬唔识得",
-      "src_2_sub_2_shifted": "帮自己嘅故事加啲教训呀锦囊呀嗰啲嘢"
+      "target_sub_1_shifted": "大角嘴春田花花幼稚园",
+      "target_sub_2_shifted": "附属小学嘅一班小朋友"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "替自己的故事加点教训呀锦囊呀那些",
-      "src_1_sub_2": "可是，浸一双脚瓜站水中⋯",
-      "src_2_sub_1": "帮自己嘅故事加啲教训呀锦囊呀嗰啲嘢",
-      "src_2_sub_2": "但系冻住两个脚瓜企喺水嗰度"
+      "ref_sub_1": "附属小学一班小朋友⋯",
+      "ref_sub_2": "争取「抢包山」",
+      "target_sub_1": "附属小学嘅一班小朋友",
+      "target_sub_2": "争取抢包山"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "可是，浸一双脚瓜站水中⋯",
-      "src_1_sub_2": "当风吹向我的脑，我会想⋯",
-      "src_2_sub_1": "但系冻住两个脚瓜企喺水嗰度",
-      "src_2_sub_2": "当风吹喺我个脑部我会谂"
+      "ref_sub_1": "争取「抢包山」",
+      "ref_sub_2": "一项几乎绝迹的运动⋯",
+      "target_sub_1": "争取抢包山"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "当风吹向我的脑，我会想⋯",
-      "src_1_sub_2": "如果妈妈看见我这个大脚瓜⋯",
-      "src_2_sub_1": "当风吹喺我个脑部我会谂",
-      "src_2_sub_2": "如果妈妈见到我呢个大脚瓜"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "如果妈妈看见我这个大脚瓜⋯",
-      "src_1_sub_2": "我猜，她会好开心",
-      "src_2_sub_1": "如果妈妈见到我呢个大脚瓜",
-      "src_2_sub_2": "我谂佢会好开心"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "不成，还是出个锦囊！",
-      "src_1_sub_2": "妈妈的dot com散掉后，她又有计",
-      "src_2_sub_1": "都系唔好呀都系出返个锦囊先得",
-      "src_2_sub_2": "妈妈个Doccom散咗之后佢又有计喇"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "妈妈的dot com散掉后，她又有计",
-      "src_1_sub_2": "她出版了一本教烹饪的食谱",
-      "src_2_sub_1": "妈妈个Doccom散咗之后佢又有计喇",
-      "src_2_sub_2": "佢出咗半教主送嘅食谱谂住捞返扎沙"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "她出版了一本教烹饪的食谱",
-      "src_1_sub_2": "食谱最后一页教人整烧鸡",
-      "src_2_sub_1": "佢出咗半教主送嘅食谱谂住捞返扎沙",
-      "src_2_sub_2": "食谱最后一页系教人整烧鸡嘅"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "食谱最后一页教人整烧鸡",
-      "src_1_sub_2": "方法简单，人人可学",
-      "src_2_sub_1": "食谱最后一页系教人整烧鸡嘅",
-      "src_2_sub_2": "方法简单人人都学得识"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "方法简单，人人可学",
-      "src_1_sub_2": "「烧鸡」",
-      "src_2_sub_1": "方法简单人人都学得识",
-      "src_2_sub_2": "烧鸡"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "「烧鸡」",
-      "src_1_sub_2": "材料是⋯鸡",
-      "src_2_sub_1": "烧鸡",
-      "src_2_sub_2": "材料系"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "材料是⋯鸡",
-      "src_1_sub_2": "方法：把鸡烧几烧",
-      "src_2_sub_1": "材料系",
-      "src_2_sub_2": "鸡方法攞只鸡去烧佢几烧"
+      "ref_sub_1": "一项几乎绝迹的运动⋯",
+      "ref_sub_2": "成为本港举办亚运的重点推介比赛项目",
+      "target_sub_2": "一项几乎绝迹嘅运动成为本港举办亚运重点推介嘅比赛项目"
     },
     "answer": {
-      "src_2_sub_1_shifted": "材料系鸡",
-      "src_2_sub_2_shifted": "方法攞只鸡去烧佢几烧"
+      "target_sub_1_shifted": "一项几乎绝迹嘅运动",
+      "target_sub_2_shifted": "成为本港举办亚运重点推介嘅比赛项目"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "方法：把鸡烧几烧",
-      "src_1_sub_2": "就这样，一味「烧鸡」大功告成",
-      "src_2_sub_1": "方法攞只鸡去烧佢几烧",
-      "src_2_sub_2": "就噉一味烧鸡就大功告成喇"
+      "ref_sub_1": "争取「抢包山」",
+      "ref_sub_2": "一项几乎绝迹的运动⋯",
+      "target_sub_1": "争取抢包山",
+      "target_sub_2": "一项几乎绝迹嘅运动"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "就这样，一味「烧鸡」大功告成",
-      "src_1_sub_2": "食谱里面补充说：",
-      "src_2_sub_1": "就噉一味烧鸡就大功告成喇",
-      "src_2_sub_2": "食谱度又补充噉话"
+      "ref_sub_1": "一项几乎绝迹的运动⋯",
+      "ref_sub_2": "成为本港举办亚运的重点推介比赛项目",
+      "target_sub_1": "一项几乎绝迹嘅运动",
+      "target_sub_2": "成为本港举办亚运重点推介嘅比赛项目"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "食谱里面补充说：",
-      "src_1_sub_2": "如果你想把鸡烧得美味可口⋯",
-      "src_2_sub_1": "食谱度又补充噉话",
-      "src_2_sub_2": "如果想你个鸡烧得美味可口"
+      "ref_sub_1": "最后⋯",
+      "ref_sub_2": "最后，一切成烟",
+      "target_sub_1": "最后",
+      "target_sub_2": "最后全部都系banana"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "如果你想把鸡烧得美味可口⋯",
-      "src_1_sub_2": "吃完后不会心肺实胃气涨",
-      "src_2_sub_1": "如果想你个鸡烧得美味可口",
-      "src_2_sub_2": "冇话食完腰心腰肺顶住个胃"
+      "ref_sub_1": "最后，一切成烟",
+      "ref_sub_2": "最后，他们选了「掷蛋挞」做推介项目",
+      "target_sub_1": "最后全部都系banana",
+      "target_sub_2": "最后佢哋选咗定蛋挞做推介项目"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "吃完后不会心肺实胃气涨",
-      "src_1_sub_2": "秘诀是：拜托，把鸡烧好一点⋯",
-      "src_2_sub_1": "冇话食完腰心腰肺顶住个胃",
-      "src_2_sub_2": "个秘诀系唔该烧得佢好啲啰"
+      "ref_sub_1": "最后，他们选了「掷蛋挞」做推介项目",
+      "ref_sub_2": "至于香港争取申办亚运的口号⋯",
+      "target_sub_1": "最后佢哋选咗定蛋挞做推介项目",
+      "target_sub_2": "至于香港争取申办亚运嘅口号"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "秘诀是：拜托，把鸡烧好一点⋯",
-      "src_1_sub_2": "多谢合作！",
-      "src_2_sub_1": "个秘诀系唔该烧得佢好啲啰",
-      "src_2_sub_2": "多谢合作"
+      "ref_sub_1": "至于香港争取申办亚运的口号⋯",
+      "ref_sub_2": "亦顺理成章叫成「香港一蛋挞」",
+      "target_sub_1": "至于香港争取申办亚运嘅口号",
+      "target_sub_2": "亦都顺理成章噉叫做香港一蛋挞"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "麻烦你，一客常餐",
-      "src_1_sub_2": "常餐？常餐有什么吃？",
-      "src_2_sub_1": "唔该我要一个常餐啦",
-      "src_2_sub_2": "常餐"
+      "ref_sub_1": "亦顺理成章叫成「香港一蛋挞」",
+      "ref_sub_2": "之后李丽珊蝉联失败⋯",
+      "target_sub_1": "亦都顺理成章噉叫做香港一蛋挞",
+      "target_sub_2": "之后李利山丧乱失败"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "常餐？常餐有什么吃？",
-      "src_1_sub_2": "跟特餐一样吧",
-      "src_2_sub_1": "常餐",
-      "src_2_sub_2": "常餐有咩食㗎"
+      "ref_sub_1": "之后李丽珊蝉联失败⋯",
+      "ref_sub_2": "亚运主办权⋯",
+      "target_sub_1": "之后李利山丧乱失败"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "亚运主办权⋯",
+      "ref_sub_2": "亦由一个香港人从未听过的地方夺得",
+      "target_sub_2": "亚运主办权亦都由一个香港人从未听过嘅地方夺得"
     },
     "answer": {
-      "src_2_sub_1_shifted": "常餐常餐有咩食㗎"
+      "target_sub_1_shifted": "亚运主办权",
+      "target_sub_2_shifted": "亦都由一个香港人从未听过嘅地方夺得"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "跟特餐一样吧",
-      "src_1_sub_2": "特餐是什么？",
-      "src_2_sub_2": "同特餐一样啰"
+      "ref_sub_1": "亦由一个香港人从未听过的地方夺得",
+      "ref_sub_2": "想著转行当运动员的茶餐厅伙记⋯",
+      "target_sub_1": "亦都由一个香港人从未听过嘅地方夺得",
+      "target_sub_2": "谂住可以转行做运动员嘅茶餐厅伙计"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "想著转行当运动员的茶餐厅伙记⋯",
+      "ref_sub_2": "都回到茶餐厅继续掷他们的蛋挞",
+      "target_sub_1": "谂住可以转行做运动员嘅茶餐厅伙计",
+      "target_sub_2": "都返返去茶餐厅继续钉佢哋嘅蛋挞"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "都回到茶餐厅继续掷他们的蛋挞",
+      "ref_sub_2": "一切回复正常",
+      "target_sub_1": "都返返去茶餐厅继续钉佢哋嘅蛋挞",
+      "target_sub_2": "一切回复正常"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "上中学后，我再没有练习抢包手",
+      "ref_sub_2": "有时候跟妈妈饮茶⋯",
+      "target_sub_1": "上个中学我已经再冇练习抢包手",
+      "target_sub_2": "间中同妈妈饮茶"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "有时候跟妈妈饮茶⋯",
+      "ref_sub_2": "我都会手快快替她抢一笼大包",
+      "target_sub_1": "间中同妈妈饮茶",
+      "target_sub_2": "我都会手快快噉帮佢抢龙大包"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我都会手快快替她抢一笼大包",
+      "ref_sub_2": "之后，茶楼再不卖大包了",
+      "target_sub_1": "我都会手快快噉帮佢抢龙大包",
+      "target_sub_2": "之后茶楼都冇埋大包"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "之后，茶楼再不卖大包了",
+      "ref_sub_2": "点心车亦转成点心纸",
+      "target_sub_1": "之后茶楼都冇埋大包",
+      "target_sub_2": "退车仔都转咗用点心纸"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "点心车亦转成点心纸",
+      "ref_sub_2": "一切落空",
+      "target_sub_1": "退车仔都转咗用点心纸",
+      "target_sub_2": "一切都落空"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "有时候我也会跟同学回到长洲烧烤",
+      "ref_sub_2": "每次看见师傅⋯",
+      "target_sub_1": "有时我都会同班同学仔返长洲宵夜食",
+      "target_sub_2": "每次见到师傅"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "每次看见师傅⋯",
+      "ref_sub_2": "他都好像老了一点",
+      "target_sub_1": "每次见到师傅",
+      "target_sub_2": "佢都好似老咗啲噉"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "因为环保⋯",
+      "ref_sub_2": "长洲的抢包都转为塑胶",
+      "target_sub_1": "因为环保",
+      "target_sub_2": "长洲嘅厂包经已转咗用塑胶"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "长洲的抢包都转为塑胶",
+      "ref_sub_2": "师傅说，那阵胶气，相当臭",
+      "target_sub_1": "长洲嘅厂包经已转咗用塑胶",
+      "target_sub_2": "师傅话嗰阵胶气都几丑下"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "长洲有个张保仔洞",
+      "ref_sub_2": "听说张保仔在洞内藏了很多宝藏",
+      "target_sub_1": "墙后个张宝仔洞",
+      "target_sub_2": "听讲海盗张宝仔喺里面收埋咗好多宝藏"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "听说张保仔在洞内藏了很多宝藏",
+      "ref_sub_2": "因为我练过抢包手，身手比较灵活⋯",
+      "target_sub_1": "听讲海盗张宝仔喺里面收埋咗好多宝藏",
+      "target_sub_2": "因为我练过抢包手身手比较灵活"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "因为我练过抢包手，身手比较灵活⋯",
+      "ref_sub_2": "同学们叫我爬进去看看，说不定会发达",
+      "target_sub_1": "因为我练过抢包手身手比较灵活",
+      "target_sub_2": "班同我叫我爬佢睇下话唔定会发达"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "同学们叫我爬进去看看，说不定会发达",
+      "ref_sub_2": "于是我就向著这个又黑又窄的洞⋯",
+      "target_sub_1": "班同我叫我爬佢睇下话唔定会发达",
+      "target_sub_2": "于是我就向住呢一个又黑又窄嘅洞"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "于是我就向著这个又黑又窄的洞⋯",
+      "ref_sub_2": "一直爬",
+      "target_sub_1": "于是我就向住呢一个又黑又窄嘅洞",
+      "target_sub_2": "系噉爬爬"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "一直爬",
+      "ref_sub_2": "洞里面什么也没有，只有一个盒",
+      "target_sub_1": "系噉爬爬",
+      "target_sub_2": "洞里面乜都冇净系有一个盒"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "洞里面什么也没有，只有一个盒",
+      "ref_sub_2": "我小心揭开盒⋯",
+      "target_sub_1": "洞里面乜都冇净系有一个盒",
+      "target_sub_2": "我好小心揭开呢个盒"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我小心揭开盒⋯",
+      "ref_sub_2": "发现里面一个没吃完的大包",
+      "target_sub_1": "我好小心揭开呢个盒",
+      "target_sub_2": "发现入面系一个食净咗嘅大包"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "发现里面一个没吃完的大包",
+      "ref_sub_2": "是不是张保仔吃过的呢？",
+      "target_sub_1": "发现入面系一个食净咗嘅大包",
+      "target_sub_2": "唔知系咪张宝仔食净㗎啦"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "是不是张保仔吃过的呢？",
+      "ref_sub_2": "「寻晚，食了六个餐包」",
+      "target_sub_1": "唔知系咪张宝仔食净㗎啦"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "「年晚，又培育了珊珊！可惜⋯」",
+      "ref_sub_2": "揸住个包，我忽然明白⋯",
+      "target_sub_2": "揸住个包我忽然明白"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "揸住个包，我忽然明白⋯",
+      "ref_sub_2": "原来有些事情，没有就是没有",
+      "target_sub_1": "揸住个包我忽然明白",
+      "target_sub_2": "原来有啲嘢冇就真系冇"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "原来有些事情，没有就是没有",
+      "ref_sub_2": "唔得，就是唔得",
+      "target_sub_1": "原来有啲嘢冇就真系冇",
+      "target_sub_2": "唔得就真系唔得"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "唔得，就是唔得",
+      "ref_sub_2": "没有鱼蛋没有粗面没去成马尔代夫⋯",
+      "target_sub_1": "唔得就真系唔得",
+      "target_sub_2": "冇鱼蛋冇粗面"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "没有鱼蛋没有粗面没去成马尔代夫⋯",
+      "ref_sub_2": "没有奖牌没有张保仔宝藏",
+      "target_sub_1": "冇鱼蛋冇粗面",
+      "target_sub_2": "冇去买义大夫冇奖牌冇张宝仔宝藏"
     },
     "answer": {
-      "src_2_sub_1_shifted": "同特餐一样啰"
+      "target_sub_1_shifted": "冇鱼蛋冇粗面冇去买义大夫",
+      "target_sub_2_shifted": "冇奖牌冇张宝仔宝藏"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "特餐是什么？",
-      "src_1_sub_2": "跟快餐差不多",
-      "src_2_sub_2": "噉特餐系咩嚟㗎同快餐咁上下啰"
+      "ref_sub_1": "唔得，就是唔得",
+      "ref_sub_2": "没有鱼蛋没有粗面没去成马尔代夫⋯",
+      "target_sub_1": "唔得就真系唔得",
+      "target_sub_2": "冇鱼蛋冇粗面冇去买义大夫"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "没有鱼蛋没有粗面没去成马尔代夫⋯",
+      "ref_sub_2": "没有奖牌没有张保仔宝藏",
+      "target_sub_1": "冇鱼蛋冇粗面冇去买义大夫",
+      "target_sub_2": "冇奖牌冇张宝仔宝藏"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "没有奖牌没有张保仔宝藏",
+      "ref_sub_2": "而张保仔，也没有咬过那个包",
+      "target_sub_1": "冇奖牌冇张宝仔宝藏",
+      "target_sub_2": "而张宝仔亦都冇咬过个包"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "而张保仔，也没有咬过那个包",
+      "ref_sub_2": "原来蠢，并不那么好笑",
+      "target_sub_1": "而张宝仔亦都冇咬过个包",
+      "target_sub_2": "原来唔系咁好笑"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "原来蠢，并不那么好笑",
+      "ref_sub_2": "蠢会失败⋯",
+      "target_sub_1": "原来唔系咁好笑",
+      "target_sub_2": "会失败"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "蠢会失败⋯",
+      "ref_sub_2": "会失望",
+      "target_sub_1": "会失败",
+      "target_sub_2": "会失望"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "会失望",
+      "ref_sub_2": "失望，并不那么好笑",
+      "target_sub_1": "会失望",
+      "target_sub_2": "失望唔系咁好笑"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "失望，并不那么好笑",
+      "ref_sub_2": "肥，都不一定好笑",
+      "target_sub_1": "失望唔系咁好笑",
+      "target_sub_2": "肥都未必好笑"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "肥，都不一定好笑",
+      "ref_sub_2": "肥，不一定大力",
+      "target_sub_1": "肥都未必好笑",
+      "target_sub_2": "肥唔一定大力"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "肥，不一定大力",
+      "ref_sub_2": "大力，亦不一定得",
+      "target_sub_1": "肥唔一定大力",
+      "target_sub_2": "大力亦都唔一定得"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "大力，亦不一定得",
+      "ref_sub_2": "揸住个包，我忽然想⋯",
+      "target_sub_1": "大力亦都唔一定得",
+      "target_sub_2": "揸住个包我忽然喺度谂"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "揸住个包，我忽然想⋯",
+      "ref_sub_2": "长大了，到我要面对这个实掘掘⋯",
+      "target_sub_1": "揸住个包我忽然喺度谂",
+      "target_sub_2": "大个咗到我要面对呢一个实角局"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "长大了，到我要面对这个实掘掘⋯",
+      "ref_sub_2": "未必可以发梦，未必那么好笑的⋯",
+      "target_sub_1": "大个咗到我要面对呢一个实角局",
+      "target_sub_2": "未必到你发梦"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "未必可以发梦，未必那么好笑的⋯",
+      "ref_sub_2": "世界的时候，我会怎么样？",
+      "target_sub_1": "未必到你发梦",
+      "target_sub_2": "又未必咁好笑嘅世界嘅时候我会系点㗎呢"
     },
     "answer": {
-      "src_2_sub_1_shifted": "噉特餐系咩嚟㗎",
-      "src_2_sub_2_shifted": "同快餐咁上下啰"
+      "target_sub_1_shifted": "未必到你发梦又未必咁好笑嘅",
+      "target_sub_2_shifted": "世界嘅时候我会系点㗎呢"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "跟快餐差不多",
-      "src_1_sub_2": "快餐又是什么？",
-      "src_2_sub_1": "同快餐咁上下啰",
-      "src_2_sub_2": "噉快餐又系咩嚟㗎"
+      "ref_sub_1": "是的，我就是大个佬麦兜",
+      "ref_sub_2": "肥，算大力",
+      "target_sub_1": "系呀我就系大个佬麦豆喇",
+      "target_sub_2": "肥啰算大力啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "快餐又是什么？",
-      "src_1_sub_2": "快餐即是午餐",
-      "src_2_sub_1": "噉快餐又系咩嚟㗎",
-      "src_2_sub_2": "即系快餐咪真系午餐"
+      "ref_sub_1": "肥，算大力",
+      "ref_sub_2": "麻麻地可以",
+      "target_sub_1": "肥啰算大力啦",
+      "target_sub_2": "麻麻地得咁啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "快餐即是午餐",
-      "src_1_sub_2": "午餐吃什么？",
-      "src_2_sub_1": "即系快餐咪真系午餐"
+      "ref_sub_1": "麻麻地可以",
+      "ref_sub_2": "负家产",
+      "target_sub_1": "麻麻地得咁啦",
+      "target_sub_2": "富家产啰"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "午餐吃什么？",
-      "src_1_sub_2": "午餐跟晚餐一样",
-      "src_2_sub_2": "午餐食咩㗎午餐同晚餐一样㗎"
+      "ref_sub_1": "负家产",
+      "ref_sub_2": "脚瓜是真的大，比一节瓜还要大",
+      "target_sub_1": "富家产啰",
+      "target_sub_2": "脚瓜真系几大仲大过个折瓜"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "脚瓜是真的大，比一节瓜还要大",
+      "ref_sub_2": "脚瓜上的肌肉非常结实⋯",
+      "target_sub_1": "脚瓜真系几大仲大过个折瓜",
+      "target_sub_2": "脚瓜上面个肌肉非常结实"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "脚瓜上的肌肉非常结实⋯",
+      "ref_sub_2": "青筋一条条凸出来，似钢筋",
+      "target_sub_1": "脚瓜上面个肌肉非常结实",
+      "target_sub_2": "啲青筋一条一条凸下凸下好似钢筋"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "青筋一条条凸出来，似钢筋",
+      "ref_sub_2": "至于脚趾甲⋯",
+      "target_sub_1": "啲青筋一条一条凸下凸下好似钢筋",
+      "target_sub_2": "至于脚趾弓啲脚甲"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "至于脚趾甲⋯",
+      "ref_sub_2": "有次我无无聊聊真的量了一下⋯",
+      "target_sub_1": "至于脚趾弓啲脚甲",
+      "target_sub_2": "有次我无无聊聊真系走去卡下佢"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "有次我无无聊聊真的量了一下⋯",
+      "ref_sub_2": "足有一寸厚",
+      "target_sub_1": "有次我无无聊聊真系走去卡下佢",
+      "target_sub_2": "哗粥粥成串咁厚"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "足有一寸厚",
+      "ref_sub_2": "是的，故事讲完了",
+      "target_sub_1": "哗粥粥成串咁厚",
+      "target_sub_2": "系呀故事讲完喇"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "是的，故事讲完了",
+      "ref_sub_2": "这是一个尝试",
+      "target_sub_1": "系呀故事讲完喇",
+      "target_sub_2": "呢个系一个尝试"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "这是一个尝试",
+      "ref_sub_2": "失败⋯尝试⋯",
+      "target_sub_1": "呢个系一个尝试",
+      "target_sub_2": "失败尝试"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "失败⋯尝试⋯",
+      "ref_sub_2": "好多包⋯可是没有包保成功的故事",
+      "target_sub_1": "失败尝试",
+      "target_sub_2": "好多包但系冇包补成功嘅故事"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "好多包⋯可是没有包保成功的故事",
+      "ref_sub_2": "故事说了一轮⋯",
+      "target_sub_1": "好多包但系冇包补成功嘅故事",
+      "target_sub_2": "故事讲咗一轮"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "故事说了一轮⋯",
+      "ref_sub_2": "什么也没有？也不是",
+      "target_sub_1": "故事讲咗一轮",
+      "target_sub_2": "乜都冇又唔系噃"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "什么也没有？也不是",
+      "ref_sub_2": "就是大了双脚瓜",
+      "target_sub_1": "乜都冇又唔系噃",
+      "target_sub_2": "就系大咗两个脚瓜"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "就是大了双脚瓜",
+      "ref_sub_2": "可是楝一双脚瓜站这儿⋯",
+      "target_sub_1": "就系大咗两个脚瓜",
+      "target_sub_2": "但系冻住两个脚瓜企喺度"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "可是楝一双脚瓜站这儿⋯",
+      "ref_sub_2": "当浪打过来⋯",
+      "target_sub_1": "但系冻住两个脚瓜企喺度",
+      "target_sub_2": "当啲浪打埋嚟"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "当浪打过来⋯",
+      "ref_sub_2": "那感觉还真不错",
+      "target_sub_1": "当啲浪打埋嚟",
+      "target_sub_2": "嗰张感觉真系好好"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "那感觉还真不错",
+      "ref_sub_2": "你知道我麻麻地叻佬，不懂得⋯",
+      "target_sub_1": "嗰张感觉真系好好",
+      "target_sub_2": "你知我麻麻地叻佬"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "你知道我麻麻地叻佬，不懂得⋯",
+      "ref_sub_2": "替自己的故事加点教训呀锦囊呀那些",
+      "target_sub_1": "你知我麻麻地叻佬",
+      "target_sub_2": "唔识得帮自己嘅故事加啲教训呀锦囊呀嗰啲嘢"
     },
     "answer": {
-      "src_2_sub_1_shifted": "午餐食咩㗎",
-      "src_2_sub_2_shifted": "午餐同晚餐一样㗎"
+      "target_sub_1_shifted": "你知我麻麻地叻佬唔识得",
+      "target_sub_2_shifted": "帮自己嘅故事加啲教训呀锦囊呀嗰啲嘢"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "午餐跟晚餐一样",
-      "src_1_sub_2": "晚餐又吃什么？",
-      "src_2_sub_1": "午餐同晚餐一样㗎",
-      "src_2_sub_2": "噉晚餐又食啲咩呀"
+      "ref_sub_1": "替自己的故事加点教训呀锦囊呀那些",
+      "ref_sub_2": "可是，浸一双脚瓜站水中⋯",
+      "target_sub_1": "帮自己嘅故事加啲教训呀锦囊呀嗰啲嘢",
+      "target_sub_2": "但系冻住两个脚瓜企喺水嗰度"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "晚餐又吃什么？",
-      "src_1_sub_2": "晚餐即是常餐",
-      "src_2_sub_1": "噉晚餐又食啲咩呀",
-      "src_2_sub_2": "晚餐咪真系常餐啰"
+      "ref_sub_1": "可是，浸一双脚瓜站水中⋯",
+      "ref_sub_2": "当风吹向我的脑，我会想⋯",
+      "target_sub_1": "但系冻住两个脚瓜企喺水嗰度",
+      "target_sub_2": "当风吹喺我个脑部我会谂"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "晚餐即是常餐",
-      "src_1_sub_2": "那么，两客常餐吧",
-      "src_2_sub_1": "晚餐咪真系常餐啰",
-      "src_2_sub_2": "噉呀我要两个常餐啦"
+      "ref_sub_1": "当风吹向我的脑，我会想⋯",
+      "ref_sub_2": "如果妈妈看见我这个大脚瓜⋯",
+      "target_sub_1": "当风吹喺我个脑部我会谂",
+      "target_sub_2": "如果妈妈见到我呢个大脚瓜"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "那么，两客常餐吧",
-      "src_1_sub_2": "今天常餐精采呀！",
-      "src_2_sub_1": "噉呀我要两个常餐啦",
-      "src_2_sub_2": "好嘢呀我哋今日啲常餐"
+      "ref_sub_1": "如果妈妈看见我这个大脚瓜⋯",
+      "ref_sub_2": "我猜，她会好开心",
+      "target_sub_1": "如果妈妈见到我呢个大脚瓜",
+      "target_sub_2": "我谂佢会好开心"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "对不起，常餐卖光了",
-      "src_1_sub_2": "那改要特餐吧",
-      "src_2_sub_1": "唔好意思上餐卖晒",
-      "src_2_sub_2": "咁改要特餐啦"
+      "ref_sub_1": "不成，还是出个锦囊！",
+      "ref_sub_2": "妈妈的dot com散掉后，她又有计",
+      "target_sub_1": "都系唔好呀都系出返个锦囊先得",
+      "target_sub_2": "妈妈个Doccom散咗之后佢又有计喇"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "那改要特餐吧",
-      "src_1_sub_2": "特餐？特餐有什么吃？",
-      "src_2_sub_1": "咁改要特餐啦",
-      "src_2_sub_2": "特餐"
+      "ref_sub_1": "妈妈的dot com散掉后，她又有计",
+      "ref_sub_2": "她出版了一本教烹饪的食谱",
+      "target_sub_1": "妈妈个Doccom散咗之后佢又有计喇",
+      "target_sub_2": "佢出咗半教主送嘅食谱谂住捞返扎沙"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "特餐？特餐有什么吃？",
-      "src_1_sub_2": "特餐即是午餐呀",
-      "src_2_sub_1": "特餐",
-      "src_2_sub_2": "特餐有咩食㗎特餐就即系午餐啰"
+      "ref_sub_1": "她出版了一本教烹饪的食谱",
+      "ref_sub_2": "食谱最后一页教人整烧鸡",
+      "target_sub_1": "佢出咗半教主送嘅食谱谂住捞返扎沙",
+      "target_sub_2": "食谱最后一页系教人整烧鸡嘅"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "食谱最后一页教人整烧鸡",
+      "ref_sub_2": "方法简单，人人可学",
+      "target_sub_1": "食谱最后一页系教人整烧鸡嘅",
+      "target_sub_2": "方法简单人人都学得识"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "方法简单，人人可学",
+      "ref_sub_2": "「烧鸡」",
+      "target_sub_1": "方法简单人人都学得识",
+      "target_sub_2": "烧鸡"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "「烧鸡」",
+      "ref_sub_2": "材料是⋯鸡",
+      "target_sub_1": "烧鸡",
+      "target_sub_2": "材料系"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "材料是⋯鸡",
+      "ref_sub_2": "方法：把鸡烧几烧",
+      "target_sub_1": "材料系",
+      "target_sub_2": "鸡方法攞只鸡去烧佢几烧"
     },
     "answer": {
-      "src_2_sub_1_shifted": "特餐特餐有咩食㗎",
-      "src_2_sub_2_shifted": "特餐就即系午餐啰"
+      "target_sub_1_shifted": "材料系鸡",
+      "target_sub_2_shifted": "方法攞只鸡去烧佢几烧"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "特餐即是午餐呀",
-      "src_1_sub_2": "午餐又吃什么呢？",
-      "src_2_sub_1": "特餐就即系午餐啰",
-      "src_2_sub_2": "午餐食乜嘢㗎"
+      "ref_sub_1": "方法：把鸡烧几烧",
+      "ref_sub_2": "就这样，一味「烧鸡」大功告成",
+      "target_sub_1": "方法攞只鸡去烧佢几烧",
+      "target_sub_2": "就噉一味烧鸡就大功告成喇"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "午餐又吃什么呢？",
-      "src_1_sub_2": "都是晚餐那些吧",
-      "src_2_sub_1": "午餐食乜嘢㗎",
-      "src_2_sub_2": "都系晚餐嗰啲嘢啰"
+      "ref_sub_1": "就这样，一味「烧鸡」大功告成",
+      "ref_sub_2": "食谱里面补充说：",
+      "target_sub_1": "就噉一味烧鸡就大功告成喇",
+      "target_sub_2": "食谱度又补充噉话"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "都是晚餐那些吧",
-      "src_1_sub_2": "什么是晚餐？",
-      "src_2_sub_1": "都系晚餐嗰啲嘢啰"
+      "ref_sub_1": "食谱里面补充说：",
+      "ref_sub_2": "如果你想把鸡烧得美味可口⋯",
+      "target_sub_1": "食谱度又补充噉话",
+      "target_sub_2": "如果想你个鸡烧得美味可口"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "什么是晚餐？",
-      "src_1_sub_2": "跟快餐一样",
-      "src_2_sub_2": "咁乜嘢系晚餐呀"
+      "ref_sub_1": "如果你想把鸡烧得美味可口⋯",
+      "ref_sub_2": "吃完后不会心肺实胃气涨",
+      "target_sub_1": "如果想你个鸡烧得美味可口",
+      "target_sub_2": "冇话食完腰心腰肺顶住个胃"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "吃完后不会心肺实胃气涨",
+      "ref_sub_2": "秘诀是：拜托，把鸡烧好一点⋯",
+      "target_sub_1": "冇话食完腰心腰肺顶住个胃",
+      "target_sub_2": "个秘诀系唔该烧得佢好啲啰"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "秘诀是：拜托，把鸡烧好一点⋯",
+      "ref_sub_2": "多谢合作！",
+      "target_sub_1": "个秘诀系唔该烧得佢好啲啰",
+      "target_sub_2": "多谢合作"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "麻烦你，一客常餐",
+      "ref_sub_2": "常餐？常餐有什么吃？",
+      "target_sub_1": "唔该我要一个常餐啦",
+      "target_sub_2": "常餐"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "常餐？常餐有什么吃？",
+      "ref_sub_2": "跟特餐一样吧",
+      "target_sub_1": "常餐",
+      "target_sub_2": "常餐有咩食㗎"
     },
     "answer": {
-      "src_2_sub_1_shifted": "咁乜嘢系晚餐呀"
+      "target_sub_1_shifted": "常餐常餐有咩食㗎"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "跟快餐一样",
-      "src_1_sub_2": "快餐吃什么？",
-      "src_2_sub_2": "同快餐一样啰咁快餐食咩㗎"
+      "ref_sub_1": "跟特餐一样吧",
+      "ref_sub_2": "特餐是什么？",
+      "target_sub_2": "同特餐一样啰"
     },
     "answer": {
-      "src_2_sub_1_shifted": "同快餐一样啰",
-      "src_2_sub_2_shifted": "咁快餐食咩㗎"
+      "target_sub_1_shifted": "同特餐一样啰"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "快餐吃什么？",
-      "src_1_sub_2": "唉，快餐不就是常餐",
-      "src_2_sub_1": "咁快餐食咩㗎",
-      "src_2_sub_2": "系快餐就即系上餐啰"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "唉，快餐不就是常餐",
-      "src_1_sub_2": "常餐不是卖光了吗？",
-      "src_2_sub_1": "系快餐就即系上餐啰",
-      "src_2_sub_2": "咁你头先又话冇上餐"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "常餐不是卖光了吗？",
-      "src_1_sub_2": "对，常餐卖光了，要吃特餐吗？",
-      "src_2_sub_1": "咁你头先又话冇上餐",
-      "src_2_sub_2": "系呀上餐就系卖晒呀咁你试唔试下特餐啦"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "对，常餐卖光了，要吃特餐吗？",
-      "src_1_sub_2": "来两份特餐吧",
-      "src_2_sub_1": "系呀上餐就系卖晒呀咁你试唔试下特餐啦",
-      "src_2_sub_2": "两份特餐啦"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "来两份特餐吧",
-      "src_1_sub_2": "对不起，特餐卖光了",
-      "src_2_sub_1": "两份特餐啦",
-      "src_2_sub_2": "唔好意思特餐卖晒嘅"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "对不起，特餐卖光了",
-      "src_1_sub_2": "妈妈，改快餐吧",
-      "src_2_sub_1": "唔好意思特餐卖晒嘅",
-      "src_2_sub_2": "妈妈"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "妈妈，改快餐吧",
-      "src_1_sub_2": "快餐有什么？",
-      "src_2_sub_1": "妈妈",
-      "src_2_sub_2": "不如改快餐啦快餐有咩㗎"
+      "ref_sub_1": "特餐是什么？",
+      "ref_sub_2": "跟快餐差不多",
+      "target_sub_2": "噉特餐系咩嚟㗎同快餐咁上下啰"
     },
     "answer": {
-      "src_2_sub_1_shifted": "妈妈不如改快餐啦",
-      "src_2_sub_2_shifted": "快餐有咩㗎"
+      "target_sub_1_shifted": "噉特餐系咩嚟㗎",
+      "target_sub_2_shifted": "同快餐咁上下啰"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "快餐有什么？",
-      "src_1_sub_2": "快餐即是常餐",
-      "src_2_sub_1": "快餐有咩㗎",
-      "src_2_sub_2": "快餐即系上餐"
+      "ref_sub_1": "跟快餐差不多",
+      "ref_sub_2": "快餐又是什么？",
+      "target_sub_1": "同快餐咁上下啰",
+      "target_sub_2": "噉快餐又系咩嚟㗎"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "快餐即是常餐",
-      "src_1_sub_2": "常餐又有什么呢？",
-      "src_2_sub_1": "快餐即系上餐",
-      "src_2_sub_2": "咁上餐有咩㗎"
+      "ref_sub_1": "快餐又是什么？",
+      "ref_sub_2": "快餐即是午餐",
+      "target_sub_1": "噉快餐又系咩嚟㗎",
+      "target_sub_2": "即系快餐咪真系午餐"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "常餐又有什么呢？",
-      "src_1_sub_2": "常餐即是午餐",
-      "src_2_sub_1": "咁上餐有咩㗎",
-      "src_2_sub_2": "上餐就即系午餐啰"
+      "ref_sub_1": "快餐即是午餐",
+      "ref_sub_2": "午餐吃什么？",
+      "target_sub_1": "即系快餐咪真系午餐"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "常餐即是午餐",
-      "src_1_sub_2": "那么午餐又有什么吃？",
-      "src_2_sub_1": "上餐就即系午餐啰",
-      "src_2_sub_2": "哎呀咁午餐有咩食呀"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "那么午餐又有什么吃？",
-      "src_1_sub_2": "午餐跟晚餐一样",
-      "src_2_sub_1": "哎呀咁午餐有咩食呀",
-      "src_2_sub_2": "午餐同晚餐一样㗎"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "午餐跟晚餐一样",
-      "src_1_sub_2": "晚餐呢？",
-      "src_2_sub_1": "午餐同晚餐一样㗎"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "晚餐呢？",
-      "src_1_sub_2": "晚餐不就是特餐",
-      "src_2_sub_2": "咁晚餐呢晚餐就即系特餐啰"
+      "ref_sub_1": "午餐吃什么？",
+      "ref_sub_2": "午餐跟晚餐一样",
+      "target_sub_2": "午餐食咩㗎午餐同晚餐一样㗎"
     },
     "answer": {
-      "src_2_sub_1_shifted": "咁晚餐呢",
-      "src_2_sub_2_shifted": "晚餐就即系特餐啰"
+      "target_sub_1_shifted": "午餐食咩㗎",
+      "target_sub_2_shifted": "午餐同晚餐一样㗎"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "晚餐不就是特餐",
-      "src_1_sub_2": "不是说特餐卖光了吗？",
-      "src_2_sub_1": "晚餐就即系特餐啰",
-      "src_2_sub_2": "咁你头先又话冇特餐"
+      "ref_sub_1": "午餐跟晚餐一样",
+      "ref_sub_2": "晚餐又吃什么？",
+      "target_sub_1": "午餐同晚餐一样㗎",
+      "target_sub_2": "噉晚餐又食啲咩呀"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "不是说特餐卖光了吗？",
-      "src_1_sub_2": "特餐卖光了，要试试快餐吗？都一样的",
-      "src_2_sub_1": "咁你头先又话冇特餐",
-      "src_2_sub_2": "系呀特餐系卖晒呀咁你试唔试下个快餐啦"
+      "ref_sub_1": "晚餐又吃什么？",
+      "ref_sub_2": "晚餐即是常餐",
+      "target_sub_1": "噉晚餐又食啲咩呀",
+      "target_sub_2": "晚餐咪真系常餐啰"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "特餐卖光了，要试试快餐吗？都一样的",
-      "src_1_sub_2": "来两份快餐吧",
-      "src_2_sub_1": "系呀特餐系卖晒呀咁你试唔试下个快餐啦",
-      "src_2_sub_2": "一样嘅啫咁两份快餐啦"
-    },
-    "answer": {
-      "src_2_sub_1_shifted": "系呀特餐系卖晒呀咁你试唔试下个快餐啦一样嘅啫",
-      "src_2_sub_2_shifted": "咁两份快餐啦"
-    },
-    "difficulty": 1,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "对不起，没快餐了",
-      "src_1_sub_2": "太过份了吧？你们究竟有吃的没？",
-      "src_2_sub_1": "唔好意思冇快餐呀",
-      "src_2_sub_2": "嚟唔嚟普啲呀噉你哋究竟有啲咩餐呀"
+      "ref_sub_1": "晚餐即是常餐",
+      "ref_sub_2": "那么，两客常餐吧",
+      "target_sub_1": "晚餐咪真系常餐啰",
+      "target_sub_2": "噉呀我要两个常餐啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "太过份了吧？你们究竟有吃的没？",
-      "src_1_sub_2": "午餐吧，午餐精采呀",
-      "src_2_sub_1": "嚟唔嚟普啲呀噉你哋究竟有啲咩餐呀",
-      "src_2_sub_2": "午餐啦"
+      "ref_sub_1": "那么，两客常餐吧",
+      "ref_sub_2": "今天常餐精采呀！",
+      "target_sub_1": "噉呀我要两个常餐啦",
+      "target_sub_2": "好嘢呀我哋今日啲常餐"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "午餐吧，午餐精采呀",
-      "src_1_sub_2": "怎么个精采法？",
-      "src_2_sub_1": "午餐啦",
-      "src_2_sub_2": "午餐好嘢呀"
-    },
-    "answer": {
-      "src_2_sub_1_shifted": "午餐啦午餐好嘢呀"
-    },
-    "difficulty": 1,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "怎么个精采法？",
-      "src_1_sub_2": "跟晚餐一样精采",
-      "src_2_sub_2": "点好嘢法呀"
-    },
-    "answer": {
-      "src_2_sub_1_shifted": "点好嘢法呀"
-    },
-    "difficulty": 1,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "跟晚餐一样精采",
-      "src_1_sub_2": "晚餐又怎样呢？",
-      "src_2_sub_2": "同晚餐一样咁好嘢"
-    },
-    "answer": {
-      "src_2_sub_1_shifted": "同晚餐一样咁好嘢"
-    },
-    "difficulty": 1,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "晚餐又怎样呢？",
-      "src_1_sub_2": "跟常餐一样精采",
-      "src_2_sub_2": "噉晚餐又点好嘢法呀同上餐一样咁好嘢啰"
-    },
-    "answer": {
-      "src_2_sub_1_shifted": "噉晚餐又点好嘢法呀",
-      "src_2_sub_2_shifted": "同上餐一样咁好嘢啰"
-    },
-    "difficulty": 1,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "跟常餐一样精采",
-      "src_1_sub_2": "常餐又怎样呢？",
-      "src_2_sub_1": "同上餐一样咁好嘢啰"
+      "ref_sub_1": "对不起，常餐卖光了",
+      "ref_sub_2": "那改要特餐吧",
+      "target_sub_1": "唔好意思上餐卖晒",
+      "target_sub_2": "咁改要特餐啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "常餐又怎样呢？",
-      "src_1_sub_2": "常餐早卖光了，你说精采不？",
-      "src_2_sub_2": "噉上餐又点好嘢法呀上餐上餐一早卖晒啦你话好唔好嘢"
-    },
-    "answer": {
-      "src_2_sub_1_shifted": "噉上餐又点好嘢法呀",
-      "src_2_sub_2_shifted": "上餐上餐一早卖晒啦你话好唔好嘢"
-    },
-    "difficulty": 1,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "常餐早卖光了，你说精采不？",
-      "src_1_sub_2": "好吧好吧！两份午餐好了",
-      "src_2_sub_1": "上餐上餐一早卖晒啦你话好唔好嘢",
-      "src_2_sub_2": "好啦好啦要两份午餐啦"
+      "ref_sub_1": "那改要特餐吧",
+      "ref_sub_2": "特餐？特餐有什么吃？",
+      "target_sub_1": "咁改要特餐啦",
+      "target_sub_2": "特餐"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "对不起，午餐卖光了",
-      "src_1_sub_2": "要试试我们的晚餐吗？都一样的",
-      "src_2_sub_1": "唔好意思",
-      "src_2_sub_2": "午餐卖晒试唔试下我哋嘅晚餐啦"
+      "ref_sub_1": "特餐？特餐有什么吃？",
+      "ref_sub_2": "特餐即是午餐呀",
+      "target_sub_1": "特餐",
+      "target_sub_2": "特餐有咩食㗎特餐就即系午餐啰"
     },
     "answer": {
-      "src_2_sub_1_shifted": "唔好意思午餐卖晒",
-      "src_2_sub_2_shifted": "试唔试下我哋嘅晚餐啦"
+      "target_sub_1_shifted": "特餐特餐有咩食㗎",
+      "target_sub_2_shifted": "特餐就即系午餐啰"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "要试试我们的晚餐吗？都一样的",
-      "src_1_sub_2": "光天白日，吃什么鬼晚餐？",
-      "src_2_sub_1": "试唔试下我哋嘅晚餐啦",
-      "src_2_sub_2": "一样嘅啫日光日白食乜鬼嘢晚餐啊"
+      "ref_sub_1": "特餐即是午餐呀",
+      "ref_sub_2": "午餐又吃什么呢？",
+      "target_sub_1": "特餐就即系午餐啰",
+      "target_sub_2": "午餐食乜嘢㗎"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "午餐又吃什么呢？",
+      "ref_sub_2": "都是晚餐那些吧",
+      "target_sub_1": "午餐食乜嘢㗎",
+      "target_sub_2": "都系晚餐嗰啲嘢啰"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "都是晚餐那些吧",
+      "ref_sub_2": "什么是晚餐？",
+      "target_sub_1": "都系晚餐嗰啲嘢啰"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "什么是晚餐？",
+      "ref_sub_2": "跟快餐一样",
+      "target_sub_2": "咁乜嘢系晚餐呀"
     },
     "answer": {
-      "src_2_sub_1_shifted": "试唔试下我哋嘅晚餐啦一样嘅啫",
-      "src_2_sub_2_shifted": "日光日白食乜鬼嘢晚餐啊"
+      "target_sub_1_shifted": "咁乜嘢系晚餐呀"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "光天白日，吃什么鬼晚餐？",
-      "src_1_sub_2": "唉，说是说晚餐，还不就是午餐？",
-      "src_2_sub_1": "日光日白食乜鬼嘢晚餐啊",
-      "src_2_sub_2": "系个名叫晚餐啫其实唔系真系午餐"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "唉，说是说晚餐，还不就是午餐？",
-      "src_1_sub_2": "好吧好吧，拜托！两份晚餐！快！",
-      "src_2_sub_1": "系个名叫晚餐啫其实唔系真系午餐",
-      "src_2_sub_2": "好啦好啦怕咗你啦要两份晚餐啦"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "好吧好吧，拜托！两份晚餐！快！",
-      "src_1_sub_2": "要快吗？那得吃快餐了！",
-      "src_2_sub_1": "好啦好啦怕咗你啦要两份晚餐啦",
-      "src_2_sub_2": "快啲手啊想快想快就要快餐啊"
+      "ref_sub_1": "跟快餐一样",
+      "ref_sub_2": "快餐吃什么？",
+      "target_sub_2": "同快餐一样啰咁快餐食咩㗎"
     },
     "answer": {
-      "src_2_sub_1_shifted": "好啦好啦怕咗你啦要两份晚餐啦快啲手啊",
-      "src_2_sub_2_shifted": "想快想快就要快餐啊"
+      "target_sub_1_shifted": "同快餐一样啰",
+      "target_sub_2_shifted": "咁快餐食咩㗎"
+    },
+    "difficulty": 1,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "快餐吃什么？",
+      "ref_sub_2": "唉，快餐不就是常餐",
+      "target_sub_1": "咁快餐食咩㗎",
+      "target_sub_2": "系快餐就即系上餐啰"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "唉，快餐不就是常餐",
+      "ref_sub_2": "常餐不是卖光了吗？",
+      "target_sub_1": "系快餐就即系上餐啰",
+      "target_sub_2": "咁你头先又话冇上餐"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "常餐不是卖光了吗？",
+      "ref_sub_2": "对，常餐卖光了，要吃特餐吗？",
+      "target_sub_1": "咁你头先又话冇上餐",
+      "target_sub_2": "系呀上餐就系卖晒呀咁你试唔试下特餐啦"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "对，常餐卖光了，要吃特餐吗？",
+      "ref_sub_2": "来两份特餐吧",
+      "target_sub_1": "系呀上餐就系卖晒呀咁你试唔试下特餐啦",
+      "target_sub_2": "两份特餐啦"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "来两份特餐吧",
+      "ref_sub_2": "对不起，特餐卖光了",
+      "target_sub_1": "两份特餐啦",
+      "target_sub_2": "唔好意思特餐卖晒嘅"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "对不起，特餐卖光了",
+      "ref_sub_2": "妈妈，改快餐吧",
+      "target_sub_1": "唔好意思特餐卖晒嘅",
+      "target_sub_2": "妈妈"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "妈妈，改快餐吧",
+      "ref_sub_2": "快餐有什么？",
+      "target_sub_1": "妈妈",
+      "target_sub_2": "不如改快餐啦快餐有咩㗎"
+    },
+    "answer": {
+      "target_sub_1_shifted": "妈妈不如改快餐啦",
+      "target_sub_2_shifted": "快餐有咩㗎"
+    },
+    "difficulty": 1,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "快餐有什么？",
+      "ref_sub_2": "快餐即是常餐",
+      "target_sub_1": "快餐有咩㗎",
+      "target_sub_2": "快餐即系上餐"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "快餐即是常餐",
+      "ref_sub_2": "常餐又有什么呢？",
+      "target_sub_1": "快餐即系上餐",
+      "target_sub_2": "咁上餐有咩㗎"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "常餐又有什么呢？",
+      "ref_sub_2": "常餐即是午餐",
+      "target_sub_1": "咁上餐有咩㗎",
+      "target_sub_2": "上餐就即系午餐啰"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "常餐即是午餐",
+      "ref_sub_2": "那么午餐又有什么吃？",
+      "target_sub_1": "上餐就即系午餐啰",
+      "target_sub_2": "哎呀咁午餐有咩食呀"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "那么午餐又有什么吃？",
+      "ref_sub_2": "午餐跟晚餐一样",
+      "target_sub_1": "哎呀咁午餐有咩食呀",
+      "target_sub_2": "午餐同晚餐一样㗎"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "午餐跟晚餐一样",
+      "ref_sub_2": "晚餐呢？",
+      "target_sub_1": "午餐同晚餐一样㗎"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "晚餐呢？",
+      "ref_sub_2": "晚餐不就是特餐",
+      "target_sub_2": "咁晚餐呢晚餐就即系特餐啰"
+    },
+    "answer": {
+      "target_sub_1_shifted": "咁晚餐呢",
+      "target_sub_2_shifted": "晚餐就即系特餐啰"
+    },
+    "difficulty": 1,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "晚餐不就是特餐",
+      "ref_sub_2": "不是说特餐卖光了吗？",
+      "target_sub_1": "晚餐就即系特餐啰",
+      "target_sub_2": "咁你头先又话冇特餐"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "不是说特餐卖光了吗？",
+      "ref_sub_2": "特餐卖光了，要试试快餐吗？都一样的",
+      "target_sub_1": "咁你头先又话冇特餐",
+      "target_sub_2": "系呀特餐系卖晒呀咁你试唔试下个快餐啦"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "特餐卖光了，要试试快餐吗？都一样的",
+      "ref_sub_2": "来两份快餐吧",
+      "target_sub_1": "系呀特餐系卖晒呀咁你试唔试下个快餐啦",
+      "target_sub_2": "一样嘅啫咁两份快餐啦"
+    },
+    "answer": {
+      "target_sub_1_shifted": "系呀特餐系卖晒呀咁你试唔试下个快餐啦一样嘅啫",
+      "target_sub_2_shifted": "咁两份快餐啦"
+    },
+    "difficulty": 1,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "对不起，没快餐了",
+      "ref_sub_2": "太过份了吧？你们究竟有吃的没？",
+      "target_sub_1": "唔好意思冇快餐呀",
+      "target_sub_2": "嚟唔嚟普啲呀噉你哋究竟有啲咩餐呀"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "太过份了吧？你们究竟有吃的没？",
+      "ref_sub_2": "午餐吧，午餐精采呀",
+      "target_sub_1": "嚟唔嚟普啲呀噉你哋究竟有啲咩餐呀",
+      "target_sub_2": "午餐啦"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "午餐吧，午餐精采呀",
+      "ref_sub_2": "怎么个精采法？",
+      "target_sub_1": "午餐啦",
+      "target_sub_2": "午餐好嘢呀"
+    },
+    "answer": {
+      "target_sub_1_shifted": "午餐啦午餐好嘢呀"
+    },
+    "difficulty": 1,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "怎么个精采法？",
+      "ref_sub_2": "跟晚餐一样精采",
+      "target_sub_2": "点好嘢法呀"
+    },
+    "answer": {
+      "target_sub_1_shifted": "点好嘢法呀"
+    },
+    "difficulty": 1,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "跟晚餐一样精采",
+      "ref_sub_2": "晚餐又怎样呢？",
+      "target_sub_2": "同晚餐一样咁好嘢"
+    },
+    "answer": {
+      "target_sub_1_shifted": "同晚餐一样咁好嘢"
+    },
+    "difficulty": 1,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "晚餐又怎样呢？",
+      "ref_sub_2": "跟常餐一样精采",
+      "target_sub_2": "噉晚餐又点好嘢法呀同上餐一样咁好嘢啰"
+    },
+    "answer": {
+      "target_sub_1_shifted": "噉晚餐又点好嘢法呀",
+      "target_sub_2_shifted": "同上餐一样咁好嘢啰"
+    },
+    "difficulty": 1,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "跟常餐一样精采",
+      "ref_sub_2": "常餐又怎样呢？",
+      "target_sub_1": "同上餐一样咁好嘢啰"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "常餐又怎样呢？",
+      "ref_sub_2": "常餐早卖光了，你说精采不？",
+      "target_sub_2": "噉上餐又点好嘢法呀上餐上餐一早卖晒啦你话好唔好嘢"
+    },
+    "answer": {
+      "target_sub_1_shifted": "噉上餐又点好嘢法呀",
+      "target_sub_2_shifted": "上餐上餐一早卖晒啦你话好唔好嘢"
+    },
+    "difficulty": 1,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "常餐早卖光了，你说精采不？",
+      "ref_sub_2": "好吧好吧！两份午餐好了",
+      "target_sub_1": "上餐上餐一早卖晒啦你话好唔好嘢",
+      "target_sub_2": "好啦好啦要两份午餐啦"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "对不起，午餐卖光了",
+      "ref_sub_2": "要试试我们的晚餐吗？都一样的",
+      "target_sub_1": "唔好意思",
+      "target_sub_2": "午餐卖晒试唔试下我哋嘅晚餐啦"
+    },
+    "answer": {
+      "target_sub_1_shifted": "唔好意思午餐卖晒",
+      "target_sub_2_shifted": "试唔试下我哋嘅晚餐啦"
+    },
+    "difficulty": 1,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "要试试我们的晚餐吗？都一样的",
+      "ref_sub_2": "光天白日，吃什么鬼晚餐？",
+      "target_sub_1": "试唔试下我哋嘅晚餐啦",
+      "target_sub_2": "一样嘅啫日光日白食乜鬼嘢晚餐啊"
+    },
+    "answer": {
+      "target_sub_1_shifted": "试唔试下我哋嘅晚餐啦一样嘅啫",
+      "target_sub_2_shifted": "日光日白食乜鬼嘢晚餐啊"
+    },
+    "difficulty": 1,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "光天白日，吃什么鬼晚餐？",
+      "ref_sub_2": "唉，说是说晚餐，还不就是午餐？",
+      "target_sub_1": "日光日白食乜鬼嘢晚餐啊",
+      "target_sub_2": "系个名叫晚餐啫其实唔系真系午餐"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "唉，说是说晚餐，还不就是午餐？",
+      "ref_sub_2": "好吧好吧，拜托！两份晚餐！快！",
+      "target_sub_1": "系个名叫晚餐啫其实唔系真系午餐",
+      "target_sub_2": "好啦好啦怕咗你啦要两份晚餐啦"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "好吧好吧，拜托！两份晚餐！快！",
+      "ref_sub_2": "要快吗？那得吃快餐了！",
+      "target_sub_1": "好啦好啦怕咗你啦要两份晚餐啦",
+      "target_sub_2": "快啲手啊想快想快就要快餐啊"
+    },
+    "answer": {
+      "target_sub_1_shifted": "好啦好啦怕咗你啦要两份晚餐啦快啲手啊",
+      "target_sub_2_shifted": "想快想快就要快餐啊"
     },
     "difficulty": 1,
     "verified": true

--- a/test/data/mlamd/output/yue-Hans_transcribe/lang/yue_zho/transcription/delineation/mps.json
+++ b/test/data/mlamd/output/yue-Hans_transcribe/lang/yue_zho/transcription/delineation/mps.json
@@ -1,71 +1,40 @@
 [
   {
     "query": {
-      "src_1_sub_1": "在麦太即将临盆的时候",
-      "src_1_sub_2": "一只胶兜在九龙上空飞过",
-      "src_2_sub_1": "就喺麦太快要临盘嘅时候",
-      "src_2_sub_2": "有一个胶兜喺九龙上空飞过"
+      "ref_sub_1": "在麦太即将临盆的时候",
+      "ref_sub_2": "一只胶兜在九龙上空飞过",
+      "target_sub_1": "就喺麦太快要临盘嘅时候",
+      "target_sub_2": "有一个胶兜喺九龙上空飞过"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "一只胶兜在九龙上空飞过",
-      "src_1_sub_2": "沿荔枝角道直出大角咀道",
-      "src_2_sub_1": "有一个胶兜喺九龙上空飞过",
-      "src_2_sub_2": "沿住荔枝角度直出大角咀度"
+      "ref_sub_1": "一只胶兜在九龙上空飞过",
+      "ref_sub_2": "沿荔枝角道直出大角咀道",
+      "target_sub_1": "有一个胶兜喺九龙上空飞过",
+      "target_sub_2": "沿住荔枝角度直出大角咀度"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "沿荔枝角道直出大角咀道",
-      "src_1_sub_2": "经好彩酒家左转花园街乐园牛丸王⋯",
-      "src_2_sub_1": "沿住荔枝角度直出大角咀度",
-      "src_2_sub_2": "经过好彩走家再左转返出花园街乐园牛园望对上"
+      "ref_sub_1": "沿荔枝角道直出大角咀道",
+      "ref_sub_2": "经好彩酒家左转花园街乐园牛丸王⋯",
+      "target_sub_1": "沿住荔枝角度直出大角咀度",
+      "target_sub_2": "经过好彩走家再左转返出花园街乐园牛园望对上"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "经好彩酒家左转花园街乐园牛丸王⋯",
-      "src_1_sub_2": "更正一下：",
-      "src_2_sub_1": "经过好彩走家再左转返出花园街乐园牛园望对上",
-      "src_2_sub_2": "都系唔好"
-    },
-    "answer": {},
-    "few_shot": true,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "更正一下：",
-      "src_1_sub_2": "先到街市大楼妹记鱼腩粥外边",
-      "src_2_sub_1": "都系唔好",
-      "src_2_sub_2": "先去街市大楼嗰间妹记鱼腩粥嗰度"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "先到街市大楼妹记鱼腩粥外边",
-      "src_1_sub_2": "转呀，转⋯再更正一下：",
-      "src_2_sub_1": "先去街市大楼嗰间妹记鱼腩粥嗰度",
-      "src_2_sub_2": "转下转下都系唔好"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "转呀，转⋯再更正一下：",
-      "src_1_sub_2": "直出亚皆老街跨过火车桥右转太平道",
-      "src_2_sub_1": "转下转下都系唔好",
-      "src_2_sub_2": "都系出返去阿街路街飞过火车桥右转入太平道"
+      "ref_sub_1": "经好彩酒家左转花园街乐园牛丸王⋯",
+      "ref_sub_2": "更正一下：",
+      "target_sub_1": "经过好彩走家再左转返出花园街乐园牛园望对上",
+      "target_sub_2": "都系唔好"
     },
     "answer": {},
     "few_shot": true,
@@ -73,151 +42,30 @@
   },
   {
     "query": {
-      "src_1_sub_1": "直出亚皆老街跨过火车桥右转太平道",
-      "src_1_sub_2": "再右拐窝打老道向女人街方向飞⋯",
-      "src_2_sub_1": "都系出返去阿街路街飞过火车桥右转入太平道",
-      "src_2_sub_2": "再右转抹返出去窝打炉道向女人街方向飞下下"
+      "ref_sub_1": "更正一下：",
+      "ref_sub_2": "先到街市大楼妹记鱼腩粥外边",
+      "target_sub_1": "都系唔好",
+      "target_sub_2": "先去街市大楼嗰间妹记鱼腩粥嗰度"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "再右拐窝打老道向女人街方向飞⋯",
-      "src_1_sub_2": "飞呀，飞⋯",
-      "src_2_sub_1": "再右转抹返出去窝打炉道向女人街方向飞下下",
-      "src_2_sub_2": "飞下飞下"
-    },
-    "answer": {},
-    "few_shot": true,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "飞呀，飞⋯",
-      "src_1_sub_2": "胶兜最后飞进广华医院候产房",
-      "src_2_sub_1": "飞下飞下",
-      "src_2_sub_2": "最后胶兜飞咗入广华医院嘅后产房"
+      "ref_sub_1": "先到街市大楼妹记鱼腩粥外边",
+      "ref_sub_2": "转呀，转⋯再更正一下：",
+      "target_sub_1": "先去街市大楼嗰间妹记鱼腩粥嗰度",
+      "target_sub_2": "转下转下都系唔好"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "胶兜最后飞进广华医院候产房",
-      "src_1_sub_2": "也就是在麦太右边额角上⋯",
-      "src_2_sub_1": "最后胶兜飞咗入广华医院嘅后产房",
-      "src_2_sub_2": "亦即系麦太右边云晶对上"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "也就是在麦太右边额角上⋯",
-      "src_1_sub_2": "更正：左边额角上⋯",
-      "src_2_sub_1": "亦即系麦太右边云晶对上",
-      "src_2_sub_2": "都系唔好左边云晶对上"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "更正：左边额角上⋯",
-      "src_1_sub_2": "转呀，转⋯",
-      "src_2_sub_1": "都系唔好左边云晶对上",
-      "src_2_sub_2": "转下转下转下噉"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "转呀，转⋯",
-      "src_1_sub_2": "麦太认定这是异像",
-      "src_2_sub_1": "转下转下转下噉",
-      "src_2_sub_2": "麦太认定呢个系异象"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "麦太认定这是异像",
-      "src_1_sub_2": "于是向额角上的胶兜许愿",
-      "src_2_sub_1": "麦太认定呢个系异象",
-      "src_2_sub_2": "于是向云晶对上嘅胶兜许愿"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "于是向额角上的胶兜许愿",
-      "src_1_sub_2": "脑海中同时出现即将诞生的儿子容貌⋯",
-      "src_2_sub_1": "于是向云晶对上嘅胶兜许愿",
-      "src_2_sub_2": "而脑入面亦即时出现咗快要出世个仔嘅样"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "脑海中同时出现即将诞生的儿子容貌⋯",
-      "src_1_sub_2": "希望他好聪明，读书好叻！",
-      "src_2_sub_1": "而脑入面亦即时出现咗快要出世个仔嘅样",
-      "src_2_sub_2": "希望佢好聪明读书好叻"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "希望他好聪明，读书好叻！",
-      "src_1_sub_2": "胶兜对麦太的愿望似乎没有反应",
-      "src_2_sub_1": "希望佢好聪明读书好叻",
-      "src_2_sub_2": "胶兜对麦太嘅愿望似乎冇咩表示"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "胶兜对麦太的愿望似乎没有反应",
-      "src_1_sub_2": "于是她向胶兜补充说：",
-      "src_2_sub_1": "胶兜对麦太嘅愿望似乎冇咩表示",
-      "src_2_sub_2": "于是佢对住胶兜补充噉话"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "于是她向胶兜补充说：",
-      "src_1_sub_2": "或者读书唔叻，工作叻呢？",
-      "src_2_sub_1": "于是佢对住胶兜补充噉话",
-      "src_2_sub_2": "或者读书唔叻出嚟做嘢叻啦"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "或者读书唔叻，工作叻呢？",
-      "src_1_sub_2": "又或者⋯",
-      "src_2_sub_1": "或者读书唔叻出嚟做嘢叻啦",
-      "src_2_sub_2": "又或者呢"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "又或者⋯",
-      "src_1_sub_2": "又或者好靓仔，好靓仔",
-      "src_2_sub_1": "又或者呢",
-      "src_2_sub_2": "又或者系好靓仔好靓仔"
+      "ref_sub_1": "转呀，转⋯再更正一下：",
+      "ref_sub_2": "直出亚皆老街跨过火车桥右转太平道",
+      "target_sub_1": "转下转下都系唔好",
+      "target_sub_2": "都系出返去阿街路街飞过火车桥右转入太平道"
     },
     "answer": {},
     "few_shot": true,
@@ -225,234 +73,386 @@
   },
   {
     "query": {
-      "src_1_sub_1": "又或者好靓仔，好靓仔",
-      "src_1_sub_2": "跟周润发，梁朝伟那么靓仔！",
-      "src_2_sub_1": "又或者系好靓仔好靓仔",
-      "src_2_sub_2": "好似周润发同埋梁朝伟咁靓仔"
+      "ref_sub_1": "直出亚皆老街跨过火车桥右转太平道",
+      "ref_sub_2": "再右拐窝打老道向女人街方向飞⋯",
+      "target_sub_1": "都系出返去阿街路街飞过火车桥右转入太平道",
+      "target_sub_2": "再右转抹返出去窝打炉道向女人街方向飞下下"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "跟周润发，梁朝伟那么靓仔！",
-      "src_1_sub_2": "胶兜仍然在转，毫无点头迹象",
-      "src_2_sub_1": "好似周润发同埋梁朝伟咁靓仔",
-      "src_2_sub_2": "胶兜依然系噉喺度转好似一啲应承嘅迹象都冇"
+      "ref_sub_1": "再右拐窝打老道向女人街方向飞⋯",
+      "ref_sub_2": "飞呀，飞⋯",
+      "target_sub_1": "再右转抹返出去窝打炉道向女人街方向飞下下",
+      "target_sub_2": "飞下飞下"
+    },
+    "answer": {},
+    "few_shot": true,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "飞呀，飞⋯",
+      "ref_sub_2": "胶兜最后飞进广华医院候产房",
+      "target_sub_1": "飞下飞下",
+      "target_sub_2": "最后胶兜飞咗入广华医院嘅后产房"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "胶兜仍然在转，毫无点头迹象",
-      "src_1_sub_2": "麦太一时心虚",
-      "src_2_sub_1": "胶兜依然系噉喺度转好似一啲应承嘅迹象都冇",
-      "src_2_sub_2": "麦太一时心虚"
+      "ref_sub_1": "胶兜最后飞进广华医院候产房",
+      "ref_sub_2": "也就是在麦太右边额角上⋯",
+      "target_sub_1": "最后胶兜飞咗入广华医院嘅后产房",
+      "target_sub_2": "亦即系麦太右边云晶对上"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "麦太一时心虚",
-      "src_1_sub_2": "赶忙趁胶兜落地前另许一个愿望：",
-      "src_2_sub_1": "麦太一时心虚",
-      "src_2_sub_2": "嗱嗱嗱喺胶兜未落地之前起过另外一个愿望"
+      "ref_sub_1": "也就是在麦太右边额角上⋯",
+      "ref_sub_2": "更正：左边额角上⋯",
+      "target_sub_1": "亦即系麦太右边云晶对上",
+      "target_sub_2": "都系唔好左边云晶对上"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "赶忙趁胶兜落地前另许一个愿望：",
-      "src_1_sub_2": "唔聪明唔靓仔也算了，只要福星高照",
-      "src_2_sub_1": "嗱嗱嗱喺胶兜未落地之前起过另外一个愿望",
-      "src_2_sub_2": "就算唔系咁聪明同咁靓仔只要复星高照"
+      "ref_sub_1": "更正：左边额角上⋯",
+      "ref_sub_2": "转呀，转⋯",
+      "target_sub_1": "都系唔好左边云晶对上",
+      "target_sub_2": "转下转下转下噉"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "唔聪明唔靓仔也算了，只要福星高照",
-      "src_1_sub_2": "一世够运，逢凶化吉！",
-      "src_2_sub_1": "就算唔系咁聪明同咁靓仔只要复星高照",
-      "src_2_sub_2": "一世救运乜嘢事都逢凶化㗎喇"
+      "ref_sub_1": "转呀，转⋯",
+      "ref_sub_2": "麦太认定这是异像",
+      "target_sub_1": "转下转下转下噉",
+      "target_sub_2": "麦太认定呢个系异象"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "一世够运，逢凶化吉！",
-      "src_1_sub_2": "靠自己能力解决事情当然最好",
-      "src_2_sub_1": "一世救运乜嘢事都逢凶化㗎喇",
-      "src_2_sub_2": "佢靠自己有料解决啲嘢就梗系好啦"
+      "ref_sub_1": "麦太认定这是异像",
+      "ref_sub_2": "于是向额角上的胶兜许愿",
+      "target_sub_1": "麦太认定呢个系异象",
+      "target_sub_2": "于是向云晶对上嘅胶兜许愿"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "靠自己能力解决事情当然最好",
-      "src_1_sub_2": "不过运气还是很重要的",
-      "src_2_sub_1": "佢靠自己有料解决啲嘢就梗系好啦",
-      "src_2_sub_2": "不过运气都好紧要㖞"
+      "ref_sub_1": "于是向额角上的胶兜许愿",
+      "ref_sub_2": "脑海中同时出现即将诞生的儿子容貌⋯",
+      "target_sub_1": "于是向云晶对上嘅胶兜许愿",
+      "target_sub_2": "而脑入面亦即时出现咗快要出世个仔嘅样"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "不过运气还是很重要的",
-      "src_1_sub_2": "虽是说像梁朝伟周润发也行运定了",
-      "src_2_sub_1": "不过运气都好紧要㖞",
-      "src_2_sub_2": "虽然似梁朝伟周润发都唔返去冒运行"
+      "ref_sub_1": "脑海中同时出现即将诞生的儿子容貌⋯",
+      "ref_sub_2": "希望他好聪明，读书好叻！",
+      "target_sub_1": "而脑入面亦即时出现咗快要出世个仔嘅样",
+      "target_sub_2": "希望佢好聪明读书好叻"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "虽是说像梁朝伟周润发也行运定了",
-      "src_1_sub_2": "但总得要叻仔呀！",
-      "src_2_sub_1": "虽然似梁朝伟周润发都唔返去冒运行",
-      "src_2_sub_2": "但系都要叻仔先得㗎"
+      "ref_sub_1": "希望他好聪明，读书好叻！",
+      "ref_sub_2": "胶兜对麦太的愿望似乎没有反应",
+      "target_sub_1": "希望佢好聪明读书好叻",
+      "target_sub_2": "胶兜对麦太嘅愿望似乎冇咩表示"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "最后，胶兜「嘀督」一声落地",
-      "src_1_sub_2": "嘀督？嘀督，就是答应了",
-      "src_2_sub_1": "最后胶兜滴嘟一声咁落地",
-      "src_2_sub_2": "滴嘟滴嘟㖞即系应承啦"
+      "ref_sub_1": "胶兜对麦太的愿望似乎没有反应",
+      "ref_sub_2": "于是她向胶兜补充说：",
+      "target_sub_1": "胶兜对麦太嘅愿望似乎冇咩表示",
+      "target_sub_2": "于是佢对住胶兜补充噉话"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "嘀督？嘀督，就是答应了",
-      "src_1_sub_2": "麦太想，这次走运了！",
-      "src_2_sub_1": "滴嘟滴嘟㖞即系应承啦",
-      "src_2_sub_2": "麦太心谂今次冇死喇"
+      "ref_sub_1": "于是她向胶兜补充说：",
+      "ref_sub_2": "或者读书唔叻，工作叻呢？",
+      "target_sub_1": "于是佢对住胶兜补充噉话",
+      "target_sub_2": "或者读书唔叻出嚟做嘢叻啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "麦太想，这次走运了！",
-      "src_1_sub_2": "可是答应了些什么呢？",
-      "src_2_sub_1": "麦太心谂今次冇死喇",
-      "src_2_sub_2": "但你应承咗啲咩呢"
+      "ref_sub_1": "或者读书唔叻，工作叻呢？",
+      "ref_sub_2": "又或者⋯",
+      "target_sub_1": "或者读书唔叻出嚟做嘢叻啦",
+      "target_sub_2": "又或者呢"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "可是答应了些什么呢？",
-      "src_1_sub_2": "叻仔？好运？",
-      "src_2_sub_1": "但你应承咗啲咩呢",
-      "src_2_sub_2": "叻仔好运"
+      "ref_sub_1": "又或者⋯",
+      "ref_sub_2": "又或者好靓仔，好靓仔",
+      "target_sub_1": "又或者呢",
+      "target_sub_2": "又或者系好靓仔好靓仔"
+    },
+    "answer": {},
+    "few_shot": true,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "又或者好靓仔，好靓仔",
+      "ref_sub_2": "跟周润发，梁朝伟那么靓仔！",
+      "target_sub_1": "又或者系好靓仔好靓仔",
+      "target_sub_2": "好似周润发同埋梁朝伟咁靓仔"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "叻仔？好运？",
-      "src_1_sub_2": "还是似周润发？",
-      "src_2_sub_1": "叻仔好运",
-      "src_2_sub_2": "定系话自周人烦啊"
+      "ref_sub_1": "跟周润发，梁朝伟那么靓仔！",
+      "ref_sub_2": "胶兜仍然在转，毫无点头迹象",
+      "target_sub_1": "好似周润发同埋梁朝伟咁靓仔",
+      "target_sub_2": "胶兜依然系噉喺度转好似一啲应承嘅迹象都冇"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "还是似周润发？",
-      "src_1_sub_2": "为了纪念这赐福的胶兜",
-      "src_2_sub_1": "定系话自周人烦啊",
-      "src_2_sub_2": "为咗纪念呢个赤幅嘅胶兜"
+      "ref_sub_1": "胶兜仍然在转，毫无点头迹象",
+      "ref_sub_2": "麦太一时心虚",
+      "target_sub_1": "胶兜依然系噉喺度转好似一啲应承嘅迹象都冇",
+      "target_sub_2": "麦太一时心虚"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "为了纪念这赐福的胶兜",
-      "src_1_sub_2": "麦太决定把儿子命名麦胶",
-      "src_2_sub_1": "为咗纪念呢个赤幅嘅胶兜",
-      "src_2_sub_2": "麦太决定将个仔嘅名叫做麦胶"
+      "ref_sub_1": "麦太一时心虚",
+      "ref_sub_2": "赶忙趁胶兜落地前另许一个愿望：",
+      "target_sub_1": "麦太一时心虚",
+      "target_sub_2": "嗱嗱嗱喺胶兜未落地之前起过另外一个愿望"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "麦太决定把儿子命名麦胶",
-      "src_1_sub_2": "不行，胶胶声，多难听！",
-      "src_2_sub_1": "麦太决定将个仔嘅名叫做麦胶",
-      "src_2_sub_2": "都系唔好胶胶声咁难听"
+      "ref_sub_1": "赶忙趁胶兜落地前另许一个愿望：",
+      "ref_sub_2": "唔聪明唔靓仔也算了，只要福星高照",
+      "target_sub_1": "嗱嗱嗱喺胶兜未落地之前起过另外一个愿望",
+      "target_sub_2": "就算唔系咁聪明同咁靓仔只要复星高照"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "不行，胶胶声，多难听！",
-      "src_1_sub_2": "还是唤他麦兜！",
-      "src_2_sub_1": "都系唔好胶胶声咁难听",
-      "src_2_sub_2": "不如叫麦兜啦"
+      "ref_sub_1": "唔聪明唔靓仔也算了，只要福星高照",
+      "ref_sub_2": "一世够运，逢凶化吉！",
+      "target_sub_1": "就算唔系咁聪明同咁靓仔只要复星高照",
+      "target_sub_2": "一世救运乜嘢事都逢凶化㗎喇"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "还是唤他麦兜！",
-      "src_1_sub_2": "各位⋯",
-      "src_2_sub_1": "不如叫麦兜啦",
-      "src_2_sub_2": "各位"
+      "ref_sub_1": "一世够运，逢凶化吉！",
+      "ref_sub_2": "靠自己能力解决事情当然最好",
+      "target_sub_1": "一世救运乜嘢事都逢凶化㗎喇",
+      "target_sub_2": "佢靠自己有料解决啲嘢就梗系好啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "各位⋯",
-      "src_1_sub_2": "我就是险些给定名麦胶的小朋友⋯",
-      "src_2_sub_1": "各位",
-      "src_2_sub_2": "我就系呢个差少少就叫做麦胶嘅小朋友"
+      "ref_sub_1": "靠自己能力解决事情当然最好",
+      "ref_sub_2": "不过运气还是很重要的",
+      "target_sub_1": "佢靠自己有料解决啲嘢就梗系好啦",
+      "target_sub_2": "不过运气都好紧要㖞"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我就是险些给定名麦胶的小朋友⋯",
-      "src_1_sub_2": "麦兜！",
-      "src_2_sub_1": "我就系呢个差少少就叫做麦胶嘅小朋友",
-      "src_2_sub_2": "麦兜"
+      "ref_sub_1": "不过运气还是很重要的",
+      "ref_sub_2": "虽是说像梁朝伟周润发也行运定了",
+      "target_sub_1": "不过运气都好紧要㖞",
+      "target_sub_2": "虽然似梁朝伟周润发都唔返去冒运行"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "麦太，没见面一阵",
-      "src_1_sub_2": "怎么小腿粗起来了？",
-      "src_2_sub_1": "咦麦太",
-      "src_2_sub_2": "咩唔见你一排个脚刮囊粗咗咁多呀"
+      "ref_sub_1": "虽是说像梁朝伟周润发也行运定了",
+      "ref_sub_2": "但总得要叻仔呀！",
+      "target_sub_1": "虽然似梁朝伟周润发都唔返去冒运行",
+      "target_sub_2": "但系都要叻仔先得㗎"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "最后，胶兜「嘀督」一声落地",
+      "ref_sub_2": "嘀督？嘀督，就是答应了",
+      "target_sub_1": "最后胶兜滴嘟一声咁落地",
+      "target_sub_2": "滴嘟滴嘟㖞即系应承啦"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "嘀督？嘀督，就是答应了",
+      "ref_sub_2": "麦太想，这次走运了！",
+      "target_sub_1": "滴嘟滴嘟㖞即系应承啦",
+      "target_sub_2": "麦太心谂今次冇死喇"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "麦太想，这次走运了！",
+      "ref_sub_2": "可是答应了些什么呢？",
+      "target_sub_1": "麦太心谂今次冇死喇",
+      "target_sub_2": "但你应承咗啲咩呢"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "可是答应了些什么呢？",
+      "ref_sub_2": "叻仔？好运？",
+      "target_sub_1": "但你应承咗啲咩呢",
+      "target_sub_2": "叻仔好运"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "叻仔？好运？",
+      "ref_sub_2": "还是似周润发？",
+      "target_sub_1": "叻仔好运",
+      "target_sub_2": "定系话自周人烦啊"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "还是似周润发？",
+      "ref_sub_2": "为了纪念这赐福的胶兜",
+      "target_sub_1": "定系话自周人烦啊",
+      "target_sub_2": "为咗纪念呢个赤幅嘅胶兜"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "为了纪念这赐福的胶兜",
+      "ref_sub_2": "麦太决定把儿子命名麦胶",
+      "target_sub_1": "为咗纪念呢个赤幅嘅胶兜",
+      "target_sub_2": "麦太决定将个仔嘅名叫做麦胶"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "麦太决定把儿子命名麦胶",
+      "ref_sub_2": "不行，胶胶声，多难听！",
+      "target_sub_1": "麦太决定将个仔嘅名叫做麦胶",
+      "target_sub_2": "都系唔好胶胶声咁难听"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "不行，胶胶声，多难听！",
+      "ref_sub_2": "还是唤他麦兜！",
+      "target_sub_1": "都系唔好胶胶声咁难听",
+      "target_sub_2": "不如叫麦兜啦"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "还是唤他麦兜！",
+      "ref_sub_2": "各位⋯",
+      "target_sub_1": "不如叫麦兜啦",
+      "target_sub_2": "各位"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "各位⋯",
+      "ref_sub_2": "我就是险些给定名麦胶的小朋友⋯",
+      "target_sub_1": "各位",
+      "target_sub_2": "我就系呢个差少少就叫做麦胶嘅小朋友"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我就是险些给定名麦胶的小朋友⋯",
+      "ref_sub_2": "麦兜！",
+      "target_sub_1": "我就系呢个差少少就叫做麦胶嘅小朋友",
+      "target_sub_2": "麦兜"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "麦太，没见面一阵",
+      "ref_sub_2": "怎么小腿粗起来了？",
+      "target_sub_1": "咦麦太",
+      "target_sub_2": "咩唔见你一排个脚刮囊粗咗咁多呀"
     },
     "answer": {
-      "src_2_sub_1_shifted": "咦麦太咩唔见你一排",
-      "src_2_sub_2_shifted": "个脚刮囊粗咗咁多呀"
+      "target_sub_1_shifted": "咦麦太咩唔见你一排",
+      "target_sub_2_shifted": "个脚刮囊粗咗咁多呀"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -460,10 +460,10 @@
   },
   {
     "query": {
-      "src_1_sub_1": "怎么小腿粗起来了？",
-      "src_1_sub_2": "可怜呀，每天扑来扑去⋯",
-      "src_2_sub_1": "个脚刮囊粗咗咁多呀",
-      "src_2_sub_2": "鬼咩"
+      "ref_sub_1": "怎么小腿粗起来了？",
+      "ref_sub_2": "可怜呀，每天扑来扑去⋯",
+      "target_sub_1": "个脚刮囊粗咗咁多呀",
+      "target_sub_2": "鬼咩"
     },
     "answer": {},
     "few_shot": true,
@@ -471,14 +471,14 @@
   },
   {
     "query": {
-      "src_1_sub_1": "可怜呀，每天扑来扑去⋯",
-      "src_1_sub_2": "替儿子找幼稚园！",
-      "src_2_sub_1": "鬼咩",
-      "src_2_sub_2": "日日扑嚟扑去同我仔揾幼稚园吖嘛"
+      "ref_sub_1": "可怜呀，每天扑来扑去⋯",
+      "ref_sub_2": "替儿子找幼稚园！",
+      "target_sub_1": "鬼咩",
+      "target_sub_2": "日日扑嚟扑去同我仔揾幼稚园吖嘛"
     },
     "answer": {
-      "src_2_sub_1_shifted": "鬼咩日日扑嚟扑去",
-      "src_2_sub_2_shifted": "同我仔揾幼稚园吖嘛"
+      "target_sub_1_shifted": "鬼咩日日扑嚟扑去",
+      "target_sub_2_shifted": "同我仔揾幼稚园吖嘛"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -486,52 +486,52 @@
   },
   {
     "query": {
-      "src_1_sub_1": "替儿子找幼稚园！",
-      "src_1_sub_2": "怎么不试一试好彩酒楼对面",
-      "src_2_sub_1": "同我仔揾幼稚园吖嘛",
-      "src_2_sub_2": "点解唔试下好彩走楼斜对面"
+      "ref_sub_1": "替儿子找幼稚园！",
+      "ref_sub_2": "怎么不试一试好彩酒楼对面",
+      "target_sub_1": "同我仔揾幼稚园吖嘛",
+      "target_sub_2": "点解唔试下好彩走楼斜对面"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "怎么不试一试好彩酒楼对面",
-      "src_1_sub_2": "旧中侨国货楼上的⋯",
-      "src_2_sub_1": "点解唔试下好彩走楼斜对面"
+      "ref_sub_1": "怎么不试一试好彩酒楼对面",
+      "ref_sub_2": "旧中侨国货楼上的⋯",
+      "target_sub_1": "点解唔试下好彩走楼斜对面"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "旧中侨国货楼上的⋯",
-      "src_1_sub_2": "春田花花幼稚园？",
-      "src_2_sub_2": "旧中桥百货公司楼上嗰间春田花花幼稚园呢"
+      "ref_sub_1": "旧中侨国货楼上的⋯",
+      "ref_sub_2": "春田花花幼稚园？",
+      "target_sub_2": "旧中桥百货公司楼上嗰间春田花花幼稚园呢"
     },
     "answer": {
-      "src_2_sub_1_shifted": "旧中桥百货公司楼上嗰间",
-      "src_2_sub_2_shifted": "春田花花幼稚园呢"
+      "target_sub_1_shifted": "旧中桥百货公司楼上嗰间",
+      "target_sub_2_shifted": "春田花花幼稚园呢"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "怎么不试一试好彩酒楼对面",
-      "src_1_sub_2": "旧中侨国货楼上的⋯",
-      "src_2_sub_1": "点解唔试下好彩走楼斜对面",
-      "src_2_sub_2": "旧中桥百货公司楼上嗰间"
+      "ref_sub_1": "怎么不试一试好彩酒楼对面",
+      "ref_sub_2": "旧中侨国货楼上的⋯",
+      "target_sub_1": "点解唔试下好彩走楼斜对面",
+      "target_sub_2": "旧中桥百货公司楼上嗰间"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "旧中侨国货楼上的⋯",
-      "src_1_sub_2": "春田花花幼稚园？",
-      "src_2_sub_1": "旧中桥百货公司楼上嗰间",
-      "src_2_sub_2": "春田花花幼稚园呢"
+      "ref_sub_1": "旧中侨国货楼上的⋯",
+      "ref_sub_2": "春田花花幼稚园？",
+      "target_sub_1": "旧中桥百货公司楼上嗰间",
+      "target_sub_2": "春田花花幼稚园呢"
     },
     "answer": {},
     "few_shot": true,
@@ -539,32 +539,32 @@
   },
   {
     "query": {
-      "src_1_sub_1": "春田花花幼稚园？",
-      "src_1_sub_2": "就是座落界限街南昌街交界⋯",
-      "src_2_sub_1": "春田花花幼稚园呢",
-      "src_2_sub_2": "就系坐落喺界限街同南昌街交界"
+      "ref_sub_1": "春田花花幼稚园？",
+      "ref_sub_2": "就是座落界限街南昌街交界⋯",
+      "target_sub_1": "春田花花幼稚园呢",
+      "target_sub_2": "就系坐落喺界限街同南昌街交界"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "就是座落界限街南昌街交界⋯",
-      "src_1_sub_2": "银城美食广场附近的⋯",
-      "src_2_sub_1": "就系坐落喺界限街同南昌街交界"
+      "ref_sub_1": "就是座落界限街南昌街交界⋯",
+      "ref_sub_2": "银城美食广场附近的⋯",
+      "target_sub_1": "就系坐落喺界限街同南昌街交界"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "银城美食广场附近的⋯",
-      "src_1_sub_2": "春田花花幼稚园？",
-      "src_2_sub_2": "银城美食广场附近嗰间春田花花幼稚园呀"
+      "ref_sub_1": "银城美食广场附近的⋯",
+      "ref_sub_2": "春田花花幼稚园？",
+      "target_sub_2": "银城美食广场附近嗰间春田花花幼稚园呀"
     },
     "answer": {
-      "src_2_sub_1_shifted": "银城美食广场附近嗰间",
-      "src_2_sub_2_shifted": "春田花花幼稚园呀"
+      "target_sub_1_shifted": "银城美食广场附近嗰间",
+      "target_sub_2_shifted": "春田花花幼稚园呀"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -572,70 +572,70 @@
   },
   {
     "query": {
-      "src_1_sub_1": "春田花花幼稚园？",
-      "src_1_sub_2": "对！深水埗地铁站步行不用10分钟！",
-      "src_2_sub_1": "春田花花幼稚园呀",
-      "src_2_sub_2": "系呀深水埗地铁站口行过去唔使十分钟呀"
+      "ref_sub_1": "春田花花幼稚园？",
+      "ref_sub_2": "对！深水埗地铁站步行不用10分钟！",
+      "target_sub_1": "春田花花幼稚园呀",
+      "target_sub_2": "系呀深水埗地铁站口行过去唔使十分钟呀"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "对！深水埗地铁站步行不用10分钟！",
-      "src_1_sub_2": "春田花花幼稚园，师资优良⋯",
-      "src_2_sub_1": "系呀深水埗地铁站口行过去唔使十分钟呀",
-      "src_2_sub_2": "春田花花幼稚园"
+      "ref_sub_1": "对！深水埗地铁站步行不用10分钟！",
+      "ref_sub_2": "春田花花幼稚园，师资优良⋯",
+      "target_sub_1": "系呀深水埗地铁站口行过去唔使十分钟呀",
+      "target_sub_2": "春田花花幼稚园"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "春田花花幼稚园，师资优良⋯",
-      "src_1_sub_2": "而且还有西人教英文！",
-      "src_2_sub_1": "春田花花幼稚园",
-      "src_2_sub_2": "诗诗优良仲系西人教英文添㗎"
+      "ref_sub_1": "春田花花幼稚园，师资优良⋯",
+      "ref_sub_2": "而且还有西人教英文！",
+      "target_sub_1": "春田花花幼稚园",
+      "target_sub_2": "诗诗优良仲系西人教英文添㗎"
     },
     "answer": {
-      "src_2_sub_1_shifted": "春田花花幼稚园诗诗优良",
-      "src_2_sub_2_shifted": "仲系西人教英文添㗎"
+      "target_sub_1_shifted": "春田花花幼稚园诗诗优良",
+      "target_sub_2_shifted": "仲系西人教英文添㗎"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "而且还有西人教英文！",
-      "src_1_sub_2": "西人教英文？",
-      "src_2_sub_1": "仲系西人教英文添㗎",
-      "src_2_sub_2": "咦"
+      "ref_sub_1": "而且还有西人教英文！",
+      "ref_sub_2": "西人教英文？",
+      "target_sub_1": "仲系西人教英文添㗎",
+      "target_sub_2": "咦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "西人教英文？",
-      "src_1_sub_2": "是呀！",
-      "src_2_sub_1": "咦",
-      "src_2_sub_2": "西人教英文"
+      "ref_sub_1": "西人教英文？",
+      "ref_sub_2": "是呀！",
+      "target_sub_1": "咦",
+      "target_sub_2": "西人教英文"
     },
     "answer": {
-      "src_2_sub_1_shifted": "咦西人教英文"
+      "target_sub_1_shifted": "咦西人教英文"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "是呀！",
-      "src_1_sub_2": "春田花花，确有好多西人呀！",
-      "src_2_sub_2": "系呀春田花花真系好多西人㗎"
+      "ref_sub_1": "是呀！",
+      "ref_sub_2": "春田花花，确有好多西人呀！",
+      "target_sub_2": "系呀春田花花真系好多西人㗎"
     },
     "answer": {
-      "src_2_sub_1_shifted": "系呀",
-      "src_2_sub_2_shifted": "春田花花真系好多西人㗎"
+      "target_sub_1_shifted": "系呀",
+      "target_sub_2_shifted": "春田花花真系好多西人㗎"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -643,9 +643,9 @@
   },
   {
     "query": {
-      "src_1_sub_1": "〝鹅闷是春天滴化！〞",
-      "src_1_sub_2": "这个猪样白兔小朋友⋯",
-      "src_2_sub_2": "呢个扮紧白兔猪样嘅小朋友"
+      "ref_sub_1": "〝鹅闷是春天滴化！〞",
+      "ref_sub_2": "这个猪样白兔小朋友⋯",
+      "target_sub_2": "呢个扮紧白兔猪样嘅小朋友"
     },
     "answer": {},
     "few_shot": true,
@@ -653,84 +653,84 @@
   },
   {
     "query": {
-      "src_1_sub_1": "这个猪样白兔小朋友⋯",
-      "src_1_sub_2": "横看竖看也不像发哥伟仔的一个⋯",
-      "src_2_sub_1": "呢个扮紧白兔猪样嘅小朋友",
-      "src_2_sub_2": "即系横睇掂睇都唔似发哥或者"
+      "ref_sub_1": "这个猪样白兔小朋友⋯",
+      "ref_sub_2": "横看竖看也不像发哥伟仔的一个⋯",
+      "target_sub_1": "呢个扮紧白兔猪样嘅小朋友",
+      "target_sub_2": "即系横睇掂睇都唔似发哥或者"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "横看竖看也不像发哥伟仔的一个⋯",
-      "src_1_sub_2": "就是我，麦兜",
-      "src_2_sub_1": "即系横睇掂睇都唔似发哥或者",
-      "src_2_sub_2": "位仔嗰个呢就系我麦兜"
+      "ref_sub_1": "横看竖看也不像发哥伟仔的一个⋯",
+      "ref_sub_2": "就是我，麦兜",
+      "target_sub_1": "即系横睇掂睇都唔似发哥或者",
+      "target_sub_2": "位仔嗰个呢就系我麦兜"
     },
     "answer": {
-      "src_2_sub_1_shifted": "即系横睇掂睇都唔似发哥或者位仔嗰个呢",
-      "src_2_sub_2_shifted": "就系我麦兜"
+      "target_sub_1_shifted": "即系横睇掂睇都唔似发哥或者位仔嗰个呢",
+      "target_sub_2_shifted": "就系我麦兜"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "就是我，麦兜",
-      "src_1_sub_2": "这是我就读的幼稚园",
-      "src_2_sub_1": "就系我麦兜",
-      "src_2_sub_2": "呢间就系我读嘅幼稚园"
+      "ref_sub_1": "就是我，麦兜",
+      "ref_sub_2": "这是我就读的幼稚园",
+      "target_sub_1": "就系我麦兜",
+      "target_sub_2": "呢间就系我读嘅幼稚园"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "这是我就读的幼稚园",
-      "src_1_sub_2": "校长是潮州人",
-      "src_2_sub_1": "呢间就系我读嘅幼稚园",
-      "src_2_sub_2": "校长系潮州人"
+      "ref_sub_1": "这是我就读的幼稚园",
+      "ref_sub_2": "校长是潮州人",
+      "target_sub_1": "呢间就系我读嘅幼稚园",
+      "target_sub_2": "校长系潮州人"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "校长是潮州人",
-      "src_1_sub_2": "可能是潮州口音的关系",
-      "src_2_sub_1": "校长系潮州人",
-      "src_2_sub_2": "可能仲系讲紧潮州话嘅"
+      "ref_sub_1": "校长是潮州人",
+      "ref_sub_2": "可能是潮州口音的关系",
+      "target_sub_1": "校长系潮州人",
+      "target_sub_2": "可能仲系讲紧潮州话嘅"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "可能是潮州口音的关系",
-      "src_1_sub_2": "这么多年来⋯",
-      "src_2_sub_1": "可能仲系讲紧潮州话嘅",
-      "src_2_sub_2": "所以咁多年嚟"
+      "ref_sub_1": "可能是潮州口音的关系",
+      "ref_sub_2": "这么多年来⋯",
+      "target_sub_1": "可能仲系讲紧潮州话嘅",
+      "target_sub_2": "所以咁多年嚟"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "这么多年来⋯",
-      "src_1_sub_2": "我其实不大明白他的说话",
-      "src_2_sub_1": "所以咁多年嚟",
-      "src_2_sub_2": "我其实唔系好知佢噏文"
+      "ref_sub_1": "这么多年来⋯",
+      "ref_sub_2": "我其实不大明白他的说话",
+      "target_sub_1": "所以咁多年嚟",
+      "target_sub_2": "我其实唔系好知佢噏文"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我其实不大明白他的说话",
-      "src_1_sub_2": "蛋挞！　　蛋挞！",
-      "src_2_sub_1": "我其实唔系好知佢噏文",
-      "src_2_sub_2": "大湖荒岩宅"
+      "ref_sub_1": "我其实不大明白他的说话",
+      "ref_sub_2": "蛋挞！　　蛋挞！",
+      "target_sub_1": "我其实唔系好知佢噏文",
+      "target_sub_2": "大湖荒岩宅"
     },
     "answer": {},
     "difficulty": 3,
@@ -738,10 +738,10 @@
   },
   {
     "query": {
-      "src_1_sub_1": "蛋挞！　　蛋挞！",
-      "src_1_sub_2": "荔芋火鸭札！　　荔芋火鸭札！",
-      "src_2_sub_1": "大湖荒岩宅",
-      "src_2_sub_2": "湾吉校坟交涉设"
+      "ref_sub_1": "蛋挞！　　蛋挞！",
+      "ref_sub_2": "荔芋火鸭札！　　荔芋火鸭札！",
+      "target_sub_1": "大湖荒岩宅",
+      "target_sub_2": "湾吉校坟交涉设"
     },
     "answer": {},
     "difficulty": 3,
@@ -749,9 +749,9 @@
   },
   {
     "query": {
-      "src_1_sub_1": "荔芋火鸭札！　　荔芋火鸭札！",
-      "src_1_sub_2": "忘记校训九十七⋯　　忘记校训九十七⋯",
-      "src_2_sub_1": "湾吉校坟交涉设"
+      "ref_sub_1": "荔芋火鸭札！　　荔芋火鸭札！",
+      "ref_sub_2": "忘记校训九十七⋯　　忘记校训九十七⋯",
+      "target_sub_1": "湾吉校坟交涉设"
     },
     "answer": {},
     "difficulty": 3,
@@ -759,9 +759,9 @@
   },
   {
     "query": {
-      "src_1_sub_1": "忘记校训九十七⋯　　忘记校训九十七⋯",
-      "src_1_sub_2": "也不能忘记校训九十八！",
-      "src_2_sub_2": "都唔好湾吉校坟交涉白"
+      "ref_sub_1": "忘记校训九十七⋯　　忘记校训九十七⋯",
+      "ref_sub_2": "也不能忘记校训九十八！",
+      "target_sub_2": "都唔好湾吉校坟交涉白"
     },
     "answer": {},
     "difficulty": 3,
@@ -769,18 +769,18 @@
   },
   {
     "query": {
-      "src_1_sub_1": "也不能忘记校训九十八！",
-      "src_1_sub_2": "也不能忘记校训九十八！",
-      "src_2_sub_1": "都唔好湾吉校坟交涉白"
+      "ref_sub_1": "也不能忘记校训九十八！",
+      "ref_sub_2": "也不能忘记校训九十八！",
+      "target_sub_1": "都唔好湾吉校坟交涉白"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "也不能忘记校训九十八！",
-      "src_1_sub_2": "好！各位同学⋯",
-      "src_2_sub_2": "嗰个位同学"
+      "ref_sub_1": "也不能忘记校训九十八！",
+      "ref_sub_2": "好！各位同学⋯",
+      "target_sub_2": "嗰个位同学"
     },
     "answer": {},
     "few_shot": true,
@@ -788,293 +788,62 @@
   },
   {
     "query": {
-      "src_1_sub_1": "好！各位同学⋯",
-      "src_1_sub_2": "今天的早会主要是跟大家分享",
-      "src_2_sub_1": "嗰个位同学"
+      "ref_sub_1": "好！各位同学⋯",
+      "ref_sub_2": "今天的早会主要是跟大家分享",
+      "target_sub_1": "嗰个位同学"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "今天的早会主要是跟大家分享",
-      "src_1_sub_2": "一个重要主题：",
-      "src_2_sub_2": "今次座会系要同大家分享一个可重要嘅主题"
+      "ref_sub_1": "今天的早会主要是跟大家分享",
+      "ref_sub_2": "一个重要主题：",
+      "target_sub_2": "今次座会系要同大家分享一个可重要嘅主题"
     },
     "answer": {
-      "src_2_sub_1_shifted": "今次座会系要同大家分享",
-      "src_2_sub_2_shifted": "一个可重要嘅主题"
+      "target_sub_1_shifted": "今次座会系要同大家分享",
+      "target_sub_2_shifted": "一个可重要嘅主题"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "好！各位同学⋯",
-      "src_1_sub_2": "今天的早会主要是跟大家分享",
-      "src_2_sub_1": "嗰个位同学",
-      "src_2_sub_2": "今次座会系要同大家分享"
+      "ref_sub_1": "好！各位同学⋯",
+      "ref_sub_2": "今天的早会主要是跟大家分享",
+      "target_sub_1": "嗰个位同学",
+      "target_sub_2": "今次座会系要同大家分享"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "今天的早会主要是跟大家分享",
-      "src_1_sub_2": "一个重要主题：",
-      "src_2_sub_1": "今次座会系要同大家分享",
-      "src_2_sub_2": "一个可重要嘅主题"
+      "ref_sub_1": "今天的早会主要是跟大家分享",
+      "ref_sub_2": "一个重要主题：",
+      "target_sub_1": "今次座会系要同大家分享",
+      "target_sub_2": "一个可重要嘅主题"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "一个重要主题：",
-      "src_1_sub_2": "小朋友，这个月你们交过学费没有？",
-      "src_2_sub_1": "一个可重要嘅主题",
-      "src_2_sub_2": "小朋友你哋今个月交咗学费咩呀"
+      "ref_sub_1": "一个重要主题：",
+      "ref_sub_2": "小朋友，这个月你们交过学费没有？",
+      "target_sub_1": "一个可重要嘅主题",
+      "target_sub_2": "小朋友你哋今个月交咗学费咩呀"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "小朋友，这个月你们交过学费没有？",
-      "src_1_sub_2": "交过了！",
-      "src_2_sub_1": "小朋友你哋今个月交咗学费咩呀",
-      "src_2_sub_2": "交"
-    },
-    "answer": {},
-    "few_shot": true,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "交过了！",
-      "src_1_sub_2": "太好了！大家去上堂吧",
-      "src_2_sub_1": "交",
-      "src_2_sub_2": "哎好在噉大家可以返去上堂喇"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "你们可能觉得这间幼稚园很烂",
-      "src_1_sub_2": "可是，对我和我一班同学",
-      "src_2_sub_1": "你哋可能觉得呢间幼稚园好逗利",
-      "src_2_sub_2": "但系对于我同埋我班同学仔嚟讲"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "可是，对我和我一班同学",
-      "src_1_sub_2": "这儿是我们最快乐，最美丽的乐园⋯",
-      "src_2_sub_1": "但系对于我同埋我班同学仔嚟讲",
-      "src_2_sub_2": "呢度系我哋最快乐最美丽嘅乐园"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "这儿是我们最快乐，最美丽的乐园⋯",
-      "src_1_sub_2": "⋯还有一个很疼我们",
-      "src_2_sub_1": "呢度系我哋最快乐最美丽嘅乐园",
-      "src_2_sub_2": "仲有一个好疼我哋"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "⋯还有一个很疼我们",
-      "src_1_sub_2": "就是有点游魂的Miss Chan",
-      "src_2_sub_1": "仲有一个好疼我哋",
-      "src_2_sub_2": "不过就有少少失魂嘅班主有MissChan"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "就是有点游魂的Miss Chan",
-      "src_1_sub_2": "她的志愿是做第二个王菲",
-      "src_2_sub_1": "不过就有少少失魂嘅班主有MissChan",
-      "src_2_sub_2": "佢嘅志愿系做下一个王妃"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "她的志愿是做第二个王菲",
-      "src_1_sub_2": "做第二个陈慧琳也可以",
-      "src_2_sub_1": "佢嘅志愿系做下一个王妃",
-      "src_2_sub_2": "或者系做下一个陈维林都得"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "做第二个陈慧琳也可以",
-      "src_1_sub_2": "我们现在开始点名",
-      "src_2_sub_1": "或者系做下一个陈维林都得",
-      "src_2_sub_2": "好喇我哋而家开始点名"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我们现在开始点名",
-      "src_1_sub_2": "麦唛同学！　　到！",
-      "src_2_sub_1": "好喇我哋而家开始点名",
-      "src_2_sub_2": "麦麦同学"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "麦唛同学！　　到！",
-      "src_1_sub_2": "亚辉同学！　　到！",
-      "src_2_sub_1": "麦麦同学",
-      "src_2_sub_2": "到阿辉同学"
-    },
-    "answer": {
-      "src_2_sub_1_shifted": "麦麦同学到",
-      "src_2_sub_2_shifted": "阿辉同学"
-    },
-    "difficulty": 1,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "亚辉同学！　　到！",
-      "src_1_sub_2": "菇时同学！　　到！",
-      "src_2_sub_1": "阿辉同学",
-      "src_2_sub_2": "到Boosie同学"
-    },
-    "answer": {
-      "src_2_sub_1_shifted": "阿辉同学到",
-      "src_2_sub_2_shifted": "Boosie同学"
-    },
-    "difficulty": 1,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "菇时同学！　　到！",
-      "src_1_sub_2": "得巴同学！　　到！",
-      "src_2_sub_1": "Boosie同学",
-      "src_2_sub_2": "到德巴同学"
-    },
-    "answer": {
-      "src_2_sub_1_shifted": "Boosie同学到",
-      "src_2_sub_2_shifted": "德巴同学"
-    },
-    "difficulty": 1,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "得巴同学！　　到！",
-      "src_1_sub_2": "阿May同学！　　到！",
-      "src_2_sub_1": "德巴同学",
-      "src_2_sub_2": "到阿May同学到"
-    },
-    "answer": {
-      "src_2_sub_1_shifted": "德巴同学到",
-      "src_2_sub_2_shifted": "阿May同学到"
-    },
-    "difficulty": 1,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "阿May同学！　　到！",
-      "src_1_sub_2": "阿June同学！　　到！",
-      "src_2_sub_1": "阿May同学到",
-      "src_2_sub_2": "阿June同学"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "阿June同学！　　到！",
-      "src_1_sub_2": "阿May同学！　　到！",
-      "src_2_sub_1": "阿June同学",
-      "src_2_sub_2": "到阿May同学到"
-    },
-    "answer": {
-      "src_2_sub_1_shifted": "阿June同学到",
-      "src_2_sub_2_shifted": "阿May同学到"
-    },
-    "difficulty": 1,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "阿May同学！　　到！",
-      "src_1_sub_2": "麦唛同学！　　到！",
-      "src_2_sub_1": "阿May同学到",
-      "src_2_sub_2": "麦麦同学到"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "麦唛同学！　　到！",
-      "src_1_sub_2": "阿May同学！",
-      "src_2_sub_1": "麦麦同学到"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "阿May同学！",
-      "src_1_sub_2": "Miss Chan，我点过两次了！",
-      "src_2_sub_2": "阿May同学MissChan你点咗我两次喇"
-    },
-    "answer": {
-      "src_2_sub_1_shifted": "阿May同学",
-      "src_2_sub_2_shifted": "MissChan你点咗我两次喇"
-    },
-    "difficulty": 1,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "Miss Chan，我点过两次了！",
-      "src_1_sub_2": "呀，真的吗？",
-      "src_2_sub_1": "MissChan你点咗我两次喇",
-      "src_2_sub_2": "啊系咩"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "呀，真的吗？",
-      "src_1_sub_2": "校长早晨！",
-      "src_2_sub_1": "啊系咩"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "校长再见！",
-      "src_1_sub_2": "我们现在继续点名",
-      "src_2_sub_2": "好我哋而家继续点名"
+      "ref_sub_1": "小朋友，这个月你们交过学费没有？",
+      "ref_sub_2": "交过了！",
+      "target_sub_1": "小朋友你哋今个月交咗学费咩呀",
+      "target_sub_2": "交"
     },
     "answer": {},
     "few_shot": true,
@@ -1082,305 +851,230 @@
   },
   {
     "query": {
-      "src_1_sub_1": "我们现在继续点名",
-      "src_1_sub_2": "阿June同学！　　到！",
-      "src_2_sub_1": "好我哋而家继续点名",
-      "src_2_sub_2": "阿June同学"
+      "ref_sub_1": "交过了！",
+      "ref_sub_2": "太好了！大家去上堂吧",
+      "target_sub_1": "交",
+      "target_sub_2": "哎好在噉大家可以返去上堂喇"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "阿June同学！　　到！",
-      "src_1_sub_2": "亚辉同学！　　到！",
-      "src_2_sub_1": "阿June同学",
-      "src_2_sub_2": "到阿辉同学"
+      "ref_sub_1": "你们可能觉得这间幼稚园很烂",
+      "ref_sub_2": "可是，对我和我一班同学",
+      "target_sub_1": "你哋可能觉得呢间幼稚园好逗利",
+      "target_sub_2": "但系对于我同埋我班同学仔嚟讲"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "可是，对我和我一班同学",
+      "ref_sub_2": "这儿是我们最快乐，最美丽的乐园⋯",
+      "target_sub_1": "但系对于我同埋我班同学仔嚟讲",
+      "target_sub_2": "呢度系我哋最快乐最美丽嘅乐园"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "这儿是我们最快乐，最美丽的乐园⋯",
+      "ref_sub_2": "⋯还有一个很疼我们",
+      "target_sub_1": "呢度系我哋最快乐最美丽嘅乐园",
+      "target_sub_2": "仲有一个好疼我哋"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "⋯还有一个很疼我们",
+      "ref_sub_2": "就是有点游魂的Miss Chan",
+      "target_sub_1": "仲有一个好疼我哋",
+      "target_sub_2": "不过就有少少失魂嘅班主有MissChan"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "就是有点游魂的Miss Chan",
+      "ref_sub_2": "她的志愿是做第二个王菲",
+      "target_sub_1": "不过就有少少失魂嘅班主有MissChan",
+      "target_sub_2": "佢嘅志愿系做下一个王妃"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "她的志愿是做第二个王菲",
+      "ref_sub_2": "做第二个陈慧琳也可以",
+      "target_sub_1": "佢嘅志愿系做下一个王妃",
+      "target_sub_2": "或者系做下一个陈维林都得"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "做第二个陈慧琳也可以",
+      "ref_sub_2": "我们现在开始点名",
+      "target_sub_1": "或者系做下一个陈维林都得",
+      "target_sub_2": "好喇我哋而家开始点名"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我们现在开始点名",
+      "ref_sub_2": "麦唛同学！　　到！",
+      "target_sub_1": "好喇我哋而家开始点名",
+      "target_sub_2": "麦麦同学"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "麦唛同学！　　到！",
+      "ref_sub_2": "亚辉同学！　　到！",
+      "target_sub_1": "麦麦同学",
+      "target_sub_2": "到阿辉同学"
     },
     "answer": {
-      "src_2_sub_1_shifted": "阿June同学到",
-      "src_2_sub_2_shifted": "阿辉同学"
+      "target_sub_1_shifted": "麦麦同学到",
+      "target_sub_2_shifted": "阿辉同学"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "亚辉同学！　　到！",
-      "src_1_sub_2": "得巴同学！　　到！",
-      "src_2_sub_1": "阿辉同学",
-      "src_2_sub_2": "到德巴同学到"
+      "ref_sub_1": "亚辉同学！　　到！",
+      "ref_sub_2": "菇时同学！　　到！",
+      "target_sub_1": "阿辉同学",
+      "target_sub_2": "到Boosie同学"
     },
     "answer": {
-      "src_2_sub_1_shifted": "阿辉同学到",
-      "src_2_sub_2_shifted": "德巴同学到"
+      "target_sub_1_shifted": "阿辉同学到",
+      "target_sub_2_shifted": "Boosie同学"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "得巴同学！　　到！",
-      "src_1_sub_2": "阿May同学！　　到！",
-      "src_2_sub_1": "德巴同学到",
-      "src_2_sub_2": "阿May同学"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "阿May同学！　　到！",
-      "src_1_sub_2": "麦唛同学！　　到！",
-      "src_2_sub_1": "阿May同学",
-      "src_2_sub_2": "到麦麦同学到"
+      "ref_sub_1": "菇时同学！　　到！",
+      "ref_sub_2": "得巴同学！　　到！",
+      "target_sub_1": "Boosie同学",
+      "target_sub_2": "到德巴同学"
     },
     "answer": {
-      "src_2_sub_1_shifted": "阿May同学到",
-      "src_2_sub_2_shifted": "麦麦同学到"
+      "target_sub_1_shifted": "Boosie同学到",
+      "target_sub_2_shifted": "德巴同学"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "麦唛同学！　　到！",
-      "src_1_sub_2": "菇时同学！　　到！",
-      "src_2_sub_1": "麦麦同学到",
-      "src_2_sub_2": "Boosie同学到"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "菇时同学！　　到！",
-      "src_1_sub_2": "菇时同学！　　到！",
-      "src_2_sub_1": "Boosie同学到",
-      "src_2_sub_2": "川明同学"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "菇时同学！　　到！",
-      "src_1_sub_2": "还有谁没点过吗？",
-      "src_2_sub_1": "川明同学",
-      "src_2_sub_2": "到好仲有边个未点"
+      "ref_sub_1": "得巴同学！　　到！",
+      "ref_sub_2": "阿May同学！　　到！",
+      "target_sub_1": "德巴同学",
+      "target_sub_2": "到阿May同学到"
     },
     "answer": {
-      "src_2_sub_1_shifted": "川明同学到",
-      "src_2_sub_2_shifted": "好仲有边个未点"
+      "target_sub_1_shifted": "德巴同学到",
+      "target_sub_2_shifted": "阿May同学到"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "还有谁没点过吗？",
-      "src_1_sub_2": "麦兜！",
-      "src_2_sub_1": "好仲有边个未点",
-      "src_2_sub_2": "猫"
+      "ref_sub_1": "阿May同学！　　到！",
+      "ref_sub_2": "阿June同学！　　到！",
+      "target_sub_1": "阿May同学到",
+      "target_sub_2": "阿June同学"
     },
     "answer": {},
-    "difficulty": 3,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "麦兜！",
-      "src_1_sub_2": "麦兜同学！",
-      "src_2_sub_1": "猫",
-      "src_2_sub_2": "噢麦兜同学"
+      "ref_sub_1": "阿June同学！　　到！",
+      "ref_sub_2": "阿May同学！　　到！",
+      "target_sub_1": "阿June同学",
+      "target_sub_2": "到阿May同学到"
     },
     "answer": {
-      "src_2_sub_1_shifted": "猫噢",
-      "src_2_sub_2_shifted": "麦兜同学"
+      "target_sub_1_shifted": "阿June同学到",
+      "target_sub_2_shifted": "阿May同学到"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "麦兜同学！",
-      "src_1_sub_2": "麦兜同学！",
-      "src_2_sub_1": "麦兜同学",
-      "src_2_sub_2": "麦兜同学"
+      "ref_sub_1": "阿May同学！　　到！",
+      "ref_sub_2": "麦唛同学！　　到！",
+      "target_sub_1": "阿May同学到",
+      "target_sub_2": "麦麦同学到"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "麦兜同学！",
-      "src_1_sub_2": "麦唛呀，即是呢⋯",
-      "src_2_sub_1": "麦兜同学",
-      "src_2_sub_2": "妈妈啊麦兜同学"
+      "ref_sub_1": "麦唛同学！　　到！",
+      "ref_sub_2": "阿May同学！",
+      "target_sub_1": "麦麦同学到"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "麦唛呀，即是呢⋯",
-      "src_1_sub_2": "我好像觉得呢⋯",
-      "src_2_sub_1": "妈妈啊麦兜同学",
-      "src_2_sub_2": "即系呢"
+      "ref_sub_1": "阿May同学！",
+      "ref_sub_2": "Miss Chan，我点过两次了！",
+      "target_sub_2": "阿May同学MissChan你点咗我两次喇"
     },
     "answer": {
-      "src_2_sub_1_shifted": "妈妈啊麦兜同学即系呢"
+      "target_sub_1_shifted": "阿May同学",
+      "target_sub_2_shifted": "MissChan你点咗我两次喇"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我好像觉得呢⋯",
-      "src_1_sub_2": "有什么人在喊我似的",
-      "src_2_sub_2": "我个心总系仁住仁住好似有人嗌紧我个名噉嘅"
-    },
-    "answer": {
-      "src_2_sub_1_shifted": "我个心总系仁住仁住",
-      "src_2_sub_2_shifted": "好似有人嗌紧我个名噉嘅"
-    },
-    "difficulty": 1,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "有什么人在喊我似的",
-      "src_1_sub_2": "你们不要以为我心散",
-      "src_2_sub_1": "好似有人嗌紧我个名噉嘅",
-      "src_2_sub_2": "你哋唔好以为我心散啊"
+      "ref_sub_1": "Miss Chan，我点过两次了！",
+      "ref_sub_2": "呀，真的吗？",
+      "target_sub_1": "MissChan你点咗我两次喇",
+      "target_sub_2": "啊系咩"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "你们不要以为我心散",
-      "src_1_sub_2": "其实我正在思考一个学术问题：",
-      "src_2_sub_1": "你哋唔好以为我心散啊",
-      "src_2_sub_2": "其实我系喺度思考紧一啲学术性嘅问题"
+      "ref_sub_1": "呀，真的吗？",
+      "ref_sub_2": "校长早晨！",
+      "target_sub_1": "啊系咩"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "其实我正在思考一个学术问题：",
-      "src_1_sub_2": "橙，为什么会是「屙－烂－煮」呢？",
-      "src_2_sub_1": "其实我系喺度思考紧一啲学术性嘅问题",
-      "src_2_sub_2": "点解橙叫Orange呢"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "橙，为什么会是「屙－烂－煮」呢？",
-      "src_1_sub_2": "妈妈说吃橙可通大便",
-      "src_2_sub_1": "点解橙叫Orange呢",
-      "src_2_sub_2": "妈妈话食橙会通大"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "妈妈说吃橙可通大便",
-      "src_1_sub_2": "「屙」这个我明白，可是「烂－煮」呢？",
-      "src_2_sub_1": "妈妈话食橙会通大",
-      "src_2_sub_2": "变噢呢个我明白但系橙呢"
-    },
-    "answer": {
-      "src_2_sub_1_shifted": "妈妈话食橙会通大变",
-      "src_2_sub_2_shifted": "噢呢个我明白但系橙呢"
-    },
-    "difficulty": 1,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "「屙」这个我明白，可是「烂－煮」呢？",
-      "src_1_sub_2": "还有这个「芭－娜－哪」香蕉",
-      "src_2_sub_1": "噢呢个我明白但系橙呢",
-      "src_2_sub_2": "仲有呢个啊芭拉娜啊"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "还有这个「芭－娜－哪」香蕉",
-      "src_1_sub_2": "为什么雨伞又会是「暗－芭－娜－哪」呢？",
-      "src_2_sub_1": "仲有呢个啊芭拉娜啊",
-      "src_2_sub_2": "香蕉啊点解雨姐会叫做暗芭拉娜呢"
-    },
-    "answer": {
-      "src_2_sub_1_shifted": "仲有呢个啊芭拉娜啊香蕉啊",
-      "src_2_sub_2_shifted": "点解雨姐会叫做暗芭拉娜呢"
-    },
-    "difficulty": 1,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "为什么雨伞又会是「暗－芭－娜－哪」呢？",
-      "src_1_sub_2": "我「暗」的「暗」掉一条蕉",
-      "src_2_sub_1": "点解雨姐会叫做暗芭拉娜呢",
-      "src_2_sub_2": "嗱我暗啦噉我暗嗰条香蕉"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我「暗」的「暗」掉一条蕉",
-      "src_1_sub_2": "至多是屙烂煮，怎么会下起雨来呢？",
-      "src_2_sub_1": "嗱我暗啦噉我暗嗰条香蕉",
-      "src_2_sub_2": "至多会Orange啫点解会搞到落雨呢"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "至多是屙烂煮，怎么会下起雨来呢？",
-      "src_1_sub_2": "这世界还有很多事情我弄不明白",
-      "src_2_sub_1": "至多会Orange啫点解会搞到落雨呢",
-      "src_2_sub_2": "呢个世界仲有好多嘢我谂唔明"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "这世界还有很多事情我弄不明白",
-      "src_1_sub_2": "但我不害怕",
-      "src_2_sub_1": "呢个世界仲有好多嘢我谂唔明",
-      "src_2_sub_2": "不过我唔怕"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "但我不害怕",
-      "src_1_sub_2": "我想，有天我念完幼稚园",
-      "src_2_sub_1": "不过我唔怕",
-      "src_2_sub_2": "我谂到我读完幼稚园"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我想，有天我念完幼稚园",
-      "src_1_sub_2": "升小学，上中学",
-      "src_2_sub_1": "我谂到我读完幼稚园",
-      "src_2_sub_2": "识埋小学上到中学"
+      "ref_sub_1": "校长再见！",
+      "ref_sub_2": "我们现在继续点名",
+      "target_sub_2": "好我哋而家继续点名"
     },
     "answer": {},
     "few_shot": true,
@@ -1388,717 +1082,106 @@
   },
   {
     "query": {
-      "src_1_sub_1": "升小学，上中学",
-      "src_1_sub_2": "再念大学⋯",
-      "src_2_sub_1": "识埋小学上到中学",
-      "src_2_sub_2": "再入埋大学"
+      "ref_sub_1": "我们现在继续点名",
+      "ref_sub_2": "阿June同学！　　到！",
+      "target_sub_1": "好我哋而家继续点名",
+      "target_sub_2": "阿June同学"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "再念大学⋯",
-      "src_1_sub_2": "当我大学毕业的时候",
-      "src_2_sub_1": "再入埋大学",
-      "src_2_sub_2": "等我大学毕业嗰阵"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "当我大学毕业的时候",
-      "src_1_sub_2": "我知道我会明白一切！",
-      "src_2_sub_1": "等我大学毕业嗰阵",
-      "src_2_sub_2": "我谂我乜都会明白晒"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我知道我会明白一切！",
-      "src_1_sub_2": "那时候⋯",
-      "src_2_sub_1": "我谂我乜都会明白晒",
-      "src_2_sub_2": "到嗰阵"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "那时候⋯",
-      "src_1_sub_2": "我买所房子给妈妈！",
-      "src_2_sub_1": "到嗰阵",
-      "src_2_sub_2": "我买层楼畀我妈妈"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "幼稚园楼下，由校长兼营的茶餐厅",
-      "src_1_sub_2": "我们一班同学下课后经常光顾",
-      "src_2_sub_1": "喺幼稚园楼下校长兼营嘅间茶餐厅",
-      "src_2_sub_2": "我哋一班同学仔放咗学都经常系傍陈"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我们一班同学下课后经常光顾",
-      "src_1_sub_2": "鱼蛋粗面，麻烦你　　粗面买光了",
-      "src_2_sub_1": "我哋一班同学仔放咗学都经常系傍陈",
-      "src_2_sub_2": "唔该鱼蛋粗啊"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "鱼蛋粗面，麻烦你　　粗面买光了",
-      "src_1_sub_2": "那样子⋯来碗鱼蛋河粉吧　　鱼蛋买光了",
-      "src_2_sub_1": "唔该鱼蛋粗啊",
-      "src_2_sub_2": "冇粗面噃噉啊要碗鱼蛋好啊冇鱼蛋噃"
+      "ref_sub_1": "阿June同学！　　到！",
+      "ref_sub_2": "亚辉同学！　　到！",
+      "target_sub_1": "阿June同学",
+      "target_sub_2": "到阿辉同学"
     },
     "answer": {
-      "src_2_sub_1_shifted": "唔该鱼蛋粗啊冇粗面噃",
-      "src_2_sub_2_shifted": "噉啊要碗鱼蛋好啊冇鱼蛋噃"
+      "target_sub_1_shifted": "阿June同学到",
+      "target_sub_2_shifted": "阿辉同学"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "那样子⋯来碗鱼蛋河粉吧　　鱼蛋买光了",
-      "src_1_sub_2": "那么⋯金钱肚粗面好了　　粗面买光了",
-      "src_2_sub_1": "噉啊要碗鱼蛋好啊冇鱼蛋噃",
-      "src_2_sub_2": "噉啊要金钱透粗啊冇粗面噃"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "那么⋯金钱肚粗面好了　　粗面买光了",
-      "src_1_sub_2": "那么要鱼蛋油面吧　　鱼蛋买光了",
-      "src_2_sub_1": "噉啊要金钱透粗啊冇粗面噃",
-      "src_2_sub_2": "噉啊咁要鱼蛋油面啊"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "那么要鱼蛋油面吧　　鱼蛋买光了",
-      "src_1_sub_2": "怎么都买光了？",
-      "src_2_sub_1": "噉啊咁要鱼蛋油面啊",
-      "src_2_sub_2": "冇鱼蛋噃乜样样都冇嘅"
+      "ref_sub_1": "亚辉同学！　　到！",
+      "ref_sub_2": "得巴同学！　　到！",
+      "target_sub_1": "阿辉同学",
+      "target_sub_2": "到德巴同学到"
     },
     "answer": {
-      "src_2_sub_1_shifted": "噉啊咁要鱼蛋油面啊冇鱼蛋噃",
-      "src_2_sub_2_shifted": "乜样样都冇嘅"
+      "target_sub_1_shifted": "阿辉同学到",
+      "target_sub_2_shifted": "德巴同学到"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "怎么都买光了？",
-      "src_1_sub_2": "来个墨鱼丸粗面吧　　粗面买光了",
-      "src_2_sub_1": "乜样样都冇嘅",
-      "src_2_sub_2": "噉要蜜丸粗啊"
+      "ref_sub_1": "得巴同学！　　到！",
+      "ref_sub_2": "阿May同学！　　到！",
+      "target_sub_1": "德巴同学到",
+      "target_sub_2": "阿May同学"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "来个墨鱼丸粗面吧　　粗面买光了",
-      "src_1_sub_2": "又买光了？",
-      "src_2_sub_1": "噉要蜜丸粗啊",
-      "src_2_sub_2": "冇粗面噃又冇啊"
+      "ref_sub_1": "阿May同学！　　到！",
+      "ref_sub_2": "麦唛同学！　　到！",
+      "target_sub_1": "阿May同学",
+      "target_sub_2": "到麦麦同学到"
     },
     "answer": {
-      "src_2_sub_1_shifted": "噉要蜜丸粗啊冇粗面噃",
-      "src_2_sub_2_shifted": "又冇啊"
+      "target_sub_1_shifted": "阿May同学到",
+      "target_sub_2_shifted": "麦麦同学到"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "又买光了？",
-      "src_1_sub_2": "麻烦来碗鱼蛋濑吧　　鱼蛋买光了",
-      "src_2_sub_1": "又冇啊",
-      "src_2_sub_2": "噉唔该畀碗鱼蛋奶啊"
+      "ref_sub_1": "麦唛同学！　　到！",
+      "ref_sub_2": "菇时同学！　　到！",
+      "target_sub_1": "麦麦同学到",
+      "target_sub_2": "Boosie同学到"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "麻烦来碗鱼蛋濑吧　　鱼蛋买光了",
-      "src_1_sub_2": "麦兜呀，鱼蛋跟粗面都买光了",
-      "src_2_sub_1": "噉唔该畀碗鱼蛋奶啊",
-      "src_2_sub_2": "冇鱼蛋噃麦兜啊佢哋啲鱼蛋同粗面卖晒㗎啦"
+      "ref_sub_1": "菇时同学！　　到！",
+      "ref_sub_2": "菇时同学！　　到！",
+      "target_sub_1": "Boosie同学到",
+      "target_sub_2": "川明同学"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "菇时同学！　　到！",
+      "ref_sub_2": "还有谁没点过吗？",
+      "target_sub_1": "川明同学",
+      "target_sub_2": "到好仲有边个未点"
     },
     "answer": {
-      "src_2_sub_1_shifted": "噉唔该畀碗鱼蛋奶啊冇鱼蛋噃",
-      "src_2_sub_2_shifted": "麦兜啊佢哋啲鱼蛋同粗面卖晒㗎啦"
+      "target_sub_1_shifted": "川明同学到",
+      "target_sub_2_shifted": "好仲有边个未点"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "麦兜呀，鱼蛋跟粗面都买光了",
-      "src_1_sub_2": "即是所有鱼蛋跟粗面的配搭都没了",
-      "src_2_sub_1": "麦兜啊佢哋啲鱼蛋同粗面卖晒㗎啦",
-      "src_2_sub_2": "即系所有要鱼蛋或者粗面嘅配搭都冇㗎啦"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "即是所有鱼蛋跟粗面的配搭都没了",
-      "src_1_sub_2": "没有那些配搭吗？",
-      "src_2_sub_1": "即系所有要鱼蛋或者粗面嘅配搭都冇㗎啦",
-      "src_2_sub_2": "噢冇嗰啲配搭啊"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "没有那些配搭吗？",
-      "src_1_sub_2": "麻烦你，净要鱼蛋吧　　鱼蛋买光了",
-      "src_2_sub_1": "噢冇嗰啲配搭啊",
-      "src_2_sub_2": "噉唔该净鱼蛋啊"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "麻烦你，净要鱼蛋吧　　鱼蛋买光了",
-      "src_1_sub_2": "那么净要粗面呢？　　粗面买光了",
-      "src_2_sub_1": "噉唔该净鱼蛋啊",
-      "src_2_sub_2": "冇鱼蛋噃净粗面呢冇粗面噃"
-    },
-    "answer": {
-      "src_2_sub_1_shifted": "噉唔该净鱼蛋啊冇鱼蛋噃",
-      "src_2_sub_2_shifted": "净粗面呢冇粗面噃"
-    },
-    "difficulty": 1,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "那么净要粗面呢？　　粗面买光了",
-      "src_1_sub_2": "看到这里⋯",
-      "src_2_sub_1": "净粗面呢冇粗面噃",
-      "src_2_sub_2": "睇到呢度"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "看到这里⋯",
-      "src_1_sub_2": "大家大概都知道我是个怎么样的叻仔",
-      "src_2_sub_1": "睇到呢度",
-      "src_2_sub_2": "大家大概都知道我有几叻仔嘞"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "大家大概都知道我是个怎么样的叻仔",
-      "src_1_sub_2": "那时候我无忧无虑，万事无所谓－－",
-      "src_2_sub_1": "大家大概都知道我有几叻仔嘞",
-      "src_2_sub_2": "果只我无忧无虑冇乜所谓"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "那时候我无忧无虑，万事无所谓－－",
-      "src_1_sub_2": "鱼蛋买光了？那么粗面吧",
-      "src_2_sub_1": "果只我无忧无虑冇乜所谓",
-      "src_2_sub_2": "冇鱼蛋咩粗面都好啊"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "鱼蛋买光了？那么粗面吧",
-      "src_1_sub_2": "麦兜，射呀！",
-      "src_2_sub_1": "冇鱼蛋咩粗面都好啊",
-      "src_2_sub_2": "麦兜转身食啊"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "看著自己每天屙烂煮⋯",
-      "src_1_sub_2": "每天长肉⋯",
-      "src_2_sub_1": "睇住自己日日柯能处",
-      "src_2_sub_2": "日日掌肉"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "每天长肉⋯",
-      "src_1_sub_2": "我感到充满力量！",
-      "src_2_sub_1": "日日掌肉",
-      "src_2_sub_2": "感到充满力量"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我感到充满力量！",
-      "src_1_sub_2": "世界好美丽！",
-      "src_2_sub_1": "感到充满力量",
-      "src_2_sub_2": "世界好美丽"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "有一首歌，Miss Chan唱的好听",
-      "src_1_sub_2": "我时常想著学习",
-      "src_2_sub_1": "有一首歌麦词春唱得好好听呀",
-      "src_2_sub_2": "我成日想学习"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我时常想著学习",
-      "src_1_sub_2": "可每次我总唱成「屙」什么什么的⋯",
-      "src_2_sub_1": "我成日想学习",
-      "src_2_sub_2": "但系唱嚟唱去都系阿伦厨"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "可每次我总唱成「屙」什么什么的⋯",
-      "src_1_sub_2": "是All Things Bright and Beautiful吧？",
-      "src_2_sub_1": "但系唱嚟唱去都系阿伦厨",
-      "src_2_sub_2": "咁Ballana噉系唔系AllThingsBrightandBeautiful呀"
-    },
-    "answer": {
-      "src_2_sub_1_shifted": "但系唱嚟唱去都系阿伦厨咁Ballana噉",
-      "src_2_sub_2_shifted": "系唔系AllThingsBrightandBeautiful呀"
-    },
-    "difficulty": 1,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "是All Things Bright and Beautiful吧？",
-      "src_1_sub_2": "是的，一切都好！",
-      "src_2_sub_1": "系唔系AllThingsBrightandBeautiful呀",
-      "src_2_sub_2": "系呀"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "是的，一切都好！",
-      "src_1_sub_2": "世上一切，一切一切⋯",
-      "src_2_sub_1": "系呀",
-      "src_2_sub_2": "所有嘢都几好喇"
-    },
-    "answer": {
-      "src_2_sub_1_shifted": "系呀所有嘢都几好喇"
-    },
-    "difficulty": 1,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "世上一切，一切一切⋯",
-      "src_1_sub_2": "所有那些，都好！",
-      "src_2_sub_2": "世上一切所有嗰啲嘢都几好AllThingsBrightandBeautiful"
-    },
-    "answer": {
-      "src_2_sub_1_shifted": "世上一切",
-      "src_2_sub_2_shifted": "所有嗰啲嘢都几好AllThingsBrightandBeautiful"
-    },
-    "difficulty": 1,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "一、二、三、四、五、六、七⋯",
-      "src_1_sub_2": "多劳多得！",
-      "src_2_sub_2": "1234567多喽多得"
-    },
-    "answer": {
-      "src_2_sub_1_shifted": "1234567",
-      "src_2_sub_2_shifted": "多喽多得"
-    },
-    "difficulty": 1,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "一、二、三、四、五、六、七⋯",
-      "src_1_sub_2": "多劳多得！",
-      "src_2_sub_1": "1234567",
-      "src_2_sub_2": "多喽多得"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "多劳多得！",
-      "src_1_sub_2": "星期一至星期七⋯多劳多得！",
-      "src_2_sub_1": "多喽多得",
-      "src_2_sub_2": "星期一至星期七多喽多得"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "星期一至星期七⋯多劳多得！",
-      "src_1_sub_2": "这位喊得特劲的中年母猪",
-      "src_2_sub_1": "星期一至星期七多喽多得"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "这位喊得特劲的中年母猪",
-      "src_1_sub_2": "就是我妈妈麦太",
-      "src_2_sub_2": "呢个嗌得特别劲嘅中年母猪就系我妈妈麦太"
-    },
-    "answer": {
-      "src_2_sub_1_shifted": "呢个嗌得特别劲嘅中年母猪",
-      "src_2_sub_2_shifted": "就系我妈妈麦太"
-    },
-    "difficulty": 1,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "星期一至星期七⋯多劳多得！",
-      "src_1_sub_2": "这位喊得特劲的中年母猪",
-      "src_2_sub_1": "星期一至星期七多喽多得",
-      "src_2_sub_2": "呢个嗌得特别劲嘅中年母猪"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "这位喊得特劲的中年母猪",
-      "src_1_sub_2": "就是我妈妈麦太",
-      "src_2_sub_1": "呢个嗌得特别劲嘅中年母猪",
-      "src_2_sub_2": "就系我妈妈麦太"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "就是我妈妈麦太",
-      "src_1_sub_2": "我妈妈真的很劲",
-      "src_2_sub_1": "就系我妈妈麦太",
-      "src_2_sub_2": "我妈妈真系好劲呀"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我妈妈真的很劲",
-      "src_1_sub_2": "一个女人背起整个世界！",
-      "src_2_sub_1": "我妈妈真系好劲呀",
-      "src_2_sub_2": "一个女人揹起成个世界"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "是的，我妈妈真的很厉害",
-      "src_1_sub_2": "除了兼任保险，地产经纪及trading⋯",
-      "src_2_sub_1": "系呀我妈妈真系好犀利㗎",
-      "src_2_sub_2": "除咗做保险地产经纪同埋trading之外"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "除了兼任保险，地产经纪及trading⋯",
-      "src_1_sub_2": "她还趁高科技热潮搞了个烹饪网站⋯",
-      "src_2_sub_1": "除咗做保险地产经纪同埋trading之外",
-      "src_2_sub_2": "佢仲趁住高科技热潮搞咗个煮𩠌嘅网站"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "她还趁高科技热潮搞了个烹饪网站⋯",
-      "src_1_sub_2": "www．麦太世界．com",
-      "src_2_sub_1": "佢仲趁住高科技热潮搞咗个煮𩠌嘅网站",
-      "src_2_sub_2": "www.mcticege.com"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "www．麦太世界．com",
-      "src_1_sub_2": "她做的菜，同样厉害",
-      "src_2_sub_1": "www.mcticege.com",
-      "src_2_sub_2": "佢煮嘅𩠌一样咁犀利"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "她做的菜，同样厉害",
-      "src_1_sub_2": "欢迎大家收看＜麦太世界＞",
-      "src_2_sub_1": "佢煮嘅𩠌一样咁犀利",
-      "src_2_sub_2": "欢迎大家收睇麦太世界"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "欢迎大家收看＜麦太世界＞",
-      "src_1_sub_2": "今日为大家介绍一个⋯",
-      "src_2_sub_1": "欢迎大家收睇麦太世界"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "今日为大家介绍一个⋯",
-      "src_1_sub_2": "简单别致的小菜纸包鸡",
-      "src_2_sub_2": "今日我为大家介绍个简单又别致嘅小菜自包鸡"
-    },
-    "answer": {
-      "src_2_sub_1_shifted": "今日我为大家介绍个",
-      "src_2_sub_2_shifted": "简单又别致嘅小菜自包鸡"
-    },
-    "difficulty": 1,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "欢迎大家收看＜麦太世界＞",
-      "src_1_sub_2": "今日为大家介绍一个⋯",
-      "src_2_sub_1": "欢迎大家收睇麦太世界",
-      "src_2_sub_2": "今日我为大家介绍个"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "今日为大家介绍一个⋯",
-      "src_1_sub_2": "简单别致的小菜纸包鸡",
-      "src_2_sub_1": "今日我为大家介绍个",
-      "src_2_sub_2": "简单又别致嘅小菜自包鸡"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "简单别致的小菜纸包鸡",
-      "src_1_sub_2": "家中小朋友一定好喜欢",
-      "src_2_sub_1": "简单又别致嘅小菜自包鸡",
-      "src_2_sub_2": "家里头嘅小朋友一定好喜欢㗎"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "家中小朋友一定好喜欢",
-      "src_1_sub_2": "材料很简单：一个鸡包",
-      "src_2_sub_1": "家里头嘅小朋友一定好喜欢㗎",
-      "src_2_sub_2": "材料系好简单我哋只需要一个鸡包"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "材料很简单：一个鸡包",
-      "src_1_sub_2": "将鸡包底部的纸撕下来⋯慢慢地撕",
-      "src_2_sub_1": "材料系好简单我哋只需要一个鸡包",
-      "src_2_sub_2": "我哋将黐喺鸡包底嘅纸撕出嚟慢慢撕"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "将鸡包底部的纸撕下来⋯慢慢地撕",
-      "src_1_sub_2": "就会得到一张鸡包纸",
-      "src_2_sub_1": "我哋将黐喺鸡包底嘅纸撕出嚟慢慢撕",
-      "src_2_sub_2": "咁就会得到一张鸡包纸喇"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "就会得到一张鸡包纸",
-      "src_1_sub_2": "把鸡包纸一反反转",
-      "src_2_sub_1": "咁就会得到一张鸡包纸喇",
-      "src_2_sub_2": "然后将鸡包纸一反反转"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "把鸡包纸一反反转",
-      "src_1_sub_2": "这一味纸包鸡就完成了，很容易是吧？",
-      "src_2_sub_1": "然后将鸡包纸一反反转",
-      "src_2_sub_2": "呢味自包鸡就完成喇系咪好易整啦"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "这一味纸包鸡就完成了，很容易是吧？",
-      "src_1_sub_2": "多谢大家收看",
-      "src_2_sub_1": "呢味自包鸡就完成喇系咪好易整啦",
-      "src_2_sub_2": "多谢大家收睇"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "好高兴这么快又跟大家见面",
-      "src_1_sub_2": "接下来我会教大家整一味纸鸡包",
-      "src_2_sub_1": "好高兴咁快又同大家见面",
-      "src_2_sub_2": "跟住落嚟我会教大家整一味纸鸡包"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "接下来我会教大家整一味纸鸡包",
-      "src_1_sub_2": "材料也很简单，只需要白纸一张",
-      "src_2_sub_1": "跟住落嚟我会教大家整一味纸鸡包",
-      "src_2_sub_2": "材料都好简单只需要白纸一张"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "材料也很简单，只需要白纸一张",
-      "src_1_sub_2": "只要把这纸这样子⋯",
-      "src_2_sub_1": "材料都好简单只需要白纸一张",
-      "src_2_sub_2": "我哋只需要张张纸咁样"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "只要把这纸这样子⋯",
-      "src_1_sub_2": "一个纸鸡包就这样完成了",
-      "src_2_sub_1": "我哋只需要张张纸咁样",
-      "src_2_sub_2": "一个纸鸡包就咁完成咗喇"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "一个纸鸡包就这样完成了",
-      "src_1_sub_2": "各位小朋友，像鸡包不像呀？",
-      "src_2_sub_1": "一个纸鸡包就咁完成咗喇",
-      "src_2_sub_2": "各位小朋友你哋话似唔似鸡包啊"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "现在要教大家一味别致小菜－",
-      "src_1_sub_2": "包鸡纸包鸡包纸包鸡",
-      "src_2_sub_1": "间阵要教大家一味几别节嘅小菜",
-      "src_2_sub_2": "包鸡子包鸡包子包鸡"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "包鸡纸包鸡包纸包鸡",
-      "src_1_sub_2": "首先将纸包鸡小心撕开",
-      "src_2_sub_1": "包鸡子包鸡包子包鸡",
-      "src_2_sub_2": "首先将子包鸡小心噉撕开"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "首先将纸包鸡小心撕开",
-      "src_1_sub_2": "大家就会有一张纸包鸡及一块鸡",
-      "src_2_sub_1": "首先将子包鸡小心噉撕开",
-      "src_2_sub_2": "大家就会有一张包鸡子同埋一嚿鸡啦"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "大家就会有一张纸包鸡及一块鸡",
-      "src_1_sub_2": "接著把鸡包纸这样子包起那块鸡",
-      "src_2_sub_1": "大家就会有一张包鸡子同埋一嚿鸡啦",
-      "src_2_sub_2": "跟住将鸡包子好似我噉包住牛鸡"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "接著把鸡包纸这样子包起那块鸡",
-      "src_1_sub_2": "再依照这样子用包鸡纸把它包起",
-      "src_2_sub_1": "跟住将鸡包子好似我噉包住牛鸡",
-      "src_2_sub_2": "然后再好似噉样将包鸡子包包包包包包住佢"
+      "ref_sub_1": "还有谁没点过吗？",
+      "ref_sub_2": "麦兜！",
+      "target_sub_1": "好仲有边个未点",
+      "target_sub_2": "猫"
     },
     "answer": {},
     "difficulty": 3,
@@ -2106,806 +1189,198 @@
   },
   {
     "query": {
-      "src_1_sub_1": "再依照这样子用包鸡纸把它包起",
-      "src_1_sub_2": "一味「包鸡纸包鸡包纸包鸡」完成了！",
-      "src_2_sub_1": "然后再好似噉样将包鸡子包包包包包包住佢",
-      "src_2_sub_2": "咁一味包鸡子包鸡包子包鸡就完成喇"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "一味「包鸡纸包鸡包纸包鸡」完成了！",
-      "src_1_sub_2": "真的很简单吧？",
-      "src_2_sub_1": "咁一味包鸡子包鸡包子包鸡就完成喇",
-      "src_2_sub_2": "系咪好简单呢"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "真的很简单吧？",
-      "src_1_sub_2": "还真有一块鸡吃呢！",
-      "src_2_sub_1": "系咪好简单呢",
-      "src_2_sub_2": "仲真系有嚿鸡食添"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "今日为大家介绍一味⋯",
-      "src_1_sub_2": "小朋友一定喜欢的⋯",
-      "src_2_sub_1": "今日要同大家介绍一味",
-      "src_2_sub_2": "小朋友一定喜欢嘅"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "小朋友一定喜欢的⋯",
-      "src_1_sub_2": "鸡包包鸡包包鸡包纸包纸⋯",
-      "src_2_sub_1": "小朋友一定喜欢嘅",
-      "src_2_sub_2": "鸡包包鸡包包鸡包纸包"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "鸡包包鸡包包鸡包纸包纸⋯",
-      "src_1_sub_2": "包鸡包鸡包纸包鸡",
-      "src_2_sub_1": "鸡包包鸡包包鸡包纸包",
-      "src_2_sub_2": "纸包鸡包包鸡纸包鸡包纸包鸡"
+      "ref_sub_1": "麦兜！",
+      "ref_sub_2": "麦兜同学！",
+      "target_sub_1": "猫",
+      "target_sub_2": "噢麦兜同学"
     },
     "answer": {
-      "src_2_sub_1_shifted": "鸡包包鸡包包鸡包纸包纸包鸡包包鸡",
-      "src_2_sub_2_shifted": "纸包鸡包纸包鸡"
+      "target_sub_1_shifted": "猫噢",
+      "target_sub_2_shifted": "麦兜同学"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "包鸡包鸡包纸包鸡",
-      "src_1_sub_2": "做法亦很简单",
-      "src_2_sub_1": "纸包鸡包纸包鸡",
-      "src_2_sub_2": "做法都好简单"
+      "ref_sub_1": "麦兜同学！",
+      "ref_sub_2": "麦兜同学！",
+      "target_sub_1": "麦兜同学",
+      "target_sub_2": "麦兜同学"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "做法亦很简单",
-      "src_1_sub_2": "只要将鸡包包住个鸡包",
-      "src_2_sub_1": "做法都好简单",
-      "src_2_sub_2": "我哋先将鸡包包住个鸡包"
+      "ref_sub_1": "麦兜同学！",
+      "ref_sub_2": "麦唛呀，即是呢⋯",
+      "target_sub_1": "麦兜同学",
+      "target_sub_2": "妈妈啊麦兜同学"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "只要将鸡包包住个鸡包",
-      "src_1_sub_2": "再包住个鸡包⋯",
-      "src_2_sub_1": "我哋先将鸡包包住个鸡包",
-      "src_2_sub_2": "再包住个鸡包"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "再包住个鸡包⋯",
-      "src_1_sub_2": "包住张鸡包纸",
-      "src_2_sub_1": "再包住个鸡包",
-      "src_2_sub_2": "包住张鸡包纸"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "包住张鸡包纸",
-      "src_1_sub_2": "再包包包包包住个纸鸡包",
-      "src_2_sub_1": "包住张鸡包纸",
-      "src_2_sub_2": "再包包包包包住个纸包鸡"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "再包包包包包住个纸鸡包",
-      "src_1_sub_2": "再包包包，纸纸纸",
-      "src_2_sub_1": "再包包包包包住个纸包鸡",
-      "src_2_sub_2": "再包包包包包鸡包纸包纸纸纸纸纸"
-    },
-    "answer": {},
-    "difficulty": 3,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "再包包包，纸纸纸",
-      "src_1_sub_2": "纸包纸，纸包鸡，鸡包纸，纸包鸡⋯",
-      "src_2_sub_1": "再包包包包包鸡包纸包纸纸纸纸纸",
-      "src_2_sub_2": "纸包纸纸包鸡包鸡纸纸包鸡鸡鸡鸡纸纸纸再包鸡鸡"
+      "ref_sub_1": "麦唛呀，即是呢⋯",
+      "ref_sub_2": "我好像觉得呢⋯",
+      "target_sub_1": "妈妈啊麦兜同学",
+      "target_sub_2": "即系呢"
     },
     "answer": {
-      "src_2_sub_1_shifted": "再包包包包包鸡包纸包纸纸纸纸纸纸包纸",
-      "src_2_sub_2_shifted": "纸包鸡包鸡纸纸包鸡鸡鸡鸡纸纸纸再包鸡鸡"
-    },
-    "difficulty": 3,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "纸包纸，纸包鸡，鸡包纸，纸包鸡⋯",
-      "src_1_sub_2": "可我妈妈也有她温柔的一面",
-      "src_2_sub_1": "纸包鸡包鸡纸纸包鸡鸡鸡鸡纸纸纸再包鸡鸡",
-      "src_2_sub_2": "不过我妈妈都有佢温柔嘅一面"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "可我妈妈也有她温柔的一面",
-      "src_1_sub_2": "例如每晚睡觉前，她都会说故事给我听",
-      "src_2_sub_1": "不过我妈妈都有佢温柔嘅一面",
-      "src_2_sub_2": "例如每晚临睡前佢都会讲故事畀我听"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "例如每晚睡觉前，她都会说故事给我听",
-      "src_1_sub_2": "从前，有个小朋友撒谎；有一天⋯",
-      "src_2_sub_1": "例如每晚临睡前佢都会讲故事畀我听",
-      "src_2_sub_2": "从前有个小朋友讲大话"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "从前，有个小朋友撒谎；有一天⋯",
-      "src_1_sub_2": "他死了！",
-      "src_2_sub_1": "从前有个小朋友讲大话",
-      "src_2_sub_2": "有一日佢死咗"
-    },
-    "answer": {
-      "src_2_sub_1_shifted": "从前有个小朋友讲大话有一日",
-      "src_2_sub_2_shifted": "佢死咗"
-    },
-    "difficulty": 1,
-    "few_shot": true,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "他死了！",
-      "src_1_sub_2": "从前，有个小朋友很勤力念书⋯",
-      "src_2_sub_1": "佢死咗",
-      "src_2_sub_2": "从前有个小朋友好勤力读书"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "从前，有个小朋友很勤力念书⋯",
-      "src_1_sub_2": "他长大后，发财了！",
-      "src_2_sub_1": "从前有个小朋友好勤力读书",
-      "src_2_sub_2": "佢长大发咗"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "他长大后，发财了！",
-      "src_1_sub_2": "从前，有个小朋友不孝，有天⋯",
-      "src_2_sub_1": "佢长大发咗",
-      "src_2_sub_2": "从前有个小朋友唔孝顺"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "从前，有个小朋友不孝，有天⋯",
-      "src_1_sub_2": "他扭了脚骹！",
-      "src_2_sub_1": "从前有个小朋友唔孝顺",
-      "src_2_sub_2": "有一日佢屈亲个脚脚"
-    },
-    "answer": {
-      "src_2_sub_1_shifted": "从前有个小朋友唔孝顺有一日",
-      "src_2_sub_2_shifted": "佢屈亲个脚脚"
+      "target_sub_1_shifted": "妈妈啊麦兜同学即系呢"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "他扭了脚骹！",
-      "src_1_sub_2": "妈妈，我想睡觉",
-      "src_2_sub_1": "佢屈亲个脚脚",
-      "src_2_sub_2": "妈我想瞓啦"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "从前，有个小朋友早睡晚起；第二天⋯",
-      "src_1_sub_2": "他死了！",
-      "src_2_sub_1": "从前有个小朋友早睡晚起第二朝社群提供",
-      "src_2_sub_2": "佢死咗"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "他死了！",
-      "src_1_sub_2": "我妈妈就是这样子，一切都那么直接",
-      "src_2_sub_1": "佢死咗",
-      "src_2_sub_2": "我妈妈就系噉一切都咁直接"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我妈妈就是这样子，一切都那么直接",
-      "src_1_sub_2": "她爱得我直接⋯",
-      "src_2_sub_1": "我妈妈就系噉一切都咁直接",
-      "src_2_sub_2": "佢爱得我直接"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "她爱得我直接⋯",
-      "src_1_sub_2": "对我的期望直接",
-      "src_2_sub_1": "佢爱得我直接",
-      "src_2_sub_2": "对我嘅期望直接"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "对我的期望直接",
-      "src_1_sub_2": "对她，一、二、三、四、五、六、七",
-      "src_2_sub_1": "对我嘅期望直接"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "对她，一、二、三、四、五、六、七",
-      "src_1_sub_2": "没有不成的事",
-      "src_2_sub_2": "佢一二三四五六七唔得都要得字幕由Amara.org"
+      "ref_sub_1": "我好像觉得呢⋯",
+      "ref_sub_2": "有什么人在喊我似的",
+      "target_sub_2": "我个心总系仁住仁住好似有人嗌紧我个名噉嘅"
     },
     "answer": {
-      "src_2_sub_1_shifted": "佢一二三四五六七",
-      "src_2_sub_2_shifted": "唔得都要得字幕由Amara.org"
+      "target_sub_1_shifted": "我个心总系仁住仁住",
+      "target_sub_2_shifted": "好似有人嗌紧我个名噉嘅"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "对我的期望直接",
-      "src_1_sub_2": "对她，一、二、三、四、五、六、七",
-      "src_2_sub_1": "对我嘅期望直接",
-      "src_2_sub_2": "佢一二三四五六七"
+      "ref_sub_1": "有什么人在喊我似的",
+      "ref_sub_2": "你们不要以为我心散",
+      "target_sub_1": "好似有人嗌紧我个名噉嘅",
+      "target_sub_2": "你哋唔好以为我心散啊"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "对她，一、二、三、四、五、六、七",
-      "src_1_sub_2": "没有不成的事",
-      "src_2_sub_1": "佢一二三四五六七",
-      "src_2_sub_2": "唔得都要得字幕由Amara.org"
+      "ref_sub_1": "你们不要以为我心散",
+      "ref_sub_2": "其实我正在思考一个学术问题：",
+      "target_sub_1": "你哋唔好以为我心散啊",
+      "target_sub_2": "其实我系喺度思考紧一啲学术性嘅问题"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "可有些事情，要是真的不成呢？",
-      "src_1_sub_2": "日子一天一天的过",
-      "src_2_sub_1": "但系如果有啲嘢真系真系唔得呢",
-      "src_2_sub_2": "日子一日一日咁过"
+      "ref_sub_1": "其实我正在思考一个学术问题：",
+      "ref_sub_2": "橙，为什么会是「屙－烂－煮」呢？",
+      "target_sub_1": "其实我系喺度思考紧一啲学术性嘅问题",
+      "target_sub_2": "点解橙叫Orange呢"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "日子一天一天的过",
-      "src_1_sub_2": "首先是周润发事件⋯",
-      "src_2_sub_1": "日子一日一日咁过",
-      "src_2_sub_2": "首先周润发嗰单嘢"
+      "ref_sub_1": "橙，为什么会是「屙－烂－煮」呢？",
+      "ref_sub_2": "妈妈说吃橙可通大便",
+      "target_sub_1": "点解橙叫Orange呢",
+      "target_sub_2": "妈妈话食橙会通大"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "首先是周润发事件⋯",
-      "src_1_sub_2": "拜托不要再提了！",
-      "src_2_sub_1": "首先周润发嗰单嘢",
-      "src_2_sub_2": "大家都唔好再提"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "拜托不要再提了！",
-      "src_1_sub_2": "至于好运⋯",
-      "src_2_sub_1": "大家都唔好再提"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "至于好运⋯",
-      "src_1_sub_2": "我用一双童子手替妈妈抽的六合彩号码",
-      "src_2_sub_2": "至于好运我用我嘅同事手帮妈妈抽嘅六合彩number"
+      "ref_sub_1": "妈妈说吃橙可通大便",
+      "ref_sub_2": "「屙」这个我明白，可是「烂－煮」呢？",
+      "target_sub_1": "妈妈话食橙会通大",
+      "target_sub_2": "变噢呢个我明白但系橙呢"
     },
     "answer": {
-      "src_2_sub_1_shifted": "至于好运",
-      "src_2_sub_2_shifted": "我用我嘅同事手帮妈妈抽嘅六合彩number"
+      "target_sub_1_shifted": "妈妈话食橙会通大变",
+      "target_sub_2_shifted": "噢呢个我明白但系橙呢"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我用一双童子手替妈妈抽的六合彩号码",
-      "src_1_sub_2": "奇迹般似的一个号码也没中过！",
-      "src_2_sub_1": "我用我嘅同事手帮妈妈抽嘅六合彩number",
-      "src_2_sub_2": "竟然奇迹一样一个都未中过"
+      "ref_sub_1": "「屙」这个我明白，可是「烂－煮」呢？",
+      "ref_sub_2": "还有这个「芭－娜－哪」香蕉",
+      "target_sub_1": "噢呢个我明白但系橙呢",
+      "target_sub_2": "仲有呢个啊芭拉娜啊"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "奇迹般似的一个号码也没中过！",
-      "src_1_sub_2": "叻仔？",
-      "src_2_sub_1": "竟然奇迹一样一个都未中过",
-      "src_2_sub_2": "叻仔"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "叻仔？",
-      "src_1_sub_2": "我也试过努力念书，可是⋯",
-      "src_2_sub_1": "叻仔",
-      "src_2_sub_2": "我试过好努力咁读书但系"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我也试过努力念书，可是⋯",
-      "src_1_sub_2": "可是⋯我仍然有梦",
-      "src_2_sub_1": "我试过好努力咁读书但系",
-      "src_2_sub_2": "但系我仲可以发梦"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "马尔代夫，座落于印度洋的世外桃源",
-      "src_1_sub_2": "蓝天白云，椰林树影，水清沙幼",
-      "src_2_sub_1": "马尔代夫坐落于印度洋嘅世外桃源",
-      "src_2_sub_2": "蓝天白云椰林树影水清沙游"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "蓝天白云，椰林树影，水清沙幼",
-      "src_1_sub_2": "七彩缤纷的珊瑚，目不暇给的热带鱼",
-      "src_2_sub_1": "蓝天白云椰林树影水清沙游",
-      "src_2_sub_2": "七彩缤纷嘅珊瑚目不下级嘅热带鱼群"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "七彩缤纷的珊瑚，目不暇给的热带鱼",
-      "src_1_sub_2": "充满赤道活力的原始海洋，脱离繁嚣",
-      "src_2_sub_1": "七彩缤纷嘅珊瑚目不下级嘅热带鱼群",
-      "src_2_sub_2": "充满住赤道热力嘅原始海洋远离凡嚣"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "充满赤道活力的原始海洋，脱离繁嚣",
-      "src_1_sub_2": "体验热情如火的风土人情",
-      "src_2_sub_1": "充满住赤道热力嘅原始海洋远离凡嚣",
-      "src_2_sub_2": "体验热情如火嘅风土人情"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "体验热情如火的风土人情",
-      "src_1_sub_2": "享受一个脱俗出尘的梦幻之旅",
-      "src_2_sub_1": "体验热情如火嘅风土人情",
-      "src_2_sub_2": "享受一个脱轴出尘嘅梦幻之旅"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "享受一个脱俗出尘的梦幻之旅",
-      "src_1_sub_2": "犀利旅行社，旅行社牌照号码350999",
-      "src_2_sub_1": "享受一个脱轴出尘嘅梦幻之旅",
-      "src_2_sub_2": "犀利旅行社旅行社牌照号码350999"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "犀利旅行社，旅行社牌照号码350999",
-      "src_1_sub_2": "妈妈你知道马尔代夫在哪儿吗？",
-      "src_2_sub_1": "犀利旅行社旅行社牌照号码350999",
-      "src_2_sub_2": "妈妈你知唔知到马尔代夫系边㗎"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "妈妈你知道马尔代夫在哪儿吗？",
-      "src_1_sub_2": "很远的",
-      "src_2_sub_1": "妈妈你知唔知到马尔代夫系边㗎"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "很远的",
-      "src_1_sub_2": "有多远？",
-      "src_2_sub_2": "啊好远㗎点远发呀"
+      "ref_sub_1": "还有这个「芭－娜－哪」香蕉",
+      "ref_sub_2": "为什么雨伞又会是「暗－芭－娜－哪」呢？",
+      "target_sub_1": "仲有呢个啊芭拉娜啊",
+      "target_sub_2": "香蕉啊点解雨姐会叫做暗芭拉娜呢"
     },
     "answer": {
-      "src_2_sub_1_shifted": "啊好远㗎",
-      "src_2_sub_2_shifted": "点远发呀"
+      "target_sub_1_shifted": "仲有呢个啊芭拉娜啊香蕉啊",
+      "target_sub_2_shifted": "点解雨姐会叫做暗芭拉娜呢"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "有多远？",
-      "src_1_sub_2": "得搭飞机",
-      "src_2_sub_1": "点远发呀",
-      "src_2_sub_2": "搭飞机至到啰"
+      "ref_sub_1": "为什么雨伞又会是「暗－芭－娜－哪」呢？",
+      "ref_sub_2": "我「暗」的「暗」掉一条蕉",
+      "target_sub_1": "点解雨姐会叫做暗芭拉娜呢",
+      "target_sub_2": "嗱我暗啦噉我暗嗰条香蕉"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "得搭飞机",
-      "src_1_sub_2": "妈妈你会带我去吗？",
-      "src_2_sub_1": "搭飞机至到啰",
-      "src_2_sub_2": "咁妈妈你会唔会走落去㗎"
+      "ref_sub_1": "我「暗」的「暗」掉一条蕉",
+      "ref_sub_2": "至多是屙烂煮，怎么会下起雨来呢？",
+      "target_sub_1": "嗱我暗啦噉我暗嗰条香蕉",
+      "target_sub_2": "至多会Orange啫点解会搞到落雨呢"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈你会带我去吗？",
-      "src_1_sub_2": "会！发财了再说吧",
-      "src_2_sub_1": "咁妈妈你会唔会走落去㗎",
-      "src_2_sub_2": "会得学发咗先啦"
+      "ref_sub_1": "至多是屙烂煮，怎么会下起雨来呢？",
+      "ref_sub_2": "这世界还有很多事情我弄不明白",
+      "target_sub_1": "至多会Orange啫点解会搞到落雨呢",
+      "target_sub_2": "呢个世界仲有好多嘢我谂唔明"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "会！发财了再说吧",
-      "src_1_sub_2": "那么妈妈你什么时候发？",
-      "src_2_sub_1": "会得学发咗先啦",
-      "src_2_sub_2": "咁妈妈你几时发得呀"
+      "ref_sub_1": "这世界还有很多事情我弄不明白",
+      "ref_sub_2": "但我不害怕",
+      "target_sub_1": "呢个世界仲有好多嘢我谂唔明",
+      "target_sub_2": "不过我唔怕"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "那么妈妈你什么时候发？",
-      "src_1_sub_2": "快了⋯",
-      "src_2_sub_1": "咁妈妈你几时发得呀",
-      "src_2_sub_2": "呃就快啦"
+      "ref_sub_1": "但我不害怕",
+      "ref_sub_2": "我想，有天我念完幼稚园",
+      "target_sub_1": "不过我唔怕",
+      "target_sub_2": "我谂到我读完幼稚园"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "快了⋯",
-      "src_1_sub_2": "发梦呀！",
-      "src_2_sub_1": "呃就快啦",
-      "src_2_sub_2": "发梦吖嘛"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "校长早晨！",
-      "src_1_sub_2": "校长再见！",
-      "src_2_sub_1": "嗨"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "校长再见！",
-      "src_1_sub_2": "你最喜爱的地方是哪儿？",
-      "src_2_sub_2": "你最喜爱嘅地方喺边度呀"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "你最喜爱的地方是哪儿？",
-      "src_1_sub_2": "我最喜爱的地方是日本",
-      "src_2_sub_1": "你最喜爱嘅地方喺边度呀",
-      "src_2_sub_2": "我最喜爱嘅地方呢就系日本喇"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我最喜爱的地方是日本",
-      "src_1_sub_2": "那儿有 Disneyland 和 Hello Kitty Land",
-      "src_2_sub_1": "我最喜爱嘅地方呢就系日本喇",
-      "src_2_sub_2": "嗰度好迪士尼呢同埋HelloTT呢"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "那儿有 Disneyland 和 Hello Kitty Land",
-      "src_1_sub_2": "我这个发夹也是在那儿买的",
-      "src_2_sub_1": "嗰度好迪士尼呢同埋HelloTT呢",
-      "src_2_sub_2": "我而家打紧个发卷都系嗰边买嘅"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我这个发夹也是在那儿买的",
-      "src_1_sub_2": "我最喜爱的地方是加拿大",
-      "src_2_sub_1": "我而家打紧个发卷都系嗰边买嘅",
-      "src_2_sub_2": "我最钟意嘅地方就系加拿大"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我最喜爱的地方是加拿大",
-      "src_1_sub_2": "婆婆跟舅父他们都在加拿大",
-      "src_2_sub_1": "我最钟意嘅地方就系加拿大",
-      "src_2_sub_2": "婆婆同埋舅父呀佢哋都系加拿大㗎"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "婆婆跟舅父他们都在加拿大",
-      "src_1_sub_2": "我最喜爱的地方是泰国",
-      "src_2_sub_1": "婆婆同埋舅父呀佢哋都系加拿大㗎",
-      "src_2_sub_2": "我最钟意去嘅地方就系泰国喇"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我最喜爱的地方是泰国",
-      "src_1_sub_2": "那儿有很多水上活动，还有鱼翅吃",
-      "src_2_sub_1": "我最钟意去嘅地方就系泰国喇",
-      "src_2_sub_2": "嗰度有好多水晶活动㗎仲有一次食添㖞"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "那儿有很多水上活动，还有鱼翅吃",
-      "src_1_sub_2": "我最喜爱的地方⋯",
-      "src_2_sub_1": "嗰度有好多水晶活动㗎仲有一次食添㖞",
-      "src_2_sub_2": "呃我最喜爱嘅地方呢"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我最喜爱的地方⋯",
-      "src_1_sub_2": "就是那间什么！",
-      "src_2_sub_1": "呃我最喜爱嘅地方呢",
-      "src_2_sub_2": "就系嗰间咩嚟啰"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "就是那间什么！",
-      "src_1_sub_2": "那儿有欢乐天地，还有美食广场",
-      "src_2_sub_1": "就系嗰间咩嚟啰",
-      "src_2_sub_2": "嗰度有欢乐天地啦仲有米食广场啦"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "那儿有欢乐天地，还有美食广场",
-      "src_1_sub_2": "那儿的海南鸡饭很大碟的",
-      "src_2_sub_1": "嗰度有欢乐天地啦仲有米食广场啦",
-      "src_2_sub_2": "嗰度啲可能几份好大碟㗎"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "那儿的海南鸡饭很大碟的",
-      "src_1_sub_2": "对了，那地方叫银城中心",
-      "src_2_sub_1": "嗰度啲可能几份好大碟㗎",
-      "src_2_sub_2": "系喇系喇嗰间叫做银城中心"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "对了，那地方叫银城中心",
-      "src_1_sub_2": "那店子的饭很多，很大碟的！",
-      "src_2_sub_1": "系喇系喇嗰间叫做银城中心",
-      "src_2_sub_2": "嗰间嘢啲饭好多人好大碟㗎"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "那店子的饭很多，很大碟的！",
-      "src_1_sub_2": "不过说到我最想去的地方，那可厉害了",
-      "src_2_sub_1": "嗰间嘢啲饭好多人好大碟㗎",
-      "src_2_sub_2": "不过讲到我最想去嘅地方呢嗰度细嚟啰"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "不过说到我最想去的地方，那可厉害了",
-      "src_1_sub_2": "那儿蓝天白云，椰林树影，水清沙幼",
-      "src_2_sub_1": "不过讲到我最想去嘅地方呢嗰度细嚟啰",
-      "src_2_sub_2": "嗰度南天白云夜临树影水清沙幽"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "那儿蓝天白云，椰林树影，水清沙幼",
-      "src_1_sub_2": "座落于印度洋的世外桃源",
-      "src_2_sub_1": "嗰度南天白云夜临树影水清沙幽",
-      "src_2_sub_2": "独来鱼印度洋嘅世外桃源"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "衰仔，快点起床上学",
-      "src_1_sub_2": "咦？",
-      "src_2_sub_1": "喂衰仔啊快啲起身返学喇",
-      "src_2_sub_2": "咦"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "咦？",
-      "src_1_sub_2": "妈妈！",
-      "src_2_sub_1": "咦",
-      "src_2_sub_2": "妈妈"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "开点药给他吃就没事了",
-      "src_1_sub_2": "医生，吃了药会不会有那个什么的？",
-      "src_2_sub_1": "开啲药过佢食就冇事㗎喇",
-      "src_2_sub_2": "医生啊"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "医生，吃了药会不会有那个什么的？",
-      "src_1_sub_2": "不会！",
-      "src_2_sub_1": "医生啊",
-      "src_2_sub_2": "啲药食咗会唔会有嗰啲咩㗎唔会"
-    },
-    "answer": {
-      "src_2_sub_1_shifted": "医生啊啲药食咗会唔会有嗰啲咩㗎",
-      "src_2_sub_2_shifted": "唔会"
-    },
-    "difficulty": 1,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "不会！",
-      "src_1_sub_2": "那么吃药用不用那个什么的？",
-      "src_2_sub_1": "唔会",
-      "src_2_sub_2": "噉佢食药使唔使咩啊"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "那么吃药用不用那个什么的？",
-      "src_1_sub_2": "不用！给他打口针吧！",
-      "src_2_sub_1": "噉佢食药使唔使咩啊",
-      "src_2_sub_2": "唔使同佢打多支针添呢"
+      "ref_sub_1": "我想，有天我念完幼稚园",
+      "ref_sub_2": "升小学，上中学",
+      "target_sub_1": "我谂到我读完幼稚园",
+      "target_sub_2": "识埋小学上到中学"
     },
     "answer": {},
     "few_shot": true,
@@ -2913,124 +1388,901 @@
   },
   {
     "query": {
-      "src_1_sub_1": "不用！给他打口针吧！",
-      "src_1_sub_2": "怎么？得打针？",
-      "src_2_sub_1": "唔使同佢打多支针添呢",
-      "src_2_sub_2": "吓要打针啊"
+      "ref_sub_1": "升小学，上中学",
+      "ref_sub_2": "再念大学⋯",
+      "target_sub_1": "识埋小学上到中学",
+      "target_sub_2": "再入埋大学"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "怎么？得打针？",
-      "src_1_sub_2": "他最怕打针的了",
-      "src_2_sub_1": "吓要打针啊",
-      "src_2_sub_2": "佢好怕打针㗎㖞"
+      "ref_sub_1": "再念大学⋯",
+      "ref_sub_2": "当我大学毕业的时候",
+      "target_sub_1": "再入埋大学",
+      "target_sub_2": "等我大学毕业嗰阵"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "他最怕打针的了",
-      "src_1_sub_2": "那么他怕不怕死？",
-      "src_2_sub_1": "佢好怕打针㗎㖞",
-      "src_2_sub_2": "噉佢怕唔怕死呀"
+      "ref_sub_1": "当我大学毕业的时候",
+      "ref_sub_2": "我知道我会明白一切！",
+      "target_sub_1": "等我大学毕业嗰阵",
+      "target_sub_2": "我谂我乜都会明白晒"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "没事吧？快点先把药水喝掉！",
-      "src_1_sub_2": "妈妈我不想喝药水",
-      "src_2_sub_1": "冇嘢吖嘛快啲食埋啲药水佢先啦",
-      "src_2_sub_2": "妈妈我唔想食药水呀"
+      "ref_sub_1": "我知道我会明白一切！",
+      "ref_sub_2": "那时候⋯",
+      "target_sub_1": "我谂我乜都会明白晒",
+      "target_sub_2": "到嗰阵"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈我不想喝药水",
-      "src_1_sub_2": "不要呀妈妈，我不喝呀",
-      "src_2_sub_1": "妈妈我唔想食药水呀",
-      "src_2_sub_2": "唔好捞妈妈我唔食呀"
+      "ref_sub_1": "那时候⋯",
+      "ref_sub_2": "我买所房子给妈妈！",
+      "target_sub_1": "到嗰阵",
+      "target_sub_2": "我买层楼畀我妈妈"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "不要呀妈妈，我不喝呀",
-      "src_1_sub_2": "我不喝士多啤梨药水呀！",
-      "src_2_sub_1": "唔好捞妈妈我唔食呀",
-      "src_2_sub_2": "我唔食士多啤梨药水呀"
+      "ref_sub_1": "幼稚园楼下，由校长兼营的茶餐厅",
+      "ref_sub_2": "我们一班同学下课后经常光顾",
+      "target_sub_1": "喺幼稚园楼下校长兼营嘅间茶餐厅",
+      "target_sub_2": "我哋一班同学仔放咗学都经常系傍陈"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我不喝士多啤梨药水呀！",
-      "src_1_sub_2": "别哭了，不喝药水病不会好的",
-      "src_2_sub_1": "我唔食士多啤梨药水呀",
-      "src_2_sub_2": "唔好喊啦唔食药唔会好㗎"
+      "ref_sub_1": "我们一班同学下课后经常光顾",
+      "ref_sub_2": "鱼蛋粗面，麻烦你　　粗面买光了",
+      "target_sub_1": "我哋一班同学仔放咗学都经常系傍陈",
+      "target_sub_2": "唔该鱼蛋粗啊"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "别哭了，不喝药水病不会好的",
-      "src_1_sub_2": "乖乖，病好了妈妈带你去马尔代夫",
-      "src_2_sub_1": "唔好喊啦唔食药唔会好㗎",
-      "src_2_sub_2": "乖乖啲病好咗妈妈大理马尔代夫"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "乖乖，病好了妈妈带你去马尔代夫",
-      "src_1_sub_2": "真的吗？",
-      "src_2_sub_1": "乖乖啲病好咗妈妈大理马尔代夫",
-      "src_2_sub_2": "真嘅"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "真的吗？",
-      "src_1_sub_2": "妈妈什么时候骗过你？",
-      "src_2_sub_1": "真嘅",
-      "src_2_sub_2": "妈妈几时呃过你呀"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "妈妈什么时候骗过你？",
-      "src_1_sub_2": "乖，先把药水喝掉",
-      "src_2_sub_1": "妈妈几时呃过你呀",
-      "src_2_sub_2": "乖食埋啲药水先啦"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "好呀，马尔代夫！",
-      "src_1_sub_2": "马尔代夫！",
-      "src_2_sub_1": "嘻嘻好嘢",
-      "src_2_sub_2": "买二代夫买二代夫"
+      "ref_sub_1": "鱼蛋粗面，麻烦你　　粗面买光了",
+      "ref_sub_2": "那样子⋯来碗鱼蛋河粉吧　　鱼蛋买光了",
+      "target_sub_1": "唔该鱼蛋粗啊",
+      "target_sub_2": "冇粗面噃噉啊要碗鱼蛋好啊冇鱼蛋噃"
     },
     "answer": {
-      "src_2_sub_1_shifted": "嘻嘻好嘢买二代夫",
-      "src_2_sub_2_shifted": "买二代夫"
+      "target_sub_1_shifted": "唔该鱼蛋粗啊冇粗面噃",
+      "target_sub_2_shifted": "噉啊要碗鱼蛋好啊冇鱼蛋噃"
+    },
+    "difficulty": 1,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "那样子⋯来碗鱼蛋河粉吧　　鱼蛋买光了",
+      "ref_sub_2": "那么⋯金钱肚粗面好了　　粗面买光了",
+      "target_sub_1": "噉啊要碗鱼蛋好啊冇鱼蛋噃",
+      "target_sub_2": "噉啊要金钱透粗啊冇粗面噃"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "那么⋯金钱肚粗面好了　　粗面买光了",
+      "ref_sub_2": "那么要鱼蛋油面吧　　鱼蛋买光了",
+      "target_sub_1": "噉啊要金钱透粗啊冇粗面噃",
+      "target_sub_2": "噉啊咁要鱼蛋油面啊"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "那么要鱼蛋油面吧　　鱼蛋买光了",
+      "ref_sub_2": "怎么都买光了？",
+      "target_sub_1": "噉啊咁要鱼蛋油面啊",
+      "target_sub_2": "冇鱼蛋噃乜样样都冇嘅"
+    },
+    "answer": {
+      "target_sub_1_shifted": "噉啊咁要鱼蛋油面啊冇鱼蛋噃",
+      "target_sub_2_shifted": "乜样样都冇嘅"
+    },
+    "difficulty": 1,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "怎么都买光了？",
+      "ref_sub_2": "来个墨鱼丸粗面吧　　粗面买光了",
+      "target_sub_1": "乜样样都冇嘅",
+      "target_sub_2": "噉要蜜丸粗啊"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "来个墨鱼丸粗面吧　　粗面买光了",
+      "ref_sub_2": "又买光了？",
+      "target_sub_1": "噉要蜜丸粗啊",
+      "target_sub_2": "冇粗面噃又冇啊"
+    },
+    "answer": {
+      "target_sub_1_shifted": "噉要蜜丸粗啊冇粗面噃",
+      "target_sub_2_shifted": "又冇啊"
+    },
+    "difficulty": 1,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "又买光了？",
+      "ref_sub_2": "麻烦来碗鱼蛋濑吧　　鱼蛋买光了",
+      "target_sub_1": "又冇啊",
+      "target_sub_2": "噉唔该畀碗鱼蛋奶啊"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "麻烦来碗鱼蛋濑吧　　鱼蛋买光了",
+      "ref_sub_2": "麦兜呀，鱼蛋跟粗面都买光了",
+      "target_sub_1": "噉唔该畀碗鱼蛋奶啊",
+      "target_sub_2": "冇鱼蛋噃麦兜啊佢哋啲鱼蛋同粗面卖晒㗎啦"
+    },
+    "answer": {
+      "target_sub_1_shifted": "噉唔该畀碗鱼蛋奶啊冇鱼蛋噃",
+      "target_sub_2_shifted": "麦兜啊佢哋啲鱼蛋同粗面卖晒㗎啦"
+    },
+    "difficulty": 1,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "麦兜呀，鱼蛋跟粗面都买光了",
+      "ref_sub_2": "即是所有鱼蛋跟粗面的配搭都没了",
+      "target_sub_1": "麦兜啊佢哋啲鱼蛋同粗面卖晒㗎啦",
+      "target_sub_2": "即系所有要鱼蛋或者粗面嘅配搭都冇㗎啦"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "即是所有鱼蛋跟粗面的配搭都没了",
+      "ref_sub_2": "没有那些配搭吗？",
+      "target_sub_1": "即系所有要鱼蛋或者粗面嘅配搭都冇㗎啦",
+      "target_sub_2": "噢冇嗰啲配搭啊"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "没有那些配搭吗？",
+      "ref_sub_2": "麻烦你，净要鱼蛋吧　　鱼蛋买光了",
+      "target_sub_1": "噢冇嗰啲配搭啊",
+      "target_sub_2": "噉唔该净鱼蛋啊"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "麻烦你，净要鱼蛋吧　　鱼蛋买光了",
+      "ref_sub_2": "那么净要粗面呢？　　粗面买光了",
+      "target_sub_1": "噉唔该净鱼蛋啊",
+      "target_sub_2": "冇鱼蛋噃净粗面呢冇粗面噃"
+    },
+    "answer": {
+      "target_sub_1_shifted": "噉唔该净鱼蛋啊冇鱼蛋噃",
+      "target_sub_2_shifted": "净粗面呢冇粗面噃"
+    },
+    "difficulty": 1,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "那么净要粗面呢？　　粗面买光了",
+      "ref_sub_2": "看到这里⋯",
+      "target_sub_1": "净粗面呢冇粗面噃",
+      "target_sub_2": "睇到呢度"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "看到这里⋯",
+      "ref_sub_2": "大家大概都知道我是个怎么样的叻仔",
+      "target_sub_1": "睇到呢度",
+      "target_sub_2": "大家大概都知道我有几叻仔嘞"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "大家大概都知道我是个怎么样的叻仔",
+      "ref_sub_2": "那时候我无忧无虑，万事无所谓－－",
+      "target_sub_1": "大家大概都知道我有几叻仔嘞",
+      "target_sub_2": "果只我无忧无虑冇乜所谓"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "那时候我无忧无虑，万事无所谓－－",
+      "ref_sub_2": "鱼蛋买光了？那么粗面吧",
+      "target_sub_1": "果只我无忧无虑冇乜所谓",
+      "target_sub_2": "冇鱼蛋咩粗面都好啊"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "鱼蛋买光了？那么粗面吧",
+      "ref_sub_2": "麦兜，射呀！",
+      "target_sub_1": "冇鱼蛋咩粗面都好啊",
+      "target_sub_2": "麦兜转身食啊"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "看著自己每天屙烂煮⋯",
+      "ref_sub_2": "每天长肉⋯",
+      "target_sub_1": "睇住自己日日柯能处",
+      "target_sub_2": "日日掌肉"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "每天长肉⋯",
+      "ref_sub_2": "我感到充满力量！",
+      "target_sub_1": "日日掌肉",
+      "target_sub_2": "感到充满力量"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我感到充满力量！",
+      "ref_sub_2": "世界好美丽！",
+      "target_sub_1": "感到充满力量",
+      "target_sub_2": "世界好美丽"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "有一首歌，Miss Chan唱的好听",
+      "ref_sub_2": "我时常想著学习",
+      "target_sub_1": "有一首歌麦词春唱得好好听呀",
+      "target_sub_2": "我成日想学习"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我时常想著学习",
+      "ref_sub_2": "可每次我总唱成「屙」什么什么的⋯",
+      "target_sub_1": "我成日想学习",
+      "target_sub_2": "但系唱嚟唱去都系阿伦厨"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "可每次我总唱成「屙」什么什么的⋯",
+      "ref_sub_2": "是All Things Bright and Beautiful吧？",
+      "target_sub_1": "但系唱嚟唱去都系阿伦厨",
+      "target_sub_2": "咁Ballana噉系唔系AllThingsBrightandBeautiful呀"
+    },
+    "answer": {
+      "target_sub_1_shifted": "但系唱嚟唱去都系阿伦厨咁Ballana噉",
+      "target_sub_2_shifted": "系唔系AllThingsBrightandBeautiful呀"
+    },
+    "difficulty": 1,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "是All Things Bright and Beautiful吧？",
+      "ref_sub_2": "是的，一切都好！",
+      "target_sub_1": "系唔系AllThingsBrightandBeautiful呀",
+      "target_sub_2": "系呀"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "是的，一切都好！",
+      "ref_sub_2": "世上一切，一切一切⋯",
+      "target_sub_1": "系呀",
+      "target_sub_2": "所有嘢都几好喇"
+    },
+    "answer": {
+      "target_sub_1_shifted": "系呀所有嘢都几好喇"
+    },
+    "difficulty": 1,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "世上一切，一切一切⋯",
+      "ref_sub_2": "所有那些，都好！",
+      "target_sub_2": "世上一切所有嗰啲嘢都几好AllThingsBrightandBeautiful"
+    },
+    "answer": {
+      "target_sub_1_shifted": "世上一切",
+      "target_sub_2_shifted": "所有嗰啲嘢都几好AllThingsBrightandBeautiful"
+    },
+    "difficulty": 1,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "一、二、三、四、五、六、七⋯",
+      "ref_sub_2": "多劳多得！",
+      "target_sub_2": "1234567多喽多得"
+    },
+    "answer": {
+      "target_sub_1_shifted": "1234567",
+      "target_sub_2_shifted": "多喽多得"
+    },
+    "difficulty": 1,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "一、二、三、四、五、六、七⋯",
+      "ref_sub_2": "多劳多得！",
+      "target_sub_1": "1234567",
+      "target_sub_2": "多喽多得"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "多劳多得！",
+      "ref_sub_2": "星期一至星期七⋯多劳多得！",
+      "target_sub_1": "多喽多得",
+      "target_sub_2": "星期一至星期七多喽多得"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "星期一至星期七⋯多劳多得！",
+      "ref_sub_2": "这位喊得特劲的中年母猪",
+      "target_sub_1": "星期一至星期七多喽多得"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "这位喊得特劲的中年母猪",
+      "ref_sub_2": "就是我妈妈麦太",
+      "target_sub_2": "呢个嗌得特别劲嘅中年母猪就系我妈妈麦太"
+    },
+    "answer": {
+      "target_sub_1_shifted": "呢个嗌得特别劲嘅中年母猪",
+      "target_sub_2_shifted": "就系我妈妈麦太"
+    },
+    "difficulty": 1,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "星期一至星期七⋯多劳多得！",
+      "ref_sub_2": "这位喊得特劲的中年母猪",
+      "target_sub_1": "星期一至星期七多喽多得",
+      "target_sub_2": "呢个嗌得特别劲嘅中年母猪"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "这位喊得特劲的中年母猪",
+      "ref_sub_2": "就是我妈妈麦太",
+      "target_sub_1": "呢个嗌得特别劲嘅中年母猪",
+      "target_sub_2": "就系我妈妈麦太"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "就是我妈妈麦太",
+      "ref_sub_2": "我妈妈真的很劲",
+      "target_sub_1": "就系我妈妈麦太",
+      "target_sub_2": "我妈妈真系好劲呀"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我妈妈真的很劲",
+      "ref_sub_2": "一个女人背起整个世界！",
+      "target_sub_1": "我妈妈真系好劲呀",
+      "target_sub_2": "一个女人揹起成个世界"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "是的，我妈妈真的很厉害",
+      "ref_sub_2": "除了兼任保险，地产经纪及trading⋯",
+      "target_sub_1": "系呀我妈妈真系好犀利㗎",
+      "target_sub_2": "除咗做保险地产经纪同埋trading之外"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "除了兼任保险，地产经纪及trading⋯",
+      "ref_sub_2": "她还趁高科技热潮搞了个烹饪网站⋯",
+      "target_sub_1": "除咗做保险地产经纪同埋trading之外",
+      "target_sub_2": "佢仲趁住高科技热潮搞咗个煮𩠌嘅网站"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "她还趁高科技热潮搞了个烹饪网站⋯",
+      "ref_sub_2": "www．麦太世界．com",
+      "target_sub_1": "佢仲趁住高科技热潮搞咗个煮𩠌嘅网站",
+      "target_sub_2": "www.mcticege.com"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "www．麦太世界．com",
+      "ref_sub_2": "她做的菜，同样厉害",
+      "target_sub_1": "www.mcticege.com",
+      "target_sub_2": "佢煮嘅𩠌一样咁犀利"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "她做的菜，同样厉害",
+      "ref_sub_2": "欢迎大家收看＜麦太世界＞",
+      "target_sub_1": "佢煮嘅𩠌一样咁犀利",
+      "target_sub_2": "欢迎大家收睇麦太世界"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "欢迎大家收看＜麦太世界＞",
+      "ref_sub_2": "今日为大家介绍一个⋯",
+      "target_sub_1": "欢迎大家收睇麦太世界"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "今日为大家介绍一个⋯",
+      "ref_sub_2": "简单别致的小菜纸包鸡",
+      "target_sub_2": "今日我为大家介绍个简单又别致嘅小菜自包鸡"
+    },
+    "answer": {
+      "target_sub_1_shifted": "今日我为大家介绍个",
+      "target_sub_2_shifted": "简单又别致嘅小菜自包鸡"
+    },
+    "difficulty": 1,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "欢迎大家收看＜麦太世界＞",
+      "ref_sub_2": "今日为大家介绍一个⋯",
+      "target_sub_1": "欢迎大家收睇麦太世界",
+      "target_sub_2": "今日我为大家介绍个"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "今日为大家介绍一个⋯",
+      "ref_sub_2": "简单别致的小菜纸包鸡",
+      "target_sub_1": "今日我为大家介绍个",
+      "target_sub_2": "简单又别致嘅小菜自包鸡"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "简单别致的小菜纸包鸡",
+      "ref_sub_2": "家中小朋友一定好喜欢",
+      "target_sub_1": "简单又别致嘅小菜自包鸡",
+      "target_sub_2": "家里头嘅小朋友一定好喜欢㗎"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "家中小朋友一定好喜欢",
+      "ref_sub_2": "材料很简单：一个鸡包",
+      "target_sub_1": "家里头嘅小朋友一定好喜欢㗎",
+      "target_sub_2": "材料系好简单我哋只需要一个鸡包"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "材料很简单：一个鸡包",
+      "ref_sub_2": "将鸡包底部的纸撕下来⋯慢慢地撕",
+      "target_sub_1": "材料系好简单我哋只需要一个鸡包",
+      "target_sub_2": "我哋将黐喺鸡包底嘅纸撕出嚟慢慢撕"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "将鸡包底部的纸撕下来⋯慢慢地撕",
+      "ref_sub_2": "就会得到一张鸡包纸",
+      "target_sub_1": "我哋将黐喺鸡包底嘅纸撕出嚟慢慢撕",
+      "target_sub_2": "咁就会得到一张鸡包纸喇"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "就会得到一张鸡包纸",
+      "ref_sub_2": "把鸡包纸一反反转",
+      "target_sub_1": "咁就会得到一张鸡包纸喇",
+      "target_sub_2": "然后将鸡包纸一反反转"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "把鸡包纸一反反转",
+      "ref_sub_2": "这一味纸包鸡就完成了，很容易是吧？",
+      "target_sub_1": "然后将鸡包纸一反反转",
+      "target_sub_2": "呢味自包鸡就完成喇系咪好易整啦"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "这一味纸包鸡就完成了，很容易是吧？",
+      "ref_sub_2": "多谢大家收看",
+      "target_sub_1": "呢味自包鸡就完成喇系咪好易整啦",
+      "target_sub_2": "多谢大家收睇"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "好高兴这么快又跟大家见面",
+      "ref_sub_2": "接下来我会教大家整一味纸鸡包",
+      "target_sub_1": "好高兴咁快又同大家见面",
+      "target_sub_2": "跟住落嚟我会教大家整一味纸鸡包"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "接下来我会教大家整一味纸鸡包",
+      "ref_sub_2": "材料也很简单，只需要白纸一张",
+      "target_sub_1": "跟住落嚟我会教大家整一味纸鸡包",
+      "target_sub_2": "材料都好简单只需要白纸一张"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "材料也很简单，只需要白纸一张",
+      "ref_sub_2": "只要把这纸这样子⋯",
+      "target_sub_1": "材料都好简单只需要白纸一张",
+      "target_sub_2": "我哋只需要张张纸咁样"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "只要把这纸这样子⋯",
+      "ref_sub_2": "一个纸鸡包就这样完成了",
+      "target_sub_1": "我哋只需要张张纸咁样",
+      "target_sub_2": "一个纸鸡包就咁完成咗喇"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "一个纸鸡包就这样完成了",
+      "ref_sub_2": "各位小朋友，像鸡包不像呀？",
+      "target_sub_1": "一个纸鸡包就咁完成咗喇",
+      "target_sub_2": "各位小朋友你哋话似唔似鸡包啊"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "现在要教大家一味别致小菜－",
+      "ref_sub_2": "包鸡纸包鸡包纸包鸡",
+      "target_sub_1": "间阵要教大家一味几别节嘅小菜",
+      "target_sub_2": "包鸡子包鸡包子包鸡"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "包鸡纸包鸡包纸包鸡",
+      "ref_sub_2": "首先将纸包鸡小心撕开",
+      "target_sub_1": "包鸡子包鸡包子包鸡",
+      "target_sub_2": "首先将子包鸡小心噉撕开"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "首先将纸包鸡小心撕开",
+      "ref_sub_2": "大家就会有一张纸包鸡及一块鸡",
+      "target_sub_1": "首先将子包鸡小心噉撕开",
+      "target_sub_2": "大家就会有一张包鸡子同埋一嚿鸡啦"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "大家就会有一张纸包鸡及一块鸡",
+      "ref_sub_2": "接著把鸡包纸这样子包起那块鸡",
+      "target_sub_1": "大家就会有一张包鸡子同埋一嚿鸡啦",
+      "target_sub_2": "跟住将鸡包子好似我噉包住牛鸡"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "接著把鸡包纸这样子包起那块鸡",
+      "ref_sub_2": "再依照这样子用包鸡纸把它包起",
+      "target_sub_1": "跟住将鸡包子好似我噉包住牛鸡",
+      "target_sub_2": "然后再好似噉样将包鸡子包包包包包包住佢"
+    },
+    "answer": {},
+    "difficulty": 3,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "再依照这样子用包鸡纸把它包起",
+      "ref_sub_2": "一味「包鸡纸包鸡包纸包鸡」完成了！",
+      "target_sub_1": "然后再好似噉样将包鸡子包包包包包包住佢",
+      "target_sub_2": "咁一味包鸡子包鸡包子包鸡就完成喇"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "一味「包鸡纸包鸡包纸包鸡」完成了！",
+      "ref_sub_2": "真的很简单吧？",
+      "target_sub_1": "咁一味包鸡子包鸡包子包鸡就完成喇",
+      "target_sub_2": "系咪好简单呢"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "真的很简单吧？",
+      "ref_sub_2": "还真有一块鸡吃呢！",
+      "target_sub_1": "系咪好简单呢",
+      "target_sub_2": "仲真系有嚿鸡食添"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "今日为大家介绍一味⋯",
+      "ref_sub_2": "小朋友一定喜欢的⋯",
+      "target_sub_1": "今日要同大家介绍一味",
+      "target_sub_2": "小朋友一定喜欢嘅"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "小朋友一定喜欢的⋯",
+      "ref_sub_2": "鸡包包鸡包包鸡包纸包纸⋯",
+      "target_sub_1": "小朋友一定喜欢嘅",
+      "target_sub_2": "鸡包包鸡包包鸡包纸包"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "鸡包包鸡包包鸡包纸包纸⋯",
+      "ref_sub_2": "包鸡包鸡包纸包鸡",
+      "target_sub_1": "鸡包包鸡包包鸡包纸包",
+      "target_sub_2": "纸包鸡包包鸡纸包鸡包纸包鸡"
+    },
+    "answer": {
+      "target_sub_1_shifted": "鸡包包鸡包包鸡包纸包纸包鸡包包鸡",
+      "target_sub_2_shifted": "纸包鸡包纸包鸡"
+    },
+    "difficulty": 1,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "包鸡包鸡包纸包鸡",
+      "ref_sub_2": "做法亦很简单",
+      "target_sub_1": "纸包鸡包纸包鸡",
+      "target_sub_2": "做法都好简单"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "做法亦很简单",
+      "ref_sub_2": "只要将鸡包包住个鸡包",
+      "target_sub_1": "做法都好简单",
+      "target_sub_2": "我哋先将鸡包包住个鸡包"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "只要将鸡包包住个鸡包",
+      "ref_sub_2": "再包住个鸡包⋯",
+      "target_sub_1": "我哋先将鸡包包住个鸡包",
+      "target_sub_2": "再包住个鸡包"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "再包住个鸡包⋯",
+      "ref_sub_2": "包住张鸡包纸",
+      "target_sub_1": "再包住个鸡包",
+      "target_sub_2": "包住张鸡包纸"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "包住张鸡包纸",
+      "ref_sub_2": "再包包包包包住个纸鸡包",
+      "target_sub_1": "包住张鸡包纸",
+      "target_sub_2": "再包包包包包住个纸包鸡"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "再包包包包包住个纸鸡包",
+      "ref_sub_2": "再包包包，纸纸纸",
+      "target_sub_1": "再包包包包包住个纸包鸡",
+      "target_sub_2": "再包包包包包鸡包纸包纸纸纸纸纸"
+    },
+    "answer": {},
+    "difficulty": 3,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "再包包包，纸纸纸",
+      "ref_sub_2": "纸包纸，纸包鸡，鸡包纸，纸包鸡⋯",
+      "target_sub_1": "再包包包包包鸡包纸包纸纸纸纸纸",
+      "target_sub_2": "纸包纸纸包鸡包鸡纸纸包鸡鸡鸡鸡纸纸纸再包鸡鸡"
+    },
+    "answer": {
+      "target_sub_1_shifted": "再包包包包包鸡包纸包纸纸纸纸纸纸包纸",
+      "target_sub_2_shifted": "纸包鸡包鸡纸纸包鸡鸡鸡鸡纸纸纸再包鸡鸡"
+    },
+    "difficulty": 3,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "纸包纸，纸包鸡，鸡包纸，纸包鸡⋯",
+      "ref_sub_2": "可我妈妈也有她温柔的一面",
+      "target_sub_1": "纸包鸡包鸡纸纸包鸡鸡鸡鸡纸纸纸再包鸡鸡",
+      "target_sub_2": "不过我妈妈都有佢温柔嘅一面"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "可我妈妈也有她温柔的一面",
+      "ref_sub_2": "例如每晚睡觉前，她都会说故事给我听",
+      "target_sub_1": "不过我妈妈都有佢温柔嘅一面",
+      "target_sub_2": "例如每晚临睡前佢都会讲故事畀我听"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "例如每晚睡觉前，她都会说故事给我听",
+      "ref_sub_2": "从前，有个小朋友撒谎；有一天⋯",
+      "target_sub_1": "例如每晚临睡前佢都会讲故事畀我听",
+      "target_sub_2": "从前有个小朋友讲大话"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "从前，有个小朋友撒谎；有一天⋯",
+      "ref_sub_2": "他死了！",
+      "target_sub_1": "从前有个小朋友讲大话",
+      "target_sub_2": "有一日佢死咗"
+    },
+    "answer": {
+      "target_sub_1_shifted": "从前有个小朋友讲大话有一日",
+      "target_sub_2_shifted": "佢死咗"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -3038,238 +2290,622 @@
   },
   {
     "query": {
-      "src_1_sub_1": "马尔代夫！",
-      "src_1_sub_2": "马尔代夫！",
-      "src_2_sub_1": "买二代夫"
+      "ref_sub_1": "他死了！",
+      "ref_sub_2": "从前，有个小朋友很勤力念书⋯",
+      "target_sub_1": "佢死咗",
+      "target_sub_2": "从前有个小朋友好勤力读书"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "马尔代夫！",
-      "src_1_sub_2": "马尔代夫！",
-      "src_2_sub_2": "买二代夫买二代夫"
+      "ref_sub_1": "从前，有个小朋友很勤力念书⋯",
+      "ref_sub_2": "他长大后，发财了！",
+      "target_sub_1": "从前有个小朋友好勤力读书",
+      "target_sub_2": "佢长大发咗"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "他长大后，发财了！",
+      "ref_sub_2": "从前，有个小朋友不孝，有天⋯",
+      "target_sub_1": "佢长大发咗",
+      "target_sub_2": "从前有个小朋友唔孝顺"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "从前，有个小朋友不孝，有天⋯",
+      "ref_sub_2": "他扭了脚骹！",
+      "target_sub_1": "从前有个小朋友唔孝顺",
+      "target_sub_2": "有一日佢屈亲个脚脚"
     },
     "answer": {
-      "src_2_sub_1_shifted": "买二代夫",
-      "src_2_sub_2_shifted": "买二代夫"
+      "target_sub_1_shifted": "从前有个小朋友唔孝顺有一日",
+      "target_sub_2_shifted": "佢屈亲个脚脚"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "马尔代夫！",
-      "src_1_sub_2": "妈妈，那么我们什么时候去？",
-      "src_2_sub_1": "买二代夫",
-      "src_2_sub_2": "妈妈咁我哋几时去呀"
+      "ref_sub_1": "他扭了脚骹！",
+      "ref_sub_2": "妈妈，我想睡觉",
+      "target_sub_1": "佢屈亲个脚脚",
+      "target_sub_2": "妈我想瞓啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈，那么我们什么时候去？",
-      "src_1_sub_2": "你先把药水喝掉，病好了我就去订机票",
-      "src_2_sub_1": "妈妈咁我哋几时去呀",
-      "src_2_sub_2": "嗯你乖乖哋食埋啲药好返晒啦我即刻订机票"
+      "ref_sub_1": "从前，有个小朋友早睡晚起；第二天⋯",
+      "ref_sub_2": "他死了！",
+      "target_sub_1": "从前有个小朋友早睡晚起第二朝社群提供",
+      "target_sub_2": "佢死咗"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "你先把药水喝掉，病好了我就去订机票",
-      "src_1_sub_2": "来，多喝一点！",
-      "src_2_sub_1": "嗯你乖乖哋食埋啲药好返晒啦我即刻订机票",
-      "src_2_sub_2": "嚟啦食多更"
+      "ref_sub_1": "他死了！",
+      "ref_sub_2": "我妈妈就是这样子，一切都那么直接",
+      "target_sub_1": "佢死咗",
+      "target_sub_2": "我妈妈就系噉一切都咁直接"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈，你看！",
-      "src_1_sub_2": "妈妈你看，我病好了！",
-      "src_2_sub_2": "妈妈你睇我好返喇"
-    },
-    "answer": {},
-    "difficulty": 3,
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "妈妈你看，我病好了！",
-      "src_1_sub_2": "我把药都吃光了",
-      "src_2_sub_1": "妈妈你睇我好返喇",
-      "src_2_sub_2": "啲嘢所以我全部食晒喇"
+      "ref_sub_1": "我妈妈就是这样子，一切都那么直接",
+      "ref_sub_2": "她爱得我直接⋯",
+      "target_sub_1": "我妈妈就系噉一切都咁直接",
+      "target_sub_2": "佢爱得我直接"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我把药都吃光了",
-      "src_1_sub_2": "家中的东西有什么没给你吃光的？",
-      "src_2_sub_1": "啲嘢所以我全部食晒喇",
-      "src_2_sub_2": "即系间屋有乜嘢唔系畀你食晒㗎"
+      "ref_sub_1": "她爱得我直接⋯",
+      "ref_sub_2": "对我的期望直接",
+      "target_sub_1": "佢爱得我直接",
+      "target_sub_2": "对我嘅期望直接"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "家中的东西有什么没给你吃光的？",
-      "src_1_sub_2": "这次不同呀，原来这么一大樽的",
-      "src_2_sub_1": "即系间屋有乜嘢唔系畀你食晒㗎",
-      "src_2_sub_2": "妈妈呢次唔同㗎本来咁大樽嘅"
+      "ref_sub_1": "对我的期望直接",
+      "ref_sub_2": "对她，一、二、三、四、五、六、七",
+      "target_sub_1": "对我嘅期望直接"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "这次不同呀，原来这么一大樽的",
-      "src_1_sub_2": "我喝一格，又喝一格，又喝一格⋯",
-      "src_2_sub_1": "妈妈呢次唔同㗎本来咁大樽嘅",
-      "src_2_sub_2": "我饮下一格又一格又一格"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "我喝一格，又喝一格，又喝一格⋯",
-      "src_1_sub_2": "就给我喝光了！",
-      "src_2_sub_1": "我饮下一格又一格又一格",
-      "src_2_sub_2": "吓咪我饮晒㖞"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "喝光了就叻仔了！",
-      "src_1_sub_2": "喝光了就病好了！",
-      "src_2_sub_1": "饮实就叻仔啦",
-      "src_2_sub_2": "饮实就好返实啦"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "喝光了就病好了！",
-      "src_1_sub_2": "妈妈呀⋯",
-      "src_2_sub_1": "饮实就好返实啦"
-    },
-    "answer": {},
-    "verified": true
-  },
-  {
-    "query": {
-      "src_1_sub_1": "妈妈呀⋯",
-      "src_1_sub_2": "什么事？",
-      "src_2_sub_2": "妈妈乜嘢啊"
+      "ref_sub_1": "对她，一、二、三、四、五、六、七",
+      "ref_sub_2": "没有不成的事",
+      "target_sub_2": "佢一二三四五六七唔得都要得字幕由Amara.org"
     },
     "answer": {
-      "src_2_sub_1_shifted": "妈妈",
-      "src_2_sub_2_shifted": "乜嘢啊"
+      "target_sub_1_shifted": "佢一二三四五六七",
+      "target_sub_2_shifted": "唔得都要得字幕由Amara.org"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "什么事？",
-      "src_1_sub_2": "我们什么时候去马尔代夫？",
-      "src_2_sub_1": "乜嘢啊",
-      "src_2_sub_2": "阿哋几时去马尔代夫啊"
+      "ref_sub_1": "对我的期望直接",
+      "ref_sub_2": "对她，一、二、三、四、五、六、七",
+      "target_sub_1": "对我嘅期望直接",
+      "target_sub_2": "佢一二三四五六七"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我们什么时候去马尔代夫？",
-      "src_1_sub_2": "什么马尔代夫？",
-      "src_2_sub_1": "阿哋几时去马尔代夫啊",
-      "src_2_sub_2": "乜嘢马尔代夫啊"
+      "ref_sub_1": "对她，一、二、三、四、五、六、七",
+      "ref_sub_2": "没有不成的事",
+      "target_sub_1": "佢一二三四五六七",
+      "target_sub_2": "唔得都要得字幕由Amara.org"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "什么马尔代夫？",
-      "src_1_sub_2": "你说我病好带我去马尔代夫的呀！",
-      "src_2_sub_1": "乜嘢马尔代夫啊",
-      "src_2_sub_2": "呢你话我返就同我去马尔代夫㗎嘛"
+      "ref_sub_1": "可有些事情，要是真的不成呢？",
+      "ref_sub_2": "日子一天一天的过",
+      "target_sub_1": "但系如果有啲嘢真系真系唔得呢",
+      "target_sub_2": "日子一日一日咁过"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "你说我病好带我去马尔代夫的呀！",
-      "src_1_sub_2": "马尔代夫，椰林树影，水清沙幼⋯",
-      "src_2_sub_1": "呢你话我返就同我去马尔代夫㗎嘛",
-      "src_2_sub_2": "马尔代夫呢耶南树影"
+      "ref_sub_1": "日子一天一天的过",
+      "ref_sub_2": "首先是周润发事件⋯",
+      "target_sub_1": "日子一日一日咁过",
+      "target_sub_2": "首先周润发嗰单嘢"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "马尔代夫，椰林树影，水清沙幼⋯",
-      "src_1_sub_2": "座落于印度洋的世外桃源呀！",
-      "src_2_sub_1": "马尔代夫呢耶南树影",
-      "src_2_sub_2": "水清沙游助流于印度园嘅世外导演啦"
+      "ref_sub_1": "首先是周润发事件⋯",
+      "ref_sub_2": "拜托不要再提了！",
+      "target_sub_1": "首先周润发嗰单嘢",
+      "target_sub_2": "大家都唔好再提"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "拜托不要再提了！",
+      "ref_sub_2": "至于好运⋯",
+      "target_sub_1": "大家都唔好再提"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "至于好运⋯",
+      "ref_sub_2": "我用一双童子手替妈妈抽的六合彩号码",
+      "target_sub_2": "至于好运我用我嘅同事手帮妈妈抽嘅六合彩number"
     },
     "answer": {
-      "src_2_sub_1_shifted": "马尔代夫呢耶南树影水清沙游",
-      "src_2_sub_2_shifted": "助流于印度园嘅世外导演啦"
+      "target_sub_1_shifted": "至于好运",
+      "target_sub_2_shifted": "我用我嘅同事手帮妈妈抽嘅六合彩number"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "座落于印度洋的世外桃源呀！",
-      "src_1_sub_2": "想不到你还有点文采",
-      "src_2_sub_1": "助流于印度园嘅世外导演啦",
-      "src_2_sub_2": "啊估唔到你几好文采㗎噃"
+      "ref_sub_1": "我用一双童子手替妈妈抽的六合彩号码",
+      "ref_sub_2": "奇迹般似的一个号码也没中过！",
+      "target_sub_1": "我用我嘅同事手帮妈妈抽嘅六合彩number",
+      "target_sub_2": "竟然奇迹一样一个都未中过"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "想不到你还有点文采",
-      "src_1_sub_2": "说得不错呀！",
-      "src_2_sub_1": "啊估唔到你几好文采㗎噃",
-      "src_2_sub_2": "讲得几好听啊"
+      "ref_sub_1": "奇迹般似的一个号码也没中过！",
+      "ref_sub_2": "叻仔？",
+      "target_sub_1": "竟然奇迹一样一个都未中过",
+      "target_sub_2": "叻仔"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "说得不错呀！",
-      "src_1_sub_2": "我不是光说的呀，妈妈你说过⋯",
-      "src_2_sub_1": "讲得几好听啊",
-      "src_2_sub_2": "妈妈我唔系讲喇㗎又系你话嘅"
+      "ref_sub_1": "叻仔？",
+      "ref_sub_2": "我也试过努力念书，可是⋯",
+      "target_sub_1": "叻仔",
+      "target_sub_2": "我试过好努力咁读书但系"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我不是光说的呀，妈妈你说过⋯",
-      "src_1_sub_2": "我病好了带我去马尔代夫的！",
-      "src_2_sub_1": "妈妈我唔系讲喇㗎又系你话嘅",
-      "src_2_sub_2": "你话我病好咗之日就同我去马尔代夫㗎你讲过㗎"
+      "ref_sub_1": "我也试过努力念书，可是⋯",
+      "ref_sub_2": "可是⋯我仍然有梦",
+      "target_sub_1": "我试过好努力咁读书但系",
+      "target_sub_2": "但系我仲可以发梦"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "马尔代夫，座落于印度洋的世外桃源",
+      "ref_sub_2": "蓝天白云，椰林树影，水清沙幼",
+      "target_sub_1": "马尔代夫坐落于印度洋嘅世外桃源",
+      "target_sub_2": "蓝天白云椰林树影水清沙游"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "蓝天白云，椰林树影，水清沙幼",
+      "ref_sub_2": "七彩缤纷的珊瑚，目不暇给的热带鱼",
+      "target_sub_1": "蓝天白云椰林树影水清沙游",
+      "target_sub_2": "七彩缤纷嘅珊瑚目不下级嘅热带鱼群"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "七彩缤纷的珊瑚，目不暇给的热带鱼",
+      "ref_sub_2": "充满赤道活力的原始海洋，脱离繁嚣",
+      "target_sub_1": "七彩缤纷嘅珊瑚目不下级嘅热带鱼群",
+      "target_sub_2": "充满住赤道热力嘅原始海洋远离凡嚣"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "充满赤道活力的原始海洋，脱离繁嚣",
+      "ref_sub_2": "体验热情如火的风土人情",
+      "target_sub_1": "充满住赤道热力嘅原始海洋远离凡嚣",
+      "target_sub_2": "体验热情如火嘅风土人情"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "体验热情如火的风土人情",
+      "ref_sub_2": "享受一个脱俗出尘的梦幻之旅",
+      "target_sub_1": "体验热情如火嘅风土人情",
+      "target_sub_2": "享受一个脱轴出尘嘅梦幻之旅"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "享受一个脱俗出尘的梦幻之旅",
+      "ref_sub_2": "犀利旅行社，旅行社牌照号码350999",
+      "target_sub_1": "享受一个脱轴出尘嘅梦幻之旅",
+      "target_sub_2": "犀利旅行社旅行社牌照号码350999"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "犀利旅行社，旅行社牌照号码350999",
+      "ref_sub_2": "妈妈你知道马尔代夫在哪儿吗？",
+      "target_sub_1": "犀利旅行社旅行社牌照号码350999",
+      "target_sub_2": "妈妈你知唔知到马尔代夫系边㗎"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "妈妈你知道马尔代夫在哪儿吗？",
+      "ref_sub_2": "很远的",
+      "target_sub_1": "妈妈你知唔知到马尔代夫系边㗎"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "很远的",
+      "ref_sub_2": "有多远？",
+      "target_sub_2": "啊好远㗎点远发呀"
+    },
+    "answer": {
+      "target_sub_1_shifted": "啊好远㗎",
+      "target_sub_2_shifted": "点远发呀"
+    },
+    "difficulty": 1,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "有多远？",
+      "ref_sub_2": "得搭飞机",
+      "target_sub_1": "点远发呀",
+      "target_sub_2": "搭飞机至到啰"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "得搭飞机",
+      "ref_sub_2": "妈妈你会带我去吗？",
+      "target_sub_1": "搭飞机至到啰",
+      "target_sub_2": "咁妈妈你会唔会走落去㗎"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "妈妈你会带我去吗？",
+      "ref_sub_2": "会！发财了再说吧",
+      "target_sub_1": "咁妈妈你会唔会走落去㗎",
+      "target_sub_2": "会得学发咗先啦"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "会！发财了再说吧",
+      "ref_sub_2": "那么妈妈你什么时候发？",
+      "target_sub_1": "会得学发咗先啦",
+      "target_sub_2": "咁妈妈你几时发得呀"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "那么妈妈你什么时候发？",
+      "ref_sub_2": "快了⋯",
+      "target_sub_1": "咁妈妈你几时发得呀",
+      "target_sub_2": "呃就快啦"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "快了⋯",
+      "ref_sub_2": "发梦呀！",
+      "target_sub_1": "呃就快啦",
+      "target_sub_2": "发梦吖嘛"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "校长早晨！",
+      "ref_sub_2": "校长再见！",
+      "target_sub_1": "嗨"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "校长再见！",
+      "ref_sub_2": "你最喜爱的地方是哪儿？",
+      "target_sub_2": "你最喜爱嘅地方喺边度呀"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "你最喜爱的地方是哪儿？",
+      "ref_sub_2": "我最喜爱的地方是日本",
+      "target_sub_1": "你最喜爱嘅地方喺边度呀",
+      "target_sub_2": "我最喜爱嘅地方呢就系日本喇"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我最喜爱的地方是日本",
+      "ref_sub_2": "那儿有 Disneyland 和 Hello Kitty Land",
+      "target_sub_1": "我最喜爱嘅地方呢就系日本喇",
+      "target_sub_2": "嗰度好迪士尼呢同埋HelloTT呢"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "那儿有 Disneyland 和 Hello Kitty Land",
+      "ref_sub_2": "我这个发夹也是在那儿买的",
+      "target_sub_1": "嗰度好迪士尼呢同埋HelloTT呢",
+      "target_sub_2": "我而家打紧个发卷都系嗰边买嘅"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我这个发夹也是在那儿买的",
+      "ref_sub_2": "我最喜爱的地方是加拿大",
+      "target_sub_1": "我而家打紧个发卷都系嗰边买嘅",
+      "target_sub_2": "我最钟意嘅地方就系加拿大"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我最喜爱的地方是加拿大",
+      "ref_sub_2": "婆婆跟舅父他们都在加拿大",
+      "target_sub_1": "我最钟意嘅地方就系加拿大",
+      "target_sub_2": "婆婆同埋舅父呀佢哋都系加拿大㗎"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "婆婆跟舅父他们都在加拿大",
+      "ref_sub_2": "我最喜爱的地方是泰国",
+      "target_sub_1": "婆婆同埋舅父呀佢哋都系加拿大㗎",
+      "target_sub_2": "我最钟意去嘅地方就系泰国喇"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我最喜爱的地方是泰国",
+      "ref_sub_2": "那儿有很多水上活动，还有鱼翅吃",
+      "target_sub_1": "我最钟意去嘅地方就系泰国喇",
+      "target_sub_2": "嗰度有好多水晶活动㗎仲有一次食添㖞"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "那儿有很多水上活动，还有鱼翅吃",
+      "ref_sub_2": "我最喜爱的地方⋯",
+      "target_sub_1": "嗰度有好多水晶活动㗎仲有一次食添㖞",
+      "target_sub_2": "呃我最喜爱嘅地方呢"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我最喜爱的地方⋯",
+      "ref_sub_2": "就是那间什么！",
+      "target_sub_1": "呃我最喜爱嘅地方呢",
+      "target_sub_2": "就系嗰间咩嚟啰"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "就是那间什么！",
+      "ref_sub_2": "那儿有欢乐天地，还有美食广场",
+      "target_sub_1": "就系嗰间咩嚟啰",
+      "target_sub_2": "嗰度有欢乐天地啦仲有米食广场啦"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "那儿有欢乐天地，还有美食广场",
+      "ref_sub_2": "那儿的海南鸡饭很大碟的",
+      "target_sub_1": "嗰度有欢乐天地啦仲有米食广场啦",
+      "target_sub_2": "嗰度啲可能几份好大碟㗎"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "那儿的海南鸡饭很大碟的",
+      "ref_sub_2": "对了，那地方叫银城中心",
+      "target_sub_1": "嗰度啲可能几份好大碟㗎",
+      "target_sub_2": "系喇系喇嗰间叫做银城中心"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "对了，那地方叫银城中心",
+      "ref_sub_2": "那店子的饭很多，很大碟的！",
+      "target_sub_1": "系喇系喇嗰间叫做银城中心",
+      "target_sub_2": "嗰间嘢啲饭好多人好大碟㗎"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "那店子的饭很多，很大碟的！",
+      "ref_sub_2": "不过说到我最想去的地方，那可厉害了",
+      "target_sub_1": "嗰间嘢啲饭好多人好大碟㗎",
+      "target_sub_2": "不过讲到我最想去嘅地方呢嗰度细嚟啰"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "不过说到我最想去的地方，那可厉害了",
+      "ref_sub_2": "那儿蓝天白云，椰林树影，水清沙幼",
+      "target_sub_1": "不过讲到我最想去嘅地方呢嗰度细嚟啰",
+      "target_sub_2": "嗰度南天白云夜临树影水清沙幽"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "那儿蓝天白云，椰林树影，水清沙幼",
+      "ref_sub_2": "座落于印度洋的世外桃源",
+      "target_sub_1": "嗰度南天白云夜临树影水清沙幽",
+      "target_sub_2": "独来鱼印度洋嘅世外桃源"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "衰仔，快点起床上学",
+      "ref_sub_2": "咦？",
+      "target_sub_1": "喂衰仔啊快啲起身返学喇",
+      "target_sub_2": "咦"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "咦？",
+      "ref_sub_2": "妈妈！",
+      "target_sub_1": "咦",
+      "target_sub_2": "妈妈"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "开点药给他吃就没事了",
+      "ref_sub_2": "医生，吃了药会不会有那个什么的？",
+      "target_sub_1": "开啲药过佢食就冇事㗎喇",
+      "target_sub_2": "医生啊"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "医生，吃了药会不会有那个什么的？",
+      "ref_sub_2": "不会！",
+      "target_sub_1": "医生啊",
+      "target_sub_2": "啲药食咗会唔会有嗰啲咩㗎唔会"
+    },
+    "answer": {
+      "target_sub_1_shifted": "医生啊啲药食咗会唔会有嗰啲咩㗎",
+      "target_sub_2_shifted": "唔会"
+    },
+    "difficulty": 1,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "不会！",
+      "ref_sub_2": "那么吃药用不用那个什么的？",
+      "target_sub_1": "唔会",
+      "target_sub_2": "噉佢食药使唔使咩啊"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "那么吃药用不用那个什么的？",
+      "ref_sub_2": "不用！给他打口针吧！",
+      "target_sub_1": "噉佢食药使唔使咩啊",
+      "target_sub_2": "唔使同佢打多支针添呢"
     },
     "answer": {},
     "few_shot": true,
@@ -3277,5871 +2913,6235 @@
   },
   {
     "query": {
-      "src_1_sub_1": "我病好了带我去马尔代夫的！",
-      "src_1_sub_2": "我是说发了财就带你去",
-      "src_2_sub_1": "你话我病好咗之日就同我去马尔代夫㗎你讲过㗎",
-      "src_2_sub_2": "我话发咗先至同你去㗎"
+      "ref_sub_1": "不用！给他打口针吧！",
+      "ref_sub_2": "怎么？得打针？",
+      "target_sub_1": "唔使同佢打多支针添呢",
+      "target_sub_2": "吓要打针啊"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我是说发了财就带你去",
-      "src_1_sub_2": "不是的，妈妈你说我病好了就去的",
-      "src_2_sub_1": "我话发咗先至同你去㗎",
-      "src_2_sub_2": "唔系㖞妈妈你话好咗就同我去㗎㖞"
+      "ref_sub_1": "怎么？得打针？",
+      "ref_sub_2": "他最怕打针的了",
+      "target_sub_1": "吓要打针啊",
+      "target_sub_2": "佢好怕打针㗎㖞"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "不是的，妈妈你说我病好了就去的",
-      "src_1_sub_2": "你分明讲过病好了就去马尔代夫的",
-      "src_2_sub_1": "唔系㖞妈妈你话好咗就同我去㗎㖞",
-      "src_2_sub_2": "你明明讲过好返就同你去马尔代夫㗎㖞"
+      "ref_sub_1": "他最怕打针的了",
+      "ref_sub_2": "那么他怕不怕死？",
+      "target_sub_1": "佢好怕打针㗎㖞",
+      "target_sub_2": "噉佢怕唔怕死呀"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "你分明讲过病好了就去马尔代夫的",
-      "src_1_sub_2": "你讲过的！",
-      "src_2_sub_1": "你明明讲过好返就同你去马尔代夫㗎㖞",
-      "src_2_sub_2": "你讲过㗎"
+      "ref_sub_1": "没事吧？快点先把药水喝掉！",
+      "ref_sub_2": "妈妈我不想喝药水",
+      "target_sub_1": "冇嘢吖嘛快啲食埋啲药水佢先啦",
+      "target_sub_2": "妈妈我唔想食药水呀"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "你讲过的！",
-      "src_1_sub_2": "好了，别哭了",
-      "src_2_sub_1": "你讲过㗎",
-      "src_2_sub_2": "得啦得啦唔好喊啦"
+      "ref_sub_1": "妈妈我不想喝药水",
+      "ref_sub_2": "不要呀妈妈，我不喝呀",
+      "target_sub_1": "妈妈我唔想食药水呀",
+      "target_sub_2": "唔好捞妈妈我唔食呀"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "好了，别哭了",
-      "src_1_sub_2": "带你去马尔代夫好了",
-      "src_2_sub_1": "得啦得啦唔好喊啦",
-      "src_2_sub_2": "同你去马尔代夫啦"
+      "ref_sub_1": "不要呀妈妈，我不喝呀",
+      "ref_sub_2": "我不喝士多啤梨药水呀！",
+      "target_sub_1": "唔好捞妈妈我唔食呀",
+      "target_sub_2": "我唔食士多啤梨药水呀"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "带你去马尔代夫好了",
-      "src_1_sub_2": "真的吗？　　对",
-      "src_2_sub_1": "同你去马尔代夫啦",
-      "src_2_sub_2": "真嘅系啊"
+      "ref_sub_1": "我不喝士多啤梨药水呀！",
+      "ref_sub_2": "别哭了，不喝药水病不会好的",
+      "target_sub_1": "我唔食士多啤梨药水呀",
+      "target_sub_2": "唔好喊啦唔食药唔会好㗎"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "真的吗？　　对",
-      "src_1_sub_2": "什么时候去？",
-      "src_2_sub_1": "真嘅系啊",
-      "src_2_sub_2": "咁几时去啊"
+      "ref_sub_1": "别哭了，不喝药水病不会好的",
+      "ref_sub_2": "乖乖，病好了妈妈带你去马尔代夫",
+      "target_sub_1": "唔好喊啦唔食药唔会好㗎",
+      "target_sub_2": "乖乖啲病好咗妈妈大理马尔代夫"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "什么时候去？",
-      "src_1_sub_2": "发财再说",
-      "src_2_sub_1": "咁几时去啊",
-      "src_2_sub_2": "等我发咗先啰"
+      "ref_sub_1": "乖乖，病好了妈妈带你去马尔代夫",
+      "ref_sub_2": "真的吗？",
+      "target_sub_1": "乖乖啲病好咗妈妈大理马尔代夫",
+      "target_sub_2": "真嘅"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "发财再说",
-      "src_1_sub_2": "你早发财了⋯",
-      "src_2_sub_1": "等我发咗先啰",
-      "src_2_sub_2": "你发咗㗎喇"
+      "ref_sub_1": "真的吗？",
+      "ref_sub_2": "妈妈什么时候骗过你？",
+      "target_sub_1": "真嘅",
+      "target_sub_2": "妈妈几时呃过你呀"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "你早发财了⋯",
-      "src_1_sub_2": "好了好了，发财了",
-      "src_2_sub_1": "你发咗㗎喇",
-      "src_2_sub_2": "你发咗㗎喇系喇系喇系喇发咗喇"
+      "ref_sub_1": "妈妈什么时候骗过你？",
+      "ref_sub_2": "乖，先把药水喝掉",
+      "target_sub_1": "妈妈几时呃过你呀",
+      "target_sub_2": "乖食埋啲药水先啦"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "好呀，马尔代夫！",
+      "ref_sub_2": "马尔代夫！",
+      "target_sub_1": "嘻嘻好嘢",
+      "target_sub_2": "买二代夫买二代夫"
     },
     "answer": {
-      "src_2_sub_1_shifted": "你发咗㗎喇你发咗㗎喇",
-      "src_2_sub_2_shifted": "系喇系喇系喇发咗喇"
+      "target_sub_1_shifted": "嘻嘻好嘢买二代夫",
+      "target_sub_2_shifted": "买二代夫"
+    },
+    "difficulty": 1,
+    "few_shot": true,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "马尔代夫！",
+      "ref_sub_2": "马尔代夫！",
+      "target_sub_1": "买二代夫"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "马尔代夫！",
+      "ref_sub_2": "马尔代夫！",
+      "target_sub_2": "买二代夫买二代夫"
+    },
+    "answer": {
+      "target_sub_1_shifted": "买二代夫",
+      "target_sub_2_shifted": "买二代夫"
+    },
+    "difficulty": 1,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "马尔代夫！",
+      "ref_sub_2": "妈妈，那么我们什么时候去？",
+      "target_sub_1": "买二代夫",
+      "target_sub_2": "妈妈咁我哋几时去呀"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "妈妈，那么我们什么时候去？",
+      "ref_sub_2": "你先把药水喝掉，病好了我就去订机票",
+      "target_sub_1": "妈妈咁我哋几时去呀",
+      "target_sub_2": "嗯你乖乖哋食埋啲药好返晒啦我即刻订机票"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "你先把药水喝掉，病好了我就去订机票",
+      "ref_sub_2": "来，多喝一点！",
+      "target_sub_1": "嗯你乖乖哋食埋啲药好返晒啦我即刻订机票",
+      "target_sub_2": "嚟啦食多更"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "妈妈，你看！",
+      "ref_sub_2": "妈妈你看，我病好了！",
+      "target_sub_2": "妈妈你睇我好返喇"
+    },
+    "answer": {},
+    "difficulty": 3,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "妈妈你看，我病好了！",
+      "ref_sub_2": "我把药都吃光了",
+      "target_sub_1": "妈妈你睇我好返喇",
+      "target_sub_2": "啲嘢所以我全部食晒喇"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我把药都吃光了",
+      "ref_sub_2": "家中的东西有什么没给你吃光的？",
+      "target_sub_1": "啲嘢所以我全部食晒喇",
+      "target_sub_2": "即系间屋有乜嘢唔系畀你食晒㗎"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "家中的东西有什么没给你吃光的？",
+      "ref_sub_2": "这次不同呀，原来这么一大樽的",
+      "target_sub_1": "即系间屋有乜嘢唔系畀你食晒㗎",
+      "target_sub_2": "妈妈呢次唔同㗎本来咁大樽嘅"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "这次不同呀，原来这么一大樽的",
+      "ref_sub_2": "我喝一格，又喝一格，又喝一格⋯",
+      "target_sub_1": "妈妈呢次唔同㗎本来咁大樽嘅",
+      "target_sub_2": "我饮下一格又一格又一格"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我喝一格，又喝一格，又喝一格⋯",
+      "ref_sub_2": "就给我喝光了！",
+      "target_sub_1": "我饮下一格又一格又一格",
+      "target_sub_2": "吓咪我饮晒㖞"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "喝光了就叻仔了！",
+      "ref_sub_2": "喝光了就病好了！",
+      "target_sub_1": "饮实就叻仔啦",
+      "target_sub_2": "饮实就好返实啦"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "喝光了就病好了！",
+      "ref_sub_2": "妈妈呀⋯",
+      "target_sub_1": "饮实就好返实啦"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "妈妈呀⋯",
+      "ref_sub_2": "什么事？",
+      "target_sub_2": "妈妈乜嘢啊"
+    },
+    "answer": {
+      "target_sub_1_shifted": "妈妈",
+      "target_sub_2_shifted": "乜嘢啊"
+    },
+    "difficulty": 1,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "什么事？",
+      "ref_sub_2": "我们什么时候去马尔代夫？",
+      "target_sub_1": "乜嘢啊",
+      "target_sub_2": "阿哋几时去马尔代夫啊"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我们什么时候去马尔代夫？",
+      "ref_sub_2": "什么马尔代夫？",
+      "target_sub_1": "阿哋几时去马尔代夫啊",
+      "target_sub_2": "乜嘢马尔代夫啊"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "什么马尔代夫？",
+      "ref_sub_2": "你说我病好带我去马尔代夫的呀！",
+      "target_sub_1": "乜嘢马尔代夫啊",
+      "target_sub_2": "呢你话我返就同我去马尔代夫㗎嘛"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "你说我病好带我去马尔代夫的呀！",
+      "ref_sub_2": "马尔代夫，椰林树影，水清沙幼⋯",
+      "target_sub_1": "呢你话我返就同我去马尔代夫㗎嘛",
+      "target_sub_2": "马尔代夫呢耶南树影"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "马尔代夫，椰林树影，水清沙幼⋯",
+      "ref_sub_2": "座落于印度洋的世外桃源呀！",
+      "target_sub_1": "马尔代夫呢耶南树影",
+      "target_sub_2": "水清沙游助流于印度园嘅世外导演啦"
+    },
+    "answer": {
+      "target_sub_1_shifted": "马尔代夫呢耶南树影水清沙游",
+      "target_sub_2_shifted": "助流于印度园嘅世外导演啦"
+    },
+    "difficulty": 1,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "座落于印度洋的世外桃源呀！",
+      "ref_sub_2": "想不到你还有点文采",
+      "target_sub_1": "助流于印度园嘅世外导演啦",
+      "target_sub_2": "啊估唔到你几好文采㗎噃"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "想不到你还有点文采",
+      "ref_sub_2": "说得不错呀！",
+      "target_sub_1": "啊估唔到你几好文采㗎噃",
+      "target_sub_2": "讲得几好听啊"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "说得不错呀！",
+      "ref_sub_2": "我不是光说的呀，妈妈你说过⋯",
+      "target_sub_1": "讲得几好听啊",
+      "target_sub_2": "妈妈我唔系讲喇㗎又系你话嘅"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我不是光说的呀，妈妈你说过⋯",
+      "ref_sub_2": "我病好了带我去马尔代夫的！",
+      "target_sub_1": "妈妈我唔系讲喇㗎又系你话嘅",
+      "target_sub_2": "你话我病好咗之日就同我去马尔代夫㗎你讲过㗎"
+    },
+    "answer": {},
+    "few_shot": true,
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我病好了带我去马尔代夫的！",
+      "ref_sub_2": "我是说发了财就带你去",
+      "target_sub_1": "你话我病好咗之日就同我去马尔代夫㗎你讲过㗎",
+      "target_sub_2": "我话发咗先至同你去㗎"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "我是说发了财就带你去",
+      "ref_sub_2": "不是的，妈妈你说我病好了就去的",
+      "target_sub_1": "我话发咗先至同你去㗎",
+      "target_sub_2": "唔系㖞妈妈你话好咗就同我去㗎㖞"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "不是的，妈妈你说我病好了就去的",
+      "ref_sub_2": "你分明讲过病好了就去马尔代夫的",
+      "target_sub_1": "唔系㖞妈妈你话好咗就同我去㗎㖞",
+      "target_sub_2": "你明明讲过好返就同你去马尔代夫㗎㖞"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "你分明讲过病好了就去马尔代夫的",
+      "ref_sub_2": "你讲过的！",
+      "target_sub_1": "你明明讲过好返就同你去马尔代夫㗎㖞",
+      "target_sub_2": "你讲过㗎"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "你讲过的！",
+      "ref_sub_2": "好了，别哭了",
+      "target_sub_1": "你讲过㗎",
+      "target_sub_2": "得啦得啦唔好喊啦"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "好了，别哭了",
+      "ref_sub_2": "带你去马尔代夫好了",
+      "target_sub_1": "得啦得啦唔好喊啦",
+      "target_sub_2": "同你去马尔代夫啦"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "带你去马尔代夫好了",
+      "ref_sub_2": "真的吗？　　对",
+      "target_sub_1": "同你去马尔代夫啦",
+      "target_sub_2": "真嘅系啊"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "真的吗？　　对",
+      "ref_sub_2": "什么时候去？",
+      "target_sub_1": "真嘅系啊",
+      "target_sub_2": "咁几时去啊"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "什么时候去？",
+      "ref_sub_2": "发财再说",
+      "target_sub_1": "咁几时去啊",
+      "target_sub_2": "等我发咗先啰"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "发财再说",
+      "ref_sub_2": "你早发财了⋯",
+      "target_sub_1": "等我发咗先啰",
+      "target_sub_2": "你发咗㗎喇"
+    },
+    "answer": {},
+    "verified": true
+  },
+  {
+    "query": {
+      "ref_sub_1": "你早发财了⋯",
+      "ref_sub_2": "好了好了，发财了",
+      "target_sub_1": "你发咗㗎喇",
+      "target_sub_2": "你发咗㗎喇系喇系喇系喇发咗喇"
+    },
+    "answer": {
+      "target_sub_1_shifted": "你发咗㗎喇你发咗㗎喇",
+      "target_sub_2_shifted": "系喇系喇系喇发咗喇"
     },
     "difficulty": 3,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "好了好了，发财了",
-      "src_1_sub_2": "我们下个星期去，好了吧？",
-      "src_2_sub_1": "系喇系喇系喇发咗喇",
-      "src_2_sub_2": "下个礼拜同你去啦"
+      "ref_sub_1": "好了好了，发财了",
+      "ref_sub_2": "我们下个星期去，好了吧？",
+      "target_sub_1": "系喇系喇系喇发咗喇",
+      "target_sub_2": "下个礼拜同你去啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我们下个星期去，好了吧？",
-      "src_1_sub_2": "太好了！",
-      "src_2_sub_1": "下个礼拜同你去啦",
-      "src_2_sub_2": "得未啊好嘢"
+      "ref_sub_1": "我们下个星期去，好了吧？",
+      "ref_sub_2": "太好了！",
+      "target_sub_1": "下个礼拜同你去啦",
+      "target_sub_2": "得未啊好嘢"
     },
     "answer": {
-      "src_2_sub_1_shifted": "下个礼拜同你去啦得未啊",
-      "src_2_sub_2_shifted": "好嘢"
+      "target_sub_1_shifted": "下个礼拜同你去啦得未啊",
+      "target_sub_2_shifted": "好嘢"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "麦唛，我是麦兜呀",
-      "src_1_sub_2": "是这样子的，我明天就飞了",
-      "src_2_sub_1": "喂麦麦啊麦豆啊我系",
-      "src_2_sub_2": "即系呢我明日就要飞喇"
+      "ref_sub_1": "麦唛，我是麦兜呀",
+      "ref_sub_2": "是这样子的，我明天就飞了",
+      "target_sub_1": "喂麦麦啊麦豆啊我系",
+      "target_sub_2": "即系呢我明日就要飞喇"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "是这样子的，我明天就飞了",
-      "src_1_sub_2": "对　　⋯是吗？",
-      "src_2_sub_1": "即系呢我明日就要飞喇",
-      "src_2_sub_2": "系啊系咩"
+      "ref_sub_1": "是这样子的，我明天就飞了",
+      "ref_sub_2": "对　　⋯是吗？",
+      "target_sub_1": "即系呢我明日就要飞喇",
+      "target_sub_2": "系啊系咩"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "对　　⋯是吗？",
-      "src_1_sub_2": "飞机餐很难吃的吗？",
-      "src_2_sub_1": "系啊系咩",
-      "src_2_sub_2": "飞机真好难食㗎"
+      "ref_sub_1": "对　　⋯是吗？",
+      "ref_sub_2": "飞机餐很难吃的吗？",
+      "target_sub_1": "系啊系咩",
+      "target_sub_2": "飞机真好难食㗎"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "飞机餐很难吃的吗？",
-      "src_1_sub_2": "也得吃呀！",
-      "src_2_sub_1": "飞机真好难食㗎",
-      "src_2_sub_2": "但点都要食㗎啦"
+      "ref_sub_1": "飞机餐很难吃的吗？",
+      "ref_sub_2": "也得吃呀！",
+      "target_sub_1": "飞机真好难食㗎",
+      "target_sub_2": "但点都要食㗎啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "也得吃呀！",
-      "src_1_sub_2": "难道自己带东西上去吃吗？",
-      "src_2_sub_1": "但点都要食㗎啦",
-      "src_2_sub_2": "唔通自己带嘢上去食咩"
+      "ref_sub_1": "也得吃呀！",
+      "ref_sub_2": "难道自己带东西上去吃吗？",
+      "target_sub_1": "但点都要食㗎啦",
+      "target_sub_2": "唔通自己带嘢上去食咩"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "难道自己带东西上去吃吗？",
-      "src_1_sub_2": "还在讲？",
-      "src_2_sub_1": "唔通自己带嘢上去食咩",
-      "src_2_sub_2": "仲讲"
+      "ref_sub_1": "难道自己带东西上去吃吗？",
+      "ref_sub_2": "还在讲？",
+      "target_sub_1": "唔通自己带嘢上去食咩",
+      "target_sub_2": "仲讲"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "还在讲？",
-      "src_1_sub_2": "快点帮手执行李",
-      "src_2_sub_1": "仲讲",
-      "src_2_sub_2": "哦快啲嚟执埋啲行李先啦"
+      "ref_sub_1": "还在讲？",
+      "ref_sub_2": "快点帮手执行李",
+      "target_sub_1": "仲讲",
+      "target_sub_2": "哦快啲嚟执埋啲行李先啦"
     },
     "answer": {
-      "src_2_sub_1_shifted": "仲讲哦",
-      "src_2_sub_2_shifted": "快啲嚟执埋啲行李先啦"
+      "target_sub_1_shifted": "仲讲哦",
+      "target_sub_2_shifted": "快啲嚟执埋啲行李先啦"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "快点帮手执行李",
-      "src_1_sub_2": "跟我向他们说，我明天去马尔代夫了",
-      "src_2_sub_1": "快啲嚟执埋啲行李先啦",
-      "src_2_sub_2": "哦你帮我话畀佢哋知我明日去买热带裤薄"
+      "ref_sub_1": "快点帮手执行李",
+      "ref_sub_2": "跟我向他们说，我明天去马尔代夫了",
+      "target_sub_1": "快啲嚟执埋啲行李先啦",
+      "target_sub_2": "哦你帮我话畀佢哋知我明日去买热带裤薄"
     },
     "answer": {
-      "src_2_sub_1_shifted": "快啲嚟执埋啲行李先啦哦",
-      "src_2_sub_2_shifted": "你帮我话畀佢哋知我明日去买热带裤薄"
+      "target_sub_1_shifted": "快啲嚟执埋啲行李先啦哦",
+      "target_sub_2_shifted": "你帮我话畀佢哋知我明日去买热带裤薄"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "跟我向他们说，我明天去马尔代夫了",
-      "src_1_sub_2": "那边蓝天白云，椰林树影⋯",
-      "src_2_sub_1": "你帮我话畀佢哋知我明日去买热带裤薄",
-      "src_2_sub_2": "嗰度蓝天五百云夜临雪"
+      "ref_sub_1": "跟我向他们说，我明天去马尔代夫了",
+      "ref_sub_2": "那边蓝天白云，椰林树影⋯",
+      "target_sub_1": "你帮我话畀佢哋知我明日去买热带裤薄",
+      "target_sub_2": "嗰度蓝天五百云夜临雪"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "那边蓝天白云，椰林树影⋯",
-      "src_1_sub_2": "还在讲！",
-      "src_2_sub_1": "嗰度蓝天五百云夜临雪",
-      "src_2_sub_2": "水清净沙有"
+      "ref_sub_1": "那边蓝天白云，椰林树影⋯",
+      "ref_sub_2": "还在讲！",
+      "target_sub_1": "嗰度蓝天五百云夜临雪",
+      "target_sub_2": "水清净沙有"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "还在讲！",
-      "src_1_sub_2": "来了！",
-      "src_2_sub_1": "水清净沙有",
-      "src_2_sub_2": "我嚟紧㗎喇"
+      "ref_sub_1": "还在讲！",
+      "ref_sub_2": "来了！",
+      "target_sub_1": "水清净沙有",
+      "target_sub_2": "我嚟紧㗎喇"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "来了！",
-      "src_1_sub_2": "要执行李了，回来再跟你说吧",
-      "src_2_sub_1": "我嚟紧㗎喇",
-      "src_2_sub_2": "我要执行你喇返嚟先再同你倾过啦"
+      "ref_sub_1": "来了！",
+      "ref_sub_2": "要执行李了，回来再跟你说吧",
+      "target_sub_1": "我嚟紧㗎喇",
+      "target_sub_2": "我要执行你喇返嚟先再同你倾过啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "要执行李了，回来再跟你说吧",
-      "src_1_sub_2": "再见！",
-      "src_2_sub_1": "我要执行你喇返嚟先再同你倾过啦",
-      "src_2_sub_2": "拜拜"
+      "ref_sub_1": "要执行李了，回来再跟你说吧",
+      "ref_sub_2": "再见！",
+      "target_sub_1": "我要执行你喇返嚟先再同你倾过啦",
+      "target_sub_2": "拜拜"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈，我得把出世纸带着吗？",
-      "src_1_sub_2": "也要的",
-      "src_2_sub_1": "哎哟妈妈我系咪要带埋出世纸去㗎"
+      "ref_sub_1": "妈妈，我得把出世纸带着吗？",
+      "ref_sub_2": "也要的",
+      "target_sub_1": "哎哟妈妈我系咪要带埋出世纸去㗎"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "也要的",
-      "src_1_sub_2": "那么成绩表呢？",
-      "src_2_sub_2": "都要㗎"
+      "ref_sub_1": "也要的",
+      "ref_sub_2": "那么成绩表呢？",
+      "target_sub_2": "都要㗎"
     },
     "answer": {
-      "src_2_sub_1_shifted": "都要㗎"
+      "target_sub_1_shifted": "都要㗎"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "那么成绩表呢？",
-      "src_1_sub_2": "成绩表就不用了",
-      "src_2_sub_2": "咁成绩表呢成绩表又唔使"
+      "ref_sub_1": "那么成绩表呢？",
+      "ref_sub_2": "成绩表就不用了",
+      "target_sub_2": "咁成绩表呢成绩表又唔使"
     },
     "answer": {
-      "src_2_sub_1_shifted": "咁成绩表呢",
-      "src_2_sub_2_shifted": "成绩表又唔使"
+      "target_sub_1_shifted": "咁成绩表呢",
+      "target_sub_2_shifted": "成绩表又唔使"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "成绩表就不用了",
-      "src_1_sub_2": "太好了！吓得我！",
-      "src_2_sub_1": "成绩表又唔使",
-      "src_2_sub_2": "好嘢嚇得我啊咁都好啲"
+      "ref_sub_1": "成绩表就不用了",
+      "ref_sub_2": "太好了！吓得我！",
+      "target_sub_1": "成绩表又唔使",
+      "target_sub_2": "好嘢嚇得我啊咁都好啲"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "找到了！",
-      "src_1_sub_2": "出世纸给我找到了！",
-      "src_2_sub_1": "揾到喇"
+      "ref_sub_1": "找到了！",
+      "ref_sub_2": "出世纸给我找到了！",
+      "target_sub_1": "揾到喇"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "出世纸给我找到了！",
-      "src_1_sub_2": "妈妈你替我收好它别抛掉",
-      "src_2_sub_2": "竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然"
+      "ref_sub_1": "出世纸给我找到了！",
+      "ref_sub_2": "妈妈你替我收好它别抛掉",
+      "target_sub_2": "竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然"
     },
     "answer": {
-      "src_2_sub_1_shifted": "竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然"
+      "target_sub_1_shifted": "竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然"
     },
     "difficulty": 3,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "早机去，晚机返",
-      "src_1_sub_2": "妈妈说这样才够精明",
-      "src_2_sub_1": "早机去晚机返",
-      "src_2_sub_2": "妈妈话噉先最著数"
+      "ref_sub_1": "早机去，晚机返",
+      "ref_sub_2": "妈妈说这样才够精明",
+      "target_sub_1": "早机去晚机返",
+      "target_sub_2": "妈妈话噉先最著数"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈说这样才够精明",
-      "src_1_sub_2": "就这样⋯",
-      "src_2_sub_1": "妈妈话噉先最著数",
-      "src_2_sub_2": "就系噉样"
+      "ref_sub_1": "妈妈说这样才够精明",
+      "ref_sub_2": "就这样⋯",
+      "target_sub_1": "妈妈话噉先最著数",
+      "target_sub_2": "就系噉样"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "就这样⋯",
-      "src_1_sub_2": "我过了我小时候最精明⋯",
-      "src_2_sub_1": "就系噉样",
-      "src_2_sub_2": "我过咗我小时候最著数"
+      "ref_sub_1": "就这样⋯",
+      "ref_sub_2": "我过了我小时候最精明⋯",
+      "target_sub_1": "就系噉样",
+      "target_sub_2": "我过咗我小时候最著数"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我过了我小时候最精明⋯",
-      "src_1_sub_2": "最美丽的一天",
-      "src_2_sub_1": "我过咗我小时候最著数",
-      "src_2_sub_2": "最完美嘅一日"
+      "ref_sub_1": "我过了我小时候最精明⋯",
+      "ref_sub_2": "最美丽的一天",
+      "target_sub_1": "我过咗我小时候最著数",
+      "target_sub_2": "最完美嘅一日"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "最美丽的一天",
-      "src_1_sub_2": "依你说，纸是否可以包着鸡呢？",
-      "src_2_sub_1": "最完美嘅一日",
-      "src_2_sub_2": "噉你话纸包唔包得绝鸡呢"
+      "ref_sub_1": "最美丽的一天",
+      "ref_sub_2": "依你说，纸是否可以包着鸡呢？",
+      "target_sub_1": "最完美嘅一日",
+      "target_sub_2": "噉你话纸包唔包得绝鸡呢"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "依你说，纸是否可以包着鸡呢？",
-      "src_1_sub_2": "也可以的⋯",
-      "src_2_sub_1": "噉你话纸包唔包得绝鸡呢",
-      "src_2_sub_2": "都得嘅"
+      "ref_sub_1": "依你说，纸是否可以包着鸡呢？",
+      "ref_sub_2": "也可以的⋯",
+      "target_sub_1": "噉你话纸包唔包得绝鸡呢",
+      "target_sub_2": "都得嘅"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "也可以的⋯",
-      "src_1_sub_2": "特别是小小一块的",
-      "src_2_sub_1": "都得嘅",
-      "src_2_sub_2": "尤其系细细旧嗰啲"
+      "ref_sub_1": "也可以的⋯",
+      "ref_sub_2": "特别是小小一块的",
+      "target_sub_1": "都得嘅",
+      "target_sub_2": "尤其系细细旧嗰啲"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "最新消息",
-      "src_1_sub_2": "奥运滑浪风帆选手李丽珊五场四胜",
-      "src_2_sub_1": "啱啱收到消息"
+      "ref_sub_1": "最新消息",
+      "ref_sub_2": "奥运滑浪风帆选手李丽珊五场四胜",
+      "target_sub_1": "啱啱收到消息"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "奥运滑浪风帆选手李丽珊五场四胜",
-      "src_1_sub_2": "夺得香港历史上第一面奥运金牌！",
-      "src_2_sub_2": "奥运滑浪风帆选手李丽珊以五场四胜嘅结果夺取香港历史上第一面奥运金牌"
+      "ref_sub_1": "奥运滑浪风帆选手李丽珊五场四胜",
+      "ref_sub_2": "夺得香港历史上第一面奥运金牌！",
+      "target_sub_2": "奥运滑浪风帆选手李丽珊以五场四胜嘅结果夺取香港历史上第一面奥运金牌"
     },
     "answer": {
-      "src_2_sub_1_shifted": "奥运滑浪风帆选手李丽珊以五场四胜嘅结果",
-      "src_2_sub_2_shifted": "夺取香港历史上第一面奥运金牌"
+      "target_sub_1_shifted": "奥运滑浪风帆选手李丽珊以五场四胜嘅结果",
+      "target_sub_2_shifted": "夺取香港历史上第一面奥运金牌"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "最新消息",
-      "src_1_sub_2": "奥运滑浪风帆选手李丽珊五场四胜",
-      "src_2_sub_1": "啱啱收到消息",
-      "src_2_sub_2": "奥运滑浪风帆选手李丽珊以五场四胜嘅结果"
+      "ref_sub_1": "最新消息",
+      "ref_sub_2": "奥运滑浪风帆选手李丽珊五场四胜",
+      "target_sub_1": "啱啱收到消息",
+      "target_sub_2": "奥运滑浪风帆选手李丽珊以五场四胜嘅结果"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "奥运滑浪风帆选手李丽珊五场四胜",
-      "src_1_sub_2": "夺得香港历史上第一面奥运金牌！",
-      "src_2_sub_1": "奥运滑浪风帆选手李丽珊以五场四胜嘅结果",
-      "src_2_sub_2": "夺取香港历史上第一面奥运金牌"
+      "ref_sub_1": "奥运滑浪风帆选手李丽珊五场四胜",
+      "ref_sub_2": "夺得香港历史上第一面奥运金牌！",
+      "target_sub_1": "奥运滑浪风帆选手李丽珊以五场四胜嘅结果",
+      "target_sub_2": "夺取香港历史上第一面奥运金牌"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "夺得香港历史上第一面奥运金牌！",
-      "src_1_sub_2": "消息说当李丽珊获悉自己稳夺金牌后",
-      "src_2_sub_1": "夺取香港历史上第一面奥运金牌"
+      "ref_sub_1": "夺得香港历史上第一面奥运金牌！",
+      "ref_sub_2": "消息说当李丽珊获悉自己稳夺金牌后",
+      "target_sub_1": "夺取香港历史上第一面奥运金牌"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "消息说当李丽珊获悉自己稳夺金牌后",
-      "src_1_sub_2": "激动地对在场记者表示她今次的成绩⋯",
-      "src_2_sub_2": "消息话李丽珊喺知道自己稳夺奥运金牌之后好激动噉同在场嘅记者讲"
+      "ref_sub_1": "消息说当李丽珊获悉自己稳夺金牌后",
+      "ref_sub_2": "激动地对在场记者表示她今次的成绩⋯",
+      "target_sub_2": "消息话李丽珊喺知道自己稳夺奥运金牌之后好激动噉同在场嘅记者讲"
     },
     "answer": {
-      "src_2_sub_1_shifted": "消息话李丽珊喺知道自己稳夺奥运金牌之后",
-      "src_2_sub_2_shifted": "好激动噉同在场嘅记者讲"
+      "target_sub_1_shifted": "消息话李丽珊喺知道自己稳夺奥运金牌之后",
+      "target_sub_2_shifted": "好激动噉同在场嘅记者讲"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "夺得香港历史上第一面奥运金牌！",
-      "src_1_sub_2": "消息说当李丽珊获悉自己稳夺金牌后",
-      "src_2_sub_1": "夺取香港历史上第一面奥运金牌",
-      "src_2_sub_2": "消息话李丽珊喺知道自己稳夺奥运金牌之后"
+      "ref_sub_1": "夺得香港历史上第一面奥运金牌！",
+      "ref_sub_2": "消息说当李丽珊获悉自己稳夺金牌后",
+      "target_sub_1": "夺取香港历史上第一面奥运金牌",
+      "target_sub_2": "消息话李丽珊喺知道自己稳夺奥运金牌之后"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "消息说当李丽珊获悉自己稳夺金牌后",
-      "src_1_sub_2": "激动地对在场记者表示她今次的成绩⋯",
-      "src_2_sub_1": "消息话李丽珊喺知道自己稳夺奥运金牌之后",
-      "src_2_sub_2": "好激动噉同在场嘅记者讲"
+      "ref_sub_1": "消息说当李丽珊获悉自己稳夺金牌后",
+      "ref_sub_2": "激动地对在场记者表示她今次的成绩⋯",
+      "target_sub_1": "消息话李丽珊喺知道自己稳夺奥运金牌之后",
+      "target_sub_2": "好激动噉同在场嘅记者讲"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "激动地对在场记者表示她今次的成绩⋯",
-      "src_1_sub_2": "足以证明香港运动员不是腊鸭！",
-      "src_2_sub_1": "好激动噉同在场嘅记者讲",
-      "src_2_sub_2": "今次佢嘅成绩可以证明到香港嘅运动员唔系𫚭鸭"
+      "ref_sub_1": "激动地对在场记者表示她今次的成绩⋯",
+      "ref_sub_2": "足以证明香港运动员不是腊鸭！",
+      "target_sub_1": "好激动噉同在场嘅记者讲",
+      "target_sub_2": "今次佢嘅成绩可以证明到香港嘅运动员唔系𫚭鸭"
     },
     "answer": {
-      "src_2_sub_1_shifted": "好激动噉同在场嘅记者讲今次佢嘅成绩",
-      "src_2_sub_2_shifted": "可以证明到香港嘅运动员唔系𫚭鸭"
+      "target_sub_1_shifted": "好激动噉同在场嘅记者讲今次佢嘅成绩",
+      "target_sub_2_shifted": "可以证明到香港嘅运动员唔系𫚭鸭"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "足以证明香港运动员不是腊鸭！",
-      "src_1_sub_2": "对不起，应该　　是垃圾，不是腊鸭！",
-      "src_2_sub_1": "可以证明到香港嘅运动员唔系𫚭鸭",
-      "src_2_sub_2": "各位对唔住应该系垃圾唔系𫚭鸭"
+      "ref_sub_1": "足以证明香港运动员不是腊鸭！",
+      "ref_sub_2": "对不起，应该　　是垃圾，不是腊鸭！",
+      "target_sub_1": "可以证明到香港嘅运动员唔系𫚭鸭",
+      "target_sub_2": "各位对唔住应该系垃圾唔系𫚭鸭"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "对不起，应该　　是垃圾，不是腊鸭！",
-      "src_1_sub_2": "对不起，应该　　不是垃圾，也不是腊鸭！",
-      "src_2_sub_1": "各位对唔住应该系垃圾唔系𫚭鸭",
-      "src_2_sub_2": "对唔住应该系唔系垃圾亦都唔系𫚭鸭"
+      "ref_sub_1": "对不起，应该　　是垃圾，不是腊鸭！",
+      "ref_sub_2": "对不起，应该　　不是垃圾，也不是腊鸭！",
+      "target_sub_1": "各位对唔住应该系垃圾唔系𫚭鸭",
+      "target_sub_2": "对唔住应该系唔系垃圾亦都唔系𫚭鸭"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "对不起，应该　　不是垃圾，也不是腊鸭！",
-      "src_1_sub_2": "特别报告完毕",
-      "src_2_sub_1": "对唔住应该系唔系垃圾亦都唔系𫚭鸭",
-      "src_2_sub_2": "特别报个原不"
+      "ref_sub_1": "对不起，应该　　不是垃圾，也不是腊鸭！",
+      "ref_sub_2": "特别报告完毕",
+      "target_sub_1": "对唔住应该系唔系垃圾亦都唔系𫚭鸭",
+      "target_sub_2": "特别报个原不"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈好像又有计了",
-      "src_1_sub_2": "靓仔，好运，叻仔⋯",
-      "src_2_sub_1": "咦妈妈好似又有计噉噃",
-      "src_2_sub_2": "靓仔好运"
+      "ref_sub_1": "妈妈好像又有计了",
+      "ref_sub_2": "靓仔，好运，叻仔⋯",
+      "target_sub_1": "咦妈妈好似又有计噉噃",
+      "target_sub_2": "靓仔好运"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "靓仔，好运，叻仔⋯",
-      "src_1_sub_2": "好像都没希望了",
-      "src_2_sub_1": "靓仔好运",
-      "src_2_sub_2": "叻仔呀睇嚟都唔多靠得住"
+      "ref_sub_1": "靓仔，好运，叻仔⋯",
+      "ref_sub_2": "好像都没希望了",
+      "target_sub_1": "靓仔好运",
+      "target_sub_2": "叻仔呀睇嚟都唔多靠得住"
     },
     "answer": {
-      "src_2_sub_1_shifted": "靓仔好运叻仔呀",
-      "src_2_sub_2_shifted": "睇嚟都唔多靠得住"
+      "target_sub_1_shifted": "靓仔好运叻仔呀",
+      "target_sub_2_shifted": "睇嚟都唔多靠得住"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "好像都没希望了",
-      "src_1_sub_2": "是不是可以靠手瓜呢？",
-      "src_2_sub_1": "睇嚟都唔多靠得住",
-      "src_2_sub_2": "哗好唔好靠下个手瓜噉呢"
+      "ref_sub_1": "好像都没希望了",
+      "ref_sub_2": "是不是可以靠手瓜呢？",
+      "target_sub_1": "睇嚟都唔多靠得住",
+      "target_sub_2": "哗好唔好靠下个手瓜噉呢"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "是不是可以靠手瓜呢？",
-      "src_1_sub_2": "于是，一个梦还没醒⋯",
-      "src_2_sub_1": "哗好唔好靠下个手瓜噉呢",
-      "src_2_sub_2": "于是一个梦都未醒"
+      "ref_sub_1": "是不是可以靠手瓜呢？",
+      "ref_sub_2": "于是，一个梦还没醒⋯",
+      "target_sub_1": "哗好唔好靠下个手瓜噉呢",
+      "target_sub_2": "于是一个梦都未醒"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "于是，一个梦还没醒⋯",
-      "src_1_sub_2": "我又得到另一个梦",
-      "src_2_sub_1": "于是一个梦都未醒",
-      "src_2_sub_2": "我又得到另外一个梦"
+      "ref_sub_1": "于是，一个梦还没醒⋯",
+      "ref_sub_2": "我又得到另一个梦",
+      "target_sub_1": "于是一个梦都未醒",
+      "target_sub_2": "我又得到另外一个梦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我又得到另一个梦",
-      "src_1_sub_2": "应该是脚瓜",
-      "src_2_sub_1": "我又得到另外一个梦",
-      "src_2_sub_2": "系咪应该系脚瓜之争"
+      "ref_sub_1": "我又得到另一个梦",
+      "ref_sub_2": "应该是脚瓜",
+      "target_sub_1": "我又得到另外一个梦",
+      "target_sub_2": "系咪应该系脚瓜之争"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "应该是脚瓜",
-      "src_1_sub_2": "我知道一点也不容易",
-      "src_2_sub_1": "系咪应该系脚瓜之争",
-      "src_2_sub_2": "我知道一啲都唔容易"
+      "ref_sub_1": "应该是脚瓜",
+      "ref_sub_2": "我知道一点也不容易",
+      "target_sub_1": "系咪应该系脚瓜之争",
+      "target_sub_2": "我知道一啲都唔容易"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我知道一点也不容易",
-      "src_1_sub_2": "我知道要找到黎根绝对不容易",
-      "src_2_sub_1": "我知道一啲都唔容易",
-      "src_2_sub_2": "我知道要揾到励根绝对唔容易"
+      "ref_sub_1": "我知道一点也不容易",
+      "ref_sub_2": "我知道要找到黎根绝对不容易",
+      "target_sub_1": "我知道一啲都唔容易",
+      "target_sub_2": "我知道要揾到励根绝对唔容易"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我知道要找到黎根绝对不容易",
-      "src_1_sub_2": "我知道要他收我做徒弟更加不容易",
-      "src_2_sub_1": "我知道要揾到励根绝对唔容易",
-      "src_2_sub_2": "我知道要佢收我做徒弟更加唔容易"
+      "ref_sub_1": "我知道要找到黎根绝对不容易",
+      "ref_sub_2": "我知道要他收我做徒弟更加不容易",
+      "target_sub_1": "我知道要揾到励根绝对唔容易",
+      "target_sub_2": "我知道要佢收我做徒弟更加唔容易"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "但无论多不容易，我都要试一试",
-      "src_1_sub_2": "我要黎根收我做徒弟！",
-      "src_2_sub_1": "但无论几唔容易我都要试一试",
-      "src_2_sub_2": "我要来紧收我度徒弟"
+      "ref_sub_1": "但无论多不容易，我都要试一试",
+      "ref_sub_2": "我要黎根收我做徒弟！",
+      "target_sub_1": "但无论几唔容易我都要试一试",
+      "target_sub_2": "我要来紧收我度徒弟"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我要黎根收我做徒弟！",
-      "src_1_sub_2": "无论几辛苦，我一定要得到奥运金牌！",
-      "src_2_sub_1": "我要来紧收我度徒弟",
-      "src_2_sub_2": "无论几辛苦我一定要捞到奥运金牌"
+      "ref_sub_1": "我要黎根收我做徒弟！",
+      "ref_sub_2": "无论几辛苦，我一定要得到奥运金牌！",
+      "target_sub_1": "我要来紧收我度徒弟",
+      "target_sub_2": "无论几辛苦我一定要捞到奥运金牌"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "你孕育了珊珊！你也会孕育我！",
-      "src_1_sub_2": "当我站在奥运会颁奖台上",
-      "src_2_sub_2": "三张堂上面"
+      "ref_sub_1": "你孕育了珊珊！你也会孕育我！",
+      "ref_sub_2": "当我站在奥运会颁奖台上",
+      "target_sub_2": "三张堂上面"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "当我站在奥运会颁奖台上",
-      "src_1_sub_2": "我会举起金牌跟全世界说：",
-      "src_2_sub_1": "三张堂上面",
-      "src_2_sub_2": "系今排同全世界讲"
+      "ref_sub_1": "当我站在奥运会颁奖台上",
+      "ref_sub_2": "我会举起金牌跟全世界说：",
+      "target_sub_1": "三张堂上面",
+      "target_sub_2": "系今排同全世界讲"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我会举起金牌跟全世界说：",
-      "src_1_sub_2": "香港运动员不是垃圾！",
-      "src_2_sub_1": "系今排同全世界讲"
+      "ref_sub_1": "我会举起金牌跟全世界说：",
+      "ref_sub_2": "香港运动员不是垃圾！",
+      "target_sub_1": "系今排同全世界讲"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "小朋友，这儿是南丫岛呀！",
-      "src_1_sub_2": "南丫岛？它也孕育了周润发！",
-      "src_2_sub_1": "小朋友呀呢度系南丫岛噃",
-      "src_2_sub_2": "南丫岛都引用咗周润发噃"
+      "ref_sub_1": "小朋友，这儿是南丫岛呀！",
+      "ref_sub_2": "南丫岛？它也孕育了周润发！",
+      "target_sub_1": "小朋友呀呢度系南丫岛噃",
+      "target_sub_2": "南丫岛都引用咗周润发噃"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "想不到我黎根避进南丫岛也给你发现",
-      "src_1_sub_2": "小朋友，你知道什么是狗仔队吧？",
-      "src_2_sub_1": "制估唔到我嚟跟你入嚟南丫岛都畀你揾到",
-      "src_2_sub_2": "小朋友我谂你都知道乜嘢叫做狗仔队嘞"
+      "ref_sub_1": "想不到我黎根避进南丫岛也给你发现",
+      "ref_sub_2": "小朋友，你知道什么是狗仔队吧？",
+      "target_sub_1": "制估唔到我嚟跟你入嚟南丫岛都畀你揾到",
+      "target_sub_2": "小朋友我谂你都知道乜嘢叫做狗仔队嘞"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "小朋友，你知道什么是狗仔队吧？",
-      "src_1_sub_2": "加上总有小朋友及家长来说要拜我为师",
-      "src_2_sub_1": "小朋友我谂你都知道乜嘢叫做狗仔队嘞",
-      "src_2_sub_2": "再加上不时有啲小朋友同埋家长嚟揾我话要拜我为师"
+      "ref_sub_1": "小朋友，你知道什么是狗仔队吧？",
+      "ref_sub_2": "加上总有小朋友及家长来说要拜我为师",
+      "target_sub_1": "小朋友我谂你都知道乜嘢叫做狗仔队嘞",
+      "target_sub_2": "再加上不时有啲小朋友同埋家长嚟揾我话要拜我为师"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "加上总有小朋友及家长来说要拜我为师",
-      "src_1_sub_2": "我才过来南丫岛避一避",
-      "src_2_sub_1": "再加上不时有啲小朋友同埋家长嚟揾我话要拜我为师",
-      "src_2_sub_2": "所以我咪过嚟南丫岛避一避"
+      "ref_sub_1": "加上总有小朋友及家长来说要拜我为师",
+      "ref_sub_2": "我才过来南丫岛避一避",
+      "target_sub_1": "再加上不时有啲小朋友同埋家长嚟揾我话要拜我为师",
+      "target_sub_2": "所以我咪过嚟南丫岛避一避"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我才过来南丫岛避一避",
-      "src_1_sub_2": "至于拜师的事⋯",
-      "src_2_sub_1": "所以我咪过嚟南丫岛避一避",
-      "src_2_sub_2": "至于拜师嘅嘢"
+      "ref_sub_1": "我才过来南丫岛避一避",
+      "ref_sub_2": "至于拜师的事⋯",
+      "target_sub_1": "所以我咪过嚟南丫岛避一避",
+      "target_sub_2": "至于拜师嘅嘢"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "至于拜师的事⋯",
-      "src_1_sub_2": "拜你个头！",
-      "src_2_sub_1": "至于拜师嘅嘢",
-      "src_2_sub_2": "拜你个头嘅"
+      "ref_sub_1": "至于拜师的事⋯",
+      "ref_sub_2": "拜你个头！",
+      "target_sub_1": "至于拜师嘅嘢",
+      "target_sub_2": "拜你个头嘅"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "拜你个头！",
-      "src_1_sub_2": "你们这些住香港岛的小朋友骄生惯养",
-      "src_2_sub_1": "拜你个头嘅",
-      "src_2_sub_2": "你哋呢班住喺香港岛嘅小朋友娇生惯养边挨得苦㗎"
+      "ref_sub_1": "拜你个头！",
+      "ref_sub_2": "你们这些住香港岛的小朋友骄生惯养",
+      "target_sub_1": "拜你个头嘅",
+      "target_sub_2": "你哋呢班住喺香港岛嘅小朋友娇生惯养边挨得苦㗎"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "你们这些住香港岛的小朋友骄生惯养",
-      "src_1_sub_2": "怎么吃得苦？",
-      "src_2_sub_1": "你哋呢班住喺香港岛嘅小朋友娇生惯养边挨得苦㗎"
+      "ref_sub_1": "你们这些住香港岛的小朋友骄生惯养",
+      "ref_sub_2": "怎么吃得苦？",
+      "target_sub_1": "你哋呢班住喺香港岛嘅小朋友娇生惯养边挨得苦㗎"
     },
     "answer": {
-      "src_2_sub_1_shifted": "你哋呢班住喺香港岛嘅小朋友娇生惯养",
-      "src_2_sub_2_shifted": "边挨得苦㗎"
+      "target_sub_1_shifted": "你哋呢班住喺香港岛嘅小朋友娇生惯养",
+      "target_sub_2_shifted": "边挨得苦㗎"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "拜你个头！",
-      "src_1_sub_2": "你们这些住香港岛的小朋友骄生惯养",
-      "src_2_sub_1": "拜你个头嘅",
-      "src_2_sub_2": "你哋呢班住喺香港岛嘅小朋友娇生惯养"
+      "ref_sub_1": "拜你个头！",
+      "ref_sub_2": "你们这些住香港岛的小朋友骄生惯养",
+      "target_sub_1": "拜你个头嘅",
+      "target_sub_2": "你哋呢班住喺香港岛嘅小朋友娇生惯养"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "你们这些住香港岛的小朋友骄生惯养",
-      "src_1_sub_2": "怎么吃得苦？",
-      "src_2_sub_1": "你哋呢班住喺香港岛嘅小朋友娇生惯养",
-      "src_2_sub_2": "边挨得苦㗎"
+      "ref_sub_1": "你们这些住香港岛的小朋友骄生惯养",
+      "ref_sub_2": "怎么吃得苦？",
+      "target_sub_1": "你哋呢班住喺香港岛嘅小朋友娇生惯养",
+      "target_sub_2": "边挨得苦㗎"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "怎么吃得苦？",
-      "src_1_sub_2": "想跟珊珊般得奥运金牌？",
-      "src_2_sub_1": "边挨得苦㗎"
+      "ref_sub_1": "怎么吃得苦？",
+      "ref_sub_2": "想跟珊珊般得奥运金牌？",
+      "target_sub_1": "边挨得苦㗎"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "想跟珊珊般得奥运金牌？",
-      "src_1_sub_2": "别作梦了！",
-      "src_2_sub_2": "想学山伞攞奥运金牌食母你嘢"
+      "ref_sub_1": "想跟珊珊般得奥运金牌？",
+      "ref_sub_2": "别作梦了！",
+      "target_sub_2": "想学山伞攞奥运金牌食母你嘢"
     },
     "answer": {
-      "src_2_sub_1_shifted": "想学山伞攞奥运金牌",
-      "src_2_sub_2_shifted": "食母你嘢"
+      "target_sub_1_shifted": "想学山伞攞奥运金牌",
+      "target_sub_2_shifted": "食母你嘢"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "怎么吃得苦？",
-      "src_1_sub_2": "想跟珊珊般得奥运金牌？",
-      "src_2_sub_1": "边挨得苦㗎",
-      "src_2_sub_2": "想学山伞攞奥运金牌"
+      "ref_sub_1": "怎么吃得苦？",
+      "ref_sub_2": "想跟珊珊般得奥运金牌？",
+      "target_sub_1": "边挨得苦㗎",
+      "target_sub_2": "想学山伞攞奥运金牌"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "想跟珊珊般得奥运金牌？",
-      "src_1_sub_2": "别作梦了！",
-      "src_2_sub_1": "想学山伞攞奥运金牌",
-      "src_2_sub_2": "食母你嘢"
+      "ref_sub_1": "想跟珊珊般得奥运金牌？",
+      "ref_sub_2": "别作梦了！",
+      "target_sub_1": "想学山伞攞奥运金牌",
+      "target_sub_2": "食母你嘢"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "这个⋯",
-      "src_1_sub_2": "这脚瓜⋯好粗好大！比一节瓜还要大！",
-      "src_2_sub_1": "哗",
-      "src_2_sub_2": "呢只呢只脚瓜好粗好大呀仲大个只瓜呀"
+      "ref_sub_1": "这个⋯",
+      "ref_sub_2": "这脚瓜⋯好粗好大！比一节瓜还要大！",
+      "target_sub_1": "哗",
+      "target_sub_2": "呢只呢只脚瓜好粗好大呀仲大个只瓜呀"
     },
     "answer": {
-      "src_2_sub_1_shifted": "哗呢只",
-      "src_2_sub_2_shifted": "呢只脚瓜好粗好大呀仲大个只瓜呀"
+      "target_sub_1_shifted": "哗呢只",
+      "target_sub_2_shifted": "呢只脚瓜好粗好大呀仲大个只瓜呀"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "这脚瓜⋯好粗好大！比一节瓜还要大！",
-      "src_1_sub_2": "脚瓜的肌肉非常结实⋯",
-      "src_2_sub_1": "呢只脚瓜好粗好大呀仲大个只瓜呀",
-      "src_2_sub_2": "脚瓜啲肌肉非常结实"
+      "ref_sub_1": "这脚瓜⋯好粗好大！比一节瓜还要大！",
+      "ref_sub_2": "脚瓜的肌肉非常结实⋯",
+      "target_sub_1": "呢只脚瓜好粗好大呀仲大个只瓜呀",
+      "target_sub_2": "脚瓜啲肌肉非常结实"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "脚瓜的肌肉非常结实⋯",
-      "src_1_sub_2": "青筋凸现，钢线似的",
-      "src_2_sub_1": "脚瓜啲肌肉非常结实",
-      "src_2_sub_2": "啲青筋凸晒出嚟好似钢线噉"
+      "ref_sub_1": "脚瓜的肌肉非常结实⋯",
+      "ref_sub_2": "青筋凸现，钢线似的",
+      "target_sub_1": "脚瓜啲肌肉非常结实",
+      "target_sub_2": "啲青筋凸晒出嚟好似钢线噉"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "青筋凸现，钢线似的",
-      "src_1_sub_2": "每一条脚毛都硬似铁钉",
-      "src_2_sub_1": "啲青筋凸晒出嚟好似钢线噉",
-      "src_2_sub_2": "啲脚毛每一条好似铁钉噉硬"
+      "ref_sub_1": "青筋凸现，钢线似的",
+      "ref_sub_2": "每一条脚毛都硬似铁钉",
+      "target_sub_1": "啲青筋凸晒出嚟好似钢线噉",
+      "target_sub_2": "啲脚毛每一条好似铁钉噉硬"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "每一条脚毛都硬似铁钉",
-      "src_1_sub_2": "脚趾甲有一寸厚，究竟⋯",
-      "src_2_sub_1": "啲脚毛每一条好似铁钉噉硬",
-      "src_2_sub_2": "脚趾弓啲脚甲成吋噉厚"
+      "ref_sub_1": "每一条脚毛都硬似铁钉",
+      "ref_sub_2": "脚趾甲有一寸厚，究竟⋯",
+      "target_sub_1": "啲脚毛每一条好似铁钉噉硬",
+      "target_sub_2": "脚趾弓啲脚甲成吋噉厚"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "脚趾甲有一寸厚，究竟⋯",
-      "src_1_sub_2": "要行过几多座山⋯",
-      "src_2_sub_1": "脚趾弓啲脚甲成吋噉厚",
-      "src_2_sub_2": "究竟要行我几多座山"
+      "ref_sub_1": "脚趾甲有一寸厚，究竟⋯",
+      "ref_sub_2": "要行过几多座山⋯",
+      "target_sub_1": "脚趾弓啲脚甲成吋噉厚",
+      "target_sub_2": "究竟要行我几多座山"
     },
     "answer": {
-      "src_2_sub_1_shifted": "脚趾弓啲脚甲成吋噉厚究竟",
-      "src_2_sub_2_shifted": "要行我几多座山"
+      "target_sub_1_shifted": "脚趾弓啲脚甲成吋噉厚究竟",
+      "target_sub_2_shifted": "要行我几多座山"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "要行过几多座山⋯",
-      "src_1_sub_2": "跨过几多个海⋯",
-      "src_2_sub_1": "要行我几多座山",
-      "src_2_sub_2": "跨我几多个海"
+      "ref_sub_1": "要行过几多座山⋯",
+      "ref_sub_2": "跨过几多个海⋯",
+      "target_sub_1": "要行我几多座山",
+      "target_sub_2": "跨我几多个海"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "跨过几多个海⋯",
-      "src_1_sub_2": "吃过几多苦头⋯",
-      "src_2_sub_1": "跨我几多个海"
+      "ref_sub_1": "跨过几多个海⋯",
+      "ref_sub_2": "吃过几多苦头⋯",
+      "target_sub_1": "跨我几多个海"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "吃过几多苦头⋯",
-      "src_1_sub_2": "才可以练成这举世无双的脚瓜？",
-      "src_2_sub_2": "挨过几多苦头先至可以练成呢只举世无双嘅脚瓜"
+      "ref_sub_1": "吃过几多苦头⋯",
+      "ref_sub_2": "才可以练成这举世无双的脚瓜？",
+      "target_sub_2": "挨过几多苦头先至可以练成呢只举世无双嘅脚瓜"
     },
     "answer": {
-      "src_2_sub_1_shifted": "挨过几多苦头",
-      "src_2_sub_2_shifted": "先至可以练成呢只举世无双嘅脚瓜"
+      "target_sub_1_shifted": "挨过几多苦头",
+      "target_sub_2_shifted": "先至可以练成呢只举世无双嘅脚瓜"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我⋯我一定要练成这脚瓜！",
-      "src_1_sub_2": "师傅！",
-      "src_2_sub_1": "我我一定要练成呢只脚挂",
-      "src_2_sub_2": "师父"
+      "ref_sub_1": "我⋯我一定要练成这脚瓜！",
+      "ref_sub_2": "师傅！",
+      "target_sub_1": "我我一定要练成呢只脚挂",
+      "target_sub_2": "师父"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "每次唱这首歌，我都会急小便",
-      "src_1_sub_2": "现在先去，一回恐怕还是会急",
-      "src_2_sub_1": "而知点解每一字唱呢首歌都会急小便",
-      "src_2_sub_2": "仅次去定先都怕一阵会再急过"
+      "ref_sub_1": "每次唱这首歌，我都会急小便",
+      "ref_sub_2": "现在先去，一回恐怕还是会急",
+      "target_sub_1": "而知点解每一字唱呢首歌都会急小便",
+      "target_sub_2": "仅次去定先都怕一阵会再急过"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "现在先去，一回恐怕还是会急",
-      "src_1_sub_2": "但是我现在一定要唱这首歌",
-      "src_2_sub_1": "仅次去定先都怕一阵会再急过",
-      "src_2_sub_2": "但系我而家一定要唱呢首歌"
+      "ref_sub_1": "现在先去，一回恐怕还是会急",
+      "ref_sub_2": "但是我现在一定要唱这首歌",
+      "target_sub_1": "仅次去定先都怕一阵会再急过",
+      "target_sub_2": "但系我而家一定要唱呢首歌"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "但是我现在一定要唱这首歌",
-      "src_1_sub_2": "希望可以改变黎根对我的看法",
-      "src_2_sub_1": "但系我而家一定要唱呢首歌",
-      "src_2_sub_2": "希望可以改变黎根对我嘅睇法"
+      "ref_sub_1": "但是我现在一定要唱这首歌",
+      "ref_sub_2": "希望可以改变黎根对我的看法",
+      "target_sub_1": "但系我而家一定要唱呢首歌",
+      "target_sub_2": "希望可以改变黎根对我嘅睇法"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "希望可以改变黎根对我的看法",
-      "src_1_sub_2": "我要用这歌打动黎根",
-      "src_2_sub_1": "希望可以改变黎根对我嘅睇法",
-      "src_2_sub_2": "我要用呢首歌打动黎根"
+      "ref_sub_1": "希望可以改变黎根对我的看法",
+      "ref_sub_2": "我要用这歌打动黎根",
+      "target_sub_1": "希望可以改变黎根对我嘅睇法",
+      "target_sub_2": "我要用呢首歌打动黎根"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我要用这歌打动黎根",
-      "src_1_sub_2": "我要黎根收我做徒弟！",
-      "src_2_sub_1": "我要用呢首歌打动黎根",
-      "src_2_sub_2": "我要黎根收我做徒弟"
+      "ref_sub_1": "我要用这歌打动黎根",
+      "ref_sub_2": "我要黎根收我做徒弟！",
+      "target_sub_1": "我要用呢首歌打动黎根",
+      "target_sub_2": "我要黎根收我做徒弟"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我要黎根收我做徒弟！",
-      "src_1_sub_2": "歌，是这样唱的⋯",
-      "src_2_sub_1": "我要黎根收我做徒弟",
-      "src_2_sub_2": "嗰首歌系噉唱嘅"
+      "ref_sub_1": "我要黎根收我做徒弟！",
+      "ref_sub_2": "歌，是这样唱的⋯",
+      "target_sub_1": "我要黎根收我做徒弟",
+      "target_sub_2": "嗰首歌系噉唱嘅"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "歌，是这样唱的⋯",
-      "src_1_sub_2": "「大包，整多两笼」",
-      "src_2_sub_1": "嗰首歌系噉唱嘅"
+      "ref_sub_1": "歌，是这样唱的⋯",
+      "ref_sub_2": "「大包，整多两笼」",
+      "target_sub_1": "嗰首歌系噉唱嘅"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "黎根听完歌以后，表情有点古怪⋯",
-      "src_1_sub_2": "我一定要好好把握这机会",
-      "src_2_sub_1": "黎今听完首歌之后啲表情有啲古怪",
-      "src_2_sub_2": "唔我一定要好好把握呢个机会"
+      "ref_sub_1": "黎根听完歌以后，表情有点古怪⋯",
+      "ref_sub_2": "我一定要好好把握这机会",
+      "target_sub_1": "黎今听完首歌之后啲表情有啲古怪",
+      "target_sub_2": "唔我一定要好好把握呢个机会"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我一定要好好把握这机会",
-      "src_1_sub_2": "师傅！你收我做徒弟吧！",
-      "src_2_sub_1": "唔我一定要好好把握呢个机会",
-      "src_2_sub_2": "师父你收我做徒弟啦"
+      "ref_sub_1": "我一定要好好把握这机会",
+      "ref_sub_2": "师傅！你收我做徒弟吧！",
+      "target_sub_1": "唔我一定要好好把握呢个机会",
+      "target_sub_2": "师父你收我做徒弟啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "师傅！你收我做徒弟吧！",
-      "src_1_sub_2": "你唔收我做徒弟，我一世都这么跪着！",
-      "src_2_sub_1": "师父你收我做徒弟啦",
-      "src_2_sub_2": "你收我做徒弟我呢一世都跪喺度"
+      "ref_sub_1": "师傅！你收我做徒弟吧！",
+      "ref_sub_2": "你唔收我做徒弟，我一世都这么跪着！",
+      "target_sub_1": "师父你收我做徒弟啦",
+      "target_sub_2": "你收我做徒弟我呢一世都跪喺度"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "你唔收我做徒弟，我一世都这么跪着！",
-      "src_1_sub_2": "起来呀！",
-      "src_2_sub_1": "你收我做徒弟我呢一世都跪喺度",
-      "src_2_sub_2": "起身啊"
+      "ref_sub_1": "你唔收我做徒弟，我一世都这么跪着！",
+      "ref_sub_2": "起来呀！",
+      "target_sub_1": "你收我做徒弟我呢一世都跪喺度",
+      "target_sub_2": "起身啊"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "起来呀！",
-      "src_1_sub_2": "多谢师傅！",
-      "src_2_sub_1": "起身啊",
-      "src_2_sub_2": "多谢师父"
+      "ref_sub_1": "起来呀！",
+      "ref_sub_2": "多谢师傅！",
+      "target_sub_1": "起身啊",
+      "target_sub_2": "多谢师父"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "多谢师傅！",
-      "src_1_sub_2": "不⋯我是叫你扶我起来呀！",
-      "src_2_sub_1": "多谢师父",
-      "src_2_sub_2": "唔系啊我系叫你扶我起身啊"
+      "ref_sub_1": "多谢师傅！",
+      "ref_sub_2": "不⋯我是叫你扶我起来呀！",
+      "target_sub_1": "多谢师父",
+      "target_sub_2": "唔系啊我系叫你扶我起身啊"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "不⋯我是叫你扶我起来呀！",
-      "src_1_sub_2": "不成了！我的脚瓜太痹了！",
-      "src_2_sub_1": "唔系啊我系叫你扶我起身啊",
-      "src_2_sub_2": "顶唔顺啊我个腿挂好鼻啊字幕由Amara.org社群提供"
+      "ref_sub_1": "不⋯我是叫你扶我起来呀！",
+      "ref_sub_2": "不成了！我的脚瓜太痹了！",
+      "target_sub_1": "唔系啊我系叫你扶我起身啊",
+      "target_sub_2": "顶唔顺啊我个腿挂好鼻啊字幕由Amara.org社群提供"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我将今天发生的事讲给妈妈听",
-      "src_1_sub_2": "妈妈一句话也没说",
-      "src_2_sub_1": "我将今日发生嘅嘢话晒畀妈妈听",
-      "src_2_sub_2": "妈妈佢乜嘢都冇讲到"
+      "ref_sub_1": "我将今天发生的事讲给妈妈听",
+      "ref_sub_2": "妈妈一句话也没说",
+      "target_sub_1": "我将今日发生嘅嘢话晒畀妈妈听",
+      "target_sub_2": "妈妈佢乜嘢都冇讲到"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈一句话也没说",
-      "src_1_sub_2": "从冰箱内拿了只雪鸡出来解冻",
-      "src_2_sub_1": "妈妈佢乜嘢都冇讲到",
-      "src_2_sub_2": "净系喺冰箱度攞咗只雪鸡出嚟解冻"
+      "ref_sub_1": "妈妈一句话也没说",
+      "ref_sub_2": "从冰箱内拿了只雪鸡出来解冻",
+      "target_sub_1": "妈妈佢乜嘢都冇讲到",
+      "target_sub_2": "净系喺冰箱度攞咗只雪鸡出嚟解冻"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "从冰箱内拿了只雪鸡出来解冻",
-      "src_1_sub_2": "晚饭时，妈妈倒了三杯米酒",
-      "src_2_sub_1": "净系喺冰箱度攞咗只雪鸡出嚟解冻",
-      "src_2_sub_2": "晚饭时候妈妈倒咗三杯米酒"
+      "ref_sub_1": "从冰箱内拿了只雪鸡出来解冻",
+      "ref_sub_2": "晚饭时，妈妈倒了三杯米酒",
+      "target_sub_1": "净系喺冰箱度攞咗只雪鸡出嚟解冻",
+      "target_sub_2": "晚饭时候妈妈倒咗三杯米酒"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "晚饭时，妈妈倒了三杯米酒",
-      "src_1_sub_2": "又将几只橙和蒸好的鸡放到祖先前",
-      "src_2_sub_1": "晚饭时候妈妈倒咗三杯米酒",
-      "src_2_sub_2": "再将几个铲同埋蒸熟咗嘅鸡放喺祖先前面"
+      "ref_sub_1": "晚饭时，妈妈倒了三杯米酒",
+      "ref_sub_2": "又将几只橙和蒸好的鸡放到祖先前",
+      "target_sub_1": "晚饭时候妈妈倒咗三杯米酒",
+      "target_sub_2": "再将几个铲同埋蒸熟咗嘅鸡放喺祖先前面"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "又将几只橙和蒸好的鸡放到祖先前",
-      "src_1_sub_2": "妈妈叫我跪低，向祖先请请",
-      "src_2_sub_1": "再将几个铲同埋蒸熟咗嘅鸡放喺祖先前面",
-      "src_2_sub_2": "妈妈叫我跪低同祖先请请"
+      "ref_sub_1": "又将几只橙和蒸好的鸡放到祖先前",
+      "ref_sub_2": "妈妈叫我跪低，向祖先请请",
+      "target_sub_1": "再将几个铲同埋蒸熟咗嘅鸡放喺祖先前面",
+      "target_sub_2": "妈妈叫我跪低同祖先请请"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈叫我跪低，向祖先请请",
-      "src_1_sub_2": "妈妈跟着又念念有词的",
-      "src_2_sub_1": "妈妈叫我跪低同祖先请请",
-      "src_2_sub_2": "跟住妈妈口噏噏噉讲咗一啲嘢"
+      "ref_sub_1": "妈妈叫我跪低，向祖先请请",
+      "ref_sub_2": "妈妈跟着又念念有词的",
+      "target_sub_1": "妈妈叫我跪低同祖先请请",
+      "target_sub_2": "跟住妈妈口噏噏噉讲咗一啲嘢"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈跟着又念念有词的",
-      "src_1_sub_2": "然后我们一起向祖先再拜了几拜",
-      "src_2_sub_1": "跟住妈妈口噏噏噉讲咗一啲嘢",
-      "src_2_sub_2": "然之后我哋又一齐对住祖先拜多几拜"
+      "ref_sub_1": "妈妈跟着又念念有词的",
+      "ref_sub_2": "然后我们一起向祖先再拜了几拜",
+      "target_sub_1": "跟住妈妈口噏噏噉讲咗一啲嘢",
+      "target_sub_2": "然之后我哋又一齐对住祖先拜多几拜"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "然后我们一起向祖先再拜了几拜",
-      "src_1_sub_2": "妈妈蹲低把酒洒到地上",
-      "src_2_sub_1": "然之后我哋又一齐对住祖先拜多几拜",
-      "src_2_sub_2": "妈妈虎低身将啲酒倒喺地上面"
+      "ref_sub_1": "然后我们一起向祖先再拜了几拜",
+      "ref_sub_2": "妈妈蹲低把酒洒到地上",
+      "target_sub_1": "然之后我哋又一齐对住祖先拜多几拜",
+      "target_sub_2": "妈妈虎低身将啲酒倒喺地上面"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈蹲低把酒洒到地上",
-      "src_1_sub_2": "庄重而温柔地跟我说：",
-      "src_2_sub_1": "妈妈虎低身将啲酒倒喺地上面",
-      "src_2_sub_2": "庄重又温柔紧同我讲"
+      "ref_sub_1": "妈妈蹲低把酒洒到地上",
+      "ref_sub_2": "庄重而温柔地跟我说：",
+      "target_sub_1": "妈妈虎低身将啲酒倒喺地上面",
+      "target_sub_2": "庄重又温柔紧同我讲"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "庄重而温柔地跟我说：",
-      "src_1_sub_2": "以后生生性性",
-      "src_2_sub_1": "庄重又温柔紧同我讲",
-      "src_2_sub_2": "以后要生生性性"
+      "ref_sub_1": "庄重而温柔地跟我说：",
+      "ref_sub_2": "以后生生性性",
+      "target_sub_1": "庄重又温柔紧同我讲",
+      "target_sub_2": "以后要生生性性"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "以后生生性性",
-      "src_1_sub_2": "跟师傅学习，光宗耀祖！",
-      "src_2_sub_1": "以后要生生性性",
-      "src_2_sub_2": "跟师父学嘢当中要祖"
+      "ref_sub_1": "以后生生性性",
+      "ref_sub_2": "跟师傅学习，光宗耀祖！",
+      "target_sub_1": "以后要生生性性",
+      "target_sub_2": "跟师父学嘢当中要祖"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈在长洲找了间酒楼摆拜师宴",
-      "src_1_sub_2": "因为我是师傅最后一个入室弟子",
-      "src_2_sub_1": "妈妈喺长洲揾咗间酒楼摆咗几回白丝宴",
-      "src_2_sub_2": "因为我系师父最后一个入室弟子"
+      "ref_sub_1": "妈妈在长洲找了间酒楼摆拜师宴",
+      "ref_sub_2": "因为我是师傅最后一个入室弟子",
+      "target_sub_1": "妈妈喺长洲揾咗间酒楼摆咗几回白丝宴",
+      "target_sub_2": "因为我系师父最后一个入室弟子"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "因为我是师傅最后一个入室弟子",
-      "src_1_sub_2": "到贺的乡绅父老特别多",
-      "src_2_sub_1": "因为我系师父最后一个入室弟子",
-      "src_2_sub_2": "所以到学嘅乡亲父老特别多"
+      "ref_sub_1": "因为我是师傅最后一个入室弟子",
+      "ref_sub_2": "到贺的乡绅父老特别多",
+      "target_sub_1": "因为我系师父最后一个入室弟子",
+      "target_sub_2": "所以到学嘅乡亲父老特别多"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "到贺的乡绅父老特别多",
-      "src_1_sub_2": "想不到黄德森也来了",
-      "src_2_sub_1": "所以到学嘅乡亲父老特别多",
-      "src_2_sub_2": "估唔到黄德森都有嚟饮"
+      "ref_sub_1": "到贺的乡绅父老特别多",
+      "ref_sub_2": "想不到黄德森也来了",
+      "target_sub_1": "所以到学嘅乡亲父老特别多",
+      "target_sub_2": "估唔到黄德森都有嚟饮"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "想不到黄德森也来了",
-      "src_1_sub_2": "还赞我背上的肉厚",
-      "src_2_sub_1": "估唔到黄德森都有嚟饮",
-      "src_2_sub_2": "仲赞我背著啲肉口添"
+      "ref_sub_1": "想不到黄德森也来了",
+      "ref_sub_2": "还赞我背上的肉厚",
+      "target_sub_1": "估唔到黄德森都有嚟饮",
+      "target_sub_2": "仲赞我背著啲肉口添"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "还赞我背上的肉厚",
-      "src_1_sub_2": "珊珊因为去了集训，没来",
-      "src_2_sub_1": "仲赞我背著啲肉口添",
-      "src_2_sub_2": "但系山神就去咗集训冇嚟到"
+      "ref_sub_1": "还赞我背上的肉厚",
+      "ref_sub_2": "珊珊因为去了集训，没来",
+      "target_sub_1": "仲赞我背著啲肉口添",
+      "target_sub_2": "但系山神就去咗集训冇嚟到"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "珊珊因为去了集训，没来",
-      "src_1_sub_2": "麦唛，菇时跟得巴都来了",
-      "src_2_sub_1": "但系山神就去咗集训冇嚟到",
-      "src_2_sub_2": "默默姑侍同德巴都嚟咗"
+      "ref_sub_1": "珊珊因为去了集训，没来",
+      "ref_sub_2": "麦唛，菇时跟得巴都来了",
+      "target_sub_1": "但系山神就去咗集训冇嚟到",
+      "target_sub_2": "默默姑侍同德巴都嚟咗"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "麦唛，菇时跟得巴都来了",
-      "src_1_sub_2": "还带着成绩表，奖牌和大包",
-      "src_2_sub_1": "默默姑侍同德巴都嚟咗",
-      "src_2_sub_2": "仲带埋成绩表奖牌同大包嚟添"
+      "ref_sub_1": "麦唛，菇时跟得巴都来了",
+      "ref_sub_2": "还带着成绩表，奖牌和大包",
+      "target_sub_1": "默默姑侍同德巴都嚟咗",
+      "target_sub_2": "仲带埋成绩表奖牌同大包嚟添"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "还带着成绩表，奖牌和大包",
-      "src_1_sub_2": "他们都希望黎根也可以收他们做徒弟",
-      "src_2_sub_1": "仲带埋成绩表奖牌同大包嚟添",
-      "src_2_sub_2": "佢哋都希望嚟今可以收埋佢哋做徒弟"
+      "ref_sub_1": "还带着成绩表，奖牌和大包",
+      "ref_sub_2": "他们都希望黎根也可以收他们做徒弟",
+      "target_sub_1": "仲带埋成绩表奖牌同大包嚟添",
+      "target_sub_2": "佢哋都希望嚟今可以收埋佢哋做徒弟"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "他们都希望黎根也可以收他们做徒弟",
-      "src_1_sub_2": "吃过鸡丝翅，就是拜师仪式",
-      "src_2_sub_1": "佢哋都希望嚟今可以收埋佢哋做徒弟",
-      "src_2_sub_2": "食完鸡丝翅就到咗拜师仪式"
+      "ref_sub_1": "他们都希望黎根也可以收他们做徒弟",
+      "ref_sub_2": "吃过鸡丝翅，就是拜师仪式",
+      "target_sub_1": "佢哋都希望嚟今可以收埋佢哋做徒弟",
+      "target_sub_2": "食完鸡丝翅就到咗拜师仪式"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "吃过鸡丝翅，就是拜师仪式",
-      "src_1_sub_2": "妈妈倒了杯茶给我，让我给师傅喝",
-      "src_2_sub_1": "食完鸡丝翅就到咗拜师仪式",
-      "src_2_sub_2": "妈妈针咗杯热茶畀我叫我弟畀师父饮"
+      "ref_sub_1": "吃过鸡丝翅，就是拜师仪式",
+      "ref_sub_2": "妈妈倒了杯茶给我，让我给师傅喝",
+      "target_sub_1": "食完鸡丝翅就到咗拜师仪式",
+      "target_sub_2": "妈妈针咗杯热茶畀我叫我弟畀师父饮"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈倒了杯茶给我，让我给师傅喝",
-      "src_1_sub_2": "我千辛万苦来长洲找黎根⋯",
-      "src_2_sub_1": "妈妈针咗杯热茶畀我叫我弟畀师父饮",
-      "src_2_sub_2": "哦我前三万苦嚟到长洲揾嚟近"
+      "ref_sub_1": "妈妈倒了杯茶给我，让我给师傅喝",
+      "ref_sub_2": "我千辛万苦来长洲找黎根⋯",
+      "target_sub_1": "妈妈针咗杯热茶畀我叫我弟畀师父饮",
+      "target_sub_2": "哦我前三万苦嚟到长洲揾嚟近"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我千辛万苦来长洲找黎根⋯",
-      "src_1_sub_2": "我终于可以跟珊珊一起练滑浪风帆了！",
-      "src_2_sub_1": "哦我前三万苦嚟到长洲揾嚟近",
-      "src_2_sub_2": "哦我终于可以同山神一齐练习玩弄风范啊"
+      "ref_sub_1": "我千辛万苦来长洲找黎根⋯",
+      "ref_sub_2": "我终于可以跟珊珊一起练滑浪风帆了！",
+      "target_sub_1": "哦我前三万苦嚟到长洲揾嚟近",
+      "target_sub_2": "哦我终于可以同山神一齐练习玩弄风范啊"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我终于可以跟珊珊一起练滑浪风帆了！",
-      "src_1_sub_2": "我将茶递给黎根，黎根他⋯",
-      "src_2_sub_1": "哦我终于可以同山神一齐练习玩弄风范啊",
-      "src_2_sub_2": "我将杯茶递咗畀嚟跟嚟跟佢"
+      "ref_sub_1": "我终于可以跟珊珊一起练滑浪风帆了！",
+      "ref_sub_2": "我将茶递给黎根，黎根他⋯",
+      "target_sub_1": "哦我终于可以同山神一齐练习玩弄风范啊",
+      "target_sub_2": "我将杯茶递咗畀嚟跟嚟跟佢"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我将茶递给黎根，黎根他⋯",
-      "src_1_sub_2": "师傅他把茶喝了，正式收我做徒弟",
-      "src_2_sub_1": "我将杯茶递咗畀嚟跟嚟跟佢",
-      "src_2_sub_2": "亦唔系师父佢饮咗杯茶正式收咗我做徒弟嘞"
+      "ref_sub_1": "我将茶递给黎根，黎根他⋯",
+      "ref_sub_2": "师傅他把茶喝了，正式收我做徒弟",
+      "target_sub_1": "我将杯茶递咗畀嚟跟嚟跟佢",
+      "target_sub_2": "亦唔系师父佢饮咗杯茶正式收咗我做徒弟嘞"
     },
     "answer": {
-      "src_2_sub_1_shifted": "我将杯茶递咗畀嚟跟嚟跟佢亦唔系",
-      "src_2_sub_2_shifted": "师父佢饮咗杯茶正式收咗我做徒弟嘞"
+      "target_sub_1_shifted": "我将杯茶递咗畀嚟跟嚟跟佢亦唔系",
+      "target_sub_2_shifted": "师父佢饮咗杯茶正式收咗我做徒弟嘞"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "师傅他把茶喝了，正式收我做徒弟",
-      "src_1_sub_2": "宾客们好像都很高兴",
-      "src_2_sub_1": "师父佢饮咗杯茶正式收咗我做徒弟嘞",
-      "src_2_sub_2": "啲来宾睇嚟好高气"
+      "ref_sub_1": "师傅他把茶喝了，正式收我做徒弟",
+      "ref_sub_2": "宾客们好像都很高兴",
+      "target_sub_1": "师父佢饮咗杯茶正式收咗我做徒弟嘞",
+      "target_sub_2": "啲来宾睇嚟好高气"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "宾客们好像都很高兴",
-      "src_1_sub_2": "长洲的乡绅父老拍掌拍得特别落力",
-      "src_2_sub_1": "啲来宾睇嚟好高气",
-      "src_2_sub_2": "特别系长洲啲乡亲父老拍奖拍得特别落力"
+      "ref_sub_1": "宾客们好像都很高兴",
+      "ref_sub_2": "长洲的乡绅父老拍掌拍得特别落力",
+      "target_sub_1": "啲来宾睇嚟好高气",
+      "target_sub_2": "特别系长洲啲乡亲父老拍奖拍得特别落力"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "长洲的乡绅父老拍掌拍得特别落力",
-      "src_1_sub_2": "多谢各位赏面！多谢各位！",
-      "src_2_sub_1": "特别系长洲啲乡亲父老拍奖拍得特别落力",
-      "src_2_sub_2": "多谢各位上面多谢各位"
+      "ref_sub_1": "长洲的乡绅父老拍掌拍得特别落力",
+      "ref_sub_2": "多谢各位赏面！多谢各位！",
+      "target_sub_1": "特别系长洲啲乡亲父老拍奖拍得特别落力",
+      "target_sub_2": "多谢各位上面多谢各位"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "多谢各位赏面！多谢各位！",
-      "src_1_sub_2": "在下平生有两项称得上得意的绝技",
-      "src_2_sub_1": "多谢各位上面多谢各位",
-      "src_2_sub_2": "在下评生有两项称得上得意嘅绝技"
+      "ref_sub_1": "多谢各位赏面！多谢各位！",
+      "ref_sub_2": "在下平生有两项称得上得意的绝技",
+      "target_sub_1": "多谢各位上面多谢各位",
+      "target_sub_2": "在下评生有两项称得上得意嘅绝技"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "在下平生有两项称得上得意的绝技",
-      "src_1_sub_2": "第一项，是滑浪风帆！",
-      "src_2_sub_1": "在下评生有两项称得上得意嘅绝技",
-      "src_2_sub_2": "第一样系滑浪风范"
+      "ref_sub_1": "在下平生有两项称得上得意的绝技",
+      "ref_sub_2": "第一项，是滑浪风帆！",
+      "target_sub_1": "在下评生有两项称得上得意嘅绝技",
+      "target_sub_2": "第一样系滑浪风范"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "第一项，是滑浪风帆！",
-      "src_1_sub_2": "我把它传给外甥女珊珊了",
-      "src_2_sub_1": "第一样系滑浪风范",
-      "src_2_sub_2": "呢样早已传咗畀我外甥女山神啊"
+      "ref_sub_1": "第一项，是滑浪风帆！",
+      "ref_sub_2": "我把它传给外甥女珊珊了",
+      "target_sub_1": "第一样系滑浪风范",
+      "target_sub_2": "呢样早已传咗畀我外甥女山神啊"
     },
     "answer": {
-      "src_2_sub_1_shifted": "第一样系滑浪风范呢样早已",
-      "src_2_sub_2_shifted": "传咗畀我外甥女山神啊"
+      "target_sub_1_shifted": "第一样系滑浪风范呢样早已",
+      "target_sub_2_shifted": "传咗畀我外甥女山神啊"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我把它传给外甥女珊珊了",
-      "src_1_sub_2": "另一项绝技，我打算传给这个新徒弟⋯",
-      "src_2_sub_1": "传咗畀我外甥女山神啊",
-      "src_2_sub_2": "另一项绝技我打算传畀呢个新修嘅徒弟"
+      "ref_sub_1": "我把它传给外甥女珊珊了",
+      "ref_sub_2": "另一项绝技，我打算传给这个新徒弟⋯",
+      "target_sub_1": "传咗畀我外甥女山神啊",
+      "target_sub_2": "另一项绝技我打算传畀呢个新修嘅徒弟"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "另一项绝技，我打算传给这个新徒弟⋯",
-      "src_1_sub_2": "希望他把长洲人世世代代的绝技",
-      "src_2_sub_1": "另一项绝技我打算传畀呢个新修嘅徒弟",
-      "src_2_sub_2": "希望我可以将我哋长洲人世世代代嘅传统发扬光大"
+      "ref_sub_1": "另一项绝技，我打算传给这个新徒弟⋯",
+      "ref_sub_2": "希望他把长洲人世世代代的绝技",
+      "target_sub_1": "另一项绝技我打算传畀呢个新修嘅徒弟",
+      "target_sub_2": "希望我可以将我哋长洲人世世代代嘅传统发扬光大"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "希望他把长洲人世世代代的绝技",
-      "src_1_sub_2": "发扬光大！",
-      "src_2_sub_1": "希望我可以将我哋长洲人世世代代嘅传统发扬光大"
+      "ref_sub_1": "希望他把长洲人世世代代的绝技",
+      "ref_sub_2": "发扬光大！",
+      "target_sub_1": "希望我可以将我哋长洲人世世代代嘅传统发扬光大"
     },
     "answer": {
-      "src_2_sub_1_shifted": "希望我可以将我哋长洲人世世代代嘅传统",
-      "src_2_sub_2_shifted": "发扬光大"
+      "target_sub_1_shifted": "希望我可以将我哋长洲人世世代代嘅传统",
+      "target_sub_2_shifted": "发扬光大"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "另一项绝技，我打算传给这个新徒弟⋯",
-      "src_1_sub_2": "希望他把长洲人世世代代的绝技",
-      "src_2_sub_1": "另一项绝技我打算传畀呢个新修嘅徒弟",
-      "src_2_sub_2": "希望我可以将我哋长洲人世世代代嘅传统"
+      "ref_sub_1": "另一项绝技，我打算传给这个新徒弟⋯",
+      "ref_sub_2": "希望他把长洲人世世代代的绝技",
+      "target_sub_1": "另一项绝技我打算传畀呢个新修嘅徒弟",
+      "target_sub_2": "希望我可以将我哋长洲人世世代代嘅传统"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "希望他把长洲人世世代代的绝技",
-      "src_1_sub_2": "发扬光大！",
-      "src_2_sub_1": "希望我可以将我哋长洲人世世代代嘅传统",
-      "src_2_sub_2": "发扬光大"
+      "ref_sub_1": "希望他把长洲人世世代代的绝技",
+      "ref_sub_2": "发扬光大！",
+      "target_sub_1": "希望我可以将我哋长洲人世世代代嘅传统",
+      "target_sub_2": "发扬光大"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "发扬光大！",
-      "src_1_sub_2": "请问那是什么绝技呢？",
-      "src_2_sub_1": "发扬光大",
-      "src_2_sub_2": "噉请问嗰样绝技系乜嘢啊"
+      "ref_sub_1": "发扬光大！",
+      "ref_sub_2": "请问那是什么绝技呢？",
+      "target_sub_1": "发扬光大",
+      "target_sub_2": "噉请问嗰样绝技系乜嘢啊"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "第二项绝技，就是⋯",
-      "src_1_sub_2": "抢包山！",
-      "src_2_sub_1": "第二样绝技就系抢爆山"
+      "ref_sub_1": "第二项绝技，就是⋯",
+      "ref_sub_2": "抢包山！",
+      "target_sub_1": "第二样绝技就系抢爆山"
     },
     "answer": {
-      "src_2_sub_1_shifted": "第二样绝技就系",
-      "src_2_sub_2_shifted": "抢爆山"
+      "target_sub_1_shifted": "第二样绝技就系",
+      "target_sub_2_shifted": "抢爆山"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "第二项绝技，就是⋯",
-      "src_1_sub_2": "抢包山！",
-      "src_2_sub_1": "第二样绝技就系",
-      "src_2_sub_2": "抢爆山"
+      "ref_sub_1": "第二项绝技，就是⋯",
+      "ref_sub_2": "抢包山！",
+      "target_sub_1": "第二样绝技就系",
+      "target_sub_2": "抢爆山"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "抢包山？",
-      "src_1_sub_2": "年轻观众可能不知「抢包山」何物",
-      "src_2_sub_1": "抢包山?",
-      "src_2_sub_2": "年轻嘅观众可能唔知乜嘢系抢包山呀"
+      "ref_sub_1": "抢包山？",
+      "ref_sub_2": "年轻观众可能不知「抢包山」何物",
+      "target_sub_1": "抢包山?",
+      "target_sub_2": "年轻嘅观众可能唔知乜嘢系抢包山呀"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "年轻观众可能不知「抢包山」何物",
-      "src_1_sub_2": "抢包山乃长洲独有传统节日",
-      "src_2_sub_1": "年轻嘅观众可能唔知乜嘢系抢包山呀",
-      "src_2_sub_2": "抢包山系长洲独有嘅传统节日"
+      "ref_sub_1": "年轻观众可能不知「抢包山」何物",
+      "ref_sub_2": "抢包山乃长洲独有传统节日",
+      "target_sub_1": "年轻嘅观众可能唔知乜嘢系抢包山呀",
+      "target_sub_2": "抢包山系长洲独有嘅传统节日"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "抢包山乃长洲独有传统节日",
-      "src_1_sub_2": "每年农历四月",
-      "src_2_sub_1": "抢包山系长洲独有嘅传统节日",
-      "src_2_sub_2": "每年农历四月"
+      "ref_sub_1": "抢包山乃长洲独有传统节日",
+      "ref_sub_2": "每年农历四月",
+      "target_sub_1": "抢包山系长洲独有嘅传统节日",
+      "target_sub_2": "每年农历四月"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "每年农历四月",
-      "src_1_sub_2": "长洲居民均举办太平清醮",
-      "src_2_sub_1": "每年农历四月",
-      "src_2_sub_2": "长洲嘅居民都会举办太平清朝"
+      "ref_sub_1": "每年农历四月",
+      "ref_sub_2": "长洲居民均举办太平清醮",
+      "target_sub_1": "每年农历四月",
+      "target_sub_2": "长洲嘅居民都会举办太平清朝"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "长洲居民均举办太平清醮",
-      "src_1_sub_2": "于北帝庙前搭起三座包山",
-      "src_2_sub_1": "长洲嘅居民都会举办太平清朝",
-      "src_2_sub_2": "喺北帝庙前搭起三座包山"
+      "ref_sub_1": "长洲居民均举办太平清醮",
+      "ref_sub_2": "于北帝庙前搭起三座包山",
+      "target_sub_1": "长洲嘅居民都会举办太平清朝",
+      "target_sub_2": "喺北帝庙前搭起三座包山"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "于北帝庙前搭起三座包山",
-      "src_1_sub_2": "什么是包山呢？",
-      "src_2_sub_1": "喺北帝庙前搭起三座包山",
-      "src_2_sub_2": "噉乜嘢系包山呢?"
+      "ref_sub_1": "于北帝庙前搭起三座包山",
+      "ref_sub_2": "什么是包山呢？",
+      "target_sub_1": "喺北帝庙前搭起三座包山",
+      "target_sub_2": "噉乜嘢系包山呢?"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "什么是包山呢？",
-      "src_1_sub_2": "顾名思义⋯",
-      "src_2_sub_1": "噉乜嘢系包山呢?",
-      "src_2_sub_2": "顾名思义"
+      "ref_sub_1": "什么是包山呢？",
+      "ref_sub_2": "顾名思义⋯",
+      "target_sub_1": "噉乜嘢系包山呢?",
+      "target_sub_2": "顾名思义"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "顾名思义⋯",
-      "src_1_sub_2": "包山就是一座由好多好多包砌起的山！",
-      "src_2_sub_1": "顾名思义",
-      "src_2_sub_2": "包山就系一座由好多好多好多包砌起嘅山"
+      "ref_sub_1": "顾名思义⋯",
+      "ref_sub_2": "包山就是一座由好多好多包砌起的山！",
+      "target_sub_1": "顾名思义",
+      "target_sub_2": "包山就系一座由好多好多好多包砌起嘅山"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "包山就是一座由好多好多包砌起的山！",
-      "src_1_sub_2": "一座包山，起码六、七层楼高⋯",
-      "src_2_sub_1": "包山就系一座由好多好多好多包砌起嘅山",
-      "src_2_sub_2": "一座包山起码六七层楼高"
+      "ref_sub_1": "包山就是一座由好多好多包砌起的山！",
+      "ref_sub_2": "一座包山，起码六、七层楼高⋯",
+      "target_sub_1": "包山就系一座由好多好多好多包砌起嘅山",
+      "target_sub_2": "一座包山起码六七层楼高"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "一座包山，起码六、七层楼高⋯",
-      "src_1_sub_2": "你可以想像一下包山有多高了吧？",
-      "src_2_sub_1": "一座包山起码六七层楼高",
-      "src_2_sub_2": "噉你可以想像一下嗰度有几多包喇"
+      "ref_sub_1": "一座包山，起码六、七层楼高⋯",
+      "ref_sub_2": "你可以想像一下包山有多高了吧？",
+      "target_sub_1": "一座包山起码六七层楼高",
+      "target_sub_2": "噉你可以想像一下嗰度有几多包喇"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "你可以想像一下包山有多高了吧？",
-      "src_1_sub_2": "抢包山，就是要把包山上的包抢到手！",
-      "src_2_sub_1": "噉你可以想像一下嗰度有几多包喇",
-      "src_2_sub_2": "噉抢包山自然就系要将包山嘅包抢到手"
+      "ref_sub_1": "你可以想像一下包山有多高了吧？",
+      "ref_sub_2": "抢包山，就是要把包山上的包抢到手！",
+      "target_sub_1": "噉你可以想像一下嗰度有几多包喇",
+      "target_sub_2": "噉抢包山自然就系要将包山嘅包抢到手"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "抢包山，就是要把包山上的包抢到手！",
-      "src_1_sub_2": "锣鼓响起",
-      "src_2_sub_1": "噉抢包山自然就系要将包山嘅包抢到手",
-      "src_2_sub_2": "罗古响起"
+      "ref_sub_1": "抢包山，就是要把包山上的包抢到手！",
+      "ref_sub_2": "锣鼓响起",
+      "target_sub_1": "噉抢包山自然就系要将包山嘅包抢到手",
+      "target_sub_2": "罗古响起"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "锣鼓响起",
-      "src_1_sub_2": "数以百计的青年一涌而上抢包",
-      "src_2_sub_1": "罗古响起",
-      "src_2_sub_2": "数以百计嘅青年就会一涌而上去抢包"
+      "ref_sub_1": "锣鼓响起",
+      "ref_sub_2": "数以百计的青年一涌而上抢包",
+      "target_sub_1": "罗古响起",
+      "target_sub_2": "数以百计嘅青年就会一涌而上去抢包"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "数以百计的青年一涌而上抢包",
-      "src_1_sub_2": "抢得位置愈高的包，就是愈大的祝福",
-      "src_2_sub_1": "数以百计嘅青年就会一涌而上去抢包",
-      "src_2_sub_2": "抢到位置越高嘅包就代表越大嘅祝福"
+      "ref_sub_1": "数以百计的青年一涌而上抢包",
+      "ref_sub_2": "抢得位置愈高的包，就是愈大的祝福",
+      "target_sub_1": "数以百计嘅青年就会一涌而上去抢包",
+      "target_sub_2": "抢到位置越高嘅包就代表越大嘅祝福"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "抢得位置愈高的包，就是愈大的祝福",
-      "src_1_sub_2": "更可以表现自己的不凡身手",
-      "src_2_sub_1": "抢到位置越高嘅包就代表越大嘅祝福",
-      "src_2_sub_2": "更加可以表现自己不凡嘅身手"
+      "ref_sub_1": "抢得位置愈高的包，就是愈大的祝福",
+      "ref_sub_2": "更可以表现自己的不凡身手",
+      "target_sub_1": "抢到位置越高嘅包就代表越大嘅祝福",
+      "target_sub_2": "更加可以表现自己不凡嘅身手"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "更可以表现自己的不凡身手",
-      "src_1_sub_2": "在1978年两座包山忽然倒下，多人重伤",
-      "src_2_sub_1": "更加可以表现自己不凡嘅身手",
-      "src_2_sub_2": "但喺1978年两座包山突然塌咗都去抢包山"
+      "ref_sub_1": "更可以表现自己的不凡身手",
+      "ref_sub_2": "在1978年两座包山忽然倒下，多人重伤",
+      "target_sub_1": "更加可以表现自己不凡嘅身手",
+      "target_sub_2": "但喺1978年两座包山突然塌咗都去抢包山"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "在1978年两座包山忽然倒下，多人重伤",
-      "src_1_sub_2": "「抢包山」从此被禁！",
-      "src_2_sub_1": "但喺1978年两座包山突然塌咗都去抢包山",
-      "src_2_sub_2": "而长洲特有嘅传统亦占备为榜"
+      "ref_sub_1": "在1978年两座包山忽然倒下，多人重伤",
+      "ref_sub_2": "「抢包山」从此被禁！",
+      "target_sub_1": "但喺1978年两座包山突然塌咗都去抢包山",
+      "target_sub_2": "而长洲特有嘅传统亦占备为榜"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「抢包山」从此被禁！",
-      "src_1_sub_2": "而长洲独有的传统，亦渐被遗忘",
-      "src_2_sub_1": "而长洲特有嘅传统亦占备为榜",
-      "src_2_sub_2": "长洲特有嘅传统亦占备为榜"
+      "ref_sub_1": "「抢包山」从此被禁！",
+      "ref_sub_2": "而长洲独有的传统，亦渐被遗忘",
+      "target_sub_1": "而长洲特有嘅传统亦占备为榜",
+      "target_sub_2": "长洲特有嘅传统亦占备为榜"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "奥运金牌⋯这一世是没有机会的了",
-      "src_1_sub_2": "每个星期六我都搭船过长洲",
-      "src_2_sub_1": "奥运金牌我谂呢一世都唔会攞到",
-      "src_2_sub_2": "每个礼拜六我都会搭船过长洲"
+      "ref_sub_1": "奥运金牌⋯这一世是没有机会的了",
+      "ref_sub_2": "每个星期六我都搭船过长洲",
+      "target_sub_1": "奥运金牌我谂呢一世都唔会攞到",
+      "target_sub_2": "每个礼拜六我都会搭船过长洲"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "每个星期六我都搭船过长洲",
-      "src_1_sub_2": "去学抢包山⋯",
-      "src_2_sub_1": "每个礼拜六我都会搭船过长洲",
-      "src_2_sub_2": "去学抢包山"
+      "ref_sub_1": "每个星期六我都搭船过长洲",
+      "ref_sub_2": "去学抢包山⋯",
+      "target_sub_1": "每个礼拜六我都会搭船过长洲",
+      "target_sub_2": "去学抢包山"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "去学抢包山⋯",
-      "src_1_sub_2": "一项没有奖牌，没有对手，没有比赛⋯",
-      "src_2_sub_1": "去学抢包山",
-      "src_2_sub_2": "一日冇奖牌冇对手冇比赛"
+      "ref_sub_1": "去学抢包山⋯",
+      "ref_sub_2": "一项没有奖牌，没有对手，没有比赛⋯",
+      "target_sub_1": "去学抢包山",
+      "target_sub_2": "一日冇奖牌冇对手冇比赛"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "一项没有奖牌，没有对手，没有比赛⋯",
-      "src_1_sub_2": "什至没有人知道是运动的运动",
-      "src_2_sub_1": "一日冇奖牌冇对手冇比赛",
-      "src_2_sub_2": "甚至乎冇人知对佢系运动嘅运动"
+      "ref_sub_1": "一项没有奖牌，没有对手，没有比赛⋯",
+      "ref_sub_2": "什至没有人知道是运动的运动",
+      "target_sub_1": "一日冇奖牌冇对手冇比赛",
+      "target_sub_2": "甚至乎冇人知对佢系运动嘅运动"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "什至没有人知道是运动的运动",
-      "src_1_sub_2": "更坏的是，连包山也没有！",
-      "src_2_sub_1": "甚至乎冇人知对佢系运动嘅运动",
-      "src_2_sub_2": "更衰嘅系连包山都冇"
+      "ref_sub_1": "什至没有人知道是运动的运动",
+      "ref_sub_2": "更坏的是，连包山也没有！",
+      "target_sub_1": "甚至乎冇人知对佢系运动嘅运动",
+      "target_sub_2": "更衰嘅系连包山都冇"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "更坏的是，连包山也没有！",
-      "src_1_sub_2": "师傅只是叫我去他的家⋯",
-      "src_2_sub_1": "更衰嘅系连包山都冇",
-      "src_2_sub_2": "师傅净系叫我去佢屋企"
+      "ref_sub_1": "更坏的是，连包山也没有！",
+      "ref_sub_2": "师傅只是叫我去他的家⋯",
+      "target_sub_1": "更衰嘅系连包山都冇",
+      "target_sub_2": "师傅净系叫我去佢屋企"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "师傅只是叫我去他的家⋯",
-      "src_1_sub_2": "在组合柜爬来爬去",
-      "src_2_sub_1": "师傅净系叫我去佢屋企",
-      "src_2_sub_2": "喺个组合柜度爬嚟爬去"
+      "ref_sub_1": "师傅只是叫我去他的家⋯",
+      "ref_sub_2": "在组合柜爬来爬去",
+      "target_sub_1": "师傅净系叫我去佢屋企",
+      "target_sub_2": "喺个组合柜度爬嚟爬去"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "在组合柜爬来爬去",
-      "src_1_sub_2": "碰！三番！",
-      "src_2_sub_1": "喺个组合柜度爬嚟爬去",
-      "src_2_sub_2": "通三番"
+      "ref_sub_1": "在组合柜爬来爬去",
+      "ref_sub_2": "碰！三番！",
+      "target_sub_1": "喺个组合柜度爬嚟爬去",
+      "target_sub_2": "通三番"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "碰！三番！",
-      "src_1_sub_2": "别躲懒！继续练！",
-      "src_2_sub_1": "通三番",
-      "src_2_sub_2": "冇偷懒继续练"
+      "ref_sub_1": "碰！三番！",
+      "ref_sub_2": "别躲懒！继续练！",
+      "target_sub_1": "通三番",
+      "target_sub_2": "冇偷懒继续练"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "别躲懒！继续练！",
-      "src_1_sub_2": "一天，珊珊到了师传家！",
-      "src_2_sub_1": "冇偷懒继续练",
-      "src_2_sub_2": "有一日山伞嚟咗师傅屋企"
+      "ref_sub_1": "别躲懒！继续练！",
+      "ref_sub_2": "一天，珊珊到了师传家！",
+      "target_sub_1": "冇偷懒继续练",
+      "target_sub_2": "有一日山伞嚟咗师傅屋企"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "一天，珊珊到了师传家！",
-      "src_1_sub_2": "珊珊！我的师姐珊珊！",
-      "src_2_sub_1": "有一日山伞嚟咗师傅屋企",
-      "src_2_sub_2": "山伞我个师仔山伞啊"
+      "ref_sub_1": "一天，珊珊到了师传家！",
+      "ref_sub_2": "珊珊！我的师姐珊珊！",
+      "target_sub_1": "有一日山伞嚟咗师傅屋企",
+      "target_sub_2": "山伞我个师仔山伞啊"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "珊珊！我的师姐珊珊！",
-      "src_1_sub_2": "可以看见珊珊⋯",
-      "src_2_sub_1": "山伞我个师仔山伞啊",
-      "src_2_sub_2": "可以见到山伞"
+      "ref_sub_1": "珊珊！我的师姐珊珊！",
+      "ref_sub_2": "可以看见珊珊⋯",
+      "target_sub_1": "山伞我个师仔山伞啊",
+      "target_sub_2": "可以见到山伞"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "可以看见珊珊⋯",
-      "src_1_sub_2": "这几个星期爬得再辛苦也是值得的！",
-      "src_2_sub_1": "可以见到山伞",
-      "src_2_sub_2": "爬得咁辛苦都系值得㗎"
+      "ref_sub_1": "可以看见珊珊⋯",
+      "ref_sub_2": "这几个星期爬得再辛苦也是值得的！",
+      "target_sub_1": "可以见到山伞",
+      "target_sub_2": "爬得咁辛苦都系值得㗎"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "这几个星期爬得再辛苦也是值得的！",
-      "src_1_sub_2": "珊珊！",
-      "src_2_sub_1": "爬得咁辛苦都系值得㗎",
-      "src_2_sub_2": "山伞"
+      "ref_sub_1": "这几个星期爬得再辛苦也是值得的！",
+      "ref_sub_2": "珊珊！",
+      "target_sub_1": "爬得咁辛苦都系值得㗎",
+      "target_sub_2": "山伞"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "珊珊！",
-      "src_1_sub_2": "珊你个头！继续练习！",
-      "src_2_sub_1": "山伞",
-      "src_2_sub_2": "伞你个头啊继续练习"
+      "ref_sub_1": "珊珊！",
+      "ref_sub_2": "珊你个头！继续练习！",
+      "target_sub_1": "山伞",
+      "target_sub_2": "伞你个头啊继续练习"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "还不去？",
-      "src_1_sub_2": "珊珊没看见我这个师弟",
-      "src_2_sub_1": "仲唔系",
-      "src_2_sub_2": "山神佢见唔到我呢个师弟"
+      "ref_sub_1": "还不去？",
+      "ref_sub_2": "珊珊没看见我这个师弟",
+      "target_sub_1": "仲唔系",
+      "target_sub_2": "山神佢见唔到我呢个师弟"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "珊珊没看见我这个师弟",
-      "src_1_sub_2": "我只有死死气再爬上组合柜",
-      "src_2_sub_1": "山神佢见唔到我呢个师弟",
-      "src_2_sub_2": "我唯有死死气爬返上个组合柜"
+      "ref_sub_1": "珊珊没看见我这个师弟",
+      "ref_sub_2": "我只有死死气再爬上组合柜",
+      "target_sub_1": "山神佢见唔到我呢个师弟",
+      "target_sub_2": "我唯有死死气爬返上个组合柜"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我只有死死气再爬上组合柜",
-      "src_1_sub_2": "我咁大个仔，什么「头」也给骂过⋯",
-      "src_2_sub_1": "我唯有死死气爬返上个组合柜",
-      "src_2_sub_2": "我咁大个仔乜嘢头都畀人闹过"
+      "ref_sub_1": "我只有死死气再爬上组合柜",
+      "ref_sub_2": "我咁大个仔，什么「头」也给骂过⋯",
+      "target_sub_1": "我唯有死死气爬返上个组合柜",
+      "target_sub_2": "我咁大个仔乜嘢头都畀人闹过"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我咁大个仔，什么「头」也给骂过⋯",
-      "src_1_sub_2": "不知道为什么「珊你个头」却特别刺耳",
-      "src_2_sub_1": "我咁大个仔乜嘢头都畀人闹过",
-      "src_2_sub_2": "但系山呢个头唔知点解特别瘾"
+      "ref_sub_1": "我咁大个仔，什么「头」也给骂过⋯",
+      "ref_sub_2": "不知道为什么「珊你个头」却特别刺耳",
+      "target_sub_1": "我咁大个仔乜嘢头都畀人闹过",
+      "target_sub_2": "但系山呢个头唔知点解特别瘾"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "不知道为什么「珊你个头」却特别刺耳",
-      "src_1_sub_2": "我⋯我⋯",
-      "src_2_sub_1": "但系山呢个头唔知点解特别瘾",
-      "src_2_sub_2": "我我"
+      "ref_sub_1": "不知道为什么「珊你个头」却特别刺耳",
+      "ref_sub_2": "我⋯我⋯",
+      "target_sub_1": "但系山呢个头唔知点解特别瘾",
+      "target_sub_2": "我我"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我⋯我⋯",
-      "src_1_sub_2": "我唔学抢包山了！",
-      "src_2_sub_1": "我我",
-      "src_2_sub_2": "我唔好抢包纱嘞字幕由纱友提供"
+      "ref_sub_1": "我⋯我⋯",
+      "ref_sub_2": "我唔学抢包山了！",
+      "target_sub_1": "我我",
+      "target_sub_2": "我唔好抢包纱嘞字幕由纱友提供"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "其实今天是我第一次近距离见黎根",
-      "src_1_sub_2": "他恐怕都有五十岁了",
-      "src_2_sub_1": "其实今日系我第一次咁近距离同丽根见面",
-      "src_2_sub_2": "睇怕佢都有五十岁啦"
+      "ref_sub_1": "其实今天是我第一次近距离见黎根",
+      "ref_sub_2": "他恐怕都有五十岁了",
+      "target_sub_1": "其实今日系我第一次咁近距离同丽根见面",
+      "target_sub_2": "睇怕佢都有五十岁啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "他恐怕都有五十岁了",
-      "src_1_sub_2": "却还是一副孩子脸",
-      "src_2_sub_1": "睇怕佢都有五十岁啦",
-      "src_2_sub_2": "但系仲有一副孩子脸"
+      "ref_sub_1": "他恐怕都有五十岁了",
+      "ref_sub_2": "却还是一副孩子脸",
+      "target_sub_1": "睇怕佢都有五十岁啦",
+      "target_sub_2": "但系仲有一副孩子脸"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "却还是一副孩子脸",
-      "src_1_sub_2": "鸡尾包！新鲜出炉！",
-      "src_2_sub_1": "但系仲有一副孩子脸",
-      "src_2_sub_2": "鸡尾包啱啱出炉嘅"
+      "ref_sub_1": "却还是一副孩子脸",
+      "ref_sub_2": "鸡尾包！新鲜出炉！",
+      "target_sub_1": "但系仲有一副孩子脸",
+      "target_sub_2": "鸡尾包啱啱出炉嘅"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "其实鸡尾包呢⋯",
-      "src_1_sub_2": "你说这似不似鸡尾？",
-      "src_2_sub_1": "其实鸡尾爆呢",
-      "src_2_sub_2": "吓你话噉样似唔似鸡尾呀哈哈哈哈"
+      "ref_sub_1": "其实鸡尾包呢⋯",
+      "ref_sub_2": "你说这似不似鸡尾？",
+      "target_sub_1": "其实鸡尾爆呢",
+      "target_sub_2": "吓你话噉样似唔似鸡尾呀哈哈哈哈"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "麦兜他学东西⋯还可以",
-      "src_1_sub_2": "黎根接著说了一大堆话⋯",
-      "src_2_sub_1": "麦兜嘅学嘢呢都仲可以",
-      "src_2_sub_2": "跟住黎根讲咗一大堆说话"
+      "ref_sub_1": "麦兜他学东西⋯还可以",
+      "ref_sub_2": "黎根接著说了一大堆话⋯",
+      "target_sub_1": "麦兜嘅学嘢呢都仲可以",
+      "target_sub_2": "跟住黎根讲咗一大堆说话"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "黎根接著说了一大堆话⋯",
-      "src_1_sub_2": "他的抱负，他对麦兜的期望",
-      "src_2_sub_1": "跟住黎根讲咗一大堆说话",
-      "src_2_sub_2": "讲下佢嘅抱负佢对麦兜嘅期望"
+      "ref_sub_1": "黎根接著说了一大堆话⋯",
+      "ref_sub_2": "他的抱负，他对麦兜的期望",
+      "target_sub_1": "跟住黎根讲咗一大堆说话",
+      "target_sub_2": "讲下佢嘅抱负佢对麦兜嘅期望"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "他的抱负，他对麦兜的期望",
-      "src_1_sub_2": "他说他会把他所识的毫不保留教给麦兜",
-      "src_2_sub_1": "讲下佢嘅抱负佢对麦兜嘅期望",
-      "src_2_sub_2": "佢话会将佢识嘅嘢毫无保留噉教晒畀麦兜"
+      "ref_sub_1": "他的抱负，他对麦兜的期望",
+      "ref_sub_2": "他说他会把他所识的毫不保留教给麦兜",
+      "target_sub_1": "讲下佢嘅抱负佢对麦兜嘅期望",
+      "target_sub_2": "佢话会将佢识嘅嘢毫无保留噉教晒畀麦兜"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "他说他会把他所识的毫不保留教给麦兜",
-      "src_1_sub_2": "黎根越说越兴奋，直到双眼发光",
-      "src_2_sub_1": "佢话会将佢识嘅嘢毫无保留噉教晒畀麦兜",
-      "src_2_sub_2": "黎根越讲越兴奋"
+      "ref_sub_1": "他说他会把他所识的毫不保留教给麦兜",
+      "ref_sub_2": "黎根越说越兴奋，直到双眼发光",
+      "target_sub_1": "佢话会将佢识嘅嘢毫无保留噉教晒畀麦兜",
+      "target_sub_2": "黎根越讲越兴奋"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "黎根越说越兴奋，直到双眼发光",
-      "src_1_sub_2": "他又说滑浪风帆并不是他最犀利的项目",
-      "src_2_sub_1": "黎根越讲越兴奋",
-      "src_2_sub_2": "佢话滑浪风帆都唔系佢最犀利嗰样"
+      "ref_sub_1": "黎根越说越兴奋，直到双眼发光",
+      "ref_sub_2": "他又说滑浪风帆并不是他最犀利的项目",
+      "target_sub_1": "黎根越讲越兴奋",
+      "target_sub_2": "佢话滑浪风帆都唔系佢最犀利嗰样"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "他又说滑浪风帆并不是他最犀利的项目",
-      "src_1_sub_2": "他最大强项是抢包山",
-      "src_2_sub_1": "佢话滑浪风帆都唔系佢最犀利嗰样",
-      "src_2_sub_2": "佢最劲嘅就系抢包山"
+      "ref_sub_1": "他又说滑浪风帆并不是他最犀利的项目",
+      "ref_sub_2": "他最大强项是抢包山",
+      "target_sub_1": "佢话滑浪风帆都唔系佢最犀利嗰样",
+      "target_sub_2": "佢最劲嘅就系抢包山"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "他最大强项是抢包山",
-      "src_1_sub_2": "他说抢包山结合了南拳",
-      "src_2_sub_1": "佢最劲嘅就系抢包山",
-      "src_2_sub_2": "佢话抢包山结合咗南拳"
+      "ref_sub_1": "他最大强项是抢包山",
+      "ref_sub_2": "他说抢包山结合了南拳",
+      "target_sub_1": "佢最劲嘅就系抢包山",
+      "target_sub_2": "佢话抢包山结合咗南拳"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "他说抢包山结合了南拳",
-      "src_1_sub_2": "神功戏和现代器械操",
-      "src_2_sub_1": "佢话抢包山结合咗南拳",
-      "src_2_sub_2": "神功气现代气蟹粗"
+      "ref_sub_1": "他说抢包山结合了南拳",
+      "ref_sub_2": "神功戏和现代器械操",
+      "target_sub_1": "佢话抢包山结合咗南拳",
+      "target_sub_2": "神功气现代气蟹粗"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "神功戏和现代器械操",
-      "src_1_sub_2": "他说抢包山才是他一生最大成就",
-      "src_2_sub_1": "神功气现代气蟹粗",
-      "src_2_sub_2": "佢话抢包山先至系佢呢世人最大嘅成就"
+      "ref_sub_1": "神功戏和现代器械操",
+      "ref_sub_2": "他说抢包山才是他一生最大成就",
+      "target_sub_1": "神功气现代气蟹粗",
+      "target_sub_2": "佢话抢包山先至系佢呢世人最大嘅成就"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "他说抢包山才是他一生最大成就",
-      "src_1_sub_2": "缩脚，唔该！",
-      "src_2_sub_1": "佢话抢包山先至系佢呢世人最大嘅成就",
-      "src_2_sub_2": "缩嗰只脚唔该"
+      "ref_sub_1": "他说抢包山才是他一生最大成就",
+      "ref_sub_2": "缩脚，唔该！",
+      "target_sub_1": "佢话抢包山先至系佢呢世人最大嘅成就",
+      "target_sub_2": "缩嗰只脚唔该"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "缩脚，唔该！",
-      "src_1_sub_2": "你看！",
-      "src_2_sub_1": "缩嗰只脚唔该",
-      "src_2_sub_2": "你睇下"
+      "ref_sub_1": "缩脚，唔该！",
+      "ref_sub_2": "你看！",
+      "target_sub_1": "缩嗰只脚唔该",
+      "target_sub_2": "你睇下"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "你看！",
-      "src_1_sub_2": "这脚瓜⋯好粗好大！比一节瓜还要大！",
-      "src_2_sub_1": "你睇下",
-      "src_2_sub_2": "哗呢节呢节脚瓜好粗好大呀仲大过节瓜"
+      "ref_sub_1": "你看！",
+      "ref_sub_2": "这脚瓜⋯好粗好大！比一节瓜还要大！",
+      "target_sub_1": "你睇下",
+      "target_sub_2": "哗呢节呢节脚瓜好粗好大呀仲大过节瓜"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "这脚瓜⋯好粗好大！比一节瓜还要大！",
-      "src_1_sub_2": "脚瓜的肌肉非常结实⋯",
-      "src_2_sub_1": "哗呢节呢节脚瓜好粗好大呀仲大过节瓜",
-      "src_2_sub_2": "脚瓜嘅肌肉非常结实"
+      "ref_sub_1": "这脚瓜⋯好粗好大！比一节瓜还要大！",
+      "ref_sub_2": "脚瓜的肌肉非常结实⋯",
+      "target_sub_1": "哗呢节呢节脚瓜好粗好大呀仲大过节瓜",
+      "target_sub_2": "脚瓜嘅肌肉非常结实"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "脚瓜的肌肉非常结实⋯",
-      "src_1_sub_2": "青筋凸现，钢线似的",
-      "src_2_sub_1": "脚瓜嘅肌肉非常结实",
-      "src_2_sub_2": "啲青筋凸晒出嚟好似钢线噉"
+      "ref_sub_1": "脚瓜的肌肉非常结实⋯",
+      "ref_sub_2": "青筋凸现，钢线似的",
+      "target_sub_1": "脚瓜嘅肌肉非常结实",
+      "target_sub_2": "啲青筋凸晒出嚟好似钢线噉"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "青筋凸现，钢线似的",
-      "src_1_sub_2": "每一条脚毛都硬似铁钉",
-      "src_2_sub_1": "啲青筋凸晒出嚟好似钢线噉",
-      "src_2_sub_2": "啲脚毛每一条都好似铁钉咁硬"
+      "ref_sub_1": "青筋凸现，钢线似的",
+      "ref_sub_2": "每一条脚毛都硬似铁钉",
+      "target_sub_1": "啲青筋凸晒出嚟好似钢线噉",
+      "target_sub_2": "啲脚毛每一条都好似铁钉咁硬"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "每一条脚毛都硬似铁钉",
-      "src_1_sub_2": "脚趾甲有一寸厚，究竟⋯",
-      "src_2_sub_1": "啲脚毛每一条都好似铁钉咁硬",
-      "src_2_sub_2": "脚趾弓啲脚夹成串咁厚"
+      "ref_sub_1": "每一条脚毛都硬似铁钉",
+      "ref_sub_2": "脚趾甲有一寸厚，究竟⋯",
+      "target_sub_1": "啲脚毛每一条都好似铁钉咁硬",
+      "target_sub_2": "脚趾弓啲脚夹成串咁厚"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "脚趾甲有一寸厚，究竟⋯",
-      "src_1_sub_2": "要走过几多座山",
-      "src_2_sub_1": "脚趾弓啲脚夹成串咁厚",
-      "src_2_sub_2": "究竟要行个几度呢?"
+      "ref_sub_1": "脚趾甲有一寸厚，究竟⋯",
+      "ref_sub_2": "要走过几多座山",
+      "target_sub_1": "脚趾弓啲脚夹成串咁厚",
+      "target_sub_2": "究竟要行个几度呢?"
     },
     "answer": {
-      "src_2_sub_1_shifted": "脚趾弓啲脚夹成串咁厚究竟",
-      "src_2_sub_2_shifted": "要行个几度呢?"
+      "target_sub_1_shifted": "脚趾弓啲脚夹成串咁厚究竟",
+      "target_sub_2_shifted": "要行个几度呢?"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "要走过几多座山",
-      "src_1_sub_2": "跨过几多个海",
-      "src_2_sub_1": "要行个几度呢?",
-      "src_2_sub_2": "几多座山挂过几多个海"
+      "ref_sub_1": "要走过几多座山",
+      "ref_sub_2": "跨过几多个海",
+      "target_sub_1": "要行个几度呢?",
+      "target_sub_2": "几多座山挂过几多个海"
     },
     "answer": {
-      "src_2_sub_1_shifted": "要行个几度呢?几多座山",
-      "src_2_sub_2_shifted": "挂过几多个海"
+      "target_sub_1_shifted": "要行个几度呢?几多座山",
+      "target_sub_2_shifted": "挂过几多个海"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "跨过几多个海",
-      "src_1_sub_2": "吃过几多苦头",
-      "src_2_sub_1": "挂过几多个海",
-      "src_2_sub_2": "挨过几多斧头"
+      "ref_sub_1": "跨过几多个海",
+      "ref_sub_2": "吃过几多苦头",
+      "target_sub_1": "挂过几多个海",
+      "target_sub_2": "挨过几多斧头"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "吃过几多苦头",
-      "src_1_sub_2": "才可以练成这举世无双的脚瓜？",
-      "src_2_sub_1": "挨过几多斧头",
-      "src_2_sub_2": "先至可以练成呢一只举细无伤嘅脚瓜"
+      "ref_sub_1": "吃过几多苦头",
+      "ref_sub_2": "才可以练成这举世无双的脚瓜？",
+      "target_sub_1": "挨过几多斧头",
+      "target_sub_2": "先至可以练成呢一只举细无伤嘅脚瓜"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我个仔⋯",
-      "src_1_sub_2": "你个仔，他日都会有这只大脚瓜",
-      "src_2_sub_1": "我个仔",
-      "src_2_sub_2": "你个仔第时都会有我咁大只脚瓜"
+      "ref_sub_1": "我个仔⋯",
+      "ref_sub_2": "你个仔，他日都会有这只大脚瓜",
+      "target_sub_1": "我个仔",
+      "target_sub_2": "你个仔第时都会有我咁大只脚瓜"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "你个仔，他日都会有这只大脚瓜",
-      "src_1_sub_2": "其实我也不知道个仔要这么粗的脚瓜⋯",
-      "src_2_sub_1": "你个仔第时都会有我咁大只脚瓜",
-      "src_2_sub_2": "其实我都唔知我仔要咁粗嘅脚瓜有咩用"
+      "ref_sub_1": "你个仔，他日都会有这只大脚瓜",
+      "ref_sub_2": "其实我也不知道个仔要这么粗的脚瓜⋯",
+      "target_sub_1": "你个仔第时都会有我咁大只脚瓜",
+      "target_sub_2": "其实我都唔知我仔要咁粗嘅脚瓜有咩用"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "其实我也不知道个仔要这么粗的脚瓜⋯",
-      "src_1_sub_2": "有什么用",
-      "src_2_sub_1": "其实我都唔知我仔要咁粗嘅脚瓜有咩用"
+      "ref_sub_1": "其实我也不知道个仔要这么粗的脚瓜⋯",
+      "ref_sub_2": "有什么用",
+      "target_sub_1": "其实我都唔知我仔要咁粗嘅脚瓜有咩用"
     },
     "answer": {
-      "src_2_sub_1_shifted": "其实我都唔知我仔要咁粗嘅脚瓜",
-      "src_2_sub_2_shifted": "有咩用"
+      "target_sub_1_shifted": "其实我都唔知我仔要咁粗嘅脚瓜",
+      "target_sub_2_shifted": "有咩用"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "你个仔，他日都会有这只大脚瓜",
-      "src_1_sub_2": "其实我也不知道个仔要这么粗的脚瓜⋯",
-      "src_2_sub_1": "你个仔第时都会有我咁大只脚瓜",
-      "src_2_sub_2": "其实我都唔知我仔要咁粗嘅脚瓜"
+      "ref_sub_1": "你个仔，他日都会有这只大脚瓜",
+      "ref_sub_2": "其实我也不知道个仔要这么粗的脚瓜⋯",
+      "target_sub_1": "你个仔第时都会有我咁大只脚瓜",
+      "target_sub_2": "其实我都唔知我仔要咁粗嘅脚瓜"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "其实我也不知道个仔要这么粗的脚瓜⋯",
-      "src_1_sub_2": "有什么用",
-      "src_2_sub_1": "其实我都唔知我仔要咁粗嘅脚瓜",
-      "src_2_sub_2": "有咩用"
+      "ref_sub_1": "其实我也不知道个仔要这么粗的脚瓜⋯",
+      "ref_sub_2": "有什么用",
+      "target_sub_1": "其实我都唔知我仔要咁粗嘅脚瓜",
+      "target_sub_2": "有咩用"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "有什么用",
-      "src_1_sub_2": "可是看见那些凸现的青筋，不知怎样⋯",
-      "src_2_sub_1": "有咩用",
-      "src_2_sub_2": "但系见到佢一条条凸起嘅青筋唔知点解"
+      "ref_sub_1": "有什么用",
+      "ref_sub_2": "可是看见那些凸现的青筋，不知怎样⋯",
+      "target_sub_1": "有咩用",
+      "target_sub_2": "但系见到佢一条条凸起嘅青筋唔知点解"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "可是看见那些凸现的青筋，不知怎样⋯",
-      "src_1_sub_2": "我想起麦兜的爸爸，阿炳",
-      "src_2_sub_1": "但系见到佢一条条凸起嘅青筋唔知点解",
-      "src_2_sub_2": "我我谂起麦兜嘅爸爸阿炳"
+      "ref_sub_1": "可是看见那些凸现的青筋，不知怎样⋯",
+      "ref_sub_2": "我想起麦兜的爸爸，阿炳",
+      "target_sub_1": "但系见到佢一条条凸起嘅青筋唔知点解",
+      "target_sub_2": "我我谂起麦兜嘅爸爸阿炳"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我找来找去也找不到那部电子英文辞典",
-      "src_1_sub_2": "跑哪去了？",
-      "src_2_sub_1": "我揾完成间屋都揾唔到部电子英文词典",
-      "src_2_sub_2": "去咗边呢"
+      "ref_sub_1": "我找来找去也找不到那部电子英文辞典",
+      "ref_sub_2": "跑哪去了？",
+      "target_sub_1": "我揾完成间屋都揾唔到部电子英文词典",
+      "target_sub_2": "去咗边呢"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "跑哪去了？",
-      "src_1_sub_2": "难道⋯　不会吧？",
-      "src_2_sub_1": "去咗边呢",
-      "src_2_sub_2": "唔通冇理由㗎"
+      "ref_sub_1": "跑哪去了？",
+      "ref_sub_2": "难道⋯　不会吧？",
+      "target_sub_1": "去咗边呢",
+      "target_sub_2": "唔通冇理由㗎"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "想不到真的让妈妈拿去了．吓得我！",
-      "src_1_sub_2": "妈妈怎么会写起英文信？",
-      "src_2_sub_1": "咦估唔到真系妈妈攞咗㖞嚇得我啊",
-      "src_2_sub_2": "点解妈妈会用英文写信嘅"
+      "ref_sub_1": "想不到真的让妈妈拿去了．吓得我！",
+      "ref_sub_2": "妈妈怎么会写起英文信？",
+      "target_sub_1": "咦估唔到真系妈妈攞咗㖞嚇得我啊",
+      "target_sub_2": "点解妈妈会用英文写信嘅"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈怎么会写起英文信？",
-      "src_1_sub_2": "信很短",
-      "src_2_sub_1": "点解妈妈会用英文写信嘅",
-      "src_2_sub_2": "封信好短"
+      "ref_sub_1": "妈妈怎么会写起英文信？",
+      "ref_sub_2": "信很短",
+      "target_sub_1": "点解妈妈会用英文写信嘅",
+      "target_sub_2": "封信好短"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "信很短",
-      "src_1_sub_2": "我猜是妈妈用电子辞典逐个字译成英文",
-      "src_2_sub_1": "封信好短",
-      "src_2_sub_2": "我谂妈妈佢系好辛苦用电子词典逐个逐个字译做英文"
+      "ref_sub_1": "信很短",
+      "ref_sub_2": "我猜是妈妈用电子辞典逐个字译成英文",
+      "target_sub_1": "封信好短",
+      "target_sub_2": "我谂妈妈佢系好辛苦用电子词典逐个逐个字译做英文"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我猜是妈妈用电子辞典逐个字译成英文",
-      "src_1_sub_2": "于是我又用电子辞典把信译回中文",
-      "src_2_sub_1": "我谂妈妈佢系好辛苦用电子词典逐个逐个字译做英文",
-      "src_2_sub_2": "于是我让返电子词典将封信译返做中文"
+      "ref_sub_1": "我猜是妈妈用电子辞典逐个字译成英文",
+      "ref_sub_2": "于是我又用电子辞典把信译回中文",
+      "target_sub_1": "我谂妈妈佢系好辛苦用电子词典逐个逐个字译做英文",
+      "target_sub_2": "于是我让返电子词典将封信译返做中文"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "于是我又用电子辞典把信译回中文",
-      "src_1_sub_2": "信，是妈妈写给奥委会主席的",
-      "src_2_sub_1": "于是我让返电子词典将封信译返做中文",
-      "src_2_sub_2": "封信原来系妈妈写畀奥委会主席㗎"
+      "ref_sub_1": "于是我又用电子辞典把信译回中文",
+      "ref_sub_2": "信，是妈妈写给奥委会主席的",
+      "target_sub_1": "于是我让返电子词典将封信译返做中文",
+      "target_sub_2": "封信原来系妈妈写畀奥委会主席㗎"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "信，是妈妈写给奥委会主席的",
-      "src_1_sub_2": "「亲爱的主席：」",
-      "src_2_sub_1": "封信原来系妈妈写畀奥委会主席㗎",
-      "src_2_sub_2": "亲爱的主席"
+      "ref_sub_1": "信，是妈妈写给奥委会主席的",
+      "ref_sub_2": "「亲爱的主席：」",
+      "target_sub_1": "封信原来系妈妈写畀奥委会主席㗎",
+      "target_sub_2": "亲爱的主席"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「亲爱的主席：」",
-      "src_1_sub_2": "「你好吗？我很好！」",
-      "src_2_sub_1": "亲爱的主席",
-      "src_2_sub_2": "你好吗我很好"
+      "ref_sub_1": "「亲爱的主席：」",
+      "ref_sub_2": "「你好吗？我很好！」",
+      "target_sub_1": "亲爱的主席",
+      "target_sub_2": "你好吗我很好"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「你好吗？我很好！」",
-      "src_1_sub_2": "「你吃包吗？我吃包！」",
-      "src_2_sub_1": "你好吗我很好",
-      "src_2_sub_2": "你吃包吗我吃包"
+      "ref_sub_1": "「你好吗？我很好！」",
+      "ref_sub_2": "「你吃包吗？我吃包！」",
+      "target_sub_1": "你好吗我很好",
+      "target_sub_2": "你吃包吗我吃包"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「你吃包吗？我吃包！」",
-      "src_1_sub_2": "「我们居住在香港这里的人，很爱吃包」",
-      "src_2_sub_1": "你吃包吗我吃包",
-      "src_2_sub_2": "我门居住在香港这类的人肯爱吃包"
+      "ref_sub_1": "「你吃包吗？我吃包！」",
+      "ref_sub_2": "「我们居住在香港这里的人，很爱吃包」",
+      "target_sub_1": "你吃包吗我吃包",
+      "target_sub_2": "我门居住在香港这类的人肯爱吃包"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「我们居住在香港这里的人，很爱吃包」",
-      "src_1_sub_2": "「小笼包，上海包，广东包，莲蓉包」",
-      "src_2_sub_1": "我门居住在香港这类的人肯爱吃包",
-      "src_2_sub_2": "小笼包上海包广东包联融包"
+      "ref_sub_1": "「我们居住在香港这里的人，很爱吃包」",
+      "ref_sub_2": "「小笼包，上海包，广东包，莲蓉包」",
+      "target_sub_1": "我门居住在香港这类的人肯爱吃包",
+      "target_sub_2": "小笼包上海包广东包联融包"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「小笼包，上海包，广东包，莲蓉包」",
-      "src_1_sub_2": "「好朋友，我认为",
-      "src_2_sub_1": "小笼包上海包广东包联融包",
-      "src_2_sub_2": "好朋友"
+      "ref_sub_1": "「小笼包，上海包，广东包，莲蓉包」",
+      "ref_sub_2": "「好朋友，我认为",
+      "target_sub_1": "小笼包上海包广东包联融包",
+      "target_sub_2": "好朋友"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「好朋友，我认为",
-      "src_1_sub_2": "抢劫那些包，十分重要」",
-      "src_2_sub_1": "好朋友",
-      "src_2_sub_2": "我认为抢劫嗰些包十分重要"
+      "ref_sub_1": "「好朋友，我认为",
+      "ref_sub_2": "抢劫那些包，十分重要」",
+      "target_sub_1": "好朋友",
+      "target_sub_2": "我认为抢劫嗰些包十分重要"
     },
     "answer": {
-      "src_2_sub_1_shifted": "好朋友我认为",
-      "src_2_sub_2_shifted": "抢劫嗰些包十分重要"
+      "target_sub_1_shifted": "好朋友我认为",
+      "target_sub_2_shifted": "抢劫嗰些包十分重要"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "抢劫那些包，十分重要」",
-      "src_1_sub_2": "「也算是运动，就真！」",
-      "src_2_sub_1": "抢劫嗰些包十分重要",
-      "src_2_sub_2": "也算是运动就真"
+      "ref_sub_1": "抢劫那些包，十分重要」",
+      "ref_sub_2": "「也算是运动，就真！」",
+      "target_sub_1": "抢劫嗰些包十分重要",
+      "target_sub_2": "也算是运动就真"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「也算是运动，就真！」",
-      "src_1_sub_2": "「要大力！大吃晚上的粥，和大节瓜！」",
-      "src_2_sub_1": "也算是运动就真",
-      "src_2_sub_2": "要大力大吃吻上的粥和大字瓜"
+      "ref_sub_1": "「也算是运动，就真！」",
+      "ref_sub_2": "「要大力！大吃晚上的粥，和大节瓜！」",
+      "target_sub_1": "也算是运动就真",
+      "target_sub_2": "要大力大吃吻上的粥和大字瓜"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「要大力！大吃晚上的粥，和大节瓜！」",
-      "src_1_sub_2": "「按照我愚蠢的见解⋯」",
-      "src_2_sub_1": "要大力大吃吻上的粥和大字瓜",
-      "src_2_sub_2": "按照我愚蠢的见解"
+      "ref_sub_1": "「要大力！大吃晚上的粥，和大节瓜！」",
+      "ref_sub_2": "「按照我愚蠢的见解⋯」",
+      "target_sub_1": "要大力大吃吻上的粥和大字瓜",
+      "target_sub_2": "按照我愚蠢的见解"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「按照我愚蠢的见解⋯」",
-      "src_1_sub_2": "「抢劫那些包，是奥运会比赛」",
-      "src_2_sub_1": "按照我愚蠢的见解",
-      "src_2_sub_2": "抢劫嗰些包系奥运会比赛"
+      "ref_sub_1": "「按照我愚蠢的见解⋯」",
+      "ref_sub_2": "「抢劫那些包，是奥运会比赛」",
+      "target_sub_1": "按照我愚蠢的见解",
+      "target_sub_2": "抢劫嗰些包系奥运会比赛"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「抢劫那些包，是奥运会比赛」",
-      "src_1_sub_2": "「让全世界的体育家，抢过！」",
-      "src_2_sub_1": "抢劫嗰些包系奥运会比赛",
-      "src_2_sub_2": "让全世界嘅体育家抢过"
+      "ref_sub_1": "「抢劫那些包，是奥运会比赛」",
+      "ref_sub_2": "「让全世界的体育家，抢过！」",
+      "target_sub_1": "抢劫嗰些包系奥运会比赛",
+      "target_sub_2": "让全世界嘅体育家抢过"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「让全世界的体育家，抢过！」",
-      "src_1_sub_2": "「世界便和平！」",
-      "src_2_sub_1": "让全世界嘅体育家抢过",
-      "src_2_sub_2": "世界变和平"
+      "ref_sub_1": "「让全世界的体育家，抢过！」",
+      "ref_sub_2": "「世界便和平！」",
+      "target_sub_1": "让全世界嘅体育家抢过",
+      "target_sub_2": "世界变和平"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「世界便和平！」",
-      "src_1_sub_2": "「你有孩子吗？」",
-      "src_2_sub_1": "世界变和平",
-      "src_2_sub_2": "你有孩子吗"
+      "ref_sub_1": "「世界便和平！」",
+      "ref_sub_2": "「你有孩子吗？」",
+      "target_sub_1": "世界变和平",
+      "target_sub_2": "你有孩子吗"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「你有孩子吗？」",
-      "src_1_sub_2": "「我有一个孩子，麦兜」",
-      "src_2_sub_1": "你有孩子吗",
-      "src_2_sub_2": "我有一个孩子麦兜"
+      "ref_sub_1": "「你有孩子吗？」",
+      "ref_sub_2": "「我有一个孩子，麦兜」",
+      "target_sub_1": "你有孩子吗",
+      "target_sub_2": "我有一个孩子麦兜"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「我有一个孩子，麦兜」",
-      "src_1_sub_2": "终于讲到我了！",
-      "src_2_sub_1": "我有一个孩子麦兜",
-      "src_2_sub_2": "终于讲到我啦"
+      "ref_sub_1": "「我有一个孩子，麦兜」",
+      "ref_sub_2": "终于讲到我了！",
+      "target_sub_1": "我有一个孩子麦兜",
+      "target_sub_2": "终于讲到我啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "终于讲到我了！",
-      "src_1_sub_2": "「他是一个好男孩」",
-      "src_2_sub_1": "终于讲到我啦",
-      "src_2_sub_2": "她系一个好男孩"
+      "ref_sub_1": "终于讲到我了！",
+      "ref_sub_2": "「他是一个好男孩」",
+      "target_sub_1": "终于讲到我啦",
+      "target_sub_2": "她系一个好男孩"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「他是一个好男孩」",
-      "src_1_sub_2": "「他非常懂得抢劫那些包」",
-      "src_2_sub_1": "她系一个好男孩",
-      "src_2_sub_2": "她非常懂得抢劫嗰些包"
+      "ref_sub_1": "「他是一个好男孩」",
+      "ref_sub_2": "「他非常懂得抢劫那些包」",
+      "target_sub_1": "她系一个好男孩",
+      "target_sub_2": "她非常懂得抢劫嗰些包"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「他非常懂得抢劫那些包」",
-      "src_1_sub_2": "「有一天，我看见他，抢劫包⋯」",
-      "src_2_sub_1": "她非常懂得抢劫嗰些包",
-      "src_2_sub_2": "有一天我看见她抢劫包"
+      "ref_sub_1": "「他非常懂得抢劫那些包」",
+      "ref_sub_2": "「有一天，我看见他，抢劫包⋯」",
+      "target_sub_1": "她非常懂得抢劫嗰些包",
+      "target_sub_2": "有一天我看见她抢劫包"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「有一天，我看见他，抢劫包⋯」",
-      "src_1_sub_2": "「抢了一个奥运金牌」",
-      "src_2_sub_1": "有一天我看见她抢劫包",
-      "src_2_sub_2": "抢了一个奥运金牌"
+      "ref_sub_1": "「有一天，我看见他，抢劫包⋯」",
+      "ref_sub_2": "「抢了一个奥运金牌」",
+      "target_sub_1": "有一天我看见她抢劫包",
+      "target_sub_2": "抢了一个奥运金牌"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「抢了一个奥运金牌」",
-      "src_1_sub_2": "「那便是一个母亲能够有的最大的安慰」",
-      "src_2_sub_1": "抢了一个奥运金牌",
-      "src_2_sub_2": "哪便是一个母亲能够有的最好的最大的安慰"
+      "ref_sub_1": "「抢了一个奥运金牌」",
+      "ref_sub_2": "「那便是一个母亲能够有的最大的安慰」",
+      "target_sub_1": "抢了一个奥运金牌",
+      "target_sub_2": "哪便是一个母亲能够有的最好的最大的安慰"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「那便是一个母亲能够有的最大的安慰」",
-      "src_1_sub_2": "「孩子的才干，得到了世界人类的知道」",
-      "src_2_sub_1": "哪便是一个母亲能够有的最好的最大的安慰",
-      "src_2_sub_2": "孩子的才干得到了世界人类的知道"
+      "ref_sub_1": "「那便是一个母亲能够有的最大的安慰」",
+      "ref_sub_2": "「孩子的才干，得到了世界人类的知道」",
+      "target_sub_1": "哪便是一个母亲能够有的最好的最大的安慰",
+      "target_sub_2": "孩子的才干得到了世界人类的知道"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「孩子的才干，得到了世界人类的知道」",
-      "src_1_sub_2": "「父母愿意做什么的东西都得」",
-      "src_2_sub_1": "孩子的才干得到了世界人类的知道",
-      "src_2_sub_2": "父母愿意做什么的东西都得"
+      "ref_sub_1": "「孩子的才干，得到了世界人类的知道」",
+      "ref_sub_2": "「父母愿意做什么的东西都得」",
+      "target_sub_1": "孩子的才干得到了世界人类的知道",
+      "target_sub_2": "父母愿意做什么的东西都得"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「父母愿意做什么的东西都得」",
-      "src_1_sub_2": "「于是我写了这忽然间的信给你」",
-      "src_2_sub_1": "父母愿意做什么的东西都得",
-      "src_2_sub_2": "于是我写了这忽然间的信给你"
+      "ref_sub_1": "「父母愿意做什么的东西都得」",
+      "ref_sub_2": "「于是我写了这忽然间的信给你」",
+      "target_sub_1": "父母愿意做什么的东西都得",
+      "target_sub_2": "于是我写了这忽然间的信给你"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「于是我写了这忽然间的信给你」",
-      "src_1_sub_2": "「虽然你不知道我是什么微细的东西」",
-      "src_2_sub_1": "于是我写了这忽然间的信给你",
-      "src_2_sub_2": "虽然你不知道我是什么微细的东西"
+      "ref_sub_1": "「于是我写了这忽然间的信给你」",
+      "ref_sub_2": "「虽然你不知道我是什么微细的东西」",
+      "target_sub_1": "于是我写了这忽然间的信给你",
+      "target_sub_2": "虽然你不知道我是什么微细的东西"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「虽然你不知道我是什么微细的东西」",
-      "src_1_sub_2": "「但我的孩子很大，很大！」",
-      "src_2_sub_1": "虽然你不知道我是什么微细的东西",
-      "src_2_sub_2": "但我的孩子很大很大"
+      "ref_sub_1": "「虽然你不知道我是什么微细的东西」",
+      "ref_sub_2": "「但我的孩子很大，很大！」",
+      "target_sub_1": "虽然你不知道我是什么微细的东西",
+      "target_sub_2": "但我的孩子很大很大"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「但我的孩子很大，很大！」",
-      "src_1_sub_2": "「有一天，你都会知道」",
-      "src_2_sub_1": "但我的孩子很大很大",
-      "src_2_sub_2": "有一天你都会知道"
+      "ref_sub_1": "「但我的孩子很大，很大！」",
+      "ref_sub_2": "「有一天，你都会知道」",
+      "target_sub_1": "但我的孩子很大很大",
+      "target_sub_2": "有一天你都会知道"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「有一天，你都会知道」",
-      "src_1_sub_2": "「多谢合作！」",
-      "src_2_sub_1": "有一天你都会知道",
-      "src_2_sub_2": "多谢合作"
+      "ref_sub_1": "「有一天，你都会知道」",
+      "ref_sub_2": "「多谢合作！」",
+      "target_sub_1": "有一天你都会知道",
+      "target_sub_2": "多谢合作"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「多谢合作！」",
-      "src_1_sub_2": "「你忠实的，麦太」",
-      "src_2_sub_1": "多谢合作",
-      "src_2_sub_2": "你忠实的麦太"
+      "ref_sub_1": "「多谢合作！」",
+      "ref_sub_2": "「你忠实的，麦太」",
+      "target_sub_1": "多谢合作",
+      "target_sub_2": "你忠实的麦太"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "看完妈妈的信",
-      "src_1_sub_2": "我决定回长洲继续学抢包山",
-      "src_2_sub_1": "睇完妈妈封信后",
-      "src_2_sub_2": "我决定返长洲继续抢包生"
+      "ref_sub_1": "看完妈妈的信",
+      "ref_sub_2": "我决定回长洲继续学抢包山",
+      "target_sub_1": "睇完妈妈封信后",
+      "target_sub_2": "我决定返长洲继续抢包生"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我决定回长洲继续学抢包山",
-      "src_1_sub_2": "我不是为了见珊珊",
-      "src_2_sub_1": "我决定返长洲继续抢包生",
-      "src_2_sub_2": "我唔系为咗见到山神"
+      "ref_sub_1": "我决定回长洲继续学抢包山",
+      "ref_sub_2": "我不是为了见珊珊",
+      "target_sub_1": "我决定返长洲继续抢包生",
+      "target_sub_2": "我唔系为咗见到山神"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我不是为了见珊珊",
-      "src_1_sub_2": "我并不知道为什么要抢那些包",
-      "src_2_sub_1": "我唔系为咗见到山神",
-      "src_2_sub_2": "我唔知点解要抢嗰啲包"
+      "ref_sub_1": "我不是为了见珊珊",
+      "ref_sub_2": "我并不知道为什么要抢那些包",
+      "target_sub_1": "我唔系为咗见到山神",
+      "target_sub_2": "我唔知点解要抢嗰啲包"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我并不知道为什么要抢那些包",
-      "src_1_sub_2": "我也不相信抢包山会成为奥运项目",
-      "src_2_sub_1": "我唔知点解要抢嗰啲包",
-      "src_2_sub_2": "我亦唔信抢包生会成为奥运项目"
+      "ref_sub_1": "我并不知道为什么要抢那些包",
+      "ref_sub_2": "我也不相信抢包山会成为奥运项目",
+      "target_sub_1": "我唔知点解要抢嗰啲包",
+      "target_sub_2": "我亦唔信抢包生会成为奥运项目"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我也不相信抢包山会成为奥运项目",
-      "src_1_sub_2": "可是，我依然努力练习抢包山",
-      "src_2_sub_1": "我亦唔信抢包生会成为奥运项目",
-      "src_2_sub_2": "但系我依然努力练习抢包生"
+      "ref_sub_1": "我也不相信抢包山会成为奥运项目",
+      "ref_sub_2": "可是，我依然努力练习抢包山",
+      "target_sub_1": "我亦唔信抢包生会成为奥运项目",
+      "target_sub_2": "但系我依然努力练习抢包生"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "可是，我依然努力练习抢包山",
-      "src_1_sub_2": "因为，我爱我妈妈",
-      "src_2_sub_1": "但系我依然努力练习抢包生",
-      "src_2_sub_2": "因为我爱我妈妈"
+      "ref_sub_1": "可是，我依然努力练习抢包山",
+      "ref_sub_2": "因为，我爱我妈妈",
+      "target_sub_1": "但系我依然努力练习抢包生",
+      "target_sub_2": "因为我爱我妈妈"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "因为，我爱我妈妈",
-      "src_1_sub_2": "师傅说我攀爬功夫已经不错",
-      "src_2_sub_1": "因为我爱我妈妈",
-      "src_2_sub_2": "师傅话我嘅攀爬功夫已经唔错"
+      "ref_sub_1": "因为，我爱我妈妈",
+      "ref_sub_2": "师傅说我攀爬功夫已经不错",
+      "target_sub_1": "因为我爱我妈妈",
+      "target_sub_2": "师傅话我嘅攀爬功夫已经唔错"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "师傅说我攀爬功夫已经不错",
-      "src_1_sub_2": "可以开始教我「十二路抢包手」",
-      "src_2_sub_1": "师傅话我嘅攀爬功夫已经唔错",
-      "src_2_sub_2": "可以开始教我十二路抢包手"
+      "ref_sub_1": "师傅说我攀爬功夫已经不错",
+      "ref_sub_2": "可以开始教我「十二路抢包手」",
+      "target_sub_1": "师傅话我嘅攀爬功夫已经唔错",
+      "target_sub_2": "可以开始教我十二路抢包手"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "可以开始教我「十二路抢包手」",
-      "src_1_sub_2": "师傅说当年师祖耍出这套",
-      "src_2_sub_1": "可以开始教我十二路抢包手",
-      "src_2_sub_2": "师傅话"
+      "ref_sub_1": "可以开始教我「十二路抢包手」",
+      "ref_sub_2": "师傅说当年师祖耍出这套",
+      "target_sub_1": "可以开始教我十二路抢包手",
+      "target_sub_2": "师傅话"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "师傅说当年师祖耍出这套",
-      "src_1_sub_2": "「十二路抢包手」⋯",
-      "src_2_sub_1": "师傅话",
-      "src_2_sub_2": "当年师祖使出呢套十二路抢包手"
+      "ref_sub_1": "师傅说当年师祖耍出这套",
+      "ref_sub_2": "「十二路抢包手」⋯",
+      "target_sub_1": "师傅话",
+      "target_sub_2": "当年师祖使出呢套十二路抢包手"
     },
     "answer": {
-      "src_2_sub_1_shifted": "师傅话当年师祖使出呢套",
-      "src_2_sub_2_shifted": "十二路抢包手"
+      "target_sub_1_shifted": "师傅话当年师祖使出呢套",
+      "target_sub_2_shifted": "十二路抢包手"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "可以开始教我「十二路抢包手」",
-      "src_1_sub_2": "师傅说当年师祖耍出这套",
-      "src_2_sub_1": "可以开始教我十二路抢包手",
-      "src_2_sub_2": "师傅话当年师祖使出呢套"
+      "ref_sub_1": "可以开始教我「十二路抢包手」",
+      "ref_sub_2": "师傅说当年师祖耍出这套",
+      "target_sub_1": "可以开始教我十二路抢包手",
+      "target_sub_2": "师傅话当年师祖使出呢套"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "师傅说当年师祖耍出这套",
-      "src_1_sub_2": "「十二路抢包手」⋯",
-      "src_2_sub_1": "师傅话当年师祖使出呢套",
-      "src_2_sub_2": "十二路抢包手"
+      "ref_sub_1": "师傅说当年师祖耍出这套",
+      "ref_sub_2": "「十二路抢包手」⋯",
+      "target_sub_1": "师傅话当年师祖使出呢套",
+      "target_sub_2": "十二路抢包手"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「十二路抢包手」⋯",
-      "src_1_sub_2": "连林世荣也大大赞好",
-      "src_2_sub_1": "十二路抢包手",
-      "src_2_sub_2": "连林世荣睇见都大赞老爷"
+      "ref_sub_1": "「十二路抢包手」⋯",
+      "ref_sub_2": "连林世荣也大大赞好",
+      "target_sub_1": "十二路抢包手",
+      "target_sub_2": "连林世荣睇见都大赞老爷"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "连林世荣也大大赞好",
-      "src_1_sub_2": "后来麦唛告诉我⋯",
-      "src_2_sub_1": "连林世荣睇见都大赞老爷",
-      "src_2_sub_2": "后来默默话我知"
+      "ref_sub_1": "连林世荣也大大赞好",
+      "ref_sub_2": "后来麦唛告诉我⋯",
+      "target_sub_1": "连林世荣睇见都大赞老爷",
+      "target_sub_2": "后来默默话我知"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "后来麦唛告诉我⋯",
-      "src_1_sub_2": "林世荣即是猪肉荣，是黄飞鸿的徒弟",
-      "src_2_sub_1": "后来默默话我知",
-      "src_2_sub_2": "林世荣即系猪肉荣系黄飞鸿嘅徒弟"
+      "ref_sub_1": "后来麦唛告诉我⋯",
+      "ref_sub_2": "林世荣即是猪肉荣，是黄飞鸿的徒弟",
+      "target_sub_1": "后来默默话我知",
+      "target_sub_2": "林世荣即系猪肉荣系黄飞鸿嘅徒弟"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "林世荣即是猪肉荣，是黄飞鸿的徒弟",
-      "src_1_sub_2": "我不知道师傅像不像黄飞鸿",
-      "src_2_sub_1": "林世荣即系猪肉荣系黄飞鸿嘅徒弟",
-      "src_2_sub_2": "我唔知到师傅似唔似黄飞鸿"
+      "ref_sub_1": "林世荣即是猪肉荣，是黄飞鸿的徒弟",
+      "ref_sub_2": "我不知道师傅像不像黄飞鸿",
+      "target_sub_1": "林世荣即系猪肉荣系黄飞鸿嘅徒弟",
+      "target_sub_2": "我唔知到师傅似唔似黄飞鸿"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我不知道师傅像不像黄飞鸿",
-      "src_1_sub_2": "我却肯定像一块猪肉",
-      "src_2_sub_1": "我唔知到师傅似唔似黄飞鸿",
-      "src_2_sub_2": "但系我就肯定似旧猪肉"
+      "ref_sub_1": "我不知道师傅像不像黄飞鸿",
+      "ref_sub_2": "我却肯定像一块猪肉",
+      "target_sub_1": "我唔知到师傅似唔似黄飞鸿",
+      "target_sub_2": "但系我就肯定似旧猪肉"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我却肯定像一块猪肉",
-      "src_1_sub_2": "我是一块揸住两个包",
-      "src_2_sub_1": "但系我就肯定似旧猪肉",
-      "src_2_sub_2": "我就系一个揸住两个包"
+      "ref_sub_1": "我却肯定像一块猪肉",
+      "ref_sub_2": "我是一块揸住两个包",
+      "target_sub_1": "但系我就肯定似旧猪肉",
+      "target_sub_2": "我就系一个揸住两个包"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我是一块揸住两个包",
-      "src_1_sub_2": "在长洲转来转去的猪肉",
-      "src_2_sub_1": "我就系一个揸住两个包",
-      "src_2_sub_2": "喺长洲转嚟转去嘅猪肉"
+      "ref_sub_1": "我是一块揸住两个包",
+      "ref_sub_2": "在长洲转来转去的猪肉",
+      "target_sub_1": "我就系一个揸住两个包",
+      "target_sub_2": "喺长洲转嚟转去嘅猪肉"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "在长洲转来转去的猪肉",
-      "src_1_sub_2": "我一边练习，一边胡思乱想；始终⋯",
-      "src_2_sub_1": "喺长洲转嚟转去嘅猪肉",
-      "src_2_sub_2": "我一边练习一边乱练一边谂嘢始终"
+      "ref_sub_1": "在长洲转来转去的猪肉",
+      "ref_sub_2": "我一边练习，一边胡思乱想；始终⋯",
+      "target_sub_1": "喺长洲转嚟转去嘅猪肉",
+      "target_sub_2": "我一边练习一边乱练一边谂嘢始终"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我一边练习，一边胡思乱想；始终⋯",
-      "src_1_sub_2": "我还是不大喜欢抢包",
-      "src_2_sub_1": "我一边练习一边乱练一边谂嘢始终",
-      "src_2_sub_2": "我都唔系咁钟意抢包"
+      "ref_sub_1": "我一边练习，一边胡思乱想；始终⋯",
+      "ref_sub_2": "我还是不大喜欢抢包",
+      "target_sub_1": "我一边练习一边乱练一边谂嘢始终",
+      "target_sub_2": "我都唔系咁钟意抢包"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我还是不大喜欢抢包",
-      "src_1_sub_2": "我只是爱我妈妈",
-      "src_2_sub_1": "我都唔系咁钟意抢包",
-      "src_2_sub_2": "我净系爱我妈妈"
+      "ref_sub_1": "我还是不大喜欢抢包",
+      "ref_sub_2": "我只是爱我妈妈",
+      "target_sub_1": "我都唔系咁钟意抢包",
+      "target_sub_2": "我净系爱我妈妈"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我只是爱我妈妈",
-      "src_1_sub_2": "于是我咬实牙根⋯",
-      "src_2_sub_1": "我净系爱我妈妈",
-      "src_2_sub_2": "于是我咬细牙根"
+      "ref_sub_1": "我只是爱我妈妈",
+      "ref_sub_2": "于是我咬实牙根⋯",
+      "target_sub_1": "我净系爱我妈妈",
+      "target_sub_2": "于是我咬细牙根"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "于是我咬实牙根⋯",
-      "src_1_sub_2": "一步一步，一爪一爪⋯",
-      "src_2_sub_1": "于是我咬细牙根",
-      "src_2_sub_2": "一步一步一爪一爪"
+      "ref_sub_1": "于是我咬实牙根⋯",
+      "ref_sub_2": "一步一步，一爪一爪⋯",
+      "target_sub_1": "于是我咬细牙根",
+      "target_sub_2": "一步一步一爪一爪"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "一步一步，一爪一爪⋯",
-      "src_1_sub_2": "我最后终于练成「十二路抢包手」",
-      "src_2_sub_1": "一步一步一爪一爪",
-      "src_2_sub_2": "最后我终于练成十二路抢包手啦"
+      "ref_sub_1": "一步一步，一爪一爪⋯",
+      "ref_sub_2": "我最后终于练成「十二路抢包手」",
+      "target_sub_1": "一步一步一爪一爪",
+      "target_sub_2": "最后我终于练成十二路抢包手啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "喂，我是麦兜",
-      "src_1_sub_2": "刚才的是小朋友麦兜，我是大个佬麦兜",
-      "src_2_sub_1": "喂我系麦兜啊",
-      "src_2_sub_2": "正话嗰个系细路仔麦兜我系大个佬麦兜"
+      "ref_sub_1": "喂，我是麦兜",
+      "ref_sub_2": "刚才的是小朋友麦兜，我是大个佬麦兜",
+      "target_sub_1": "喂我系麦兜啊",
+      "target_sub_2": "正话嗰个系细路仔麦兜我系大个佬麦兜"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "刚才的是小朋友麦兜，我是大个佬麦兜",
-      "src_1_sub_2": "小朋友麦兜和大个佬麦兜除了声音不同⋯",
-      "src_2_sub_1": "正话嗰个系细路仔麦兜我系大个佬麦兜",
-      "src_2_sub_2": "细路仔麦兜同大个佬麦兜除咗把声唔同之外"
+      "ref_sub_1": "刚才的是小朋友麦兜，我是大个佬麦兜",
+      "ref_sub_2": "小朋友麦兜和大个佬麦兜除了声音不同⋯",
+      "target_sub_1": "正话嗰个系细路仔麦兜我系大个佬麦兜",
+      "target_sub_2": "细路仔麦兜同大个佬麦兜除咗把声唔同之外"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "小朋友麦兜和大个佬麦兜除了声音不同⋯",
-      "src_1_sub_2": "小朋友麦兜的世界仍然有好多幻想",
-      "src_2_sub_1": "细路仔麦兜同大个佬麦兜除咗把声唔同之外",
-      "src_2_sub_2": "细路仔麦兜嘅世界仲有好多幻想"
+      "ref_sub_1": "小朋友麦兜和大个佬麦兜除了声音不同⋯",
+      "ref_sub_2": "小朋友麦兜的世界仍然有好多幻想",
+      "target_sub_1": "细路仔麦兜同大个佬麦兜除咗把声唔同之外",
+      "target_sub_2": "细路仔麦兜嘅世界仲有好多幻想"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "小朋友麦兜的世界仍然有好多幻想",
-      "src_1_sub_2": "仍然有好多希望",
-      "src_2_sub_1": "细路仔麦兜嘅世界仲有好多幻想",
-      "src_2_sub_2": "仲有好多希望"
+      "ref_sub_1": "小朋友麦兜的世界仍然有好多幻想",
+      "ref_sub_2": "仍然有好多希望",
+      "target_sub_1": "细路仔麦兜嘅世界仲有好多幻想",
+      "target_sub_2": "仲有好多希望"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "仍然有好多希望",
-      "src_1_sub_2": "希望⋯失望⋯",
-      "src_2_sub_1": "仲有好多希望",
-      "src_2_sub_2": "希望失望"
+      "ref_sub_1": "仍然有好多希望",
+      "ref_sub_2": "希望⋯失望⋯",
+      "target_sub_1": "仲有好多希望",
+      "target_sub_2": "希望失望"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "希望⋯失望⋯",
-      "src_1_sub_2": "希望⋯",
-      "src_2_sub_1": "希望失望",
-      "src_2_sub_2": "希望"
+      "ref_sub_1": "希望⋯失望⋯",
+      "ref_sub_2": "希望⋯",
+      "target_sub_1": "希望失望",
+      "target_sub_2": "希望"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "希望⋯",
-      "src_1_sub_2": "失望",
-      "src_2_sub_1": "希望",
-      "src_2_sub_2": "失望"
+      "ref_sub_1": "希望⋯",
+      "ref_sub_2": "失望",
+      "target_sub_1": "希望",
+      "target_sub_2": "失望"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "失望",
-      "src_1_sub_2": "久而久之，就变成大个佬麦兜",
-      "src_2_sub_1": "失望",
-      "src_2_sub_2": "搞咗一轮就变咗大个佬麦兜"
+      "ref_sub_1": "失望",
+      "ref_sub_2": "久而久之，就变成大个佬麦兜",
+      "target_sub_1": "失望",
+      "target_sub_2": "搞咗一轮就变咗大个佬麦兜"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "久而久之，就变成大个佬麦兜",
-      "src_1_sub_2": "我现在还是多说点小朋友麦兜",
-      "src_2_sub_1": "搞咗一轮就变咗大个佬麦兜",
-      "src_2_sub_2": "不过而家我都系想讲返细路仔麦兜"
+      "ref_sub_1": "久而久之，就变成大个佬麦兜",
+      "ref_sub_2": "我现在还是多说点小朋友麦兜",
+      "target_sub_1": "搞咗一轮就变咗大个佬麦兜",
+      "target_sub_2": "不过而家我都系想讲返细路仔麦兜"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我现在还是多说点小朋友麦兜",
-      "src_1_sub_2": "小朋友麦兜仍然希望希望⋯",
-      "src_2_sub_1": "不过而家我都系想讲返细路仔麦兜",
-      "src_2_sub_2": "细路仔麦兜仲系希望希望"
+      "ref_sub_1": "我现在还是多说点小朋友麦兜",
+      "ref_sub_2": "小朋友麦兜仍然希望希望⋯",
+      "target_sub_1": "不过而家我都系想讲返细路仔麦兜",
+      "target_sub_2": "细路仔麦兜仲系希望希望"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "小朋友麦兜仍然希望希望⋯",
-      "src_1_sub_2": "希望真的有圣诞老人",
-      "src_2_sub_1": "细路仔麦兜仲系希望希望",
-      "src_2_sub_2": "希望真系有圣诞老人"
+      "ref_sub_1": "小朋友麦兜仍然希望希望⋯",
+      "ref_sub_2": "希望真的有圣诞老人",
+      "target_sub_1": "细路仔麦兜仲系希望希望",
+      "target_sub_2": "希望真系有圣诞老人"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "希望真的有圣诞老人",
-      "src_1_sub_2": "而且好想试试圣诞火鸡的滋味",
-      "src_2_sub_1": "希望真系有圣诞老人",
-      "src_2_sub_2": "仲系好想好想试下圣诞火鸡嘅滋味"
+      "ref_sub_1": "希望真的有圣诞老人",
+      "ref_sub_2": "而且好想试试圣诞火鸡的滋味",
+      "target_sub_1": "希望真系有圣诞老人",
+      "target_sub_2": "仲系好想好想试下圣诞火鸡嘅滋味"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "而且好想试试圣诞火鸡的滋味",
-      "src_1_sub_2": "对，那时我还没吃过火鸡",
-      "src_2_sub_1": "仲系好想好想试下圣诞火鸡嘅滋味",
-      "src_2_sub_2": "系啊我嗰阵我真系仲未食过火鸡"
+      "ref_sub_1": "而且好想试试圣诞火鸡的滋味",
+      "ref_sub_2": "对，那时我还没吃过火鸡",
+      "target_sub_1": "仲系好想好想试下圣诞火鸡嘅滋味",
+      "target_sub_2": "系啊我嗰阵我真系仲未食过火鸡"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "对，那时我还没吃过火鸡",
-      "src_1_sub_2": "关于火鸡的一切⋯",
-      "src_2_sub_1": "系啊我嗰阵我真系仲未食过火鸡",
-      "src_2_sub_2": "所有关于火鸡嘅嘢"
+      "ref_sub_1": "对，那时我还没吃过火鸡",
+      "ref_sub_2": "关于火鸡的一切⋯",
+      "target_sub_1": "系啊我嗰阵我真系仲未食过火鸡",
+      "target_sub_2": "所有关于火鸡嘅嘢"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "关于火鸡的一切⋯",
-      "src_1_sub_2": "圣诞树上一闪一闪的饰物",
-      "src_2_sub_1": "所有关于火鸡嘅嘢",
-      "src_2_sub_2": "圣诞树一闪一闪嘅灯饰"
+      "ref_sub_1": "关于火鸡的一切⋯",
+      "ref_sub_2": "圣诞树上一闪一闪的饰物",
+      "target_sub_1": "所有关于火鸡嘅嘢",
+      "target_sub_2": "圣诞树一闪一闪嘅灯饰"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "圣诞树上一闪一闪的饰物",
-      "src_1_sub_2": "就像天上掉落的星星",
-      "src_2_sub_1": "圣诞树一闪一闪嘅灯饰",
-      "src_2_sub_2": "就好似喺天上面落嚟嘅星星噉"
+      "ref_sub_1": "圣诞树上一闪一闪的饰物",
+      "ref_sub_2": "就像天上掉落的星星",
+      "target_sub_1": "圣诞树一闪一闪嘅灯饰",
+      "target_sub_2": "就好似喺天上面落嚟嘅星星噉"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "就像天上掉落的星星",
-      "src_1_sub_2": "落到火炉旁边",
-      "src_2_sub_1": "就好似喺天上面落嚟嘅星星噉",
-      "src_2_sub_2": "落喺火炉旁边"
+      "ref_sub_1": "就像天上掉落的星星",
+      "ref_sub_2": "落到火炉旁边",
+      "target_sub_1": "就好似喺天上面落嚟嘅星星噉",
+      "target_sub_2": "落喺火炉旁边"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "落到火炉旁边",
-      "src_1_sub_2": "一片片比外边的雪还要白的鸡胸肉⋯",
-      "src_2_sub_1": "落喺火炉旁边",
-      "src_2_sub_2": "一片一片比窗外面嘅雪仲要白嘅鸡胸肉"
+      "ref_sub_1": "落到火炉旁边",
+      "ref_sub_2": "一片片比外边的雪还要白的鸡胸肉⋯",
+      "target_sub_1": "落喺火炉旁边",
+      "target_sub_2": "一片一片比窗外面嘅雪仲要白嘅鸡胸肉"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "一片片比外边的雪还要白的鸡胸肉⋯",
-      "src_1_sub_2": "就在我们跟前",
-      "src_2_sub_1": "一片一片比窗外面嘅雪仲要白嘅鸡胸肉",
-      "src_2_sub_2": "就喺我哋面前啦"
+      "ref_sub_1": "一片片比外边的雪还要白的鸡胸肉⋯",
+      "ref_sub_2": "就在我们跟前",
+      "target_sub_1": "一片一片比窗外面嘅雪仲要白嘅鸡胸肉",
+      "target_sub_2": "就喺我哋面前啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "就在我们跟前",
-      "src_1_sub_2": "香气直入灵魂⋯",
-      "src_2_sub_1": "就喺我哋面前啦",
-      "src_2_sub_2": "香气直入灵魂"
+      "ref_sub_1": "就在我们跟前",
+      "ref_sub_2": "香气直入灵魂⋯",
+      "target_sub_1": "就喺我哋面前啦",
+      "target_sub_2": "香气直入灵魂"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "香气直入灵魂⋯",
-      "src_1_sub_2": "连守在灵魂旁边的天使都醒过来",
-      "src_2_sub_1": "香气直入灵魂",
-      "src_2_sub_2": "就连守喺灵魂旁边嘅天使都醒咗起嚟"
+      "ref_sub_1": "香气直入灵魂⋯",
+      "ref_sub_2": "连守在灵魂旁边的天使都醒过来",
+      "target_sub_1": "香气直入灵魂",
+      "target_sub_2": "就连守喺灵魂旁边嘅天使都醒咗起嚟"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "连守在灵魂旁边的天使都醒过来",
-      "src_1_sub_2": "围住这香而圣洁的肉⋯",
-      "src_2_sub_1": "就连守喺灵魂旁边嘅天使都醒咗起嚟",
-      "src_2_sub_2": "围住呢一嚿好香好香又好盛洁嘅肉"
+      "ref_sub_1": "连守在灵魂旁边的天使都醒过来",
+      "ref_sub_2": "围住这香而圣洁的肉⋯",
+      "target_sub_1": "就连守喺灵魂旁边嘅天使都醒咗起嚟",
+      "target_sub_2": "围住呢一嚿好香好香又好盛洁嘅肉"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "围住这香而圣洁的肉⋯",
-      "src_1_sub_2": "在圣诞夜中飞呀，飞⋯",
-      "src_2_sub_1": "围住呢一嚿好香好香又好盛洁嘅肉",
-      "src_2_sub_2": "喺圣诞夜里面飞呀飞呀"
+      "ref_sub_1": "围住这香而圣洁的肉⋯",
+      "ref_sub_2": "在圣诞夜中飞呀，飞⋯",
+      "target_sub_1": "围住呢一嚿好香好香又好盛洁嘅肉",
+      "target_sub_2": "喺圣诞夜里面飞呀飞呀"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "在圣诞夜中飞呀，飞⋯",
-      "src_1_sub_2": "这关于火鸡的一切，不过是我的想像",
-      "src_2_sub_1": "喺圣诞夜里面飞呀飞呀",
-      "src_2_sub_2": "但系呢一切一切关于火鸡嘅嘢都不过系我嘅想像"
+      "ref_sub_1": "在圣诞夜中飞呀，飞⋯",
+      "ref_sub_2": "这关于火鸡的一切，不过是我的想像",
+      "target_sub_1": "喺圣诞夜里面飞呀飞呀",
+      "target_sub_2": "但系呢一切一切关于火鸡嘅嘢都不过系我嘅想像"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "这关于火鸡的一切，不过是我的想像",
-      "src_1_sub_2": "我从来没吃过火鸡⋯",
-      "src_2_sub_1": "但系呢一切一切关于火鸡嘅嘢都不过系我嘅想像",
-      "src_2_sub_2": "因为我从来都未食过火鸡"
+      "ref_sub_1": "这关于火鸡的一切，不过是我的想像",
+      "ref_sub_2": "我从来没吃过火鸡⋯",
+      "target_sub_1": "但系呢一切一切关于火鸡嘅嘢都不过系我嘅想像",
+      "target_sub_2": "因为我从来都未食过火鸡"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我从来没吃过火鸡⋯",
-      "src_1_sub_2": "连它的气味也没嗅过",
-      "src_2_sub_1": "因为我从来都未食过火鸡",
-      "src_2_sub_2": "就连嗰阵味都未闻过"
+      "ref_sub_1": "我从来没吃过火鸡⋯",
+      "ref_sub_2": "连它的气味也没嗅过",
+      "target_sub_1": "因为我从来都未食过火鸡",
+      "target_sub_2": "就连嗰阵味都未闻过"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "连它的气味也没嗅过",
-      "src_1_sub_2": "妈妈说火鸡太大",
-      "src_2_sub_1": "就连嗰阵味都未闻过",
-      "src_2_sub_2": "妈妈话火鸡太大"
+      "ref_sub_1": "连它的气味也没嗅过",
+      "ref_sub_2": "妈妈说火鸡太大",
+      "target_sub_1": "就连嗰阵味都未闻过",
+      "target_sub_2": "妈妈话火鸡太大"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈说火鸡太大",
-      "src_1_sub_2": "我们一家两口，吃不下",
-      "src_2_sub_1": "妈妈话火鸡太大",
-      "src_2_sub_2": "我哋一家两口点食都食唔晒"
+      "ref_sub_1": "妈妈说火鸡太大",
+      "ref_sub_2": "我们一家两口，吃不下",
+      "target_sub_1": "妈妈话火鸡太大",
+      "target_sub_2": "我哋一家两口点食都食唔晒"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我们一家两口，吃不下",
-      "src_1_sub_2": "有年圣诞节妈妈买了半只烧鸭庆祝",
-      "src_2_sub_1": "我哋一家两口点食都食唔晒",
-      "src_2_sub_2": "有一年圣诞节妈妈买咗半边烧鸭庆祝"
+      "ref_sub_1": "我们一家两口，吃不下",
+      "ref_sub_2": "有年圣诞节妈妈买了半只烧鸭庆祝",
+      "target_sub_1": "我哋一家两口点食都食唔晒",
+      "target_sub_2": "有一年圣诞节妈妈买咗半边烧鸭庆祝"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "有年圣诞节妈妈买了半只烧鸭庆祝",
-      "src_1_sub_2": "当时的我，十分十分失望",
-      "src_2_sub_1": "有一年圣诞节妈妈买咗半边烧鸭庆祝",
-      "src_2_sub_2": "当时我真系十分十分之失望"
+      "ref_sub_1": "有年圣诞节妈妈买了半只烧鸭庆祝",
+      "ref_sub_2": "当时的我，十分十分失望",
+      "target_sub_1": "有一年圣诞节妈妈买咗半边烧鸭庆祝",
+      "target_sub_2": "当时我真系十分十分之失望"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "当时的我，十分十分失望",
-      "src_1_sub_2": "又有一年，一间百货公司结业",
-      "src_2_sub_1": "当时我真系十分十分之失望",
-      "src_2_sub_2": "又有一年有间大薄货公司倒闭"
+      "ref_sub_1": "当时的我，十分十分失望",
+      "ref_sub_2": "又有一年，一间百货公司结业",
+      "target_sub_1": "当时我真系十分十分之失望",
+      "target_sub_2": "又有一年有间大薄货公司倒闭"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "又有一年，一间百货公司结业",
-      "src_1_sub_2": "妈妈以四折买了个小小焗炉",
-      "src_2_sub_1": "又有一年有间大薄货公司倒闭",
-      "src_2_sub_2": "妈妈用四折买咗个焗炉仔返屋企"
+      "ref_sub_1": "又有一年，一间百货公司结业",
+      "ref_sub_2": "妈妈以四折买了个小小焗炉",
+      "target_sub_1": "又有一年有间大薄货公司倒闭",
+      "target_sub_2": "妈妈用四折买咗个焗炉仔返屋企"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈以四折买了个小小焗炉",
-      "src_1_sub_2": "可能因为买了焗炉而技痒",
-      "src_2_sub_1": "妈妈用四折买咗个焗炉仔返屋企",
-      "src_2_sub_2": "可能系因为买咗焗炉嘅样"
+      "ref_sub_1": "妈妈以四折买了个小小焗炉",
+      "ref_sub_2": "可能因为买了焗炉而技痒",
+      "target_sub_1": "妈妈用四折买咗个焗炉仔返屋企",
+      "target_sub_2": "可能系因为买咗焗炉嘅样"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "可能因为买了焗炉而技痒",
-      "src_1_sub_2": "那日妈妈竟然跟我说⋯",
-      "src_2_sub_1": "可能系因为买咗焗炉嘅样",
-      "src_2_sub_2": "嗰日妈妈竟然同我讲"
+      "ref_sub_1": "可能因为买了焗炉而技痒",
+      "ref_sub_2": "那日妈妈竟然跟我说⋯",
+      "target_sub_1": "可能系因为买咗焗炉嘅样",
+      "target_sub_2": "嗰日妈妈竟然同我讲"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "那日妈妈竟然跟我说⋯",
-      "src_1_sub_2": "让我们明天去超级市场揪火鸡",
-      "src_2_sub_1": "嗰日妈妈竟然同我讲",
-      "src_2_sub_2": "佢话明日我哋要超级市场抽火鸡"
+      "ref_sub_1": "那日妈妈竟然跟我说⋯",
+      "ref_sub_2": "让我们明天去超级市场揪火鸡",
+      "target_sub_1": "嗰日妈妈竟然同我讲",
+      "target_sub_2": "佢话明日我哋要超级市场抽火鸡"
     },
     "answer": {
-      "src_2_sub_1_shifted": "嗰日妈妈竟然同我讲佢话",
-      "src_2_sub_2_shifted": "明日我哋要超级市场抽火鸡"
+      "target_sub_1_shifted": "嗰日妈妈竟然同我讲佢话",
+      "target_sub_2_shifted": "明日我哋要超级市场抽火鸡"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "让我们明天去超级市场揪火鸡",
-      "src_1_sub_2": "我跟妈妈把火鸡揪回家的路上⋯",
-      "src_2_sub_1": "明日我哋要超级市场抽火鸡",
-      "src_2_sub_2": "我同妈妈抽住只火鸡行返屋企嗰阵"
+      "ref_sub_1": "让我们明天去超级市场揪火鸡",
+      "ref_sub_2": "我跟妈妈把火鸡揪回家的路上⋯",
+      "target_sub_1": "明日我哋要超级市场抽火鸡",
+      "target_sub_2": "我同妈妈抽住只火鸡行返屋企嗰阵"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我跟妈妈把火鸡揪回家的路上⋯",
-      "src_1_sub_2": "是我生命中最开心的时刻",
-      "src_2_sub_1": "我同妈妈抽住只火鸡行返屋企嗰阵",
-      "src_2_sub_2": "喺嗰阵时我谂系我生命里面最开心嘅一刻"
+      "ref_sub_1": "我跟妈妈把火鸡揪回家的路上⋯",
+      "ref_sub_2": "是我生命中最开心的时刻",
+      "target_sub_1": "我同妈妈抽住只火鸡行返屋企嗰阵",
+      "target_sub_2": "喺嗰阵时我谂系我生命里面最开心嘅一刻"
     },
     "answer": {
-      "src_2_sub_1_shifted": "我同妈妈抽住只火鸡行返屋企嗰阵喺嗰阵时",
-      "src_2_sub_2_shifted": "我谂系我生命里面最开心嘅一刻"
+      "target_sub_1_shifted": "我同妈妈抽住只火鸡行返屋企嗰阵喺嗰阵时",
+      "target_sub_2_shifted": "我谂系我生命里面最开心嘅一刻"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "是我生命中最开心的时刻",
-      "src_1_sub_2": "火鸡终于解冻了",
-      "src_2_sub_1": "我谂系我生命里面最开心嘅一刻",
-      "src_2_sub_2": "火鸡终于解冻啦"
+      "ref_sub_1": "是我生命中最开心的时刻",
+      "ref_sub_2": "火鸡终于解冻了",
+      "target_sub_1": "我谂系我生命里面最开心嘅一刻",
+      "target_sub_2": "火鸡终于解冻啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "火鸡终于解冻了",
-      "src_1_sub_2": "我学著妈妈，把双手涂满盐⋯",
-      "src_2_sub_1": "火鸡终于解冻啦",
-      "src_2_sub_2": "我同妈妈噉双手查满盐"
+      "ref_sub_1": "火鸡终于解冻了",
+      "ref_sub_2": "我学著妈妈，把双手涂满盐⋯",
+      "target_sub_1": "火鸡终于解冻啦",
+      "target_sub_2": "我同妈妈噉双手查满盐"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我学著妈妈，把双手涂满盐⋯",
-      "src_1_sub_2": "在火鸡丰厚的鸡胸上擦呀，擦",
-      "src_2_sub_1": "我同妈妈噉双手查满盐",
-      "src_2_sub_2": "喺火鸡封口嘅鸡胸度起细噉啫啫"
+      "ref_sub_1": "我学著妈妈，把双手涂满盐⋯",
+      "ref_sub_2": "在火鸡丰厚的鸡胸上擦呀，擦",
+      "target_sub_1": "我同妈妈噉双手查满盐",
+      "target_sub_2": "喺火鸡封口嘅鸡胸度起细噉啫啫"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "在火鸡丰厚的鸡胸上擦呀，擦",
-      "src_1_sub_2": "联火鸡时⋯",
-      "src_2_sub_1": "喺火鸡封口嘅鸡胸度起细噉啫啫"
+      "ref_sub_1": "在火鸡丰厚的鸡胸上擦呀，擦",
+      "ref_sub_2": "联火鸡时⋯",
+      "target_sub_1": "喺火鸡封口嘅鸡胸度起细噉啫啫"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "联火鸡时⋯",
-      "src_1_sub_2": "妈妈不留神漏出了火鸡内的洋葱粒",
-      "src_2_sub_2": "联火鸡时妈妈一个唔觉意畀酿喺火鸡里面嘅火鸡内脏洋葱粒"
+      "ref_sub_1": "联火鸡时⋯",
+      "ref_sub_2": "妈妈不留神漏出了火鸡内的洋葱粒",
+      "target_sub_2": "联火鸡时妈妈一个唔觉意畀酿喺火鸡里面嘅火鸡内脏洋葱粒"
     },
     "answer": {
-      "src_2_sub_1_shifted": "联火鸡时",
-      "src_2_sub_2_shifted": "妈妈一个唔觉意畀酿喺火鸡里面嘅火鸡内脏洋葱粒"
+      "target_sub_1_shifted": "联火鸡时",
+      "target_sub_2_shifted": "妈妈一个唔觉意畀酿喺火鸡里面嘅火鸡内脏洋葱粒"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈不留神漏出了火鸡内的洋葱粒",
-      "src_1_sub_2": "红萝卜粒",
-      "src_2_sub_1": "妈妈一个唔觉意畀酿喺火鸡里面嘅火鸡内脏洋葱粒",
-      "src_2_sub_2": "红萝虾粒流嘅出嚟"
+      "ref_sub_1": "妈妈不留神漏出了火鸡内的洋葱粒",
+      "ref_sub_2": "红萝卜粒",
+      "target_sub_1": "妈妈一个唔觉意畀酿喺火鸡里面嘅火鸡内脏洋葱粒",
+      "target_sub_2": "红萝虾粒流嘅出嚟"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "红萝卜粒",
-      "src_1_sub_2": "我说：火鸡「屙烂煮」！",
-      "src_2_sub_1": "红萝虾粒流嘅出嚟",
-      "src_2_sub_2": "我话火鸡我能住呀"
+      "ref_sub_1": "红萝卜粒",
+      "ref_sub_2": "我说：火鸡「屙烂煮」！",
+      "target_sub_1": "红萝虾粒流嘅出嚟",
+      "target_sub_2": "我话火鸡我能住呀"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我说：火鸡「屙烂煮」！",
-      "src_1_sub_2": "好勉强把火鸡塞进焗炉内",
-      "src_2_sub_1": "我话火鸡我能住呀",
-      "src_2_sub_2": "火鸡好勉强噏咗入焗炉度"
+      "ref_sub_1": "我说：火鸡「屙烂煮」！",
+      "ref_sub_2": "好勉强把火鸡塞进焗炉内",
+      "target_sub_1": "我话火鸡我能住呀",
+      "target_sub_2": "火鸡好勉强噏咗入焗炉度"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "好勉强把火鸡塞进焗炉内",
-      "src_1_sub_2": "12月24日",
-      "src_2_sub_1": "火鸡好勉强噏咗入焗炉度",
-      "src_2_sub_2": "10月24日"
+      "ref_sub_1": "好勉强把火鸡塞进焗炉内",
+      "ref_sub_2": "12月24日",
+      "target_sub_1": "火鸡好勉强噏咗入焗炉度",
+      "target_sub_2": "10月24日"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "12月24日",
-      "src_1_sub_2": "上升的白烟跟奇异的焦味拨动星星",
-      "src_2_sub_1": "10月24日",
-      "src_2_sub_2": "上升嘅白烟同奇异嘅㶶味拨动声声"
+      "ref_sub_1": "12月24日",
+      "ref_sub_2": "上升的白烟跟奇异的焦味拨动星星",
+      "target_sub_1": "10月24日",
+      "target_sub_2": "上升嘅白烟同奇异嘅㶶味拨动声声"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "上升的白烟跟奇异的焦味拨动星星",
-      "src_1_sub_2": "焗炉戚戚恻恻，戚戚恻恻⋯",
-      "src_2_sub_1": "上升嘅白烟同奇异嘅㶶味拨动声声",
-      "src_2_sub_2": "个焗炉叱叱叱叱叱叱叱咁"
+      "ref_sub_1": "上升的白烟跟奇异的焦味拨动星星",
+      "ref_sub_2": "焗炉戚戚恻恻，戚戚恻恻⋯",
+      "target_sub_1": "上升嘅白烟同奇异嘅㶶味拨动声声",
+      "target_sub_2": "个焗炉叱叱叱叱叱叱叱咁"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "焗炉戚戚恻恻，戚戚恻恻⋯",
-      "src_1_sub_2": "有如天使预早送来的福音",
-      "src_2_sub_1": "个焗炉叱叱叱叱叱叱叱咁",
-      "src_2_sub_2": "就好似天赐预祖畀我哋嘅福音"
+      "ref_sub_1": "焗炉戚戚恻恻，戚戚恻恻⋯",
+      "ref_sub_2": "有如天使预早送来的福音",
+      "target_sub_1": "个焗炉叱叱叱叱叱叱叱咁",
+      "target_sub_2": "就好似天赐预祖畀我哋嘅福音"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "好靓的晚上啊！",
-      "src_1_sub_2": "我和妈妈坐在尖东海傍",
-      "src_2_sub_1": "好靓嘅夜晚呀",
-      "src_2_sub_2": "我同妈妈坐喺尖东海旁"
+      "ref_sub_1": "好靓的晚上啊！",
+      "ref_sub_2": "我和妈妈坐在尖东海傍",
+      "target_sub_1": "好靓嘅夜晚呀",
+      "target_sub_2": "我同妈妈坐喺尖东海旁"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我和妈妈坐在尖东海傍",
-      "src_1_sub_2": "点点灯光在海面走来走去⋯",
-      "src_2_sub_1": "我同妈妈坐喺尖东海旁",
-      "src_2_sub_2": "点点点点嘅灯光喺海上面走来走去"
+      "ref_sub_1": "我和妈妈坐在尖东海傍",
+      "ref_sub_2": "点点灯光在海面走来走去⋯",
+      "target_sub_1": "我同妈妈坐喺尖东海旁",
+      "target_sub_2": "点点点点嘅灯光喺海上面走来走去"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "点点灯光在海面走来走去⋯",
-      "src_1_sub_2": "美丽又温柔",
-      "src_2_sub_1": "点点点点嘅灯光喺海上面走来走去",
-      "src_2_sub_2": "又靓又温柔"
+      "ref_sub_1": "点点灯光在海面走来走去⋯",
+      "ref_sub_2": "美丽又温柔",
+      "target_sub_1": "点点点点嘅灯光喺海上面走来走去",
+      "target_sub_2": "又靓又温柔"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "美丽又温柔",
-      "src_1_sub_2": "真的好靓！",
-      "src_2_sub_1": "又靓又温柔",
-      "src_2_sub_2": "真系好靓"
+      "ref_sub_1": "美丽又温柔",
+      "ref_sub_2": "真的好靓！",
+      "target_sub_1": "又靓又温柔",
+      "target_sub_2": "真系好靓"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我从没吃过这么浓味的东西",
-      "src_1_sub_2": "什至杯面，烧鸭的味道也没有这么浓",
-      "src_2_sub_1": "我从未食过咁浓味嘅嘢",
-      "src_2_sub_2": "连烧鸭连杯面都冇咁浓嘅味道"
+      "ref_sub_1": "我从没吃过这么浓味的东西",
+      "ref_sub_2": "什至杯面，烧鸭的味道也没有这么浓",
+      "target_sub_1": "我从未食过咁浓味嘅嘢",
+      "target_sub_2": "连烧鸭连杯面都冇咁浓嘅味道"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "什至杯面，烧鸭的味道也没有这么浓",
-      "src_1_sub_2": "火鸡的味道把我每一个味蕾缠住⋯",
-      "src_2_sub_1": "连烧鸭连杯面都冇咁浓嘅味道",
-      "src_2_sub_2": "火鸡嘅味道喺我嘅每一个味蕾度缠住"
+      "ref_sub_1": "什至杯面，烧鸭的味道也没有这么浓",
+      "ref_sub_2": "火鸡的味道把我每一个味蕾缠住⋯",
+      "target_sub_1": "连烧鸭连杯面都冇咁浓嘅味道",
+      "target_sub_2": "火鸡嘅味道喺我嘅每一个味蕾度缠住"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "火鸡的味道把我每一个味蕾缠住⋯",
-      "src_1_sub_2": "爆发⋯缠住⋯爆发⋯",
-      "src_2_sub_1": "火鸡嘅味道喺我嘅每一个味蕾度缠住",
-      "src_2_sub_2": "爆发缠住爆发"
+      "ref_sub_1": "火鸡的味道把我每一个味蕾缠住⋯",
+      "ref_sub_2": "爆发⋯缠住⋯爆发⋯",
+      "target_sub_1": "火鸡嘅味道喺我嘅每一个味蕾度缠住",
+      "target_sub_2": "爆发缠住爆发"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "爆发⋯缠住⋯爆发⋯",
-      "src_1_sub_2": "就像今晚的一切",
-      "src_2_sub_1": "爆发缠住爆发",
-      "src_2_sub_2": "就好似今晚嘅嘢噉"
+      "ref_sub_1": "爆发⋯缠住⋯爆发⋯",
+      "ref_sub_2": "就像今晚的一切",
+      "target_sub_1": "爆发缠住爆发",
+      "target_sub_2": "就好似今晚嘅嘢噉"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "就像今晚的一切",
-      "src_1_sub_2": "最靓最靓，最犀利，而且最温柔",
-      "src_2_sub_1": "就好似今晚嘅嘢噉",
-      "src_2_sub_2": "最靓最靓最犀利亦都系最温柔"
+      "ref_sub_1": "就像今晚的一切",
+      "ref_sub_2": "最靓最靓，最犀利，而且最温柔",
+      "target_sub_1": "就好似今晚嘅嘢噉",
+      "target_sub_2": "最靓最靓最犀利亦都系最温柔"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "第二天我睡得很晏⋯",
-      "src_1_sub_2": "刷过牙我还感觉到火鸡的美味",
-      "src_2_sub_1": "第二日我瞓到好硬",
-      "src_2_sub_2": "测完牙我仲感觉到火鸡嘅美味"
+      "ref_sub_1": "第二天我睡得很晏⋯",
+      "ref_sub_2": "刷过牙我还感觉到火鸡的美味",
+      "target_sub_1": "第二日我瞓到好硬",
+      "target_sub_2": "测完牙我仲感觉到火鸡嘅美味"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "刷过牙我还感觉到火鸡的美味",
-      "src_1_sub_2": "因为早餐吃得晚⋯",
-      "src_2_sub_1": "测完牙我仲感觉到火鸡嘅美味",
-      "src_2_sub_2": "因为早餐食得硬"
+      "ref_sub_1": "刷过牙我还感觉到火鸡的美味",
+      "ref_sub_2": "因为早餐吃得晚⋯",
+      "target_sub_1": "测完牙我仲感觉到火鸡嘅美味",
+      "target_sub_2": "因为早餐食得硬"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "因为早餐吃得晚⋯",
-      "src_1_sub_2": "午餐时妈妈只煮了罐粟米汤",
-      "src_2_sub_1": "因为早餐食得硬",
-      "src_2_sub_2": "唔餐妈妈净系整咗罐粟米汤畀我"
+      "ref_sub_1": "因为早餐吃得晚⋯",
+      "ref_sub_2": "午餐时妈妈只煮了罐粟米汤",
+      "target_sub_1": "因为早餐食得硬",
+      "target_sub_2": "唔餐妈妈净系整咗罐粟米汤畀我"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "午餐时妈妈只煮了罐粟米汤",
-      "src_1_sub_2": "我用汤匙撩了两下",
-      "src_2_sub_1": "唔餐妈妈净系整咗罐粟米汤畀我",
-      "src_2_sub_2": "我系噉用匙羹撩下撩下"
+      "ref_sub_1": "午餐时妈妈只煮了罐粟米汤",
+      "ref_sub_2": "我用汤匙撩了两下",
+      "target_sub_1": "唔餐妈妈净系整咗罐粟米汤畀我",
+      "target_sub_2": "我系噉用匙羹撩下撩下"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我用汤匙撩了两下",
-      "src_1_sub_2": "竟然发现美味的火鸡粒",
-      "src_2_sub_1": "我系噉用匙羹撩下撩下",
-      "src_2_sub_2": "我竟然撩到一粒美味嘅火鸡肉"
+      "ref_sub_1": "我用汤匙撩了两下",
+      "ref_sub_2": "竟然发现美味的火鸡粒",
+      "target_sub_1": "我系噉用匙羹撩下撩下",
+      "target_sub_2": "我竟然撩到一粒美味嘅火鸡肉"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "竟然发现美味的火鸡粒",
-      "src_1_sub_2": "不用说，那夜就是我渴望了⋯",
-      "src_2_sub_1": "我竟然撩到一粒美味嘅火鸡肉",
-      "src_2_sub_2": "嗰晚唔使讲"
+      "ref_sub_1": "竟然发现美味的火鸡粒",
+      "ref_sub_2": "不用说，那夜就是我渴望了⋯",
+      "target_sub_1": "我竟然撩到一粒美味嘅火鸡肉",
+      "target_sub_2": "嗰晚唔使讲"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "不用说，那夜就是我渴望了⋯",
-      "src_1_sub_2": "很久很久很久的⋯圣诞火鸡大餐！",
-      "src_2_sub_1": "嗰晚唔使讲",
-      "src_2_sub_2": "当然系食我限咗好耐好耐好耐好耐嘅圣诞火鸡大餐"
+      "ref_sub_1": "不用说，那夜就是我渴望了⋯",
+      "ref_sub_2": "很久很久很久的⋯圣诞火鸡大餐！",
+      "target_sub_1": "嗰晚唔使讲",
+      "target_sub_2": "当然系食我限咗好耐好耐好耐好耐嘅圣诞火鸡大餐"
     },
     "answer": {
-      "src_2_sub_1_shifted": "嗰晚唔使讲当然系食我限咗",
-      "src_2_sub_2_shifted": "好耐好耐好耐好耐嘅圣诞火鸡大餐"
+      "target_sub_1_shifted": "嗰晚唔使讲当然系食我限咗",
+      "target_sub_2_shifted": "好耐好耐好耐好耐嘅圣诞火鸡大餐"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "竟然发现美味的火鸡粒",
-      "src_1_sub_2": "不用说，那夜就是我渴望了⋯",
-      "src_2_sub_1": "我竟然撩到一粒美味嘅火鸡肉",
-      "src_2_sub_2": "嗰晚唔使讲当然系食我限咗"
+      "ref_sub_1": "竟然发现美味的火鸡粒",
+      "ref_sub_2": "不用说，那夜就是我渴望了⋯",
+      "target_sub_1": "我竟然撩到一粒美味嘅火鸡肉",
+      "target_sub_2": "嗰晚唔使讲当然系食我限咗"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "不用说，那夜就是我渴望了⋯",
-      "src_1_sub_2": "很久很久很久的⋯圣诞火鸡大餐！",
-      "src_2_sub_1": "嗰晚唔使讲当然系食我限咗",
-      "src_2_sub_2": "好耐好耐好耐好耐嘅圣诞火鸡大餐"
+      "ref_sub_1": "不用说，那夜就是我渴望了⋯",
+      "ref_sub_2": "很久很久很久的⋯圣诞火鸡大餐！",
+      "target_sub_1": "嗰晚唔使讲当然系食我限咗",
+      "target_sub_2": "好耐好耐好耐好耐嘅圣诞火鸡大餐"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "很久很久很久的⋯圣诞火鸡大餐！",
-      "src_1_sub_2": "一片片的火鸡肉和伴碟的薯仔和节瓜⋯",
-      "src_2_sub_1": "好耐好耐好耐好耐嘅圣诞火鸡大餐",
-      "src_2_sub_2": "一片一片嘅火鸡肉半碟嘅有薯仔同节瓜"
+      "ref_sub_1": "很久很久很久的⋯圣诞火鸡大餐！",
+      "ref_sub_2": "一片片的火鸡肉和伴碟的薯仔和节瓜⋯",
+      "target_sub_1": "好耐好耐好耐好耐嘅圣诞火鸡大餐",
+      "target_sub_2": "一片一片嘅火鸡肉半碟嘅有薯仔同节瓜"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "一片片的火鸡肉和伴碟的薯仔和节瓜⋯",
-      "src_1_sub_2": "上面淋了老抽生粉献",
-      "src_2_sub_1": "一片一片嘅火鸡肉半碟嘅有薯仔同节瓜",
-      "src_2_sub_2": "上面淋咗一层老抽生粉馅"
+      "ref_sub_1": "一片片的火鸡肉和伴碟的薯仔和节瓜⋯",
+      "ref_sub_2": "上面淋了老抽生粉献",
+      "target_sub_1": "一片一片嘅火鸡肉半碟嘅有薯仔同节瓜",
+      "target_sub_2": "上面淋咗一层老抽生粉馅"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "上面淋了老抽生粉献",
-      "src_1_sub_2": "我们真的好兴奋，好满足",
-      "src_2_sub_1": "上面淋咗一层老抽生粉馅",
-      "src_2_sub_2": "我哋真系好兴奋好满足"
+      "ref_sub_1": "上面淋了老抽生粉献",
+      "ref_sub_2": "我们真的好兴奋，好满足",
+      "target_sub_1": "上面淋咗一层老抽生粉馅",
+      "target_sub_2": "我哋真系好兴奋好满足"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我们真的好兴奋，好满足",
-      "src_1_sub_2": "之后，我们吃了一个星期的⋯",
-      "src_2_sub_1": "我哋真系好兴奋好满足"
+      "ref_sub_1": "我们真的好兴奋，好满足",
+      "ref_sub_2": "之后，我们吃了一个星期的⋯",
+      "target_sub_1": "我哋真系好兴奋好满足"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "之后，我们吃了一个星期的⋯",
-      "src_1_sub_2": "火鸡三文治早餐",
-      "src_2_sub_2": "之后我哋仲食咗一个礼拜嘅火鸡三文治做早餐"
+      "ref_sub_1": "之后，我们吃了一个星期的⋯",
+      "ref_sub_2": "火鸡三文治早餐",
+      "target_sub_2": "之后我哋仲食咗一个礼拜嘅火鸡三文治做早餐"
     },
     "answer": {
-      "src_2_sub_1_shifted": "之后我哋仲食咗一个礼拜嘅",
-      "src_2_sub_2_shifted": "火鸡三文治做早餐"
+      "target_sub_1_shifted": "之后我哋仲食咗一个礼拜嘅",
+      "target_sub_2_shifted": "火鸡三文治做早餐"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我们真的好兴奋，好满足",
-      "src_1_sub_2": "之后，我们吃了一个星期的⋯",
-      "src_2_sub_1": "我哋真系好兴奋好满足",
-      "src_2_sub_2": "之后我哋仲食咗一个礼拜嘅"
+      "ref_sub_1": "我们真的好兴奋，好满足",
+      "ref_sub_2": "之后，我们吃了一个星期的⋯",
+      "target_sub_1": "我哋真系好兴奋好满足",
+      "target_sub_2": "之后我哋仲食咗一个礼拜嘅"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "之后，我们吃了一个星期的⋯",
-      "src_1_sub_2": "火鸡三文治早餐",
-      "src_2_sub_1": "之后我哋仲食咗一个礼拜嘅",
-      "src_2_sub_2": "火鸡三文治做早餐"
+      "ref_sub_1": "之后，我们吃了一个星期的⋯",
+      "ref_sub_2": "火鸡三文治早餐",
+      "target_sub_1": "之后我哋仲食咗一个礼拜嘅",
+      "target_sub_2": "火鸡三文治做早餐"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "火鸡三文治早餐",
-      "src_1_sub_2": "星期天",
-      "src_2_sub_1": "火鸡三文治做早餐",
-      "src_2_sub_2": "星期日"
+      "ref_sub_1": "火鸡三文治早餐",
+      "ref_sub_2": "星期天",
+      "target_sub_1": "火鸡三文治做早餐",
+      "target_sub_2": "星期日"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "星期天",
-      "src_1_sub_2": "我大着胆跟妈妈说：不如去饮茶吖",
-      "src_2_sub_1": "星期日",
-      "src_2_sub_2": "我嘅记心肝同妈妈讲不如饮茶"
+      "ref_sub_1": "星期天",
+      "ref_sub_2": "我大着胆跟妈妈说：不如去饮茶吖",
+      "target_sub_1": "星期日",
+      "target_sub_2": "我嘅记心肝同妈妈讲不如饮茶"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我大着胆跟妈妈说：不如去饮茶吖",
-      "src_1_sub_2": "妈妈骂我「冇衣食」⋯",
-      "src_2_sub_1": "我嘅记心肝同妈妈讲不如饮茶",
-      "src_2_sub_2": "妈妈闹我冇意食"
+      "ref_sub_1": "我大着胆跟妈妈说：不如去饮茶吖",
+      "ref_sub_2": "妈妈骂我「冇衣食」⋯",
+      "target_sub_1": "我嘅记心肝同妈妈讲不如饮茶",
+      "target_sub_2": "妈妈闹我冇意食"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈骂我「冇衣食」⋯",
-      "src_1_sub_2": "不过还是带了我去饮茶",
-      "src_2_sub_1": "妈妈闹我冇意食",
-      "src_2_sub_2": "但系都带咗我去饮茶"
+      "ref_sub_1": "妈妈骂我「冇衣食」⋯",
+      "ref_sub_2": "不过还是带了我去饮茶",
+      "target_sub_1": "妈妈闹我冇意食",
+      "target_sub_2": "但系都带咗我去饮茶"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "不过还是带了我去饮茶",
-      "src_1_sub_2": "之后，妈妈又有计⋯",
-      "src_2_sub_1": "但系都带咗我去饮茶",
-      "src_2_sub_2": "之后妈妈又有计"
+      "ref_sub_1": "不过还是带了我去饮茶",
+      "ref_sub_2": "之后，妈妈又有计⋯",
+      "target_sub_1": "但系都带咗我去饮茶",
+      "target_sub_2": "之后妈妈又有计"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "之后，妈妈又有计⋯",
-      "src_1_sub_2": "她把冰箱内剩下来的火鸡肉撕呀撕",
-      "src_2_sub_1": "之后妈妈又有计",
-      "src_2_sub_2": "佢将雪柜净返嘅火鸡肉系噉撕系噉撕"
+      "ref_sub_1": "之后，妈妈又有计⋯",
+      "ref_sub_2": "她把冰箱内剩下来的火鸡肉撕呀撕",
+      "target_sub_1": "之后妈妈又有计",
+      "target_sub_2": "佢将雪柜净返嘅火鸡肉系噉撕系噉撕"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "她把冰箱内剩下来的火鸡肉撕呀撕",
-      "src_1_sub_2": "有时候也叫我帮手撕",
-      "src_2_sub_1": "佢将雪柜净返嘅火鸡肉系噉撕系噉撕",
-      "src_2_sub_2": "有时都叫我帮手撕"
+      "ref_sub_1": "她把冰箱内剩下来的火鸡肉撕呀撕",
+      "ref_sub_2": "有时候也叫我帮手撕",
+      "target_sub_1": "佢将雪柜净返嘅火鸡肉系噉撕系噉撕",
+      "target_sub_2": "有时都叫我帮手撕"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "有时候也叫我帮手撕",
-      "src_1_sub_2": "火鸡留在指甲的味道",
-      "src_2_sub_1": "有时都叫我帮手撕",
-      "src_2_sub_2": "火鸡留喺指甲嗰阵味"
+      "ref_sub_1": "有时候也叫我帮手撕",
+      "ref_sub_2": "火鸡留在指甲的味道",
+      "target_sub_1": "有时都叫我帮手撕",
+      "target_sub_2": "火鸡留喺指甲嗰阵味"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "火鸡留在指甲的味道",
-      "src_1_sub_2": "原来得洗好多次",
-      "src_2_sub_1": "火鸡留喺指甲嗰阵味",
-      "src_2_sub_2": "原来洗好多次都仲喺度㗎"
+      "ref_sub_1": "火鸡留在指甲的味道",
+      "ref_sub_2": "原来得洗好多次",
+      "target_sub_1": "火鸡留喺指甲嗰阵味",
+      "target_sub_2": "原来洗好多次都仲喺度㗎"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "原来得洗好多次",
-      "src_1_sub_2": "银芽火鸡丝炒米，好味道",
-      "src_2_sub_1": "原来洗好多次都仲喺度㗎",
-      "src_2_sub_2": "银牙火鸡丝炒米好味道噉"
+      "ref_sub_1": "原来得洗好多次",
+      "ref_sub_2": "银芽火鸡丝炒米，好味道",
+      "target_sub_1": "原来洗好多次都仲喺度㗎",
+      "target_sub_2": "银牙火鸡丝炒米好味道噉"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "银芽火鸡丝炒米，好味道",
-      "src_1_sub_2": "栗子炆火鸡丝㷛",
-      "src_2_sub_1": "银牙火鸡丝炒米好味道噉",
-      "src_2_sub_2": "焯焯栗子焖火鸡丝煲"
+      "ref_sub_1": "银芽火鸡丝炒米，好味道",
+      "ref_sub_2": "栗子炆火鸡丝㷛",
+      "target_sub_1": "银牙火鸡丝炒米好味道噉",
+      "target_sub_2": "焯焯栗子焖火鸡丝煲"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "栗子炆火鸡丝㷛",
-      "src_1_sub_2": "花生火鸡骨煲粥",
-      "src_2_sub_1": "焯焯栗子焖火鸡丝煲",
-      "src_2_sub_2": "花生火鸡骨煲粥"
+      "ref_sub_1": "栗子炆火鸡丝㷛",
+      "ref_sub_2": "花生火鸡骨煲粥",
+      "target_sub_1": "焯焯栗子焖火鸡丝煲",
+      "target_sub_2": "花生火鸡骨煲粥"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "花生火鸡骨煲粥",
-      "src_1_sub_2": "纸包火鸡包包纸",
-      "src_2_sub_1": "花生火鸡骨煲粥",
-      "src_2_sub_2": "纸包火鸡包包纸"
+      "ref_sub_1": "花生火鸡骨煲粥",
+      "ref_sub_2": "纸包火鸡包包纸",
+      "target_sub_1": "花生火鸡骨煲粥",
+      "target_sub_2": "纸包火鸡包包纸"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "纸包火鸡包包纸",
-      "src_1_sub_2": "包火鸡包包包火鸡包",
-      "src_2_sub_1": "纸包火鸡包包纸",
-      "src_2_sub_2": "包火鸡包包包火鸡包"
+      "ref_sub_1": "纸包火鸡包包纸",
+      "ref_sub_2": "包火鸡包包包火鸡包",
+      "target_sub_1": "纸包火鸡包包纸",
+      "target_sub_2": "包火鸡包包包火鸡包"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "包火鸡包包包火鸡包",
-      "src_1_sub_2": "酿火鸡馅搽面包",
-      "src_2_sub_1": "包火鸡包包包火鸡包",
-      "src_2_sub_2": "让火鸡馅茶面包"
+      "ref_sub_1": "包火鸡包包包火鸡包",
+      "ref_sub_2": "酿火鸡馅搽面包",
+      "target_sub_1": "包火鸡包包包火鸡包",
+      "target_sub_2": "让火鸡馅茶面包"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "酿火鸡馅搽面包",
-      "src_1_sub_2": "唉，我好后悔讲过一句「火鸡屙烂煮」",
-      "src_2_sub_1": "让火鸡馅茶面包",
-      "src_2_sub_2": "唉我后悔讲过火鸡阿宁处呢句嘢"
+      "ref_sub_1": "酿火鸡馅搽面包",
+      "ref_sub_2": "唉，我好后悔讲过一句「火鸡屙烂煮」",
+      "target_sub_1": "让火鸡馅茶面包",
+      "target_sub_2": "唉我后悔讲过火鸡阿宁处呢句嘢"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "唉，我好后悔讲过一句「火鸡屙烂煮」",
-      "src_1_sub_2": "端午节，当我翻开我最喜欢吃的裹蒸粽⋯",
-      "src_2_sub_1": "唉我后悔讲过火鸡阿宁处呢句嘢",
-      "src_2_sub_2": "到端午节当我督开我最钟意食嘅果精粽嘅时候"
+      "ref_sub_1": "唉，我好后悔讲过一句「火鸡屙烂煮」",
+      "ref_sub_2": "端午节，当我翻开我最喜欢吃的裹蒸粽⋯",
+      "target_sub_1": "唉我后悔讲过火鸡阿宁处呢句嘢",
+      "target_sub_2": "到端午节当我督开我最钟意食嘅果精粽嘅时候"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "端午节，当我翻开我最喜欢吃的裹蒸粽⋯",
-      "src_1_sub_2": "发现咸蛋旁边是一件火鸡背的时候⋯",
-      "src_2_sub_1": "到端午节当我督开我最钟意食嘅果精粽嘅时候",
-      "src_2_sub_2": "发现宿喺咸蛋旁边嘅系一件火鸡背脊"
+      "ref_sub_1": "端午节，当我翻开我最喜欢吃的裹蒸粽⋯",
+      "ref_sub_2": "发现咸蛋旁边是一件火鸡背的时候⋯",
+      "target_sub_1": "到端午节当我督开我最钟意食嘅果精粽嘅时候",
+      "target_sub_2": "发现宿喺咸蛋旁边嘅系一件火鸡背脊"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "发现咸蛋旁边是一件火鸡背的时候⋯",
-      "src_1_sub_2": "我脑部一时想唔通，哭起来",
-      "src_2_sub_1": "发现宿喺咸蛋旁边嘅系一件火鸡背脊",
-      "src_2_sub_2": "我脑部一时想唔通喊咗起上嚟"
+      "ref_sub_1": "发现咸蛋旁边是一件火鸡背的时候⋯",
+      "ref_sub_2": "我脑部一时想唔通，哭起来",
+      "target_sub_1": "发现宿喺咸蛋旁边嘅系一件火鸡背脊",
+      "target_sub_2": "我脑部一时想唔通喊咗起上嚟"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我脑部一时想唔通，哭起来",
-      "src_1_sub_2": "救命呀！",
-      "src_2_sub_1": "我脑部一时想唔通喊咗起上嚟",
-      "src_2_sub_2": "救命啊"
+      "ref_sub_1": "我脑部一时想唔通，哭起来",
+      "ref_sub_2": "救命呀！",
+      "target_sub_1": "我脑部一时想唔通喊咗起上嚟",
+      "target_sub_2": "救命啊"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "救命呀！",
-      "src_1_sub_2": "妈妈悄悄把剩下的火鸡扔掉",
-      "src_2_sub_1": "救命啊",
-      "src_2_sub_2": "妈妈净计计将净低嘅火鸡劈咗"
+      "ref_sub_1": "救命呀！",
+      "ref_sub_2": "妈妈悄悄把剩下的火鸡扔掉",
+      "target_sub_1": "救命啊",
+      "target_sub_2": "妈妈净计计将净低嘅火鸡劈咗"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈悄悄把剩下的火鸡扔掉",
-      "src_1_sub_2": "那已经是火鸡解冻后差不多半年的事",
-      "src_2_sub_1": "妈妈净计计将净低嘅火鸡劈咗",
-      "src_2_sub_2": "原来嗰阵已经系只火鸡解冻咗差唔多半年后嘅事"
+      "ref_sub_1": "妈妈悄悄把剩下的火鸡扔掉",
+      "ref_sub_2": "那已经是火鸡解冻后差不多半年的事",
+      "target_sub_1": "妈妈净计计将净低嘅火鸡劈咗",
+      "target_sub_2": "原来嗰阵已经系只火鸡解冻咗差唔多半年后嘅事"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "那已经是火鸡解冻后差不多半年的事",
-      "src_1_sub_2": "我的美梦跟恶梦亦同时完结",
-      "src_2_sub_1": "原来嗰阵已经系只火鸡解冻咗差唔多半年后嘅事",
-      "src_2_sub_2": "我嘅美梦同噩梦都同时完结"
+      "ref_sub_1": "那已经是火鸡解冻后差不多半年的事",
+      "ref_sub_2": "我的美梦跟恶梦亦同时完结",
+      "target_sub_1": "原来嗰阵已经系只火鸡解冻咗差唔多半年后嘅事",
+      "target_sub_2": "我嘅美梦同噩梦都同时完结"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我的美梦跟恶梦亦同时完结",
-      "src_1_sub_2": "后来我才知道⋯",
-      "src_2_sub_1": "我嘅美梦同噩梦都同时完结",
-      "src_2_sub_2": "后来我先知道"
+      "ref_sub_1": "我的美梦跟恶梦亦同时完结",
+      "ref_sub_2": "后来我才知道⋯",
+      "target_sub_1": "我嘅美梦同噩梦都同时完结",
+      "target_sub_2": "后来我先知道"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "后来我才知道⋯",
-      "src_1_sub_2": "一只火鸡由出世到给人宰掉",
-      "src_2_sub_1": "后来我先知道",
-      "src_2_sub_2": "一只火鸡由出世到畀人㓥"
+      "ref_sub_1": "后来我才知道⋯",
+      "ref_sub_2": "一只火鸡由出世到给人宰掉",
+      "target_sub_1": "后来我先知道",
+      "target_sub_2": "一只火鸡由出世到畀人㓥"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "一只火鸡由出世到给人宰掉",
-      "src_1_sub_2": "也不过是几个月间的事",
-      "src_2_sub_1": "一只火鸡由出世到畀人㓥",
-      "src_2_sub_2": "都不过系几个月之间嘅事"
+      "ref_sub_1": "一只火鸡由出世到给人宰掉",
+      "ref_sub_2": "也不过是几个月间的事",
+      "target_sub_1": "一只火鸡由出世到畀人㓥",
+      "target_sub_2": "都不过系几个月之间嘅事"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "也不过是几个月间的事",
-      "src_1_sub_2": "即是说，火鸡死掉后跟我们一起的日子",
-      "src_2_sub_1": "都不过系几个月之间嘅事",
-      "src_2_sub_2": "即系话只火鸡死咗之后同我哋一齐嘅日子"
+      "ref_sub_1": "也不过是几个月间的事",
+      "ref_sub_2": "即是说，火鸡死掉后跟我们一起的日子",
+      "target_sub_1": "都不过系几个月之间嘅事",
+      "target_sub_2": "即系话只火鸡死咗之后同我哋一齐嘅日子"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "即是说，火鸡死掉后跟我们一起的日子",
-      "src_1_sub_2": "还要长过它的一生",
-      "src_2_sub_1": "即系话只火鸡死咗之后同我哋一齐嘅日子",
-      "src_2_sub_2": "仲长过佢自己本身条命"
+      "ref_sub_1": "即是说，火鸡死掉后跟我们一起的日子",
+      "ref_sub_2": "还要长过它的一生",
+      "target_sub_1": "即系话只火鸡死咗之后同我哋一齐嘅日子",
+      "target_sub_2": "仲长过佢自己本身条命"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "还要长过它的一生",
-      "src_1_sub_2": "我还发觉，火鸡的味道⋯",
-      "src_2_sub_1": "仲长过佢自己本身条命",
-      "src_2_sub_2": "我仲发觉到"
+      "ref_sub_1": "还要长过它的一生",
+      "ref_sub_2": "我还发觉，火鸡的味道⋯",
+      "target_sub_1": "仲长过佢自己本身条命",
+      "target_sub_2": "我仲发觉到"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我还发觉，火鸡的味道⋯",
-      "src_1_sub_2": "将吃未吃和第一口之间已经是最高峰",
-      "src_2_sub_1": "我仲发觉到",
-      "src_2_sub_2": "火鸡嘅味道味食同食第一啖之间已经系佢嘅最高峰"
+      "ref_sub_1": "我还发觉，火鸡的味道⋯",
+      "ref_sub_2": "将吃未吃和第一口之间已经是最高峰",
+      "target_sub_1": "我仲发觉到",
+      "target_sub_2": "火鸡嘅味道味食同食第一啖之间已经系佢嘅最高峰"
     },
     "answer": {
-      "src_2_sub_1_shifted": "我仲发觉到火鸡嘅味道",
-      "src_2_sub_2_shifted": "味食同食第一啖之间已经系佢嘅最高峰"
+      "target_sub_1_shifted": "我仲发觉到火鸡嘅味道",
+      "target_sub_2_shifted": "味食同食第一啖之间已经系佢嘅最高峰"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "将吃未吃和第一口之间已经是最高峰",
-      "src_1_sub_2": "之后的，不过是开始了也就吃下去",
-      "src_2_sub_1": "味食同食第一啖之间已经系佢嘅最高峰",
-      "src_2_sub_2": "之后不过都系食开就食埋落去噉解"
+      "ref_sub_1": "将吃未吃和第一口之间已经是最高峰",
+      "ref_sub_2": "之后的，不过是开始了也就吃下去",
+      "target_sub_1": "味食同食第一啖之间已经系佢嘅最高峰",
+      "target_sub_2": "之后不过都系食开就食埋落去噉解"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "之后的，不过是开始了也就吃下去",
-      "src_1_sub_2": "我没有哲学家的头脑⋯",
-      "src_2_sub_1": "之后不过都系食开就食埋落去噉解",
-      "src_2_sub_2": "我冇知学家嘅头脑"
+      "ref_sub_1": "之后的，不过是开始了也就吃下去",
+      "ref_sub_2": "我没有哲学家的头脑⋯",
+      "target_sub_1": "之后不过都系食开就食埋落去噉解",
+      "target_sub_2": "我冇知学家嘅头脑"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我没有哲学家的头脑⋯",
-      "src_1_sub_2": "不知道两件事情应该得出什么道理",
-      "src_2_sub_1": "我冇知学家嘅头脑",
-      "src_2_sub_2": "唔知呢两样嘢要得起嘅呢个得出啲咩道理"
+      "ref_sub_1": "我没有哲学家的头脑⋯",
+      "ref_sub_2": "不知道两件事情应该得出什么道理",
+      "target_sub_1": "我冇知学家嘅头脑",
+      "target_sub_2": "唔知呢两样嘢要得起嘅呢个得出啲咩道理"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "不知道两件事情应该得出什么道理",
-      "src_1_sub_2": "可是这些想法⋯",
-      "src_2_sub_1": "唔知呢两样嘢要得起嘅呢个得出啲咩道理",
-      "src_2_sub_2": "但系呢啲谂法"
+      "ref_sub_1": "不知道两件事情应该得出什么道理",
+      "ref_sub_2": "可是这些想法⋯",
+      "target_sub_1": "唔知呢两样嘢要得起嘅呢个得出啲咩道理",
+      "target_sub_2": "但系呢啲谂法"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "可是这些想法⋯",
-      "src_1_sub_2": "在我长大后⋯",
-      "src_2_sub_1": "但系呢啲谂法",
-      "src_2_sub_2": "喺我长大之后"
+      "ref_sub_1": "可是这些想法⋯",
+      "ref_sub_2": "在我长大后⋯",
+      "target_sub_1": "但系呢啲谂法",
+      "target_sub_2": "喺我长大之后"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "在我长大后⋯",
-      "src_1_sub_2": "在一些跟圣诞节无关的日子⋯",
-      "src_2_sub_1": "喺我长大之后",
-      "src_2_sub_2": "系一啲同圣诞节无关嘅日子"
+      "ref_sub_1": "在我长大后⋯",
+      "ref_sub_2": "在一些跟圣诞节无关的日子⋯",
+      "target_sub_1": "喺我长大之后",
+      "target_sub_2": "系一啲同圣诞节无关嘅日子"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "在一些跟圣诞节无关的日子⋯",
-      "src_1_sub_2": "毫无因由的在我脑中出现过三两次",
-      "src_2_sub_1": "系一啲同圣诞节无关嘅日子",
-      "src_2_sub_2": "无端端噉喺我脑部出现过两三次"
+      "ref_sub_1": "在一些跟圣诞节无关的日子⋯",
+      "ref_sub_2": "毫无因由的在我脑中出现过三两次",
+      "target_sub_1": "系一啲同圣诞节无关嘅日子",
+      "target_sub_2": "无端端噉喺我脑部出现过两三次"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "毫无因由的在我脑中出现过三两次",
-      "src_1_sub_2": "一次，是在我自己的婚宴上",
-      "src_2_sub_1": "无端端噉喺我脑部出现过两三次",
-      "src_2_sub_2": "一次喺我自己嘅婚宴上"
+      "ref_sub_1": "毫无因由的在我脑中出现过三两次",
+      "ref_sub_2": "一次，是在我自己的婚宴上",
+      "target_sub_1": "无端端噉喺我脑部出现过两三次",
+      "target_sub_2": "一次喺我自己嘅婚宴上"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "一次，是在我自己的婚宴上",
-      "src_1_sub_2": "一次⋯",
-      "src_2_sub_1": "一次喺我自己嘅婚宴上",
-      "src_2_sub_2": "一次"
+      "ref_sub_1": "一次，是在我自己的婚宴上",
+      "ref_sub_2": "一次⋯",
+      "target_sub_1": "一次喺我自己嘅婚宴上",
+      "target_sub_2": "一次"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "一次⋯",
-      "src_1_sub_2": "是在我妈妈火化那天",
-      "src_2_sub_1": "一次",
-      "src_2_sub_2": "喺我妈妈火化嗰日"
+      "ref_sub_1": "一次⋯",
+      "ref_sub_2": "是在我妈妈火化那天",
+      "target_sub_1": "一次",
+      "target_sub_2": "喺我妈妈火化嗰日"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "是在我妈妈火化那天",
-      "src_1_sub_2": "那天，我看着天空几缕灰色的烟",
-      "src_2_sub_1": "喺我妈妈火化嗰日",
-      "src_2_sub_2": "嗰日我望住天东几条灰色嘅烟"
+      "ref_sub_1": "是在我妈妈火化那天",
+      "ref_sub_2": "那天，我看着天空几缕灰色的烟",
+      "target_sub_1": "喺我妈妈火化嗰日",
+      "target_sub_2": "嗰日我望住天东几条灰色嘅烟"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "那天，我看着天空几缕灰色的烟",
-      "src_1_sub_2": "忽然间嗅到火鸡又浓又淡的气味",
-      "src_2_sub_1": "嗰日我望住天东几条灰色嘅烟",
-      "src_2_sub_2": "忽然闻到火鸡又浓又淡嘅气味"
+      "ref_sub_1": "那天，我看着天空几缕灰色的烟",
+      "ref_sub_2": "忽然间嗅到火鸡又浓又淡的气味",
+      "target_sub_1": "嗰日我望住天东几条灰色嘅烟",
+      "target_sub_2": "忽然闻到火鸡又浓又淡嘅气味"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "忽然间嗅到火鸡又浓又淡的气味",
-      "src_1_sub_2": "我好后悔要妈妈扔掉最后几件火鸡",
-      "src_2_sub_1": "忽然闻到火鸡又浓又淡嘅气味",
-      "src_2_sub_2": "我后悔要妈妈劈咗个忌廉火鸡"
+      "ref_sub_1": "忽然间嗅到火鸡又浓又淡的气味",
+      "ref_sub_2": "我好后悔要妈妈扔掉最后几件火鸡",
+      "target_sub_1": "忽然闻到火鸡又浓又淡嘅气味",
+      "target_sub_2": "我后悔要妈妈劈咗个忌廉火鸡"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "特别报告",
-      "src_1_sub_2": "奥运金牌得主李丽珊决定参加今届奥运会",
-      "src_2_sub_1": "特别报道",
-      "src_2_sub_2": "奥运滑浪风帆金牌得主李丽珊决定参加今届嘅奥运"
+      "ref_sub_1": "特别报告",
+      "ref_sub_2": "奥运金牌得主李丽珊决定参加今届奥运会",
+      "target_sub_1": "特别报道",
+      "target_sub_2": "奥运滑浪风帆金牌得主李丽珊决定参加今届嘅奥运"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "奥运金牌得主李丽珊决定参加今届奥运会",
-      "src_1_sub_2": "向全世界人再次证明⋯",
-      "src_2_sub_1": "奥运滑浪风帆金牌得主李丽珊决定参加今届嘅奥运"
+      "ref_sub_1": "奥运金牌得主李丽珊决定参加今届奥运会",
+      "ref_sub_2": "向全世界人再次证明⋯",
+      "target_sub_1": "奥运滑浪风帆金牌得主李丽珊决定参加今届嘅奥运"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "向全世界人再次证明⋯",
-      "src_1_sub_2": "香港运动员不是腊鸭",
-      "src_2_sub_2": "向全世界人再次证明香港嘅运动员唔系腊鸭"
+      "ref_sub_1": "向全世界人再次证明⋯",
+      "ref_sub_2": "香港运动员不是腊鸭",
+      "target_sub_2": "向全世界人再次证明香港嘅运动员唔系腊鸭"
     },
     "answer": {
-      "src_2_sub_1_shifted": "向全世界人再次证明",
-      "src_2_sub_2_shifted": "香港嘅运动员唔系腊鸭"
+      "target_sub_1_shifted": "向全世界人再次证明",
+      "target_sub_2_shifted": "香港嘅运动员唔系腊鸭"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "奥运金牌得主李丽珊决定参加今届奥运会",
-      "src_1_sub_2": "向全世界人再次证明⋯",
-      "src_2_sub_1": "奥运滑浪风帆金牌得主李丽珊决定参加今届嘅奥运",
-      "src_2_sub_2": "向全世界人再次证明"
+      "ref_sub_1": "奥运金牌得主李丽珊决定参加今届奥运会",
+      "ref_sub_2": "向全世界人再次证明⋯",
+      "target_sub_1": "奥运滑浪风帆金牌得主李丽珊决定参加今届嘅奥运",
+      "target_sub_2": "向全世界人再次证明"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "向全世界人再次证明⋯",
-      "src_1_sub_2": "香港运动员不是腊鸭",
-      "src_2_sub_1": "向全世界人再次证明",
-      "src_2_sub_2": "香港嘅运动员唔系腊鸭"
+      "ref_sub_1": "向全世界人再次证明⋯",
+      "ref_sub_2": "香港运动员不是腊鸭",
+      "target_sub_1": "向全世界人再次证明",
+      "target_sub_2": "香港嘅运动员唔系腊鸭"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "香港运动员不是腊鸭",
-      "src_1_sub_2": "另方面⋯",
-      "src_2_sub_1": "香港嘅运动员唔系腊鸭"
+      "ref_sub_1": "香港运动员不是腊鸭",
+      "ref_sub_2": "另方面⋯",
+      "target_sub_1": "香港嘅运动员唔系腊鸭"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "另方面⋯",
-      "src_1_sub_2": "香港体运总会霍震霆⋯",
-      "src_2_sub_2": "另一方面"
+      "ref_sub_1": "另方面⋯",
+      "ref_sub_2": "香港体运总会霍震霆⋯",
+      "target_sub_2": "另一方面"
     },
     "answer": {
-      "src_2_sub_1_shifted": "另一方面"
+      "target_sub_1_shifted": "另一方面"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "香港体运总会霍震霆⋯",
-      "src_1_sub_2": "正式向亚运协会提出申请",
-      "src_2_sub_2": "中国香港体育协会企奥委会会长霍振庭正式向亚运协会提出申请"
+      "ref_sub_1": "香港体运总会霍震霆⋯",
+      "ref_sub_2": "正式向亚运协会提出申请",
+      "target_sub_2": "中国香港体育协会企奥委会会长霍振庭正式向亚运协会提出申请"
     },
     "answer": {
-      "src_2_sub_1_shifted": "中国香港体育协会企奥委会会长霍振庭",
-      "src_2_sub_2_shifted": "正式向亚运协会提出申请"
+      "target_sub_1_shifted": "中国香港体育协会企奥委会会长霍振庭",
+      "target_sub_2_shifted": "正式向亚运协会提出申请"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "另方面⋯",
-      "src_1_sub_2": "香港体运总会霍震霆⋯",
-      "src_2_sub_2": "另一方面中国香港体育协会企奥委会会长霍振庭"
+      "ref_sub_1": "另方面⋯",
+      "ref_sub_2": "香港体运总会霍震霆⋯",
+      "target_sub_2": "另一方面中国香港体育协会企奥委会会长霍振庭"
     },
     "answer": {
-      "src_2_sub_1_shifted": "另一方面",
-      "src_2_sub_2_shifted": "中国香港体育协会企奥委会会长霍振庭"
+      "target_sub_1_shifted": "另一方面",
+      "target_sub_2_shifted": "中国香港体育协会企奥委会会长霍振庭"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "香港体运总会霍震霆⋯",
-      "src_1_sub_2": "正式向亚运协会提出申请",
-      "src_2_sub_1": "中国香港体育协会企奥委会会长霍振庭",
-      "src_2_sub_2": "正式向亚运协会提出申请"
+      "ref_sub_1": "香港体运总会霍震霆⋯",
+      "ref_sub_2": "正式向亚运协会提出申请",
+      "target_sub_1": "中国香港体育协会企奥委会会长霍振庭",
+      "target_sub_2": "正式向亚运协会提出申请"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "正式向亚运协会提出申请",
-      "src_1_sub_2": "香港将争夺下届亚运会主办权",
-      "src_2_sub_1": "正式向亚运协会提出申请",
-      "src_2_sub_2": "香港将要争夺下届亚运会嘅主办权"
+      "ref_sub_1": "正式向亚运协会提出申请",
+      "ref_sub_2": "香港将争夺下届亚运会主办权",
+      "target_sub_1": "正式向亚运协会提出申请",
+      "target_sub_2": "香港将要争夺下届亚运会嘅主办权"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "香港将争夺下届亚运会主办权",
-      "src_1_sub_2": "多个运动团体立即表示热烈支持",
-      "src_2_sub_1": "香港将要争夺下届亚运会嘅主办权",
-      "src_2_sub_2": "多个运动团体立即表示热烈支持"
+      "ref_sub_1": "香港将争夺下届亚运会主办权",
+      "ref_sub_2": "多个运动团体立即表示热烈支持",
+      "target_sub_1": "香港将要争夺下届亚运会嘅主办权",
+      "target_sub_2": "多个运动团体立即表示热烈支持"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "多个运动团体立即表示热烈支持",
-      "src_1_sub_2": "其中港九新界竹战联谊会⋯",
-      "src_2_sub_1": "多个运动团体立即表示热烈支持"
+      "ref_sub_1": "多个运动团体立即表示热烈支持",
+      "ref_sub_2": "其中港九新界竹战联谊会⋯",
+      "target_sub_1": "多个运动团体立即表示热烈支持"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "其中港九新界竹战联谊会⋯",
-      "src_1_sub_2": "更希望打麻将可以成为亚运项目",
-      "src_2_sub_2": "其中港狗新界足战联谊会更希望打麻雀可以成为亚运项目"
+      "ref_sub_1": "其中港九新界竹战联谊会⋯",
+      "ref_sub_2": "更希望打麻将可以成为亚运项目",
+      "target_sub_2": "其中港狗新界足战联谊会更希望打麻雀可以成为亚运项目"
     },
     "answer": {
-      "src_2_sub_1_shifted": "其中港狗新界足战联谊会",
-      "src_2_sub_2_shifted": "更希望打麻雀可以成为亚运项目"
+      "target_sub_1_shifted": "其中港狗新界足战联谊会",
+      "target_sub_2_shifted": "更希望打麻雀可以成为亚运项目"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "多个运动团体立即表示热烈支持",
-      "src_1_sub_2": "其中港九新界竹战联谊会⋯",
-      "src_2_sub_1": "多个运动团体立即表示热烈支持",
-      "src_2_sub_2": "其中港狗新界足战联谊会"
+      "ref_sub_1": "多个运动团体立即表示热烈支持",
+      "ref_sub_2": "其中港九新界竹战联谊会⋯",
+      "target_sub_1": "多个运动团体立即表示热烈支持",
+      "target_sub_2": "其中港狗新界足战联谊会"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "其中港九新界竹战联谊会⋯",
-      "src_1_sub_2": "更希望打麻将可以成为亚运项目",
-      "src_2_sub_1": "其中港狗新界足战联谊会",
-      "src_2_sub_2": "更希望打麻雀可以成为亚运项目"
+      "ref_sub_1": "其中港九新界竹战联谊会⋯",
+      "ref_sub_2": "更希望打麻将可以成为亚运项目",
+      "target_sub_1": "其中港狗新界足战联谊会",
+      "target_sub_2": "更希望打麻雀可以成为亚运项目"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "更希望打麻将可以成为亚运项目",
-      "src_1_sub_2": "另外，全港茶餐厅员工协会⋯",
-      "src_2_sub_1": "更希望打麻雀可以成为亚运项目",
-      "src_2_sub_2": "另外"
+      "ref_sub_1": "更希望打麻将可以成为亚运项目",
+      "ref_sub_2": "另外，全港茶餐厅员工协会⋯",
+      "target_sub_1": "更希望打麻雀可以成为亚运项目",
+      "target_sub_2": "另外"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "另外，全港茶餐厅员工协会⋯",
-      "src_1_sub_2": "经已发动所有会员⋯",
-      "src_2_sub_1": "另外"
+      "ref_sub_1": "另外，全港茶餐厅员工协会⋯",
+      "ref_sub_2": "经已发动所有会员⋯",
+      "target_sub_1": "另外"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "经已发动所有会员⋯",
-      "src_1_sub_2": "争取「掷蛋挞」成为亚运比赛项目",
-      "src_2_sub_2": "全港茶餐厅联工协会经热发动所有会员争取掟蛋挞成为亚运会比赛项目"
+      "ref_sub_1": "经已发动所有会员⋯",
+      "ref_sub_2": "争取「掷蛋挞」成为亚运比赛项目",
+      "target_sub_2": "全港茶餐厅联工协会经热发动所有会员争取掟蛋挞成为亚运会比赛项目"
     },
     "answer": {
-      "src_2_sub_1_shifted": "全港茶餐厅联工协会经热发动所有会员",
-      "src_2_sub_2_shifted": "争取掟蛋挞成为亚运会比赛项目"
+      "target_sub_1_shifted": "全港茶餐厅联工协会经热发动所有会员",
+      "target_sub_2_shifted": "争取掟蛋挞成为亚运会比赛项目"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "另外，全港茶餐厅员工协会⋯",
-      "src_1_sub_2": "经已发动所有会员⋯",
-      "src_2_sub_1": "另外",
-      "src_2_sub_2": "全港茶餐厅联工协会经热发动所有会员"
+      "ref_sub_1": "另外，全港茶餐厅员工协会⋯",
+      "ref_sub_2": "经已发动所有会员⋯",
+      "target_sub_1": "另外",
+      "target_sub_2": "全港茶餐厅联工协会经热发动所有会员"
     },
     "answer": {
-      "src_2_sub_1_shifted": "另外全港茶餐厅联工协会",
-      "src_2_sub_2_shifted": "经热发动所有会员"
+      "target_sub_1_shifted": "另外全港茶餐厅联工协会",
+      "target_sub_2_shifted": "经热发动所有会员"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "更希望打麻将可以成为亚运项目",
-      "src_1_sub_2": "另外，全港茶餐厅员工协会⋯",
-      "src_2_sub_1": "更希望打麻雀可以成为亚运项目",
-      "src_2_sub_2": "另外全港茶餐厅联工协会"
+      "ref_sub_1": "更希望打麻将可以成为亚运项目",
+      "ref_sub_2": "另外，全港茶餐厅员工协会⋯",
+      "target_sub_1": "更希望打麻雀可以成为亚运项目",
+      "target_sub_2": "另外全港茶餐厅联工协会"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "另外，全港茶餐厅员工协会⋯",
-      "src_1_sub_2": "经已发动所有会员⋯",
-      "src_2_sub_1": "另外全港茶餐厅联工协会",
-      "src_2_sub_2": "经热发动所有会员"
+      "ref_sub_1": "另外，全港茶餐厅员工协会⋯",
+      "ref_sub_2": "经已发动所有会员⋯",
+      "target_sub_1": "另外全港茶餐厅联工协会",
+      "target_sub_2": "经热发动所有会员"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "经已发动所有会员⋯",
-      "src_1_sub_2": "争取「掷蛋挞」成为亚运比赛项目",
-      "src_2_sub_1": "经热发动所有会员",
-      "src_2_sub_2": "争取掟蛋挞成为亚运会比赛项目"
+      "ref_sub_1": "经已发动所有会员⋯",
+      "ref_sub_2": "争取「掷蛋挞」成为亚运比赛项目",
+      "target_sub_1": "经热发动所有会员",
+      "target_sub_2": "争取掟蛋挞成为亚运会比赛项目"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "争取「掷蛋挞」成为亚运比赛项目",
-      "src_1_sub_2": "港九烧味卤味腊味同业会",
-      "src_2_sub_1": "争取掟蛋挞成为亚运会比赛项目",
-      "src_2_sub_2": "港狗烧尾掳尾"
+      "ref_sub_1": "争取「掷蛋挞」成为亚运比赛项目",
+      "ref_sub_2": "港九烧味卤味腊味同业会",
+      "target_sub_1": "争取掟蛋挞成为亚运会比赛项目",
+      "target_sub_2": "港狗烧尾掳尾"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "港九烧味卤味腊味同业会",
-      "src_1_sub_2": "亦向霍主席当面提出⋯",
-      "src_2_sub_1": "港狗烧尾掳尾"
+      "ref_sub_1": "港九烧味卤味腊味同业会",
+      "ref_sub_2": "亦向霍主席当面提出⋯",
+      "target_sub_1": "港狗烧尾掳尾"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "亦向霍主席当面提出⋯",
-      "src_1_sub_2": "「挂腊鸭」可以成为亚运比赛项目",
-      "src_2_sub_2": "立尾同业会亦都向霍主席当面提出挂立鸭可以成为亚运比赛项目"
+      "ref_sub_1": "亦向霍主席当面提出⋯",
+      "ref_sub_2": "「挂腊鸭」可以成为亚运比赛项目",
+      "target_sub_2": "立尾同业会亦都向霍主席当面提出挂立鸭可以成为亚运比赛项目"
     },
     "answer": {
-      "src_2_sub_1_shifted": "立尾同业会亦都向霍主席当面提出",
-      "src_2_sub_2_shifted": "挂立鸭可以成为亚运比赛项目"
+      "target_sub_1_shifted": "立尾同业会亦都向霍主席当面提出",
+      "target_sub_2_shifted": "挂立鸭可以成为亚运比赛项目"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "港九烧味卤味腊味同业会",
-      "src_1_sub_2": "亦向霍主席当面提出⋯",
-      "src_2_sub_1": "港狗烧尾掳尾",
-      "src_2_sub_2": "立尾同业会亦都向霍主席当面提出"
+      "ref_sub_1": "港九烧味卤味腊味同业会",
+      "ref_sub_2": "亦向霍主席当面提出⋯",
+      "target_sub_1": "港狗烧尾掳尾",
+      "target_sub_2": "立尾同业会亦都向霍主席当面提出"
     },
     "answer": {
-      "src_2_sub_1_shifted": "港狗烧尾掳尾立尾同业会",
-      "src_2_sub_2_shifted": "亦都向霍主席当面提出"
+      "target_sub_1_shifted": "港狗烧尾掳尾立尾同业会",
+      "target_sub_2_shifted": "亦都向霍主席当面提出"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "亦向霍主席当面提出⋯",
-      "src_1_sub_2": "「挂腊鸭」可以成为亚运比赛项目",
-      "src_2_sub_1": "亦都向霍主席当面提出",
-      "src_2_sub_2": "挂立鸭可以成为亚运比赛项目"
+      "ref_sub_1": "亦向霍主席当面提出⋯",
+      "ref_sub_2": "「挂腊鸭」可以成为亚运比赛项目",
+      "target_sub_1": "亦都向霍主席当面提出",
+      "target_sub_2": "挂立鸭可以成为亚运比赛项目"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「挂腊鸭」可以成为亚运比赛项目",
-      "src_1_sub_2": "较为特别的是，CIC保险营业员联同⋯",
-      "src_2_sub_1": "挂立鸭可以成为亚运比赛项目",
-      "src_2_sub_2": "较为特别嘅系"
+      "ref_sub_1": "「挂腊鸭」可以成为亚运比赛项目",
+      "ref_sub_2": "较为特别的是，CIC保险营业员联同⋯",
+      "target_sub_1": "挂立鸭可以成为亚运比赛项目",
+      "target_sub_2": "较为特别嘅系"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "较为特别的是，CIC保险营业员联同⋯",
-      "src_1_sub_2": "大角咀春田花花幼稚园⋯",
-      "src_2_sub_1": "较为特别嘅系",
-      "src_2_sub_2": "CIC保险营业员联同大角嘴春田花花"
+      "ref_sub_1": "较为特别的是，CIC保险营业员联同⋯",
+      "ref_sub_2": "大角咀春田花花幼稚园⋯",
+      "target_sub_1": "较为特别嘅系",
+      "target_sub_2": "CIC保险营业员联同大角嘴春田花花"
     },
     "answer": {
-      "src_2_sub_1_shifted": "较为特别嘅系CIC保险营业员联同",
-      "src_2_sub_2_shifted": "大角嘴春田花花"
+      "target_sub_1_shifted": "较为特别嘅系CIC保险营业员联同",
+      "target_sub_2_shifted": "大角嘴春田花花"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「挂腊鸭」可以成为亚运比赛项目",
-      "src_1_sub_2": "较为特别的是，CIC保险营业员联同⋯",
-      "src_2_sub_1": "挂立鸭可以成为亚运比赛项目",
-      "src_2_sub_2": "较为特别嘅系CIC保险营业员联同"
+      "ref_sub_1": "「挂腊鸭」可以成为亚运比赛项目",
+      "ref_sub_2": "较为特别的是，CIC保险营业员联同⋯",
+      "target_sub_1": "挂立鸭可以成为亚运比赛项目",
+      "target_sub_2": "较为特别嘅系CIC保险营业员联同"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "较为特别的是，CIC保险营业员联同⋯",
-      "src_1_sub_2": "大角咀春田花花幼稚园⋯",
-      "src_2_sub_1": "较为特别嘅系CIC保险营业员联同",
-      "src_2_sub_2": "大角嘴春田花花"
+      "ref_sub_1": "较为特别的是，CIC保险营业员联同⋯",
+      "ref_sub_2": "大角咀春田花花幼稚园⋯",
+      "target_sub_1": "较为特别嘅系CIC保险营业员联同",
+      "target_sub_2": "大角嘴春田花花"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "大角咀春田花花幼稚园⋯",
-      "src_1_sub_2": "附属小学一班小朋友⋯",
-      "src_2_sub_1": "大角嘴春田花花"
+      "ref_sub_1": "大角咀春田花花幼稚园⋯",
+      "ref_sub_2": "附属小学一班小朋友⋯",
+      "target_sub_1": "大角嘴春田花花"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "附属小学一班小朋友⋯",
-      "src_1_sub_2": "争取「抢包山」",
-      "src_2_sub_2": "幼稚园附属小学嘅一班小朋友争取抢包山"
+      "ref_sub_1": "附属小学一班小朋友⋯",
+      "ref_sub_2": "争取「抢包山」",
+      "target_sub_2": "幼稚园附属小学嘅一班小朋友争取抢包山"
     },
     "answer": {
-      "src_2_sub_1_shifted": "幼稚园附属小学嘅一班小朋友",
-      "src_2_sub_2_shifted": "争取抢包山"
+      "target_sub_1_shifted": "幼稚园附属小学嘅一班小朋友",
+      "target_sub_2_shifted": "争取抢包山"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "大角咀春田花花幼稚园⋯",
-      "src_1_sub_2": "附属小学一班小朋友⋯",
-      "src_2_sub_1": "大角嘴春田花花",
-      "src_2_sub_2": "幼稚园附属小学嘅一班小朋友"
+      "ref_sub_1": "大角咀春田花花幼稚园⋯",
+      "ref_sub_2": "附属小学一班小朋友⋯",
+      "target_sub_1": "大角嘴春田花花",
+      "target_sub_2": "幼稚园附属小学嘅一班小朋友"
     },
     "answer": {
-      "src_2_sub_1_shifted": "大角嘴春田花花幼稚园",
-      "src_2_sub_2_shifted": "附属小学嘅一班小朋友"
+      "target_sub_1_shifted": "大角嘴春田花花幼稚园",
+      "target_sub_2_shifted": "附属小学嘅一班小朋友"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "附属小学一班小朋友⋯",
-      "src_1_sub_2": "争取「抢包山」",
-      "src_2_sub_1": "附属小学嘅一班小朋友",
-      "src_2_sub_2": "争取抢包山"
+      "ref_sub_1": "附属小学一班小朋友⋯",
+      "ref_sub_2": "争取「抢包山」",
+      "target_sub_1": "附属小学嘅一班小朋友",
+      "target_sub_2": "争取抢包山"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "争取「抢包山」",
-      "src_1_sub_2": "一项几乎绝迹的运动⋯",
-      "src_2_sub_1": "争取抢包山"
+      "ref_sub_1": "争取「抢包山」",
+      "ref_sub_2": "一项几乎绝迹的运动⋯",
+      "target_sub_1": "争取抢包山"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "一项几乎绝迹的运动⋯",
-      "src_1_sub_2": "成为本港举办亚运的重点推介比赛项目",
-      "src_2_sub_2": "一项几乎绝迹嘅运动成为本港举办亚运重点推介嘅比赛项目"
+      "ref_sub_1": "一项几乎绝迹的运动⋯",
+      "ref_sub_2": "成为本港举办亚运的重点推介比赛项目",
+      "target_sub_2": "一项几乎绝迹嘅运动成为本港举办亚运重点推介嘅比赛项目"
     },
     "answer": {
-      "src_2_sub_1_shifted": "一项几乎绝迹嘅运动",
-      "src_2_sub_2_shifted": "成为本港举办亚运重点推介嘅比赛项目"
+      "target_sub_1_shifted": "一项几乎绝迹嘅运动",
+      "target_sub_2_shifted": "成为本港举办亚运重点推介嘅比赛项目"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "争取「抢包山」",
-      "src_1_sub_2": "一项几乎绝迹的运动⋯",
-      "src_2_sub_1": "争取抢包山",
-      "src_2_sub_2": "一项几乎绝迹嘅运动"
+      "ref_sub_1": "争取「抢包山」",
+      "ref_sub_2": "一项几乎绝迹的运动⋯",
+      "target_sub_1": "争取抢包山",
+      "target_sub_2": "一项几乎绝迹嘅运动"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "一项几乎绝迹的运动⋯",
-      "src_1_sub_2": "成为本港举办亚运的重点推介比赛项目",
-      "src_2_sub_1": "一项几乎绝迹嘅运动",
-      "src_2_sub_2": "成为本港举办亚运重点推介嘅比赛项目"
+      "ref_sub_1": "一项几乎绝迹的运动⋯",
+      "ref_sub_2": "成为本港举办亚运的重点推介比赛项目",
+      "target_sub_1": "一项几乎绝迹嘅运动",
+      "target_sub_2": "成为本港举办亚运重点推介嘅比赛项目"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "最后⋯",
-      "src_1_sub_2": "最后，一切成烟",
-      "src_2_sub_1": "最后",
-      "src_2_sub_2": "最后全部都系banana"
+      "ref_sub_1": "最后⋯",
+      "ref_sub_2": "最后，一切成烟",
+      "target_sub_1": "最后",
+      "target_sub_2": "最后全部都系banana"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "最后，一切成烟",
-      "src_1_sub_2": "最后，他们选了「掷蛋挞」做推介项目",
-      "src_2_sub_1": "最后全部都系banana",
-      "src_2_sub_2": "最后佢哋选咗定蛋挞做推介项目"
+      "ref_sub_1": "最后，一切成烟",
+      "ref_sub_2": "最后，他们选了「掷蛋挞」做推介项目",
+      "target_sub_1": "最后全部都系banana",
+      "target_sub_2": "最后佢哋选咗定蛋挞做推介项目"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "最后，他们选了「掷蛋挞」做推介项目",
-      "src_1_sub_2": "至于香港争取申办亚运的口号⋯",
-      "src_2_sub_1": "最后佢哋选咗定蛋挞做推介项目",
-      "src_2_sub_2": "至于香港争取申办亚运嘅口号"
+      "ref_sub_1": "最后，他们选了「掷蛋挞」做推介项目",
+      "ref_sub_2": "至于香港争取申办亚运的口号⋯",
+      "target_sub_1": "最后佢哋选咗定蛋挞做推介项目",
+      "target_sub_2": "至于香港争取申办亚运嘅口号"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "至于香港争取申办亚运的口号⋯",
-      "src_1_sub_2": "亦顺理成章叫成「香港一蛋挞」",
-      "src_2_sub_1": "至于香港争取申办亚运嘅口号",
-      "src_2_sub_2": "亦都顺理成章噉叫做香港一蛋挞"
+      "ref_sub_1": "至于香港争取申办亚运的口号⋯",
+      "ref_sub_2": "亦顺理成章叫成「香港一蛋挞」",
+      "target_sub_1": "至于香港争取申办亚运嘅口号",
+      "target_sub_2": "亦都顺理成章噉叫做香港一蛋挞"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "亦顺理成章叫成「香港一蛋挞」",
-      "src_1_sub_2": "之后李丽珊蝉联失败⋯",
-      "src_2_sub_1": "亦都顺理成章噉叫做香港一蛋挞",
-      "src_2_sub_2": "之后李利山丧乱失败"
+      "ref_sub_1": "亦顺理成章叫成「香港一蛋挞」",
+      "ref_sub_2": "之后李丽珊蝉联失败⋯",
+      "target_sub_1": "亦都顺理成章噉叫做香港一蛋挞",
+      "target_sub_2": "之后李利山丧乱失败"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "之后李丽珊蝉联失败⋯",
-      "src_1_sub_2": "亚运主办权⋯",
-      "src_2_sub_1": "之后李利山丧乱失败"
+      "ref_sub_1": "之后李丽珊蝉联失败⋯",
+      "ref_sub_2": "亚运主办权⋯",
+      "target_sub_1": "之后李利山丧乱失败"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "亚运主办权⋯",
-      "src_1_sub_2": "亦由一个香港人从未听过的地方夺得",
-      "src_2_sub_2": "亚运主办权亦都由一个香港人从未听过嘅地方夺得"
+      "ref_sub_1": "亚运主办权⋯",
+      "ref_sub_2": "亦由一个香港人从未听过的地方夺得",
+      "target_sub_2": "亚运主办权亦都由一个香港人从未听过嘅地方夺得"
     },
     "answer": {
-      "src_2_sub_1_shifted": "亚运主办权",
-      "src_2_sub_2_shifted": "亦都由一个香港人从未听过嘅地方夺得"
+      "target_sub_1_shifted": "亚运主办权",
+      "target_sub_2_shifted": "亦都由一个香港人从未听过嘅地方夺得"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "亦由一个香港人从未听过的地方夺得",
-      "src_1_sub_2": "想着转行当运动员的茶餐厅伙记⋯",
-      "src_2_sub_1": "亦都由一个香港人从未听过嘅地方夺得",
-      "src_2_sub_2": "谂住可以转行做运动员嘅茶餐厅夥计"
+      "ref_sub_1": "亦由一个香港人从未听过的地方夺得",
+      "ref_sub_2": "想着转行当运动员的茶餐厅伙记⋯",
+      "target_sub_1": "亦都由一个香港人从未听过嘅地方夺得",
+      "target_sub_2": "谂住可以转行做运动员嘅茶餐厅夥计"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "想着转行当运动员的茶餐厅伙记⋯",
-      "src_1_sub_2": "都回到茶餐厅继续掷他们的蛋挞",
-      "src_2_sub_1": "谂住可以转行做运动员嘅茶餐厅夥计",
-      "src_2_sub_2": "都返返去茶餐厅继续钉佢哋嘅蛋挞"
+      "ref_sub_1": "想着转行当运动员的茶餐厅伙记⋯",
+      "ref_sub_2": "都回到茶餐厅继续掷他们的蛋挞",
+      "target_sub_1": "谂住可以转行做运动员嘅茶餐厅夥计",
+      "target_sub_2": "都返返去茶餐厅继续钉佢哋嘅蛋挞"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "都回到茶餐厅继续掷他们的蛋挞",
-      "src_1_sub_2": "一切回复正常",
-      "src_2_sub_1": "都返返去茶餐厅继续钉佢哋嘅蛋挞",
-      "src_2_sub_2": "一切回复正常"
+      "ref_sub_1": "都回到茶餐厅继续掷他们的蛋挞",
+      "ref_sub_2": "一切回复正常",
+      "target_sub_1": "都返返去茶餐厅继续钉佢哋嘅蛋挞",
+      "target_sub_2": "一切回复正常"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "上中学后，我再没有练习抢包手",
-      "src_1_sub_2": "有时候跟妈妈饮茶⋯",
-      "src_2_sub_1": "上个中学我已经再冇练习抢包手",
-      "src_2_sub_2": "间中同妈妈饮茶"
+      "ref_sub_1": "上中学后，我再没有练习抢包手",
+      "ref_sub_2": "有时候跟妈妈饮茶⋯",
+      "target_sub_1": "上个中学我已经再冇练习抢包手",
+      "target_sub_2": "间中同妈妈饮茶"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "有时候跟妈妈饮茶⋯",
-      "src_1_sub_2": "我都会手快快替她抢一笼大包",
-      "src_2_sub_1": "间中同妈妈饮茶",
-      "src_2_sub_2": "我都会手快快噉帮佢抢龙大包"
+      "ref_sub_1": "有时候跟妈妈饮茶⋯",
+      "ref_sub_2": "我都会手快快替她抢一笼大包",
+      "target_sub_1": "间中同妈妈饮茶",
+      "target_sub_2": "我都会手快快噉帮佢抢龙大包"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我都会手快快替她抢一笼大包",
-      "src_1_sub_2": "之后，茶楼再不卖大包了",
-      "src_2_sub_1": "我都会手快快噉帮佢抢龙大包",
-      "src_2_sub_2": "之后茶楼都冇埋大包"
+      "ref_sub_1": "我都会手快快替她抢一笼大包",
+      "ref_sub_2": "之后，茶楼再不卖大包了",
+      "target_sub_1": "我都会手快快噉帮佢抢龙大包",
+      "target_sub_2": "之后茶楼都冇埋大包"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "之后，茶楼再不卖大包了",
-      "src_1_sub_2": "点心车亦转成点心纸",
-      "src_2_sub_1": "之后茶楼都冇埋大包",
-      "src_2_sub_2": "退车仔都转咗用点心纸"
+      "ref_sub_1": "之后，茶楼再不卖大包了",
+      "ref_sub_2": "点心车亦转成点心纸",
+      "target_sub_1": "之后茶楼都冇埋大包",
+      "target_sub_2": "退车仔都转咗用点心纸"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "点心车亦转成点心纸",
-      "src_1_sub_2": "一切落空",
-      "src_2_sub_1": "退车仔都转咗用点心纸",
-      "src_2_sub_2": "一切都落空"
+      "ref_sub_1": "点心车亦转成点心纸",
+      "ref_sub_2": "一切落空",
+      "target_sub_1": "退车仔都转咗用点心纸",
+      "target_sub_2": "一切都落空"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "有时候我也会跟同学回到长洲烧烤",
-      "src_1_sub_2": "每次看见师傅⋯",
-      "src_2_sub_1": "有时我都会同班同学仔返长洲宵夜食",
-      "src_2_sub_2": "每次见到师傅"
+      "ref_sub_1": "有时候我也会跟同学回到长洲烧烤",
+      "ref_sub_2": "每次看见师傅⋯",
+      "target_sub_1": "有时我都会同班同学仔返长洲宵夜食",
+      "target_sub_2": "每次见到师傅"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "每次看见师傅⋯",
-      "src_1_sub_2": "他都好像老了一点",
-      "src_2_sub_1": "每次见到师傅",
-      "src_2_sub_2": "佢都好似老咗啲噉"
+      "ref_sub_1": "每次看见师傅⋯",
+      "ref_sub_2": "他都好像老了一点",
+      "target_sub_1": "每次见到师傅",
+      "target_sub_2": "佢都好似老咗啲噉"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "因为环保⋯",
-      "src_1_sub_2": "长洲的抢包都转为塑胶",
-      "src_2_sub_1": "因为环保",
-      "src_2_sub_2": "长洲嘅厂包经已转咗用塑胶"
+      "ref_sub_1": "因为环保⋯",
+      "ref_sub_2": "长洲的抢包都转为塑胶",
+      "target_sub_1": "因为环保",
+      "target_sub_2": "长洲嘅厂包经已转咗用塑胶"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "长洲的抢包都转为塑胶",
-      "src_1_sub_2": "师傅说，那阵胶气，相当臭",
-      "src_2_sub_1": "长洲嘅厂包经已转咗用塑胶",
-      "src_2_sub_2": "师傅话嗰阵胶气都几丑下"
+      "ref_sub_1": "长洲的抢包都转为塑胶",
+      "ref_sub_2": "师傅说，那阵胶气，相当臭",
+      "target_sub_1": "长洲嘅厂包经已转咗用塑胶",
+      "target_sub_2": "师傅话嗰阵胶气都几丑下"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "长洲有个张保仔洞",
-      "src_1_sub_2": "听说张保仔在洞内藏了很多宝藏",
-      "src_2_sub_1": "墙后个张宝仔洞",
-      "src_2_sub_2": "听讲海盗张宝仔喺里面收埋咗好多宝藏"
+      "ref_sub_1": "长洲有个张保仔洞",
+      "ref_sub_2": "听说张保仔在洞内藏了很多宝藏",
+      "target_sub_1": "墙后个张宝仔洞",
+      "target_sub_2": "听讲海盗张宝仔喺里面收埋咗好多宝藏"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "听说张保仔在洞内藏了很多宝藏",
-      "src_1_sub_2": "因为我练过抢包手，身手比较灵活⋯",
-      "src_2_sub_1": "听讲海盗张宝仔喺里面收埋咗好多宝藏",
-      "src_2_sub_2": "因为我练过抢包手身手比较灵活"
+      "ref_sub_1": "听说张保仔在洞内藏了很多宝藏",
+      "ref_sub_2": "因为我练过抢包手，身手比较灵活⋯",
+      "target_sub_1": "听讲海盗张宝仔喺里面收埋咗好多宝藏",
+      "target_sub_2": "因为我练过抢包手身手比较灵活"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "因为我练过抢包手，身手比较灵活⋯",
-      "src_1_sub_2": "同学们叫我爬进去看看，说不定会发达",
-      "src_2_sub_1": "因为我练过抢包手身手比较灵活",
-      "src_2_sub_2": "班同我叫我爬佢睇下话唔定会发达"
+      "ref_sub_1": "因为我练过抢包手，身手比较灵活⋯",
+      "ref_sub_2": "同学们叫我爬进去看看，说不定会发达",
+      "target_sub_1": "因为我练过抢包手身手比较灵活",
+      "target_sub_2": "班同我叫我爬佢睇下话唔定会发达"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "同学们叫我爬进去看看，说不定会发达",
-      "src_1_sub_2": "于是我就向着这个又黑又窄的洞⋯",
-      "src_2_sub_1": "班同我叫我爬佢睇下话唔定会发达",
-      "src_2_sub_2": "于是我就向住呢一个又黑又窄嘅洞"
+      "ref_sub_1": "同学们叫我爬进去看看，说不定会发达",
+      "ref_sub_2": "于是我就向着这个又黑又窄的洞⋯",
+      "target_sub_1": "班同我叫我爬佢睇下话唔定会发达",
+      "target_sub_2": "于是我就向住呢一个又黑又窄嘅洞"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "于是我就向着这个又黑又窄的洞⋯",
-      "src_1_sub_2": "一直爬",
-      "src_2_sub_1": "于是我就向住呢一个又黑又窄嘅洞",
-      "src_2_sub_2": "系噉爬爬"
+      "ref_sub_1": "于是我就向着这个又黑又窄的洞⋯",
+      "ref_sub_2": "一直爬",
+      "target_sub_1": "于是我就向住呢一个又黑又窄嘅洞",
+      "target_sub_2": "系噉爬爬"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "一直爬",
-      "src_1_sub_2": "洞里面什么也没有，只有一个盒子",
-      "src_2_sub_1": "系噉爬爬",
-      "src_2_sub_2": "洞里面乜都冇净系有一个盒"
+      "ref_sub_1": "一直爬",
+      "ref_sub_2": "洞里面什么也没有，只有一个盒子",
+      "target_sub_1": "系噉爬爬",
+      "target_sub_2": "洞里面乜都冇净系有一个盒"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "洞里面什么也没有，只有一个盒子",
-      "src_1_sub_2": "我小心揭开盒子⋯",
-      "src_2_sub_1": "洞里面乜都冇净系有一个盒",
-      "src_2_sub_2": "我好小心揭开呢个盒"
+      "ref_sub_1": "洞里面什么也没有，只有一个盒子",
+      "ref_sub_2": "我小心揭开盒子⋯",
+      "target_sub_1": "洞里面乜都冇净系有一个盒",
+      "target_sub_2": "我好小心揭开呢个盒"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "我小心揭开盒子⋯",
-      "src_1_sub_2": "发现里面一个没吃完的大包",
-      "src_2_sub_1": "我好小心揭开呢个盒",
-      "src_2_sub_2": "发现入面系一个食净咗嘅大包"
+      "ref_sub_1": "我小心揭开盒子⋯",
+      "ref_sub_2": "发现里面一个没吃完的大包",
+      "target_sub_1": "我好小心揭开呢个盒",
+      "target_sub_2": "发现入面系一个食净咗嘅大包"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "发现里面一个没吃完的大包",
-      "src_1_sub_2": "是不是张保仔吃过的呢？",
-      "src_2_sub_1": "发现入面系一个食净咗嘅大包",
-      "src_2_sub_2": "唔知系咪张宝仔食净㗎啦"
+      "ref_sub_1": "发现里面一个没吃完的大包",
+      "ref_sub_2": "是不是张保仔吃过的呢？",
+      "target_sub_1": "发现入面系一个食净咗嘅大包",
+      "target_sub_2": "唔知系咪张宝仔食净㗎啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "是不是张保仔吃过的呢？",
-      "src_1_sub_2": "「寻晚，食了六个餐包」",
-      "src_2_sub_1": "唔知系咪张宝仔食净㗎啦"
+      "ref_sub_1": "是不是张保仔吃过的呢？",
+      "ref_sub_2": "「寻晚，食了六个餐包」",
+      "target_sub_1": "唔知系咪张宝仔食净㗎啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「年晚，又培育了珊珊！可惜⋯」",
-      "src_1_sub_2": "揸住个包，我忽然明白⋯",
-      "src_2_sub_2": "揸住个包我忽然明白"
+      "ref_sub_1": "「年晚，又培育了珊珊！可惜⋯」",
+      "ref_sub_2": "揸住个包，我忽然明白⋯",
+      "target_sub_2": "揸住个包我忽然明白"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "揸住个包，我忽然明白⋯",
-      "src_1_sub_2": "原来有些事情，没有就是没有",
-      "src_2_sub_1": "揸住个包我忽然明白",
-      "src_2_sub_2": "原来有啲嘢冇就真系冇"
+      "ref_sub_1": "揸住个包，我忽然明白⋯",
+      "ref_sub_2": "原来有些事情，没有就是没有",
+      "target_sub_1": "揸住个包我忽然明白",
+      "target_sub_2": "原来有啲嘢冇就真系冇"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "原来有些事情，没有就是没有",
-      "src_1_sub_2": "唔得，就是唔得",
-      "src_2_sub_1": "原来有啲嘢冇就真系冇",
-      "src_2_sub_2": "唔得就真系唔得"
+      "ref_sub_1": "原来有些事情，没有就是没有",
+      "ref_sub_2": "唔得，就是唔得",
+      "target_sub_1": "原来有啲嘢冇就真系冇",
+      "target_sub_2": "唔得就真系唔得"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "唔得，就是唔得",
-      "src_1_sub_2": "没有鱼蛋没有粗面没去成马尔代夫⋯",
-      "src_2_sub_1": "唔得就真系唔得",
-      "src_2_sub_2": "冇鱼蛋冇粗面"
+      "ref_sub_1": "唔得，就是唔得",
+      "ref_sub_2": "没有鱼蛋没有粗面没去成马尔代夫⋯",
+      "target_sub_1": "唔得就真系唔得",
+      "target_sub_2": "冇鱼蛋冇粗面"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "没有鱼蛋没有粗面没去成马尔代夫⋯",
-      "src_1_sub_2": "没有奖牌没有张保仔宝藏",
-      "src_2_sub_1": "冇鱼蛋冇粗面",
-      "src_2_sub_2": "冇去买义大夫冇奖牌冇张宝仔宝藏"
+      "ref_sub_1": "没有鱼蛋没有粗面没去成马尔代夫⋯",
+      "ref_sub_2": "没有奖牌没有张保仔宝藏",
+      "target_sub_1": "冇鱼蛋冇粗面",
+      "target_sub_2": "冇去买义大夫冇奖牌冇张宝仔宝藏"
     },
     "answer": {
-      "src_2_sub_1_shifted": "冇鱼蛋冇粗面冇去买义大夫",
-      "src_2_sub_2_shifted": "冇奖牌冇张宝仔宝藏"
+      "target_sub_1_shifted": "冇鱼蛋冇粗面冇去买义大夫",
+      "target_sub_2_shifted": "冇奖牌冇张宝仔宝藏"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "唔得，就是唔得",
-      "src_1_sub_2": "没有鱼蛋没有粗面没去成马尔代夫⋯",
-      "src_2_sub_1": "唔得就真系唔得",
-      "src_2_sub_2": "冇鱼蛋冇粗面冇去买义大夫"
+      "ref_sub_1": "唔得，就是唔得",
+      "ref_sub_2": "没有鱼蛋没有粗面没去成马尔代夫⋯",
+      "target_sub_1": "唔得就真系唔得",
+      "target_sub_2": "冇鱼蛋冇粗面冇去买义大夫"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "没有鱼蛋没有粗面没去成马尔代夫⋯",
-      "src_1_sub_2": "没有奖牌没有张保仔宝藏",
-      "src_2_sub_1": "冇鱼蛋冇粗面冇去买义大夫",
-      "src_2_sub_2": "冇奖牌冇张宝仔宝藏"
+      "ref_sub_1": "没有鱼蛋没有粗面没去成马尔代夫⋯",
+      "ref_sub_2": "没有奖牌没有张保仔宝藏",
+      "target_sub_1": "冇鱼蛋冇粗面冇去买义大夫",
+      "target_sub_2": "冇奖牌冇张宝仔宝藏"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "没有奖牌没有张保仔宝藏",
-      "src_1_sub_2": "而张保仔，也没有咬过那个包",
-      "src_2_sub_1": "冇奖牌冇张宝仔宝藏",
-      "src_2_sub_2": "而张宝仔亦都冇咬过个包"
+      "ref_sub_1": "没有奖牌没有张保仔宝藏",
+      "ref_sub_2": "而张保仔，也没有咬过那个包",
+      "target_sub_1": "冇奖牌冇张宝仔宝藏",
+      "target_sub_2": "而张宝仔亦都冇咬过个包"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "而张保仔，也没有咬过那个包",
-      "src_1_sub_2": "原来蠢，并不那么好笑",
-      "src_2_sub_1": "而张宝仔亦都冇咬过个包",
-      "src_2_sub_2": "原来唔系咁好笑"
+      "ref_sub_1": "而张保仔，也没有咬过那个包",
+      "ref_sub_2": "原来蠢，并不那么好笑",
+      "target_sub_1": "而张宝仔亦都冇咬过个包",
+      "target_sub_2": "原来唔系咁好笑"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "原来蠢，并不那么好笑",
-      "src_1_sub_2": "蠢会失败⋯",
-      "src_2_sub_1": "原来唔系咁好笑",
-      "src_2_sub_2": "会失败"
+      "ref_sub_1": "原来蠢，并不那么好笑",
+      "ref_sub_2": "蠢会失败⋯",
+      "target_sub_1": "原来唔系咁好笑",
+      "target_sub_2": "会失败"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "蠢会失败⋯",
-      "src_1_sub_2": "会失望",
-      "src_2_sub_1": "会失败",
-      "src_2_sub_2": "会失望"
+      "ref_sub_1": "蠢会失败⋯",
+      "ref_sub_2": "会失望",
+      "target_sub_1": "会失败",
+      "target_sub_2": "会失望"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "会失望",
-      "src_1_sub_2": "失望，并不那么好笑",
-      "src_2_sub_1": "会失望",
-      "src_2_sub_2": "失望唔系咁好笑"
+      "ref_sub_1": "会失望",
+      "ref_sub_2": "失望，并不那么好笑",
+      "target_sub_1": "会失望",
+      "target_sub_2": "失望唔系咁好笑"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "失望，并不那么好笑",
-      "src_1_sub_2": "肥，都不一定好笑",
-      "src_2_sub_1": "失望唔系咁好笑",
-      "src_2_sub_2": "肥都未必好笑"
+      "ref_sub_1": "失望，并不那么好笑",
+      "ref_sub_2": "肥，都不一定好笑",
+      "target_sub_1": "失望唔系咁好笑",
+      "target_sub_2": "肥都未必好笑"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "肥，都不一定好笑",
-      "src_1_sub_2": "肥，不一定大力",
-      "src_2_sub_1": "肥都未必好笑",
-      "src_2_sub_2": "肥唔一定大力"
+      "ref_sub_1": "肥，都不一定好笑",
+      "ref_sub_2": "肥，不一定大力",
+      "target_sub_1": "肥都未必好笑",
+      "target_sub_2": "肥唔一定大力"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "肥，不一定大力",
-      "src_1_sub_2": "大力，亦不一定得",
-      "src_2_sub_1": "肥唔一定大力",
-      "src_2_sub_2": "大力亦都唔一定得"
+      "ref_sub_1": "肥，不一定大力",
+      "ref_sub_2": "大力，亦不一定得",
+      "target_sub_1": "肥唔一定大力",
+      "target_sub_2": "大力亦都唔一定得"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "大力，亦不一定得",
-      "src_1_sub_2": "揸住个包，我忽然想⋯",
-      "src_2_sub_1": "大力亦都唔一定得",
-      "src_2_sub_2": "揸住个包我忽然喺度谂"
+      "ref_sub_1": "大力，亦不一定得",
+      "ref_sub_2": "揸住个包，我忽然想⋯",
+      "target_sub_1": "大力亦都唔一定得",
+      "target_sub_2": "揸住个包我忽然喺度谂"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "揸住个包，我忽然想⋯",
-      "src_1_sub_2": "长大了，到我要面对这个实掘掘⋯",
-      "src_2_sub_1": "揸住个包我忽然喺度谂",
-      "src_2_sub_2": "大个咗到我要面对呢一个实角局"
+      "ref_sub_1": "揸住个包，我忽然想⋯",
+      "ref_sub_2": "长大了，到我要面对这个实掘掘⋯",
+      "target_sub_1": "揸住个包我忽然喺度谂",
+      "target_sub_2": "大个咗到我要面对呢一个实角局"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "长大了，到我要面对这个实掘掘⋯",
-      "src_1_sub_2": "未必可以发梦，未必那么好笑的⋯",
-      "src_2_sub_1": "大个咗到我要面对呢一个实角局",
-      "src_2_sub_2": "未必到你发梦"
+      "ref_sub_1": "长大了，到我要面对这个实掘掘⋯",
+      "ref_sub_2": "未必可以发梦，未必那么好笑的⋯",
+      "target_sub_1": "大个咗到我要面对呢一个实角局",
+      "target_sub_2": "未必到你发梦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "未必可以发梦，未必那么好笑的⋯",
-      "src_1_sub_2": "世界的时候，我会怎么样？",
-      "src_2_sub_1": "未必到你发梦",
-      "src_2_sub_2": "又未必咁好笑嘅世界嘅时候我会系点㗎呢"
+      "ref_sub_1": "未必可以发梦，未必那么好笑的⋯",
+      "ref_sub_2": "世界的时候，我会怎么样？",
+      "target_sub_1": "未必到你发梦",
+      "target_sub_2": "又未必咁好笑嘅世界嘅时候我会系点㗎呢"
     },
     "answer": {
-      "src_2_sub_1_shifted": "未必到你发梦又未必咁好笑嘅",
-      "src_2_sub_2_shifted": "世界嘅时候我会系点㗎呢"
+      "target_sub_1_shifted": "未必到你发梦又未必咁好笑嘅",
+      "target_sub_2_shifted": "世界嘅时候我会系点㗎呢"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "是的，我就是大个佬麦兜",
-      "src_1_sub_2": "肥，算大力",
-      "src_2_sub_1": "系呀我就系大个佬麦豆喇",
-      "src_2_sub_2": "肥啰算大力啦"
+      "ref_sub_1": "是的，我就是大个佬麦兜",
+      "ref_sub_2": "肥，算大力",
+      "target_sub_1": "系呀我就系大个佬麦豆喇",
+      "target_sub_2": "肥啰算大力啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "肥，算大力",
-      "src_1_sub_2": "麻麻地可以",
-      "src_2_sub_1": "肥啰算大力啦",
-      "src_2_sub_2": "麻麻地得咁啦"
+      "ref_sub_1": "肥，算大力",
+      "ref_sub_2": "麻麻地可以",
+      "target_sub_1": "肥啰算大力啦",
+      "target_sub_2": "麻麻地得咁啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "麻麻地可以",
-      "src_1_sub_2": "负家产",
-      "src_2_sub_1": "麻麻地得咁啦",
-      "src_2_sub_2": "富家产啰"
+      "ref_sub_1": "麻麻地可以",
+      "ref_sub_2": "负家产",
+      "target_sub_1": "麻麻地得咁啦",
+      "target_sub_2": "富家产啰"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "负家产",
-      "src_1_sub_2": "脚瓜是真的大，比一节瓜还要大",
-      "src_2_sub_1": "富家产啰",
-      "src_2_sub_2": "脚瓜真系几大仲大过个折瓜"
+      "ref_sub_1": "负家产",
+      "ref_sub_2": "脚瓜是真的大，比一节瓜还要大",
+      "target_sub_1": "富家产啰",
+      "target_sub_2": "脚瓜真系几大仲大过个折瓜"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "脚瓜是真的大，比一节瓜还要大",
-      "src_1_sub_2": "脚瓜上的肌肉非常结实⋯",
-      "src_2_sub_1": "脚瓜真系几大仲大过个折瓜",
-      "src_2_sub_2": "脚瓜上面个肌肉非常结实"
+      "ref_sub_1": "脚瓜是真的大，比一节瓜还要大",
+      "ref_sub_2": "脚瓜上的肌肉非常结实⋯",
+      "target_sub_1": "脚瓜真系几大仲大过个折瓜",
+      "target_sub_2": "脚瓜上面个肌肉非常结实"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "脚瓜上的肌肉非常结实⋯",
-      "src_1_sub_2": "青筋一条条凸出来，似钢筋",
-      "src_2_sub_1": "脚瓜上面个肌肉非常结实",
-      "src_2_sub_2": "啲青筋一条一条凸下凸下好似钢筋"
+      "ref_sub_1": "脚瓜上的肌肉非常结实⋯",
+      "ref_sub_2": "青筋一条条凸出来，似钢筋",
+      "target_sub_1": "脚瓜上面个肌肉非常结实",
+      "target_sub_2": "啲青筋一条一条凸下凸下好似钢筋"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "青筋一条条凸出来，似钢筋",
-      "src_1_sub_2": "至于脚趾甲⋯",
-      "src_2_sub_1": "啲青筋一条一条凸下凸下好似钢筋",
-      "src_2_sub_2": "至于脚趾弓啲脚甲"
+      "ref_sub_1": "青筋一条条凸出来，似钢筋",
+      "ref_sub_2": "至于脚趾甲⋯",
+      "target_sub_1": "啲青筋一条一条凸下凸下好似钢筋",
+      "target_sub_2": "至于脚趾弓啲脚甲"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "至于脚趾甲⋯",
-      "src_1_sub_2": "有次我无无聊聊真的量了一下⋯",
-      "src_2_sub_1": "至于脚趾弓啲脚甲",
-      "src_2_sub_2": "有次我无无聊聊真系走去卡下佢"
+      "ref_sub_1": "至于脚趾甲⋯",
+      "ref_sub_2": "有次我无无聊聊真的量了一下⋯",
+      "target_sub_1": "至于脚趾弓啲脚甲",
+      "target_sub_2": "有次我无无聊聊真系走去卡下佢"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "有次我无无聊聊真的量了一下⋯",
-      "src_1_sub_2": "足有一寸厚",
-      "src_2_sub_1": "有次我无无聊聊真系走去卡下佢",
-      "src_2_sub_2": "哗粥粥成串咁厚"
+      "ref_sub_1": "有次我无无聊聊真的量了一下⋯",
+      "ref_sub_2": "足有一寸厚",
+      "target_sub_1": "有次我无无聊聊真系走去卡下佢",
+      "target_sub_2": "哗粥粥成串咁厚"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "足有一寸厚",
-      "src_1_sub_2": "是的，故事讲完了",
-      "src_2_sub_1": "哗粥粥成串咁厚",
-      "src_2_sub_2": "系呀故事讲完喇"
+      "ref_sub_1": "足有一寸厚",
+      "ref_sub_2": "是的，故事讲完了",
+      "target_sub_1": "哗粥粥成串咁厚",
+      "target_sub_2": "系呀故事讲完喇"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "是的，故事讲完了",
-      "src_1_sub_2": "这是一个尝试",
-      "src_2_sub_1": "系呀故事讲完喇",
-      "src_2_sub_2": "呢个系一个尝试"
+      "ref_sub_1": "是的，故事讲完了",
+      "ref_sub_2": "这是一个尝试",
+      "target_sub_1": "系呀故事讲完喇",
+      "target_sub_2": "呢个系一个尝试"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "这是一个尝试",
-      "src_1_sub_2": "失败⋯尝试⋯",
-      "src_2_sub_1": "呢个系一个尝试",
-      "src_2_sub_2": "失败尝试"
+      "ref_sub_1": "这是一个尝试",
+      "ref_sub_2": "失败⋯尝试⋯",
+      "target_sub_1": "呢个系一个尝试",
+      "target_sub_2": "失败尝试"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "失败⋯尝试⋯",
-      "src_1_sub_2": "好多包⋯可是没有包保成功的故事",
-      "src_2_sub_1": "失败尝试",
-      "src_2_sub_2": "好多包但系冇包补成功嘅故事"
+      "ref_sub_1": "失败⋯尝试⋯",
+      "ref_sub_2": "好多包⋯可是没有包保成功的故事",
+      "target_sub_1": "失败尝试",
+      "target_sub_2": "好多包但系冇包补成功嘅故事"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "好多包⋯可是没有包保成功的故事",
-      "src_1_sub_2": "故事说了一轮⋯",
-      "src_2_sub_1": "好多包但系冇包补成功嘅故事",
-      "src_2_sub_2": "故事讲咗一轮"
+      "ref_sub_1": "好多包⋯可是没有包保成功的故事",
+      "ref_sub_2": "故事说了一轮⋯",
+      "target_sub_1": "好多包但系冇包补成功嘅故事",
+      "target_sub_2": "故事讲咗一轮"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "故事说了一轮⋯",
-      "src_1_sub_2": "什么也没有？也不是",
-      "src_2_sub_1": "故事讲咗一轮",
-      "src_2_sub_2": "乜都冇又唔系噃"
+      "ref_sub_1": "故事说了一轮⋯",
+      "ref_sub_2": "什么也没有？也不是",
+      "target_sub_1": "故事讲咗一轮",
+      "target_sub_2": "乜都冇又唔系噃"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "什么也没有？也不是",
-      "src_1_sub_2": "就是大了双脚瓜",
-      "src_2_sub_1": "乜都冇又唔系噃",
-      "src_2_sub_2": "就系大咗两个脚瓜"
+      "ref_sub_1": "什么也没有？也不是",
+      "ref_sub_2": "就是大了双脚瓜",
+      "target_sub_1": "乜都冇又唔系噃",
+      "target_sub_2": "就系大咗两个脚瓜"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "就是大了双脚瓜",
-      "src_1_sub_2": "可是楝一双脚瓜站这儿⋯",
-      "src_2_sub_1": "就系大咗两个脚瓜",
-      "src_2_sub_2": "但系冻住两个脚瓜企喺度"
+      "ref_sub_1": "就是大了双脚瓜",
+      "ref_sub_2": "可是楝一双脚瓜站这儿⋯",
+      "target_sub_1": "就系大咗两个脚瓜",
+      "target_sub_2": "但系冻住两个脚瓜企喺度"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "可是楝一双脚瓜站这儿⋯",
-      "src_1_sub_2": "当浪打过来⋯",
-      "src_2_sub_1": "但系冻住两个脚瓜企喺度",
-      "src_2_sub_2": "当啲浪打埋嚟"
+      "ref_sub_1": "可是楝一双脚瓜站这儿⋯",
+      "ref_sub_2": "当浪打过来⋯",
+      "target_sub_1": "但系冻住两个脚瓜企喺度",
+      "target_sub_2": "当啲浪打埋嚟"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "当浪打过来⋯",
-      "src_1_sub_2": "那感觉还真不错",
-      "src_2_sub_1": "当啲浪打埋嚟",
-      "src_2_sub_2": "嗰张感觉真系好好"
+      "ref_sub_1": "当浪打过来⋯",
+      "ref_sub_2": "那感觉还真不错",
+      "target_sub_1": "当啲浪打埋嚟",
+      "target_sub_2": "嗰张感觉真系好好"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "那感觉还真不错",
-      "src_1_sub_2": "你知道我麻麻地叻佬，不懂得⋯",
-      "src_2_sub_1": "嗰张感觉真系好好",
-      "src_2_sub_2": "你知我麻麻地叻佬"
+      "ref_sub_1": "那感觉还真不错",
+      "ref_sub_2": "你知道我麻麻地叻佬，不懂得⋯",
+      "target_sub_1": "嗰张感觉真系好好",
+      "target_sub_2": "你知我麻麻地叻佬"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "你知道我麻麻地叻佬，不懂得⋯",
-      "src_1_sub_2": "替自己的故事加点教训呀锦囊呀那些",
-      "src_2_sub_1": "你知我麻麻地叻佬",
-      "src_2_sub_2": "唔识得帮自己嘅故事加啲教训呀锦囊呀嗰啲嘢"
+      "ref_sub_1": "你知道我麻麻地叻佬，不懂得⋯",
+      "ref_sub_2": "替自己的故事加点教训呀锦囊呀那些",
+      "target_sub_1": "你知我麻麻地叻佬",
+      "target_sub_2": "唔识得帮自己嘅故事加啲教训呀锦囊呀嗰啲嘢"
     },
     "answer": {
-      "src_2_sub_1_shifted": "你知我麻麻地叻佬唔识得",
-      "src_2_sub_2_shifted": "帮自己嘅故事加啲教训呀锦囊呀嗰啲嘢"
+      "target_sub_1_shifted": "你知我麻麻地叻佬唔识得",
+      "target_sub_2_shifted": "帮自己嘅故事加啲教训呀锦囊呀嗰啲嘢"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "替自己的故事加点教训呀锦囊呀那些",
-      "src_1_sub_2": "可是，浸一双脚瓜站水中⋯",
-      "src_2_sub_1": "帮自己嘅故事加啲教训呀锦囊呀嗰啲嘢",
-      "src_2_sub_2": "但系冻住两个脚瓜企喺水嗰度"
+      "ref_sub_1": "替自己的故事加点教训呀锦囊呀那些",
+      "ref_sub_2": "可是，浸一双脚瓜站水中⋯",
+      "target_sub_1": "帮自己嘅故事加啲教训呀锦囊呀嗰啲嘢",
+      "target_sub_2": "但系冻住两个脚瓜企喺水嗰度"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "可是，浸一双脚瓜站水中⋯",
-      "src_1_sub_2": "当风吹向我的脑，我会想⋯",
-      "src_2_sub_1": "但系冻住两个脚瓜企喺水嗰度",
-      "src_2_sub_2": "当风吹喺我个脑部我会谂"
+      "ref_sub_1": "可是，浸一双脚瓜站水中⋯",
+      "ref_sub_2": "当风吹向我的脑，我会想⋯",
+      "target_sub_1": "但系冻住两个脚瓜企喺水嗰度",
+      "target_sub_2": "当风吹喺我个脑部我会谂"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "当风吹向我的脑，我会想⋯",
-      "src_1_sub_2": "如果妈妈看见我这个大脚瓜⋯",
-      "src_2_sub_1": "当风吹喺我个脑部我会谂",
-      "src_2_sub_2": "如果妈妈见到我呢个大脚瓜"
+      "ref_sub_1": "当风吹向我的脑，我会想⋯",
+      "ref_sub_2": "如果妈妈看见我这个大脚瓜⋯",
+      "target_sub_1": "当风吹喺我个脑部我会谂",
+      "target_sub_2": "如果妈妈见到我呢个大脚瓜"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "如果妈妈看见我这个大脚瓜⋯",
-      "src_1_sub_2": "我猜，她会好开心",
-      "src_2_sub_1": "如果妈妈见到我呢个大脚瓜",
-      "src_2_sub_2": "我谂佢会好开心"
+      "ref_sub_1": "如果妈妈看见我这个大脚瓜⋯",
+      "ref_sub_2": "我猜，她会好开心",
+      "target_sub_1": "如果妈妈见到我呢个大脚瓜",
+      "target_sub_2": "我谂佢会好开心"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "不成，还是出个锦囊！",
-      "src_1_sub_2": "妈妈的 dot com 散掉后，她又有计",
-      "src_2_sub_1": "都系唔好呀都系出返个锦囊先得",
-      "src_2_sub_2": "妈妈个Doccom散咗之后佢又有计喇"
+      "ref_sub_1": "不成，还是出个锦囊！",
+      "ref_sub_2": "妈妈的 dot com 散掉后，她又有计",
+      "target_sub_1": "都系唔好呀都系出返个锦囊先得",
+      "target_sub_2": "妈妈个Doccom散咗之后佢又有计喇"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈的 dot com 散掉后，她又有计",
-      "src_1_sub_2": "她出版了一本教烹饪的食谱",
-      "src_2_sub_1": "妈妈个Doccom散咗之后佢又有计喇",
-      "src_2_sub_2": "佢出咗半教主送嘅食谱谂住捞返扎沙"
+      "ref_sub_1": "妈妈的 dot com 散掉后，她又有计",
+      "ref_sub_2": "她出版了一本教烹饪的食谱",
+      "target_sub_1": "妈妈个Doccom散咗之后佢又有计喇",
+      "target_sub_2": "佢出咗半教主送嘅食谱谂住捞返扎沙"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "她出版了一本教烹饪的食谱",
-      "src_1_sub_2": "食谱最后一页教人整烧鸡",
-      "src_2_sub_1": "佢出咗半教主送嘅食谱谂住捞返扎沙",
-      "src_2_sub_2": "食谱最后一页系教人整烧鸡嘅"
+      "ref_sub_1": "她出版了一本教烹饪的食谱",
+      "ref_sub_2": "食谱最后一页教人整烧鸡",
+      "target_sub_1": "佢出咗半教主送嘅食谱谂住捞返扎沙",
+      "target_sub_2": "食谱最后一页系教人整烧鸡嘅"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "食谱最后一页教人整烧鸡",
-      "src_1_sub_2": "方法简单，人人可学",
-      "src_2_sub_1": "食谱最后一页系教人整烧鸡嘅",
-      "src_2_sub_2": "方法简单人人都学得识"
+      "ref_sub_1": "食谱最后一页教人整烧鸡",
+      "ref_sub_2": "方法简单，人人可学",
+      "target_sub_1": "食谱最后一页系教人整烧鸡嘅",
+      "target_sub_2": "方法简单人人都学得识"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "方法简单，人人可学",
-      "src_1_sub_2": "「烧鸡」",
-      "src_2_sub_1": "方法简单人人都学得识",
-      "src_2_sub_2": "烧鸡"
+      "ref_sub_1": "方法简单，人人可学",
+      "ref_sub_2": "「烧鸡」",
+      "target_sub_1": "方法简单人人都学得识",
+      "target_sub_2": "烧鸡"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "「烧鸡」",
-      "src_1_sub_2": "材料是⋯鸡",
-      "src_2_sub_1": "烧鸡",
-      "src_2_sub_2": "材料系"
+      "ref_sub_1": "「烧鸡」",
+      "ref_sub_2": "材料是⋯鸡",
+      "target_sub_1": "烧鸡",
+      "target_sub_2": "材料系"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "材料是⋯鸡",
-      "src_1_sub_2": "方法：把鸡烧几烧",
-      "src_2_sub_1": "材料系",
-      "src_2_sub_2": "鸡方法攞只鸡去烧佢几烧"
+      "ref_sub_1": "材料是⋯鸡",
+      "ref_sub_2": "方法：把鸡烧几烧",
+      "target_sub_1": "材料系",
+      "target_sub_2": "鸡方法攞只鸡去烧佢几烧"
     },
     "answer": {
-      "src_2_sub_1_shifted": "材料系鸡",
-      "src_2_sub_2_shifted": "方法攞只鸡去烧佢几烧"
+      "target_sub_1_shifted": "材料系鸡",
+      "target_sub_2_shifted": "方法攞只鸡去烧佢几烧"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "方法：把鸡烧几烧",
-      "src_1_sub_2": "就这样，一味「烧鸡」大功告成",
-      "src_2_sub_1": "方法攞只鸡去烧佢几烧",
-      "src_2_sub_2": "就噉一味烧鸡就大功告成喇"
+      "ref_sub_1": "方法：把鸡烧几烧",
+      "ref_sub_2": "就这样，一味「烧鸡」大功告成",
+      "target_sub_1": "方法攞只鸡去烧佢几烧",
+      "target_sub_2": "就噉一味烧鸡就大功告成喇"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "就这样，一味「烧鸡」大功告成",
-      "src_1_sub_2": "食谱里面补充说：",
-      "src_2_sub_1": "就噉一味烧鸡就大功告成喇",
-      "src_2_sub_2": "食谱度又补充噉话"
+      "ref_sub_1": "就这样，一味「烧鸡」大功告成",
+      "ref_sub_2": "食谱里面补充说：",
+      "target_sub_1": "就噉一味烧鸡就大功告成喇",
+      "target_sub_2": "食谱度又补充噉话"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "食谱里面补充说：",
-      "src_1_sub_2": "如果你想把鸡烧得美味可口⋯",
-      "src_2_sub_1": "食谱度又补充噉话",
-      "src_2_sub_2": "如果想你个鸡烧得美味可口"
+      "ref_sub_1": "食谱里面补充说：",
+      "ref_sub_2": "如果你想把鸡烧得美味可口⋯",
+      "target_sub_1": "食谱度又补充噉话",
+      "target_sub_2": "如果想你个鸡烧得美味可口"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "如果你想把鸡烧得美味可口⋯",
-      "src_1_sub_2": "吃完后不会心肺实胃气涨",
-      "src_2_sub_1": "如果想你个鸡烧得美味可口",
-      "src_2_sub_2": "冇话食完腰心腰肺顶住个胃"
+      "ref_sub_1": "如果你想把鸡烧得美味可口⋯",
+      "ref_sub_2": "吃完后不会心肺实胃气涨",
+      "target_sub_1": "如果想你个鸡烧得美味可口",
+      "target_sub_2": "冇话食完腰心腰肺顶住个胃"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "吃完后不会心肺实胃气涨",
-      "src_1_sub_2": "秘诀是：拜托，把鸡烧好一点⋯",
-      "src_2_sub_1": "冇话食完腰心腰肺顶住个胃",
-      "src_2_sub_2": "个秘诀系唔该烧得佢好啲啰"
+      "ref_sub_1": "吃完后不会心肺实胃气涨",
+      "ref_sub_2": "秘诀是：拜托，把鸡烧好一点⋯",
+      "target_sub_1": "冇话食完腰心腰肺顶住个胃",
+      "target_sub_2": "个秘诀系唔该烧得佢好啲啰"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "秘诀是：拜托，把鸡烧好一点⋯",
-      "src_1_sub_2": "多谢合作！",
-      "src_2_sub_1": "个秘诀系唔该烧得佢好啲啰",
-      "src_2_sub_2": "多谢合作"
+      "ref_sub_1": "秘诀是：拜托，把鸡烧好一点⋯",
+      "ref_sub_2": "多谢合作！",
+      "target_sub_1": "个秘诀系唔该烧得佢好啲啰",
+      "target_sub_2": "多谢合作"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "麻烦你，一客常餐",
-      "src_1_sub_2": "常餐？　常餐有什么吃？",
-      "src_2_sub_1": "唔该我要一个常餐啦",
-      "src_2_sub_2": "常餐"
+      "ref_sub_1": "麻烦你，一客常餐",
+      "ref_sub_2": "常餐？　常餐有什么吃？",
+      "target_sub_1": "唔该我要一个常餐啦",
+      "target_sub_2": "常餐"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "常餐？　常餐有什么吃？",
-      "src_1_sub_2": "跟特餐一样吧",
-      "src_2_sub_1": "常餐",
-      "src_2_sub_2": "常餐有咩食㗎"
+      "ref_sub_1": "常餐？　常餐有什么吃？",
+      "ref_sub_2": "跟特餐一样吧",
+      "target_sub_1": "常餐",
+      "target_sub_2": "常餐有咩食㗎"
     },
     "answer": {
-      "src_2_sub_1_shifted": "常餐常餐有咩食㗎"
+      "target_sub_1_shifted": "常餐常餐有咩食㗎"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "跟特餐一样吧",
-      "src_1_sub_2": "特餐是什么？",
-      "src_2_sub_2": "同特餐一样啰"
+      "ref_sub_1": "跟特餐一样吧",
+      "ref_sub_2": "特餐是什么？",
+      "target_sub_2": "同特餐一样啰"
     },
     "answer": {
-      "src_2_sub_1_shifted": "同特餐一样啰"
+      "target_sub_1_shifted": "同特餐一样啰"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "特餐是什么？",
-      "src_1_sub_2": "跟快餐差不多",
-      "src_2_sub_2": "噉特餐系咩嚟㗎同快餐咁上下啰"
+      "ref_sub_1": "特餐是什么？",
+      "ref_sub_2": "跟快餐差不多",
+      "target_sub_2": "噉特餐系咩嚟㗎同快餐咁上下啰"
     },
     "answer": {
-      "src_2_sub_1_shifted": "噉特餐系咩嚟㗎",
-      "src_2_sub_2_shifted": "同快餐咁上下啰"
+      "target_sub_1_shifted": "噉特餐系咩嚟㗎",
+      "target_sub_2_shifted": "同快餐咁上下啰"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "跟快餐差不多",
-      "src_1_sub_2": "快餐又是什么？",
-      "src_2_sub_1": "同快餐咁上下啰",
-      "src_2_sub_2": "噉快餐又系咩嚟㗎"
+      "ref_sub_1": "跟快餐差不多",
+      "ref_sub_2": "快餐又是什么？",
+      "target_sub_1": "同快餐咁上下啰",
+      "target_sub_2": "噉快餐又系咩嚟㗎"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "快餐又是什么？",
-      "src_1_sub_2": "快餐即是午餐",
-      "src_2_sub_1": "噉快餐又系咩嚟㗎",
-      "src_2_sub_2": "即系快餐咪真系午餐"
+      "ref_sub_1": "快餐又是什么？",
+      "ref_sub_2": "快餐即是午餐",
+      "target_sub_1": "噉快餐又系咩嚟㗎",
+      "target_sub_2": "即系快餐咪真系午餐"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "快餐即是午餐",
-      "src_1_sub_2": "午餐吃什么？",
-      "src_2_sub_1": "即系快餐咪真系午餐"
+      "ref_sub_1": "快餐即是午餐",
+      "ref_sub_2": "午餐吃什么？",
+      "target_sub_1": "即系快餐咪真系午餐"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "午餐吃什么？",
-      "src_1_sub_2": "午餐跟晚餐一样",
-      "src_2_sub_2": "午餐食咩㗎午餐同晚餐一样㗎"
+      "ref_sub_1": "午餐吃什么？",
+      "ref_sub_2": "午餐跟晚餐一样",
+      "target_sub_2": "午餐食咩㗎午餐同晚餐一样㗎"
     },
     "answer": {
-      "src_2_sub_1_shifted": "午餐食咩㗎",
-      "src_2_sub_2_shifted": "午餐同晚餐一样㗎"
+      "target_sub_1_shifted": "午餐食咩㗎",
+      "target_sub_2_shifted": "午餐同晚餐一样㗎"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "午餐跟晚餐一样",
-      "src_1_sub_2": "晚餐又吃什么？",
-      "src_2_sub_1": "午餐同晚餐一样㗎",
-      "src_2_sub_2": "噉晚餐又食啲咩呀"
+      "ref_sub_1": "午餐跟晚餐一样",
+      "ref_sub_2": "晚餐又吃什么？",
+      "target_sub_1": "午餐同晚餐一样㗎",
+      "target_sub_2": "噉晚餐又食啲咩呀"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "晚餐又吃什么？",
-      "src_1_sub_2": "晚餐即是常餐",
-      "src_2_sub_1": "噉晚餐又食啲咩呀",
-      "src_2_sub_2": "晚餐咪真系常餐啰"
+      "ref_sub_1": "晚餐又吃什么？",
+      "ref_sub_2": "晚餐即是常餐",
+      "target_sub_1": "噉晚餐又食啲咩呀",
+      "target_sub_2": "晚餐咪真系常餐啰"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "晚餐即是常餐",
-      "src_1_sub_2": "那么，两客常餐吧",
-      "src_2_sub_1": "晚餐咪真系常餐啰",
-      "src_2_sub_2": "噉呀我要两个常餐啦"
+      "ref_sub_1": "晚餐即是常餐",
+      "ref_sub_2": "那么，两客常餐吧",
+      "target_sub_1": "晚餐咪真系常餐啰",
+      "target_sub_2": "噉呀我要两个常餐啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "那么，两客常餐吧",
-      "src_1_sub_2": "今天常餐精采呀！",
-      "src_2_sub_1": "噉呀我要两个常餐啦",
-      "src_2_sub_2": "好嘢呀我哋今日啲常餐"
+      "ref_sub_1": "那么，两客常餐吧",
+      "ref_sub_2": "今天常餐精采呀！",
+      "target_sub_1": "噉呀我要两个常餐啦",
+      "target_sub_2": "好嘢呀我哋今日啲常餐"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "对不起，常餐卖光了",
-      "src_1_sub_2": "那改要特餐吧",
-      "src_2_sub_1": "唔好意思上餐卖晒",
-      "src_2_sub_2": "咁改要特餐啦"
+      "ref_sub_1": "对不起，常餐卖光了",
+      "ref_sub_2": "那改要特餐吧",
+      "target_sub_1": "唔好意思上餐卖晒",
+      "target_sub_2": "咁改要特餐啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "那改要特餐吧",
-      "src_1_sub_2": "特餐？特餐有什么吃？",
-      "src_2_sub_1": "咁改要特餐啦",
-      "src_2_sub_2": "特餐"
+      "ref_sub_1": "那改要特餐吧",
+      "ref_sub_2": "特餐？特餐有什么吃？",
+      "target_sub_1": "咁改要特餐啦",
+      "target_sub_2": "特餐"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "特餐？特餐有什么吃？",
-      "src_1_sub_2": "特餐即是午餐呀",
-      "src_2_sub_1": "特餐",
-      "src_2_sub_2": "特餐有咩食㗎特餐就即系午餐啰"
+      "ref_sub_1": "特餐？特餐有什么吃？",
+      "ref_sub_2": "特餐即是午餐呀",
+      "target_sub_1": "特餐",
+      "target_sub_2": "特餐有咩食㗎特餐就即系午餐啰"
     },
     "answer": {
-      "src_2_sub_1_shifted": "特餐特餐有咩食㗎",
-      "src_2_sub_2_shifted": "特餐就即系午餐啰"
+      "target_sub_1_shifted": "特餐特餐有咩食㗎",
+      "target_sub_2_shifted": "特餐就即系午餐啰"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "特餐即是午餐呀",
-      "src_1_sub_2": "午餐又吃什么呢？",
-      "src_2_sub_1": "特餐就即系午餐啰",
-      "src_2_sub_2": "午餐食乜嘢㗎"
+      "ref_sub_1": "特餐即是午餐呀",
+      "ref_sub_2": "午餐又吃什么呢？",
+      "target_sub_1": "特餐就即系午餐啰",
+      "target_sub_2": "午餐食乜嘢㗎"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "午餐又吃什么呢？",
-      "src_1_sub_2": "都是晚餐那些吧",
-      "src_2_sub_1": "午餐食乜嘢㗎",
-      "src_2_sub_2": "都系晚餐嗰啲嘢啰"
+      "ref_sub_1": "午餐又吃什么呢？",
+      "ref_sub_2": "都是晚餐那些吧",
+      "target_sub_1": "午餐食乜嘢㗎",
+      "target_sub_2": "都系晚餐嗰啲嘢啰"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "都是晚餐那些吧",
-      "src_1_sub_2": "什么是晚餐？",
-      "src_2_sub_1": "都系晚餐嗰啲嘢啰"
+      "ref_sub_1": "都是晚餐那些吧",
+      "ref_sub_2": "什么是晚餐？",
+      "target_sub_1": "都系晚餐嗰啲嘢啰"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "什么是晚餐？",
-      "src_1_sub_2": "跟快餐一样",
-      "src_2_sub_2": "咁乜嘢系晚餐呀"
+      "ref_sub_1": "什么是晚餐？",
+      "ref_sub_2": "跟快餐一样",
+      "target_sub_2": "咁乜嘢系晚餐呀"
     },
     "answer": {
-      "src_2_sub_1_shifted": "咁乜嘢系晚餐呀"
+      "target_sub_1_shifted": "咁乜嘢系晚餐呀"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "跟快餐一样",
-      "src_1_sub_2": "快餐吃什么？",
-      "src_2_sub_2": "同快餐一样啰咁快餐食咩㗎"
+      "ref_sub_1": "跟快餐一样",
+      "ref_sub_2": "快餐吃什么？",
+      "target_sub_2": "同快餐一样啰咁快餐食咩㗎"
     },
     "answer": {
-      "src_2_sub_1_shifted": "同快餐一样啰",
-      "src_2_sub_2_shifted": "咁快餐食咩㗎"
+      "target_sub_1_shifted": "同快餐一样啰",
+      "target_sub_2_shifted": "咁快餐食咩㗎"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "快餐吃什么？",
-      "src_1_sub_2": "唉，快餐不就是常餐",
-      "src_2_sub_1": "咁快餐食咩㗎",
-      "src_2_sub_2": "系快餐就即系上餐啰"
+      "ref_sub_1": "快餐吃什么？",
+      "ref_sub_2": "唉，快餐不就是常餐",
+      "target_sub_1": "咁快餐食咩㗎",
+      "target_sub_2": "系快餐就即系上餐啰"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "唉，快餐不就是常餐",
-      "src_1_sub_2": "常餐不是卖光了吗？",
-      "src_2_sub_1": "系快餐就即系上餐啰",
-      "src_2_sub_2": "咁你头先又话冇上餐"
+      "ref_sub_1": "唉，快餐不就是常餐",
+      "ref_sub_2": "常餐不是卖光了吗？",
+      "target_sub_1": "系快餐就即系上餐啰",
+      "target_sub_2": "咁你头先又话冇上餐"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "常餐不是卖光了吗？",
-      "src_1_sub_2": "对，常餐卖光了，要吃特餐吗？",
-      "src_2_sub_1": "咁你头先又话冇上餐",
-      "src_2_sub_2": "系呀上餐就系卖晒呀咁你试唔试下特餐啦"
+      "ref_sub_1": "常餐不是卖光了吗？",
+      "ref_sub_2": "对，常餐卖光了，要吃特餐吗？",
+      "target_sub_1": "咁你头先又话冇上餐",
+      "target_sub_2": "系呀上餐就系卖晒呀咁你试唔试下特餐啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "对，常餐卖光了，要吃特餐吗？",
-      "src_1_sub_2": "来两份特餐吧",
-      "src_2_sub_1": "系呀上餐就系卖晒呀咁你试唔试下特餐啦",
-      "src_2_sub_2": "两份特餐啦"
+      "ref_sub_1": "对，常餐卖光了，要吃特餐吗？",
+      "ref_sub_2": "来两份特餐吧",
+      "target_sub_1": "系呀上餐就系卖晒呀咁你试唔试下特餐啦",
+      "target_sub_2": "两份特餐啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "来两份特餐吧",
-      "src_1_sub_2": "对不起，特餐卖光了",
-      "src_2_sub_1": "两份特餐啦",
-      "src_2_sub_2": "唔好意思特餐卖晒嘅"
+      "ref_sub_1": "来两份特餐吧",
+      "ref_sub_2": "对不起，特餐卖光了",
+      "target_sub_1": "两份特餐啦",
+      "target_sub_2": "唔好意思特餐卖晒嘅"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "对不起，特餐卖光了",
-      "src_1_sub_2": "妈妈，改快餐吧",
-      "src_2_sub_1": "唔好意思特餐卖晒嘅",
-      "src_2_sub_2": "妈妈"
+      "ref_sub_1": "对不起，特餐卖光了",
+      "ref_sub_2": "妈妈，改快餐吧",
+      "target_sub_1": "唔好意思特餐卖晒嘅",
+      "target_sub_2": "妈妈"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "妈妈，改快餐吧",
-      "src_1_sub_2": "快餐有什么？",
-      "src_2_sub_1": "妈妈",
-      "src_2_sub_2": "不如改快餐啦快餐有咩㗎"
+      "ref_sub_1": "妈妈，改快餐吧",
+      "ref_sub_2": "快餐有什么？",
+      "target_sub_1": "妈妈",
+      "target_sub_2": "不如改快餐啦快餐有咩㗎"
     },
     "answer": {
-      "src_2_sub_1_shifted": "妈妈不如改快餐啦",
-      "src_2_sub_2_shifted": "快餐有咩㗎"
+      "target_sub_1_shifted": "妈妈不如改快餐啦",
+      "target_sub_2_shifted": "快餐有咩㗎"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "快餐有什么？",
-      "src_1_sub_2": "快餐即是常餐",
-      "src_2_sub_1": "快餐有咩㗎",
-      "src_2_sub_2": "快餐即系上餐"
+      "ref_sub_1": "快餐有什么？",
+      "ref_sub_2": "快餐即是常餐",
+      "target_sub_1": "快餐有咩㗎",
+      "target_sub_2": "快餐即系上餐"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "快餐即是常餐",
-      "src_1_sub_2": "常餐又有什么呢？",
-      "src_2_sub_1": "快餐即系上餐",
-      "src_2_sub_2": "咁上餐有咩㗎"
+      "ref_sub_1": "快餐即是常餐",
+      "ref_sub_2": "常餐又有什么呢？",
+      "target_sub_1": "快餐即系上餐",
+      "target_sub_2": "咁上餐有咩㗎"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "常餐又有什么呢？",
-      "src_1_sub_2": "常餐即是午餐",
-      "src_2_sub_1": "咁上餐有咩㗎",
-      "src_2_sub_2": "上餐就即系午餐啰"
+      "ref_sub_1": "常餐又有什么呢？",
+      "ref_sub_2": "常餐即是午餐",
+      "target_sub_1": "咁上餐有咩㗎",
+      "target_sub_2": "上餐就即系午餐啰"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "常餐即是午餐",
-      "src_1_sub_2": "那么午餐又有什么吃？",
-      "src_2_sub_1": "上餐就即系午餐啰",
-      "src_2_sub_2": "哎呀咁午餐有咩食呀"
+      "ref_sub_1": "常餐即是午餐",
+      "ref_sub_2": "那么午餐又有什么吃？",
+      "target_sub_1": "上餐就即系午餐啰",
+      "target_sub_2": "哎呀咁午餐有咩食呀"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "那么午餐又有什么吃？",
-      "src_1_sub_2": "午餐跟晚餐一样",
-      "src_2_sub_1": "哎呀咁午餐有咩食呀",
-      "src_2_sub_2": "午餐同晚餐一样㗎"
+      "ref_sub_1": "那么午餐又有什么吃？",
+      "ref_sub_2": "午餐跟晚餐一样",
+      "target_sub_1": "哎呀咁午餐有咩食呀",
+      "target_sub_2": "午餐同晚餐一样㗎"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "午餐跟晚餐一样",
-      "src_1_sub_2": "晚餐呢？",
-      "src_2_sub_1": "午餐同晚餐一样㗎"
+      "ref_sub_1": "午餐跟晚餐一样",
+      "ref_sub_2": "晚餐呢？",
+      "target_sub_1": "午餐同晚餐一样㗎"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "晚餐呢？",
-      "src_1_sub_2": "晚餐不就是特餐",
-      "src_2_sub_2": "咁晚餐呢晚餐就即系特餐啰"
+      "ref_sub_1": "晚餐呢？",
+      "ref_sub_2": "晚餐不就是特餐",
+      "target_sub_2": "咁晚餐呢晚餐就即系特餐啰"
     },
     "answer": {
-      "src_2_sub_1_shifted": "咁晚餐呢",
-      "src_2_sub_2_shifted": "晚餐就即系特餐啰"
+      "target_sub_1_shifted": "咁晚餐呢",
+      "target_sub_2_shifted": "晚餐就即系特餐啰"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "晚餐不就是特餐",
-      "src_1_sub_2": "不是说特餐卖光了吗？",
-      "src_2_sub_1": "晚餐就即系特餐啰",
-      "src_2_sub_2": "咁你头先又话冇特餐"
+      "ref_sub_1": "晚餐不就是特餐",
+      "ref_sub_2": "不是说特餐卖光了吗？",
+      "target_sub_1": "晚餐就即系特餐啰",
+      "target_sub_2": "咁你头先又话冇特餐"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "不是说特餐卖光了吗？",
-      "src_1_sub_2": "特餐卖光了，要试试快餐吗？都一样的",
-      "src_2_sub_1": "咁你头先又话冇特餐",
-      "src_2_sub_2": "系呀特餐系卖晒呀咁你试唔试下个快餐啦"
+      "ref_sub_1": "不是说特餐卖光了吗？",
+      "ref_sub_2": "特餐卖光了，要试试快餐吗？都一样的",
+      "target_sub_1": "咁你头先又话冇特餐",
+      "target_sub_2": "系呀特餐系卖晒呀咁你试唔试下个快餐啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "特餐卖光了，要试试快餐吗？都一样的",
-      "src_1_sub_2": "来两份快餐吧",
-      "src_2_sub_1": "系呀特餐系卖晒呀咁你试唔试下个快餐啦",
-      "src_2_sub_2": "一样嘅啫咁两份快餐啦"
+      "ref_sub_1": "特餐卖光了，要试试快餐吗？都一样的",
+      "ref_sub_2": "来两份快餐吧",
+      "target_sub_1": "系呀特餐系卖晒呀咁你试唔试下个快餐啦",
+      "target_sub_2": "一样嘅啫咁两份快餐啦"
     },
     "answer": {
-      "src_2_sub_1_shifted": "系呀特餐系卖晒呀咁你试唔试下个快餐啦一样嘅啫",
-      "src_2_sub_2_shifted": "咁两份快餐啦"
+      "target_sub_1_shifted": "系呀特餐系卖晒呀咁你试唔试下个快餐啦一样嘅啫",
+      "target_sub_2_shifted": "咁两份快餐啦"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "对不起，没快餐了",
-      "src_1_sub_2": "太过份了吧？你们究竟有吃的没？",
-      "src_2_sub_1": "唔好意思冇快餐呀",
-      "src_2_sub_2": "嚟唔嚟普啲呀噉你哋究竟有啲咩餐呀"
+      "ref_sub_1": "对不起，没快餐了",
+      "ref_sub_2": "太过份了吧？你们究竟有吃的没？",
+      "target_sub_1": "唔好意思冇快餐呀",
+      "target_sub_2": "嚟唔嚟普啲呀噉你哋究竟有啲咩餐呀"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "太过份了吧？你们究竟有吃的没？",
-      "src_1_sub_2": "午餐吧，午餐精采呀",
-      "src_2_sub_1": "嚟唔嚟普啲呀噉你哋究竟有啲咩餐呀",
-      "src_2_sub_2": "午餐啦"
+      "ref_sub_1": "太过份了吧？你们究竟有吃的没？",
+      "ref_sub_2": "午餐吧，午餐精采呀",
+      "target_sub_1": "嚟唔嚟普啲呀噉你哋究竟有啲咩餐呀",
+      "target_sub_2": "午餐啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "午餐吧，午餐精采呀",
-      "src_1_sub_2": "怎么个精采法？",
-      "src_2_sub_1": "午餐啦",
-      "src_2_sub_2": "午餐好嘢呀"
+      "ref_sub_1": "午餐吧，午餐精采呀",
+      "ref_sub_2": "怎么个精采法？",
+      "target_sub_1": "午餐啦",
+      "target_sub_2": "午餐好嘢呀"
     },
     "answer": {
-      "src_2_sub_1_shifted": "午餐啦午餐好嘢呀"
+      "target_sub_1_shifted": "午餐啦午餐好嘢呀"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "怎么个精采法？",
-      "src_1_sub_2": "跟晚餐一样精采",
-      "src_2_sub_2": "点好嘢法呀"
+      "ref_sub_1": "怎么个精采法？",
+      "ref_sub_2": "跟晚餐一样精采",
+      "target_sub_2": "点好嘢法呀"
     },
     "answer": {
-      "src_2_sub_1_shifted": "点好嘢法呀"
+      "target_sub_1_shifted": "点好嘢法呀"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "跟晚餐一样精采",
-      "src_1_sub_2": "晚餐又怎样呢？",
-      "src_2_sub_2": "同晚餐一样咁好嘢"
+      "ref_sub_1": "跟晚餐一样精采",
+      "ref_sub_2": "晚餐又怎样呢？",
+      "target_sub_2": "同晚餐一样咁好嘢"
     },
     "answer": {
-      "src_2_sub_1_shifted": "同晚餐一样咁好嘢"
+      "target_sub_1_shifted": "同晚餐一样咁好嘢"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "晚餐又怎样呢？",
-      "src_1_sub_2": "跟常餐一样精采",
-      "src_2_sub_2": "噉晚餐又点好嘢法呀同上餐一样咁好嘢啰"
+      "ref_sub_1": "晚餐又怎样呢？",
+      "ref_sub_2": "跟常餐一样精采",
+      "target_sub_2": "噉晚餐又点好嘢法呀同上餐一样咁好嘢啰"
     },
     "answer": {
-      "src_2_sub_1_shifted": "噉晚餐又点好嘢法呀",
-      "src_2_sub_2_shifted": "同上餐一样咁好嘢啰"
+      "target_sub_1_shifted": "噉晚餐又点好嘢法呀",
+      "target_sub_2_shifted": "同上餐一样咁好嘢啰"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "跟常餐一样精采",
-      "src_1_sub_2": "常餐又怎样呢？",
-      "src_2_sub_1": "同上餐一样咁好嘢啰"
+      "ref_sub_1": "跟常餐一样精采",
+      "ref_sub_2": "常餐又怎样呢？",
+      "target_sub_1": "同上餐一样咁好嘢啰"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "常餐又怎样呢？",
-      "src_1_sub_2": "常餐早卖光了，你说精采不？",
-      "src_2_sub_2": "噉上餐又点好嘢法呀上餐上餐一早卖晒啦你话好唔好嘢"
+      "ref_sub_1": "常餐又怎样呢？",
+      "ref_sub_2": "常餐早卖光了，你说精采不？",
+      "target_sub_2": "噉上餐又点好嘢法呀上餐上餐一早卖晒啦你话好唔好嘢"
     },
     "answer": {
-      "src_2_sub_1_shifted": "噉上餐又点好嘢法呀",
-      "src_2_sub_2_shifted": "上餐上餐一早卖晒啦你话好唔好嘢"
+      "target_sub_1_shifted": "噉上餐又点好嘢法呀",
+      "target_sub_2_shifted": "上餐上餐一早卖晒啦你话好唔好嘢"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "常餐早卖光了，你说精采不？",
-      "src_1_sub_2": "好吧好吧！两份午餐好了",
-      "src_2_sub_1": "上餐上餐一早卖晒啦你话好唔好嘢",
-      "src_2_sub_2": "好啦好啦要两份午餐啦"
+      "ref_sub_1": "常餐早卖光了，你说精采不？",
+      "ref_sub_2": "好吧好吧！两份午餐好了",
+      "target_sub_1": "上餐上餐一早卖晒啦你话好唔好嘢",
+      "target_sub_2": "好啦好啦要两份午餐啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "对不起，午餐卖光了",
-      "src_1_sub_2": "要试试我们的晚餐吗？都一样的",
-      "src_2_sub_1": "唔好意思",
-      "src_2_sub_2": "午餐卖晒试唔试下我哋嘅晚餐啦"
+      "ref_sub_1": "对不起，午餐卖光了",
+      "ref_sub_2": "要试试我们的晚餐吗？都一样的",
+      "target_sub_1": "唔好意思",
+      "target_sub_2": "午餐卖晒试唔试下我哋嘅晚餐啦"
     },
     "answer": {
-      "src_2_sub_1_shifted": "唔好意思午餐卖晒",
-      "src_2_sub_2_shifted": "试唔试下我哋嘅晚餐啦"
+      "target_sub_1_shifted": "唔好意思午餐卖晒",
+      "target_sub_2_shifted": "试唔试下我哋嘅晚餐啦"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "要试试我们的晚餐吗？都一样的",
-      "src_1_sub_2": "光天白日，吃什么鬼晚餐？",
-      "src_2_sub_1": "试唔试下我哋嘅晚餐啦",
-      "src_2_sub_2": "一样嘅啫日光日白食乜鬼嘢晚餐啊"
+      "ref_sub_1": "要试试我们的晚餐吗？都一样的",
+      "ref_sub_2": "光天白日，吃什么鬼晚餐？",
+      "target_sub_1": "试唔试下我哋嘅晚餐啦",
+      "target_sub_2": "一样嘅啫日光日白食乜鬼嘢晚餐啊"
     },
     "answer": {
-      "src_2_sub_1_shifted": "试唔试下我哋嘅晚餐啦一样嘅啫",
-      "src_2_sub_2_shifted": "日光日白食乜鬼嘢晚餐啊"
+      "target_sub_1_shifted": "试唔试下我哋嘅晚餐啦一样嘅啫",
+      "target_sub_2_shifted": "日光日白食乜鬼嘢晚餐啊"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "光天白日，吃什么鬼晚餐？",
-      "src_1_sub_2": "唉，说是说晚餐，还不就是午餐？",
-      "src_2_sub_1": "日光日白食乜鬼嘢晚餐啊",
-      "src_2_sub_2": "系个名叫晚餐啫其实唔系真系午餐"
+      "ref_sub_1": "光天白日，吃什么鬼晚餐？",
+      "ref_sub_2": "唉，说是说晚餐，还不就是午餐？",
+      "target_sub_1": "日光日白食乜鬼嘢晚餐啊",
+      "target_sub_2": "系个名叫晚餐啫其实唔系真系午餐"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "唉，说是说晚餐，还不就是午餐？",
-      "src_1_sub_2": "好吧好吧，拜托！两份晚餐！快！",
-      "src_2_sub_1": "系个名叫晚餐啫其实唔系真系午餐",
-      "src_2_sub_2": "好啦好啦怕咗你啦要两份晚餐啦"
+      "ref_sub_1": "唉，说是说晚餐，还不就是午餐？",
+      "ref_sub_2": "好吧好吧，拜托！两份晚餐！快！",
+      "target_sub_1": "系个名叫晚餐啫其实唔系真系午餐",
+      "target_sub_2": "好啦好啦怕咗你啦要两份晚餐啦"
     },
     "answer": {},
     "verified": true
   },
   {
     "query": {
-      "src_1_sub_1": "好吧好吧，拜托！两份晚餐！快！",
-      "src_1_sub_2": "要快吗？那得吃快餐了！",
-      "src_2_sub_1": "好啦好啦怕咗你啦要两份晚餐啦",
-      "src_2_sub_2": "快啲手啊想快想快就要快餐啊"
+      "ref_sub_1": "好吧好吧，拜托！两份晚餐！快！",
+      "ref_sub_2": "要快吗？那得吃快餐了！",
+      "target_sub_1": "好啦好啦怕咗你啦要两份晚餐啦",
+      "target_sub_2": "快啲手啊想快想快就要快餐啊"
     },
     "answer": {
-      "src_2_sub_1_shifted": "好啦好啦怕咗你啦要两份晚餐啦快啲手啊",
-      "src_2_sub_2_shifted": "想快想快就要快餐啊"
+      "target_sub_1_shifted": "好啦好啦怕咗你啦要两份晚餐啦快啲手啊",
+      "target_sub_2_shifted": "想快想快就要快餐啊"
     },
     "difficulty": 1,
     "verified": true

--- a/test/lang/transcription/test_delineation_alignment.py
+++ b/test/lang/transcription/test_delineation_alignment.py
@@ -16,12 +16,12 @@ from scinoephile.lang.transcription.alignment import TranscriptionAlignment
 from scinoephile.llms.delineation import DelineationPrompt, DelineationTestCase
 
 _LOCALIZED_PROMPT = DelineationPrompt(
-    src_1_sub_1="cankao_yi",
-    src_1_sub_2="cankao_er",
-    src_2_sub_1="mubiao_yi",
-    src_2_sub_2="mubiao_er",
-    src_2_sub_1_shifted="shuchu_yi",
-    src_2_sub_2_shifted="shuchu_er",
+    ref_sub_1="cankao_yi",
+    ref_sub_2="cankao_er",
+    target_sub_1="mubiao_yi",
+    target_sub_2="mubiao_er",
+    target_sub_1_shifted="shuchu_yi",
+    target_sub_2_shifted="shuchu_er",
 )
 """Delineation prompt using non-default correspondence field names."""
 

--- a/test/llms/test_delineation.py
+++ b/test/llms/test_delineation.py
@@ -30,32 +30,34 @@ from test.helpers import test_data_root
 
 _LOCALIZED_PROMPT = DelineationPrompt(
     language=Language.zho_hant,
-    src_1_sub_1="cankao_yi",
-    src_1_sub_1_desc="第一條參考字幕",
-    src_1_sub_2="cankao_er",
-    src_1_sub_2_desc="第二條參考字幕",
-    src_2_sub_1="mubiao_yi",
-    src_2_sub_1_desc="第一條初始目標字幕",
-    src_2_sub_2="mubiao_er",
-    src_2_sub_2_desc="第二條初始目標字幕",
-    src_2_sub_1_sub_2_missing_err="查詢至少要有一條目標字幕。",
-    src_2_sub_1_shifted="shuchu_yi",
-    src_2_sub_1_shifted_desc="第一條調整後目標字幕",
-    src_2_sub_2_shifted="shuchu_er",
-    src_2_sub_2_shifted_desc="第二條調整後目標字幕",
-    src_2_sub_1_sub_2_unchanged_err="調整後目標字幕不可原樣重複。",
-    src_2_chars_changed_err_tpl=(
+    ref_sub_1="cankao_yi",
+    ref_sub_1_desc="第一條參考字幕",
+    ref_sub_2="cankao_er",
+    ref_sub_2_desc="第二條參考字幕",
+    target_sub_1="mubiao_yi",
+    target_sub_1_desc="第一條初始目標字幕",
+    target_sub_2="mubiao_er",
+    target_sub_2_desc="第二條初始目標字幕",
+    target_subs_missing_err="查詢至少要有一條目標字幕。",
+    target_sub_1_shifted="shuchu_yi",
+    target_sub_1_shifted_desc="第一條調整後目標字幕",
+    target_sub_2_shifted="shuchu_er",
+    target_sub_2_shifted_desc="第二條調整後目標字幕",
+    target_subs_unchanged_err="調整後目標字幕不可原樣重複。",
+    target_chars_changed_err_tpl=(
         "調整後目標字幕字元不一致：\n期望：{expected}\n收到：{received}"
     ),
 )
 """Delineation prompt with localized correspondence field names."""
 
-_DELINEATION_PATHS = tuple(
+_MLAMD_DELINEATION_PATHS = tuple(
     sorted(
-        test_data_root.glob("*/output/*/lang/yue_zho/transcription/delineation/*.json")
+        test_data_root.glob(
+            "mlamd/output/*/lang/yue_zho/transcription/delineation/*.json"
+        )
     )
 )
-"""Tracked delineation test-case JSON paths."""
+"""Tracked MLAMD delineation test-case JSON paths."""
 
 
 def test_prompt_aliases_are_used_for_llm_correspondence():
@@ -209,7 +211,7 @@ def test_static_models_validate_target_presence_and_boundary_shifts():
     assert explicitly_difficult.difficulty == 3
     with raises(
         ValidationError,
-        match=DelineationManager.base_prompt.src_2_sub_1_sub_2_missing_err,
+        match=DelineationManager.base_prompt.target_subs_missing_err,
     ):
         DelineationTestCase.model_validate(
             {
@@ -221,7 +223,7 @@ def test_static_models_validate_target_presence_and_boundary_shifts():
         )
     with raises(
         ValidationError,
-        match=DelineationManager.base_prompt.src_2_sub_1_sub_2_unchanged_err,
+        match=DelineationManager.base_prompt.target_subs_unchanged_err,
     ):
         DelineationTestCase.model_validate(
             {
@@ -250,7 +252,7 @@ def test_generated_models_use_prompt_specific_validation_errors():
 
     with raises(
         ValidationError,
-        match=_LOCALIZED_PROMPT.src_2_sub_1_sub_2_missing_err,
+        match=_LOCALIZED_PROMPT.target_subs_missing_err,
     ):
         test_case_cls.model_validate(
             {
@@ -262,7 +264,7 @@ def test_generated_models_use_prompt_specific_validation_errors():
         )
     with raises(
         ValidationError,
-        match=_LOCALIZED_PROMPT.src_2_sub_1_sub_2_unchanged_err,
+        match=_LOCALIZED_PROMPT.target_subs_unchanged_err,
     ):
         test_case_cls.model_validate(
             {
@@ -300,25 +302,25 @@ def test_persistence_uses_base_prompt_aliases_and_omits_defaults(tmp_path: Path)
     assert json.loads(output_path.read_text(encoding="utf-8")) == [
         {
             "query": {
-                "src_1_sub_1": "參考一",
-                "src_1_sub_2": "參考二",
-                "src_2_sub_1": "甲",
+                "ref_sub_1": "參考一",
+                "ref_sub_2": "參考二",
+                "target_sub_1": "甲",
             },
-            "answer": {"src_2_sub_2_shifted": "甲"},
+            "answer": {"target_sub_2_shifted": "甲"},
             "difficulty": 1,
             "verified": True,
         }
     ]
     persisted = PersistedTestCase.from_test_case(test_case, DelineationManager)
     assert persisted.query == {
-        "src_1_sub_1": "參考一",
-        "src_1_sub_2": "參考二",
-        "src_2_sub_1": "甲",
-        "src_2_sub_2": "",
+        "ref_sub_1": "參考一",
+        "ref_sub_2": "參考二",
+        "target_sub_1": "甲",
+        "target_sub_2": "",
     }
     assert persisted.answer == {
-        "src_2_sub_1_shifted": "",
-        "src_2_sub_2_shifted": "甲",
+        "target_sub_1_shifted": "",
+        "target_sub_2_shifted": "甲",
     }
 
     loaded = load_test_cases_from_json(
@@ -330,22 +332,22 @@ def test_persistence_uses_base_prompt_aliases_and_omits_defaults(tmp_path: Path)
 
 
 def test_tracked_fixture_count():
-    """All four tracked delineation files should contain 4,252 test cases."""
+    """Both tracked MLAMD delineation files should contain 1,752 test cases."""
     counts = [
         len(json.loads(input_path.read_text(encoding="utf-8")))
-        for input_path in _DELINEATION_PATHS
+        for input_path in _MLAMD_DELINEATION_PATHS
     ]
 
-    assert len(_DELINEATION_PATHS) == 4
-    assert sum(counts) == 4252
+    assert len(_MLAMD_DELINEATION_PATHS) == 2
+    assert sum(counts) == 1752
 
 
 @mark.parametrize(
     "input_path",
-    _DELINEATION_PATHS,
+    _MLAMD_DELINEATION_PATHS,
     ids=[
         input_path.relative_to(test_data_root).as_posix()
-        for input_path in _DELINEATION_PATHS
+        for input_path in _MLAMD_DELINEATION_PATHS
     ],
 )
 def test_tracked_fixture_round_trips_without_migration(


### PR DESCRIPTION
## Summary

- rename delineation prompt fields from generic source-one/source-two terminology to explicit reference/target terminology
- update delineation managers, models, localized Cantonese prompts, and tests to use the semantic names
- mechanically migrate the two MLAMD delineation JSON fixtures without changing their cases or metadata

## Why

The previous `src_1`/`src_2` names obscured the distinct roles of the reference subtitles and the target transcription. The semantic names make prompt configuration, validation errors, and persisted data easier to understand while preserving runtime behavior.

## Impact

The base persisted delineation aliases now use `ref_sub_*` and `target_sub_*`. The localized LLM-facing aliases remain unchanged, so correspondence still uses the same Cantonese field names.

Legacy KOB Yue-Hans delineation fixtures are intentionally outside this PR. Both the focused delineation inventory and the repository-wide fixture contract temporarily select only MLAMD delineation fixtures. The planned KOB Yue-Hant corpus replacement will migrate that corpus and restore its coverage; every other fixture family remains covered here.

## Checks

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format test/core/llms/test_test_case_json_fixtures.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix test/core/llms/test_test_case_json_fixtures.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check test/core/llms/test_test_case_json_fixtures.py`
- From `test/`: `UV_CACHE_DIR=/tmp/uv-cache uv run pytest core/llms/test_test_case_json_fixtures.py llms/test_delineation.py lang/transcription/test_delineation_alignment.py -q` (96 passed)
- validated both migrated JSON files with `jq empty`
- verified each JSON file is a key-only transformation of its `master` version