### PR TITLE
Use semantic punctuation prompt fields

### DIFF
--- a/scinoephile/lang/yue_zho/transcription.py
+++ b/scinoephile/lang/yue_zho/transcription.py
@@ -78,16 +78,16 @@ YueZhoPunctuationPromptYueHant = PunctuationPrompt(
         唔好從中文字幕拷貝漢字。
         只可以調整粵文嘅標點同空格以配合中文字幕。
         除咗標點同空格之外唔好改任何粵文內容。"""),
-    src_1="yuewen_to_punctuate",
-    src_1_desc="要整理同加標點嘅粵文字幕行",
-    src_2="zhongwen",
-    src_2_desc="對應嘅中文字幕",
-    src_1_missing_err="查詢必須包含要整理同加標點嘅粵文字幕行。",
-    src_2_missing_err="查詢必須包含對應嘅中文字幕。",
-    output="yuewen_punctuated",
-    output_desc="整理同加標點後嘅粵文字幕",
-    output_missing_err="答案必須包含整理同加標點後嘅粵文字幕。",
-    src_1_chars_changed_err_tpl=(
+    ref_sub="zhongwen",
+    ref_sub_desc="對應嘅中文字幕",
+    target_subs="yuewen_to_punctuate",
+    target_subs_desc="要整理同加標點嘅粵文字幕行",
+    ref_sub_missing_err="查詢必須包含對應嘅中文字幕。",
+    target_subs_missing_err="查詢必須包含要整理同加標點嘅粵文字幕行。",
+    target_sub_punctuated="yuewen_punctuated",
+    target_sub_punctuated_desc="整理同加標點後嘅粵文字幕",
+    target_sub_punctuated_missing_err="答案必須包含整理同加標點後嘅粵文字幕。",
+    target_chars_changed_err_tpl=(
         "回答嘅 yuewen_punctuated 移除標點同空格後，同查詢入面拼埋嘅 "
         "yuewen_to_punctuate 唔一致：\n"
         "期望: {expected}\n"

--- a/scinoephile/llms/punctuation/manager.py
+++ b/scinoephile/llms/punctuation/manager.py
@@ -49,8 +49,8 @@ class PunctuationManager(Manager):
             prompt,
             {
                 "output": PromptModelField(
-                    alias=prompt.output,
-                    description=prompt.output_desc,
+                    alias=prompt.target_sub_punctuated,
+                    description=prompt.target_sub_punctuated_desc,
                 ),
             },
         )
@@ -72,13 +72,13 @@ class PunctuationManager(Manager):
             PunctuationQuery,
             prompt,
             {
-                "subtitles": PromptModelField(
-                    alias=prompt.src_1,
-                    description=prompt.src_1_desc,
-                ),
                 "guide": PromptModelField(
-                    alias=prompt.src_2,
-                    description=prompt.src_2_desc,
+                    alias=prompt.ref_sub,
+                    description=prompt.ref_sub_desc,
+                ),
+                "subtitles": PromptModelField(
+                    alias=prompt.target_subs,
+                    description=prompt.target_subs_desc,
                 ),
             },
         )

--- a/scinoephile/llms/punctuation/models.py
+++ b/scinoephile/llms/punctuation/models.py
@@ -31,18 +31,18 @@ class PunctuationQuery(Query):
 
     prompt: ClassVar[PunctuationPrompt] = _BASE_PROMPT
     """Text and field aliases for LLM correspondence."""
-    subtitles: list[str]
-    """Subtitle lines to combine and punctuate, in order."""
     guide: str
     """Guide subtitle whose punctuation informs the output."""
+    subtitles: list[str]
+    """Subtitle lines to combine and punctuate, in order."""
 
     @model_validator(mode="after")
     def validate_required_fields(self) -> Self:
         """Ensure subtitle lines and their guide are nonempty."""
-        if not self.subtitles:
-            raise ValueError(self.prompt.src_1_missing_err)
         if not self.guide:
-            raise ValueError(self.prompt.src_2_missing_err)
+            raise ValueError(self.prompt.ref_sub_missing_err)
+        if not self.subtitles:
+            raise ValueError(self.prompt.target_subs_missing_err)
         return self
 
 
@@ -58,7 +58,7 @@ class PunctuationAnswer(Answer):
     def validate_output(self) -> Self:
         """Ensure output text is nonempty."""
         if not self.output:
-            raise ValueError(self.prompt.output_missing_err)
+            raise ValueError(self.prompt.target_sub_punctuated_missing_err)
         return self
 
 
@@ -109,5 +109,5 @@ class PunctuationTestCase(TestCase):
         )
         received = remove_punc_and_whitespace(self.answer.output)
         if expected != received:
-            raise ValueError(self.prompt.src_1_chars_changed_err(expected, received))
+            raise ValueError(self.prompt.target_chars_changed_err(expected, received))
         return self

--- a/scinoephile/llms/punctuation/prompt.py
+++ b/scinoephile/llms/punctuation/prompt.py
@@ -16,55 +16,57 @@ class PunctuationPrompt(Prompt):
     """Text for LLM correspondence for punctuation."""
 
     # Query fields
-    src_1: str = "one"
-    """Name of source one field in query."""
+    ref_sub: str = "ref_sub"
+    """Name of reference subtitle field in query."""
 
-    src_1_desc: str = "Subtitle texts from source one"
-    """Description of source one field in query."""
+    ref_sub_desc: str = "Reference subtitle text"
+    """Description of reference subtitle field in query."""
 
-    src_2: str = "two"
-    """Name of source two field in query."""
+    target_subs: str = "target_subs"
+    """Name of target subtitles field in query."""
 
-    src_2_desc: str = "Subtitle text from source two"
-    """Description of source two field in query."""
+    target_subs_desc: str = "Target subtitle texts to combine and punctuate"
+    """Description of target subtitles field in query."""
 
     # Query validation errors
-    src_1_missing_err: str = "Subtitle texts from source one are required."
-    """Error when source one field is missing from query."""
+    ref_sub_missing_err: str = "Reference subtitle text is required."
+    """Error when reference subtitle field is missing from query."""
 
-    src_2_missing_err: str = "Subtitle text from source two is required."
-    """Error when source two field is missing from query."""
+    target_subs_missing_err: str = "Target subtitle texts are required."
+    """Error when target subtitles field is missing from query."""
 
     # Answer fields
-    output: str = "output"
-    """Name of output field in answer."""
+    target_sub_punctuated: str = "target_sub_punctuated"
+    """Name of punctuated target subtitle field in answer."""
 
-    output_desc: str = "Output subtitle text"
-    """Description of output field in answer."""
+    target_sub_punctuated_desc: str = "Combined and punctuated target subtitle text"
+    """Description of punctuated target subtitle field in answer."""
 
     # Answer validation errors
-    output_missing_err: str = "Output subtitle text is required."
-    """Error when output field is missing from answer."""
+    target_sub_punctuated_missing_err: str = (
+        "Combined and punctuated target subtitle text is required."
+    )
+    """Error when punctuated target subtitle field is missing from answer."""
 
     # Test case validation errors
-    src_1_chars_changed_err_tpl: str = (
-        "Answer output stripped of punctuation and whitespace does not match query "
-        "source one concatenated:\n"
+    target_chars_changed_err_tpl: str = (
+        "Answer's punctuated target subtitle stripped of punctuation and whitespace "
+        "does not match query's target subtitles concatenated:\n"
         "Expected: {expected}\n"
         "Received: {received}"
     )
-    """Error when output characters do not match source one."""
+    """Error when punctuated target characters do not match target subtitles."""
 
-    def src_1_chars_changed_err(self, expected: str, received: str) -> str:
-        """Error when output characters do not match source one.
+    def target_chars_changed_err(self, expected: str, received: str) -> str:
+        """Error when punctuated target characters do not match target subtitles.
 
         Arguments:
-            expected: expected source one characters
-            received: received output characters
+            expected: expected target subtitle characters
+            received: received punctuated target subtitle characters
         Returns:
             error message
         """
-        return self.src_1_chars_changed_err_tpl.format(
+        return self.target_chars_changed_err_tpl.format(
             expected=expected,
             received=received,
         )

--- a/test/core/llms/test_manager.py
+++ b/test/core/llms/test_manager.py
@@ -43,9 +43,9 @@ _ALTERNATIVE_REVIEW_PROMPT = ReviewPrompt(
 """Review prompt using alternative correspondence field names."""
 
 _LOCALIZED_PUNCTUATION_PROMPT = PunctuationPrompt(
-    src_1="source_one",
-    src_2="source_two",
-    output="result",
+    ref_sub="source_two",
+    target_subs="source_one",
+    target_sub_punctuated="result",
 )
 """Punctuation prompt using non-default correspondence field names."""
 

--- a/test/core/llms/test_test_case_json_fixtures.py
+++ b/test/core/llms/test_test_case_json_fixtures.py
@@ -45,7 +45,7 @@ _TEST_CASE_FAMILIES: tuple[tuple[str, type[Manager]], ...] = (
         DelineationManager,
     ),
     (
-        "*/output/*/lang/yue_zho/transcription/punctuation/*.json",
+        "mlamd/output/*/lang/yue_zho/transcription/punctuation/*.json",
         PunctuationManager,
     ),
 )
@@ -160,5 +160,5 @@ def test_tracked_test_case_json_inventory_is_complete():
         for input_path, _ in _TEST_CASE_FILES
     )
 
-    assert len(_TEST_CASE_FILES) == 83
-    assert test_case_count == 28_581
+    assert len(_TEST_CASE_FILES) == 81
+    assert test_case_count == 26_896

--- a/test/data/mlamd/output/yue-Hans_transcribe/lang/yue_zho/transcription/punctuation/cuda.json
+++ b/test/data/mlamd/output/yue-Hans_transcribe/lang/yue_zho/transcription/punctuation/cuda.json
@@ -1,28 +1,28 @@
 [
   {
     "query": {
-      "one": [
+      "ref_sub": "沿荔枝角道直出大角咀道",
+      "target_subs": [
         "沿住荔枝角度",
         "直出大角咀度"
-      ],
-      "two": "沿荔枝角道直出大角咀道"
+      ]
     },
     "answer": {
-      "output": "沿住荔枝角度直出大角咀度"
+      "target_sub_punctuated": "沿住荔枝角度直出大角咀度"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "经好彩酒家左转花园街乐园牛丸王⋯",
+      "target_subs": [
         "经过好彩走家",
         "再左转返出花园街",
         "乐园牛园望对上"
-      ],
-      "two": "经好彩酒家左转花园街乐园牛丸王⋯"
+      ]
     },
     "answer": {
-      "output": "经过好彩走家再左转返出花园街乐园牛园望对上⋯"
+      "target_sub_punctuated": "经过好彩走家再左转返出花园街乐园牛园望对上⋯"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -30,96 +30,96 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "更正一下：",
+      "target_subs": [
         "都系唔好"
-      ],
-      "two": "更正一下："
+      ]
     },
     "answer": {
-      "output": "都系唔好："
+      "target_sub_punctuated": "都系唔好："
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "转呀，转⋯再更正一下：",
+      "target_subs": [
         "转下",
         "转下",
         "都系唔好"
-      ],
-      "two": "转呀，转⋯再更正一下："
+      ]
     },
     "answer": {
-      "output": "转下，转下⋯都系唔好："
+      "target_sub_punctuated": "转下，转下⋯都系唔好："
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "直出亚皆老街跨过火车桥右转太平道",
+      "target_subs": [
         "都系出返去阿街路街飞过火车桥",
         "右转入太平道"
-      ],
-      "two": "直出亚皆老街跨过火车桥右转太平道"
+      ]
     },
     "answer": {
-      "output": "都系出返去阿街路街飞过火车桥右转入太平道"
+      "target_sub_punctuated": "都系出返去阿街路街飞过火车桥右转入太平道"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "再右拐窝打老道向女人街方向飞⋯",
+      "target_subs": [
         "再右转抹返出去窝打炉道",
         "向女人街方向飞下下"
-      ],
-      "two": "再右拐窝打老道向女人街方向飞⋯"
+      ]
     },
     "answer": {
-      "output": "再右转抹返出去窝打炉道向女人街方向飞下下⋯"
+      "target_sub_punctuated": "再右转抹返出去窝打炉道向女人街方向飞下下⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "飞呀，飞⋯",
+      "target_subs": [
         "飞下",
         "飞下"
-      ],
-      "two": "飞呀，飞⋯"
+      ]
     },
     "answer": {
-      "output": "飞下，飞下⋯"
+      "target_sub_punctuated": "飞下，飞下⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "也就是在麦太右边额角上⋯",
+      "target_subs": [
         "亦即系麦太右边云晶对上"
-      ],
-      "two": "也就是在麦太右边额角上⋯"
+      ]
     },
     "answer": {
-      "output": "亦即系麦太右边云晶对上⋯"
+      "target_sub_punctuated": "亦即系麦太右边云晶对上⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "更正：左边额角上⋯",
+      "target_subs": [
         "都系唔好",
         "左边云晶对上"
-      ],
-      "two": "更正：左边额角上⋯"
+      ]
     },
     "answer": {
-      "output": "都系唔好：左边云晶对上⋯"
+      "target_sub_punctuated": "都系唔好：左边云晶对上⋯"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -127,15 +127,15 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "转呀，转⋯",
+      "target_subs": [
         "转下",
         "转下",
         "转下噉"
-      ],
-      "two": "转呀，转⋯"
+      ]
     },
     "answer": {
-      "output": "转下，转下，转下噉⋯"
+      "target_sub_punctuated": "转下，转下，转下噉⋯"
     },
     "difficulty": 2,
     "few_shot": true,
@@ -143,93 +143,93 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "脑海中同时出现即将诞生的儿子容貌⋯",
+      "target_subs": [
         "而脑入面亦即时出现咗快要出世个仔嘅样"
-      ],
-      "two": "脑海中同时出现即将诞生的儿子容貌⋯"
+      ]
     },
     "answer": {
-      "output": "而脑入面亦即时出现咗快要出世个仔嘅样⋯"
+      "target_sub_punctuated": "而脑入面亦即时出现咗快要出世个仔嘅样⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "希望他好聪明，读书好叻！",
+      "target_subs": [
         "希望佢好聪明",
         "读书好叻"
-      ],
-      "two": "希望他好聪明，读书好叻！"
+      ]
     },
     "answer": {
-      "output": "希望佢好聪明，读书好叻！"
+      "target_sub_punctuated": "希望佢好聪明，读书好叻！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "于是她向胶兜补充说：",
+      "target_subs": [
         "于是佢对住胶兜补充噉话"
-      ],
-      "two": "于是她向胶兜补充说："
+      ]
     },
     "answer": {
-      "output": "于是佢对住胶兜补充噉话："
+      "target_sub_punctuated": "于是佢对住胶兜补充噉话："
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "或者读书唔叻，工作叻呢？",
+      "target_subs": [
         "或者读书唔叻",
         "出嚟做嘢叻啦"
-      ],
-      "two": "或者读书唔叻，工作叻呢？"
+      ]
     },
     "answer": {
-      "output": "或者读书唔叻，出嚟做嘢叻啦？"
+      "target_sub_punctuated": "或者读书唔叻，出嚟做嘢叻啦？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "又或者⋯",
+      "target_subs": [
         "又或者呢"
-      ],
-      "two": "又或者⋯"
+      ]
     },
     "answer": {
-      "output": "又或者呢⋯"
+      "target_sub_punctuated": "又或者呢⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "又或者好靓仔，好靓仔",
+      "target_subs": [
         "又或者系好靓仔好靓仔"
-      ],
-      "two": "又或者好靓仔，好靓仔"
+      ]
     },
     "answer": {
-      "output": "又或者系好靓仔，好靓仔"
+      "target_sub_punctuated": "又或者系好靓仔，好靓仔"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "跟周润发，梁朝伟那么靓仔！",
+      "target_subs": [
         "好似周润发同埋梁朝伟咁靓仔"
-      ],
-      "two": "跟周润发，梁朝伟那么靓仔！"
+      ]
     },
     "answer": {
-      "output": "好似周润发，同埋梁朝伟咁靓仔！"
+      "target_sub_punctuated": "好似周润发，同埋梁朝伟咁靓仔！"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -237,27 +237,27 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "胶兜仍然在转，毫无点头迹象",
+      "target_subs": [
         "胶兜依然系噉喺度转",
         "好似一啲应承嘅迹象都冇"
-      ],
-      "two": "胶兜仍然在转，毫无点头迹象"
+      ]
     },
     "answer": {
-      "output": "胶兜依然系噉喺度转，好似一啲应承嘅迹象都冇"
+      "target_sub_punctuated": "胶兜依然系噉喺度转，好似一啲应承嘅迹象都冇"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "赶忙趁胶兜落地前另许一个愿望：",
+      "target_subs": [
         "嗱嗱嗱喺胶兜未落地之前起过另外一个愿望"
-      ],
-      "two": "赶忙趁胶兜落地前另许一个愿望："
+      ]
     },
     "answer": {
-      "output": "嗱嗱嗱喺胶兜未落地之前起过另外一个愿望："
+      "target_sub_punctuated": "嗱嗱嗱喺胶兜未落地之前起过另外一个愿望："
     },
     "difficulty": 1,
     "few_shot": true,
@@ -265,14 +265,14 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "唔聪明唔靓仔也算了，只要福星高照",
+      "target_subs": [
         "就算唔系咁聪明同咁靓仔",
         "只要复星高照"
-      ],
-      "two": "唔聪明唔靓仔也算了，只要福星高照"
+      ]
     },
     "answer": {
-      "output": "就算唔系咁聪明同咁靓仔，只要复星高照"
+      "target_sub_punctuated": "就算唔系咁聪明同咁靓仔，只要复星高照"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -280,40 +280,40 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "一世够运，逢凶化吉！",
+      "target_subs": [
         "一世救运",
         "乜嘢事都逢凶化㗎喇"
-      ],
-      "two": "一世够运，逢凶化吉！"
+      ]
     },
     "answer": {
-      "output": "一世救运，乜嘢事都逢凶化㗎喇！"
+      "target_sub_punctuated": "一世救运，乜嘢事都逢凶化㗎喇！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "但总得要叻仔呀！",
+      "target_subs": [
         "但系都要叻仔先得㗎"
-      ],
-      "two": "但总得要叻仔呀！"
+      ]
     },
     "answer": {
-      "output": "但系都要叻仔先得㗎！"
+      "target_sub_punctuated": "但系都要叻仔先得㗎！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "最后，胶兜「嘀督」一声落地",
+      "target_subs": [
         "最后胶兜滴嘟一声咁落地"
-      ],
-      "two": "最后，胶兜「嘀督」一声落地"
+      ]
     },
     "answer": {
-      "output": "最后，胶兜「滴嘟」一声咁落地"
+      "target_sub_punctuated": "最后，胶兜「滴嘟」一声咁落地"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -321,29 +321,29 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "嘀督？嘀督，就是答应了",
+      "target_subs": [
         "滴嘟",
         "滴嘟㖞",
         "即系应承啦"
-      ],
-      "two": "嘀督？嘀督，就是答应了"
+      ]
     },
     "answer": {
-      "output": "滴嘟？滴嘟㖞，即系应承啦"
+      "target_sub_punctuated": "滴嘟？滴嘟㖞，即系应承啦"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "麦太想，这次走运了！",
+      "target_subs": [
         "麦太心谂",
         "今次冇死喇"
-      ],
-      "two": "麦太想，这次走运了！"
+      ]
     },
     "answer": {
-      "output": "麦太心谂，今次冇死喇！"
+      "target_sub_punctuated": "麦太心谂，今次冇死喇！"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -351,54 +351,54 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "可是答应了些什么呢？",
+      "target_subs": [
         "但你应承咗啲咩呢"
-      ],
-      "two": "可是答应了些什么呢？"
+      ]
     },
     "answer": {
-      "output": "但你应承咗啲咩呢？"
+      "target_sub_punctuated": "但你应承咗啲咩呢？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "叻仔？好运？",
+      "target_subs": [
         "叻仔",
         "好运"
-      ],
-      "two": "叻仔？好运？"
+      ]
     },
     "answer": {
-      "output": "叻仔？好运？"
+      "target_sub_punctuated": "叻仔？好运？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "还是似周润发？",
+      "target_subs": [
         "定系话自周人烦啊"
-      ],
-      "two": "还是似周润发？"
+      ]
     },
     "answer": {
-      "output": "定系话自周人烦啊？"
+      "target_sub_punctuated": "定系话自周人烦啊？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "不行，胶胶声，多难听！",
+      "target_subs": [
         "都系唔好",
         "胶胶声咁难听"
-      ],
-      "two": "不行，胶胶声，多难听！"
+      ]
     },
     "answer": {
-      "output": "都系唔好，胶胶声，咁难听！"
+      "target_sub_punctuated": "都系唔好，胶胶声，咁难听！"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -406,186 +406,186 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "还是唤他麦兜！",
+      "target_subs": [
         "不如叫麦兜啦"
-      ],
-      "two": "还是唤他麦兜！"
+      ]
     },
     "answer": {
-      "output": "不如叫麦兜啦！"
+      "target_sub_punctuated": "不如叫麦兜啦！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "各位⋯",
+      "target_subs": [
         "各位"
-      ],
-      "two": "各位⋯"
+      ]
     },
     "answer": {
-      "output": "各位⋯"
+      "target_sub_punctuated": "各位⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我就是险些给定名麦胶的小朋友⋯",
+      "target_subs": [
         "我就系呢个差少少就叫做麦胶嘅小朋友"
-      ],
-      "two": "我就是险些给定名麦胶的小朋友⋯"
+      ]
     },
     "answer": {
-      "output": "我就系呢个差少少就叫做麦胶嘅小朋友⋯"
+      "target_sub_punctuated": "我就系呢个差少少就叫做麦胶嘅小朋友⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "麦兜！",
+      "target_subs": [
         "麦兜"
-      ],
-      "two": "麦兜！"
+      ]
     },
     "answer": {
-      "output": "麦兜！"
+      "target_sub_punctuated": "麦兜！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "麦太，没见面一阵",
+      "target_subs": [
         "咦",
         "麦太",
         "咩唔见你一排"
-      ],
-      "two": "麦太，没见面一阵"
+      ]
     },
     "answer": {
-      "output": "咦，麦太，咩唔见你一排"
+      "target_sub_punctuated": "咦，麦太，咩唔见你一排"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "怎么小腿粗起来了？",
+      "target_subs": [
         "个脚刮囊粗咗咁多呀"
-      ],
-      "two": "怎么小腿粗起来了？"
+      ]
     },
     "answer": {
-      "output": "个脚刮囊粗咗咁多呀？"
+      "target_sub_punctuated": "个脚刮囊粗咗咁多呀？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "可怜呀，每天扑来扑去⋯",
+      "target_subs": [
         "鬼咩",
         "日日扑嚟扑去"
-      ],
-      "two": "可怜呀，每天扑来扑去⋯"
+      ]
     },
     "answer": {
-      "output": "鬼咩，日日扑嚟扑去⋯"
+      "target_sub_punctuated": "鬼咩，日日扑嚟扑去⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "替儿子找幼稚园！",
+      "target_subs": [
         "同我仔揾幼稚园吖嘛"
-      ],
-      "two": "替儿子找幼稚园！"
+      ]
     },
     "answer": {
-      "output": "同我仔揾幼稚园吖嘛！"
+      "target_sub_punctuated": "同我仔揾幼稚园吖嘛！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "旧中侨国货楼上的⋯",
+      "target_subs": [
         "旧中桥百货公司楼上嗰间"
-      ],
-      "two": "旧中侨国货楼上的⋯"
+      ]
     },
     "answer": {
-      "output": "旧中桥百货公司楼上嗰间⋯"
+      "target_sub_punctuated": "旧中桥百货公司楼上嗰间⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "春田花花幼稚园？",
+      "target_subs": [
         "春田花花幼稚园呢"
-      ],
-      "two": "春田花花幼稚园？"
+      ]
     },
     "answer": {
-      "output": "春田花花幼稚园呢？"
+      "target_sub_punctuated": "春田花花幼稚园呢？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "就是座落界限街南昌街交界⋯",
+      "target_subs": [
         "就系坐落喺界限街同南昌街交界"
-      ],
-      "two": "就是座落界限街南昌街交界⋯"
+      ]
     },
     "answer": {
-      "output": "就系坐落喺界限街同南昌街交界⋯"
+      "target_sub_punctuated": "就系坐落喺界限街同南昌街交界⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "银城美食广场附近的⋯",
+      "target_subs": [
         "银城美食广场附近嗰间"
-      ],
-      "two": "银城美食广场附近的⋯"
+      ]
     },
     "answer": {
-      "output": "银城美食广场附近嗰间⋯"
+      "target_sub_punctuated": "银城美食广场附近嗰间⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "春田花花幼稚园？",
+      "target_subs": [
         "春田花花幼稚园呀"
-      ],
-      "two": "春田花花幼稚园？"
+      ]
     },
     "answer": {
-      "output": "春田花花幼稚园呀？"
+      "target_sub_punctuated": "春田花花幼稚园呀？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "对！深水埗地铁站步行不用10分钟！",
+      "target_subs": [
         "系呀",
         "深水埗地铁站口行过去唔使十分钟呀"
-      ],
-      "two": "对！深水埗地铁站步行不用10分钟！"
+      ]
     },
     "answer": {
-      "output": "系呀！深水埗地铁站口行过去唔使十分钟呀！"
+      "target_sub_punctuated": "系呀！深水埗地铁站口行过去唔使十分钟呀！"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -593,201 +593,201 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "春田花花幼稚园，师资优良⋯",
+      "target_subs": [
         "春田花花幼稚园",
         "诗诗优良"
-      ],
-      "two": "春田花花幼稚园，师资优良⋯"
+      ]
     },
     "answer": {
-      "output": "春田花花幼稚园，诗诗优良⋯"
+      "target_sub_punctuated": "春田花花幼稚园，诗诗优良⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "而且还有西人教英文！",
+      "target_subs": [
         "仲系西人教英文添㗎"
-      ],
-      "two": "而且还有西人教英文！"
+      ]
     },
     "answer": {
-      "output": "仲系西人教英文添㗎！"
+      "target_sub_punctuated": "仲系西人教英文添㗎！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "西人教英文？",
+      "target_subs": [
         "咦",
         "西人教英文"
-      ],
-      "two": "西人教英文？"
+      ]
     },
     "answer": {
-      "output": "咦，西人教英文？"
+      "target_sub_punctuated": "咦，西人教英文？"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "是呀！",
+      "target_subs": [
         "系呀"
-      ],
-      "two": "是呀！"
+      ]
     },
     "answer": {
-      "output": "系呀！"
+      "target_sub_punctuated": "系呀！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "春田花花，确有好多西人呀！",
+      "target_subs": [
         "春田花花",
         "真系好多西人㗎"
-      ],
-      "two": "春田花花，确有好多西人呀！"
+      ]
     },
     "answer": {
-      "output": "春田花花，真系好多西人㗎！"
+      "target_sub_punctuated": "春田花花，真系好多西人㗎！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "这个猪样白兔小朋友⋯",
+      "target_subs": [
         "呢个扮紧白兔猪样嘅小朋友"
-      ],
-      "two": "这个猪样白兔小朋友⋯"
+      ]
     },
     "answer": {
-      "output": "呢个扮紧白兔猪样嘅小朋友⋯"
+      "target_sub_punctuated": "呢个扮紧白兔猪样嘅小朋友⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "横看竖看也不像发哥伟仔的一个⋯",
+      "target_subs": [
         "即系横睇掂睇都唔似发哥或者",
         "位仔嗰个呢"
-      ],
-      "two": "横看竖看也不像发哥伟仔的一个⋯"
+      ]
     },
     "answer": {
-      "output": "即系横睇掂睇都唔似发哥或者位仔嗰个呢⋯"
+      "target_sub_punctuated": "即系横睇掂睇都唔似发哥或者位仔嗰个呢⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "就是我，麦兜",
+      "target_subs": [
         "就系我",
         "麦兜"
-      ],
-      "two": "就是我，麦兜"
+      ]
     },
     "answer": {
-      "output": "就系我，麦兜"
+      "target_sub_punctuated": "就系我，麦兜"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "这么多年来⋯",
+      "target_subs": [
         "所以咁多年嚟"
-      ],
-      "two": "这么多年来⋯"
+      ]
     },
     "answer": {
-      "output": "所以咁多年嚟⋯"
+      "target_sub_punctuated": "所以咁多年嚟⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "蛋挞！　　蛋挞！",
+      "target_subs": [
         "大湖荒岩宅"
-      ],
-      "two": "蛋挞！　　蛋挞！"
+      ]
     },
     "answer": {
-      "output": "大湖荒岩宅"
+      "target_sub_punctuated": "大湖荒岩宅"
     },
     "difficulty": 3,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "荔芋火鸭札！　　荔芋火鸭札！",
+      "target_subs": [
         "湾吉校坟交涉设"
-      ],
-      "two": "荔芋火鸭札！　　荔芋火鸭札！"
+      ]
     },
     "answer": {
-      "output": "湾吉校坟交涉设"
+      "target_sub_punctuated": "湾吉校坟交涉设"
     },
     "difficulty": 3,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "也不能忘记校训九十八！",
+      "target_subs": [
         "都唔好湾吉校坟交涉白"
-      ],
-      "two": "也不能忘记校训九十八！"
+      ]
     },
     "answer": {
-      "output": "都唔好湾吉校坟交涉白！"
+      "target_sub_punctuated": "都唔好湾吉校坟交涉白！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "好！各位同学⋯",
+      "target_subs": [
         "嗰个位同学"
-      ],
-      "two": "好！各位同学⋯"
+      ]
     },
     "answer": {
-      "output": "嗰个位同学⋯"
+      "target_sub_punctuated": "嗰个位同学⋯"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "一个重要主题：",
+      "target_subs": [
         "一个可重要嘅主题"
-      ],
-      "two": "一个重要主题："
+      ]
     },
     "answer": {
-      "output": "一个可重要嘅主题："
+      "target_sub_punctuated": "一个可重要嘅主题："
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "小朋友，这个月你们交过学费没有？",
+      "target_subs": [
         "小朋友",
         "你哋今个月交咗学费咩呀"
-      ],
-      "two": "小朋友，这个月你们交过学费没有？"
+      ]
     },
     "answer": {
-      "output": "小朋友，你哋今个月交咗学费咩呀？"
+      "target_sub_punctuated": "小朋友，你哋今个月交咗学费咩呀？"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -795,13 +795,13 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "交过了！",
+      "target_subs": [
         "交"
-      ],
-      "two": "交过了！"
+      ]
     },
     "answer": {
-      "output": "交！"
+      "target_sub_punctuated": "交！"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -809,15 +809,15 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "太好了！大家去上堂吧",
+      "target_subs": [
         "哎",
         "好在",
         "噉大家可以返去上堂喇"
-      ],
-      "two": "太好了！大家去上堂吧"
+      ]
     },
     "answer": {
-      "output": "哎，好在！噉大家可以返去上堂喇"
+      "target_sub_punctuated": "哎，好在！噉大家可以返去上堂喇"
     },
     "difficulty": 2,
     "few_shot": true,
@@ -825,54 +825,54 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "可是，对我和我一班同学",
+      "target_subs": [
         "但系对于我同埋我班同学仔嚟讲"
-      ],
-      "two": "可是，对我和我一班同学"
+      ]
     },
     "answer": {
-      "output": "但系，对于我同埋我班同学仔嚟讲"
+      "target_sub_punctuated": "但系，对于我同埋我班同学仔嚟讲"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "这儿是我们最快乐，最美丽的乐园⋯",
+      "target_subs": [
         "呢度系我哋最快乐",
         "最美丽嘅乐园"
-      ],
-      "two": "这儿是我们最快乐，最美丽的乐园⋯"
+      ]
     },
     "answer": {
-      "output": "呢度系我哋最快乐，最美丽嘅乐园⋯"
+      "target_sub_punctuated": "呢度系我哋最快乐，最美丽嘅乐园⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "⋯还有一个很疼我们",
+      "target_subs": [
         "仲有一个好疼我哋"
-      ],
-      "two": "⋯还有一个很疼我们"
+      ]
     },
     "answer": {
-      "output": "⋯仲有一个好疼我哋"
+      "target_sub_punctuated": "⋯仲有一个好疼我哋"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "就是有点游魂的Miss Chan",
+      "target_subs": [
         "不过就有少少失魂嘅班主有Miss",
         "Chan"
-      ],
-      "two": "就是有点游魂的Miss Chan"
+      ]
     },
     "answer": {
-      "output": "不过就有少少失魂嘅班主有Miss Chan"
+      "target_sub_punctuated": "不过就有少少失魂嘅班主有Miss Chan"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -880,125 +880,125 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我们现在开始点名",
+      "target_subs": [
         "好喇",
         "我哋而家开始点名"
-      ],
-      "two": "我们现在开始点名"
+      ]
     },
     "answer": {
-      "output": "好喇，我哋而家开始点名"
+      "target_sub_punctuated": "好喇，我哋而家开始点名"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "麦唛同学！　　到！",
+      "target_subs": [
         "麦麦同学",
         "到"
-      ],
-      "two": "麦唛同学！　　到！"
+      ]
     },
     "answer": {
-      "output": "麦麦同学！　　到！"
+      "target_sub_punctuated": "麦麦同学！　　到！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "亚辉同学！　　到！",
+      "target_subs": [
         "阿辉同学",
         "到"
-      ],
-      "two": "亚辉同学！　　到！"
+      ]
     },
     "answer": {
-      "output": "阿辉同学！　　到！"
+      "target_sub_punctuated": "阿辉同学！　　到！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "菇时同学！　　到！",
+      "target_subs": [
         "Boosie同学",
         "到"
-      ],
-      "two": "菇时同学！　　到！"
+      ]
     },
     "answer": {
-      "output": "Boosie同学！　　到！"
+      "target_sub_punctuated": "Boosie同学！　　到！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "得巴同学！　　到！",
+      "target_subs": [
         "德巴同学",
         "到"
-      ],
-      "two": "得巴同学！　　到！"
+      ]
     },
     "answer": {
-      "output": "德巴同学！　　到！"
+      "target_sub_punctuated": "德巴同学！　　到！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "阿May同学！　　到！",
+      "target_subs": [
         "阿May同学",
         "到"
-      ],
-      "two": "阿May同学！　　到！"
+      ]
     },
     "answer": {
-      "output": "阿May同学！　　到！"
+      "target_sub_punctuated": "阿May同学！　　到！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "阿June同学！　　到！",
+      "target_subs": [
         "阿June同学",
         "到"
-      ],
-      "two": "阿June同学！　　到！"
+      ]
     },
     "answer": {
-      "output": "阿June同学！　　到！"
+      "target_sub_punctuated": "阿June同学！　　到！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "阿May同学！",
+      "target_subs": [
         "阿May同学"
-      ],
-      "two": "阿May同学！"
+      ]
     },
     "answer": {
-      "output": "阿May同学！"
+      "target_sub_punctuated": "阿May同学！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "Miss Chan，我点过两次了！",
+      "target_subs": [
         "Miss",
         "Chan你点咗我两次喇"
-      ],
-      "two": "Miss Chan，我点过两次了！"
+      ]
     },
     "answer": {
-      "output": "Miss Chan，你点咗我两次喇！"
+      "target_sub_punctuated": "Miss Chan，你点咗我两次喇！"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -1006,56 +1006,56 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "呀，真的吗？",
+      "target_subs": [
         "啊",
         "系咩"
-      ],
-      "two": "呀，真的吗？"
+      ]
     },
     "answer": {
-      "output": "啊，系咩？"
+      "target_sub_punctuated": "啊，系咩？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我们现在继续点名",
+      "target_subs": [
         "好",
         "我哋而家继续点名"
-      ],
-      "two": "我们现在继续点名"
+      ]
     },
     "answer": {
-      "output": "好，我哋而家继续点名"
+      "target_sub_punctuated": "好，我哋而家继续点名"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "菇时同学！　　到！",
+      "target_subs": [
         "川明同学",
         "到"
-      ],
-      "two": "菇时同学！　　到！"
+      ]
     },
     "answer": {
-      "output": "川明同学！　　到！"
+      "target_sub_punctuated": "川明同学！　　到！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "还有谁没点过吗？",
+      "target_subs": [
         "好",
         "仲有边个未点"
-      ],
-      "two": "还有谁没点过吗？"
+      ]
     },
     "answer": {
-      "output": "好，仲有边个未点？"
+      "target_sub_punctuated": "好，仲有边个未点？"
     },
     "difficulty": 2,
     "few_shot": true,
@@ -1063,81 +1063,81 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "麦兜！",
+      "target_subs": [
         "猫",
         "噢"
-      ],
-      "two": "麦兜！"
+      ]
     },
     "answer": {
-      "output": "猫噢！"
+      "target_sub_punctuated": "猫噢！"
     },
     "difficulty": 3,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "麦兜同学！",
+      "target_subs": [
         "麦兜同学"
-      ],
-      "two": "麦兜同学！"
+      ]
     },
     "answer": {
-      "output": "麦兜同学！"
+      "target_sub_punctuated": "麦兜同学！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "麦唛呀，即是呢⋯",
+      "target_subs": [
         "妈妈啊",
         "麦兜同学",
         "即系呢"
-      ],
-      "two": "麦唛呀，即是呢⋯"
+      ]
     },
     "answer": {
-      "output": "妈妈啊，麦兜同学，即系呢⋯"
+      "target_sub_punctuated": "妈妈啊，麦兜同学，即系呢⋯"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我好像觉得呢⋯",
+      "target_subs": [
         "我个心总系仁住仁住"
-      ],
-      "two": "我好像觉得呢⋯"
+      ]
     },
     "answer": {
-      "output": "我个心总系仁住仁住⋯"
+      "target_sub_punctuated": "我个心总系仁住仁住⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "其实我正在思考一个学术问题：",
+      "target_subs": [
         "其实我系喺度思考紧一啲学术性嘅问题"
-      ],
-      "two": "其实我正在思考一个学术问题："
+      ]
     },
     "answer": {
-      "output": "其实我系喺度思考紧一啲学术性嘅问题："
+      "target_sub_punctuated": "其实我系喺度思考紧一啲学术性嘅问题："
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "橙，为什么会是「屙－烂－煮」呢？",
+      "target_subs": [
         "点解橙叫Orange呢"
-      ],
-      "two": "橙，为什么会是「屙－烂－煮」呢？"
+      ]
     },
     "answer": {
-      "output": "点解橙叫「Orange」呢？"
+      "target_sub_punctuated": "点解橙叫「Orange」呢？"
     },
     "difficulty": 2,
     "few_shot": true,
@@ -1145,28 +1145,28 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈说吃橙可通大便",
+      "target_subs": [
         "妈妈话食橙会通大",
         "变"
-      ],
-      "two": "妈妈说吃橙可通大便"
+      ]
     },
     "answer": {
-      "output": "妈妈话食橙会通大变"
+      "target_sub_punctuated": "妈妈话食橙会通大变"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「屙」这个我明白，可是「烂－煮」呢？",
+      "target_subs": [
         "噢",
         "呢个我明白",
         "但系橙呢"
-      ],
-      "two": "「屙」这个我明白，可是「烂－煮」呢？"
+      ]
     },
     "answer": {
-      "output": "「噢」呢个我明白，但系「橙」呢？"
+      "target_sub_punctuated": "「噢」呢个我明白，但系「橙」呢？"
     },
     "difficulty": 2,
     "few_shot": true,
@@ -1174,15 +1174,15 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "还有这个「芭－娜－哪」香蕉",
+      "target_subs": [
         "仲有呢个啊",
         "芭拉娜啊",
         "香蕉啊"
-      ],
-      "two": "还有这个「芭－娜－哪」香蕉"
+      ]
     },
     "answer": {
-      "output": "仲有呢个啊「芭－拉－娜」啊香蕉啊"
+      "target_sub_punctuated": "仲有呢个啊「芭－拉－娜」啊香蕉啊"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -1190,13 +1190,13 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "为什么雨伞又会是「暗－芭－娜－哪」呢？",
+      "target_subs": [
         "点解雨姐会叫做暗芭拉娜呢"
-      ],
-      "two": "为什么雨伞又会是「暗－芭－娜－哪」呢？"
+      ]
     },
     "answer": {
-      "output": "点解雨姐会叫做「暗－芭－拉－娜」呢？"
+      "target_sub_punctuated": "点解雨姐会叫做「暗－芭－拉－娜」呢？"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -1204,15 +1204,15 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我「暗」的「暗」掉一条蕉",
+      "target_subs": [
         "嗱",
         "我暗啦",
         "噉我暗嗰条香蕉"
-      ],
-      "two": "我「暗」的「暗」掉一条蕉"
+      ]
     },
     "answer": {
-      "output": "嗱，我「暗」啦，噉我「暗」嗰条香蕉"
+      "target_sub_punctuated": "嗱，我「暗」啦，噉我「暗」嗰条香蕉"
     },
     "difficulty": 2,
     "few_shot": true,
@@ -1220,28 +1220,28 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "至多是屙烂煮，怎么会下起雨来呢？",
+      "target_subs": [
         "至多会Orange啫",
         "点解会搞到落雨呢"
-      ],
-      "two": "至多是屙烂煮，怎么会下起雨来呢？"
+      ]
     },
     "answer": {
-      "output": "至多会Orange啫，点解会搞到落雨呢？"
+      "target_sub_punctuated": "至多会Orange啫，点解会搞到落雨呢？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我想，有天我念完幼稚园",
+      "target_subs": [
         "我谂",
         "到我读完幼稚园"
-      ],
-      "two": "我想，有天我念完幼稚园"
+      ]
     },
     "answer": {
-      "output": "我谂，到我读完幼稚园"
+      "target_sub_punctuated": "我谂，到我读完幼稚园"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -1249,79 +1249,79 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "升小学，上中学",
+      "target_subs": [
         "识埋小学",
         "上到中学"
-      ],
-      "two": "升小学，上中学"
+      ]
     },
     "answer": {
-      "output": "识埋小学，上到中学"
+      "target_sub_punctuated": "识埋小学，上到中学"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "再念大学⋯",
+      "target_subs": [
         "再入埋大学"
-      ],
-      "two": "再念大学⋯"
+      ]
     },
     "answer": {
-      "output": "再入埋大学⋯"
+      "target_sub_punctuated": "再入埋大学⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我知道我会明白一切！",
+      "target_subs": [
         "我谂我乜都会明白晒"
-      ],
-      "two": "我知道我会明白一切！"
+      ]
     },
     "answer": {
-      "output": "我谂我乜都会明白晒！"
+      "target_sub_punctuated": "我谂我乜都会明白晒！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那时候⋯",
+      "target_subs": [
         "到嗰阵"
-      ],
-      "two": "那时候⋯"
+      ]
     },
     "answer": {
-      "output": "到嗰阵⋯"
+      "target_sub_punctuated": "到嗰阵⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我买所房子给妈妈！",
+      "target_subs": [
         "我买层楼畀我妈妈"
-      ],
-      "two": "我买所房子给妈妈！"
+      ]
     },
     "answer": {
-      "output": "我买层楼畀我妈妈！"
+      "target_sub_punctuated": "我买层楼畀我妈妈！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "幼稚园楼下，由校长兼营的茶餐厅",
+      "target_subs": [
         "喺幼稚园楼下校长兼营嘅间茶餐厅"
-      ],
-      "two": "幼稚园楼下，由校长兼营的茶餐厅"
+      ]
     },
     "answer": {
-      "output": "喺幼稚园楼下，校长兼营嘅间茶餐厅"
+      "target_sub_punctuated": "喺幼稚园楼下，校长兼营嘅间茶餐厅"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -1329,14 +1329,14 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "鱼蛋粗面，麻烦你　　粗面买光了",
+      "target_subs": [
         "唔该鱼蛋粗啊",
         "冇粗面噃"
-      ],
-      "two": "鱼蛋粗面，麻烦你　　粗面买光了"
+      ]
     },
     "answer": {
-      "output": "唔该，鱼蛋粗啊　　冇粗面噃"
+      "target_sub_punctuated": "唔该，鱼蛋粗啊　　冇粗面噃"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -1344,15 +1344,15 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那样子⋯来碗鱼蛋河粉吧　　鱼蛋买光了",
+      "target_subs": [
         "噉啊",
         "要碗鱼蛋好啊",
         "冇鱼蛋噃"
-      ],
-      "two": "那样子⋯来碗鱼蛋河粉吧　　鱼蛋买光了"
+      ]
     },
     "answer": {
-      "output": "噉啊⋯要碗鱼蛋好啊　　冇鱼蛋噃"
+      "target_sub_punctuated": "噉啊⋯要碗鱼蛋好啊　　冇鱼蛋噃"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -1360,30 +1360,30 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那么⋯金钱肚粗面好了　　粗面买光了",
+      "target_subs": [
         "噉啊",
         "要金钱透粗啊",
         "冇粗面噃"
-      ],
-      "two": "那么⋯金钱肚粗面好了　　粗面买光了"
+      ]
     },
     "answer": {
-      "output": "噉啊⋯要金钱透粗啊　　冇粗面噃"
+      "target_sub_punctuated": "噉啊⋯要金钱透粗啊　　冇粗面噃"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那么要鱼蛋油面吧　　鱼蛋买光了",
+      "target_subs": [
         "噉啊",
         "咁要鱼蛋油面啊",
         "冇鱼蛋噃"
-      ],
-      "two": "那么要鱼蛋油面吧　　鱼蛋买光了"
+      ]
     },
     "answer": {
-      "output": "噉啊咁要鱼蛋油面啊　　冇鱼蛋噃"
+      "target_sub_punctuated": "噉啊咁要鱼蛋油面啊　　冇鱼蛋噃"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -1391,82 +1391,82 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "怎么都买光了？",
+      "target_subs": [
         "乜样样都冇嘅"
-      ],
-      "two": "怎么都买光了？"
+      ]
     },
     "answer": {
-      "output": "乜样样都冇嘅？"
+      "target_sub_punctuated": "乜样样都冇嘅？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "来个墨鱼丸粗面吧　　粗面买光了",
+      "target_subs": [
         "噉要蜜丸粗啊",
         "冇粗面噃"
-      ],
-      "two": "来个墨鱼丸粗面吧　　粗面买光了"
+      ]
     },
     "answer": {
-      "output": "噉要蜜丸粗啊　　冇粗面噃"
+      "target_sub_punctuated": "噉要蜜丸粗啊　　冇粗面噃"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "又买光了？",
+      "target_subs": [
         "又冇啊"
-      ],
-      "two": "又买光了？"
+      ]
     },
     "answer": {
-      "output": "又冇啊？"
+      "target_sub_punctuated": "又冇啊？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "麻烦来碗鱼蛋濑吧　　鱼蛋买光了",
+      "target_subs": [
         "噉唔该畀碗鱼蛋奶啊",
         "冇鱼蛋噃"
-      ],
-      "two": "麻烦来碗鱼蛋濑吧　　鱼蛋买光了"
+      ]
     },
     "answer": {
-      "output": "噉唔该畀碗鱼蛋奶啊　　冇鱼蛋噃"
+      "target_sub_punctuated": "噉唔该畀碗鱼蛋奶啊　　冇鱼蛋噃"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "麦兜呀，鱼蛋跟粗面都买光了",
+      "target_subs": [
         "麦兜啊",
         "佢哋啲鱼蛋同粗面卖晒㗎啦"
-      ],
-      "two": "麦兜呀，鱼蛋跟粗面都买光了"
+      ]
     },
     "answer": {
-      "output": "麦兜啊，佢哋啲鱼蛋同粗面卖晒㗎啦"
+      "target_sub_punctuated": "麦兜啊，佢哋啲鱼蛋同粗面卖晒㗎啦"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "没有那些配搭吗？",
+      "target_subs": [
         "噢",
         "冇嗰啲配搭啊"
-      ],
-      "two": "没有那些配搭吗？"
+      ]
     },
     "answer": {
-      "output": "噢，冇嗰啲配搭啊？"
+      "target_sub_punctuated": "噢，冇嗰啲配搭啊？"
     },
     "difficulty": 2,
     "few_shot": true,
@@ -1474,14 +1474,14 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "麻烦你，净要鱼蛋吧　　鱼蛋买光了",
+      "target_subs": [
         "噉唔该净鱼蛋啊",
         "冇鱼蛋噃"
-      ],
-      "two": "麻烦你，净要鱼蛋吧　　鱼蛋买光了"
+      ]
     },
     "answer": {
-      "output": "噉唔该，净鱼蛋啊　　冇鱼蛋噃"
+      "target_sub_punctuated": "噉唔该，净鱼蛋啊　　冇鱼蛋噃"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -1489,14 +1489,14 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那么净要粗面呢？　　粗面买光了",
+      "target_subs": [
         "净粗面呢",
         "冇粗面噃"
-      ],
-      "two": "那么净要粗面呢？　　粗面买光了"
+      ]
     },
     "answer": {
-      "output": "净粗面呢？　　冇粗面噃"
+      "target_sub_punctuated": "净粗面呢？　　冇粗面噃"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -1504,135 +1504,135 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "看到这里⋯",
+      "target_subs": [
         "睇到呢度"
-      ],
-      "two": "看到这里⋯"
+      ]
     },
     "answer": {
-      "output": "睇到呢度⋯"
+      "target_sub_punctuated": "睇到呢度⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那时候我无忧无虑，万事无所谓－－",
+      "target_subs": [
         "果只我无忧无虑",
         "冇乜所谓"
-      ],
-      "two": "那时候我无忧无虑，万事无所谓－－"
+      ]
     },
     "answer": {
-      "output": "果只我无忧无虑，冇乜所谓－－"
+      "target_sub_punctuated": "果只我无忧无虑，冇乜所谓－－"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "鱼蛋买光了？那么粗面吧",
+      "target_subs": [
         "冇鱼蛋咩",
         "粗面都好啊"
-      ],
-      "two": "鱼蛋买光了？那么粗面吧"
+      ]
     },
     "answer": {
-      "output": "冇鱼蛋咩？粗面都好啊"
+      "target_sub_punctuated": "冇鱼蛋咩？粗面都好啊"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "麦兜，射呀！",
+      "target_subs": [
         "麦兜",
         "转身食啊"
-      ],
-      "two": "麦兜，射呀！"
+      ]
     },
     "answer": {
-      "output": "麦兜，转身食啊！"
+      "target_sub_punctuated": "麦兜，转身食啊！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "看著自己每天屙烂煮⋯",
+      "target_subs": [
         "睇住自己日日柯能处"
-      ],
-      "two": "看著自己每天屙烂煮⋯"
+      ]
     },
     "answer": {
-      "output": "睇住自己日日柯能处⋯"
+      "target_sub_punctuated": "睇住自己日日柯能处⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "每天长肉⋯",
+      "target_subs": [
         "日日掌肉"
-      ],
-      "two": "每天长肉⋯"
+      ]
     },
     "answer": {
-      "output": "日日掌肉⋯"
+      "target_sub_punctuated": "日日掌肉⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我感到充满力量！",
+      "target_subs": [
         "感到充满力量"
-      ],
-      "two": "我感到充满力量！"
+      ]
     },
     "answer": {
-      "output": "感到充满力量！"
+      "target_sub_punctuated": "感到充满力量！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "世界好美丽！",
+      "target_subs": [
         "世界好美丽"
-      ],
-      "two": "世界好美丽！"
+      ]
     },
     "answer": {
-      "output": "世界好美丽！"
+      "target_sub_punctuated": "世界好美丽！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "有一首歌，Miss Chan唱的好听",
+      "target_subs": [
         "有一首歌",
         "麦词春唱得好好听呀"
-      ],
-      "two": "有一首歌，Miss Chan唱的好听"
+      ]
     },
     "answer": {
-      "output": "有一首歌，麦词春唱得好好听呀"
+      "target_sub_punctuated": "有一首歌，麦词春唱得好好听呀"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "可每次我总唱成「屙」什么什么的⋯",
+      "target_subs": [
         "但系唱嚟唱去都系阿伦厨",
         "咁Ballana噉"
-      ],
-      "two": "可每次我总唱成「屙」什么什么的⋯"
+      ]
     },
     "answer": {
-      "output": "但系唱嚟唱去都系「阿伦厨」咁「Ballana」噉⋯"
+      "target_sub_punctuated": "但系唱嚟唱去都系「阿伦厨」咁「Ballana」噉⋯"
     },
     "difficulty": 2,
     "few_shot": true,
@@ -1640,44 +1640,44 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "是All Things Bright and Beautiful吧？",
+      "target_subs": [
         "系唔系All",
         "Things",
         "Bright",
         "and",
         "Beautiful呀"
-      ],
-      "two": "是All Things Bright and Beautiful吧？"
+      ]
     },
     "answer": {
-      "output": "系唔系All Things Bright and Beautiful呀？"
+      "target_sub_punctuated": "系唔系All Things Bright and Beautiful呀？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "是的，一切都好！",
+      "target_subs": [
         "系呀",
         "所有嘢都几好喇"
-      ],
-      "two": "是的，一切都好！"
+      ]
     },
     "answer": {
-      "output": "系呀，所有嘢都几好喇！"
+      "target_sub_punctuated": "系呀，所有嘢都几好喇！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "世上一切，一切一切⋯",
+      "target_subs": [
         "世上一切"
-      ],
-      "two": "世上一切，一切一切⋯"
+      ]
     },
     "answer": {
-      "output": "世上一切⋯"
+      "target_sub_punctuated": "世上一切⋯"
     },
     "difficulty": 2,
     "few_shot": true,
@@ -1685,7 +1685,8 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "所有那些，都好！",
+      "target_subs": [
         "所有嗰啲嘢",
         "都几好",
         "All",
@@ -1693,24 +1694,23 @@
         "Bright",
         "and",
         "Beautiful"
-      ],
-      "two": "所有那些，都好！"
+      ]
     },
     "answer": {
-      "output": "所有嗰啲嘢，都几好！All Things Bright and Beautiful"
+      "target_sub_punctuated": "所有嗰啲嘢，都几好！All Things Bright and Beautiful"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "一、二、三、四、五、六、七⋯",
+      "target_subs": [
         "1234567"
-      ],
-      "two": "一、二、三、四、五、六、七⋯"
+      ]
     },
     "answer": {
-      "output": "1, 2, 3, 4, 5, 6, 7⋯"
+      "target_sub_punctuated": "1, 2, 3, 4, 5, 6, 7⋯"
     },
     "difficulty": 2,
     "few_shot": true,
@@ -1718,79 +1718,79 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "多劳多得！",
+      "target_subs": [
         "多喽多得"
-      ],
-      "two": "多劳多得！"
+      ]
     },
     "answer": {
-      "output": "多喽多得！"
+      "target_sub_punctuated": "多喽多得！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "星期一至星期七⋯多劳多得！",
+      "target_subs": [
         "星期一至星期七多喽多得"
-      ],
-      "two": "星期一至星期七⋯多劳多得！"
+      ]
     },
     "answer": {
-      "output": "星期一至星期七⋯多喽多得！"
+      "target_sub_punctuated": "星期一至星期七⋯多喽多得！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "就是我妈妈麦太",
+      "target_subs": [
         "就系我妈妈",
         "麦太"
-      ],
-      "two": "就是我妈妈麦太"
+      ]
     },
     "answer": {
-      "output": "就系我妈妈麦太"
+      "target_sub_punctuated": "就系我妈妈麦太"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "一个女人背起整个世界！",
+      "target_subs": [
         "一个女人揹起成个世界"
-      ],
-      "two": "一个女人背起整个世界！"
+      ]
     },
     "answer": {
-      "output": "一个女人揹起成个世界！"
+      "target_sub_punctuated": "一个女人揹起成个世界！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "是的，我妈妈真的很厉害",
+      "target_subs": [
         "系呀",
         "我妈妈真系好犀利㗎"
-      ],
-      "two": "是的，我妈妈真的很厉害"
+      ]
     },
     "answer": {
-      "output": "系呀，我妈妈真系好犀利㗎"
+      "target_sub_punctuated": "系呀，我妈妈真系好犀利㗎"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "除了兼任保险，地产经纪及trading⋯",
+      "target_subs": [
         "除咗做保险地产经纪同埋trading之外"
-      ],
-      "two": "除了兼任保险，地产经纪及trading⋯"
+      ]
     },
     "answer": {
-      "output": "除咗做保险，地产经纪同埋trading之外⋯"
+      "target_sub_punctuated": "除咗做保险，地产经纪同埋trading之外⋯"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -1798,26 +1798,26 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "她还趁高科技热潮搞了个烹饪网站⋯",
+      "target_subs": [
         "佢仲趁住高科技热潮搞咗个煮𩠌嘅网站"
-      ],
-      "two": "她还趁高科技热潮搞了个烹饪网站⋯"
+      ]
     },
     "answer": {
-      "output": "佢仲趁住高科技热潮搞咗个煮𩠌嘅网站⋯"
+      "target_sub_punctuated": "佢仲趁住高科技热潮搞咗个煮𩠌嘅网站⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "www．麦太世界．com",
+      "target_subs": [
         "www.mcticege.com"
-      ],
-      "two": "www．麦太世界．com"
+      ]
     },
     "answer": {
-      "output": "www．mcticege．com"
+      "target_sub_punctuated": "www．mcticege．com"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -1825,373 +1825,373 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "她做的菜，同样厉害",
+      "target_subs": [
         "佢煮嘅𩠌一样咁犀利"
-      ],
-      "two": "她做的菜，同样厉害"
+      ]
     },
     "answer": {
-      "output": "佢煮嘅𩠌，一样咁犀利"
+      "target_sub_punctuated": "佢煮嘅𩠌，一样咁犀利"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "欢迎大家收看＜麦太世界＞",
+      "target_subs": [
         "欢迎大家收睇麦太世界"
-      ],
-      "two": "欢迎大家收看＜麦太世界＞"
+      ]
     },
     "answer": {
-      "output": "欢迎大家收睇＜麦太世界＞"
+      "target_sub_punctuated": "欢迎大家收睇＜麦太世界＞"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "今日为大家介绍一个⋯",
+      "target_subs": [
         "今日我为大家介绍个"
-      ],
-      "two": "今日为大家介绍一个⋯"
+      ]
     },
     "answer": {
-      "output": "今日我为大家介绍个⋯"
+      "target_sub_punctuated": "今日我为大家介绍个⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "简单别致的小菜纸包鸡",
+      "target_subs": [
         "简单又别致嘅小菜",
         "自包鸡"
-      ],
-      "two": "简单别致的小菜纸包鸡"
+      ]
     },
     "answer": {
-      "output": "简单又别致嘅小菜自包鸡"
+      "target_sub_punctuated": "简单又别致嘅小菜自包鸡"
     },
     "few_shot": true,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "材料很简单：一个鸡包",
+      "target_subs": [
         "材料系好简单",
         "我哋只需要一个鸡包"
-      ],
-      "two": "材料很简单：一个鸡包"
+      ]
     },
     "answer": {
-      "output": "材料系好简单：我哋只需要一个鸡包"
+      "target_sub_punctuated": "材料系好简单：我哋只需要一个鸡包"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "将鸡包底部的纸撕下来⋯慢慢地撕",
+      "target_subs": [
         "我哋将黐喺鸡包底嘅纸撕出嚟",
         "慢慢撕"
-      ],
-      "two": "将鸡包底部的纸撕下来⋯慢慢地撕"
+      ]
     },
     "answer": {
-      "output": "我哋将黐喺鸡包底嘅纸撕出嚟⋯慢慢撕"
+      "target_sub_punctuated": "我哋将黐喺鸡包底嘅纸撕出嚟⋯慢慢撕"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "把鸡包纸一反反转",
+      "target_subs": [
         "然后将鸡包纸一反",
         "反转"
-      ],
-      "two": "把鸡包纸一反反转"
+      ]
     },
     "answer": {
-      "output": "然后将鸡包纸一反反转"
+      "target_sub_punctuated": "然后将鸡包纸一反反转"
     },
     "few_shot": true,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "这一味纸包鸡就完成了，很容易是吧？",
+      "target_subs": [
         "呢味自包鸡就完成喇",
         "系咪好易整啦"
-      ],
-      "two": "这一味纸包鸡就完成了，很容易是吧？"
+      ]
     },
     "answer": {
-      "output": "呢味自包鸡就完成喇，系咪好易整啦？"
+      "target_sub_punctuated": "呢味自包鸡就完成喇，系咪好易整啦？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "材料也很简单，只需要白纸一张",
+      "target_subs": [
         "材料都好简单",
         "只需要白纸一张"
-      ],
-      "two": "材料也很简单，只需要白纸一张"
+      ]
     },
     "answer": {
-      "output": "材料都好简单，只需要白纸一张"
+      "target_sub_punctuated": "材料都好简单，只需要白纸一张"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "只要把这纸这样子⋯",
+      "target_subs": [
         "我哋只需要张张纸",
         "咁样"
-      ],
-      "two": "只要把这纸这样子⋯"
+      ]
     },
     "answer": {
-      "output": "我哋只需要张张纸咁样⋯"
+      "target_sub_punctuated": "我哋只需要张张纸咁样⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "各位小朋友，像鸡包不像呀？",
+      "target_subs": [
         "各位小朋友",
         "你哋话似唔似鸡包啊"
-      ],
-      "two": "各位小朋友，像鸡包不像呀？"
+      ]
     },
     "answer": {
-      "output": "各位小朋友，你哋话似唔似鸡包啊？"
+      "target_sub_punctuated": "各位小朋友，你哋话似唔似鸡包啊？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "现在要教大家一味别致小菜－",
+      "target_subs": [
         "间阵要教大家一味几别节嘅小菜"
-      ],
-      "two": "现在要教大家一味别致小菜－"
+      ]
     },
     "answer": {
-      "output": "间阵要教大家一味几别节嘅小菜－"
+      "target_sub_punctuated": "间阵要教大家一味几别节嘅小菜－"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "包鸡纸包鸡包纸包鸡",
+      "target_subs": [
         "包鸡子包",
         "鸡包子包鸡"
-      ],
-      "two": "包鸡纸包鸡包纸包鸡"
+      ]
     },
     "answer": {
-      "output": "包鸡子包鸡包子包鸡"
+      "target_sub_punctuated": "包鸡子包鸡包子包鸡"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "一味「包鸡纸包鸡包纸包鸡」完成了！",
+      "target_subs": [
         "咁一味包鸡子包鸡包子包鸡就完成喇"
-      ],
-      "two": "一味「包鸡纸包鸡包纸包鸡」完成了！"
+      ]
     },
     "answer": {
-      "output": "咁一味「包鸡子包鸡包子包鸡」就完成喇！"
+      "target_sub_punctuated": "咁一味「包鸡子包鸡包子包鸡」就完成喇！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "真的很简单吧？",
+      "target_subs": [
         "系咪好简单呢"
-      ],
-      "two": "真的很简单吧？"
+      ]
     },
     "answer": {
-      "output": "系咪好简单呢？"
+      "target_sub_punctuated": "系咪好简单呢？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "还真有一块鸡吃呢！",
+      "target_subs": [
         "仲真系有嚿鸡食添"
-      ],
-      "two": "还真有一块鸡吃呢！"
+      ]
     },
     "answer": {
-      "output": "仲真系有嚿鸡食添！"
+      "target_sub_punctuated": "仲真系有嚿鸡食添！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "今日为大家介绍一味⋯",
+      "target_subs": [
         "今日要同大家介绍一味"
-      ],
-      "two": "今日为大家介绍一味⋯"
+      ]
     },
     "answer": {
-      "output": "今日要同大家介绍一味⋯"
+      "target_sub_punctuated": "今日要同大家介绍一味⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "小朋友一定喜欢的⋯",
+      "target_subs": [
         "小朋友一定喜欢嘅"
-      ],
-      "two": "小朋友一定喜欢的⋯"
+      ]
     },
     "answer": {
-      "output": "小朋友一定喜欢嘅⋯"
+      "target_sub_punctuated": "小朋友一定喜欢嘅⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "鸡包包鸡包包鸡包纸包纸⋯",
+      "target_subs": [
         "鸡包包",
         "鸡包包",
         "鸡包纸包",
         "纸包鸡",
         "包包鸡"
-      ],
-      "two": "鸡包包鸡包包鸡包纸包纸⋯"
+      ]
     },
     "answer": {
-      "output": "鸡包包鸡包包鸡包纸包纸包鸡包包鸡⋯"
+      "target_sub_punctuated": "鸡包包鸡包包鸡包纸包纸包鸡包包鸡⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "包鸡包鸡包纸包鸡",
+      "target_subs": [
         "纸包鸡",
         "包纸包鸡"
-      ],
-      "two": "包鸡包鸡包纸包鸡"
+      ]
     },
     "answer": {
-      "output": "纸包鸡包纸包鸡"
+      "target_sub_punctuated": "纸包鸡包纸包鸡"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "只要将鸡包包住个鸡包",
+      "target_subs": [
         "我哋先将鸡包",
         "包住个鸡包"
-      ],
-      "two": "只要将鸡包包住个鸡包"
+      ]
     },
     "answer": {
-      "output": "我哋先将鸡包包住个鸡包"
+      "target_sub_punctuated": "我哋先将鸡包包住个鸡包"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "再包住个鸡包⋯",
+      "target_subs": [
         "再包住个鸡包"
-      ],
-      "two": "再包住个鸡包⋯"
+      ]
     },
     "answer": {
-      "output": "再包住个鸡包⋯"
+      "target_sub_punctuated": "再包住个鸡包⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "再包包包包包住个纸鸡包",
+      "target_subs": [
         "再包包包包",
         "包住个纸包鸡"
-      ],
-      "two": "再包包包包包住个纸鸡包"
+      ]
     },
     "answer": {
-      "output": "再包包包包包住个纸包鸡"
+      "target_sub_punctuated": "再包包包包包住个纸包鸡"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "再包包包，纸纸纸",
+      "target_subs": [
         "再包包包包",
         "包鸡包纸",
         "包纸",
         "纸纸纸纸",
         "纸包纸"
-      ],
-      "two": "再包包包，纸纸纸"
+      ]
     },
     "answer": {
-      "output": "再包包包包包鸡包纸包纸，纸纸纸纸纸包纸"
+      "target_sub_punctuated": "再包包包包包鸡包纸包纸，纸纸纸纸纸包纸"
     },
     "difficulty": 3,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "纸包纸，纸包鸡，鸡包纸，纸包鸡⋯",
+      "target_subs": [
         "纸包鸡",
         "包鸡纸",
         "纸包鸡",
         "鸡鸡鸡",
         "纸纸纸再包鸡鸡"
-      ],
-      "two": "纸包纸，纸包鸡，鸡包纸，纸包鸡⋯"
+      ]
     },
     "answer": {
-      "output": "纸包鸡，包鸡纸，纸包鸡，鸡鸡鸡，纸纸纸再包鸡鸡⋯"
+      "target_sub_punctuated": "纸包鸡，包鸡纸，纸包鸡，鸡鸡鸡，纸纸纸再包鸡鸡⋯"
     },
     "difficulty": 3,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "例如每晚睡觉前，她都会说故事给我听",
+      "target_subs": [
         "例如每晚临睡前",
         "佢都会讲故事畀我听"
-      ],
-      "two": "例如每晚睡觉前，她都会说故事给我听"
+      ]
     },
     "answer": {
-      "output": "例如每晚临睡前，佢都会讲故事畀我听"
+      "target_sub_punctuated": "例如每晚临睡前，佢都会讲故事畀我听"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "从前，有个小朋友撒谎；有一天⋯",
+      "target_subs": [
         "从前有个小朋友讲大话",
         "有一日"
-      ],
-      "two": "从前，有个小朋友撒谎；有一天⋯"
+      ]
     },
     "answer": {
-      "output": "从前，有个小朋友讲大话；有一日⋯"
+      "target_sub_punctuated": "从前，有个小朋友讲大话；有一日⋯"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -2199,39 +2199,39 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "他死了！",
+      "target_subs": [
         "佢死咗"
-      ],
-      "two": "他死了！"
+      ]
     },
     "answer": {
-      "output": "佢死咗！"
+      "target_sub_punctuated": "佢死咗！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "从前，有个小朋友很勤力念书⋯",
+      "target_subs": [
         "从前有个小朋友好勤力读书"
-      ],
-      "two": "从前，有个小朋友很勤力念书⋯"
+      ]
     },
     "answer": {
-      "output": "从前，有个小朋友好勤力读书⋯"
+      "target_sub_punctuated": "从前，有个小朋友好勤力读书⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "他长大后，发财了！",
+      "target_subs": [
         "佢长大发咗"
-      ],
-      "two": "他长大后，发财了！"
+      ]
     },
     "answer": {
-      "output": "佢长大，发咗！"
+      "target_sub_punctuated": "佢长大，发咗！"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -2239,14 +2239,14 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "从前，有个小朋友不孝，有天⋯",
+      "target_subs": [
         "从前有个小朋友唔孝顺",
         "有一日"
-      ],
-      "two": "从前，有个小朋友不孝，有天⋯"
+      ]
     },
     "answer": {
-      "output": "从前，有个小朋友唔孝顺，有一日⋯"
+      "target_sub_punctuated": "从前，有个小朋友唔孝顺，有一日⋯"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -2254,109 +2254,109 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "他扭了脚骹！",
+      "target_subs": [
         "佢屈亲个脚脚"
-      ],
-      "two": "他扭了脚骹！"
+      ]
     },
     "answer": {
-      "output": "佢屈亲个脚脚！"
+      "target_sub_punctuated": "佢屈亲个脚脚！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈，我想睡觉",
+      "target_subs": [
         "妈我想瞓啦"
-      ],
-      "two": "妈妈，我想睡觉"
+      ]
     },
     "answer": {
-      "output": "妈，我想瞓啦"
+      "target_sub_punctuated": "妈，我想瞓啦"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "从前，有个小朋友早睡晚起；第二天⋯",
+      "target_subs": [
         "从前有个小朋友早睡晚起",
         "第二朝",
         "社群提供"
-      ],
-      "two": "从前，有个小朋友早睡晚起；第二天⋯"
+      ]
     },
     "answer": {
-      "output": "从前，有个小朋友早睡晚起；第二朝⋯社群提供"
+      "target_sub_punctuated": "从前，有个小朋友早睡晚起；第二朝⋯社群提供"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我妈妈就是这样子，一切都那么直接",
+      "target_subs": [
         "我妈妈就系噉",
         "一切都咁直接"
-      ],
-      "two": "我妈妈就是这样子，一切都那么直接"
+      ]
     },
     "answer": {
-      "output": "我妈妈就系噉，一切都咁直接"
+      "target_sub_punctuated": "我妈妈就系噉，一切都咁直接"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "她爱得我直接⋯",
+      "target_subs": [
         "佢爱得我直接"
-      ],
-      "two": "她爱得我直接⋯"
+      ]
     },
     "answer": {
-      "output": "佢爱得我直接⋯"
+      "target_sub_punctuated": "佢爱得我直接⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "对她，一、二、三、四、五、六、七",
+      "target_subs": [
         "佢一二三四五六七"
-      ],
-      "two": "对她，一、二、三、四、五、六、七"
+      ]
     },
     "answer": {
-      "output": "佢，一、二、三、四、五、六、七"
+      "target_sub_punctuated": "佢，一、二、三、四、五、六、七"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "没有不成的事",
+      "target_subs": [
         "唔得都要得",
         "字幕由",
         "Amara.org"
-      ],
-      "two": "没有不成的事"
+      ]
     },
     "answer": {
-      "output": "唔得都要得字幕由Amara.org"
+      "target_sub_punctuated": "唔得都要得字幕由Amara.org"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "可有些事情，要是真的不成呢？",
+      "target_subs": [
         "但系如果有啲嘢真系真系唔得呢"
-      ],
-      "two": "可有些事情，要是真的不成呢？"
+      ]
     },
     "answer": {
-      "output": "但系如果有啲嘢，真系真系唔得呢？"
+      "target_sub_punctuated": "但系如果有啲嘢，真系真系唔得呢？"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -2364,53 +2364,53 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "首先是周润发事件⋯",
+      "target_subs": [
         "首先周润发嗰单嘢"
-      ],
-      "two": "首先是周润发事件⋯"
+      ]
     },
     "answer": {
-      "output": "首先周润发嗰单嘢⋯"
+      "target_sub_punctuated": "首先周润发嗰单嘢⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "拜托不要再提了！",
+      "target_subs": [
         "大家都唔好再提"
-      ],
-      "two": "拜托不要再提了！"
+      ]
     },
     "answer": {
-      "output": "大家都唔好再提！"
+      "target_sub_punctuated": "大家都唔好再提！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "至于好运⋯",
+      "target_subs": [
         "至于好运"
-      ],
-      "two": "至于好运⋯"
+      ]
     },
     "answer": {
-      "output": "至于好运⋯"
+      "target_sub_punctuated": "至于好运⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "奇迹般似的一个号码也没中过！",
+      "target_subs": [
         "竟然奇迹一样",
         "一个都未中过"
-      ],
-      "two": "奇迹般似的一个号码也没中过！"
+      ]
     },
     "answer": {
-      "output": "竟然奇迹一样一个都未中过！"
+      "target_sub_punctuated": "竟然奇迹一样一个都未中过！"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -2418,244 +2418,244 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "叻仔？",
+      "target_subs": [
         "叻仔"
-      ],
-      "two": "叻仔？"
+      ]
     },
     "answer": {
-      "output": "叻仔？"
+      "target_sub_punctuated": "叻仔？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我也试过努力念书，可是⋯",
+      "target_subs": [
         "我试过好努力咁读书",
         "但系"
-      ],
-      "two": "我也试过努力念书，可是⋯"
+      ]
     },
     "answer": {
-      "output": "我试过好努力咁读书，但系⋯"
+      "target_sub_punctuated": "我试过好努力咁读书，但系⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "可是⋯我仍然有梦",
+      "target_subs": [
         "但系我仲可以发梦"
-      ],
-      "two": "可是⋯我仍然有梦"
+      ]
     },
     "answer": {
-      "output": "但系⋯我仲可以发梦"
+      "target_sub_punctuated": "但系⋯我仲可以发梦"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "马尔代夫，座落于印度洋的世外桃源",
+      "target_subs": [
         "马尔代夫",
         "坐落于印度洋嘅世外桃源"
-      ],
-      "two": "马尔代夫，座落于印度洋的世外桃源"
+      ]
     },
     "answer": {
-      "output": "马尔代夫，坐落于印度洋嘅世外桃源"
+      "target_sub_punctuated": "马尔代夫，坐落于印度洋嘅世外桃源"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "蓝天白云，椰林树影，水清沙幼",
+      "target_subs": [
         "蓝天白云",
         "椰林树影",
         "水清沙游"
-      ],
-      "two": "蓝天白云，椰林树影，水清沙幼"
+      ]
     },
     "answer": {
-      "output": "蓝天白云，椰林树影，水清沙游"
+      "target_sub_punctuated": "蓝天白云，椰林树影，水清沙游"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "七彩缤纷的珊瑚，目不暇给的热带鱼",
+      "target_subs": [
         "七彩缤纷嘅珊瑚",
         "目不下级嘅热带鱼群"
-      ],
-      "two": "七彩缤纷的珊瑚，目不暇给的热带鱼"
+      ]
     },
     "answer": {
-      "output": "七彩缤纷嘅珊瑚，目不下级嘅热带鱼群"
+      "target_sub_punctuated": "七彩缤纷嘅珊瑚，目不下级嘅热带鱼群"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "充满赤道活力的原始海洋，脱离繁嚣",
+      "target_subs": [
         "充满住赤道热力嘅原始海洋",
         "远离凡嚣"
-      ],
-      "two": "充满赤道活力的原始海洋，脱离繁嚣"
+      ]
     },
     "answer": {
-      "output": "充满住赤道热力嘅原始海洋，远离凡嚣"
+      "target_sub_punctuated": "充满住赤道热力嘅原始海洋，远离凡嚣"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "犀利旅行社，旅行社牌照号码350999",
+      "target_subs": [
         "犀利旅行社",
         "旅行社牌照号码350999"
-      ],
-      "two": "犀利旅行社，旅行社牌照号码350999"
+      ]
     },
     "answer": {
-      "output": "犀利旅行社，旅行社牌照号码350999"
+      "target_sub_punctuated": "犀利旅行社，旅行社牌照号码350999"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈你知道马尔代夫在哪儿吗？",
+      "target_subs": [
         "妈妈你知唔知到马尔代夫系边㗎"
-      ],
-      "two": "妈妈你知道马尔代夫在哪儿吗？"
+      ]
     },
     "answer": {
-      "output": "妈妈你知唔知到马尔代夫系边㗎？"
+      "target_sub_punctuated": "妈妈你知唔知到马尔代夫系边㗎？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "有多远？",
+      "target_subs": [
         "点远发呀"
-      ],
-      "two": "有多远？"
+      ]
     },
     "answer": {
-      "output": "点远发呀？"
+      "target_sub_punctuated": "点远发呀？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈你会带我去吗？",
+      "target_subs": [
         "咁妈妈你会唔会走落去㗎"
-      ],
-      "two": "妈妈你会带我去吗？"
+      ]
     },
     "answer": {
-      "output": "咁妈妈你会唔会走落去㗎？"
+      "target_sub_punctuated": "咁妈妈你会唔会走落去㗎？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "会！发财了再说吧",
+      "target_subs": [
         "会",
         "得学发咗先啦"
-      ],
-      "two": "会！发财了再说吧"
+      ]
     },
     "answer": {
-      "output": "会！得学发咗先啦"
+      "target_sub_punctuated": "会！得学发咗先啦"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那么妈妈你什么时候发？",
+      "target_subs": [
         "咁妈妈你几时发得呀"
-      ],
-      "two": "那么妈妈你什么时候发？"
+      ]
     },
     "answer": {
-      "output": "咁妈妈你几时发得呀？"
+      "target_sub_punctuated": "咁妈妈你几时发得呀？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "快了⋯",
+      "target_subs": [
         "呃",
         "就快啦"
-      ],
-      "two": "快了⋯"
+      ]
     },
     "answer": {
-      "output": "呃，就快啦⋯"
+      "target_sub_punctuated": "呃，就快啦⋯"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "发梦呀！",
+      "target_subs": [
         "发梦吖嘛"
-      ],
-      "two": "发梦呀！"
+      ]
     },
     "answer": {
-      "output": "发梦吖嘛！"
+      "target_sub_punctuated": "发梦吖嘛！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "校长早晨！",
+      "target_subs": [
         "嗨"
-      ],
-      "two": "校长早晨！"
+      ]
     },
     "answer": {
-      "output": "嗨！"
+      "target_sub_punctuated": "嗨！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "你最喜爱的地方是哪儿？",
+      "target_subs": [
         "你最喜爱嘅地方喺边度呀"
-      ],
-      "two": "你最喜爱的地方是哪儿？"
+      ]
     },
     "answer": {
-      "output": "你最喜爱嘅地方喺边度呀？"
+      "target_sub_punctuated": "你最喜爱嘅地方喺边度呀？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我最喜爱的地方是日本",
+      "target_subs": [
         "我最喜爱嘅地方呢",
         "就系日本喇"
-      ],
-      "two": "我最喜爱的地方是日本"
+      ]
     },
     "answer": {
-      "output": "我最喜爱嘅地方呢，就系日本喇"
+      "target_sub_punctuated": "我最喜爱嘅地方呢，就系日本喇"
     },
     "difficulty": 2,
     "few_shot": true,
@@ -2663,14 +2663,14 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那儿有 Disneyland 和 Hello Kitty Land",
+      "target_subs": [
         "嗰度好迪士尼呢",
         "同埋HelloTT呢"
-      ],
-      "two": "那儿有 Disneyland 和 Hello Kitty Land"
+      ]
     },
     "answer": {
-      "output": "嗰度好迪士尼呢同埋HelloTT呢"
+      "target_sub_punctuated": "嗰度好迪士尼呢同埋HelloTT呢"
     },
     "difficulty": 2,
     "few_shot": true,
@@ -2678,28 +2678,28 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "婆婆跟舅父他们都在加拿大",
+      "target_subs": [
         "婆婆同埋舅父呀",
         "佢哋都系加拿大㗎"
-      ],
-      "two": "婆婆跟舅父他们都在加拿大"
+      ]
     },
     "answer": {
-      "output": "婆婆同埋舅父呀，佢哋都系加拿大㗎"
+      "target_sub_punctuated": "婆婆同埋舅父呀，佢哋都系加拿大㗎"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那儿有很好多水上活动，还有鱼翅吃",
+      "target_subs": [
         "嗰度有好多水晶活动㗎",
         "仲有一次食添㖞"
-      ],
-      "two": "那儿有很好多水上活动，还有鱼翅吃"
+      ]
     },
     "answer": {
-      "output": "嗰度有好多水晶活动㗎，仲有一次食添㖞"
+      "target_sub_punctuated": "嗰度有好多水晶活动㗎，仲有一次食添㖞"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -2707,83 +2707,83 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我最喜爱的地方⋯",
+      "target_subs": [
         "呃",
         "我最喜爱嘅地方呢"
-      ],
-      "two": "我最喜爱的地方⋯"
+      ]
     },
     "answer": {
-      "output": "呃，我最喜爱嘅地方呢⋯"
+      "target_sub_punctuated": "呃，我最喜爱嘅地方呢⋯"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "就是那间什么！",
+      "target_subs": [
         "就系嗰间咩嚟啰"
-      ],
-      "two": "就是那间什么！"
+      ]
     },
     "answer": {
-      "output": "就系嗰间咩嚟啰！"
+      "target_sub_punctuated": "就系嗰间咩嚟啰！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那儿有欢乐天地，还有美食广场",
+      "target_subs": [
         "嗰度有欢乐天地啦",
         "仲有米食广场啦"
-      ],
-      "two": "那儿有欢乐天地，还有美食广场"
+      ]
     },
     "answer": {
-      "output": "嗰度有欢乐天地啦，仲有米食广场啦"
+      "target_sub_punctuated": "嗰度有欢乐天地啦，仲有米食广场啦"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "对了，那地方叫银城中心",
+      "target_subs": [
         "系喇系喇",
         "嗰间叫做银城中心"
-      ],
-      "two": "对了，那地方叫银城中心"
+      ]
     },
     "answer": {
-      "output": "系喇系喇，嗰间叫做银城中心"
+      "target_sub_punctuated": "系喇系喇，嗰间叫做银城中心"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那店子的饭很多，很大碟的！",
+      "target_subs": [
         "嗰间嘢啲饭好多人",
         "好大碟㗎"
-      ],
-      "two": "那店子的饭很多，很大碟的！"
+      ]
     },
     "answer": {
-      "output": "嗰间嘢啲饭好多人，好大碟㗎！"
+      "target_sub_punctuated": "嗰间嘢啲饭好多人，好大碟㗎！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "不过说到我最想去的地方，那可厉害了",
+      "target_subs": [
         "不过讲到我最想去嘅地方呢",
         "嗰度细嚟啰"
-      ],
-      "two": "不过说到我最想去的地方，那可厉害了"
+      ]
     },
     "answer": {
-      "output": "不过讲到我最想去嘅地方呢，嗰度细嚟啰"
+      "target_sub_punctuated": "不过讲到我最想去嘅地方呢，嗰度细嚟啰"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -2791,333 +2791,333 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那儿蓝天白云，椰林树影，水清沙幼",
+      "target_subs": [
         "嗰度南天白云",
         "夜临树影",
         "水清沙幽"
-      ],
-      "two": "那儿蓝天白云，椰林树影，水清沙幼"
+      ]
     },
     "answer": {
-      "output": "嗰度南天白云，夜临树影，水清沙幽"
+      "target_sub_punctuated": "嗰度南天白云，夜临树影，水清沙幽"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "座落于印度洋的世外桃源",
+      "target_subs": [
         "独来鱼",
         "印度洋嘅世外桃源"
-      ],
-      "two": "座落于印度洋的世外桃源"
+      ]
     },
     "answer": {
-      "output": "独来鱼印度洋嘅世外桃源"
+      "target_sub_punctuated": "独来鱼印度洋嘅世外桃源"
     },
     "few_shot": true,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "衰仔，快点起床上学",
+      "target_subs": [
         "喂",
         "衰仔啊",
         "快啲起身返学喇"
-      ],
-      "two": "衰仔，快点起床上学"
+      ]
     },
     "answer": {
-      "output": "喂，衰仔啊，快啲起身返学喇"
+      "target_sub_punctuated": "喂，衰仔啊，快啲起身返学喇"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "咦？",
+      "target_subs": [
         "咦"
-      ],
-      "two": "咦？"
+      ]
     },
     "answer": {
-      "output": "咦？"
+      "target_sub_punctuated": "咦？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈！",
+      "target_subs": [
         "妈妈"
-      ],
-      "two": "妈妈！"
+      ]
     },
     "answer": {
-      "output": "妈妈！"
+      "target_sub_punctuated": "妈妈！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "医生，吃了药会不会有那个什么的？",
+      "target_subs": [
         "医生啊",
         "啲药食咗会唔会有嗰啲咩㗎"
-      ],
-      "two": "医生，吃了药会不会有那个什么的？"
+      ]
     },
     "answer": {
-      "output": "医生啊，啲药食咗会唔会有嗰啲咩㗎？"
+      "target_sub_punctuated": "医生啊，啲药食咗会唔会有嗰啲咩㗎？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "不会！",
+      "target_subs": [
         "唔会"
-      ],
-      "two": "不会！"
+      ]
     },
     "answer": {
-      "output": "唔会！"
+      "target_sub_punctuated": "唔会！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那么吃药用不用那个什么的？",
+      "target_subs": [
         "噉佢食药使唔使咩啊"
-      ],
-      "two": "那么吃药用不用那个什么的？"
+      ]
     },
     "answer": {
-      "output": "噉佢食药使唔使咩啊？"
+      "target_sub_punctuated": "噉佢食药使唔使咩啊？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "不用！给他打口针吧！",
+      "target_subs": [
         "唔使",
         "同佢打多支针添呢"
-      ],
-      "two": "不用！给他打口针吧！"
+      ]
     },
     "answer": {
-      "output": "唔使！同佢打多支针添呢！"
+      "target_sub_punctuated": "唔使！同佢打多支针添呢！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "怎么？得打针？",
+      "target_subs": [
         "吓",
         "要打针啊"
-      ],
-      "two": "怎么？得打针？"
+      ]
     },
     "answer": {
-      "output": "吓？要打针啊？"
+      "target_sub_punctuated": "吓？要打针啊？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那么他怕不怕死？",
+      "target_subs": [
         "噉佢怕唔怕死呀"
-      ],
-      "two": "那么他怕不怕死？"
+      ]
     },
     "answer": {
-      "output": "噉佢怕唔怕死呀？"
+      "target_sub_punctuated": "噉佢怕唔怕死呀？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "没事吧？快点先把药水喝掉！",
+      "target_subs": [
         "冇嘢吖嘛",
         "快啲食埋啲药水佢先啦"
-      ],
-      "two": "没事吧？快点先把药水喝掉！"
+      ]
     },
     "answer": {
-      "output": "冇嘢吖嘛？快啲食埋啲药水佢先啦！"
+      "target_sub_punctuated": "冇嘢吖嘛？快啲食埋啲药水佢先啦！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈我不想喝药水",
+      "target_subs": [
         "妈妈",
         "我唔想食药水呀"
-      ],
-      "two": "妈妈我不想喝药水"
+      ]
     },
     "answer": {
-      "output": "妈妈我唔想食药水呀"
+      "target_sub_punctuated": "妈妈我唔想食药水呀"
     },
     "few_shot": true,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "不要呀妈妈，我不喝呀",
+      "target_subs": [
         "唔好捞妈妈",
         "我唔食呀"
-      ],
-      "two": "不要呀妈妈，我不喝呀"
+      ]
     },
     "answer": {
-      "output": "唔好捞妈妈，我唔食呀"
+      "target_sub_punctuated": "唔好捞妈妈，我唔食呀"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我不喝士多啤梨药水呀！",
+      "target_subs": [
         "我唔食士多啤梨药水呀"
-      ],
-      "two": "我不喝士多啤梨药水呀！"
+      ]
     },
     "answer": {
-      "output": "我唔食士多啤梨药水呀！"
+      "target_sub_punctuated": "我唔食士多啤梨药水呀！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "别哭了，不喝药水病不会好的",
+      "target_subs": [
         "唔好喊啦",
         "唔食药唔会好㗎"
-      ],
-      "two": "别哭了，不喝药水病不会好的"
+      ]
     },
     "answer": {
-      "output": "唔好喊啦，唔食药唔会好㗎"
+      "target_sub_punctuated": "唔好喊啦，唔食药唔会好㗎"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "乖乖，病好了妈妈带你去马尔代夫",
+      "target_subs": [
         "乖乖啲",
         "病好咗",
         "妈妈大理马尔代夫"
-      ],
-      "two": "乖乖，病好了妈妈带你去马尔代夫"
+      ]
     },
     "answer": {
-      "output": "乖乖啲，病好咗妈妈大理马尔代夫"
+      "target_sub_punctuated": "乖乖啲，病好咗妈妈大理马尔代夫"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "真的吗？",
+      "target_subs": [
         "真嘅"
-      ],
-      "two": "真的吗？"
+      ]
     },
     "answer": {
-      "output": "真嘅？"
+      "target_sub_punctuated": "真嘅？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈什么时候骗过你？",
+      "target_subs": [
         "妈妈几时呃过你呀"
-      ],
-      "two": "妈妈什么时候骗过你？"
+      ]
     },
     "answer": {
-      "output": "妈妈几时呃过你呀？"
+      "target_sub_punctuated": "妈妈几时呃过你呀？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "乖，先把药水喝掉",
+      "target_subs": [
         "乖",
         "食埋啲药水先啦"
-      ],
-      "two": "乖，先把药水喝掉"
+      ]
     },
     "answer": {
-      "output": "乖，食埋啲药水先啦"
+      "target_sub_punctuated": "乖，食埋啲药水先啦"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "好呀，马尔代夫！",
+      "target_subs": [
         "嘻嘻",
         "好嘢",
         "买二代夫"
-      ],
-      "two": "好呀，马尔代夫！"
+      ]
     },
     "answer": {
-      "output": "嘻嘻，好嘢，买二代夫！"
+      "target_sub_punctuated": "嘻嘻，好嘢，买二代夫！"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "马尔代夫！",
+      "target_subs": [
         "买二代夫"
-      ],
-      "two": "马尔代夫！"
+      ]
     },
     "answer": {
-      "output": "买二代夫！"
+      "target_sub_punctuated": "买二代夫！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈，那么我们什么时候去？",
+      "target_subs": [
         "妈妈",
         "咁我哋几时去呀"
-      ],
-      "two": "妈妈，那么我们什么时候去？"
+      ]
     },
     "answer": {
-      "output": "妈妈，咁我哋几时去呀？"
+      "target_sub_punctuated": "妈妈，咁我哋几时去呀？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "你先把药水喝掉，病好了我就去订机票",
+      "target_subs": [
         "嗯",
         "你乖乖哋食埋啲药",
         "好返晒啦",
         "我即刻订机票"
-      ],
-      "two": "你先把药水喝掉，病好了我就去订机票"
+      ]
     },
     "answer": {
-      "output": "嗯，你乖乖哋食埋啲药，好返晒啦我即刻订机票"
+      "target_sub_punctuated": "嗯，你乖乖哋食埋啲药，好返晒啦我即刻订机票"
     },
     "difficulty": 2,
     "few_shot": true,
@@ -3125,56 +3125,56 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "来，多喝一点！",
+      "target_subs": [
         "嚟啦",
         "食多更"
-      ],
-      "two": "来，多喝一点！"
+      ]
     },
     "answer": {
-      "output": "嚟啦，食多更！"
+      "target_sub_punctuated": "嚟啦，食多更！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈你看，我病好了！",
+      "target_subs": [
         "妈妈你睇",
         "我好返喇"
-      ],
-      "two": "妈妈你看，我病好了！"
+      ]
     },
     "answer": {
-      "output": "妈妈你睇，我好返喇！"
+      "target_sub_punctuated": "妈妈你睇，我好返喇！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "家中的东西有什么没给你吃光的？",
+      "target_subs": [
         "即系间屋有乜嘢唔系畀你食晒㗎"
-      ],
-      "two": "家中的东西有什么没给你吃光的？"
+      ]
     },
     "answer": {
-      "output": "即系间屋有乜嘢唔系畀你食晒㗎？"
+      "target_sub_punctuated": "即系间屋有乜嘢唔系畀你食晒㗎？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "这次不同呀，原来这么一大樽的",
+      "target_subs": [
         "妈妈",
         "呢次唔同㗎",
         "本来咁大樽嘅"
-      ],
-      "two": "这次不同呀，原来这么一大樽的"
+      ]
     },
     "answer": {
-      "output": "妈妈，呢次唔同㗎，本来咁大樽嘅"
+      "target_sub_punctuated": "妈妈，呢次唔同㗎，本来咁大樽嘅"
     },
     "difficulty": 2,
     "few_shot": true,
@@ -3182,190 +3182,190 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我喝一格，又喝一格，又喝一格⋯",
+      "target_subs": [
         "我饮下一格",
         "又一格",
         "又一格"
-      ],
-      "two": "我喝一格，又喝一格，又喝一格⋯"
+      ]
     },
     "answer": {
-      "output": "我饮下一格，又一格，又一格⋯"
+      "target_sub_punctuated": "我饮下一格，又一格，又一格⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "就给我喝光了！",
+      "target_subs": [
         "吓",
         "咪我饮晒㖞"
-      ],
-      "two": "就给我喝光了！"
+      ]
     },
     "answer": {
-      "output": "吓，咪我饮晒㖞！"
+      "target_sub_punctuated": "吓，咪我饮晒㖞！"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "喝光了就叻仔了！",
+      "target_subs": [
         "饮实就叻仔啦"
-      ],
-      "two": "喝光了就叻仔了！"
+      ]
     },
     "answer": {
-      "output": "饮实就叻仔啦！"
+      "target_sub_punctuated": "饮实就叻仔啦！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "喝光了就病好了！",
+      "target_subs": [
         "饮实就好返实啦"
-      ],
-      "two": "喝光了就病好了！"
+      ]
     },
     "answer": {
-      "output": "饮实就好返实啦！"
+      "target_sub_punctuated": "饮实就好返实啦！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈呀⋯",
+      "target_subs": [
         "妈妈"
-      ],
-      "two": "妈妈呀⋯"
+      ]
     },
     "answer": {
-      "output": "妈妈⋯"
+      "target_sub_punctuated": "妈妈⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "什么事？",
+      "target_subs": [
         "乜嘢啊"
-      ],
-      "two": "什么事？"
+      ]
     },
     "answer": {
-      "output": "乜嘢啊？"
+      "target_sub_punctuated": "乜嘢啊？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我们什么时候去马尔代夫？",
+      "target_subs": [
         "阿哋几时去马尔代夫啊"
-      ],
-      "two": "我们什么时候去马尔代夫？"
+      ]
     },
     "answer": {
-      "output": "阿哋几时去马尔代夫啊？"
+      "target_sub_punctuated": "阿哋几时去马尔代夫啊？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "什么马尔代夫？",
+      "target_subs": [
         "乜嘢马尔代夫啊"
-      ],
-      "two": "什么马尔代夫？"
+      ]
     },
     "answer": {
-      "output": "乜嘢马尔代夫啊？"
+      "target_sub_punctuated": "乜嘢马尔代夫啊？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "你说我病好带我去马尔代夫的呀！",
+      "target_subs": [
         "呢",
         "你话我返就同我去马尔代夫㗎嘛"
-      ],
-      "two": "你说我病好带我去马尔代夫的呀！"
+      ]
     },
     "answer": {
-      "output": "呢，你话我返就同我去马尔代夫㗎嘛！"
+      "target_sub_punctuated": "呢，你话我返就同我去马尔代夫㗎嘛！"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "马尔代夫，椰林树影，水清沙幼⋯",
+      "target_subs": [
         "马尔代夫呢",
         "耶南树影",
         "水清沙游"
-      ],
-      "two": "马尔代夫，椰林树影，水清沙幼⋯"
+      ]
     },
     "answer": {
-      "output": "马尔代夫呢，耶南树影，水清沙游⋯"
+      "target_sub_punctuated": "马尔代夫呢，耶南树影，水清沙游⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "座落于印度洋的世外桃源呀！",
+      "target_subs": [
         "助流于印度园嘅世外导演啦"
-      ],
-      "two": "座落于印度洋的世外桃源呀！"
+      ]
     },
     "answer": {
-      "output": "助流于印度园嘅世外导演啦！"
+      "target_sub_punctuated": "助流于印度园嘅世外导演啦！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "想不到你还有点文采",
+      "target_subs": [
         "啊",
         "估唔到你几好文采㗎噃"
-      ],
-      "two": "想不到你还有点文采"
+      ]
     },
     "answer": {
-      "output": "啊，估唔到你几好文采㗎噃"
+      "target_sub_punctuated": "啊，估唔到你几好文采㗎噃"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "说得不错呀！",
+      "target_subs": [
         "讲得几好听啊"
-      ],
-      "two": "说得不错呀！"
+      ]
     },
     "answer": {
-      "output": "讲得几好听啊！"
+      "target_sub_punctuated": "讲得几好听啊！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我不是光说的呀，妈妈你说过⋯",
+      "target_subs": [
         "妈妈我唔系讲喇㗎",
         "又系你话嘅"
-      ],
-      "two": "我不是光说的呀，妈妈你说过⋯"
+      ]
     },
     "answer": {
-      "output": "妈妈我唔系讲喇㗎，又系你话嘅⋯"
+      "target_sub_punctuated": "妈妈我唔系讲喇㗎，又系你话嘅⋯"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -3373,14 +3373,14 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我病好了带我去马尔代夫的！",
+      "target_subs": [
         "你话我病好咗之日就同我去马尔代夫㗎",
         "你讲过㗎"
-      ],
-      "two": "我病好了带我去马尔代夫的！"
+      ]
     },
     "answer": {
-      "output": "你话我病好咗之日就同我去马尔代夫㗎！你讲过㗎！"
+      "target_sub_punctuated": "你话我病好咗之日就同我去马尔代夫㗎！你讲过㗎！"
     },
     "difficulty": 2,
     "few_shot": true,
@@ -3388,42 +3388,42 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "不是的，妈妈你说我病好了就去的",
+      "target_subs": [
         "唔系㖞",
         "妈妈",
         "你话好咗就同我去㗎㖞"
-      ],
-      "two": "不是的，妈妈你说我病好了就去的"
+      ]
     },
     "answer": {
-      "output": "唔系㖞，妈妈你话好咗就同我去㗎㖞"
+      "target_sub_punctuated": "唔系㖞，妈妈你话好咗就同我去㗎㖞"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "你讲过的！",
+      "target_subs": [
         "你讲过㗎"
-      ],
-      "two": "你讲过的！"
+      ]
     },
     "answer": {
-      "output": "你讲过㗎！"
+      "target_sub_punctuated": "你讲过㗎！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "好了，别哭了",
+      "target_subs": [
         "得啦得啦",
         "唔好喊啦"
-      ],
-      "two": "好了，别哭了"
+      ]
     },
     "answer": {
-      "output": "得啦得啦，唔好喊啦"
+      "target_sub_punctuated": "得啦得啦，唔好喊啦"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -3431,41 +3431,41 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "真的吗？　　对",
+      "target_subs": [
         "真嘅",
         "系啊"
-      ],
-      "two": "真的吗？　　对"
+      ]
     },
     "answer": {
-      "output": "真嘅？　　系啊"
+      "target_sub_punctuated": "真嘅？　　系啊"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "什么时候去？",
+      "target_subs": [
         "咁几时去啊"
-      ],
-      "two": "什么时候去？"
+      ]
     },
     "answer": {
-      "output": "咁几时去啊？"
+      "target_sub_punctuated": "咁几时去啊？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "你早发财了⋯",
+      "target_subs": [
         "你发咗㗎喇",
         "你发咗㗎喇"
-      ],
-      "two": "你早发财了⋯"
+      ]
     },
     "answer": {
-      "output": "你发咗㗎喇，你发咗㗎喇⋯"
+      "target_sub_punctuated": "你发咗㗎喇，你发咗㗎喇⋯"
     },
     "difficulty": 2,
     "few_shot": true,
@@ -3473,13 +3473,13 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "好了好了，发财了",
+      "target_subs": [
         "系喇系喇系喇发咗喇"
-      ],
-      "two": "好了好了，发财了"
+      ]
     },
     "answer": {
-      "output": "系喇系喇系喇，发咗喇"
+      "target_sub_punctuated": "系喇系喇系喇，发咗喇"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -3487,5337 +3487,5337 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我们下个星期去，好了吧？",
+      "target_subs": [
         "下个礼拜同你去啦",
         "得未啊"
-      ],
-      "two": "我们下个星期去，好了吧？"
+      ]
     },
     "answer": {
-      "output": "下个礼拜同你去啦，得未啊？"
+      "target_sub_punctuated": "下个礼拜同你去啦，得未啊？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "太好了！",
+      "target_subs": [
         "好嘢"
-      ],
-      "two": "太好了！"
+      ]
     },
     "answer": {
-      "output": "好嘢！"
+      "target_sub_punctuated": "好嘢！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "麦唛，我是麦兜呀",
+      "target_subs": [
         "喂",
         "麦麦啊",
         "麦豆啊我系"
-      ],
-      "two": "麦唛，我是麦兜呀"
+      ]
     },
     "answer": {
-      "output": "喂，麦麦啊，麦豆啊我系"
+      "target_sub_punctuated": "喂，麦麦啊，麦豆啊我系"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "是这样子的，我明天就飞了",
+      "target_subs": [
         "即系呢我明日就要飞喇"
-      ],
-      "two": "是这样子的，我明天就飞了"
+      ]
     },
     "answer": {
-      "output": "即系呢，我明日就要飞喇"
+      "target_sub_punctuated": "即系呢，我明日就要飞喇"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "对　　⋯是吗？",
+      "target_subs": [
         "系啊",
         "系咩"
-      ],
-      "two": "对　　⋯是吗？"
+      ]
     },
     "answer": {
-      "output": "系啊　　⋯系咩？"
+      "target_sub_punctuated": "系啊　　⋯系咩？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "飞机餐很难吃的吗？",
+      "target_subs": [
         "飞机真好难食㗎"
-      ],
-      "two": "飞机餐很难吃的吗？"
+      ]
     },
     "answer": {
-      "output": "飞机真好难食㗎？"
+      "target_sub_punctuated": "飞机真好难食㗎？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "也得吃呀！",
+      "target_subs": [
         "但点都要食㗎啦"
-      ],
-      "two": "也得吃呀！"
+      ]
     },
     "answer": {
-      "output": "但点都要食㗎啦！"
+      "target_sub_punctuated": "但点都要食㗎啦！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "难道自己带东西上去吃吗？",
+      "target_subs": [
         "唔通自己带嘢上去食咩"
-      ],
-      "two": "难道自己带东西上去吃吗？"
+      ]
     },
     "answer": {
-      "output": "唔通自己带嘢上去食咩？"
+      "target_sub_punctuated": "唔通自己带嘢上去食咩？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "还在讲？",
+      "target_subs": [
         "仲讲",
         "哦"
-      ],
-      "two": "还在讲？"
+      ]
     },
     "answer": {
-      "output": "仲讲哦？"
+      "target_sub_punctuated": "仲讲哦？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "快点帮手执行李",
+      "target_subs": [
         "快啲嚟执埋啲行李先啦",
         "哦"
-      ],
-      "two": "快点帮手执行李"
+      ]
     },
     "answer": {
-      "output": "快啲嚟执埋啲行李先啦哦"
+      "target_sub_punctuated": "快啲嚟执埋啲行李先啦哦"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "跟我向他们说，我明天去马尔代夫了",
+      "target_subs": [
         "你帮我话畀佢哋知",
         "我明日去买热带裤薄"
-      ],
-      "two": "跟我向他们说，我明天去马尔代夫了"
+      ]
     },
     "answer": {
-      "output": "你帮我话畀佢哋知，我明日去买热带裤薄"
+      "target_sub_punctuated": "你帮我话畀佢哋知，我明日去买热带裤薄"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那边蓝天白云，椰林树影⋯",
+      "target_subs": [
         "嗰度蓝天五百云",
         "夜临雪"
-      ],
-      "two": "那边蓝天白云，椰林树影⋯"
+      ]
     },
     "answer": {
-      "output": "嗰度蓝天五百云，夜临雪⋯"
+      "target_sub_punctuated": "嗰度蓝天五百云，夜临雪⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "还在讲！",
+      "target_subs": [
         "水清净沙有"
-      ],
-      "two": "还在讲！"
+      ]
     },
     "answer": {
-      "output": "水清净沙有！"
+      "target_sub_punctuated": "水清净沙有！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "来了！",
+      "target_subs": [
         "我嚟紧㗎喇"
-      ],
-      "two": "来了！"
+      ]
     },
     "answer": {
-      "output": "我嚟紧㗎喇！"
+      "target_sub_punctuated": "我嚟紧㗎喇！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "要执行李了，回来再跟你说吧",
+      "target_subs": [
         "我要执行你喇",
         "返嚟先再同你倾过啦"
-      ],
-      "two": "要执行李了，回来再跟你说吧"
+      ]
     },
     "answer": {
-      "output": "我要执行你喇，返嚟先再同你倾过啦"
+      "target_sub_punctuated": "我要执行你喇，返嚟先再同你倾过啦"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "再见！",
+      "target_subs": [
         "拜拜"
-      ],
-      "two": "再见！"
+      ]
     },
     "answer": {
-      "output": "拜拜！"
+      "target_sub_punctuated": "拜拜！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈，我得把出世纸带著吗？",
+      "target_subs": [
         "哎哟",
         "妈妈",
         "我系咪要带埋出世纸去㗎"
-      ],
-      "two": "妈妈，我得把出世纸带著吗？"
+      ]
     },
     "answer": {
-      "output": "哎哟，妈妈，我系咪要带埋出世纸去㗎？"
+      "target_sub_punctuated": "哎哟，妈妈，我系咪要带埋出世纸去㗎？"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那么成绩表呢？",
+      "target_subs": [
         "咁成绩表呢"
-      ],
-      "two": "那么成绩表呢？"
+      ]
     },
     "answer": {
-      "output": "咁成绩表呢？"
+      "target_sub_punctuated": "咁成绩表呢？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "太好了！吓得我！",
+      "target_subs": [
         "好嘢",
         "吓得我啊",
         "咁都好啲"
-      ],
-      "two": "太好了！吓得我！"
+      ]
     },
     "answer": {
-      "output": "好嘢！吓得我啊！咁都好啲"
+      "target_sub_punctuated": "好嘢！吓得我啊！咁都好啲"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "找到了！",
+      "target_subs": [
         "揾到喇"
-      ],
-      "two": "找到了！"
+      ]
     },
     "answer": {
-      "output": "揾到喇！"
+      "target_sub_punctuated": "揾到喇！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "出世纸给我找到了！",
+      "target_subs": [
         "竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然"
-      ],
-      "two": "出世纸给我找到了！"
+      ]
     },
     "answer": {
-      "output": "竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然！"
+      "target_sub_punctuated": "竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然！"
     },
     "difficulty": 3,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "早机去，晚机返",
+      "target_subs": [
         "早机去",
         "晚机返"
-      ],
-      "two": "早机去，晚机返"
+      ]
     },
     "answer": {
-      "output": "早机去，晚机返"
+      "target_sub_punctuated": "早机去，晚机返"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "就这样⋯",
+      "target_subs": [
         "就系噉样"
-      ],
-      "two": "就这样⋯"
+      ]
     },
     "answer": {
-      "output": "就系噉样⋯"
+      "target_sub_punctuated": "就系噉样⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我过了我小时候最精明⋯",
+      "target_subs": [
         "我过咗我小时候最著数"
-      ],
-      "two": "我过了我小时候最精明⋯"
+      ]
     },
     "answer": {
-      "output": "我过咗我小时候最著数⋯"
+      "target_sub_punctuated": "我过咗我小时候最著数⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "依你说，纸是否可以包著鸡呢？",
+      "target_subs": [
         "噉你话纸包唔包得绝鸡呢"
-      ],
-      "two": "依你说，纸是否可以包著鸡呢？"
+      ]
     },
     "answer": {
-      "output": "噉你话，纸包唔包得绝鸡呢？"
+      "target_sub_punctuated": "噉你话，纸包唔包得绝鸡呢？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "也可以的⋯",
+      "target_subs": [
         "都得嘅"
-      ],
-      "two": "也可以的⋯"
+      ]
     },
     "answer": {
-      "output": "都得嘅⋯"
+      "target_sub_punctuated": "都得嘅⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈晚安！",
+      "target_subs": [
         "妈妈",
         "做头"
-      ],
-      "two": "妈妈晚安！"
+      ]
     },
     "answer": {
-      "output": "妈妈做头！"
+      "target_sub_punctuated": "妈妈做头！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "夺得香港历史上第一面奥运金牌！",
+      "target_subs": [
         "夺取香港历史上第一面奥运金牌"
-      ],
-      "two": "夺得香港历史上第一面奥运金牌！"
+      ]
     },
     "answer": {
-      "output": "夺取香港历史上第一面奥运金牌！"
+      "target_sub_punctuated": "夺取香港历史上第一面奥运金牌！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "激动地对在场记者表示她今次的成绩⋯",
+      "target_subs": [
         "好激动噉同在场嘅记者讲",
         "今次佢嘅成绩"
-      ],
-      "two": "激动地对在场记者表示她今次的成绩⋯"
+      ]
     },
     "answer": {
-      "output": "好激动噉同在场嘅记者讲今次佢嘅成绩⋯"
+      "target_sub_punctuated": "好激动噉同在场嘅记者讲今次佢嘅成绩⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "足以证明香港运动员不是腊鸭！",
+      "target_subs": [
         "可以证明到香港嘅运动员唔系𫚭鸭"
-      ],
-      "two": "足以证明香港运动员不是腊鸭！"
+      ]
     },
     "answer": {
-      "output": "可以证明到香港嘅运动员唔系𫚭鸭！"
+      "target_sub_punctuated": "可以证明到香港嘅运动员唔系𫚭鸭！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "对不起，应该　　是垃圾，不是腊鸭！",
+      "target_subs": [
         "各位对唔住",
         "应该系垃圾",
         "唔系𫚭鸭"
-      ],
-      "two": "对不起，应该　　是垃圾，不是腊鸭！"
+      ]
     },
     "answer": {
-      "output": "各位对唔住，应该　　系垃圾，唔系𫚭鸭！"
+      "target_sub_punctuated": "各位对唔住，应该　　系垃圾，唔系𫚭鸭！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "对不起，应该　　不是垃圾，也不是腊鸭！",
+      "target_subs": [
         "对唔住",
         "应该系唔系垃圾",
         "亦都唔系𫚭鸭"
-      ],
-      "two": "对不起，应该　　不是垃圾，也不是腊鸭！"
+      ]
     },
     "answer": {
-      "output": "对唔住，应该系　　唔系垃圾，亦都唔系𫚭鸭！"
+      "target_sub_punctuated": "对唔住，应该系　　唔系垃圾，亦都唔系𫚭鸭！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈好像又有计了",
+      "target_subs": [
         "咦",
         "妈妈好似又有计噉噃"
-      ],
-      "two": "妈妈好像又有计了"
+      ]
     },
     "answer": {
-      "output": "咦，妈妈好似又有计噉噃"
+      "target_sub_punctuated": "咦，妈妈好似又有计噉噃"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "靓仔，好运，叻仔⋯",
+      "target_subs": [
         "靓仔",
         "好运",
         "叻仔呀"
-      ],
-      "two": "靓仔，好运，叻仔⋯"
+      ]
     },
     "answer": {
-      "output": "靓仔，好运，叻仔呀⋯"
+      "target_sub_punctuated": "靓仔，好运，叻仔呀⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "是不是可以靠手瓜呢？",
+      "target_subs": [
         "哗",
         "好唔好靠下个手瓜噉呢"
-      ],
-      "two": "是不是可以靠手瓜呢？"
+      ]
     },
     "answer": {
-      "output": "哗，好唔好靠下个手瓜噉呢？"
+      "target_sub_punctuated": "哗，好唔好靠下个手瓜噉呢？"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "于是，一个梦还没醒⋯",
+      "target_subs": [
         "于是",
         "一个梦都未醒"
-      ],
-      "two": "于是，一个梦还没醒⋯"
+      ]
     },
     "answer": {
-      "output": "于是，一个梦都未醒⋯"
+      "target_sub_punctuated": "于是，一个梦都未醒⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "但无论多不容易，我都要试一试",
+      "target_subs": [
         "但无论几唔容易",
         "我都要试一试"
-      ],
-      "two": "但无论多不容易，我都要试一试"
+      ]
     },
     "answer": {
-      "output": "但无论几唔容易，我都要试一试"
+      "target_sub_punctuated": "但无论几唔容易，我都要试一试"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我要黎根收我做徒弟！",
+      "target_subs": [
         "我要来紧收我度徒弟"
-      ],
-      "two": "我要黎根收我做徒弟！"
+      ]
     },
     "answer": {
-      "output": "我要来紧收我度徒弟！"
+      "target_sub_punctuated": "我要来紧收我度徒弟！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "无论几辛苦，我一定要得到奥运金牌！",
+      "target_subs": [
         "无论几辛苦",
         "我一定要捞到奥运金牌"
-      ],
-      "two": "无论几辛苦，我一定要得到奥运金牌！"
+      ]
     },
     "answer": {
-      "output": "无论几辛苦，我一定要捞到奥运金牌！"
+      "target_sub_punctuated": "无论几辛苦，我一定要捞到奥运金牌！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我会举起金牌跟全世界说：",
+      "target_subs": [
         "系今排同全世界讲"
-      ],
-      "two": "我会举起金牌跟全世界说："
+      ]
     },
     "answer": {
-      "output": "系今排同全世界讲："
+      "target_sub_punctuated": "系今排同全世界讲："
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "长洲，我终于来到长洲了！",
+      "target_subs": [
         "长洲",
         "我终于嚟到长洲嘞"
-      ],
-      "two": "长洲，我终于来到长洲了！"
+      ]
     },
     "answer": {
-      "output": "长洲，我终于嚟到长洲嘞！"
+      "target_sub_punctuated": "长洲，我终于嚟到长洲嘞！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "长洲，我得亲吻这片圣洁的土地！",
+      "target_subs": [
         "长洲",
         "我要亲吻呢片盛洁嘅土地"
-      ],
-      "two": "长洲，我得亲吻这片圣洁的土地！"
+      ]
     },
     "answer": {
-      "output": "长洲，我要亲吻呢片盛洁嘅土地！"
+      "target_sub_punctuated": "长洲，我要亲吻呢片盛洁嘅土地！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "小朋友，这儿是南丫岛呀！",
+      "target_subs": [
         "小朋友呀",
         "呢度系南丫岛噃"
-      ],
-      "two": "小朋友，这儿是南丫岛呀！"
+      ]
     },
     "answer": {
-      "output": "小朋友呀，呢度系南丫岛噃！"
+      "target_sub_punctuated": "小朋友呀，呢度系南丫岛噃！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "南丫岛？它也孕育了周润发！",
+      "target_subs": [
         "南丫岛",
         "都引用咗周润发噃"
-      ],
-      "two": "南丫岛？它也孕育了周润发！"
+      ]
     },
     "answer": {
-      "output": "南丫岛？都引用咗周润发噃！"
+      "target_sub_punctuated": "南丫岛？都引用咗周润发噃！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "小朋友，你知道什么是狗仔队吧？",
+      "target_subs": [
         "小朋友",
         "我谂你都知道乜嘢叫做狗仔队嘞"
-      ],
-      "two": "小朋友，你知道什么是狗仔队吧？"
+      ]
     },
     "answer": {
-      "output": "小朋友，我谂你都知道乜嘢叫做狗仔队嘞？"
+      "target_sub_punctuated": "小朋友，我谂你都知道乜嘢叫做狗仔队嘞？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "至于拜师的事⋯",
+      "target_subs": [
         "至于拜师嘅嘢"
-      ],
-      "two": "至于拜师的事⋯"
+      ]
     },
     "answer": {
-      "output": "至于拜师嘅嘢⋯"
+      "target_sub_punctuated": "至于拜师嘅嘢⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "拜你个头！",
+      "target_subs": [
         "拜你个头嘅"
-      ],
-      "two": "拜你个头！"
+      ]
     },
     "answer": {
-      "output": "拜你个头嘅！"
+      "target_sub_punctuated": "拜你个头嘅！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "怎么吃得苦？",
+      "target_subs": [
         "边挨得苦㗎"
-      ],
-      "two": "怎么吃得苦？"
+      ]
     },
     "answer": {
-      "output": "边挨得苦㗎？"
+      "target_sub_punctuated": "边挨得苦㗎？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "想跟珊珊般得奥运金牌？",
+      "target_subs": [
         "想学山伞攞奥运金牌"
-      ],
-      "two": "想跟珊珊般得奥运金牌？"
+      ]
     },
     "answer": {
-      "output": "想学山伞攞奥运金牌？"
+      "target_sub_punctuated": "想学山伞攞奥运金牌？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "别作梦了！",
+      "target_subs": [
         "食母你嘢"
-      ],
-      "two": "别作梦了！"
+      ]
     },
     "answer": {
-      "output": "食母你嘢！"
+      "target_sub_punctuated": "食母你嘢！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "小朋友，你看！",
+      "target_subs": [
         "小朋友",
         "你睇下"
-      ],
-      "two": "小朋友，你看！"
+      ]
     },
     "answer": {
-      "output": "小朋友，你睇下！"
+      "target_sub_punctuated": "小朋友，你睇下！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "这个⋯",
+      "target_subs": [
         "哗",
         "呢只"
-      ],
-      "two": "这个⋯"
+      ]
     },
     "answer": {
-      "output": "哗，呢只⋯"
+      "target_sub_punctuated": "哗，呢只⋯"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "这脚瓜⋯好粗好大！比一节瓜还要大！",
+      "target_subs": [
         "呢只脚瓜好粗好大呀",
         "仲大个只瓜呀"
-      ],
-      "two": "这脚瓜⋯好粗好大！比一节瓜还要大！"
+      ]
     },
     "answer": {
-      "output": "呢只脚瓜⋯好粗好大呀！仲大个只瓜呀！"
+      "target_sub_punctuated": "呢只脚瓜⋯好粗好大呀！仲大个只瓜呀！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "脚瓜的肌肉非常结实⋯",
+      "target_subs": [
         "脚瓜啲肌肉非常结实"
-      ],
-      "two": "脚瓜的肌肉非常结实⋯"
+      ]
     },
     "answer": {
-      "output": "脚瓜啲肌肉非常结实⋯"
+      "target_sub_punctuated": "脚瓜啲肌肉非常结实⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "青筋凸现，钢线似的",
+      "target_subs": [
         "啲青筋凸晒出嚟",
         "好似钢线噉"
-      ],
-      "two": "青筋凸现，钢线似的"
+      ]
     },
     "answer": {
-      "output": "啲青筋凸晒出嚟，好似钢线噉"
+      "target_sub_punctuated": "啲青筋凸晒出嚟，好似钢线噉"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "每一条脚毛都硬似铁钉",
+      "target_subs": [
         "啲脚毛",
         "每一条好似铁钉噉硬"
-      ],
-      "two": "每一条脚毛都硬似铁钉"
+      ]
     },
     "answer": {
-      "output": "啲脚毛，每一条好似铁钉噉硬"
+      "target_sub_punctuated": "啲脚毛，每一条好似铁钉噉硬"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "脚趾甲有一寸厚，究竟⋯",
+      "target_subs": [
         "脚趾弓啲脚甲成吋噉厚",
         "究竟"
-      ],
-      "two": "脚趾甲有一寸厚，究竟⋯"
+      ]
     },
     "answer": {
-      "output": "脚趾弓啲脚甲成吋噉厚，究竟⋯"
+      "target_sub_punctuated": "脚趾弓啲脚甲成吋噉厚，究竟⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "要行过几多座山⋯",
+      "target_subs": [
         "要行我几多座山"
-      ],
-      "two": "要行过几多座山⋯"
+      ]
     },
     "answer": {
-      "output": "要行我几多座山⋯"
+      "target_sub_punctuated": "要行我几多座山⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "跨过几多个海⋯",
+      "target_subs": [
         "跨我几多个海"
-      ],
-      "two": "跨过几多个海⋯"
+      ]
     },
     "answer": {
-      "output": "跨我几多个海⋯"
+      "target_sub_punctuated": "跨我几多个海⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "吃过几多苦头⋯",
+      "target_subs": [
         "挨过几多苦头"
-      ],
-      "two": "吃过几多苦头⋯"
+      ]
     },
     "answer": {
-      "output": "挨过几多苦头⋯"
+      "target_sub_punctuated": "挨过几多苦头⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "才可以练成这举世无双的脚瓜？",
+      "target_subs": [
         "先至可以练成呢只举世无双嘅脚瓜"
-      ],
-      "two": "才可以练成这举世无双的脚瓜？"
+      ]
     },
     "answer": {
-      "output": "先至可以练成呢只举世无双嘅脚瓜？"
+      "target_sub_punctuated": "先至可以练成呢只举世无双嘅脚瓜？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我⋯我一定要练成这脚瓜！",
+      "target_subs": [
         "我",
         "我一定要练成呢只脚挂"
-      ],
-      "two": "我⋯我一定要练成这脚瓜！"
+      ]
     },
     "answer": {
-      "output": "我⋯我一定要练成呢只脚挂！"
+      "target_sub_punctuated": "我⋯我一定要练成呢只脚挂！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "师傅！",
+      "target_subs": [
         "师父"
-      ],
-      "two": "师傅！"
+      ]
     },
     "answer": {
-      "output": "师父！"
+      "target_sub_punctuated": "师父！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我可以去小个便吗？",
+      "target_subs": [
         "我可唔可以去个小便呢"
-      ],
-      "two": "我可以去小个便吗？"
+      ]
     },
     "answer": {
-      "output": "我可唔可以去个小便呢？"
+      "target_sub_punctuated": "我可唔可以去个小便呢？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "每次唱这首歌，我都会急小便",
+      "target_subs": [
         "而知点解每一字唱呢首歌都会急小便"
-      ],
-      "two": "每次唱这首歌，我都会急小便"
+      ]
     },
     "answer": {
-      "output": "而知点解每一字唱呢首歌都会急小便"
+      "target_sub_punctuated": "而知点解每一字唱呢首歌都会急小便"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "现在先去，一回恐怕还是会急",
+      "target_subs": [
         "仅次去定先都怕一阵会再急过"
-      ],
-      "two": "现在先去，一回恐怕还是会急"
+      ]
     },
     "answer": {
-      "output": "仅次去定先，都怕一阵会再急过"
+      "target_sub_punctuated": "仅次去定先，都怕一阵会再急过"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我要黎根收我做徒弟！",
+      "target_subs": [
         "我要黎根收我做徒弟"
-      ],
-      "two": "我要黎根收我做徒弟！"
+      ]
     },
     "answer": {
-      "output": "我要黎根收我做徒弟！"
+      "target_sub_punctuated": "我要黎根收我做徒弟！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "歌，是这样唱的⋯",
+      "target_subs": [
         "嗰首歌系噉唱嘅"
-      ],
-      "two": "歌，是这样唱的⋯"
+      ]
     },
     "answer": {
-      "output": "嗰首歌，系噉唱嘅⋯"
+      "target_sub_punctuated": "嗰首歌，系噉唱嘅⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "黎根听完歌以后，表情有点古怪⋯",
+      "target_subs": [
         "黎今听完首歌之后",
         "啲表情有啲古怪"
-      ],
-      "two": "黎根听完歌以后，表情有点古怪⋯"
+      ]
     },
     "answer": {
-      "output": "黎今听完首歌之后，啲表情有啲古怪⋯"
+      "target_sub_punctuated": "黎今听完首歌之后，啲表情有啲古怪⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我一定要好好把握这机会",
+      "target_subs": [
         "唔",
         "我一定要好好把握呢个机会"
-      ],
-      "two": "我一定要好好把握这机会"
+      ]
     },
     "answer": {
-      "output": "唔，我一定要好好把握呢个机会"
+      "target_sub_punctuated": "唔，我一定要好好把握呢个机会"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "师傅！你收我做徒弟吧！",
+      "target_subs": [
         "师父",
         "你收我做徒弟啦"
-      ],
-      "two": "师傅！你收我做徒弟吧！"
+      ]
     },
     "answer": {
-      "output": "师父！你收我做徒弟啦！"
+      "target_sub_punctuated": "师父！你收我做徒弟啦！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "你唔收我做徒弟，我一世都这么跪著！",
+      "target_subs": [
         "你收我做徒弟",
         "我呢一世都跪喺度"
-      ],
-      "two": "你唔收我做徒弟，我一世都这么跪著！"
+      ]
     },
     "answer": {
-      "output": "你收我做徒弟，我呢一世都跪喺度！"
+      "target_sub_punctuated": "你收我做徒弟，我呢一世都跪喺度！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "起来呀！",
+      "target_subs": [
         "起身啊"
-      ],
-      "two": "起来呀！"
+      ]
     },
     "answer": {
-      "output": "起身啊！"
+      "target_sub_punctuated": "起身啊！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "多谢师傅！",
+      "target_subs": [
         "多谢师父"
-      ],
-      "two": "多谢师傅！"
+      ]
     },
     "answer": {
-      "output": "多谢师父！"
+      "target_sub_punctuated": "多谢师父！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "不⋯我是叫你扶我起来呀！",
+      "target_subs": [
         "唔系啊",
         "我系叫你扶我起身啊"
-      ],
-      "two": "不⋯我是叫你扶我起来呀！"
+      ]
     },
     "answer": {
-      "output": "唔系啊⋯我系叫你扶我起身啊！"
+      "target_sub_punctuated": "唔系啊⋯我系叫你扶我起身啊！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "不成了！我的脚瓜太痹了！",
+      "target_subs": [
         "顶唔顺啊",
         "我个腿挂好鼻啊",
         "字幕由",
         "Amara.org",
         "社群提供"
-      ],
-      "two": "不成了！我的脚瓜太痹了！"
+      ]
     },
     "answer": {
-      "output": "顶唔顺啊！我个腿挂好鼻啊！字幕由Amara.org社群提供"
+      "target_sub_punctuated": "顶唔顺啊！我个腿挂好鼻啊！字幕由Amara.org社群提供"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "晚饭时，妈妈倒了三杯米酒",
+      "target_subs": [
         "晚饭时候",
         "妈妈倒咗三杯米酒"
-      ],
-      "two": "晚饭时，妈妈倒了三杯米酒"
+      ]
     },
     "answer": {
-      "output": "晚饭时候，妈妈倒咗三杯米酒"
+      "target_sub_punctuated": "晚饭时候，妈妈倒咗三杯米酒"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "又将几只橙和蒸好的鸡放到祖先前",
+      "target_subs": [
         "再将几个铲同埋蒸熟咗嘅鸡",
         "放喺祖先前面"
-      ],
-      "two": "又将几只橙和蒸好的鸡放到祖先前"
+      ]
     },
     "answer": {
-      "output": "再将几个铲同埋蒸熟咗嘅鸡放喺祖先前面"
+      "target_sub_punctuated": "再将几个铲同埋蒸熟咗嘅鸡放喺祖先前面"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈叫我跪低，向祖先请请",
+      "target_subs": [
         "妈妈叫我跪低",
         "同祖先请请"
-      ],
-      "two": "妈妈叫我跪低，向祖先请请"
+      ]
     },
     "answer": {
-      "output": "妈妈叫我跪低，同祖先请请"
+      "target_sub_punctuated": "妈妈叫我跪低，同祖先请请"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈跟著又念念有词的",
+      "target_subs": [
         "跟住",
         "妈妈口噏噏噉讲咗一啲嘢"
-      ],
-      "two": "妈妈跟著又念念有词的"
+      ]
     },
     "answer": {
-      "output": "跟住，妈妈口噏噏噉讲咗一啲嘢"
+      "target_sub_punctuated": "跟住，妈妈口噏噏噉讲咗一啲嘢"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "庄重而温柔地跟我说：",
+      "target_subs": [
         "庄重又温柔紧同我讲"
-      ],
-      "two": "庄重而温柔地跟我说："
+      ]
     },
     "answer": {
-      "output": "庄重又温柔紧同我讲："
+      "target_sub_punctuated": "庄重又温柔紧同我讲："
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "跟师傅学习，光宗耀祖！",
+      "target_subs": [
         "跟师父学嘢",
         "当中要祖"
-      ],
-      "two": "跟师傅学习，光宗耀祖！"
+      ]
     },
     "answer": {
-      "output": "跟师父学嘢，当中要祖！"
+      "target_sub_punctuated": "跟师父学嘢，当中要祖！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈在长洲找了间酒楼摆拜师宴",
+      "target_subs": [
         "妈妈喺长洲揾咗间酒楼",
         "摆咗几回白丝宴"
-      ],
-      "two": "妈妈在长洲找了间酒楼摆拜师宴"
+      ]
     },
     "answer": {
-      "output": "妈妈喺长洲揾咗间酒楼摆咗几回白丝宴"
+      "target_sub_punctuated": "妈妈喺长洲揾咗间酒楼摆咗几回白丝宴"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "珊珊因为去了集训，没来",
+      "target_subs": [
         "但系山神就去咗集训",
         "冇嚟到"
-      ],
-      "two": "珊珊因为去了集训，没来"
+      ]
     },
     "answer": {
-      "output": "但系山神就去咗集训，冇嚟到"
+      "target_sub_punctuated": "但系山神就去咗集训，冇嚟到"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "麦唛，菇时跟得巴都来了",
+      "target_subs": [
         "默默",
         "姑侍同德巴都嚟咗"
-      ],
-      "two": "麦唛，菇时跟得巴都来了"
+      ]
     },
     "answer": {
-      "output": "默默，姑侍同德巴都嚟咗"
+      "target_sub_punctuated": "默默，姑侍同德巴都嚟咗"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "还带著成绩表，奖牌和大包",
+      "target_subs": [
         "仲带埋成绩表",
         "奖牌",
         "同大包嚟添"
-      ],
-      "two": "还带著成绩表，奖牌和大包"
+      ]
     },
     "answer": {
-      "output": "仲带埋成绩表，奖牌同大包嚟添"
+      "target_sub_punctuated": "仲带埋成绩表，奖牌同大包嚟添"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "吃过鸡丝翅，就是拜师仪式",
+      "target_subs": [
         "食完鸡丝翅",
         "就到咗拜师仪式"
-      ],
-      "two": "吃过鸡丝翅，就是拜师仪式"
+      ]
     },
     "answer": {
-      "output": "食完鸡丝翅，就到咗拜师仪式"
+      "target_sub_punctuated": "食完鸡丝翅，就到咗拜师仪式"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈倒了杯茶给我，让我给师傅喝",
+      "target_subs": [
         "妈妈针咗杯热茶畀我",
         "叫我弟畀师父饮"
-      ],
-      "two": "妈妈倒了杯茶给我，让我给师傅喝"
+      ]
     },
     "answer": {
-      "output": "妈妈针咗杯热茶畀我，叫我弟畀师父饮"
+      "target_sub_punctuated": "妈妈针咗杯热茶畀我，叫我弟畀师父饮"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我千辛万苦来长洲找黎根⋯",
+      "target_subs": [
         "哦",
         "我前三万苦嚟到长洲揾嚟近"
-      ],
-      "two": "我千辛万苦来长洲找黎根⋯"
+      ]
     },
     "answer": {
-      "output": "哦，我前三万苦嚟到长洲揾嚟近⋯"
+      "target_sub_punctuated": "哦，我前三万苦嚟到长洲揾嚟近⋯"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我终于可以跟珊珊一起练滑浪风帆了！",
+      "target_subs": [
         "哦",
         "我终于可以同山神一齐练习玩弄风范啊"
-      ],
-      "two": "我终于可以跟珊珊一起练滑浪风帆了！"
+      ]
     },
     "answer": {
-      "output": "哦，我终于可以同山神一齐练习玩弄风范啊！"
+      "target_sub_punctuated": "哦，我终于可以同山神一齐练习玩弄风范啊！"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我将茶递给黎根，黎根他⋯",
+      "target_subs": [
         "我将杯茶递咗畀嚟跟嚟跟佢",
         "亦唔系"
-      ],
-      "two": "我将茶递给黎根，黎根他⋯"
+      ]
     },
     "answer": {
-      "output": "我将杯茶递咗畀嚟跟，嚟跟佢⋯亦唔系"
+      "target_sub_punctuated": "我将杯茶递咗畀嚟跟，嚟跟佢⋯亦唔系"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "师傅他把茶喝了，正式收我做徒弟",
+      "target_subs": [
         "师父佢饮咗杯茶",
         "正式收咗我做徒弟嘞"
-      ],
-      "two": "师傅他把茶喝了，正式收我做徒弟"
+      ]
     },
     "answer": {
-      "output": "师父佢饮咗杯茶，正式收咗我做徒弟嘞"
+      "target_sub_punctuated": "师父佢饮咗杯茶，正式收咗我做徒弟嘞"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "长洲的乡绅父老拍掌拍得特别落力",
+      "target_subs": [
         "特别系长洲啲乡亲父老",
         "拍奖拍得特别落力"
-      ],
-      "two": "长洲的乡绅父老拍掌拍得特别落力"
+      ]
     },
     "answer": {
-      "output": "特别系长洲啲乡亲父老拍奖拍得特别落力"
+      "target_sub_punctuated": "特别系长洲啲乡亲父老拍奖拍得特别落力"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "多谢各位赏面！多谢各位！",
+      "target_subs": [
         "多谢各位上面",
         "多谢各位"
-      ],
-      "two": "多谢各位赏面！多谢各位！"
+      ]
     },
     "answer": {
-      "output": "多谢各位上面！多谢各位！"
+      "target_sub_punctuated": "多谢各位上面！多谢各位！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "第一项，是滑浪风帆！",
+      "target_subs": [
         "第一样系滑浪风范",
         "呢样早已"
-      ],
-      "two": "第一项，是滑浪风帆！"
+      ]
     },
     "answer": {
-      "output": "第一样，系滑浪风范！呢样早已"
+      "target_sub_punctuated": "第一样，系滑浪风范！呢样早已"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "另一项绝技，我打算传给这个新徒弟⋯",
+      "target_subs": [
         "另一项绝技我打算传畀呢个新修嘅徒弟"
-      ],
-      "two": "另一项绝技，我打算传给这个新徒弟⋯"
+      ]
     },
     "answer": {
-      "output": "另一项绝技，我打算传畀呢个新修嘅徒弟⋯"
+      "target_sub_punctuated": "另一项绝技，我打算传畀呢个新修嘅徒弟⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "发扬光大！",
+      "target_subs": [
         "发扬光大"
-      ],
-      "two": "发扬光大！"
+      ]
     },
     "answer": {
-      "output": "发扬光大！"
+      "target_sub_punctuated": "发扬光大！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "请问那是什么绝技呢？",
+      "target_subs": [
         "噉请问嗰样绝技系乜嘢啊"
-      ],
-      "two": "请问那是什么绝技呢？"
+      ]
     },
     "answer": {
-      "output": "噉请问嗰样绝技系乜嘢啊？"
+      "target_sub_punctuated": "噉请问嗰样绝技系乜嘢啊？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "第二项绝技，就是⋯",
+      "target_subs": [
         "第二样绝技就系"
-      ],
-      "two": "第二项绝技，就是⋯"
+      ]
     },
     "answer": {
-      "output": "第二样绝技，就系⋯"
+      "target_sub_punctuated": "第二样绝技，就系⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "抢包山！",
+      "target_subs": [
         "抢爆山"
-      ],
-      "two": "抢包山！"
+      ]
     },
     "answer": {
-      "output": "抢爆山！"
+      "target_sub_punctuated": "抢爆山！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "抢包山？",
+      "target_subs": [
         "抢包山?"
-      ],
-      "two": "抢包山？"
+      ]
     },
     "answer": {
-      "output": "抢包山？"
+      "target_sub_punctuated": "抢包山？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "年轻观众可能不知「抢包山」何物",
+      "target_subs": [
         "年轻嘅观众可能唔知乜嘢系抢包山呀"
-      ],
-      "two": "年轻观众可能不知「抢包山」何物"
+      ]
     },
     "answer": {
-      "output": "年轻嘅观众可能唔知乜嘢系「抢包山」呀"
+      "target_sub_punctuated": "年轻嘅观众可能唔知乜嘢系「抢包山」呀"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "什么是包山呢？",
+      "target_subs": [
         "噉乜嘢系包山呢?"
-      ],
-      "two": "什么是包山呢？"
+      ]
     },
     "answer": {
-      "output": "噉乜嘢系包山呢？"
+      "target_sub_punctuated": "噉乜嘢系包山呢？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "顾名思义⋯",
+      "target_subs": [
         "顾名思义"
-      ],
-      "two": "顾名思义⋯"
+      ]
     },
     "answer": {
-      "output": "顾名思义⋯"
+      "target_sub_punctuated": "顾名思义⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "包山就是一座由好多好多包砌起的山！",
+      "target_subs": [
         "包山就系一座由好多",
         "好多",
         "好多包砌起嘅山"
-      ],
-      "two": "包山就是一座由好多好多包砌起的山！"
+      ]
     },
     "answer": {
-      "output": "包山就系一座由好多好多好多包砌起嘅山！"
+      "target_sub_punctuated": "包山就系一座由好多好多好多包砌起嘅山！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "一座包山，起码六、七层楼高⋯",
+      "target_subs": [
         "一座包山起码六七层楼高"
-      ],
-      "two": "一座包山，起码六、七层楼高⋯"
+      ]
     },
     "answer": {
-      "output": "一座包山，起码六、七层楼高⋯"
+      "target_sub_punctuated": "一座包山，起码六、七层楼高⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "你可以想像一下包山有多高了吧？",
+      "target_subs": [
         "噉你可以想像一下嗰度有几多包喇"
-      ],
-      "two": "你可以想像一下包山有多高了吧？"
+      ]
     },
     "answer": {
-      "output": "噉你可以想像一下嗰度有几多包喇？"
+      "target_sub_punctuated": "噉你可以想像一下嗰度有几多包喇？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "抢包山，就是要把包山上的包抢到手！",
+      "target_subs": [
         "噉抢包山",
         "自然就系要将包山嘅包抢到手"
-      ],
-      "two": "抢包山，就是要把包山上的包抢到手！"
+      ]
     },
     "answer": {
-      "output": "噉抢包山，自然就系要将包山嘅包抢到手！"
+      "target_sub_punctuated": "噉抢包山，自然就系要将包山嘅包抢到手！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "抢得位置愈高的包，就是愈大的祝福",
+      "target_subs": [
         "抢到位置越高嘅包",
         "就代表越大嘅祝福"
-      ],
-      "two": "抢得位置愈高的包，就是愈大的祝福"
+      ]
     },
     "answer": {
-      "output": "抢到位置越高嘅包，就代表越大嘅祝福"
+      "target_sub_punctuated": "抢到位置越高嘅包，就代表越大嘅祝福"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "在1978年两座包山忽然倒下，多人重伤",
+      "target_subs": [
         "但喺1978年",
         "两座包山突然塌咗",
         "都去抢包山"
-      ],
-      "two": "在1978年两座包山忽然倒下，多人重伤"
+      ]
     },
     "answer": {
-      "output": "但喺1978年两座包山突然塌咗，都去抢包山"
+      "target_sub_punctuated": "但喺1978年两座包山突然塌咗，都去抢包山"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「抢包山」从此被禁！",
+      "target_subs": [
         "而长洲特有嘅传统亦占备为榜"
-      ],
-      "two": "「抢包山」从此被禁！"
+      ]
     },
     "answer": {
-      "output": "而长洲特有嘅传统亦占备为榜！"
+      "target_sub_punctuated": "而长洲特有嘅传统亦占备为榜！"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "而长洲独有的传统，亦渐被遗忘",
+      "target_subs": [
         "长洲特有嘅传统亦占备为榜"
-      ],
-      "two": "而长洲独有的传统，亦渐被遗忘"
+      ]
     },
     "answer": {
-      "output": "长洲特有嘅传统，亦占备为榜"
+      "target_sub_punctuated": "长洲特有嘅传统，亦占备为榜"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "奥运金牌⋯这一世是没有机会的了",
+      "target_subs": [
         "奥运金牌",
         "我谂呢一世都唔会攞到"
-      ],
-      "two": "奥运金牌⋯这一世是没有机会的了"
+      ]
     },
     "answer": {
-      "output": "奥运金牌⋯我谂呢一世都唔会攞到"
+      "target_sub_punctuated": "奥运金牌⋯我谂呢一世都唔会攞到"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "每个星期六我都搭船过长洲",
+      "target_subs": [
         "每个礼拜六",
         "我都会搭船过长洲"
-      ],
-      "two": "每个星期六我都搭船过长洲"
+      ]
     },
     "answer": {
-      "output": "每个礼拜六我都会搭船过长洲"
+      "target_sub_punctuated": "每个礼拜六我都会搭船过长洲"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "去学抢包山⋯",
+      "target_subs": [
         "去学抢包山"
-      ],
-      "two": "去学抢包山⋯"
+      ]
     },
     "answer": {
-      "output": "去学抢包山⋯"
+      "target_sub_punctuated": "去学抢包山⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "一项没有奖牌，没有对手，没有比赛⋯",
+      "target_subs": [
         "一日冇奖牌",
         "冇对手",
         "冇比赛"
-      ],
-      "two": "一项没有奖牌，没有对手，没有比赛⋯"
+      ]
     },
     "answer": {
-      "output": "一日冇奖牌，冇对手，冇比赛⋯"
+      "target_sub_punctuated": "一日冇奖牌，冇对手，冇比赛⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "更坏的是，连包山也没有！",
+      "target_subs": [
         "更衰嘅系",
         "连包山都冇"
-      ],
-      "two": "更坏的是，连包山也没有！"
+      ]
     },
     "answer": {
-      "output": "更衰嘅系，连包山都冇！"
+      "target_sub_punctuated": "更衰嘅系，连包山都冇！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "师傅只是叫我去他的家⋯",
+      "target_subs": [
         "师傅净系叫我去佢屋企"
-      ],
-      "two": "师傅只是叫我去他的家⋯"
+      ]
     },
     "answer": {
-      "output": "师傅净系叫我去佢屋企⋯"
+      "target_sub_punctuated": "师傅净系叫我去佢屋企⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "碰！三番！",
+      "target_subs": [
         "通",
         "三番"
-      ],
-      "two": "碰！三番！"
+      ]
     },
     "answer": {
-      "output": "通！三番！"
+      "target_sub_punctuated": "通！三番！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "别躲懒！继续练！",
+      "target_subs": [
         "冇偷懒",
         "继续练"
-      ],
-      "two": "别躲懒！继续练！"
+      ]
     },
     "answer": {
-      "output": "冇偷懒！继续练！"
+      "target_sub_punctuated": "冇偷懒！继续练！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "一天，珊珊到了师传家！",
+      "target_subs": [
         "有一日",
         "山伞嚟咗师傅屋企"
-      ],
-      "two": "一天，珊珊到了师传家！"
+      ]
     },
     "answer": {
-      "output": "有一日，山伞嚟咗师傅屋企！"
+      "target_sub_punctuated": "有一日，山伞嚟咗师傅屋企！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "珊珊！我的师姐珊珊！",
+      "target_subs": [
         "山伞",
         "我个师仔山伞啊"
-      ],
-      "two": "珊珊！我的师姐珊珊！"
+      ]
     },
     "answer": {
-      "output": "山伞！我个师仔山伞啊！"
+      "target_sub_punctuated": "山伞！我个师仔山伞啊！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "可以看见珊珊⋯",
+      "target_subs": [
         "可以见到山伞"
-      ],
-      "two": "可以看见珊珊⋯"
+      ]
     },
     "answer": {
-      "output": "可以见到山伞⋯"
+      "target_sub_punctuated": "可以见到山伞⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "这几个星期爬得再辛苦也是值得的！",
+      "target_subs": [
         "爬得咁辛苦",
         "都系值得㗎"
-      ],
-      "two": "这几个星期爬得再辛苦也是值得的！"
+      ]
     },
     "answer": {
-      "output": "爬得咁辛苦都系值得㗎！"
+      "target_sub_punctuated": "爬得咁辛苦都系值得㗎！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "珊珊！",
+      "target_subs": [
         "山伞"
-      ],
-      "two": "珊珊！"
+      ]
     },
     "answer": {
-      "output": "山伞！"
+      "target_sub_punctuated": "山伞！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "珊你个头！继续练习！",
+      "target_subs": [
         "伞你个头啊",
         "继续练习"
-      ],
-      "two": "珊你个头！继续练习！"
+      ]
     },
     "answer": {
-      "output": "伞你个头啊！继续练习！"
+      "target_sub_punctuated": "伞你个头啊！继续练习！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "还不去？",
+      "target_subs": [
         "仲唔系"
-      ],
-      "two": "还不去？"
+      ]
     },
     "answer": {
-      "output": "仲唔系？"
+      "target_sub_punctuated": "仲唔系？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我咁大个仔，什么「头」也给骂过⋯",
+      "target_subs": [
         "我咁大个仔",
         "乜嘢头都畀人闹过"
-      ],
-      "two": "我咁大个仔，什么「头」也给骂过⋯"
+      ]
     },
     "answer": {
-      "output": "我咁大个仔，乜嘢「头」都畀人闹过⋯"
+      "target_sub_punctuated": "我咁大个仔，乜嘢「头」都畀人闹过⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "不知道为什么「珊你个头」却特别刺耳",
+      "target_subs": [
         "但系山呢个头唔知点解特别瘾"
-      ],
-      "two": "不知道为什么「珊你个头」却特别刺耳"
+      ]
     },
     "answer": {
-      "output": "但系「山呢个头」唔知点解特别瘾"
+      "target_sub_punctuated": "但系「山呢个头」唔知点解特别瘾"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我⋯我⋯",
+      "target_subs": [
         "我",
         "我"
-      ],
-      "two": "我⋯我⋯"
+      ]
     },
     "answer": {
-      "output": "我⋯我⋯"
+      "target_sub_punctuated": "我⋯我⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我唔学抢包山了！",
+      "target_subs": [
         "我唔好抢包纱嘞",
         "字幕由纱友提供"
-      ],
-      "two": "我唔学抢包山了！"
+      ]
     },
     "answer": {
-      "output": "我唔好抢包纱嘞！字幕由纱友提供"
+      "target_sub_punctuated": "我唔好抢包纱嘞！字幕由纱友提供"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "鸡尾包！新鲜出炉！",
+      "target_subs": [
         "鸡尾包",
         "啱啱出炉嘅"
-      ],
-      "two": "鸡尾包！新鲜出炉！"
+      ]
     },
     "answer": {
-      "output": "鸡尾包！啱啱出炉嘅！"
+      "target_sub_punctuated": "鸡尾包！啱啱出炉嘅！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "其实鸡尾包呢⋯",
+      "target_subs": [
         "其实鸡尾爆呢"
-      ],
-      "two": "其实鸡尾包呢⋯"
+      ]
     },
     "answer": {
-      "output": "其实鸡尾爆呢⋯"
+      "target_sub_punctuated": "其实鸡尾爆呢⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "你说这似不似鸡尾？",
+      "target_subs": [
         "吓",
         "你话噉样似唔似鸡尾呀",
         "哈哈哈哈"
-      ],
-      "two": "你说这似不似鸡尾？"
+      ]
     },
     "answer": {
-      "output": "吓，你话噉样似唔似鸡尾呀？哈哈哈哈"
+      "target_sub_punctuated": "吓，你话噉样似唔似鸡尾呀？哈哈哈哈"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "麦兜他学东西⋯还可以",
+      "target_subs": [
         "麦兜嘅学嘢呢都仲可以"
-      ],
-      "two": "麦兜他学东西⋯还可以"
+      ]
     },
     "answer": {
-      "output": "麦兜嘅学嘢呢⋯都仲可以"
+      "target_sub_punctuated": "麦兜嘅学嘢呢⋯都仲可以"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "黎根接著说了一大堆话⋯",
+      "target_subs": [
         "跟住黎根讲咗一大堆说话"
-      ],
-      "two": "黎根接著说了一大堆话⋯"
+      ]
     },
     "answer": {
-      "output": "跟住黎根讲咗一大堆说话⋯"
+      "target_sub_punctuated": "跟住黎根讲咗一大堆说话⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "他的抱负，他对麦兜的期望",
+      "target_subs": [
         "讲下佢嘅抱负",
         "佢对麦兜嘅期望"
-      ],
-      "two": "他的抱负，他对麦兜的期望"
+      ]
     },
     "answer": {
-      "output": "讲下佢嘅抱负，佢对麦兜嘅期望"
+      "target_sub_punctuated": "讲下佢嘅抱负，佢对麦兜嘅期望"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "黎根越说越兴奋，直到双眼发光",
+      "target_subs": [
         "黎根越讲越兴奋"
-      ],
-      "two": "黎根越说越兴奋，直到双眼发光"
+      ]
     },
     "answer": {
-      "output": "黎根越讲越兴奋"
+      "target_sub_punctuated": "黎根越讲越兴奋"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "神功戏和现代器械操",
+      "target_subs": [
         "神功气",
         "现代气蟹粗"
-      ],
-      "two": "神功戏和现代器械操"
+      ]
     },
     "answer": {
-      "output": "神功气现代气蟹粗"
+      "target_sub_punctuated": "神功气现代气蟹粗"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "缩脚，唔该！",
+      "target_subs": [
         "缩嗰只脚唔该"
-      ],
-      "two": "缩脚，唔该！"
+      ]
     },
     "answer": {
-      "output": "缩嗰只脚，唔该！"
+      "target_sub_punctuated": "缩嗰只脚，唔该！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "你看！",
+      "target_subs": [
         "你睇下"
-      ],
-      "two": "你看！"
+      ]
     },
     "answer": {
-      "output": "你睇下！"
+      "target_sub_punctuated": "你睇下！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "这脚瓜⋯好粗好大！比一节瓜还要大！",
+      "target_subs": [
         "哗",
         "呢节",
         "呢节脚瓜好粗好大呀",
         "仲大过节瓜"
-      ],
-      "two": "这脚瓜⋯好粗好大！比一节瓜还要大！"
+      ]
     },
     "answer": {
-      "output": "哗，呢节⋯呢节脚瓜好粗好大呀！仲大过节瓜！"
+      "target_sub_punctuated": "哗，呢节⋯呢节脚瓜好粗好大呀！仲大过节瓜！"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "脚瓜的肌肉非常结实⋯",
+      "target_subs": [
         "脚瓜嘅肌肉非常结实"
-      ],
-      "two": "脚瓜的肌肉非常结实⋯"
+      ]
     },
     "answer": {
-      "output": "脚瓜嘅肌肉非常结实⋯"
+      "target_sub_punctuated": "脚瓜嘅肌肉非常结实⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "脚趾甲有一寸厚，究竟⋯",
+      "target_subs": [
         "脚趾弓啲脚夹成串咁厚",
         "究竟"
-      ],
-      "two": "脚趾甲有一寸厚，究竟⋯"
+      ]
     },
     "answer": {
-      "output": "脚趾弓啲脚夹成串咁厚，究竟⋯"
+      "target_sub_punctuated": "脚趾弓啲脚夹成串咁厚，究竟⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "要走过几多座山",
+      "target_subs": [
         "要行个几度呢?",
         "几多座山"
-      ],
-      "two": "要走过几多座山"
+      ]
     },
     "answer": {
-      "output": "要行个几度呢?几多座山?"
+      "target_sub_punctuated": "要行个几度呢?几多座山?"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "才可以练成这举世无双的脚瓜？",
+      "target_subs": [
         "先至可以练成呢一只举细无伤嘅脚瓜"
-      ],
-      "two": "才可以练成这举世无双的脚瓜？"
+      ]
     },
     "answer": {
-      "output": "先至可以练成呢一只举细无伤嘅脚瓜？"
+      "target_sub_punctuated": "先至可以练成呢一只举细无伤嘅脚瓜？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我个仔⋯",
+      "target_subs": [
         "我个仔"
-      ],
-      "two": "我个仔⋯"
+      ]
     },
     "answer": {
-      "output": "我个仔⋯"
+      "target_sub_punctuated": "我个仔⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "你个仔，他日都会有这只大脚瓜",
+      "target_subs": [
         "你个仔",
         "第时都会有我咁大只脚瓜"
-      ],
-      "two": "你个仔，他日都会有这只大脚瓜"
+      ]
     },
     "answer": {
-      "output": "你个仔，第时都会有我咁大只脚瓜"
+      "target_sub_punctuated": "你个仔，第时都会有我咁大只脚瓜"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "其实我也不知道个仔要这么粗的脚瓜⋯",
+      "target_subs": [
         "其实",
         "我都唔知我仔要咁粗嘅脚瓜"
-      ],
-      "two": "其实我也不知道个仔要这么粗的脚瓜⋯"
+      ]
     },
     "answer": {
-      "output": "其实我都唔知我仔要咁粗嘅脚瓜⋯"
+      "target_sub_punctuated": "其实我都唔知我仔要咁粗嘅脚瓜⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "可是看见那些凸现的青筋，不知怎样⋯",
+      "target_subs": [
         "但系见到佢一条条凸起嘅青筋",
         "唔知点解"
-      ],
-      "two": "可是看见那些凸现的青筋，不知怎样⋯"
+      ]
     },
     "answer": {
-      "output": "但系见到佢一条条凸起嘅青筋，唔知点解⋯"
+      "target_sub_punctuated": "但系见到佢一条条凸起嘅青筋，唔知点解⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我想起麦兜的爸爸，阿炳",
+      "target_subs": [
         "我",
         "我谂起麦兜嘅爸爸",
         "阿炳"
-      ],
-      "two": "我想起麦兜的爸爸，阿炳"
+      ]
     },
     "answer": {
-      "output": "我⋯我谂起麦兜嘅爸爸，阿炳"
+      "target_sub_punctuated": "我⋯我谂起麦兜嘅爸爸，阿炳"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我找来找去也找不到那部电子英文辞典",
+      "target_subs": [
         "我揾完成间屋",
         "都揾唔到部电子英文词典"
-      ],
-      "two": "我找来找去也找不到那部电子英文辞典"
+      ]
     },
     "answer": {
-      "output": "我揾完成间屋都揾唔到部电子英文词典"
+      "target_sub_punctuated": "我揾完成间屋都揾唔到部电子英文词典"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "跑哪去了？",
+      "target_subs": [
         "去咗边呢"
-      ],
-      "two": "跑哪去了？"
+      ]
     },
     "answer": {
-      "output": "去咗边呢？"
+      "target_sub_punctuated": "去咗边呢？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "难道⋯不会吧？",
+      "target_subs": [
         "唔通",
         "冇理由㗎"
-      ],
-      "two": "难道⋯不会吧？"
+      ]
     },
     "answer": {
-      "output": "唔通⋯冇理由㗎？"
+      "target_sub_punctuated": "唔通⋯冇理由㗎？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "想不到真的让妈妈拿去了．吓得我！",
+      "target_subs": [
         "咦",
         "估唔到真系妈妈攞咗㖞",
         "吓得我啊"
-      ],
-      "two": "想不到真的让妈妈拿去了．吓得我！"
+      ]
     },
     "answer": {
-      "output": "咦，估唔到真系妈妈攞咗㖞．吓得我啊！"
+      "target_sub_punctuated": "咦，估唔到真系妈妈攞咗㖞．吓得我啊！"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈怎么会写起英文信？",
+      "target_subs": [
         "点解妈妈会用英文写信嘅"
-      ],
-      "two": "妈妈怎么会写起英文信？"
+      ]
     },
     "answer": {
-      "output": "点解妈妈会用英文写信嘅？"
+      "target_sub_punctuated": "点解妈妈会用英文写信嘅？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我猜是妈妈用电子辞典逐个字译成英文",
+      "target_subs": [
         "我谂妈妈佢系好辛苦用电子词典",
         "逐个逐个字译做英文"
-      ],
-      "two": "我猜是妈妈用电子辞典逐个字译成英文"
+      ]
     },
     "answer": {
-      "output": "我谂妈妈佢系好辛苦用电子词典逐个逐个字译做英文"
+      "target_sub_punctuated": "我谂妈妈佢系好辛苦用电子词典逐个逐个字译做英文"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "于是我又用电子辞典把信译回中文",
+      "target_subs": [
         "于是我让返电子词典",
         "将封信译返做中文"
-      ],
-      "two": "于是我又用电子辞典把信译回中文"
+      ]
     },
     "answer": {
-      "output": "于是我让返电子词典将封信译返做中文"
+      "target_sub_punctuated": "于是我让返电子词典将封信译返做中文"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "信，是妈妈写给奥委会主席的",
+      "target_subs": [
         "封信原来系妈妈写畀奥委会主席㗎"
-      ],
-      "two": "信，是妈妈写给奥委会主席的"
+      ]
     },
     "answer": {
-      "output": "封信，原来系妈妈写畀奥委会主席㗎"
+      "target_sub_punctuated": "封信，原来系妈妈写畀奥委会主席㗎"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「亲爱的主席：」",
+      "target_subs": [
         "亲爱的主席"
-      ],
-      "two": "「亲爱的主席：」"
+      ]
     },
     "answer": {
-      "output": "「亲爱的主席：」"
+      "target_sub_punctuated": "「亲爱的主席：」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「你好吗？我很好！」",
+      "target_subs": [
         "你好吗",
         "我很好"
-      ],
-      "two": "「你好吗？我很好！」"
+      ]
     },
     "answer": {
-      "output": "「你好吗？我很好！」"
+      "target_sub_punctuated": "「你好吗？我很好！」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「你吃包吗？我吃包！」",
+      "target_subs": [
         "你吃包吗",
         "我吃包"
-      ],
-      "two": "「你吃包吗？我吃包！」"
+      ]
     },
     "answer": {
-      "output": "「你吃包吗？我吃包！」"
+      "target_sub_punctuated": "「你吃包吗？我吃包！」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「我们居住在香港这里的人，很爱吃包」",
+      "target_subs": [
         "我门居住在香港这类的人",
         "肯爱吃包"
-      ],
-      "two": "「我们居住在香港这里的人，很爱吃包」"
+      ]
     },
     "answer": {
-      "output": "「我门居住在香港这类的人，肯爱吃包」"
+      "target_sub_punctuated": "「我门居住在香港这类的人，肯爱吃包」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「小笼包，上海包，广东包，莲蓉包」",
+      "target_subs": [
         "小笼包",
         "上海包",
         "广东包",
         "联融包"
-      ],
-      "two": "「小笼包，上海包，广东包，莲蓉包」"
+      ]
     },
     "answer": {
-      "output": "「小笼包，上海包，广东包，联融包」"
+      "target_sub_punctuated": "「小笼包，上海包，广东包，联融包」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「好朋友，我认为",
+      "target_subs": [
         "好朋友",
         "我认为"
-      ],
-      "two": "「好朋友，我认为"
+      ]
     },
     "answer": {
-      "output": "「好朋友，我认为"
+      "target_sub_punctuated": "「好朋友，我认为"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "抢劫那些包，十分重要」",
+      "target_subs": [
         "抢劫嗰些包十分重要"
-      ],
-      "two": "抢劫那些包，十分重要」"
+      ]
     },
     "answer": {
-      "output": "抢劫嗰些包，十分重要」"
+      "target_sub_punctuated": "抢劫嗰些包，十分重要」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「也算是运动，就真！」",
+      "target_subs": [
         "也算是运动就真"
-      ],
-      "two": "「也算是运动，就真！」"
+      ]
     },
     "answer": {
-      "output": "「也算是运动，就真！」"
+      "target_sub_punctuated": "「也算是运动，就真！」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「要大力！大吃晚上的粥，和大节瓜！」",
+      "target_subs": [
         "要大力",
         "大吃",
         "吻上的粥",
         "和大字瓜"
-      ],
-      "two": "「要大力！大吃晚上的粥，和大节瓜！」"
+      ]
     },
     "answer": {
-      "output": "「要大力！大吃吻上的粥，和大字瓜！」"
+      "target_sub_punctuated": "「要大力！大吃吻上的粥，和大字瓜！」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「按照我愚蠢的见解⋯」",
+      "target_subs": [
         "按照我愚蠢的见解"
-      ],
-      "two": "「按照我愚蠢的见解⋯」"
+      ]
     },
     "answer": {
-      "output": "「按照我愚蠢的见解⋯」"
+      "target_sub_punctuated": "「按照我愚蠢的见解⋯」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「抢劫那些包，是奥运会比赛」",
+      "target_subs": [
         "抢劫嗰些包",
         "系奥运会比赛"
-      ],
-      "two": "「抢劫那些包，是奥运会比赛」"
+      ]
     },
     "answer": {
-      "output": "「抢劫嗰些包，系奥运会比赛」"
+      "target_sub_punctuated": "「抢劫嗰些包，系奥运会比赛」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「让全世界的体育家，抢过！」",
+      "target_subs": [
         "让全世界嘅体育家抢过"
-      ],
-      "two": "「让全世界的体育家，抢过！」"
+      ]
     },
     "answer": {
-      "output": "「让全世界嘅体育家，抢过！」"
+      "target_sub_punctuated": "「让全世界嘅体育家，抢过！」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「世界便和平！」",
+      "target_subs": [
         "世界变和平"
-      ],
-      "two": "「世界便和平！」"
+      ]
     },
     "answer": {
-      "output": "「世界变和平！」"
+      "target_sub_punctuated": "「世界变和平！」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「你有孩子吗？」",
+      "target_subs": [
         "你有孩子吗"
-      ],
-      "two": "「你有孩子吗？」"
+      ]
     },
     "answer": {
-      "output": "「你有孩子吗？」"
+      "target_sub_punctuated": "「你有孩子吗？」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「我有一个孩子，麦兜」",
+      "target_subs": [
         "我有一个孩子",
         "麦兜"
-      ],
-      "two": "「我有一个孩子，麦兜」"
+      ]
     },
     "answer": {
-      "output": "「我有一个孩子，麦兜」"
+      "target_sub_punctuated": "「我有一个孩子，麦兜」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "终于讲到我了！",
+      "target_subs": [
         "终于讲到我啦"
-      ],
-      "two": "终于讲到我了！"
+      ]
     },
     "answer": {
-      "output": "终于讲到我啦！"
+      "target_sub_punctuated": "终于讲到我啦！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「他是一个好男孩」",
+      "target_subs": [
         "她系一个好男孩"
-      ],
-      "two": "「他是一个好男孩」"
+      ]
     },
     "answer": {
-      "output": "「她系一个好男孩」"
+      "target_sub_punctuated": "「她系一个好男孩」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「他非常懂得抢劫那些包」",
+      "target_subs": [
         "她非常懂得抢劫嗰些包"
-      ],
-      "two": "「他非常懂得抢劫那些包」"
+      ]
     },
     "answer": {
-      "output": "「她非常懂得抢劫嗰些包」"
+      "target_sub_punctuated": "「她非常懂得抢劫嗰些包」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「有一天，我看见他，抢劫包⋯」",
+      "target_subs": [
         "有一天我看见她抢劫包"
-      ],
-      "two": "「有一天，我看见他，抢劫包⋯」"
+      ]
     },
     "answer": {
-      "output": "「有一天，我看见她抢劫包⋯」"
+      "target_sub_punctuated": "「有一天，我看见她抢劫包⋯」"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「抢了一个奥运金牌」",
+      "target_subs": [
         "抢了一个奥运金牌"
-      ],
-      "two": "「抢了一个奥运金牌」"
+      ]
     },
     "answer": {
-      "output": "「抢了一个奥运金牌」"
+      "target_sub_punctuated": "「抢了一个奥运金牌」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「那便是一个母亲能够有的最大的安慰」",
+      "target_subs": [
         "哪便是一个母亲能够有的最好的",
         "最大的安慰"
-      ],
-      "two": "「那便是一个母亲能够有的最大的安慰」"
+      ]
     },
     "answer": {
-      "output": "「哪便是一个母亲能够有的最好的最大的安慰」"
+      "target_sub_punctuated": "「哪便是一个母亲能够有的最好的最大的安慰」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「孩子的才干，得到了世界人类的知道」",
+      "target_subs": [
         "孩子的才干得到了世界人类的知道"
-      ],
-      "two": "「孩子的才干，得到了世界人类的知道」"
+      ]
     },
     "answer": {
-      "output": "「孩子的才干，得到了世界人类的知道」"
+      "target_sub_punctuated": "「孩子的才干，得到了世界人类的知道」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「父母愿意做什么的东西都得」",
+      "target_subs": [
         "父母愿意做什么的东西都得"
-      ],
-      "two": "「父母愿意做什么的东西都得」"
+      ]
     },
     "answer": {
-      "output": "「父母愿意做什么的东西都得」"
+      "target_sub_punctuated": "「父母愿意做什么的东西都得」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「于是我写了这忽然间的信给你」",
+      "target_subs": [
         "于是我写了这忽然间的信给你"
-      ],
-      "two": "「于是我写了这忽然间的信给你」"
+      ]
     },
     "answer": {
-      "output": "「于是我写了这忽然间的信给你」"
+      "target_sub_punctuated": "「于是我写了这忽然间的信给你」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「虽然你不知道我是什么微细的东西」",
+      "target_subs": [
         "虽然你不知道我是什么微细的东西"
-      ],
-      "two": "「虽然你不知道我是什么微细的东西」"
+      ]
     },
     "answer": {
-      "output": "「虽然你不知道我是什么微细的东西」"
+      "target_sub_punctuated": "「虽然你不知道我是什么微细的东西」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「但我的孩子很大，很大！」",
+      "target_subs": [
         "但我的孩子很大很大"
-      ],
-      "two": "「但我的孩子很大，很大！」"
+      ]
     },
     "answer": {
-      "output": "「但我的孩子很大，很大！」"
+      "target_sub_punctuated": "「但我的孩子很大，很大！」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「有一天，你都会知道」",
+      "target_subs": [
         "有一天你都会知道"
-      ],
-      "two": "「有一天，你都会知道」"
+      ]
     },
     "answer": {
-      "output": "「有一天，你都会知道」"
+      "target_sub_punctuated": "「有一天，你都会知道」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「多谢合作！」",
+      "target_subs": [
         "多谢合作"
-      ],
-      "two": "「多谢合作！」"
+      ]
     },
     "answer": {
-      "output": "「多谢合作！」"
+      "target_sub_punctuated": "「多谢合作！」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「你忠实的，麦太」",
+      "target_subs": [
         "你忠实的",
         "麦太"
-      ],
-      "two": "「你忠实的，麦太」"
+      ]
     },
     "answer": {
-      "output": "「你忠实的，麦太」"
+      "target_sub_punctuated": "「你忠实的，麦太」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "可是，我依然努力练习抢包山",
+      "target_subs": [
         "但系",
         "我依然努力练习抢包生"
-      ],
-      "two": "可是，我依然努力练习抢包山"
+      ]
     },
     "answer": {
-      "output": "但系，我依然努力练习抢包生"
+      "target_sub_punctuated": "但系，我依然努力练习抢包生"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "因为，我爱我妈妈",
+      "target_subs": [
         "因为我爱我妈妈"
-      ],
-      "two": "因为，我爱我妈妈"
+      ]
     },
     "answer": {
-      "output": "因为，我爱我妈妈"
+      "target_sub_punctuated": "因为，我爱我妈妈"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "师傅说我攀爬功夫已经不错",
+      "target_subs": [
         "师傅话",
         "我嘅攀爬功夫已经唔错"
-      ],
-      "two": "师傅说我攀爬功夫已经不错"
+      ]
     },
     "answer": {
-      "output": "师傅话我嘅攀爬功夫已经唔错"
+      "target_sub_punctuated": "师傅话我嘅攀爬功夫已经唔错"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "可以开始教我「十二路抢包手」",
+      "target_subs": [
         "可以开始教我十二路抢包手"
-      ],
-      "two": "可以开始教我「十二路抢包手」"
+      ]
     },
     "answer": {
-      "output": "可以开始教我「十二路抢包手」"
+      "target_sub_punctuated": "可以开始教我「十二路抢包手」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "师傅说当年师祖耍出这套",
+      "target_subs": [
         "师傅话",
         "当年师祖使出呢套"
-      ],
-      "two": "师傅说当年师祖耍出这套"
+      ]
     },
     "answer": {
-      "output": "师傅话当年师祖使出呢套"
+      "target_sub_punctuated": "师傅话当年师祖使出呢套"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「十二路抢包手」⋯",
+      "target_subs": [
         "十二路抢包手"
-      ],
-      "two": "「十二路抢包手」⋯"
+      ]
     },
     "answer": {
-      "output": "「十二路抢包手」⋯"
+      "target_sub_punctuated": "「十二路抢包手」⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "后来麦唛告诉我⋯",
+      "target_subs": [
         "后来",
         "默默话我知"
-      ],
-      "two": "后来麦唛告诉我⋯"
+      ]
     },
     "answer": {
-      "output": "后来默默话我知⋯"
+      "target_sub_punctuated": "后来默默话我知⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "林世荣即是猪肉荣，是黄飞鸿的徒弟",
+      "target_subs": [
         "林世荣即系猪肉荣",
         "系黄飞鸿嘅徒弟"
-      ],
-      "two": "林世荣即是猪肉荣，是黄飞鸿的徒弟"
+      ]
     },
     "answer": {
-      "output": "林世荣即系猪肉荣，系黄飞鸿嘅徒弟"
+      "target_sub_punctuated": "林世荣即系猪肉荣，系黄飞鸿嘅徒弟"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我一边练习，一边胡思乱想；始终⋯",
+      "target_subs": [
         "我一边练习",
         "一边乱练",
         "一边谂嘢",
         "始终"
-      ],
-      "two": "我一边练习，一边胡思乱想；始终⋯"
+      ]
     },
     "answer": {
-      "output": "我一边练习，一边乱练，一边谂嘢；始终⋯"
+      "target_sub_punctuated": "我一边练习，一边乱练，一边谂嘢；始终⋯"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "于是我咬实牙根⋯",
+      "target_subs": [
         "于是我咬细牙根"
-      ],
-      "two": "于是我咬实牙根⋯"
+      ]
     },
     "answer": {
-      "output": "于是我咬细牙根⋯"
+      "target_sub_punctuated": "于是我咬细牙根⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "一步一步，一爪一爪⋯",
+      "target_subs": [
         "一步一步",
         "一爪一爪"
-      ],
-      "two": "一步一步，一爪一爪⋯"
+      ]
     },
     "answer": {
-      "output": "一步一步，一爪一爪⋯"
+      "target_sub_punctuated": "一步一步，一爪一爪⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我最后终于练成「十二路抢包手」",
+      "target_subs": [
         "最后",
         "我终于练成十二路抢包手啦"
-      ],
-      "two": "我最后终于练成「十二路抢包手」"
+      ]
     },
     "answer": {
-      "output": "最后我终于练成「十二路抢包手」啦"
+      "target_sub_punctuated": "最后我终于练成「十二路抢包手」啦"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "喂，我是麦兜",
+      "target_subs": [
         "喂",
         "我系麦兜啊"
-      ],
-      "two": "喂，我是麦兜"
+      ]
     },
     "answer": {
-      "output": "喂，我系麦兜啊"
+      "target_sub_punctuated": "喂，我系麦兜啊"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "刚才的是小朋友麦兜，我是大个佬麦兜",
+      "target_subs": [
         "正话嗰个系细路仔麦兜",
         "我系大个佬麦兜"
-      ],
-      "two": "刚才的是小朋友麦兜，我是大个佬麦兜"
+      ]
     },
     "answer": {
-      "output": "正话嗰个系细路仔麦兜，我系大个佬麦兜"
+      "target_sub_punctuated": "正话嗰个系细路仔麦兜，我系大个佬麦兜"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "小朋友麦兜和大个佬麦兜除了声音不同⋯",
+      "target_subs": [
         "细路仔麦兜同大个佬麦兜除咗把声唔同之外"
-      ],
-      "two": "小朋友麦兜和大个佬麦兜除了声音不同⋯"
+      ]
     },
     "answer": {
-      "output": "细路仔麦兜同大个佬麦兜除咗把声唔同之外⋯"
+      "target_sub_punctuated": "细路仔麦兜同大个佬麦兜除咗把声唔同之外⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "希望⋯失望⋯",
+      "target_subs": [
         "希望",
         "失望"
-      ],
-      "two": "希望⋯失望⋯"
+      ]
     },
     "answer": {
-      "output": "希望⋯失望⋯"
+      "target_sub_punctuated": "希望⋯失望⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "希望⋯",
+      "target_subs": [
         "希望"
-      ],
-      "two": "希望⋯"
+      ]
     },
     "answer": {
-      "output": "希望⋯"
+      "target_sub_punctuated": "希望⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "久而久之，就变成大个佬麦兜",
+      "target_subs": [
         "搞咗一轮",
         "就变咗大个佬麦兜"
-      ],
-      "two": "久而久之，就变成大个佬麦兜"
+      ]
     },
     "answer": {
-      "output": "搞咗一轮，就变咗大个佬麦兜"
+      "target_sub_punctuated": "搞咗一轮，就变咗大个佬麦兜"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我现在还是多说点小朋友麦兜",
+      "target_subs": [
         "不过",
         "而家我都系想讲返细路仔麦兜"
-      ],
-      "two": "我现在还是多说点小朋友麦兜"
+      ]
     },
     "answer": {
-      "output": "不过，而家我都系想讲返细路仔麦兜"
+      "target_sub_punctuated": "不过，而家我都系想讲返细路仔麦兜"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "小朋友麦兜仍然希望希望⋯",
+      "target_subs": [
         "细路仔麦兜仲系希望希望"
-      ],
-      "two": "小朋友麦兜仍然希望希望⋯"
+      ]
     },
     "answer": {
-      "output": "细路仔麦兜仲系希望希望⋯"
+      "target_sub_punctuated": "细路仔麦兜仲系希望希望⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "对，那时我还没吃过火鸡",
+      "target_subs": [
         "系啊",
         "我嗰阵",
         "我真系仲未食过火鸡"
-      ],
-      "two": "对，那时我还没吃过火鸡"
+      ]
     },
     "answer": {
-      "output": "系啊，我嗰阵我真系仲未食过火鸡"
+      "target_sub_punctuated": "系啊，我嗰阵我真系仲未食过火鸡"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "关于火鸡的一切⋯",
+      "target_subs": [
         "所有关于火鸡嘅嘢"
-      ],
-      "two": "关于火鸡的一切⋯"
+      ]
     },
     "answer": {
-      "output": "所有关于火鸡嘅嘢⋯"
+      "target_sub_punctuated": "所有关于火鸡嘅嘢⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "一片片比外边的雪还要白的鸡胸肉⋯",
+      "target_subs": [
         "一片一片",
         "比窗外面嘅雪仲要白嘅鸡胸肉"
-      ],
-      "two": "一片片比外边的雪还要白的鸡胸肉⋯"
+      ]
     },
     "answer": {
-      "output": "一片一片比窗外面嘅雪仲要白嘅鸡胸肉⋯"
+      "target_sub_punctuated": "一片一片比窗外面嘅雪仲要白嘅鸡胸肉⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "香气直入灵魂⋯",
+      "target_subs": [
         "香气直入灵魂"
-      ],
-      "two": "香气直入灵魂⋯"
+      ]
     },
     "answer": {
-      "output": "香气直入灵魂⋯"
+      "target_sub_punctuated": "香气直入灵魂⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "围住这香而圣洁的肉⋯",
+      "target_subs": [
         "围住呢一嚿好香好香又好盛洁嘅肉"
-      ],
-      "two": "围住这香而圣洁的肉⋯"
+      ]
     },
     "answer": {
-      "output": "围住呢一嚿好香好香又好盛洁嘅肉⋯"
+      "target_sub_punctuated": "围住呢一嚿好香好香又好盛洁嘅肉⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "在圣诞夜中飞呀，飞⋯",
+      "target_subs": [
         "喺圣诞夜里面",
         "飞呀",
         "飞呀"
-      ],
-      "two": "在圣诞夜中飞呀，飞⋯"
+      ]
     },
     "answer": {
-      "output": "喺圣诞夜里面飞呀，飞呀⋯"
+      "target_sub_punctuated": "喺圣诞夜里面飞呀，飞呀⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "这关于火鸡的一切，不过是我的想像",
+      "target_subs": [
         "但系呢一切一切关于火鸡嘅嘢",
         "都不过系我嘅想像"
-      ],
-      "two": "这关于火鸡的一切，不过是我的想像"
+      ]
     },
     "answer": {
-      "output": "但系呢一切一切关于火鸡嘅嘢，都不过系我嘅想像"
+      "target_sub_punctuated": "但系呢一切一切关于火鸡嘅嘢，都不过系我嘅想像"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我从来没吃过火鸡⋯",
+      "target_subs": [
         "因为我从来都未食过火鸡"
-      ],
-      "two": "我从来没吃过火鸡⋯"
+      ]
     },
     "answer": {
-      "output": "因为我从来都未食过火鸡⋯"
+      "target_sub_punctuated": "因为我从来都未食过火鸡⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我们一家两口，吃不下",
+      "target_subs": [
         "我哋一家两口点食都食唔晒"
-      ],
-      "two": "我们一家两口，吃不下"
+      ]
     },
     "answer": {
-      "output": "我哋一家两口，点食都食唔晒"
+      "target_sub_punctuated": "我哋一家两口，点食都食唔晒"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "有年圣诞节妈妈买了半只烧鸭庆祝",
+      "target_subs": [
         "有一年圣诞节",
         "妈妈买咗半边烧鸭庆祝"
-      ],
-      "two": "有年圣诞节妈妈买了半只烧鸭庆祝"
+      ]
     },
     "answer": {
-      "output": "有一年圣诞节妈妈买咗半边烧鸭庆祝"
+      "target_sub_punctuated": "有一年圣诞节妈妈买咗半边烧鸭庆祝"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "当时的我，十分十分失望",
+      "target_subs": [
         "当时我真系十分十分之失望"
-      ],
-      "two": "当时的我，十分十分失望"
+      ]
     },
     "answer": {
-      "output": "当时我，真系十分十分之失望"
+      "target_sub_punctuated": "当时我，真系十分十分之失望"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "又有一年，一间百货公司结业",
+      "target_subs": [
         "又有一年",
         "有间大薄货公司倒闭"
-      ],
-      "two": "又有一年，一间百货公司结业"
+      ]
     },
     "answer": {
-      "output": "又有一年，有间大薄货公司倒闭"
+      "target_sub_punctuated": "又有一年，有间大薄货公司倒闭"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那日妈妈竟然跟我说⋯",
+      "target_subs": [
         "嗰日妈妈竟然同我讲",
         "佢话"
-      ],
-      "two": "那日妈妈竟然跟我说⋯"
+      ]
     },
     "answer": {
-      "output": "嗰日妈妈竟然同我讲⋯佢话⋯"
+      "target_sub_punctuated": "嗰日妈妈竟然同我讲⋯佢话⋯"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我跟妈妈把火鸡揪回家的路上⋯",
+      "target_subs": [
         "我同妈妈抽住只火鸡行返屋企嗰阵",
         "喺嗰阵时"
-      ],
-      "two": "我跟妈妈把火鸡揪回家的路上⋯"
+      ]
     },
     "answer": {
-      "output": "我同妈妈抽住只火鸡行返屋企嗰阵，喺嗰阵时⋯"
+      "target_sub_punctuated": "我同妈妈抽住只火鸡行返屋企嗰阵，喺嗰阵时⋯"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我学著妈妈，把双手涂满盐⋯",
+      "target_subs": [
         "我同妈妈噉双手查满盐"
-      ],
-      "two": "我学著妈妈，把双手涂满盐⋯"
+      ]
     },
     "answer": {
-      "output": "我同妈妈，噉双手查满盐⋯"
+      "target_sub_punctuated": "我同妈妈，噉双手查满盐⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "在火鸡丰厚的鸡胸上擦呀，擦",
+      "target_subs": [
         "喺火鸡封口嘅鸡胸度",
         "起细噉啫啫"
-      ],
-      "two": "在火鸡丰厚的鸡胸上擦呀，擦"
+      ]
     },
     "answer": {
-      "output": "喺火鸡封口嘅鸡胸度，起细噉啫啫"
+      "target_sub_punctuated": "喺火鸡封口嘅鸡胸度，起细噉啫啫"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "联火鸡时⋯",
+      "target_subs": [
         "联火鸡时"
-      ],
-      "two": "联火鸡时⋯"
+      ]
     },
     "answer": {
-      "output": "联火鸡时⋯"
+      "target_sub_punctuated": "联火鸡时⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈不留神漏出了火鸡内的洋葱粒",
+      "target_subs": [
         "妈妈一个唔觉意",
         "畀酿喺火鸡里面嘅火鸡内脏洋葱粒"
-      ],
-      "two": "妈妈不留神漏出了火鸡内的洋葱粒"
+      ]
     },
     "answer": {
-      "output": "妈妈一个唔觉意畀酿喺火鸡里面嘅火鸡内脏洋葱粒"
+      "target_sub_punctuated": "妈妈一个唔觉意畀酿喺火鸡里面嘅火鸡内脏洋葱粒"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我说：火鸡「屙烂煮」！",
+      "target_subs": [
         "我话",
         "火鸡我能住呀"
-      ],
-      "two": "我说：火鸡「屙烂煮」！"
+      ]
     },
     "answer": {
-      "output": "我话：火鸡「我能住」呀！"
+      "target_sub_punctuated": "我话：火鸡「我能住」呀！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "焗炉戚戚恻恻，戚戚恻恻⋯",
+      "target_subs": [
         "个焗炉叱叱叱叱",
         "叱叱叱咁"
-      ],
-      "two": "焗炉戚戚恻恻，戚戚恻恻⋯"
+      ]
     },
     "answer": {
-      "output": "个焗炉叱叱叱叱，叱叱叱咁⋯"
+      "target_sub_punctuated": "个焗炉叱叱叱叱，叱叱叱咁⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "好靓的晚上啊！",
+      "target_subs": [
         "好靓嘅夜晚呀"
-      ],
-      "two": "好靓的晚上啊！"
+      ]
     },
     "answer": {
-      "output": "好靓嘅夜晚呀！"
+      "target_sub_punctuated": "好靓嘅夜晚呀！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "点点灯光在海面走来走去⋯",
+      "target_subs": [
         "点点点点嘅灯光喺海上面走来走去"
-      ],
-      "two": "点点灯光在海面走来走去⋯"
+      ]
     },
     "answer": {
-      "output": "点点点点嘅灯光喺海上面走来走去⋯"
+      "target_sub_punctuated": "点点点点嘅灯光喺海上面走来走去⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "美丽又温柔",
+      "target_subs": [
         "又靓",
         "又温柔"
-      ],
-      "two": "美丽又温柔"
+      ]
     },
     "answer": {
-      "output": "又靓又温柔"
+      "target_sub_punctuated": "又靓又温柔"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "真的好靓！",
+      "target_subs": [
         "真系好靓"
-      ],
-      "two": "真的好靓！"
+      ]
     },
     "answer": {
-      "output": "真系好靓！"
+      "target_sub_punctuated": "真系好靓！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "甚至杯面，烧鸭的味道也没有这么浓",
+      "target_subs": [
         "连烧鸭连杯面都冇咁浓嘅味道"
-      ],
-      "two": "甚至杯面，烧鸭的味道也没有这么浓"
+      ]
     },
     "answer": {
-      "output": "连烧鸭连杯面都冇咁浓嘅味道"
+      "target_sub_punctuated": "连烧鸭连杯面都冇咁浓嘅味道"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "火鸡的味道把我每一个味蕾缠住⋯",
+      "target_subs": [
         "火鸡嘅味道喺我嘅每一个味蕾度缠住"
-      ],
-      "two": "火鸡的味道把我每一个味蕾缠住⋯"
+      ]
     },
     "answer": {
-      "output": "火鸡嘅味道喺我嘅每一个味蕾度缠住⋯"
+      "target_sub_punctuated": "火鸡嘅味道喺我嘅每一个味蕾度缠住⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "爆发⋯缠住⋯爆发⋯",
+      "target_subs": [
         "爆发",
         "缠住",
         "爆发"
-      ],
-      "two": "爆发⋯缠住⋯爆发⋯"
+      ]
     },
     "answer": {
-      "output": "爆发⋯缠住⋯爆发⋯"
+      "target_sub_punctuated": "爆发⋯缠住⋯爆发⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "最靓最靓，最犀利，而且最温柔",
+      "target_subs": [
         "最靓",
         "最靓",
         "最犀利",
         "亦都系最温柔"
-      ],
-      "two": "最靓最靓，最犀利，而且最温柔"
+      ]
     },
     "answer": {
-      "output": "最靓最靓，最犀利，亦都系最温柔"
+      "target_sub_punctuated": "最靓最靓，最犀利，亦都系最温柔"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "第二天我睡得很晏⋯",
+      "target_subs": [
         "第二日我瞓到好硬"
-      ],
-      "two": "第二天我睡得很晏⋯"
+      ]
     },
     "answer": {
-      "output": "第二日我瞓到好硬⋯"
+      "target_sub_punctuated": "第二日我瞓到好硬⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "刷过牙我还感觉到火鸡的美味",
+      "target_subs": [
         "测完牙",
         "我仲感觉到火鸡嘅美味"
-      ],
-      "two": "刷过牙我还感觉到火鸡的美味"
+      ]
     },
     "answer": {
-      "output": "测完牙我仲感觉到火鸡嘅美味"
+      "target_sub_punctuated": "测完牙我仲感觉到火鸡嘅美味"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "因为早餐吃得晚⋯",
+      "target_subs": [
         "因为早餐食得硬"
-      ],
-      "two": "因为早餐吃得晚⋯"
+      ]
     },
     "answer": {
-      "output": "因为早餐食得硬⋯"
+      "target_sub_punctuated": "因为早餐食得硬⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "不用说，那夜就是我渴望了⋯",
+      "target_subs": [
         "嗰晚唔使讲",
         "当然系食我限咗"
-      ],
-      "two": "不用说，那夜就是我渴望了⋯"
+      ]
     },
     "answer": {
-      "output": "嗰晚唔使讲，当然系食我限咗⋯"
+      "target_sub_punctuated": "嗰晚唔使讲，当然系食我限咗⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "很久很久很久的⋯圣诞火鸡大餐！",
+      "target_subs": [
         "好耐好耐好耐好耐嘅圣诞火鸡大餐"
-      ],
-      "two": "很久很久很久的⋯圣诞火鸡大餐！"
+      ]
     },
     "answer": {
-      "output": "好耐好耐好耐好耐嘅⋯圣诞火鸡大餐！"
+      "target_sub_punctuated": "好耐好耐好耐好耐嘅⋯圣诞火鸡大餐！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "一片片的火鸡肉和伴碟的薯仔和节瓜⋯",
+      "target_subs": [
         "一片一片嘅火鸡肉",
         "半碟嘅有薯仔同节瓜"
-      ],
-      "two": "一片片的火鸡肉和伴碟的薯仔和节瓜⋯"
+      ]
     },
     "answer": {
-      "output": "一片一片嘅火鸡肉半碟嘅有薯仔同节瓜⋯"
+      "target_sub_punctuated": "一片一片嘅火鸡肉半碟嘅有薯仔同节瓜⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我们真的好兴奋，好满足",
+      "target_subs": [
         "我哋真系好兴奋",
         "好满足"
-      ],
-      "two": "我们真的好兴奋，好满足"
+      ]
     },
     "answer": {
-      "output": "我哋真系好兴奋，好满足"
+      "target_sub_punctuated": "我哋真系好兴奋，好满足"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "之后，我们吃了一个星期的⋯",
+      "target_subs": [
         "之后我哋仲食咗一个礼拜嘅"
-      ],
-      "two": "之后，我们吃了一个星期的⋯"
+      ]
     },
     "answer": {
-      "output": "之后，我哋仲食咗一个礼拜嘅⋯"
+      "target_sub_punctuated": "之后，我哋仲食咗一个礼拜嘅⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我大著胆跟妈妈说：不如去饮茶吖",
+      "target_subs": [
         "我嘅记心肝同妈妈讲",
         "不如饮茶"
-      ],
-      "two": "我大著胆跟妈妈说：不如去饮茶吖"
+      ]
     },
     "answer": {
-      "output": "我嘅记心肝同妈妈讲：不如饮茶"
+      "target_sub_punctuated": "我嘅记心肝同妈妈讲：不如饮茶"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈骂我「冇衣食」⋯",
+      "target_subs": [
         "妈妈闹我冇意食"
-      ],
-      "two": "妈妈骂我「冇衣食」⋯"
+      ]
     },
     "answer": {
-      "output": "妈妈闹我「冇意食」⋯"
+      "target_sub_punctuated": "妈妈闹我「冇意食」⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "之后，妈妈又有计⋯",
+      "target_subs": [
         "之后妈妈又有计"
-      ],
-      "two": "之后，妈妈又有计⋯"
+      ]
     },
     "answer": {
-      "output": "之后，妈妈又有计⋯"
+      "target_sub_punctuated": "之后，妈妈又有计⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "她把冰箱内剩下来的火鸡肉撕呀撕",
+      "target_subs": [
         "佢将雪柜净返嘅火鸡肉",
         "系噉撕系噉撕"
-      ],
-      "two": "她把冰箱内剩下来的火鸡肉撕呀撕"
+      ]
     },
     "answer": {
-      "output": "佢将雪柜净返嘅火鸡肉系噉撕系噉撕"
+      "target_sub_punctuated": "佢将雪柜净返嘅火鸡肉系噉撕系噉撕"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "银芽火鸡丝炒米，好味道",
+      "target_subs": [
         "银牙火鸡丝炒米好味道噉"
-      ],
-      "two": "银芽火鸡丝炒米，好味道"
+      ]
     },
     "answer": {
-      "output": "银牙火鸡丝炒米，好味道噉"
+      "target_sub_punctuated": "银牙火鸡丝炒米，好味道噉"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "唉，我好后悔讲过一句「火鸡屙烂煮」",
+      "target_subs": [
         "唉",
         "我后悔讲过火鸡阿宁处呢句嘢"
-      ],
-      "two": "唉，我好后悔讲过一句「火鸡屙烂煮」"
+      ]
     },
     "answer": {
-      "output": "唉，我后悔讲过「火鸡阿宁处」呢句嘢"
+      "target_sub_punctuated": "唉，我后悔讲过「火鸡阿宁处」呢句嘢"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "端午节，当我翻开我最喜欢吃的裹蒸粽⋯",
+      "target_subs": [
         "到端午节",
         "当我督开我最钟意食嘅果精粽嘅时候"
-      ],
-      "two": "端午节，当我翻开我最喜欢吃的裹蒸粽⋯"
+      ]
     },
     "answer": {
-      "output": "到端午节，当我督开我最钟意食嘅果精粽嘅时候⋯"
+      "target_sub_punctuated": "到端午节，当我督开我最钟意食嘅果精粽嘅时候⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "发现咸蛋旁边是一件火鸡背的时候⋯",
+      "target_subs": [
         "发现宿喺咸蛋旁边嘅系一件火鸡背脊"
-      ],
-      "two": "发现咸蛋旁边是一件火鸡背的时候⋯"
+      ]
     },
     "answer": {
-      "output": "发现宿喺咸蛋旁边嘅系一件火鸡背脊⋯"
+      "target_sub_punctuated": "发现宿喺咸蛋旁边嘅系一件火鸡背脊⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我脑部一时想唔通，哭起来",
+      "target_subs": [
         "我脑部一时想唔通",
         "喊咗起上嚟"
-      ],
-      "two": "我脑部一时想唔通，哭起来"
+      ]
     },
     "answer": {
-      "output": "我脑部一时想唔通，喊咗起上嚟"
+      "target_sub_punctuated": "我脑部一时想唔通，喊咗起上嚟"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "救命呀！",
+      "target_subs": [
         "救命啊"
-      ],
-      "two": "救命呀！"
+      ]
     },
     "answer": {
-      "output": "救命啊！"
+      "target_sub_punctuated": "救命啊！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我的美梦跟恶梦亦同时完结",
+      "target_subs": [
         "我嘅美梦同噩梦",
         "都同时完结"
-      ],
-      "two": "我的美梦跟恶梦亦同时完结"
+      ]
     },
     "answer": {
-      "output": "我嘅美梦同噩梦都同时完结"
+      "target_sub_punctuated": "我嘅美梦同噩梦都同时完结"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "后来我才知道⋯",
+      "target_subs": [
         "后来我先知道"
-      ],
-      "two": "后来我才知道⋯"
+      ]
     },
     "answer": {
-      "output": "后来我先知道⋯"
+      "target_sub_punctuated": "后来我先知道⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "即是说，火鸡死掉后跟我们一起的日子",
+      "target_subs": [
         "即系话",
         "只火鸡死咗之后",
         "同我哋一齐嘅日子"
-      ],
-      "two": "即是说，火鸡死掉后跟我们一起的日子"
+      ]
     },
     "answer": {
-      "output": "即系话，只火鸡死咗之后同我哋一齐嘅日子"
+      "target_sub_punctuated": "即系话，只火鸡死咗之后同我哋一齐嘅日子"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我还发觉，火鸡的味道⋯",
+      "target_subs": [
         "我仲发觉到",
         "火鸡嘅味道"
-      ],
-      "two": "我还发觉，火鸡的味道⋯"
+      ]
     },
     "answer": {
-      "output": "我仲发觉到，火鸡嘅味道⋯"
+      "target_sub_punctuated": "我仲发觉到，火鸡嘅味道⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "将吃未吃和第一口之间已经是最高峰",
+      "target_subs": [
         "味食同食第一啖之间",
         "已经系佢嘅最高峰"
-      ],
-      "two": "将吃未吃和第一口之间已经是最高峰"
+      ]
     },
     "answer": {
-      "output": "味食同食第一啖之间已经系佢嘅最高峰"
+      "target_sub_punctuated": "味食同食第一啖之间已经系佢嘅最高峰"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "之后的，不过是开始了也就吃下去",
+      "target_subs": [
         "之后",
         "不过都系食开就食埋落去噉解"
-      ],
-      "two": "之后的，不过是开始了也就吃下去"
+      ]
     },
     "answer": {
-      "output": "之后，不过都系食开就食埋落去噉解"
+      "target_sub_punctuated": "之后，不过都系食开就食埋落去噉解"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我没有哲学家的头脑⋯",
+      "target_subs": [
         "我冇知学家嘅头脑"
-      ],
-      "two": "我没有哲学家的头脑⋯"
+      ]
     },
     "answer": {
-      "output": "我冇知学家嘅头脑⋯"
+      "target_sub_punctuated": "我冇知学家嘅头脑⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "不知道两件事情应该得出什么道理",
+      "target_subs": [
         "唔知呢两样嘢要得起嘅呢个",
         "得出啲咩道理"
-      ],
-      "two": "不知道两件事情应该得出什么道理"
+      ]
     },
     "answer": {
-      "output": "唔知呢两样嘢要得起嘅呢个得出啲咩道理"
+      "target_sub_punctuated": "唔知呢两样嘢要得起嘅呢个得出啲咩道理"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "可是这些想法⋯",
+      "target_subs": [
         "但系呢啲谂法"
-      ],
-      "two": "可是这些想法⋯"
+      ]
     },
     "answer": {
-      "output": "但系呢啲谂法⋯"
+      "target_sub_punctuated": "但系呢啲谂法⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "在我长大后⋯",
+      "target_subs": [
         "喺我长大之后"
-      ],
-      "two": "在我长大后⋯"
+      ]
     },
     "answer": {
-      "output": "喺我长大之后⋯"
+      "target_sub_punctuated": "喺我长大之后⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "在一些跟圣诞节无关的日子⋯",
+      "target_subs": [
         "系一啲同圣诞节无关嘅日子"
-      ],
-      "two": "在一些跟圣诞节无关的日子⋯"
+      ]
     },
     "answer": {
-      "output": "系一啲同圣诞节无关嘅日子⋯"
+      "target_sub_punctuated": "系一啲同圣诞节无关嘅日子⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "毫无因由的在我脑中出现过三两次",
+      "target_subs": [
         "无端端噉喺我脑部",
         "出现过两三次"
-      ],
-      "two": "毫无因由的在我脑中出现过三两次"
+      ]
     },
     "answer": {
-      "output": "无端端噉喺我脑部出现过两三次"
+      "target_sub_punctuated": "无端端噉喺我脑部出现过两三次"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "一次，是在我自己的婚宴上",
+      "target_subs": [
         "一次",
         "喺我自己嘅婚宴上"
-      ],
-      "two": "一次，是在我自己的婚宴上"
+      ]
     },
     "answer": {
-      "output": "一次，喺我自己嘅婚宴上"
+      "target_sub_punctuated": "一次，喺我自己嘅婚宴上"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "一次⋯",
+      "target_subs": [
         "一次"
-      ],
-      "two": "一次⋯"
+      ]
     },
     "answer": {
-      "output": "一次⋯"
+      "target_sub_punctuated": "一次⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那天，我看著天空几缕灰色的烟",
+      "target_subs": [
         "嗰日",
         "我望住天东几条灰色嘅烟"
-      ],
-      "two": "那天，我看著天空几缕灰色的烟"
+      ]
     },
     "answer": {
-      "output": "嗰日，我望住天东几条灰色嘅烟"
+      "target_sub_punctuated": "嗰日，我望住天东几条灰色嘅烟"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我好后悔要妈妈扔掉最后几件火鸡",
+      "target_subs": [
         "我后悔",
         "要妈妈劈咗个忌廉",
         "火鸡"
-      ],
-      "two": "我好后悔要妈妈扔掉最后几件火鸡"
+      ]
     },
     "answer": {
-      "output": "我后悔要妈妈劈咗个忌廉火鸡"
+      "target_sub_punctuated": "我后悔要妈妈劈咗个忌廉火鸡"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "向全世界人再次证明⋯",
+      "target_subs": [
         "向全世界人再次证明"
-      ],
-      "two": "向全世界人再次证明⋯"
+      ]
     },
     "answer": {
-      "output": "向全世界人再次证明⋯"
+      "target_sub_punctuated": "向全世界人再次证明⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "另方面⋯",
+      "target_subs": [
         "另一方面"
-      ],
-      "two": "另方面⋯"
+      ]
     },
     "answer": {
-      "output": "另一方面⋯"
+      "target_sub_punctuated": "另一方面⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "香港体运总会霍震霆⋯",
+      "target_subs": [
         "中国香港体育协会企奥委会会长霍振庭"
-      ],
-      "two": "香港体运总会霍震霆⋯"
+      ]
     },
     "answer": {
-      "output": "中国香港体育协会企奥委会会长霍振庭⋯"
+      "target_sub_punctuated": "中国香港体育协会企奥委会会长霍振庭⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "其中港九新界竹战联谊会⋯",
+      "target_subs": [
         "其中港狗新界足战联谊会"
-      ],
-      "two": "其中港九新界竹战联谊会⋯"
+      ]
     },
     "answer": {
-      "output": "其中港狗新界足战联谊会⋯"
+      "target_sub_punctuated": "其中港狗新界足战联谊会⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "另外，全港茶餐厅员工协会⋯",
+      "target_subs": [
         "另外",
         "全港茶餐厅联工协会"
-      ],
-      "two": "另外，全港茶餐厅员工协会⋯"
+      ]
     },
     "answer": {
-      "output": "另外，全港茶餐厅联工协会⋯"
+      "target_sub_punctuated": "另外，全港茶餐厅联工协会⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "经已发动所有会员⋯",
+      "target_subs": [
         "经热发动所有会员"
-      ],
-      "two": "经已发动所有会员⋯"
+      ]
     },
     "answer": {
-      "output": "经热发动所有会员⋯"
+      "target_sub_punctuated": "经热发动所有会员⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "争取「掷蛋挞」成为亚运比赛项目",
+      "target_subs": [
         "争取掟蛋挞成为亚运会比赛项目"
-      ],
-      "two": "争取「掷蛋挞」成为亚运比赛项目"
+      ]
     },
     "answer": {
-      "output": "争取「掟蛋挞」成为亚运会比赛项目"
+      "target_sub_punctuated": "争取「掟蛋挞」成为亚运会比赛项目"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "港九烧味卤味腊味同业会",
+      "target_subs": [
         "港狗烧尾",
         "掳尾",
         "立尾同业会"
-      ],
-      "two": "港九烧味卤味腊味同业会"
+      ]
     },
     "answer": {
-      "output": "港狗烧尾掳尾立尾同业会"
+      "target_sub_punctuated": "港狗烧尾掳尾立尾同业会"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "亦向霍主席当面提出⋯",
+      "target_subs": [
         "亦都向霍主席当面提出"
-      ],
-      "two": "亦向霍主席当面提出⋯"
+      ]
     },
     "answer": {
-      "output": "亦都向霍主席当面提出⋯"
+      "target_sub_punctuated": "亦都向霍主席当面提出⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「挂腊鸭」可以成为亚运比赛项目",
+      "target_subs": [
         "挂立鸭可以成为亚运比赛项目"
-      ],
-      "two": "「挂腊鸭」可以成为亚运比赛项目"
+      ]
     },
     "answer": {
-      "output": "「挂立鸭」可以成为亚运比赛项目"
+      "target_sub_punctuated": "「挂立鸭」可以成为亚运比赛项目"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "较为特别的是，CIC保险营业员联同⋯",
+      "target_subs": [
         "较为特别嘅系",
         "CIC保险营业员联同"
-      ],
-      "two": "较为特别的是，CIC保险营业员联同⋯"
+      ]
     },
     "answer": {
-      "output": "较为特别嘅系，CIC保险营业员联同⋯"
+      "target_sub_punctuated": "较为特别嘅系，CIC保险营业员联同⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "大角咀春田花花幼稚园⋯",
+      "target_subs": [
         "大角嘴春田花花",
         "幼稚园"
-      ],
-      "two": "大角咀春田花花幼稚园⋯"
+      ]
     },
     "answer": {
-      "output": "大角嘴春田花花幼稚园⋯"
+      "target_sub_punctuated": "大角嘴春田花花幼稚园⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "附属小学一班小朋友⋯",
+      "target_subs": [
         "附属小学嘅一班小朋友"
-      ],
-      "two": "附属小学一班小朋友⋯"
+      ]
     },
     "answer": {
-      "output": "附属小学嘅一班小朋友⋯"
+      "target_sub_punctuated": "附属小学嘅一班小朋友⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "争取「抢包山」",
+      "target_subs": [
         "争取抢包山"
-      ],
-      "two": "争取「抢包山」"
+      ]
     },
     "answer": {
-      "output": "争取「抢包山」"
+      "target_sub_punctuated": "争取「抢包山」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "一项几乎绝迹的运动⋯",
+      "target_subs": [
         "一项几乎绝迹嘅运动"
-      ],
-      "two": "一项几乎绝迹的运动⋯"
+      ]
     },
     "answer": {
-      "output": "一项几乎绝迹嘅运动⋯"
+      "target_sub_punctuated": "一项几乎绝迹嘅运动⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "最后⋯",
+      "target_subs": [
         "最后"
-      ],
-      "two": "最后⋯"
+      ]
     },
     "answer": {
-      "output": "最后⋯"
+      "target_sub_punctuated": "最后⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "最后，一切成烟",
+      "target_subs": [
         "最后全部都系banana"
-      ],
-      "two": "最后，一切成烟"
+      ]
     },
     "answer": {
-      "output": "最后，全部都系banana"
+      "target_sub_punctuated": "最后，全部都系banana"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "最后，他们选了「掷蛋挞」做推介项目",
+      "target_subs": [
         "最后佢哋选咗定蛋挞做推介项目"
-      ],
-      "two": "最后，他们选了「掷蛋挞」做推介项目"
+      ]
     },
     "answer": {
-      "output": "最后，佢哋选咗「定蛋挞」做推介项目"
+      "target_sub_punctuated": "最后，佢哋选咗「定蛋挞」做推介项目"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "至于香港争取申办亚运的口号⋯",
+      "target_subs": [
         "至于香港争取申办亚运嘅口号"
-      ],
-      "two": "至于香港争取申办亚运的口号⋯"
+      ]
     },
     "answer": {
-      "output": "至于香港争取申办亚运嘅口号⋯"
+      "target_sub_punctuated": "至于香港争取申办亚运嘅口号⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "亦顺理成章叫成「香港一蛋挞」",
+      "target_subs": [
         "亦都顺理成章噉叫做香港一蛋挞"
-      ],
-      "two": "亦顺理成章叫成「香港一蛋挞」"
+      ]
     },
     "answer": {
-      "output": "亦都顺理成章噉叫做「香港一蛋挞」"
+      "target_sub_punctuated": "亦都顺理成章噉叫做「香港一蛋挞」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "之后李丽珊蝉联失败⋯",
+      "target_subs": [
         "之后李利山丧乱失败"
-      ],
-      "two": "之后李丽珊蝉联失败⋯"
+      ]
     },
     "answer": {
-      "output": "之后李利山丧乱失败⋯"
+      "target_sub_punctuated": "之后李利山丧乱失败⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "亚运主办权⋯",
+      "target_subs": [
         "亚运主办权"
-      ],
-      "two": "亚运主办权⋯"
+      ]
     },
     "answer": {
-      "output": "亚运主办权⋯"
+      "target_sub_punctuated": "亚运主办权⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "想著转行当运动员的茶餐厅伙记⋯",
+      "target_subs": [
         "谂住可以转行做运动员嘅茶餐厅伙计"
-      ],
-      "two": "想著转行当运动员的茶餐厅伙记⋯"
+      ]
     },
     "answer": {
-      "output": "谂住可以转行做运动员嘅茶餐厅伙计⋯"
+      "target_sub_punctuated": "谂住可以转行做运动员嘅茶餐厅伙计⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "上中学后，我再没有练习抢包手",
+      "target_subs": [
         "上个中学",
         "我已经再冇练习抢包手"
-      ],
-      "two": "上中学后，我再没有练习抢包手"
+      ]
     },
     "answer": {
-      "output": "上个中学，我已经再冇练习抢包手"
+      "target_sub_punctuated": "上个中学，我已经再冇练习抢包手"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "有时候跟妈妈饮茶⋯",
+      "target_subs": [
         "间中同妈妈饮茶"
-      ],
-      "two": "有时候跟妈妈饮茶⋯"
+      ]
     },
     "answer": {
-      "output": "间中同妈妈饮茶⋯"
+      "target_sub_punctuated": "间中同妈妈饮茶⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "之后，茶楼再不卖大包了",
+      "target_subs": [
         "之后茶楼都冇埋大包"
-      ],
-      "two": "之后，茶楼再不卖大包了"
+      ]
     },
     "answer": {
-      "output": "之后，茶楼都冇埋大包"
+      "target_sub_punctuated": "之后，茶楼都冇埋大包"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "每次看见师傅⋯",
+      "target_subs": [
         "每次见到师傅"
-      ],
-      "two": "每次看见师傅⋯"
+      ]
     },
     "answer": {
-      "output": "每次见到师傅⋯"
+      "target_sub_punctuated": "每次见到师傅⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "因为环保⋯",
+      "target_subs": [
         "因为环保"
-      ],
-      "two": "因为环保⋯"
+      ]
     },
     "answer": {
-      "output": "因为环保⋯"
+      "target_sub_punctuated": "因为环保⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "师傅说，那阵胶气，相当臭",
+      "target_subs": [
         "师傅话嗰阵胶气都几丑下"
-      ],
-      "two": "师傅说，那阵胶气，相当臭"
+      ]
     },
     "answer": {
-      "output": "师傅话，嗰阵胶气，都几丑下"
+      "target_sub_punctuated": "师傅话，嗰阵胶气，都几丑下"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "因为我练过抢包手，身手比较灵活⋯",
+      "target_subs": [
         "因为我练过抢包手",
         "身手比较灵活"
-      ],
-      "two": "因为我练过抢包手，身手比较灵活⋯"
+      ]
     },
     "answer": {
-      "output": "因为我练过抢包手，身手比较灵活⋯"
+      "target_sub_punctuated": "因为我练过抢包手，身手比较灵活⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "同学们叫我爬进去看看，说不定会发达",
+      "target_subs": [
         "班同我叫我爬佢睇下",
         "话唔定会发达"
-      ],
-      "two": "同学们叫我爬进去看看，说不定会发达"
+      ]
     },
     "answer": {
-      "output": "班同我叫我爬佢睇下，话唔定会发达"
+      "target_sub_punctuated": "班同我叫我爬佢睇下，话唔定会发达"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "于是我就向著这个又黑又窄的洞⋯",
+      "target_subs": [
         "于是我就向住呢一个又黑又窄嘅洞"
-      ],
-      "two": "于是我就向著这个又黑又窄的洞⋯"
+      ]
     },
     "answer": {
-      "output": "于是我就向住呢一个又黑又窄嘅洞⋯"
+      "target_sub_punctuated": "于是我就向住呢一个又黑又窄嘅洞⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "一直爬",
+      "target_subs": [
         "系噉爬",
         "爬"
-      ],
-      "two": "一直爬"
+      ]
     },
     "answer": {
-      "output": "系噉爬爬"
+      "target_sub_punctuated": "系噉爬爬"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "洞里面什么也没有，只有一个盒",
+      "target_subs": [
         "洞里面乜都冇",
         "净系有一个盒"
-      ],
-      "two": "洞里面什么也没有，只有一个盒"
+      ]
     },
     "answer": {
-      "output": "洞里面乜都冇，净系有一个盒"
+      "target_sub_punctuated": "洞里面乜都冇，净系有一个盒"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我小心揭开盒⋯",
+      "target_subs": [
         "我好小心揭开呢个盒"
-      ],
-      "two": "我小心揭开盒⋯"
+      ]
     },
     "answer": {
-      "output": "我好小心揭开呢个盒⋯"
+      "target_sub_punctuated": "我好小心揭开呢个盒⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "是不是张保仔吃过的呢？",
+      "target_subs": [
         "唔知系咪张宝仔食净㗎啦"
-      ],
-      "two": "是不是张保仔吃过的呢？"
+      ]
     },
     "answer": {
-      "output": "唔知系咪张宝仔食净㗎啦？"
+      "target_sub_punctuated": "唔知系咪张宝仔食净㗎啦？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "揸住个包，我忽然明白⋯",
+      "target_subs": [
         "揸住个包",
         "我忽然明白"
-      ],
-      "two": "揸住个包，我忽然明白⋯"
+      ]
     },
     "answer": {
-      "output": "揸住个包，我忽然明白⋯"
+      "target_sub_punctuated": "揸住个包，我忽然明白⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "原来有些事情，没有就是没有",
+      "target_subs": [
         "原来有啲嘢冇",
         "就真系冇"
-      ],
-      "two": "原来有些事情，没有就是没有"
+      ]
     },
     "answer": {
-      "output": "原来有啲嘢，冇就真系冇"
+      "target_sub_punctuated": "原来有啲嘢，冇就真系冇"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "唔得，就是唔得",
+      "target_subs": [
         "唔得",
         "就真系唔得"
-      ],
-      "two": "唔得，就是唔得"
+      ]
     },
     "answer": {
-      "output": "唔得，就真系唔得"
+      "target_sub_punctuated": "唔得，就真系唔得"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "没有鱼蛋没有粗面没去成马尔代夫⋯",
+      "target_subs": [
         "冇鱼蛋",
         "冇粗面",
         "冇去买义大夫"
-      ],
-      "two": "没有鱼蛋没有粗面没去成马尔代夫⋯"
+      ]
     },
     "answer": {
-      "output": "冇鱼蛋冇粗面冇去买义大夫⋯"
+      "target_sub_punctuated": "冇鱼蛋冇粗面冇去买义大夫⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "而张保仔，也没有咬过那个包",
+      "target_subs": [
         "而张宝仔亦都冇咬过个包"
-      ],
-      "two": "而张保仔，也没有咬过那个包"
+      ]
     },
     "answer": {
-      "output": "而张宝仔，亦都冇咬过个包"
+      "target_sub_punctuated": "而张宝仔，亦都冇咬过个包"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "原来蠢，并不那么好笑",
+      "target_subs": [
         "原来",
         "唔系咁好笑"
-      ],
-      "two": "原来蠢，并不那么好笑"
+      ]
     },
     "answer": {
-      "output": "原来，唔系咁好笑"
+      "target_sub_punctuated": "原来，唔系咁好笑"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "蠢会失败⋯",
+      "target_subs": [
         "会失败"
-      ],
-      "two": "蠢会失败⋯"
+      ]
     },
     "answer": {
-      "output": "会失败⋯"
+      "target_sub_punctuated": "会失败⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "失望，并不那么好笑",
+      "target_subs": [
         "失望",
         "唔系咁好笑"
-      ],
-      "two": "失望，并不那么好笑"
+      ]
     },
     "answer": {
-      "output": "失望，唔系咁好笑"
+      "target_sub_punctuated": "失望，唔系咁好笑"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "肥，都不一定好笑",
+      "target_subs": [
         "肥",
         "都未必好笑"
-      ],
-      "two": "肥，都不一定好笑"
+      ]
     },
     "answer": {
-      "output": "肥，都未必好笑"
+      "target_sub_punctuated": "肥，都未必好笑"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "肥，不一定大力",
+      "target_subs": [
         "肥",
         "唔一定大力"
-      ],
-      "two": "肥，不一定大力"
+      ]
     },
     "answer": {
-      "output": "肥，唔一定大力"
+      "target_sub_punctuated": "肥，唔一定大力"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "大力，亦不一定得",
+      "target_subs": [
         "大力",
         "亦都唔一定得"
-      ],
-      "two": "大力，亦不一定得"
+      ]
     },
     "answer": {
-      "output": "大力，亦都唔一定得"
+      "target_sub_punctuated": "大力，亦都唔一定得"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "揸住个包，我忽然想⋯",
+      "target_subs": [
         "揸住个包",
         "我忽然喺度谂"
-      ],
-      "two": "揸住个包，我忽然想⋯"
+      ]
     },
     "answer": {
-      "output": "揸住个包，我忽然喺度谂⋯"
+      "target_sub_punctuated": "揸住个包，我忽然喺度谂⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "长大了，到我要面对这个实掘掘⋯",
+      "target_subs": [
         "大个咗到我要面对呢一个实角局"
-      ],
-      "two": "长大了，到我要面对这个实掘掘⋯"
+      ]
     },
     "answer": {
-      "output": "大个咗，到我要面对呢一个实角局⋯"
+      "target_sub_punctuated": "大个咗，到我要面对呢一个实角局⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "未必可以发梦，未必那么好笑的⋯",
+      "target_subs": [
         "未必到你发梦",
         "又未必咁好笑嘅"
-      ],
-      "two": "未必可以发梦，未必那么好笑的⋯"
+      ]
     },
     "answer": {
-      "output": "未必到你发梦，又未必咁好笑嘅⋯"
+      "target_sub_punctuated": "未必到你发梦，又未必咁好笑嘅⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "世界的时候，我会怎么样？",
+      "target_subs": [
         "世界嘅时候",
         "我会系点㗎呢"
-      ],
-      "two": "世界的时候，我会怎么样？"
+      ]
     },
     "answer": {
-      "output": "世界嘅时候，我会系点㗎呢？"
+      "target_sub_punctuated": "世界嘅时候，我会系点㗎呢？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「⋯无力挽！」",
+      "target_subs": [
         "无泪弯"
-      ],
-      "two": "「⋯无力挽！」"
+      ]
     },
     "answer": {
-      "output": "「⋯无泪弯！」"
+      "target_sub_punctuated": "「⋯无泪弯！」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "是的，我就是大个佬麦兜",
+      "target_subs": [
         "系呀",
         "我就系大个佬麦豆喇"
-      ],
-      "two": "是的，我就是大个佬麦兜"
+      ]
     },
     "answer": {
-      "output": "系呀，我就系大个佬麦豆喇"
+      "target_sub_punctuated": "系呀，我就系大个佬麦豆喇"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "肥，算大力",
+      "target_subs": [
         "肥啰",
         "算大力啦"
-      ],
-      "two": "肥，算大力"
+      ]
     },
     "answer": {
-      "output": "肥啰，算大力啦"
+      "target_sub_punctuated": "肥啰，算大力啦"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "脚瓜是真的大，比一节瓜还要大",
+      "target_subs": [
         "脚瓜真系几大",
         "仲大过个折瓜"
-      ],
-      "two": "脚瓜是真的大，比一节瓜还要大"
+      ]
     },
     "answer": {
-      "output": "脚瓜真系几大，仲大过个折瓜"
+      "target_sub_punctuated": "脚瓜真系几大，仲大过个折瓜"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "脚瓜上的肌肉非常结实⋯",
+      "target_subs": [
         "脚瓜上面个肌肉非常结实"
-      ],
-      "two": "脚瓜上的肌肉非常结实⋯"
+      ]
     },
     "answer": {
-      "output": "脚瓜上面个肌肉非常结实⋯"
+      "target_sub_punctuated": "脚瓜上面个肌肉非常结实⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "青筋一条条凸出来，似钢筋",
+      "target_subs": [
         "啲青筋一条一条凸下凸下",
         "好似钢筋"
-      ],
-      "two": "青筋一条条凸出来，似钢筋"
+      ]
     },
     "answer": {
-      "output": "啲青筋一条一条凸下凸下，好似钢筋"
+      "target_sub_punctuated": "啲青筋一条一条凸下凸下，好似钢筋"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "至于脚趾甲⋯",
+      "target_subs": [
         "至于脚趾弓啲脚甲"
-      ],
-      "two": "至于脚趾甲⋯"
+      ]
     },
     "answer": {
-      "output": "至于脚趾弓啲脚甲⋯"
+      "target_sub_punctuated": "至于脚趾弓啲脚甲⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "有次我无无聊聊真的量了一下⋯",
+      "target_subs": [
         "有次我无无聊聊真系走去卡下佢"
-      ],
-      "two": "有次我无无聊聊真的量了一下⋯"
+      ]
     },
     "answer": {
-      "output": "有次我无无聊聊真系走去卡下佢⋯"
+      "target_sub_punctuated": "有次我无无聊聊真系走去卡下佢⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "足有一寸厚",
+      "target_subs": [
         "哗",
         "粥粥成串咁厚"
-      ],
-      "two": "足有一寸厚"
+      ]
     },
     "answer": {
-      "output": "哗，粥粥成串咁厚"
+      "target_sub_punctuated": "哗，粥粥成串咁厚"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "是的，故事讲完了",
+      "target_subs": [
         "系呀",
         "故事讲完喇"
-      ],
-      "two": "是的，故事讲完了"
+      ]
     },
     "answer": {
-      "output": "系呀，故事讲完喇"
+      "target_sub_punctuated": "系呀，故事讲完喇"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "失败⋯尝试⋯",
+      "target_subs": [
         "失败",
         "尝试"
-      ],
-      "two": "失败⋯尝试⋯"
+      ]
     },
     "answer": {
-      "output": "失败⋯尝试⋯"
+      "target_sub_punctuated": "失败⋯尝试⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "好多包⋯可是没有包保成功的故事",
+      "target_subs": [
         "好多包",
         "但系冇包补成功嘅故事"
-      ],
-      "two": "好多包⋯可是没有包保成功的故事"
+      ]
     },
     "answer": {
-      "output": "好多包⋯但系冇包补成功嘅故事"
+      "target_sub_punctuated": "好多包⋯但系冇包补成功嘅故事"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "故事说了一轮⋯",
+      "target_subs": [
         "故事讲咗一轮"
-      ],
-      "two": "故事说了一轮⋯"
+      ]
     },
     "answer": {
-      "output": "故事讲咗一轮⋯"
+      "target_sub_punctuated": "故事讲咗一轮⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "什么也没有？也不是",
+      "target_subs": [
         "乜都冇",
         "又唔系噃"
-      ],
-      "two": "什么也没有？也不是"
+      ]
     },
     "answer": {
-      "output": "乜都冇？又唔系噃"
+      "target_sub_punctuated": "乜都冇？又唔系噃"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "可是楝一双脚瓜站这儿⋯",
+      "target_subs": [
         "但系冻住两个脚瓜企喺度"
-      ],
-      "two": "可是楝一双脚瓜站这儿⋯"
+      ]
     },
     "answer": {
-      "output": "但系冻住两个脚瓜企喺度⋯"
+      "target_sub_punctuated": "但系冻住两个脚瓜企喺度⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "当浪打过来⋯",
+      "target_subs": [
         "当啲浪打埋嚟"
-      ],
-      "two": "当浪打过来⋯"
+      ]
     },
     "answer": {
-      "output": "当啲浪打埋嚟⋯"
+      "target_sub_punctuated": "当啲浪打埋嚟⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "你知道我麻麻地叻佬，不懂得⋯",
+      "target_subs": [
         "你知我麻麻地叻佬",
         "唔识得"
-      ],
-      "two": "你知道我麻麻地叻佬，不懂得⋯"
+      ]
     },
     "answer": {
-      "output": "你知我麻麻地叻佬，唔识得⋯"
+      "target_sub_punctuated": "你知我麻麻地叻佬，唔识得⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "替自己的故事加点教训呀锦囊呀那些",
+      "target_subs": [
         "帮自己嘅故事加啲教训呀",
         "锦囊呀嗰啲嘢"
-      ],
-      "two": "替自己的故事加点教训呀锦囊呀那些"
+      ]
     },
     "answer": {
-      "output": "帮自己嘅故事加啲教训呀锦囊呀嗰啲嘢"
+      "target_sub_punctuated": "帮自己嘅故事加啲教训呀锦囊呀嗰啲嘢"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "可是，浸一双脚瓜站水中⋯",
+      "target_subs": [
         "但系冻住两个脚瓜企喺水嗰度"
-      ],
-      "two": "可是，浸一双脚瓜站水中⋯"
+      ]
     },
     "answer": {
-      "output": "但系，冻住两个脚瓜企喺水嗰度⋯"
+      "target_sub_punctuated": "但系，冻住两个脚瓜企喺水嗰度⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "当风吹向我的脑，我会想⋯",
+      "target_subs": [
         "当风",
         "吹喺我个脑部",
         "我会谂"
-      ],
-      "two": "当风吹向我的脑，我会想⋯"
+      ]
     },
     "answer": {
-      "output": "当风吹喺我个脑部，我会谂⋯"
+      "target_sub_punctuated": "当风吹喺我个脑部，我会谂⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "如果妈妈看见我这个大脚瓜⋯",
+      "target_subs": [
         "如果妈妈见到我呢个大脚瓜"
-      ],
-      "two": "如果妈妈看见我这个大脚瓜⋯"
+      ]
     },
     "answer": {
-      "output": "如果妈妈见到我呢个大脚瓜⋯"
+      "target_sub_punctuated": "如果妈妈见到我呢个大脚瓜⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我猜，她会好开心",
+      "target_subs": [
         "我谂佢会好开心"
-      ],
-      "two": "我猜，她会好开心"
+      ]
     },
     "answer": {
-      "output": "我谂，佢会好开心"
+      "target_sub_punctuated": "我谂，佢会好开心"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "不成，还是出个锦囊！",
+      "target_subs": [
         "都系唔好呀",
         "都系出返个锦囊先得"
-      ],
-      "two": "不成，还是出个锦囊！"
+      ]
     },
     "answer": {
-      "output": "都系唔好呀，都系出返个锦囊先得！"
+      "target_sub_punctuated": "都系唔好呀，都系出返个锦囊先得！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈的dot com散掉后，她又有计",
+      "target_subs": [
         "妈妈个Doccom散咗之后",
         "佢又有计喇"
-      ],
-      "two": "妈妈的dot com散掉后，她又有计"
+      ]
     },
     "answer": {
-      "output": "妈妈个Doccom散咗之后，佢又有计喇"
+      "target_sub_punctuated": "妈妈个Doccom散咗之后，佢又有计喇"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "她出版了一本教烹饪的食谱",
+      "target_subs": [
         "佢出咗半教主送嘅食谱",
         "谂住捞返扎沙"
-      ],
-      "two": "她出版了一本教烹饪的食谱"
+      ]
     },
     "answer": {
-      "output": "佢出咗半教主送嘅食谱，谂住捞返扎沙"
+      "target_sub_punctuated": "佢出咗半教主送嘅食谱，谂住捞返扎沙"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "方法简单，人人可学",
+      "target_subs": [
         "方法简单",
         "人人都学得识"
-      ],
-      "two": "方法简单，人人可学"
+      ]
     },
     "answer": {
-      "output": "方法简单，人人都学得识"
+      "target_sub_punctuated": "方法简单，人人都学得识"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「烧鸡」",
+      "target_subs": [
         "烧鸡"
-      ],
-      "two": "「烧鸡」"
+      ]
     },
     "answer": {
-      "output": "「烧鸡」"
+      "target_sub_punctuated": "「烧鸡」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "材料是⋯鸡",
+      "target_subs": [
         "材料系",
         "鸡"
-      ],
-      "two": "材料是⋯鸡"
+      ]
     },
     "answer": {
-      "output": "材料系⋯鸡"
+      "target_sub_punctuated": "材料系⋯鸡"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "方法：把鸡烧几烧",
+      "target_subs": [
         "方法",
         "攞只鸡",
         "去烧佢几烧"
-      ],
-      "two": "方法：把鸡烧几烧"
+      ]
     },
     "answer": {
-      "output": "方法：攞只鸡去烧佢几烧"
+      "target_sub_punctuated": "方法：攞只鸡去烧佢几烧"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "就这样，一味「烧鸡」大功告成",
+      "target_subs": [
         "就噉",
         "一味烧鸡",
         "就大功告成喇"
-      ],
-      "two": "就这样，一味「烧鸡」大功告成"
+      ]
     },
     "answer": {
-      "output": "就噉，一味「烧鸡」就大功告成喇"
+      "target_sub_punctuated": "就噉，一味「烧鸡」就大功告成喇"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "食谱里面补充说：",
+      "target_subs": [
         "食谱度又补充噉话"
-      ],
-      "two": "食谱里面补充说："
+      ]
     },
     "answer": {
-      "output": "食谱度又补充噉话："
+      "target_sub_punctuated": "食谱度又补充噉话："
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "如果你想把鸡烧得美味可口⋯",
+      "target_subs": [
         "如果想你个鸡烧得美味可口"
-      ],
-      "two": "如果你想把鸡烧得美味可口⋯"
+      ]
     },
     "answer": {
-      "output": "如果想你个鸡烧得美味可口⋯"
+      "target_sub_punctuated": "如果想你个鸡烧得美味可口⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "秘诀是：拜托，把鸡烧好一点⋯",
+      "target_subs": [
         "个秘诀系唔该",
         "烧得佢好啲啰"
-      ],
-      "two": "秘诀是：拜托，把鸡烧好一点⋯"
+      ]
     },
     "answer": {
-      "output": "个秘诀系：唔该，烧得佢好啲啰⋯"
+      "target_sub_punctuated": "个秘诀系：唔该，烧得佢好啲啰⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "多谢合作！",
+      "target_subs": [
         "多谢合作"
-      ],
-      "two": "多谢合作！"
+      ]
     },
     "answer": {
-      "output": "多谢合作！"
+      "target_sub_punctuated": "多谢合作！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "麻烦你，一客常餐",
+      "target_subs": [
         "唔该",
         "我要一个常餐啦"
-      ],
-      "two": "麻烦你，一客常餐"
+      ]
     },
     "answer": {
-      "output": "唔该，我要一个常餐啦"
+      "target_sub_punctuated": "唔该，我要一个常餐啦"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "常餐？常餐有什么吃？",
+      "target_subs": [
         "常餐",
         "常餐有咩食㗎"
-      ],
-      "two": "常餐？常餐有什么吃？"
+      ]
     },
     "answer": {
-      "output": "常餐？常餐有咩食㗎？"
+      "target_sub_punctuated": "常餐？常餐有咩食㗎？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "特餐是什么？",
+      "target_subs": [
         "噉特餐系咩嚟㗎"
-      ],
-      "two": "特餐是什么？"
+      ]
     },
     "answer": {
-      "output": "噉特餐系咩嚟㗎？"
+      "target_sub_punctuated": "噉特餐系咩嚟㗎？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "快餐又是什么？",
+      "target_subs": [
         "噉快餐又系咩嚟㗎"
-      ],
-      "two": "快餐又是什么？"
+      ]
     },
     "answer": {
-      "output": "噉快餐又系咩嚟㗎？"
+      "target_sub_punctuated": "噉快餐又系咩嚟㗎？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "午餐吃什么？",
+      "target_subs": [
         "午餐食咩㗎"
-      ],
-      "two": "午餐吃什么？"
+      ]
     },
     "answer": {
-      "output": "午餐食咩㗎？"
+      "target_sub_punctuated": "午餐食咩㗎？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "晚餐又吃什么？",
+      "target_subs": [
         "噉晚餐又食啲咩呀"
-      ],
-      "two": "晚餐又吃什么？"
+      ]
     },
     "answer": {
-      "output": "噉晚餐又食啲咩呀？"
+      "target_sub_punctuated": "噉晚餐又食啲咩呀？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那么，两客常餐吧",
+      "target_subs": [
         "噉呀",
         "我要两个常餐啦"
-      ],
-      "two": "那么，两客常餐吧"
+      ]
     },
     "answer": {
-      "output": "噉呀，我要两个常餐啦"
+      "target_sub_punctuated": "噉呀，我要两个常餐啦"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "今天常餐精采呀！",
+      "target_subs": [
         "好嘢呀",
         "我哋今日啲常餐"
-      ],
-      "two": "今天常餐精采呀！"
+      ]
     },
     "answer": {
-      "output": "好嘢呀，我哋今日啲常餐！"
+      "target_sub_punctuated": "好嘢呀，我哋今日啲常餐！"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "对不起，常餐卖光了",
+      "target_subs": [
         "唔好意思",
         "上餐卖晒"
-      ],
-      "two": "对不起，常餐卖光了"
+      ]
     },
     "answer": {
-      "output": "唔好意思，上餐卖晒"
+      "target_sub_punctuated": "唔好意思，上餐卖晒"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "特餐？特餐有什么吃？",
+      "target_subs": [
         "特餐",
         "特餐有咩食㗎"
-      ],
-      "two": "特餐？特餐有什么吃？"
+      ]
     },
     "answer": {
-      "output": "特餐？特餐有咩食㗎？"
+      "target_sub_punctuated": "特餐？特餐有咩食㗎？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "午餐又吃什么呢？",
+      "target_subs": [
         "午餐食乜嘢㗎"
-      ],
-      "two": "午餐又吃什么呢？"
+      ]
     },
     "answer": {
-      "output": "午餐食乜嘢㗎？"
+      "target_sub_punctuated": "午餐食乜嘢㗎？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "什么是晚餐？",
+      "target_subs": [
         "咁乜嘢系晚餐呀"
-      ],
-      "two": "什么是晚餐？"
+      ]
     },
     "answer": {
-      "output": "咁乜嘢系晚餐呀？"
+      "target_sub_punctuated": "咁乜嘢系晚餐呀？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "快餐吃什么？",
+      "target_subs": [
         "咁快餐食咩㗎"
-      ],
-      "two": "快餐吃什么？"
+      ]
     },
     "answer": {
-      "output": "咁快餐食咩㗎？"
+      "target_sub_punctuated": "咁快餐食咩㗎？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "唉，快餐不就是常餐",
+      "target_subs": [
         "系",
         "快餐就即系上餐啰"
-      ],
-      "two": "唉，快餐不就是常餐"
+      ]
     },
     "answer": {
-      "output": "系，快餐就即系上餐啰"
+      "target_sub_punctuated": "系，快餐就即系上餐啰"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "常餐不是卖光了吗？",
+      "target_subs": [
         "咁你头先又话冇上餐"
-      ],
-      "two": "常餐不是卖光了吗？"
+      ]
     },
     "answer": {
-      "output": "咁你头先又话冇上餐？"
+      "target_sub_punctuated": "咁你头先又话冇上餐？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "对，常餐卖光了，要吃特餐吗？",
+      "target_subs": [
         "系呀",
         "上餐就系卖晒呀",
         "咁你试唔试下特餐啦"
-      ],
-      "two": "对，常餐卖光了，要吃特餐吗？"
+      ]
     },
     "answer": {
-      "output": "系呀，上餐就系卖晒呀，咁你试唔试下特餐啦？"
+      "target_sub_punctuated": "系呀，上餐就系卖晒呀，咁你试唔试下特餐啦？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "对不起，特餐卖光了",
+      "target_subs": [
         "唔好意思",
         "特餐卖晒嘅"
-      ],
-      "two": "对不起，特餐卖光了"
+      ]
     },
     "answer": {
-      "output": "唔好意思，特餐卖晒嘅"
+      "target_sub_punctuated": "唔好意思，特餐卖晒嘅"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈，改快餐吧",
+      "target_subs": [
         "妈妈",
         "不如改快餐啦"
-      ],
-      "two": "妈妈，改快餐吧"
+      ]
     },
     "answer": {
-      "output": "妈妈，不如改快餐啦"
+      "target_sub_punctuated": "妈妈，不如改快餐啦"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "快餐有什么？",
+      "target_subs": [
         "快餐有咩㗎"
-      ],
-      "two": "快餐有什么？"
+      ]
     },
     "answer": {
-      "output": "快餐有咩㗎？"
+      "target_sub_punctuated": "快餐有咩㗎？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "常餐又有什么呢？",
+      "target_subs": [
         "咁上餐有咩㗎"
-      ],
-      "two": "常餐又有什么呢？"
+      ]
     },
     "answer": {
-      "output": "咁上餐有咩㗎？"
+      "target_sub_punctuated": "咁上餐有咩㗎？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那么午餐又有什么吃？",
+      "target_subs": [
         "哎呀",
         "咁午餐有咩食呀"
-      ],
-      "two": "那么午餐又有什么吃？"
+      ]
     },
     "answer": {
-      "output": "哎呀，咁午餐有咩食呀？"
+      "target_sub_punctuated": "哎呀，咁午餐有咩食呀？"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "晚餐呢？",
+      "target_subs": [
         "咁晚餐呢"
-      ],
-      "two": "晚餐呢？"
+      ]
     },
     "answer": {
-      "output": "咁晚餐呢？"
+      "target_sub_punctuated": "咁晚餐呢？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "不是说特餐卖光了吗？",
+      "target_subs": [
         "咁你头先又话冇特餐"
-      ],
-      "two": "不是说特餐卖光了吗？"
+      ]
     },
     "answer": {
-      "output": "咁你头先又话冇特餐？"
+      "target_sub_punctuated": "咁你头先又话冇特餐？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "特餐卖光了，要试试快餐吗？都一样的",
+      "target_subs": [
         "系呀",
         "特餐系卖晒呀",
         "咁你试唔试下个快餐啦",
         "一样嘅啫"
-      ],
-      "two": "特餐卖光了，要试试快餐吗？都一样的"
+      ]
     },
     "answer": {
-      "output": "系呀，特餐系卖晒呀，咁你试唔试下个快餐啦？一样嘅啫"
+      "target_sub_punctuated": "系呀，特餐系卖晒呀，咁你试唔试下个快餐啦？一样嘅啫"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "对不起，没快餐了",
+      "target_subs": [
         "唔好意思冇快餐呀"
-      ],
-      "two": "对不起，没快餐了"
+      ]
     },
     "answer": {
-      "output": "唔好意思，冇快餐呀"
+      "target_sub_punctuated": "唔好意思，冇快餐呀"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "太过份了吧？你们究竟有吃的没？",
+      "target_subs": [
         "嚟唔嚟普啲呀",
         "噉你哋究竟有啲咩餐呀"
-      ],
-      "two": "太过份了吧？你们究竟有吃的没？"
+      ]
     },
     "answer": {
-      "output": "嚟唔嚟普啲呀？噉你哋究竟有啲咩餐呀？"
+      "target_sub_punctuated": "嚟唔嚟普啲呀？噉你哋究竟有啲咩餐呀？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "午餐吧，午餐精采呀",
+      "target_subs": [
         "午餐啦",
         "午餐好嘢呀"
-      ],
-      "two": "午餐吧，午餐精采呀"
+      ]
     },
     "answer": {
-      "output": "午餐啦，午餐好嘢呀"
+      "target_sub_punctuated": "午餐啦，午餐好嘢呀"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "怎么个精采法？",
+      "target_subs": [
         "点好嘢法呀"
-      ],
-      "two": "怎么个精采法？"
+      ]
     },
     "answer": {
-      "output": "点好嘢法呀？"
+      "target_sub_punctuated": "点好嘢法呀？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "晚餐又怎样呢？",
+      "target_subs": [
         "噉晚餐又点好嘢法呀"
-      ],
-      "two": "晚餐又怎样呢？"
+      ]
     },
     "answer": {
-      "output": "噉晚餐又点好嘢法呀？"
+      "target_sub_punctuated": "噉晚餐又点好嘢法呀？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "常餐又怎样呢？",
+      "target_subs": [
         "噉上餐又点好嘢法呀"
-      ],
-      "two": "常餐又怎样呢？"
+      ]
     },
     "answer": {
-      "output": "噉上餐又点好嘢法呀？"
+      "target_sub_punctuated": "噉上餐又点好嘢法呀？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "常餐早卖光了，你说精采不？",
+      "target_subs": [
         "上餐",
         "上餐一早卖晒啦",
         "你话好唔好嘢"
-      ],
-      "two": "常餐早卖光了，你说精采不？"
+      ]
     },
     "answer": {
-      "output": "上餐，上餐一早卖晒啦，你话好唔好嘢？"
+      "target_sub_punctuated": "上餐，上餐一早卖晒啦，你话好唔好嘢？"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "好吧好吧！两份午餐好了",
+      "target_subs": [
         "好啦好啦",
         "要两份午餐啦"
-      ],
-      "two": "好吧好吧！两份午餐好了"
+      ]
     },
     "answer": {
-      "output": "好啦好啦！要两份午餐啦"
+      "target_sub_punctuated": "好啦好啦！要两份午餐啦"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "对不起，午餐卖光了",
+      "target_subs": [
         "唔好意思",
         "午餐卖晒"
-      ],
-      "two": "对不起，午餐卖光了"
+      ]
     },
     "answer": {
-      "output": "唔好意思，午餐卖晒"
+      "target_sub_punctuated": "唔好意思，午餐卖晒"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "要试试我们的晚餐吗？都一样的",
+      "target_subs": [
         "试唔试下我哋嘅晚餐啦",
         "一样嘅啫"
-      ],
-      "two": "要试试我们的晚餐吗？都一样的"
+      ]
     },
     "answer": {
-      "output": "试唔试下我哋嘅晚餐啦？一样嘅啫"
+      "target_sub_punctuated": "试唔试下我哋嘅晚餐啦？一样嘅啫"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "光天白日，吃什么鬼晚餐？",
+      "target_subs": [
         "日光日白食乜鬼嘢晚餐啊"
-      ],
-      "two": "光天白日，吃什么鬼晚餐？"
+      ]
     },
     "answer": {
-      "output": "日光日白，食乜鬼嘢晚餐啊？"
+      "target_sub_punctuated": "日光日白，食乜鬼嘢晚餐啊？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "唉，说是说晚餐，还不就是午餐？",
+      "target_subs": [
         "系",
         "个名叫晚餐啫",
         "其实唔系真系午餐"
-      ],
-      "two": "唉，说是说晚餐，还不就是午餐？"
+      ]
     },
     "answer": {
-      "output": "系，个名叫晚餐啫，其实唔系真系午餐？"
+      "target_sub_punctuated": "系，个名叫晚餐啫，其实唔系真系午餐？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "好吧好吧，拜托！两份晚餐！快！",
+      "target_subs": [
         "好啦好啦",
         "怕咗你啦",
         "要两份晚餐啦",
         "快啲手啊"
-      ],
-      "two": "好吧好吧，拜托！两份晚餐！快！"
+      ]
     },
     "answer": {
-      "output": "好啦好啦，怕咗你啦！要两份晚餐啦！快啲手啊！"
+      "target_sub_punctuated": "好啦好啦，怕咗你啦！要两份晚餐啦！快啲手啊！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "要快吗？那得吃快餐了！",
+      "target_subs": [
         "想快",
         "想快就要快餐啊"
-      ],
-      "two": "要快吗？那得吃快餐了！"
+      ]
     },
     "answer": {
-      "output": "想快？想快就要快餐啊！"
+      "target_sub_punctuated": "想快？想快就要快餐啊！"
     },
     "difficulty": 1,
     "verified": true

--- a/test/data/mlamd/output/yue-Hans_transcribe/lang/yue_zho/transcription/punctuation/mps.json
+++ b/test/data/mlamd/output/yue-Hans_transcribe/lang/yue_zho/transcription/punctuation/mps.json
@@ -1,28 +1,28 @@
 [
   {
     "query": {
-      "one": [
+      "ref_sub": "沿荔枝角道直出大角咀道",
+      "target_subs": [
         "沿住荔枝角度",
         "直出大角咀度"
-      ],
-      "two": "沿荔枝角道直出大角咀道"
+      ]
     },
     "answer": {
-      "output": "沿住荔枝角度直出大角咀度"
+      "target_sub_punctuated": "沿住荔枝角度直出大角咀度"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "经好彩酒家左转花园街乐园牛丸王⋯",
+      "target_subs": [
         "经过好彩走家",
         "再左转返出花园街",
         "乐园牛园望对上"
-      ],
-      "two": "经好彩酒家左转花园街乐园牛丸王⋯"
+      ]
     },
     "answer": {
-      "output": "经过好彩走家再左转返出花园街乐园牛园望对上⋯"
+      "target_sub_punctuated": "经过好彩走家再左转返出花园街乐园牛园望对上⋯"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -30,96 +30,96 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "更正一下：",
+      "target_subs": [
         "都系唔好"
-      ],
-      "two": "更正一下："
+      ]
     },
     "answer": {
-      "output": "都系唔好："
+      "target_sub_punctuated": "都系唔好："
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "转呀，转⋯再更正一下：",
+      "target_subs": [
         "转下",
         "转下",
         "都系唔好"
-      ],
-      "two": "转呀，转⋯再更正一下："
+      ]
     },
     "answer": {
-      "output": "转下，转下⋯都系唔好："
+      "target_sub_punctuated": "转下，转下⋯都系唔好："
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "直出亚皆老街跨过火车桥右转太平道",
+      "target_subs": [
         "都系出返去阿街路街飞过火车桥",
         "右转入太平道"
-      ],
-      "two": "直出亚皆老街跨过火车桥右转太平道"
+      ]
     },
     "answer": {
-      "output": "都系出返去阿街路街飞过火车桥右转入太平道"
+      "target_sub_punctuated": "都系出返去阿街路街飞过火车桥右转入太平道"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "再右拐窝打老道向女人街方向飞⋯",
+      "target_subs": [
         "再右转抹返出去窝打炉道",
         "向女人街方向飞下下"
-      ],
-      "two": "再右拐窝打老道向女人街方向飞⋯"
+      ]
     },
     "answer": {
-      "output": "再右转抹返出去窝打炉道向女人街方向飞下下⋯"
+      "target_sub_punctuated": "再右转抹返出去窝打炉道向女人街方向飞下下⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "飞呀，飞⋯",
+      "target_subs": [
         "飞下",
         "飞下"
-      ],
-      "two": "飞呀，飞⋯"
+      ]
     },
     "answer": {
-      "output": "飞下，飞下⋯"
+      "target_sub_punctuated": "飞下，飞下⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "也就是在麦太右边额角上⋯",
+      "target_subs": [
         "亦即系麦太右边云晶对上"
-      ],
-      "two": "也就是在麦太右边额角上⋯"
+      ]
     },
     "answer": {
-      "output": "亦即系麦太右边云晶对上⋯"
+      "target_sub_punctuated": "亦即系麦太右边云晶对上⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "更正：左边额角上⋯",
+      "target_subs": [
         "都系唔好",
         "左边云晶对上"
-      ],
-      "two": "更正：左边额角上⋯"
+      ]
     },
     "answer": {
-      "output": "都系唔好：左边云晶对上⋯"
+      "target_sub_punctuated": "都系唔好：左边云晶对上⋯"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -127,15 +127,15 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "转呀，转⋯",
+      "target_subs": [
         "转下",
         "转下",
         "转下噉"
-      ],
-      "two": "转呀，转⋯"
+      ]
     },
     "answer": {
-      "output": "转下，转下，转下噉⋯"
+      "target_sub_punctuated": "转下，转下，转下噉⋯"
     },
     "difficulty": 2,
     "few_shot": true,
@@ -143,93 +143,93 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "脑海中同时出现即将诞生的儿子容貌⋯",
+      "target_subs": [
         "而脑入面亦即时出现咗快要出世个仔嘅样"
-      ],
-      "two": "脑海中同时出现即将诞生的儿子容貌⋯"
+      ]
     },
     "answer": {
-      "output": "而脑入面亦即时出现咗快要出世个仔嘅样⋯"
+      "target_sub_punctuated": "而脑入面亦即时出现咗快要出世个仔嘅样⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "希望他好聪明，读书好叻！",
+      "target_subs": [
         "希望佢好聪明",
         "读书好叻"
-      ],
-      "two": "希望他好聪明，读书好叻！"
+      ]
     },
     "answer": {
-      "output": "希望佢好聪明，读书好叻！"
+      "target_sub_punctuated": "希望佢好聪明，读书好叻！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "于是她向胶兜补充说：",
+      "target_subs": [
         "于是佢对住胶兜补充噉话"
-      ],
-      "two": "于是她向胶兜补充说："
+      ]
     },
     "answer": {
-      "output": "于是佢对住胶兜补充噉话："
+      "target_sub_punctuated": "于是佢对住胶兜补充噉话："
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "或者读书唔叻，工作叻呢？",
+      "target_subs": [
         "或者读书唔叻",
         "出嚟做嘢叻啦"
-      ],
-      "two": "或者读书唔叻，工作叻呢？"
+      ]
     },
     "answer": {
-      "output": "或者读书唔叻，出嚟做嘢叻啦？"
+      "target_sub_punctuated": "或者读书唔叻，出嚟做嘢叻啦？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "又或者⋯",
+      "target_subs": [
         "又或者呢"
-      ],
-      "two": "又或者⋯"
+      ]
     },
     "answer": {
-      "output": "又或者呢⋯"
+      "target_sub_punctuated": "又或者呢⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "又或者好靓仔，好靓仔",
+      "target_subs": [
         "又或者系好靓仔好靓仔"
-      ],
-      "two": "又或者好靓仔，好靓仔"
+      ]
     },
     "answer": {
-      "output": "又或者系好靓仔，好靓仔"
+      "target_sub_punctuated": "又或者系好靓仔，好靓仔"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "跟周润发，梁朝伟那么靓仔！",
+      "target_subs": [
         "好似周润发同埋梁朝伟咁靓仔"
-      ],
-      "two": "跟周润发，梁朝伟那么靓仔！"
+      ]
     },
     "answer": {
-      "output": "好似周润发，同埋梁朝伟咁靓仔！"
+      "target_sub_punctuated": "好似周润发，同埋梁朝伟咁靓仔！"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -237,27 +237,27 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "胶兜仍然在转，毫无点头迹象",
+      "target_subs": [
         "胶兜依然系噉喺度转",
         "好似一啲应承嘅迹象都冇"
-      ],
-      "two": "胶兜仍然在转，毫无点头迹象"
+      ]
     },
     "answer": {
-      "output": "胶兜依然系噉喺度转，好似一啲应承嘅迹象都冇"
+      "target_sub_punctuated": "胶兜依然系噉喺度转，好似一啲应承嘅迹象都冇"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "赶忙趁胶兜落地前另许一个愿望：",
+      "target_subs": [
         "嗱嗱嗱喺胶兜未落地之前起过另外一个愿望"
-      ],
-      "two": "赶忙趁胶兜落地前另许一个愿望："
+      ]
     },
     "answer": {
-      "output": "嗱嗱嗱喺胶兜未落地之前起过另外一个愿望："
+      "target_sub_punctuated": "嗱嗱嗱喺胶兜未落地之前起过另外一个愿望："
     },
     "difficulty": 1,
     "few_shot": true,
@@ -265,14 +265,14 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "唔聪明唔靓仔也算了，只要福星高照",
+      "target_subs": [
         "就算唔系咁聪明同咁靓仔",
         "只要复星高照"
-      ],
-      "two": "唔聪明唔靓仔也算了，只要福星高照"
+      ]
     },
     "answer": {
-      "output": "就算唔系咁聪明同咁靓仔，只要复星高照"
+      "target_sub_punctuated": "就算唔系咁聪明同咁靓仔，只要复星高照"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -280,40 +280,40 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "一世够运，逢凶化吉！",
+      "target_subs": [
         "一世救运",
         "乜嘢事都逢凶化㗎喇"
-      ],
-      "two": "一世够运，逢凶化吉！"
+      ]
     },
     "answer": {
-      "output": "一世救运，乜嘢事都逢凶化㗎喇！"
+      "target_sub_punctuated": "一世救运，乜嘢事都逢凶化㗎喇！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "但总得要叻仔呀！",
+      "target_subs": [
         "但系都要叻仔先得㗎"
-      ],
-      "two": "但总得要叻仔呀！"
+      ]
     },
     "answer": {
-      "output": "但系都要叻仔先得㗎！"
+      "target_sub_punctuated": "但系都要叻仔先得㗎！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "最后，胶兜「嘀督」一声落地",
+      "target_subs": [
         "最后胶兜滴嘟一声咁落地"
-      ],
-      "two": "最后，胶兜「嘀督」一声落地"
+      ]
     },
     "answer": {
-      "output": "最后，胶兜「滴嘟」一声咁落地"
+      "target_sub_punctuated": "最后，胶兜「滴嘟」一声咁落地"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -321,29 +321,29 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "嘀督？嘀督，就是答应了",
+      "target_subs": [
         "滴嘟",
         "滴嘟㖞",
         "即系应承啦"
-      ],
-      "two": "嘀督？嘀督，就是答应了"
+      ]
     },
     "answer": {
-      "output": "滴嘟？滴嘟㖞，即系应承啦"
+      "target_sub_punctuated": "滴嘟？滴嘟㖞，即系应承啦"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "麦太想，这次走运了！",
+      "target_subs": [
         "麦太心谂",
         "今次冇死喇"
-      ],
-      "two": "麦太想，这次走运了！"
+      ]
     },
     "answer": {
-      "output": "麦太心谂，今次冇死喇！"
+      "target_sub_punctuated": "麦太心谂，今次冇死喇！"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -351,54 +351,54 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "可是答应了些什么呢？",
+      "target_subs": [
         "但你应承咗啲咩呢"
-      ],
-      "two": "可是答应了些什么呢？"
+      ]
     },
     "answer": {
-      "output": "但你应承咗啲咩呢？"
+      "target_sub_punctuated": "但你应承咗啲咩呢？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "叻仔？好运？",
+      "target_subs": [
         "叻仔",
         "好运"
-      ],
-      "two": "叻仔？好运？"
+      ]
     },
     "answer": {
-      "output": "叻仔？好运？"
+      "target_sub_punctuated": "叻仔？好运？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "还是似周润发？",
+      "target_subs": [
         "定系话自周人烦啊"
-      ],
-      "two": "还是似周润发？"
+      ]
     },
     "answer": {
-      "output": "定系话自周人烦啊？"
+      "target_sub_punctuated": "定系话自周人烦啊？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "不行，胶胶声，多难听！",
+      "target_subs": [
         "都系唔好",
         "胶胶声咁难听"
-      ],
-      "two": "不行，胶胶声，多难听！"
+      ]
     },
     "answer": {
-      "output": "都系唔好，胶胶声，咁难听！"
+      "target_sub_punctuated": "都系唔好，胶胶声，咁难听！"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -406,186 +406,186 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "还是唤他麦兜！",
+      "target_subs": [
         "不如叫麦兜啦"
-      ],
-      "two": "还是唤他麦兜！"
+      ]
     },
     "answer": {
-      "output": "不如叫麦兜啦！"
+      "target_sub_punctuated": "不如叫麦兜啦！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "各位⋯",
+      "target_subs": [
         "各位"
-      ],
-      "two": "各位⋯"
+      ]
     },
     "answer": {
-      "output": "各位⋯"
+      "target_sub_punctuated": "各位⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我就是险些给定名麦胶的小朋友⋯",
+      "target_subs": [
         "我就系呢个差少少就叫做麦胶嘅小朋友"
-      ],
-      "two": "我就是险些给定名麦胶的小朋友⋯"
+      ]
     },
     "answer": {
-      "output": "我就系呢个差少少就叫做麦胶嘅小朋友⋯"
+      "target_sub_punctuated": "我就系呢个差少少就叫做麦胶嘅小朋友⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "麦兜！",
+      "target_subs": [
         "麦兜"
-      ],
-      "two": "麦兜！"
+      ]
     },
     "answer": {
-      "output": "麦兜！"
+      "target_sub_punctuated": "麦兜！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "麦太，没见面一阵",
+      "target_subs": [
         "咦",
         "麦太",
         "咩唔见你一排"
-      ],
-      "two": "麦太，没见面一阵"
+      ]
     },
     "answer": {
-      "output": "咦，麦太，咩唔见你一排"
+      "target_sub_punctuated": "咦，麦太，咩唔见你一排"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "怎么小腿粗起来了？",
+      "target_subs": [
         "个脚刮囊粗咗咁多呀"
-      ],
-      "two": "怎么小腿粗起来了？"
+      ]
     },
     "answer": {
-      "output": "个脚刮囊粗咗咁多呀？"
+      "target_sub_punctuated": "个脚刮囊粗咗咁多呀？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "可怜呀，每天扑来扑去⋯",
+      "target_subs": [
         "鬼咩",
         "日日扑嚟扑去"
-      ],
-      "two": "可怜呀，每天扑来扑去⋯"
+      ]
     },
     "answer": {
-      "output": "鬼咩，日日扑嚟扑去⋯"
+      "target_sub_punctuated": "鬼咩，日日扑嚟扑去⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "替儿子找幼稚园！",
+      "target_subs": [
         "同我仔揾幼稚园吖嘛"
-      ],
-      "two": "替儿子找幼稚园！"
+      ]
     },
     "answer": {
-      "output": "同我仔揾幼稚园吖嘛！"
+      "target_sub_punctuated": "同我仔揾幼稚园吖嘛！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "旧中侨国货楼上的⋯",
+      "target_subs": [
         "旧中桥百货公司楼上嗰间"
-      ],
-      "two": "旧中侨国货楼上的⋯"
+      ]
     },
     "answer": {
-      "output": "旧中桥百货公司楼上嗰间⋯"
+      "target_sub_punctuated": "旧中桥百货公司楼上嗰间⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "春田花花幼稚园？",
+      "target_subs": [
         "春田花花幼稚园呢"
-      ],
-      "two": "春田花花幼稚园？"
+      ]
     },
     "answer": {
-      "output": "春田花花幼稚园呢？"
+      "target_sub_punctuated": "春田花花幼稚园呢？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "就是座落界限街南昌街交界⋯",
+      "target_subs": [
         "就系坐落喺界限街同南昌街交界"
-      ],
-      "two": "就是座落界限街南昌街交界⋯"
+      ]
     },
     "answer": {
-      "output": "就系坐落喺界限街同南昌街交界⋯"
+      "target_sub_punctuated": "就系坐落喺界限街同南昌街交界⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "银城美食广场附近的⋯",
+      "target_subs": [
         "银城美食广场附近嗰间"
-      ],
-      "two": "银城美食广场附近的⋯"
+      ]
     },
     "answer": {
-      "output": "银城美食广场附近嗰间⋯"
+      "target_sub_punctuated": "银城美食广场附近嗰间⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "春田花花幼稚园？",
+      "target_subs": [
         "春田花花幼稚园呀"
-      ],
-      "two": "春田花花幼稚园？"
+      ]
     },
     "answer": {
-      "output": "春田花花幼稚园呀？"
+      "target_sub_punctuated": "春田花花幼稚园呀？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "对！深水埗地铁站步行不用10分钟！",
+      "target_subs": [
         "系呀",
         "深水埗地铁站口行过去唔使十分钟呀"
-      ],
-      "two": "对！深水埗地铁站步行不用10分钟！"
+      ]
     },
     "answer": {
-      "output": "系呀！深水埗地铁站口行过去唔使十分钟呀！"
+      "target_sub_punctuated": "系呀！深水埗地铁站口行过去唔使十分钟呀！"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -593,201 +593,201 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "春田花花幼稚园，师资优良⋯",
+      "target_subs": [
         "春田花花幼稚园",
         "诗诗优良"
-      ],
-      "two": "春田花花幼稚园，师资优良⋯"
+      ]
     },
     "answer": {
-      "output": "春田花花幼稚园，诗诗优良⋯"
+      "target_sub_punctuated": "春田花花幼稚园，诗诗优良⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "而且还有西人教英文！",
+      "target_subs": [
         "仲系西人教英文添㗎"
-      ],
-      "two": "而且还有西人教英文！"
+      ]
     },
     "answer": {
-      "output": "仲系西人教英文添㗎！"
+      "target_sub_punctuated": "仲系西人教英文添㗎！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "西人教英文？",
+      "target_subs": [
         "咦",
         "西人教英文"
-      ],
-      "two": "西人教英文？"
+      ]
     },
     "answer": {
-      "output": "咦，西人教英文？"
+      "target_sub_punctuated": "咦，西人教英文？"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "是呀！",
+      "target_subs": [
         "系呀"
-      ],
-      "two": "是呀！"
+      ]
     },
     "answer": {
-      "output": "系呀！"
+      "target_sub_punctuated": "系呀！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "春田花花，确有好多西人呀！",
+      "target_subs": [
         "春田花花",
         "真系好多西人㗎"
-      ],
-      "two": "春田花花，确有好多西人呀！"
+      ]
     },
     "answer": {
-      "output": "春田花花，真系好多西人㗎！"
+      "target_sub_punctuated": "春田花花，真系好多西人㗎！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "这个猪样白兔小朋友⋯",
+      "target_subs": [
         "呢个扮紧白兔猪样嘅小朋友"
-      ],
-      "two": "这个猪样白兔小朋友⋯"
+      ]
     },
     "answer": {
-      "output": "呢个扮紧白兔猪样嘅小朋友⋯"
+      "target_sub_punctuated": "呢个扮紧白兔猪样嘅小朋友⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "横看竖看也不像发哥伟仔的一个⋯",
+      "target_subs": [
         "即系横睇掂睇都唔似发哥或者",
         "位仔嗰个呢"
-      ],
-      "two": "横看竖看也不像发哥伟仔的一个⋯"
+      ]
     },
     "answer": {
-      "output": "即系横睇掂睇都唔似发哥或者位仔嗰个呢⋯"
+      "target_sub_punctuated": "即系横睇掂睇都唔似发哥或者位仔嗰个呢⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "就是我，麦兜",
+      "target_subs": [
         "就系我",
         "麦兜"
-      ],
-      "two": "就是我，麦兜"
+      ]
     },
     "answer": {
-      "output": "就系我，麦兜"
+      "target_sub_punctuated": "就系我，麦兜"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "这么多年来⋯",
+      "target_subs": [
         "所以咁多年嚟"
-      ],
-      "two": "这么多年来⋯"
+      ]
     },
     "answer": {
-      "output": "所以咁多年嚟⋯"
+      "target_sub_punctuated": "所以咁多年嚟⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "蛋挞！　　蛋挞！",
+      "target_subs": [
         "大湖荒岩宅"
-      ],
-      "two": "蛋挞！　　蛋挞！"
+      ]
     },
     "answer": {
-      "output": "大湖荒岩宅"
+      "target_sub_punctuated": "大湖荒岩宅"
     },
     "difficulty": 3,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "荔芋火鸭札！　　荔芋火鸭札！",
+      "target_subs": [
         "湾吉校坟交涉设"
-      ],
-      "two": "荔芋火鸭札！　　荔芋火鸭札！"
+      ]
     },
     "answer": {
-      "output": "湾吉校坟交涉设"
+      "target_sub_punctuated": "湾吉校坟交涉设"
     },
     "difficulty": 3,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "也不能忘记校训九十八！",
+      "target_subs": [
         "都唔好湾吉校坟交涉白"
-      ],
-      "two": "也不能忘记校训九十八！"
+      ]
     },
     "answer": {
-      "output": "都唔好湾吉校坟交涉白！"
+      "target_sub_punctuated": "都唔好湾吉校坟交涉白！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "好！各位同学⋯",
+      "target_subs": [
         "嗰个位同学"
-      ],
-      "two": "好！各位同学⋯"
+      ]
     },
     "answer": {
-      "output": "嗰个位同学⋯"
+      "target_sub_punctuated": "嗰个位同学⋯"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "一个重要主题：",
+      "target_subs": [
         "一个可重要嘅主题"
-      ],
-      "two": "一个重要主题："
+      ]
     },
     "answer": {
-      "output": "一个可重要嘅主题："
+      "target_sub_punctuated": "一个可重要嘅主题："
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "小朋友，这个月你们交过学费没有？",
+      "target_subs": [
         "小朋友",
         "你哋今个月交咗学费咩呀"
-      ],
-      "two": "小朋友，这个月你们交过学费没有？"
+      ]
     },
     "answer": {
-      "output": "小朋友，你哋今个月交咗学费咩呀？"
+      "target_sub_punctuated": "小朋友，你哋今个月交咗学费咩呀？"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -795,13 +795,13 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "交过了！",
+      "target_subs": [
         "交"
-      ],
-      "two": "交过了！"
+      ]
     },
     "answer": {
-      "output": "交！"
+      "target_sub_punctuated": "交！"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -809,15 +809,15 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "太好了！大家去上堂吧",
+      "target_subs": [
         "哎",
         "好在",
         "噉大家可以返去上堂喇"
-      ],
-      "two": "太好了！大家去上堂吧"
+      ]
     },
     "answer": {
-      "output": "哎，好在！噉大家可以返去上堂喇"
+      "target_sub_punctuated": "哎，好在！噉大家可以返去上堂喇"
     },
     "difficulty": 2,
     "few_shot": true,
@@ -825,54 +825,54 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "可是，对我和我一班同学",
+      "target_subs": [
         "但系对于我同埋我班同学仔嚟讲"
-      ],
-      "two": "可是，对我和我一班同学"
+      ]
     },
     "answer": {
-      "output": "但系，对于我同埋我班同学仔嚟讲"
+      "target_sub_punctuated": "但系，对于我同埋我班同学仔嚟讲"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "这儿是我们最快乐，最美丽的乐园⋯",
+      "target_subs": [
         "呢度系我哋最快乐",
         "最美丽嘅乐园"
-      ],
-      "two": "这儿是我们最快乐，最美丽的乐园⋯"
+      ]
     },
     "answer": {
-      "output": "呢度系我哋最快乐，最美丽嘅乐园⋯"
+      "target_sub_punctuated": "呢度系我哋最快乐，最美丽嘅乐园⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "⋯还有一个很疼我们",
+      "target_subs": [
         "仲有一个好疼我哋"
-      ],
-      "two": "⋯还有一个很疼我们"
+      ]
     },
     "answer": {
-      "output": "⋯仲有一个好疼我哋"
+      "target_sub_punctuated": "⋯仲有一个好疼我哋"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "就是有点游魂的Miss Chan",
+      "target_subs": [
         "不过就有少少失魂嘅班主有Miss",
         "Chan"
-      ],
-      "two": "就是有点游魂的Miss Chan"
+      ]
     },
     "answer": {
-      "output": "不过就有少少失魂嘅班主有Miss Chan"
+      "target_sub_punctuated": "不过就有少少失魂嘅班主有Miss Chan"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -880,125 +880,125 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我们现在开始点名",
+      "target_subs": [
         "好喇",
         "我哋而家开始点名"
-      ],
-      "two": "我们现在开始点名"
+      ]
     },
     "answer": {
-      "output": "好喇，我哋而家开始点名"
+      "target_sub_punctuated": "好喇，我哋而家开始点名"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "麦唛同学！　　到！",
+      "target_subs": [
         "麦麦同学",
         "到"
-      ],
-      "two": "麦唛同学！　　到！"
+      ]
     },
     "answer": {
-      "output": "麦麦同学！　　到！"
+      "target_sub_punctuated": "麦麦同学！　　到！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "亚辉同学！　　到！",
+      "target_subs": [
         "阿辉同学",
         "到"
-      ],
-      "two": "亚辉同学！　　到！"
+      ]
     },
     "answer": {
-      "output": "阿辉同学！　　到！"
+      "target_sub_punctuated": "阿辉同学！　　到！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "菇时同学！　　到！",
+      "target_subs": [
         "Boosie同学",
         "到"
-      ],
-      "two": "菇时同学！　　到！"
+      ]
     },
     "answer": {
-      "output": "Boosie同学！　　到！"
+      "target_sub_punctuated": "Boosie同学！　　到！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "得巴同学！　　到！",
+      "target_subs": [
         "德巴同学",
         "到"
-      ],
-      "two": "得巴同学！　　到！"
+      ]
     },
     "answer": {
-      "output": "德巴同学！　　到！"
+      "target_sub_punctuated": "德巴同学！　　到！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "阿May同学！　　到！",
+      "target_subs": [
         "阿May同学",
         "到"
-      ],
-      "two": "阿May同学！　　到！"
+      ]
     },
     "answer": {
-      "output": "阿May同学！　　到！"
+      "target_sub_punctuated": "阿May同学！　　到！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "阿June同学！　　到！",
+      "target_subs": [
         "阿June同学",
         "到"
-      ],
-      "two": "阿June同学！　　到！"
+      ]
     },
     "answer": {
-      "output": "阿June同学！　　到！"
+      "target_sub_punctuated": "阿June同学！　　到！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "阿May同学！",
+      "target_subs": [
         "阿May同学"
-      ],
-      "two": "阿May同学！"
+      ]
     },
     "answer": {
-      "output": "阿May同学！"
+      "target_sub_punctuated": "阿May同学！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "Miss Chan，我点过两次了！",
+      "target_subs": [
         "Miss",
         "Chan你点咗我两次喇"
-      ],
-      "two": "Miss Chan，我点过两次了！"
+      ]
     },
     "answer": {
-      "output": "Miss Chan，你点咗我两次喇！"
+      "target_sub_punctuated": "Miss Chan，你点咗我两次喇！"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -1006,56 +1006,56 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "呀，真的吗？",
+      "target_subs": [
         "啊",
         "系咩"
-      ],
-      "two": "呀，真的吗？"
+      ]
     },
     "answer": {
-      "output": "啊，系咩？"
+      "target_sub_punctuated": "啊，系咩？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我们现在继续点名",
+      "target_subs": [
         "好",
         "我哋而家继续点名"
-      ],
-      "two": "我们现在继续点名"
+      ]
     },
     "answer": {
-      "output": "好，我哋而家继续点名"
+      "target_sub_punctuated": "好，我哋而家继续点名"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "菇时同学！　　到！",
+      "target_subs": [
         "川明同学",
         "到"
-      ],
-      "two": "菇时同学！　　到！"
+      ]
     },
     "answer": {
-      "output": "川明同学！　　到！"
+      "target_sub_punctuated": "川明同学！　　到！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "还有谁没点过吗？",
+      "target_subs": [
         "好",
         "仲有边个未点"
-      ],
-      "two": "还有谁没点过吗？"
+      ]
     },
     "answer": {
-      "output": "好，仲有边个未点？"
+      "target_sub_punctuated": "好，仲有边个未点？"
     },
     "difficulty": 2,
     "few_shot": true,
@@ -1063,81 +1063,81 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "麦兜！",
+      "target_subs": [
         "猫",
         "噢"
-      ],
-      "two": "麦兜！"
+      ]
     },
     "answer": {
-      "output": "猫噢！"
+      "target_sub_punctuated": "猫噢！"
     },
     "difficulty": 3,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "麦兜同学！",
+      "target_subs": [
         "麦兜同学"
-      ],
-      "two": "麦兜同学！"
+      ]
     },
     "answer": {
-      "output": "麦兜同学！"
+      "target_sub_punctuated": "麦兜同学！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "麦唛呀，即是呢⋯",
+      "target_subs": [
         "妈妈啊",
         "麦兜同学",
         "即系呢"
-      ],
-      "two": "麦唛呀，即是呢⋯"
+      ]
     },
     "answer": {
-      "output": "妈妈啊，麦兜同学，即系呢⋯"
+      "target_sub_punctuated": "妈妈啊，麦兜同学，即系呢⋯"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我好像觉得呢⋯",
+      "target_subs": [
         "我个心总系仁住仁住"
-      ],
-      "two": "我好像觉得呢⋯"
+      ]
     },
     "answer": {
-      "output": "我个心总系仁住仁住⋯"
+      "target_sub_punctuated": "我个心总系仁住仁住⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "其实我正在思考一个学术问题：",
+      "target_subs": [
         "其实我系喺度思考紧一啲学术性嘅问题"
-      ],
-      "two": "其实我正在思考一个学术问题："
+      ]
     },
     "answer": {
-      "output": "其实我系喺度思考紧一啲学术性嘅问题："
+      "target_sub_punctuated": "其实我系喺度思考紧一啲学术性嘅问题："
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "橙，为什么会是「屙－烂－煮」呢？",
+      "target_subs": [
         "点解橙叫Orange呢"
-      ],
-      "two": "橙，为什么会是「屙－烂－煮」呢？"
+      ]
     },
     "answer": {
-      "output": "点解橙叫「Orange」呢？"
+      "target_sub_punctuated": "点解橙叫「Orange」呢？"
     },
     "difficulty": 2,
     "few_shot": true,
@@ -1145,28 +1145,28 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈说吃橙可通大便",
+      "target_subs": [
         "妈妈话食橙会通大",
         "变"
-      ],
-      "two": "妈妈说吃橙可通大便"
+      ]
     },
     "answer": {
-      "output": "妈妈话食橙会通大变"
+      "target_sub_punctuated": "妈妈话食橙会通大变"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「屙」这个我明白，可是「烂－煮」呢？",
+      "target_subs": [
         "噢",
         "呢个我明白",
         "但系橙呢"
-      ],
-      "two": "「屙」这个我明白，可是「烂－煮」呢？"
+      ]
     },
     "answer": {
-      "output": "「噢」呢个我明白，但系「橙」呢？"
+      "target_sub_punctuated": "「噢」呢个我明白，但系「橙」呢？"
     },
     "difficulty": 2,
     "few_shot": true,
@@ -1174,15 +1174,15 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "还有这个「芭－娜－哪」香蕉",
+      "target_subs": [
         "仲有呢个啊",
         "芭拉娜啊",
         "香蕉啊"
-      ],
-      "two": "还有这个「芭－娜－哪」香蕉"
+      ]
     },
     "answer": {
-      "output": "仲有呢个啊「芭－拉－娜」啊香蕉啊"
+      "target_sub_punctuated": "仲有呢个啊「芭－拉－娜」啊香蕉啊"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -1190,13 +1190,13 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "为什么雨伞又会是「暗－芭－娜－哪」呢？",
+      "target_subs": [
         "点解雨姐会叫做暗芭拉娜呢"
-      ],
-      "two": "为什么雨伞又会是「暗－芭－娜－哪」呢？"
+      ]
     },
     "answer": {
-      "output": "点解雨姐会叫做「暗－芭－拉－娜」呢？"
+      "target_sub_punctuated": "点解雨姐会叫做「暗－芭－拉－娜」呢？"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -1204,15 +1204,15 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我「暗」的「暗」掉一条蕉",
+      "target_subs": [
         "嗱",
         "我暗啦",
         "噉我暗嗰条香蕉"
-      ],
-      "two": "我「暗」的「暗」掉一条蕉"
+      ]
     },
     "answer": {
-      "output": "嗱，我「暗」啦，噉我「暗」嗰条香蕉"
+      "target_sub_punctuated": "嗱，我「暗」啦，噉我「暗」嗰条香蕉"
     },
     "difficulty": 2,
     "few_shot": true,
@@ -1220,28 +1220,28 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "至多是屙烂煮，怎么会下起雨来呢？",
+      "target_subs": [
         "至多会Orange啫",
         "点解会搞到落雨呢"
-      ],
-      "two": "至多是屙烂煮，怎么会下起雨来呢？"
+      ]
     },
     "answer": {
-      "output": "至多会Orange啫，点解会搞到落雨呢？"
+      "target_sub_punctuated": "至多会Orange啫，点解会搞到落雨呢？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我想，有天我念完幼稚园",
+      "target_subs": [
         "我谂",
         "到我读完幼稚园"
-      ],
-      "two": "我想，有天我念完幼稚园"
+      ]
     },
     "answer": {
-      "output": "我谂，到我读完幼稚园"
+      "target_sub_punctuated": "我谂，到我读完幼稚园"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -1249,79 +1249,79 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "升小学，上中学",
+      "target_subs": [
         "识埋小学",
         "上到中学"
-      ],
-      "two": "升小学，上中学"
+      ]
     },
     "answer": {
-      "output": "识埋小学，上到中学"
+      "target_sub_punctuated": "识埋小学，上到中学"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "再念大学⋯",
+      "target_subs": [
         "再入埋大学"
-      ],
-      "two": "再念大学⋯"
+      ]
     },
     "answer": {
-      "output": "再入埋大学⋯"
+      "target_sub_punctuated": "再入埋大学⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我知道我会明白一切！",
+      "target_subs": [
         "我谂我乜都会明白晒"
-      ],
-      "two": "我知道我会明白一切！"
+      ]
     },
     "answer": {
-      "output": "我谂我乜都会明白晒！"
+      "target_sub_punctuated": "我谂我乜都会明白晒！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那时候⋯",
+      "target_subs": [
         "到嗰阵"
-      ],
-      "two": "那时候⋯"
+      ]
     },
     "answer": {
-      "output": "到嗰阵⋯"
+      "target_sub_punctuated": "到嗰阵⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我买所房子给妈妈！",
+      "target_subs": [
         "我买层楼畀我妈妈"
-      ],
-      "two": "我买所房子给妈妈！"
+      ]
     },
     "answer": {
-      "output": "我买层楼畀我妈妈！"
+      "target_sub_punctuated": "我买层楼畀我妈妈！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "幼稚园楼下，由校长兼营的茶餐厅",
+      "target_subs": [
         "喺幼稚园楼下校长兼营嘅间茶餐厅"
-      ],
-      "two": "幼稚园楼下，由校长兼营的茶餐厅"
+      ]
     },
     "answer": {
-      "output": "喺幼稚园楼下，校长兼营嘅间茶餐厅"
+      "target_sub_punctuated": "喺幼稚园楼下，校长兼营嘅间茶餐厅"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -1329,14 +1329,14 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "鱼蛋粗面，麻烦你　　粗面买光了",
+      "target_subs": [
         "唔该鱼蛋粗啊",
         "冇粗面噃"
-      ],
-      "two": "鱼蛋粗面，麻烦你　　粗面买光了"
+      ]
     },
     "answer": {
-      "output": "唔该，鱼蛋粗啊　　冇粗面噃"
+      "target_sub_punctuated": "唔该，鱼蛋粗啊　　冇粗面噃"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -1344,15 +1344,15 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那样子⋯来碗鱼蛋河粉吧　　鱼蛋买光了",
+      "target_subs": [
         "噉啊",
         "要碗鱼蛋好啊",
         "冇鱼蛋噃"
-      ],
-      "two": "那样子⋯来碗鱼蛋河粉吧　　鱼蛋买光了"
+      ]
     },
     "answer": {
-      "output": "噉啊⋯要碗鱼蛋好啊　　冇鱼蛋噃"
+      "target_sub_punctuated": "噉啊⋯要碗鱼蛋好啊　　冇鱼蛋噃"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -1360,30 +1360,30 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那么⋯金钱肚粗面好了　　粗面买光了",
+      "target_subs": [
         "噉啊",
         "要金钱透粗啊",
         "冇粗面噃"
-      ],
-      "two": "那么⋯金钱肚粗面好了　　粗面买光了"
+      ]
     },
     "answer": {
-      "output": "噉啊⋯要金钱透粗啊　　冇粗面噃"
+      "target_sub_punctuated": "噉啊⋯要金钱透粗啊　　冇粗面噃"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那么要鱼蛋油面吧　　鱼蛋买光了",
+      "target_subs": [
         "噉啊",
         "咁要鱼蛋油面啊",
         "冇鱼蛋噃"
-      ],
-      "two": "那么要鱼蛋油面吧　　鱼蛋买光了"
+      ]
     },
     "answer": {
-      "output": "噉啊咁要鱼蛋油面啊　　冇鱼蛋噃"
+      "target_sub_punctuated": "噉啊咁要鱼蛋油面啊　　冇鱼蛋噃"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -1391,82 +1391,82 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "怎么都买光了？",
+      "target_subs": [
         "乜样样都冇嘅"
-      ],
-      "two": "怎么都买光了？"
+      ]
     },
     "answer": {
-      "output": "乜样样都冇嘅？"
+      "target_sub_punctuated": "乜样样都冇嘅？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "来个墨鱼丸粗面吧　　粗面买光了",
+      "target_subs": [
         "噉要蜜丸粗啊",
         "冇粗面噃"
-      ],
-      "two": "来个墨鱼丸粗面吧　　粗面买光了"
+      ]
     },
     "answer": {
-      "output": "噉要蜜丸粗啊　　冇粗面噃"
+      "target_sub_punctuated": "噉要蜜丸粗啊　　冇粗面噃"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "又买光了？",
+      "target_subs": [
         "又冇啊"
-      ],
-      "two": "又买光了？"
+      ]
     },
     "answer": {
-      "output": "又冇啊？"
+      "target_sub_punctuated": "又冇啊？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "麻烦来碗鱼蛋濑吧　　鱼蛋买光了",
+      "target_subs": [
         "噉唔该畀碗鱼蛋奶啊",
         "冇鱼蛋噃"
-      ],
-      "two": "麻烦来碗鱼蛋濑吧　　鱼蛋买光了"
+      ]
     },
     "answer": {
-      "output": "噉唔该畀碗鱼蛋奶啊　　冇鱼蛋噃"
+      "target_sub_punctuated": "噉唔该畀碗鱼蛋奶啊　　冇鱼蛋噃"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "麦兜呀，鱼蛋跟粗面都买光了",
+      "target_subs": [
         "麦兜啊",
         "佢哋啲鱼蛋同粗面卖晒㗎啦"
-      ],
-      "two": "麦兜呀，鱼蛋跟粗面都买光了"
+      ]
     },
     "answer": {
-      "output": "麦兜啊，佢哋啲鱼蛋同粗面卖晒㗎啦"
+      "target_sub_punctuated": "麦兜啊，佢哋啲鱼蛋同粗面卖晒㗎啦"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "没有那些配搭吗？",
+      "target_subs": [
         "噢",
         "冇嗰啲配搭啊"
-      ],
-      "two": "没有那些配搭吗？"
+      ]
     },
     "answer": {
-      "output": "噢，冇嗰啲配搭啊？"
+      "target_sub_punctuated": "噢，冇嗰啲配搭啊？"
     },
     "difficulty": 2,
     "few_shot": true,
@@ -1474,14 +1474,14 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "麻烦你，净要鱼蛋吧　　鱼蛋买光了",
+      "target_subs": [
         "噉唔该净鱼蛋啊",
         "冇鱼蛋噃"
-      ],
-      "two": "麻烦你，净要鱼蛋吧　　鱼蛋买光了"
+      ]
     },
     "answer": {
-      "output": "噉唔该，净鱼蛋啊　　冇鱼蛋噃"
+      "target_sub_punctuated": "噉唔该，净鱼蛋啊　　冇鱼蛋噃"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -1489,14 +1489,14 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那么净要粗面呢？　　粗面买光了",
+      "target_subs": [
         "净粗面呢",
         "冇粗面噃"
-      ],
-      "two": "那么净要粗面呢？　　粗面买光了"
+      ]
     },
     "answer": {
-      "output": "净粗面呢？　　冇粗面噃"
+      "target_sub_punctuated": "净粗面呢？　　冇粗面噃"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -1504,135 +1504,135 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "看到这里⋯",
+      "target_subs": [
         "睇到呢度"
-      ],
-      "two": "看到这里⋯"
+      ]
     },
     "answer": {
-      "output": "睇到呢度⋯"
+      "target_sub_punctuated": "睇到呢度⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那时候我无忧无虑，万事无所谓－－",
+      "target_subs": [
         "果只我无忧无虑",
         "冇乜所谓"
-      ],
-      "two": "那时候我无忧无虑，万事无所谓－－"
+      ]
     },
     "answer": {
-      "output": "果只我无忧无虑，冇乜所谓－－"
+      "target_sub_punctuated": "果只我无忧无虑，冇乜所谓－－"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "鱼蛋买光了？那么粗面吧",
+      "target_subs": [
         "冇鱼蛋咩",
         "粗面都好啊"
-      ],
-      "two": "鱼蛋买光了？那么粗面吧"
+      ]
     },
     "answer": {
-      "output": "冇鱼蛋咩？粗面都好啊"
+      "target_sub_punctuated": "冇鱼蛋咩？粗面都好啊"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "麦兜，射呀！",
+      "target_subs": [
         "麦兜",
         "转身食啊"
-      ],
-      "two": "麦兜，射呀！"
+      ]
     },
     "answer": {
-      "output": "麦兜，转身食啊！"
+      "target_sub_punctuated": "麦兜，转身食啊！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "看著自己每天屙烂煮⋯",
+      "target_subs": [
         "睇住自己日日柯能处"
-      ],
-      "two": "看著自己每天屙烂煮⋯"
+      ]
     },
     "answer": {
-      "output": "睇住自己日日柯能处⋯"
+      "target_sub_punctuated": "睇住自己日日柯能处⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "每天长肉⋯",
+      "target_subs": [
         "日日掌肉"
-      ],
-      "two": "每天长肉⋯"
+      ]
     },
     "answer": {
-      "output": "日日掌肉⋯"
+      "target_sub_punctuated": "日日掌肉⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我感到充满力量！",
+      "target_subs": [
         "感到充满力量"
-      ],
-      "two": "我感到充满力量！"
+      ]
     },
     "answer": {
-      "output": "感到充满力量！"
+      "target_sub_punctuated": "感到充满力量！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "世界好美丽！",
+      "target_subs": [
         "世界好美丽"
-      ],
-      "two": "世界好美丽！"
+      ]
     },
     "answer": {
-      "output": "世界好美丽！"
+      "target_sub_punctuated": "世界好美丽！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "有一首歌，Miss Chan唱的好听",
+      "target_subs": [
         "有一首歌",
         "麦词春唱得好好听呀"
-      ],
-      "two": "有一首歌，Miss Chan唱的好听"
+      ]
     },
     "answer": {
-      "output": "有一首歌，麦词春唱得好好听呀"
+      "target_sub_punctuated": "有一首歌，麦词春唱得好好听呀"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "可每次我总唱成「屙」什么什么的⋯",
+      "target_subs": [
         "但系唱嚟唱去都系阿伦厨",
         "咁Ballana噉"
-      ],
-      "two": "可每次我总唱成「屙」什么什么的⋯"
+      ]
     },
     "answer": {
-      "output": "但系唱嚟唱去都系「阿伦厨」咁「Ballana」噉⋯"
+      "target_sub_punctuated": "但系唱嚟唱去都系「阿伦厨」咁「Ballana」噉⋯"
     },
     "difficulty": 2,
     "few_shot": true,
@@ -1640,44 +1640,44 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "是All Things Bright and Beautiful吧？",
+      "target_subs": [
         "系唔系All",
         "Things",
         "Bright",
         "and",
         "Beautiful呀"
-      ],
-      "two": "是All Things Bright and Beautiful吧？"
+      ]
     },
     "answer": {
-      "output": "系唔系All Things Bright and Beautiful呀？"
+      "target_sub_punctuated": "系唔系All Things Bright and Beautiful呀？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "是的，一切都好！",
+      "target_subs": [
         "系呀",
         "所有嘢都几好喇"
-      ],
-      "two": "是的，一切都好！"
+      ]
     },
     "answer": {
-      "output": "系呀，所有嘢都几好喇！"
+      "target_sub_punctuated": "系呀，所有嘢都几好喇！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "世上一切，一切一切⋯",
+      "target_subs": [
         "世上一切"
-      ],
-      "two": "世上一切，一切一切⋯"
+      ]
     },
     "answer": {
-      "output": "世上一切⋯"
+      "target_sub_punctuated": "世上一切⋯"
     },
     "difficulty": 2,
     "few_shot": true,
@@ -1685,7 +1685,8 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "所有那些，都好！",
+      "target_subs": [
         "所有嗰啲嘢",
         "都几好",
         "All",
@@ -1693,24 +1694,23 @@
         "Bright",
         "and",
         "Beautiful"
-      ],
-      "two": "所有那些，都好！"
+      ]
     },
     "answer": {
-      "output": "所有嗰啲嘢，都几好！All Things Bright and Beautiful"
+      "target_sub_punctuated": "所有嗰啲嘢，都几好！All Things Bright and Beautiful"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "一、二、三、四、五、六、七⋯",
+      "target_subs": [
         "1234567"
-      ],
-      "two": "一、二、三、四、五、六、七⋯"
+      ]
     },
     "answer": {
-      "output": "1, 2, 3, 4, 5, 6, 7⋯"
+      "target_sub_punctuated": "1, 2, 3, 4, 5, 6, 7⋯"
     },
     "difficulty": 2,
     "few_shot": true,
@@ -1718,79 +1718,79 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "多劳多得！",
+      "target_subs": [
         "多喽多得"
-      ],
-      "two": "多劳多得！"
+      ]
     },
     "answer": {
-      "output": "多喽多得！"
+      "target_sub_punctuated": "多喽多得！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "星期一至星期七⋯多劳多得！",
+      "target_subs": [
         "星期一至星期七多喽多得"
-      ],
-      "two": "星期一至星期七⋯多劳多得！"
+      ]
     },
     "answer": {
-      "output": "星期一至星期七⋯多喽多得！"
+      "target_sub_punctuated": "星期一至星期七⋯多喽多得！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "就是我妈妈麦太",
+      "target_subs": [
         "就系我妈妈",
         "麦太"
-      ],
-      "two": "就是我妈妈麦太"
+      ]
     },
     "answer": {
-      "output": "就系我妈妈麦太"
+      "target_sub_punctuated": "就系我妈妈麦太"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "一个女人背起整个世界！",
+      "target_subs": [
         "一个女人揹起成个世界"
-      ],
-      "two": "一个女人背起整个世界！"
+      ]
     },
     "answer": {
-      "output": "一个女人揹起成个世界！"
+      "target_sub_punctuated": "一个女人揹起成个世界！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "是的，我妈妈真的很厉害",
+      "target_subs": [
         "系呀",
         "我妈妈真系好犀利㗎"
-      ],
-      "two": "是的，我妈妈真的很厉害"
+      ]
     },
     "answer": {
-      "output": "系呀，我妈妈真系好犀利㗎"
+      "target_sub_punctuated": "系呀，我妈妈真系好犀利㗎"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "除了兼任保险，地产经纪及trading⋯",
+      "target_subs": [
         "除咗做保险地产经纪同埋trading之外"
-      ],
-      "two": "除了兼任保险，地产经纪及trading⋯"
+      ]
     },
     "answer": {
-      "output": "除咗做保险，地产经纪同埋trading之外⋯"
+      "target_sub_punctuated": "除咗做保险，地产经纪同埋trading之外⋯"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -1798,26 +1798,26 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "她还趁高科技热潮搞了个烹饪网站⋯",
+      "target_subs": [
         "佢仲趁住高科技热潮搞咗个煮𩠌嘅网站"
-      ],
-      "two": "她还趁高科技热潮搞了个烹饪网站⋯"
+      ]
     },
     "answer": {
-      "output": "佢仲趁住高科技热潮搞咗个煮𩠌嘅网站⋯"
+      "target_sub_punctuated": "佢仲趁住高科技热潮搞咗个煮𩠌嘅网站⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "www．麦太世界．com",
+      "target_subs": [
         "www.mcticege.com"
-      ],
-      "two": "www．麦太世界．com"
+      ]
     },
     "answer": {
-      "output": "www．mcticege．com"
+      "target_sub_punctuated": "www．mcticege．com"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -1825,373 +1825,373 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "她做的菜，同样厉害",
+      "target_subs": [
         "佢煮嘅𩠌一样咁犀利"
-      ],
-      "two": "她做的菜，同样厉害"
+      ]
     },
     "answer": {
-      "output": "佢煮嘅𩠌，一样咁犀利"
+      "target_sub_punctuated": "佢煮嘅𩠌，一样咁犀利"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "欢迎大家收看＜麦太世界＞",
+      "target_subs": [
         "欢迎大家收睇麦太世界"
-      ],
-      "two": "欢迎大家收看＜麦太世界＞"
+      ]
     },
     "answer": {
-      "output": "欢迎大家收睇＜麦太世界＞"
+      "target_sub_punctuated": "欢迎大家收睇＜麦太世界＞"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "今日为大家介绍一个⋯",
+      "target_subs": [
         "今日我为大家介绍个"
-      ],
-      "two": "今日为大家介绍一个⋯"
+      ]
     },
     "answer": {
-      "output": "今日我为大家介绍个⋯"
+      "target_sub_punctuated": "今日我为大家介绍个⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "简单别致的小菜纸包鸡",
+      "target_subs": [
         "简单又别致嘅小菜",
         "自包鸡"
-      ],
-      "two": "简单别致的小菜纸包鸡"
+      ]
     },
     "answer": {
-      "output": "简单又别致嘅小菜自包鸡"
+      "target_sub_punctuated": "简单又别致嘅小菜自包鸡"
     },
     "few_shot": true,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "材料很简单：一个鸡包",
+      "target_subs": [
         "材料系好简单",
         "我哋只需要一个鸡包"
-      ],
-      "two": "材料很简单：一个鸡包"
+      ]
     },
     "answer": {
-      "output": "材料系好简单：我哋只需要一个鸡包"
+      "target_sub_punctuated": "材料系好简单：我哋只需要一个鸡包"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "将鸡包底部的纸撕下来⋯慢慢地撕",
+      "target_subs": [
         "我哋将黐喺鸡包底嘅纸撕出嚟",
         "慢慢撕"
-      ],
-      "two": "将鸡包底部的纸撕下来⋯慢慢地撕"
+      ]
     },
     "answer": {
-      "output": "我哋将黐喺鸡包底嘅纸撕出嚟⋯慢慢撕"
+      "target_sub_punctuated": "我哋将黐喺鸡包底嘅纸撕出嚟⋯慢慢撕"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "把鸡包纸一反反转",
+      "target_subs": [
         "然后将鸡包纸一反",
         "反转"
-      ],
-      "two": "把鸡包纸一反反转"
+      ]
     },
     "answer": {
-      "output": "然后将鸡包纸一反反转"
+      "target_sub_punctuated": "然后将鸡包纸一反反转"
     },
     "few_shot": true,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "这一味纸包鸡就完成了，很容易是吧？",
+      "target_subs": [
         "呢味自包鸡就完成喇",
         "系咪好易整啦"
-      ],
-      "two": "这一味纸包鸡就完成了，很容易是吧？"
+      ]
     },
     "answer": {
-      "output": "呢味自包鸡就完成喇，系咪好易整啦？"
+      "target_sub_punctuated": "呢味自包鸡就完成喇，系咪好易整啦？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "材料也很简单，只需要白纸一张",
+      "target_subs": [
         "材料都好简单",
         "只需要白纸一张"
-      ],
-      "two": "材料也很简单，只需要白纸一张"
+      ]
     },
     "answer": {
-      "output": "材料都好简单，只需要白纸一张"
+      "target_sub_punctuated": "材料都好简单，只需要白纸一张"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "只要把这纸这样子⋯",
+      "target_subs": [
         "我哋只需要张张纸",
         "咁样"
-      ],
-      "two": "只要把这纸这样子⋯"
+      ]
     },
     "answer": {
-      "output": "我哋只需要张张纸咁样⋯"
+      "target_sub_punctuated": "我哋只需要张张纸咁样⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "各位小朋友，像鸡包不像呀？",
+      "target_subs": [
         "各位小朋友",
         "你哋话似唔似鸡包啊"
-      ],
-      "two": "各位小朋友，像鸡包不像呀？"
+      ]
     },
     "answer": {
-      "output": "各位小朋友，你哋话似唔似鸡包啊？"
+      "target_sub_punctuated": "各位小朋友，你哋话似唔似鸡包啊？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "现在要教大家一味别致小菜－",
+      "target_subs": [
         "间阵要教大家一味几别节嘅小菜"
-      ],
-      "two": "现在要教大家一味别致小菜－"
+      ]
     },
     "answer": {
-      "output": "间阵要教大家一味几别节嘅小菜－"
+      "target_sub_punctuated": "间阵要教大家一味几别节嘅小菜－"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "包鸡纸包鸡包纸包鸡",
+      "target_subs": [
         "包鸡子包",
         "鸡包子包鸡"
-      ],
-      "two": "包鸡纸包鸡包纸包鸡"
+      ]
     },
     "answer": {
-      "output": "包鸡子包鸡包子包鸡"
+      "target_sub_punctuated": "包鸡子包鸡包子包鸡"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "一味「包鸡纸包鸡包纸包鸡」完成了！",
+      "target_subs": [
         "咁一味包鸡子包鸡包子包鸡就完成喇"
-      ],
-      "two": "一味「包鸡纸包鸡包纸包鸡」完成了！"
+      ]
     },
     "answer": {
-      "output": "咁一味「包鸡子包鸡包子包鸡」就完成喇！"
+      "target_sub_punctuated": "咁一味「包鸡子包鸡包子包鸡」就完成喇！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "真的很简单吧？",
+      "target_subs": [
         "系咪好简单呢"
-      ],
-      "two": "真的很简单吧？"
+      ]
     },
     "answer": {
-      "output": "系咪好简单呢？"
+      "target_sub_punctuated": "系咪好简单呢？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "还真有一块鸡吃呢！",
+      "target_subs": [
         "仲真系有嚿鸡食添"
-      ],
-      "two": "还真有一块鸡吃呢！"
+      ]
     },
     "answer": {
-      "output": "仲真系有嚿鸡食添！"
+      "target_sub_punctuated": "仲真系有嚿鸡食添！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "今日为大家介绍一味⋯",
+      "target_subs": [
         "今日要同大家介绍一味"
-      ],
-      "two": "今日为大家介绍一味⋯"
+      ]
     },
     "answer": {
-      "output": "今日要同大家介绍一味⋯"
+      "target_sub_punctuated": "今日要同大家介绍一味⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "小朋友一定喜欢的⋯",
+      "target_subs": [
         "小朋友一定喜欢嘅"
-      ],
-      "two": "小朋友一定喜欢的⋯"
+      ]
     },
     "answer": {
-      "output": "小朋友一定喜欢嘅⋯"
+      "target_sub_punctuated": "小朋友一定喜欢嘅⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "鸡包包鸡包包鸡包纸包纸⋯",
+      "target_subs": [
         "鸡包包",
         "鸡包包",
         "鸡包纸包",
         "纸包鸡",
         "包包鸡"
-      ],
-      "two": "鸡包包鸡包包鸡包纸包纸⋯"
+      ]
     },
     "answer": {
-      "output": "鸡包包鸡包包鸡包纸包纸包鸡包包鸡⋯"
+      "target_sub_punctuated": "鸡包包鸡包包鸡包纸包纸包鸡包包鸡⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "包鸡包鸡包纸包鸡",
+      "target_subs": [
         "纸包鸡",
         "包纸包鸡"
-      ],
-      "two": "包鸡包鸡包纸包鸡"
+      ]
     },
     "answer": {
-      "output": "纸包鸡包纸包鸡"
+      "target_sub_punctuated": "纸包鸡包纸包鸡"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "只要将鸡包包住个鸡包",
+      "target_subs": [
         "我哋先将鸡包",
         "包住个鸡包"
-      ],
-      "two": "只要将鸡包包住个鸡包"
+      ]
     },
     "answer": {
-      "output": "我哋先将鸡包包住个鸡包"
+      "target_sub_punctuated": "我哋先将鸡包包住个鸡包"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "再包住个鸡包⋯",
+      "target_subs": [
         "再包住个鸡包"
-      ],
-      "two": "再包住个鸡包⋯"
+      ]
     },
     "answer": {
-      "output": "再包住个鸡包⋯"
+      "target_sub_punctuated": "再包住个鸡包⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "再包包包包包住个纸鸡包",
+      "target_subs": [
         "再包包包包",
         "包住个纸包鸡"
-      ],
-      "two": "再包包包包包住个纸鸡包"
+      ]
     },
     "answer": {
-      "output": "再包包包包包住个纸包鸡"
+      "target_sub_punctuated": "再包包包包包住个纸包鸡"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "再包包包，纸纸纸",
+      "target_subs": [
         "再包包包包",
         "包鸡包纸",
         "包纸",
         "纸纸纸纸",
         "纸包纸"
-      ],
-      "two": "再包包包，纸纸纸"
+      ]
     },
     "answer": {
-      "output": "再包包包包包鸡包纸包纸，纸纸纸纸纸包纸"
+      "target_sub_punctuated": "再包包包包包鸡包纸包纸，纸纸纸纸纸包纸"
     },
     "difficulty": 3,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "纸包纸，纸包鸡，鸡包纸，纸包鸡⋯",
+      "target_subs": [
         "纸包鸡",
         "包鸡纸",
         "纸包鸡",
         "鸡鸡鸡",
         "纸纸纸再包鸡鸡"
-      ],
-      "two": "纸包纸，纸包鸡，鸡包纸，纸包鸡⋯"
+      ]
     },
     "answer": {
-      "output": "纸包鸡，包鸡纸，纸包鸡，鸡鸡鸡，纸纸纸再包鸡鸡⋯"
+      "target_sub_punctuated": "纸包鸡，包鸡纸，纸包鸡，鸡鸡鸡，纸纸纸再包鸡鸡⋯"
     },
     "difficulty": 3,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "例如每晚睡觉前，她都会说故事给我听",
+      "target_subs": [
         "例如每晚临睡前",
         "佢都会讲故事畀我听"
-      ],
-      "two": "例如每晚睡觉前，她都会说故事给我听"
+      ]
     },
     "answer": {
-      "output": "例如每晚临睡前，佢都会讲故事畀我听"
+      "target_sub_punctuated": "例如每晚临睡前，佢都会讲故事畀我听"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "从前，有个小朋友撒谎；有一天⋯",
+      "target_subs": [
         "从前有个小朋友讲大话",
         "有一日"
-      ],
-      "two": "从前，有个小朋友撒谎；有一天⋯"
+      ]
     },
     "answer": {
-      "output": "从前，有个小朋友讲大话；有一日⋯"
+      "target_sub_punctuated": "从前，有个小朋友讲大话；有一日⋯"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -2199,39 +2199,39 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "他死了！",
+      "target_subs": [
         "佢死咗"
-      ],
-      "two": "他死了！"
+      ]
     },
     "answer": {
-      "output": "佢死咗！"
+      "target_sub_punctuated": "佢死咗！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "从前，有个小朋友很勤力念书⋯",
+      "target_subs": [
         "从前有个小朋友好勤力读书"
-      ],
-      "two": "从前，有个小朋友很勤力念书⋯"
+      ]
     },
     "answer": {
-      "output": "从前，有个小朋友好勤力读书⋯"
+      "target_sub_punctuated": "从前，有个小朋友好勤力读书⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "他长大后，发财了！",
+      "target_subs": [
         "佢长大发咗"
-      ],
-      "two": "他长大后，发财了！"
+      ]
     },
     "answer": {
-      "output": "佢长大，发咗！"
+      "target_sub_punctuated": "佢长大，发咗！"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -2239,14 +2239,14 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "从前，有个小朋友不孝，有天⋯",
+      "target_subs": [
         "从前有个小朋友唔孝顺",
         "有一日"
-      ],
-      "two": "从前，有个小朋友不孝，有天⋯"
+      ]
     },
     "answer": {
-      "output": "从前，有个小朋友唔孝顺，有一日⋯"
+      "target_sub_punctuated": "从前，有个小朋友唔孝顺，有一日⋯"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -2254,109 +2254,109 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "他扭了脚骹！",
+      "target_subs": [
         "佢屈亲个脚脚"
-      ],
-      "two": "他扭了脚骹！"
+      ]
     },
     "answer": {
-      "output": "佢屈亲个脚脚！"
+      "target_sub_punctuated": "佢屈亲个脚脚！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈，我想睡觉",
+      "target_subs": [
         "妈我想瞓啦"
-      ],
-      "two": "妈妈，我想睡觉"
+      ]
     },
     "answer": {
-      "output": "妈，我想瞓啦"
+      "target_sub_punctuated": "妈，我想瞓啦"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "从前，有个小朋友早睡晚起；第二天⋯",
+      "target_subs": [
         "从前有个小朋友早睡晚起",
         "第二朝",
         "社群提供"
-      ],
-      "two": "从前，有个小朋友早睡晚起；第二天⋯"
+      ]
     },
     "answer": {
-      "output": "从前，有个小朋友早睡晚起；第二朝⋯社群提供"
+      "target_sub_punctuated": "从前，有个小朋友早睡晚起；第二朝⋯社群提供"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我妈妈就是这样子，一切都那么直接",
+      "target_subs": [
         "我妈妈就系噉",
         "一切都咁直接"
-      ],
-      "two": "我妈妈就是这样子，一切都那么直接"
+      ]
     },
     "answer": {
-      "output": "我妈妈就系噉，一切都咁直接"
+      "target_sub_punctuated": "我妈妈就系噉，一切都咁直接"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "她爱得我直接⋯",
+      "target_subs": [
         "佢爱得我直接"
-      ],
-      "two": "她爱得我直接⋯"
+      ]
     },
     "answer": {
-      "output": "佢爱得我直接⋯"
+      "target_sub_punctuated": "佢爱得我直接⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "对她，一、二、三、四、五、六、七",
+      "target_subs": [
         "佢一二三四五六七"
-      ],
-      "two": "对她，一、二、三、四、五、六、七"
+      ]
     },
     "answer": {
-      "output": "佢，一、二、三、四、五、六、七"
+      "target_sub_punctuated": "佢，一、二、三、四、五、六、七"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "没有不成的事",
+      "target_subs": [
         "唔得都要得",
         "字幕由",
         "Amara.org"
-      ],
-      "two": "没有不成的事"
+      ]
     },
     "answer": {
-      "output": "唔得都要得字幕由Amara.org"
+      "target_sub_punctuated": "唔得都要得字幕由Amara.org"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "可有些事情，要是真的不成呢？",
+      "target_subs": [
         "但系如果有啲嘢真系真系唔得呢"
-      ],
-      "two": "可有些事情，要是真的不成呢？"
+      ]
     },
     "answer": {
-      "output": "但系如果有啲嘢，真系真系唔得呢？"
+      "target_sub_punctuated": "但系如果有啲嘢，真系真系唔得呢？"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -2364,53 +2364,53 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "首先是周润发事件⋯",
+      "target_subs": [
         "首先周润发嗰单嘢"
-      ],
-      "two": "首先是周润发事件⋯"
+      ]
     },
     "answer": {
-      "output": "首先周润发嗰单嘢⋯"
+      "target_sub_punctuated": "首先周润发嗰单嘢⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "拜托不要再提了！",
+      "target_subs": [
         "大家都唔好再提"
-      ],
-      "two": "拜托不要再提了！"
+      ]
     },
     "answer": {
-      "output": "大家都唔好再提！"
+      "target_sub_punctuated": "大家都唔好再提！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "至于好运⋯",
+      "target_subs": [
         "至于好运"
-      ],
-      "two": "至于好运⋯"
+      ]
     },
     "answer": {
-      "output": "至于好运⋯"
+      "target_sub_punctuated": "至于好运⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "奇迹般似的一个号码也没中过！",
+      "target_subs": [
         "竟然奇迹一样",
         "一个都未中过"
-      ],
-      "two": "奇迹般似的一个号码也没中过！"
+      ]
     },
     "answer": {
-      "output": "竟然奇迹一样一个都未中过！"
+      "target_sub_punctuated": "竟然奇迹一样一个都未中过！"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -2418,244 +2418,244 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "叻仔？",
+      "target_subs": [
         "叻仔"
-      ],
-      "two": "叻仔？"
+      ]
     },
     "answer": {
-      "output": "叻仔？"
+      "target_sub_punctuated": "叻仔？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我也试过努力念书，可是⋯",
+      "target_subs": [
         "我试过好努力咁读书",
         "但系"
-      ],
-      "two": "我也试过努力念书，可是⋯"
+      ]
     },
     "answer": {
-      "output": "我试过好努力咁读书，但系⋯"
+      "target_sub_punctuated": "我试过好努力咁读书，但系⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "可是⋯我仍然有梦",
+      "target_subs": [
         "但系我仲可以发梦"
-      ],
-      "two": "可是⋯我仍然有梦"
+      ]
     },
     "answer": {
-      "output": "但系⋯我仲可以发梦"
+      "target_sub_punctuated": "但系⋯我仲可以发梦"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "马尔代夫，座落于印度洋的世外桃源",
+      "target_subs": [
         "马尔代夫",
         "坐落于印度洋嘅世外桃源"
-      ],
-      "two": "马尔代夫，座落于印度洋的世外桃源"
+      ]
     },
     "answer": {
-      "output": "马尔代夫，坐落于印度洋嘅世外桃源"
+      "target_sub_punctuated": "马尔代夫，坐落于印度洋嘅世外桃源"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "蓝天白云，椰林树影，水清沙幼",
+      "target_subs": [
         "蓝天白云",
         "椰林树影",
         "水清沙游"
-      ],
-      "two": "蓝天白云，椰林树影，水清沙幼"
+      ]
     },
     "answer": {
-      "output": "蓝天白云，椰林树影，水清沙游"
+      "target_sub_punctuated": "蓝天白云，椰林树影，水清沙游"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "七彩缤纷的珊瑚，目不暇给的热带鱼",
+      "target_subs": [
         "七彩缤纷嘅珊瑚",
         "目不下级嘅热带鱼群"
-      ],
-      "two": "七彩缤纷的珊瑚，目不暇给的热带鱼"
+      ]
     },
     "answer": {
-      "output": "七彩缤纷嘅珊瑚，目不下级嘅热带鱼群"
+      "target_sub_punctuated": "七彩缤纷嘅珊瑚，目不下级嘅热带鱼群"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "充满赤道活力的原始海洋，脱离繁嚣",
+      "target_subs": [
         "充满住赤道热力嘅原始海洋",
         "远离凡嚣"
-      ],
-      "two": "充满赤道活力的原始海洋，脱离繁嚣"
+      ]
     },
     "answer": {
-      "output": "充满住赤道热力嘅原始海洋，远离凡嚣"
+      "target_sub_punctuated": "充满住赤道热力嘅原始海洋，远离凡嚣"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "犀利旅行社，旅行社牌照号码350999",
+      "target_subs": [
         "犀利旅行社",
         "旅行社牌照号码350999"
-      ],
-      "two": "犀利旅行社，旅行社牌照号码350999"
+      ]
     },
     "answer": {
-      "output": "犀利旅行社，旅行社牌照号码350999"
+      "target_sub_punctuated": "犀利旅行社，旅行社牌照号码350999"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈你知道马尔代夫在哪儿吗？",
+      "target_subs": [
         "妈妈你知唔知到马尔代夫系边㗎"
-      ],
-      "two": "妈妈你知道马尔代夫在哪儿吗？"
+      ]
     },
     "answer": {
-      "output": "妈妈你知唔知到马尔代夫系边㗎？"
+      "target_sub_punctuated": "妈妈你知唔知到马尔代夫系边㗎？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "有多远？",
+      "target_subs": [
         "点远发呀"
-      ],
-      "two": "有多远？"
+      ]
     },
     "answer": {
-      "output": "点远发呀？"
+      "target_sub_punctuated": "点远发呀？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈你会带我去吗？",
+      "target_subs": [
         "咁妈妈你会唔会走落去㗎"
-      ],
-      "two": "妈妈你会带我去吗？"
+      ]
     },
     "answer": {
-      "output": "咁妈妈你会唔会走落去㗎？"
+      "target_sub_punctuated": "咁妈妈你会唔会走落去㗎？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "会！发财了再说吧",
+      "target_subs": [
         "会",
         "得学发咗先啦"
-      ],
-      "two": "会！发财了再说吧"
+      ]
     },
     "answer": {
-      "output": "会！得学发咗先啦"
+      "target_sub_punctuated": "会！得学发咗先啦"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那么妈妈你什么时候发？",
+      "target_subs": [
         "咁妈妈你几时发得呀"
-      ],
-      "two": "那么妈妈你什么时候发？"
+      ]
     },
     "answer": {
-      "output": "咁妈妈你几时发得呀？"
+      "target_sub_punctuated": "咁妈妈你几时发得呀？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "快了⋯",
+      "target_subs": [
         "呃",
         "就快啦"
-      ],
-      "two": "快了⋯"
+      ]
     },
     "answer": {
-      "output": "呃，就快啦⋯"
+      "target_sub_punctuated": "呃，就快啦⋯"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "发梦呀！",
+      "target_subs": [
         "发梦吖嘛"
-      ],
-      "two": "发梦呀！"
+      ]
     },
     "answer": {
-      "output": "发梦吖嘛！"
+      "target_sub_punctuated": "发梦吖嘛！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "校长早晨！",
+      "target_subs": [
         "嗨"
-      ],
-      "two": "校长早晨！"
+      ]
     },
     "answer": {
-      "output": "嗨！"
+      "target_sub_punctuated": "嗨！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "你最喜爱的地方是哪儿？",
+      "target_subs": [
         "你最喜爱嘅地方喺边度呀"
-      ],
-      "two": "你最喜爱的地方是哪儿？"
+      ]
     },
     "answer": {
-      "output": "你最喜爱嘅地方喺边度呀？"
+      "target_sub_punctuated": "你最喜爱嘅地方喺边度呀？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我最喜爱的地方是日本",
+      "target_subs": [
         "我最喜爱嘅地方呢",
         "就系日本喇"
-      ],
-      "two": "我最喜爱的地方是日本"
+      ]
     },
     "answer": {
-      "output": "我最喜爱嘅地方呢，就系日本喇"
+      "target_sub_punctuated": "我最喜爱嘅地方呢，就系日本喇"
     },
     "difficulty": 2,
     "few_shot": true,
@@ -2663,14 +2663,14 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那儿有 Disneyland 和 Hello Kitty Land",
+      "target_subs": [
         "嗰度好迪士尼呢",
         "同埋HelloTT呢"
-      ],
-      "two": "那儿有 Disneyland 和 Hello Kitty Land"
+      ]
     },
     "answer": {
-      "output": "嗰度好迪士尼呢同埋HelloTT呢"
+      "target_sub_punctuated": "嗰度好迪士尼呢同埋HelloTT呢"
     },
     "difficulty": 2,
     "few_shot": true,
@@ -2678,28 +2678,28 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "婆婆跟舅父他们都在加拿大",
+      "target_subs": [
         "婆婆同埋舅父呀",
         "佢哋都系加拿大㗎"
-      ],
-      "two": "婆婆跟舅父他们都在加拿大"
+      ]
     },
     "answer": {
-      "output": "婆婆同埋舅父呀，佢哋都系加拿大㗎"
+      "target_sub_punctuated": "婆婆同埋舅父呀，佢哋都系加拿大㗎"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那儿有很多水上活动，还有鱼翅吃",
+      "target_subs": [
         "嗰度有好多水晶活动㗎",
         "仲有一次食添㖞"
-      ],
-      "two": "那儿有很多水上活动，还有鱼翅吃"
+      ]
     },
     "answer": {
-      "output": "嗰度有好多水晶活动㗎，仲有一次食添㖞"
+      "target_sub_punctuated": "嗰度有好多水晶活动㗎，仲有一次食添㖞"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -2707,83 +2707,83 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我最喜爱的地方⋯",
+      "target_subs": [
         "呃",
         "我最喜爱嘅地方呢"
-      ],
-      "two": "我最喜爱的地方⋯"
+      ]
     },
     "answer": {
-      "output": "呃，我最喜爱嘅地方呢⋯"
+      "target_sub_punctuated": "呃，我最喜爱嘅地方呢⋯"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "就是那间什么！",
+      "target_subs": [
         "就系嗰间咩嚟啰"
-      ],
-      "two": "就是那间什么！"
+      ]
     },
     "answer": {
-      "output": "就系嗰间咩嚟啰！"
+      "target_sub_punctuated": "就系嗰间咩嚟啰！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那儿有欢乐天地，还有美食广场",
+      "target_subs": [
         "嗰度有欢乐天地啦",
         "仲有米食广场啦"
-      ],
-      "two": "那儿有欢乐天地，还有美食广场"
+      ]
     },
     "answer": {
-      "output": "嗰度有欢乐天地啦，仲有米食广场啦"
+      "target_sub_punctuated": "嗰度有欢乐天地啦，仲有米食广场啦"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "对了，那地方叫银城中心",
+      "target_subs": [
         "系喇系喇",
         "嗰间叫做银城中心"
-      ],
-      "two": "对了，那地方叫银城中心"
+      ]
     },
     "answer": {
-      "output": "系喇系喇，嗰间叫做银城中心"
+      "target_sub_punctuated": "系喇系喇，嗰间叫做银城中心"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那店子的饭很多，很大碟的！",
+      "target_subs": [
         "嗰间嘢啲饭好多人",
         "好大碟㗎"
-      ],
-      "two": "那店子的饭很多，很大碟的！"
+      ]
     },
     "answer": {
-      "output": "嗰间嘢啲饭好多人，好大碟㗎！"
+      "target_sub_punctuated": "嗰间嘢啲饭好多人，好大碟㗎！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "不过说到我最想去的地方，那可厉害了",
+      "target_subs": [
         "不过讲到我最想去嘅地方呢",
         "嗰度细嚟啰"
-      ],
-      "two": "不过说到我最想去的地方，那可厉害了"
+      ]
     },
     "answer": {
-      "output": "不过讲到我最想去嘅地方呢，嗰度细嚟啰"
+      "target_sub_punctuated": "不过讲到我最想去嘅地方呢，嗰度细嚟啰"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -2791,333 +2791,333 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那儿蓝天白云，椰林树影，水清沙幼",
+      "target_subs": [
         "嗰度南天白云",
         "夜临树影",
         "水清沙幽"
-      ],
-      "two": "那儿蓝天白云，椰林树影，水清沙幼"
+      ]
     },
     "answer": {
-      "output": "嗰度南天白云，夜临树影，水清沙幽"
+      "target_sub_punctuated": "嗰度南天白云，夜临树影，水清沙幽"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "座落于印度洋的世外桃源",
+      "target_subs": [
         "独来鱼",
         "印度洋嘅世外桃源"
-      ],
-      "two": "座落于印度洋的世外桃源"
+      ]
     },
     "answer": {
-      "output": "独来鱼印度洋嘅世外桃源"
+      "target_sub_punctuated": "独来鱼印度洋嘅世外桃源"
     },
     "few_shot": true,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "衰仔，快点起床上学",
+      "target_subs": [
         "喂",
         "衰仔啊",
         "快啲起身返学喇"
-      ],
-      "two": "衰仔，快点起床上学"
+      ]
     },
     "answer": {
-      "output": "喂，衰仔啊，快啲起身返学喇"
+      "target_sub_punctuated": "喂，衰仔啊，快啲起身返学喇"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "咦？",
+      "target_subs": [
         "咦"
-      ],
-      "two": "咦？"
+      ]
     },
     "answer": {
-      "output": "咦？"
+      "target_sub_punctuated": "咦？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈！",
+      "target_subs": [
         "妈妈"
-      ],
-      "two": "妈妈！"
+      ]
     },
     "answer": {
-      "output": "妈妈！"
+      "target_sub_punctuated": "妈妈！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "医生，吃了药会不会有那个什么的？",
+      "target_subs": [
         "医生啊",
         "啲药食咗会唔会有嗰啲咩㗎"
-      ],
-      "two": "医生，吃了药会不会有那个什么的？"
+      ]
     },
     "answer": {
-      "output": "医生啊，啲药食咗会唔会有嗰啲咩㗎？"
+      "target_sub_punctuated": "医生啊，啲药食咗会唔会有嗰啲咩㗎？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "不会！",
+      "target_subs": [
         "唔会"
-      ],
-      "two": "不会！"
+      ]
     },
     "answer": {
-      "output": "唔会！"
+      "target_sub_punctuated": "唔会！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那么吃药用不用那个什么的？",
+      "target_subs": [
         "噉佢食药使唔使咩啊"
-      ],
-      "two": "那么吃药用不用那个什么的？"
+      ]
     },
     "answer": {
-      "output": "噉佢食药使唔使咩啊？"
+      "target_sub_punctuated": "噉佢食药使唔使咩啊？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "不用！给他打口针吧！",
+      "target_subs": [
         "唔使",
         "同佢打多支针添呢"
-      ],
-      "two": "不用！给他打口针吧！"
+      ]
     },
     "answer": {
-      "output": "唔使！同佢打多支针添呢！"
+      "target_sub_punctuated": "唔使！同佢打多支针添呢！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "怎么？得打针？",
+      "target_subs": [
         "吓",
         "要打针啊"
-      ],
-      "two": "怎么？得打针？"
+      ]
     },
     "answer": {
-      "output": "吓？要打针啊？"
+      "target_sub_punctuated": "吓？要打针啊？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那么他怕不怕死？",
+      "target_subs": [
         "噉佢怕唔怕死呀"
-      ],
-      "two": "那么他怕不怕死？"
+      ]
     },
     "answer": {
-      "output": "噉佢怕唔怕死呀？"
+      "target_sub_punctuated": "噉佢怕唔怕死呀？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "没事吧？快点先把药水喝掉！",
+      "target_subs": [
         "冇嘢吖嘛",
         "快啲食埋啲药水佢先啦"
-      ],
-      "two": "没事吧？快点先把药水喝掉！"
+      ]
     },
     "answer": {
-      "output": "冇嘢吖嘛？快啲食埋啲药水佢先啦！"
+      "target_sub_punctuated": "冇嘢吖嘛？快啲食埋啲药水佢先啦！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈我不想喝药水",
+      "target_subs": [
         "妈妈",
         "我唔想食药水呀"
-      ],
-      "two": "妈妈我不想喝药水"
+      ]
     },
     "answer": {
-      "output": "妈妈我唔想食药水呀"
+      "target_sub_punctuated": "妈妈我唔想食药水呀"
     },
     "few_shot": true,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "不要呀妈妈，我不喝呀",
+      "target_subs": [
         "唔好捞妈妈",
         "我唔食呀"
-      ],
-      "two": "不要呀妈妈，我不喝呀"
+      ]
     },
     "answer": {
-      "output": "唔好捞妈妈，我唔食呀"
+      "target_sub_punctuated": "唔好捞妈妈，我唔食呀"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我不喝士多啤梨药水呀！",
+      "target_subs": [
         "我唔食士多啤梨药水呀"
-      ],
-      "two": "我不喝士多啤梨药水呀！"
+      ]
     },
     "answer": {
-      "output": "我唔食士多啤梨药水呀！"
+      "target_sub_punctuated": "我唔食士多啤梨药水呀！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "别哭了，不喝药水病不会好的",
+      "target_subs": [
         "唔好喊啦",
         "唔食药唔会好㗎"
-      ],
-      "two": "别哭了，不喝药水病不会好的"
+      ]
     },
     "answer": {
-      "output": "唔好喊啦，唔食药唔会好㗎"
+      "target_sub_punctuated": "唔好喊啦，唔食药唔会好㗎"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "乖乖，病好了妈妈带你去马尔代夫",
+      "target_subs": [
         "乖乖啲",
         "病好咗",
         "妈妈大理马尔代夫"
-      ],
-      "two": "乖乖，病好了妈妈带你去马尔代夫"
+      ]
     },
     "answer": {
-      "output": "乖乖啲，病好咗妈妈大理马尔代夫"
+      "target_sub_punctuated": "乖乖啲，病好咗妈妈大理马尔代夫"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "真的吗？",
+      "target_subs": [
         "真嘅"
-      ],
-      "two": "真的吗？"
+      ]
     },
     "answer": {
-      "output": "真嘅？"
+      "target_sub_punctuated": "真嘅？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈什么时候骗过你？",
+      "target_subs": [
         "妈妈几时呃过你呀"
-      ],
-      "two": "妈妈什么时候骗过你？"
+      ]
     },
     "answer": {
-      "output": "妈妈几时呃过你呀？"
+      "target_sub_punctuated": "妈妈几时呃过你呀？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "乖，先把药水喝掉",
+      "target_subs": [
         "乖",
         "食埋啲药水先啦"
-      ],
-      "two": "乖，先把药水喝掉"
+      ]
     },
     "answer": {
-      "output": "乖，食埋啲药水先啦"
+      "target_sub_punctuated": "乖，食埋啲药水先啦"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "好呀，马尔代夫！",
+      "target_subs": [
         "嘻嘻",
         "好嘢",
         "买二代夫"
-      ],
-      "two": "好呀，马尔代夫！"
+      ]
     },
     "answer": {
-      "output": "嘻嘻，好嘢，买二代夫！"
+      "target_sub_punctuated": "嘻嘻，好嘢，买二代夫！"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "马尔代夫！",
+      "target_subs": [
         "买二代夫"
-      ],
-      "two": "马尔代夫！"
+      ]
     },
     "answer": {
-      "output": "买二代夫！"
+      "target_sub_punctuated": "买二代夫！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈，那么我们什么时候去？",
+      "target_subs": [
         "妈妈",
         "咁我哋几时去呀"
-      ],
-      "two": "妈妈，那么我们什么时候去？"
+      ]
     },
     "answer": {
-      "output": "妈妈，咁我哋几时去呀？"
+      "target_sub_punctuated": "妈妈，咁我哋几时去呀？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "你先把药水喝掉，病好了我就去订机票",
+      "target_subs": [
         "嗯",
         "你乖乖哋食埋啲药",
         "好返晒啦",
         "我即刻订机票"
-      ],
-      "two": "你先把药水喝掉，病好了我就去订机票"
+      ]
     },
     "answer": {
-      "output": "嗯，你乖乖哋食埋啲药，好返晒啦我即刻订机票"
+      "target_sub_punctuated": "嗯，你乖乖哋食埋啲药，好返晒啦我即刻订机票"
     },
     "difficulty": 2,
     "few_shot": true,
@@ -3125,56 +3125,56 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "来，多喝一点！",
+      "target_subs": [
         "嚟啦",
         "食多更"
-      ],
-      "two": "来，多喝一点！"
+      ]
     },
     "answer": {
-      "output": "嚟啦，食多更！"
+      "target_sub_punctuated": "嚟啦，食多更！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈你看，我病好了！",
+      "target_subs": [
         "妈妈你睇",
         "我好返喇"
-      ],
-      "two": "妈妈你看，我病好了！"
+      ]
     },
     "answer": {
-      "output": "妈妈你睇，我好返喇！"
+      "target_sub_punctuated": "妈妈你睇，我好返喇！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "家中的东西有什么没给你吃光的？",
+      "target_subs": [
         "即系间屋有乜嘢唔系畀你食晒㗎"
-      ],
-      "two": "家中的东西有什么没给你吃光的？"
+      ]
     },
     "answer": {
-      "output": "即系间屋有乜嘢唔系畀你食晒㗎？"
+      "target_sub_punctuated": "即系间屋有乜嘢唔系畀你食晒㗎？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "这次不同呀，原来这么一大樽的",
+      "target_subs": [
         "妈妈",
         "呢次唔同㗎",
         "本来咁大樽嘅"
-      ],
-      "two": "这次不同呀，原来这么一大樽的"
+      ]
     },
     "answer": {
-      "output": "妈妈，呢次唔同㗎，本来咁大樽嘅"
+      "target_sub_punctuated": "妈妈，呢次唔同㗎，本来咁大樽嘅"
     },
     "difficulty": 2,
     "few_shot": true,
@@ -3182,190 +3182,190 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我喝一格，又喝一格，又喝一格⋯",
+      "target_subs": [
         "我饮下一格",
         "又一格",
         "又一格"
-      ],
-      "two": "我喝一格，又喝一格，又喝一格⋯"
+      ]
     },
     "answer": {
-      "output": "我饮下一格，又一格，又一格⋯"
+      "target_sub_punctuated": "我饮下一格，又一格，又一格⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "就给我喝光了！",
+      "target_subs": [
         "吓",
         "咪我饮晒㖞"
-      ],
-      "two": "就给我喝光了！"
+      ]
     },
     "answer": {
-      "output": "吓，咪我饮晒㖞！"
+      "target_sub_punctuated": "吓，咪我饮晒㖞！"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "喝光了就叻仔了！",
+      "target_subs": [
         "饮实就叻仔啦"
-      ],
-      "two": "喝光了就叻仔了！"
+      ]
     },
     "answer": {
-      "output": "饮实就叻仔啦！"
+      "target_sub_punctuated": "饮实就叻仔啦！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "喝光了就病好了！",
+      "target_subs": [
         "饮实就好返实啦"
-      ],
-      "two": "喝光了就病好了！"
+      ]
     },
     "answer": {
-      "output": "饮实就好返实啦！"
+      "target_sub_punctuated": "饮实就好返实啦！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈呀⋯",
+      "target_subs": [
         "妈妈"
-      ],
-      "two": "妈妈呀⋯"
+      ]
     },
     "answer": {
-      "output": "妈妈⋯"
+      "target_sub_punctuated": "妈妈⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "什么事？",
+      "target_subs": [
         "乜嘢啊"
-      ],
-      "two": "什么事？"
+      ]
     },
     "answer": {
-      "output": "乜嘢啊？"
+      "target_sub_punctuated": "乜嘢啊？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我们什么时候去马尔代夫？",
+      "target_subs": [
         "阿哋几时去马尔代夫啊"
-      ],
-      "two": "我们什么时候去马尔代夫？"
+      ]
     },
     "answer": {
-      "output": "阿哋几时去马尔代夫啊？"
+      "target_sub_punctuated": "阿哋几时去马尔代夫啊？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "什么马尔代夫？",
+      "target_subs": [
         "乜嘢马尔代夫啊"
-      ],
-      "two": "什么马尔代夫？"
+      ]
     },
     "answer": {
-      "output": "乜嘢马尔代夫啊？"
+      "target_sub_punctuated": "乜嘢马尔代夫啊？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "你说我病好带我去马尔代夫的呀！",
+      "target_subs": [
         "呢",
         "你话我返就同我去马尔代夫㗎嘛"
-      ],
-      "two": "你说我病好带我去马尔代夫的呀！"
+      ]
     },
     "answer": {
-      "output": "呢，你话我返就同我去马尔代夫㗎嘛！"
+      "target_sub_punctuated": "呢，你话我返就同我去马尔代夫㗎嘛！"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "马尔代夫，椰林树影，水清沙幼⋯",
+      "target_subs": [
         "马尔代夫呢",
         "耶南树影",
         "水清沙游"
-      ],
-      "two": "马尔代夫，椰林树影，水清沙幼⋯"
+      ]
     },
     "answer": {
-      "output": "马尔代夫呢，耶南树影，水清沙游⋯"
+      "target_sub_punctuated": "马尔代夫呢，耶南树影，水清沙游⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "座落于印度洋的世外桃源呀！",
+      "target_subs": [
         "助流于印度园嘅世外导演啦"
-      ],
-      "two": "座落于印度洋的世外桃源呀！"
+      ]
     },
     "answer": {
-      "output": "助流于印度园嘅世外导演啦！"
+      "target_sub_punctuated": "助流于印度园嘅世外导演啦！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "想不到你还有点文采",
+      "target_subs": [
         "啊",
         "估唔到你几好文采㗎噃"
-      ],
-      "two": "想不到你还有点文采"
+      ]
     },
     "answer": {
-      "output": "啊，估唔到你几好文采㗎噃"
+      "target_sub_punctuated": "啊，估唔到你几好文采㗎噃"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "说得不错呀！",
+      "target_subs": [
         "讲得几好听啊"
-      ],
-      "two": "说得不错呀！"
+      ]
     },
     "answer": {
-      "output": "讲得几好听啊！"
+      "target_sub_punctuated": "讲得几好听啊！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我不是光说的呀，妈妈你说过⋯",
+      "target_subs": [
         "妈妈我唔系讲喇㗎",
         "又系你话嘅"
-      ],
-      "two": "我不是光说的呀，妈妈你说过⋯"
+      ]
     },
     "answer": {
-      "output": "妈妈我唔系讲喇㗎，又系你话嘅⋯"
+      "target_sub_punctuated": "妈妈我唔系讲喇㗎，又系你话嘅⋯"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -3373,14 +3373,14 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我病好了带我去马尔代夫的！",
+      "target_subs": [
         "你话我病好咗之日就同我去马尔代夫㗎",
         "你讲过㗎"
-      ],
-      "two": "我病好了带我去马尔代夫的！"
+      ]
     },
     "answer": {
-      "output": "你话我病好咗之日就同我去马尔代夫㗎！你讲过㗎！"
+      "target_sub_punctuated": "你话我病好咗之日就同我去马尔代夫㗎！你讲过㗎！"
     },
     "difficulty": 2,
     "few_shot": true,
@@ -3388,42 +3388,42 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "不是的，妈妈你说我病好了就去的",
+      "target_subs": [
         "唔系㖞",
         "妈妈",
         "你话好咗就同我去㗎㖞"
-      ],
-      "two": "不是的，妈妈你说我病好了就去的"
+      ]
     },
     "answer": {
-      "output": "唔系㖞，妈妈你话好咗就同我去㗎㖞"
+      "target_sub_punctuated": "唔系㖞，妈妈你话好咗就同我去㗎㖞"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "你讲过的！",
+      "target_subs": [
         "你讲过㗎"
-      ],
-      "two": "你讲过的！"
+      ]
     },
     "answer": {
-      "output": "你讲过㗎！"
+      "target_sub_punctuated": "你讲过㗎！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "好了，别哭了",
+      "target_subs": [
         "得啦得啦",
         "唔好喊啦"
-      ],
-      "two": "好了，别哭了"
+      ]
     },
     "answer": {
-      "output": "得啦得啦，唔好喊啦"
+      "target_sub_punctuated": "得啦得啦，唔好喊啦"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -3431,41 +3431,41 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "真的吗？　　对",
+      "target_subs": [
         "真嘅",
         "系啊"
-      ],
-      "two": "真的吗？　　对"
+      ]
     },
     "answer": {
-      "output": "真嘅？　　系啊"
+      "target_sub_punctuated": "真嘅？　　系啊"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "什么时候去？",
+      "target_subs": [
         "咁几时去啊"
-      ],
-      "two": "什么时候去？"
+      ]
     },
     "answer": {
-      "output": "咁几时去啊？"
+      "target_sub_punctuated": "咁几时去啊？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "你早发财了⋯",
+      "target_subs": [
         "你发咗㗎喇",
         "你发咗㗎喇"
-      ],
-      "two": "你早发财了⋯"
+      ]
     },
     "answer": {
-      "output": "你发咗㗎喇，你发咗㗎喇⋯"
+      "target_sub_punctuated": "你发咗㗎喇，你发咗㗎喇⋯"
     },
     "difficulty": 2,
     "few_shot": true,
@@ -3473,13 +3473,13 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "好了好了，发财了",
+      "target_subs": [
         "系喇系喇系喇发咗喇"
-      ],
-      "two": "好了好了，发财了"
+      ]
     },
     "answer": {
-      "output": "系喇系喇系喇，发咗喇"
+      "target_sub_punctuated": "系喇系喇系喇，发咗喇"
     },
     "difficulty": 1,
     "few_shot": true,
@@ -3487,5337 +3487,5337 @@
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我们下个星期去，好了吧？",
+      "target_subs": [
         "下个礼拜同你去啦",
         "得未啊"
-      ],
-      "two": "我们下个星期去，好了吧？"
+      ]
     },
     "answer": {
-      "output": "下个礼拜同你去啦，得未啊？"
+      "target_sub_punctuated": "下个礼拜同你去啦，得未啊？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "太好了！",
+      "target_subs": [
         "好嘢"
-      ],
-      "two": "太好了！"
+      ]
     },
     "answer": {
-      "output": "好嘢！"
+      "target_sub_punctuated": "好嘢！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "麦唛，我是麦兜呀",
+      "target_subs": [
         "喂",
         "麦麦啊",
         "麦豆啊我系"
-      ],
-      "two": "麦唛，我是麦兜呀"
+      ]
     },
     "answer": {
-      "output": "喂，麦麦啊，麦豆啊我系"
+      "target_sub_punctuated": "喂，麦麦啊，麦豆啊我系"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "是这样子的，我明天就飞了",
+      "target_subs": [
         "即系呢我明日就要飞喇"
-      ],
-      "two": "是这样子的，我明天就飞了"
+      ]
     },
     "answer": {
-      "output": "即系呢，我明日就要飞喇"
+      "target_sub_punctuated": "即系呢，我明日就要飞喇"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "对　　⋯是吗？",
+      "target_subs": [
         "系啊",
         "系咩"
-      ],
-      "two": "对　　⋯是吗？"
+      ]
     },
     "answer": {
-      "output": "系啊　　⋯系咩？"
+      "target_sub_punctuated": "系啊　　⋯系咩？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "飞机餐很难吃的吗？",
+      "target_subs": [
         "飞机真好难食㗎"
-      ],
-      "two": "飞机餐很难吃的吗？"
+      ]
     },
     "answer": {
-      "output": "飞机真好难食㗎？"
+      "target_sub_punctuated": "飞机真好难食㗎？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "也得吃呀！",
+      "target_subs": [
         "但点都要食㗎啦"
-      ],
-      "two": "也得吃呀！"
+      ]
     },
     "answer": {
-      "output": "但点都要食㗎啦！"
+      "target_sub_punctuated": "但点都要食㗎啦！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "难道自己带东西上去吃吗？",
+      "target_subs": [
         "唔通自己带嘢上去食咩"
-      ],
-      "two": "难道自己带东西上去吃吗？"
+      ]
     },
     "answer": {
-      "output": "唔通自己带嘢上去食咩？"
+      "target_sub_punctuated": "唔通自己带嘢上去食咩？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "还在讲？",
+      "target_subs": [
         "仲讲",
         "哦"
-      ],
-      "two": "还在讲？"
+      ]
     },
     "answer": {
-      "output": "仲讲哦？"
+      "target_sub_punctuated": "仲讲哦？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "快点帮手执行李",
+      "target_subs": [
         "快啲嚟执埋啲行李先啦",
         "哦"
-      ],
-      "two": "快点帮手执行李"
+      ]
     },
     "answer": {
-      "output": "快啲嚟执埋啲行李先啦哦"
+      "target_sub_punctuated": "快啲嚟执埋啲行李先啦哦"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "跟我向他们说，我明天去马尔代夫了",
+      "target_subs": [
         "你帮我话畀佢哋知",
         "我明日去买热带裤薄"
-      ],
-      "two": "跟我向他们说，我明天去马尔代夫了"
+      ]
     },
     "answer": {
-      "output": "你帮我话畀佢哋知，我明日去买热带裤薄"
+      "target_sub_punctuated": "你帮我话畀佢哋知，我明日去买热带裤薄"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那边蓝天白云，椰林树影⋯",
+      "target_subs": [
         "嗰度蓝天五百云",
         "夜临雪"
-      ],
-      "two": "那边蓝天白云，椰林树影⋯"
+      ]
     },
     "answer": {
-      "output": "嗰度蓝天五百云，夜临雪⋯"
+      "target_sub_punctuated": "嗰度蓝天五百云，夜临雪⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "还在讲！",
+      "target_subs": [
         "水清净沙有"
-      ],
-      "two": "还在讲！"
+      ]
     },
     "answer": {
-      "output": "水清净沙有！"
+      "target_sub_punctuated": "水清净沙有！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "来了！",
+      "target_subs": [
         "我嚟紧㗎喇"
-      ],
-      "two": "来了！"
+      ]
     },
     "answer": {
-      "output": "我嚟紧㗎喇！"
+      "target_sub_punctuated": "我嚟紧㗎喇！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "要执行李了，回来再跟你说吧",
+      "target_subs": [
         "我要执行你喇",
         "返嚟先再同你倾过啦"
-      ],
-      "two": "要执行李了，回来再跟你说吧"
+      ]
     },
     "answer": {
-      "output": "我要执行你喇，返嚟先再同你倾过啦"
+      "target_sub_punctuated": "我要执行你喇，返嚟先再同你倾过啦"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "再见！",
+      "target_subs": [
         "拜拜"
-      ],
-      "two": "再见！"
+      ]
     },
     "answer": {
-      "output": "拜拜！"
+      "target_sub_punctuated": "拜拜！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈，我得把出世纸带着吗？",
+      "target_subs": [
         "哎哟",
         "妈妈",
         "我系咪要带埋出世纸去㗎"
-      ],
-      "two": "妈妈，我得把出世纸带着吗？"
+      ]
     },
     "answer": {
-      "output": "哎哟，妈妈，我系咪要带埋出世纸去㗎？"
+      "target_sub_punctuated": "哎哟，妈妈，我系咪要带埋出世纸去㗎？"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那么成绩表呢？",
+      "target_subs": [
         "咁成绩表呢"
-      ],
-      "two": "那么成绩表呢？"
+      ]
     },
     "answer": {
-      "output": "咁成绩表呢？"
+      "target_sub_punctuated": "咁成绩表呢？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "太好了！吓得我！",
+      "target_subs": [
         "好嘢",
         "嚇得我啊",
         "咁都好啲"
-      ],
-      "two": "太好了！吓得我！"
+      ]
     },
     "answer": {
-      "output": "好嘢！嚇得我啊！咁都好啲"
+      "target_sub_punctuated": "好嘢！嚇得我啊！咁都好啲"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "找到了！",
+      "target_subs": [
         "揾到喇"
-      ],
-      "two": "找到了！"
+      ]
     },
     "answer": {
-      "output": "揾到喇！"
+      "target_sub_punctuated": "揾到喇！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "出世纸给我找到了！",
+      "target_subs": [
         "竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然"
-      ],
-      "two": "出世纸给我找到了！"
+      ]
     },
     "answer": {
-      "output": "竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然！"
+      "target_sub_punctuated": "竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然竟然！"
     },
     "difficulty": 3,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "早机去，晚机返",
+      "target_subs": [
         "早机去",
         "晚机返"
-      ],
-      "two": "早机去，晚机返"
+      ]
     },
     "answer": {
-      "output": "早机去，晚机返"
+      "target_sub_punctuated": "早机去，晚机返"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "就这样⋯",
+      "target_subs": [
         "就系噉样"
-      ],
-      "two": "就这样⋯"
+      ]
     },
     "answer": {
-      "output": "就系噉样⋯"
+      "target_sub_punctuated": "就系噉样⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我过了我小时候最精明⋯",
+      "target_subs": [
         "我过咗我小时候最著数"
-      ],
-      "two": "我过了我小时候最精明⋯"
+      ]
     },
     "answer": {
-      "output": "我过咗我小时候最著数⋯"
+      "target_sub_punctuated": "我过咗我小时候最著数⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "依你说，纸是否可以包着鸡呢？",
+      "target_subs": [
         "噉你话纸包唔包得绝鸡呢"
-      ],
-      "two": "依你说，纸是否可以包着鸡呢？"
+      ]
     },
     "answer": {
-      "output": "噉你话，纸包唔包得绝鸡呢？"
+      "target_sub_punctuated": "噉你话，纸包唔包得绝鸡呢？"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "也可以的⋯",
+      "target_subs": [
         "都得嘅"
-      ],
-      "two": "也可以的⋯"
+      ]
     },
     "answer": {
-      "output": "都得嘅⋯"
+      "target_sub_punctuated": "都得嘅⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈晚安！",
+      "target_subs": [
         "妈妈",
         "做头"
-      ],
-      "two": "妈妈晚安！"
+      ]
     },
     "answer": {
-      "output": "妈妈做头！"
+      "target_sub_punctuated": "妈妈做头！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "夺得香港历史上第一面奥运金牌！",
+      "target_subs": [
         "夺取香港历史上第一面奥运金牌"
-      ],
-      "two": "夺得香港历史上第一面奥运金牌！"
+      ]
     },
     "answer": {
-      "output": "夺取香港历史上第一面奥运金牌！"
+      "target_sub_punctuated": "夺取香港历史上第一面奥运金牌！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "激动地对在场记者表示她今次的成绩⋯",
+      "target_subs": [
         "好激动噉同在场嘅记者讲",
         "今次佢嘅成绩"
-      ],
-      "two": "激动地对在场记者表示她今次的成绩⋯"
+      ]
     },
     "answer": {
-      "output": "好激动噉同在场嘅记者讲今次佢嘅成绩⋯"
+      "target_sub_punctuated": "好激动噉同在场嘅记者讲今次佢嘅成绩⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "足以证明香港运动员不是腊鸭！",
+      "target_subs": [
         "可以证明到香港嘅运动员唔系𫚭鸭"
-      ],
-      "two": "足以证明香港运动员不是腊鸭！"
+      ]
     },
     "answer": {
-      "output": "可以证明到香港嘅运动员唔系𫚭鸭！"
+      "target_sub_punctuated": "可以证明到香港嘅运动员唔系𫚭鸭！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "对不起，应该　　是垃圾，不是腊鸭！",
+      "target_subs": [
         "各位对唔住",
         "应该系垃圾",
         "唔系𫚭鸭"
-      ],
-      "two": "对不起，应该　　是垃圾，不是腊鸭！"
+      ]
     },
     "answer": {
-      "output": "各位对唔住，应该　　系垃圾，唔系𫚭鸭！"
+      "target_sub_punctuated": "各位对唔住，应该　　系垃圾，唔系𫚭鸭！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "对不起，应该　　不是垃圾，也不是腊鸭！",
+      "target_subs": [
         "对唔住",
         "应该系唔系垃圾",
         "亦都唔系𫚭鸭"
-      ],
-      "two": "对不起，应该　　不是垃圾，也不是腊鸭！"
+      ]
     },
     "answer": {
-      "output": "对唔住，应该系　　唔系垃圾，亦都唔系𫚭鸭！"
+      "target_sub_punctuated": "对唔住，应该系　　唔系垃圾，亦都唔系𫚭鸭！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈好像又有计了",
+      "target_subs": [
         "咦",
         "妈妈好似又有计噉噃"
-      ],
-      "two": "妈妈好像又有计了"
+      ]
     },
     "answer": {
-      "output": "咦，妈妈好似又有计噉噃"
+      "target_sub_punctuated": "咦，妈妈好似又有计噉噃"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "靓仔，好运，叻仔⋯",
+      "target_subs": [
         "靓仔",
         "好运",
         "叻仔呀"
-      ],
-      "two": "靓仔，好运，叻仔⋯"
+      ]
     },
     "answer": {
-      "output": "靓仔，好运，叻仔呀⋯"
+      "target_sub_punctuated": "靓仔，好运，叻仔呀⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "是不是可以靠手瓜呢？",
+      "target_subs": [
         "哗",
         "好唔好靠下个手瓜噉呢"
-      ],
-      "two": "是不是可以靠手瓜呢？"
+      ]
     },
     "answer": {
-      "output": "哗，好唔好靠下个手瓜噉呢？"
+      "target_sub_punctuated": "哗，好唔好靠下个手瓜噉呢？"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "于是，一个梦还没醒⋯",
+      "target_subs": [
         "于是",
         "一个梦都未醒"
-      ],
-      "two": "于是，一个梦还没醒⋯"
+      ]
     },
     "answer": {
-      "output": "于是，一个梦都未醒⋯"
+      "target_sub_punctuated": "于是，一个梦都未醒⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "但无论多不容易，我都要试一试",
+      "target_subs": [
         "但无论几唔容易",
         "我都要试一试"
-      ],
-      "two": "但无论多不容易，我都要试一试"
+      ]
     },
     "answer": {
-      "output": "但无论几唔容易，我都要试一试"
+      "target_sub_punctuated": "但无论几唔容易，我都要试一试"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我要黎根收我做徒弟！",
+      "target_subs": [
         "我要来紧收我度徒弟"
-      ],
-      "two": "我要黎根收我做徒弟！"
+      ]
     },
     "answer": {
-      "output": "我要来紧收我度徒弟！"
+      "target_sub_punctuated": "我要来紧收我度徒弟！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "无论几辛苦，我一定要得到奥运金牌！",
+      "target_subs": [
         "无论几辛苦",
         "我一定要捞到奥运金牌"
-      ],
-      "two": "无论几辛苦，我一定要得到奥运金牌！"
+      ]
     },
     "answer": {
-      "output": "无论几辛苦，我一定要捞到奥运金牌！"
+      "target_sub_punctuated": "无论几辛苦，我一定要捞到奥运金牌！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我会举起金牌跟全世界说：",
+      "target_subs": [
         "系今排同全世界讲"
-      ],
-      "two": "我会举起金牌跟全世界说："
+      ]
     },
     "answer": {
-      "output": "系今排同全世界讲："
+      "target_sub_punctuated": "系今排同全世界讲："
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "长洲，我终于来到长洲了！",
+      "target_subs": [
         "长洲",
         "我终于嚟到长洲嘞"
-      ],
-      "two": "长洲，我终于来到长洲了！"
+      ]
     },
     "answer": {
-      "output": "长洲，我终于嚟到长洲嘞！"
+      "target_sub_punctuated": "长洲，我终于嚟到长洲嘞！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "长洲，我得亲吻这片圣洁的土地！",
+      "target_subs": [
         "长洲",
         "我要亲吻呢片盛洁嘅土地"
-      ],
-      "two": "长洲，我得亲吻这片圣洁的土地！"
+      ]
     },
     "answer": {
-      "output": "长洲，我要亲吻呢片盛洁嘅土地！"
+      "target_sub_punctuated": "长洲，我要亲吻呢片盛洁嘅土地！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "小朋友，这儿是南丫岛呀！",
+      "target_subs": [
         "小朋友呀",
         "呢度系南丫岛噃"
-      ],
-      "two": "小朋友，这儿是南丫岛呀！"
+      ]
     },
     "answer": {
-      "output": "小朋友呀，呢度系南丫岛噃！"
+      "target_sub_punctuated": "小朋友呀，呢度系南丫岛噃！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "南丫岛？它也孕育了周润发！",
+      "target_subs": [
         "南丫岛",
         "都引用咗周润发噃"
-      ],
-      "two": "南丫岛？它也孕育了周润发！"
+      ]
     },
     "answer": {
-      "output": "南丫岛？都引用咗周润发噃！"
+      "target_sub_punctuated": "南丫岛？都引用咗周润发噃！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "小朋友，你知道什么是狗仔队吧？",
+      "target_subs": [
         "小朋友",
         "我谂你都知道乜嘢叫做狗仔队嘞"
-      ],
-      "two": "小朋友，你知道什么是狗仔队吧？"
+      ]
     },
     "answer": {
-      "output": "小朋友，我谂你都知道乜嘢叫做狗仔队嘞？"
+      "target_sub_punctuated": "小朋友，我谂你都知道乜嘢叫做狗仔队嘞？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "至于拜师的事⋯",
+      "target_subs": [
         "至于拜师嘅嘢"
-      ],
-      "two": "至于拜师的事⋯"
+      ]
     },
     "answer": {
-      "output": "至于拜师嘅嘢⋯"
+      "target_sub_punctuated": "至于拜师嘅嘢⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "拜你个头！",
+      "target_subs": [
         "拜你个头嘅"
-      ],
-      "two": "拜你个头！"
+      ]
     },
     "answer": {
-      "output": "拜你个头嘅！"
+      "target_sub_punctuated": "拜你个头嘅！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "怎么吃得苦？",
+      "target_subs": [
         "边挨得苦㗎"
-      ],
-      "two": "怎么吃得苦？"
+      ]
     },
     "answer": {
-      "output": "边挨得苦㗎？"
+      "target_sub_punctuated": "边挨得苦㗎？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "想跟珊珊般得奥运金牌？",
+      "target_subs": [
         "想学山伞攞奥运金牌"
-      ],
-      "two": "想跟珊珊般得奥运金牌？"
+      ]
     },
     "answer": {
-      "output": "想学山伞攞奥运金牌？"
+      "target_sub_punctuated": "想学山伞攞奥运金牌？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "别作梦了！",
+      "target_subs": [
         "食母你嘢"
-      ],
-      "two": "别作梦了！"
+      ]
     },
     "answer": {
-      "output": "食母你嘢！"
+      "target_sub_punctuated": "食母你嘢！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "小朋友，你看！",
+      "target_subs": [
         "小朋友",
         "你睇下"
-      ],
-      "two": "小朋友，你看！"
+      ]
     },
     "answer": {
-      "output": "小朋友，你睇下！"
+      "target_sub_punctuated": "小朋友，你睇下！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "这个⋯",
+      "target_subs": [
         "哗",
         "呢只"
-      ],
-      "two": "这个⋯"
+      ]
     },
     "answer": {
-      "output": "哗，呢只⋯"
+      "target_sub_punctuated": "哗，呢只⋯"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "这脚瓜⋯好粗好大！比一节瓜还要大！",
+      "target_subs": [
         "呢只脚瓜好粗好大呀",
         "仲大个只瓜呀"
-      ],
-      "two": "这脚瓜⋯好粗好大！比一节瓜还要大！"
+      ]
     },
     "answer": {
-      "output": "呢只脚瓜⋯好粗好大呀！仲大个只瓜呀！"
+      "target_sub_punctuated": "呢只脚瓜⋯好粗好大呀！仲大个只瓜呀！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "脚瓜的肌肉非常结实⋯",
+      "target_subs": [
         "脚瓜啲肌肉非常结实"
-      ],
-      "two": "脚瓜的肌肉非常结实⋯"
+      ]
     },
     "answer": {
-      "output": "脚瓜啲肌肉非常结实⋯"
+      "target_sub_punctuated": "脚瓜啲肌肉非常结实⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "青筋凸现，钢线似的",
+      "target_subs": [
         "啲青筋凸晒出嚟",
         "好似钢线噉"
-      ],
-      "two": "青筋凸现，钢线似的"
+      ]
     },
     "answer": {
-      "output": "啲青筋凸晒出嚟，好似钢线噉"
+      "target_sub_punctuated": "啲青筋凸晒出嚟，好似钢线噉"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "每一条脚毛都硬似铁钉",
+      "target_subs": [
         "啲脚毛",
         "每一条好似铁钉噉硬"
-      ],
-      "two": "每一条脚毛都硬似铁钉"
+      ]
     },
     "answer": {
-      "output": "啲脚毛，每一条好似铁钉噉硬"
+      "target_sub_punctuated": "啲脚毛，每一条好似铁钉噉硬"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "脚趾甲有一寸厚，究竟⋯",
+      "target_subs": [
         "脚趾弓啲脚甲成吋噉厚",
         "究竟"
-      ],
-      "two": "脚趾甲有一寸厚，究竟⋯"
+      ]
     },
     "answer": {
-      "output": "脚趾弓啲脚甲成吋噉厚，究竟⋯"
+      "target_sub_punctuated": "脚趾弓啲脚甲成吋噉厚，究竟⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "要行过几多座山⋯",
+      "target_subs": [
         "要行我几多座山"
-      ],
-      "two": "要行过几多座山⋯"
+      ]
     },
     "answer": {
-      "output": "要行我几多座山⋯"
+      "target_sub_punctuated": "要行我几多座山⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "跨过几多个海⋯",
+      "target_subs": [
         "跨我几多个海"
-      ],
-      "two": "跨过几多个海⋯"
+      ]
     },
     "answer": {
-      "output": "跨我几多个海⋯"
+      "target_sub_punctuated": "跨我几多个海⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "吃过几多苦头⋯",
+      "target_subs": [
         "挨过几多苦头"
-      ],
-      "two": "吃过几多苦头⋯"
+      ]
     },
     "answer": {
-      "output": "挨过几多苦头⋯"
+      "target_sub_punctuated": "挨过几多苦头⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "才可以练成这举世无双的脚瓜？",
+      "target_subs": [
         "先至可以练成呢只举世无双嘅脚瓜"
-      ],
-      "two": "才可以练成这举世无双的脚瓜？"
+      ]
     },
     "answer": {
-      "output": "先至可以练成呢只举世无双嘅脚瓜？"
+      "target_sub_punctuated": "先至可以练成呢只举世无双嘅脚瓜？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我⋯我一定要练成这脚瓜！",
+      "target_subs": [
         "我",
         "我一定要练成呢只脚挂"
-      ],
-      "two": "我⋯我一定要练成这脚瓜！"
+      ]
     },
     "answer": {
-      "output": "我⋯我一定要练成呢只脚挂！"
+      "target_sub_punctuated": "我⋯我一定要练成呢只脚挂！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "师傅！",
+      "target_subs": [
         "师父"
-      ],
-      "two": "师傅！"
+      ]
     },
     "answer": {
-      "output": "师父！"
+      "target_sub_punctuated": "师父！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我可以去小个便吗？",
+      "target_subs": [
         "我可唔可以去个小便呢"
-      ],
-      "two": "我可以去小个便吗？"
+      ]
     },
     "answer": {
-      "output": "我可唔可以去个小便呢？"
+      "target_sub_punctuated": "我可唔可以去个小便呢？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "每次唱这首歌，我都会急小便",
+      "target_subs": [
         "而知点解每一字唱呢首歌都会急小便"
-      ],
-      "two": "每次唱这首歌，我都会急小便"
+      ]
     },
     "answer": {
-      "output": "而知点解每一字唱呢首歌都会急小便"
+      "target_sub_punctuated": "而知点解每一字唱呢首歌都会急小便"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "现在先去，一回恐怕还是会急",
+      "target_subs": [
         "仅次去定先都怕一阵会再急过"
-      ],
-      "two": "现在先去，一回恐怕还是会急"
+      ]
     },
     "answer": {
-      "output": "仅次去定先，都怕一阵会再急过"
+      "target_sub_punctuated": "仅次去定先，都怕一阵会再急过"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我要黎根收我做徒弟！",
+      "target_subs": [
         "我要黎根收我做徒弟"
-      ],
-      "two": "我要黎根收我做徒弟！"
+      ]
     },
     "answer": {
-      "output": "我要黎根收我做徒弟！"
+      "target_sub_punctuated": "我要黎根收我做徒弟！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "歌，是这样唱的⋯",
+      "target_subs": [
         "嗰首歌系噉唱嘅"
-      ],
-      "two": "歌，是这样唱的⋯"
+      ]
     },
     "answer": {
-      "output": "嗰首歌，系噉唱嘅⋯"
+      "target_sub_punctuated": "嗰首歌，系噉唱嘅⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "黎根听完歌以后，表情有点古怪⋯",
+      "target_subs": [
         "黎今听完首歌之后",
         "啲表情有啲古怪"
-      ],
-      "two": "黎根听完歌以后，表情有点古怪⋯"
+      ]
     },
     "answer": {
-      "output": "黎今听完首歌之后，啲表情有啲古怪⋯"
+      "target_sub_punctuated": "黎今听完首歌之后，啲表情有啲古怪⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我一定要好好把握这机会",
+      "target_subs": [
         "唔",
         "我一定要好好把握呢个机会"
-      ],
-      "two": "我一定要好好把握这机会"
+      ]
     },
     "answer": {
-      "output": "唔，我一定要好好把握呢个机会"
+      "target_sub_punctuated": "唔，我一定要好好把握呢个机会"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "师傅！你收我做徒弟吧！",
+      "target_subs": [
         "师父",
         "你收我做徒弟啦"
-      ],
-      "two": "师傅！你收我做徒弟吧！"
+      ]
     },
     "answer": {
-      "output": "师父！你收我做徒弟啦！"
+      "target_sub_punctuated": "师父！你收我做徒弟啦！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "你唔收我做徒弟，我一世都这么跪着！",
+      "target_subs": [
         "你收我做徒弟",
         "我呢一世都跪喺度"
-      ],
-      "two": "你唔收我做徒弟，我一世都这么跪着！"
+      ]
     },
     "answer": {
-      "output": "你收我做徒弟，我呢一世都跪喺度！"
+      "target_sub_punctuated": "你收我做徒弟，我呢一世都跪喺度！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "起来呀！",
+      "target_subs": [
         "起身啊"
-      ],
-      "two": "起来呀！"
+      ]
     },
     "answer": {
-      "output": "起身啊！"
+      "target_sub_punctuated": "起身啊！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "多谢师傅！",
+      "target_subs": [
         "多谢师父"
-      ],
-      "two": "多谢师傅！"
+      ]
     },
     "answer": {
-      "output": "多谢师父！"
+      "target_sub_punctuated": "多谢师父！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "不⋯我是叫你扶我起来呀！",
+      "target_subs": [
         "唔系啊",
         "我系叫你扶我起身啊"
-      ],
-      "two": "不⋯我是叫你扶我起来呀！"
+      ]
     },
     "answer": {
-      "output": "唔系啊⋯我系叫你扶我起身啊！"
+      "target_sub_punctuated": "唔系啊⋯我系叫你扶我起身啊！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "不成了！我的脚瓜太痹了！",
+      "target_subs": [
         "顶唔顺啊",
         "我个腿挂好鼻啊",
         "字幕由",
         "Amara.org",
         "社群提供"
-      ],
-      "two": "不成了！我的脚瓜太痹了！"
+      ]
     },
     "answer": {
-      "output": "顶唔顺啊！我个腿挂好鼻啊！字幕由Amara.org社群提供"
+      "target_sub_punctuated": "顶唔顺啊！我个腿挂好鼻啊！字幕由Amara.org社群提供"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "晚饭时，妈妈倒了三杯米酒",
+      "target_subs": [
         "晚饭时候",
         "妈妈倒咗三杯米酒"
-      ],
-      "two": "晚饭时，妈妈倒了三杯米酒"
+      ]
     },
     "answer": {
-      "output": "晚饭时候，妈妈倒咗三杯米酒"
+      "target_sub_punctuated": "晚饭时候，妈妈倒咗三杯米酒"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "又将几只橙和蒸好的鸡放到祖先前",
+      "target_subs": [
         "再将几个铲同埋蒸熟咗嘅鸡",
         "放喺祖先前面"
-      ],
-      "two": "又将几只橙和蒸好的鸡放到祖先前"
+      ]
     },
     "answer": {
-      "output": "再将几个铲同埋蒸熟咗嘅鸡放喺祖先前面"
+      "target_sub_punctuated": "再将几个铲同埋蒸熟咗嘅鸡放喺祖先前面"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈叫我跪低，向祖先请请",
+      "target_subs": [
         "妈妈叫我跪低",
         "同祖先请请"
-      ],
-      "two": "妈妈叫我跪低，向祖先请请"
+      ]
     },
     "answer": {
-      "output": "妈妈叫我跪低，同祖先请请"
+      "target_sub_punctuated": "妈妈叫我跪低，同祖先请请"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈跟着又念念有词的",
+      "target_subs": [
         "跟住",
         "妈妈口噏噏噉讲咗一啲嘢"
-      ],
-      "two": "妈妈跟着又念念有词的"
+      ]
     },
     "answer": {
-      "output": "跟住，妈妈口噏噏噉讲咗一啲嘢"
+      "target_sub_punctuated": "跟住，妈妈口噏噏噉讲咗一啲嘢"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "庄重而温柔地跟我说：",
+      "target_subs": [
         "庄重又温柔紧同我讲"
-      ],
-      "two": "庄重而温柔地跟我说："
+      ]
     },
     "answer": {
-      "output": "庄重又温柔紧同我讲："
+      "target_sub_punctuated": "庄重又温柔紧同我讲："
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "跟师傅学习，光宗耀祖！",
+      "target_subs": [
         "跟师父学嘢",
         "当中要祖"
-      ],
-      "two": "跟师傅学习，光宗耀祖！"
+      ]
     },
     "answer": {
-      "output": "跟师父学嘢，当中要祖！"
+      "target_sub_punctuated": "跟师父学嘢，当中要祖！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈在长洲找了间酒楼摆拜师宴",
+      "target_subs": [
         "妈妈喺长洲揾咗间酒楼",
         "摆咗几回白丝宴"
-      ],
-      "two": "妈妈在长洲找了间酒楼摆拜师宴"
+      ]
     },
     "answer": {
-      "output": "妈妈喺长洲揾咗间酒楼摆咗几回白丝宴"
+      "target_sub_punctuated": "妈妈喺长洲揾咗间酒楼摆咗几回白丝宴"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "珊珊因为去了集训，没来",
+      "target_subs": [
         "但系山神就去咗集训",
         "冇嚟到"
-      ],
-      "two": "珊珊因为去了集训，没来"
+      ]
     },
     "answer": {
-      "output": "但系山神就去咗集训，冇嚟到"
+      "target_sub_punctuated": "但系山神就去咗集训，冇嚟到"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "麦唛，菇时跟得巴都来了",
+      "target_subs": [
         "默默",
         "姑侍同德巴都嚟咗"
-      ],
-      "two": "麦唛，菇时跟得巴都来了"
+      ]
     },
     "answer": {
-      "output": "默默，姑侍同德巴都嚟咗"
+      "target_sub_punctuated": "默默，姑侍同德巴都嚟咗"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "还带着成绩表，奖牌和大包",
+      "target_subs": [
         "仲带埋成绩表",
         "奖牌",
         "同大包嚟添"
-      ],
-      "two": "还带着成绩表，奖牌和大包"
+      ]
     },
     "answer": {
-      "output": "仲带埋成绩表，奖牌同大包嚟添"
+      "target_sub_punctuated": "仲带埋成绩表，奖牌同大包嚟添"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "吃过鸡丝翅，就是拜师仪式",
+      "target_subs": [
         "食完鸡丝翅",
         "就到咗拜师仪式"
-      ],
-      "two": "吃过鸡丝翅，就是拜师仪式"
+      ]
     },
     "answer": {
-      "output": "食完鸡丝翅，就到咗拜师仪式"
+      "target_sub_punctuated": "食完鸡丝翅，就到咗拜师仪式"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈倒了杯茶给我，让我给师傅喝",
+      "target_subs": [
         "妈妈针咗杯热茶畀我",
         "叫我弟畀师父饮"
-      ],
-      "two": "妈妈倒了杯茶给我，让我给师傅喝"
+      ]
     },
     "answer": {
-      "output": "妈妈针咗杯热茶畀我，叫我弟畀师父饮"
+      "target_sub_punctuated": "妈妈针咗杯热茶畀我，叫我弟畀师父饮"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我千辛万苦来长洲找黎根⋯",
+      "target_subs": [
         "哦",
         "我前三万苦嚟到长洲揾嚟近"
-      ],
-      "two": "我千辛万苦来长洲找黎根⋯"
+      ]
     },
     "answer": {
-      "output": "哦，我前三万苦嚟到长洲揾嚟近⋯"
+      "target_sub_punctuated": "哦，我前三万苦嚟到长洲揾嚟近⋯"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我终于可以跟珊珊一起练滑浪风帆了！",
+      "target_subs": [
         "哦",
         "我终于可以同山神一齐练习玩弄风范啊"
-      ],
-      "two": "我终于可以跟珊珊一起练滑浪风帆了！"
+      ]
     },
     "answer": {
-      "output": "哦，我终于可以同山神一齐练习玩弄风范啊！"
+      "target_sub_punctuated": "哦，我终于可以同山神一齐练习玩弄风范啊！"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我将茶递给黎根，黎根他⋯",
+      "target_subs": [
         "我将杯茶递咗畀嚟跟嚟跟佢",
         "亦唔系"
-      ],
-      "two": "我将茶递给黎根，黎根他⋯"
+      ]
     },
     "answer": {
-      "output": "我将杯茶递咗畀嚟跟，嚟跟佢⋯亦唔系"
+      "target_sub_punctuated": "我将杯茶递咗畀嚟跟，嚟跟佢⋯亦唔系"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "师傅他把茶喝了，正式收我做徒弟",
+      "target_subs": [
         "师父佢饮咗杯茶",
         "正式收咗我做徒弟嘞"
-      ],
-      "two": "师傅他把茶喝了，正式收我做徒弟"
+      ]
     },
     "answer": {
-      "output": "师父佢饮咗杯茶，正式收咗我做徒弟嘞"
+      "target_sub_punctuated": "师父佢饮咗杯茶，正式收咗我做徒弟嘞"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "长洲的乡绅父老拍掌拍得特别落力",
+      "target_subs": [
         "特别系长洲啲乡亲父老",
         "拍奖拍得特别落力"
-      ],
-      "two": "长洲的乡绅父老拍掌拍得特别落力"
+      ]
     },
     "answer": {
-      "output": "特别系长洲啲乡亲父老拍奖拍得特别落力"
+      "target_sub_punctuated": "特别系长洲啲乡亲父老拍奖拍得特别落力"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "多谢各位赏面！多谢各位！",
+      "target_subs": [
         "多谢各位上面",
         "多谢各位"
-      ],
-      "two": "多谢各位赏面！多谢各位！"
+      ]
     },
     "answer": {
-      "output": "多谢各位上面！多谢各位！"
+      "target_sub_punctuated": "多谢各位上面！多谢各位！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "第一项，是滑浪风帆！",
+      "target_subs": [
         "第一样系滑浪风范",
         "呢样早已"
-      ],
-      "two": "第一项，是滑浪风帆！"
+      ]
     },
     "answer": {
-      "output": "第一样，系滑浪风范！呢样早已"
+      "target_sub_punctuated": "第一样，系滑浪风范！呢样早已"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "另一项绝技，我打算传给这个新徒弟⋯",
+      "target_subs": [
         "另一项绝技我打算传畀呢个新修嘅徒弟"
-      ],
-      "two": "另一项绝技，我打算传给这个新徒弟⋯"
+      ]
     },
     "answer": {
-      "output": "另一项绝技，我打算传畀呢个新修嘅徒弟⋯"
+      "target_sub_punctuated": "另一项绝技，我打算传畀呢个新修嘅徒弟⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "发扬光大！",
+      "target_subs": [
         "发扬光大"
-      ],
-      "two": "发扬光大！"
+      ]
     },
     "answer": {
-      "output": "发扬光大！"
+      "target_sub_punctuated": "发扬光大！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "请问那是什么绝技呢？",
+      "target_subs": [
         "噉请问嗰样绝技系乜嘢啊"
-      ],
-      "two": "请问那是什么绝技呢？"
+      ]
     },
     "answer": {
-      "output": "噉请问嗰样绝技系乜嘢啊？"
+      "target_sub_punctuated": "噉请问嗰样绝技系乜嘢啊？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "第二项绝技，就是⋯",
+      "target_subs": [
         "第二样绝技就系"
-      ],
-      "two": "第二项绝技，就是⋯"
+      ]
     },
     "answer": {
-      "output": "第二样绝技，就系⋯"
+      "target_sub_punctuated": "第二样绝技，就系⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "抢包山！",
+      "target_subs": [
         "抢爆山"
-      ],
-      "two": "抢包山！"
+      ]
     },
     "answer": {
-      "output": "抢爆山！"
+      "target_sub_punctuated": "抢爆山！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "抢包山？",
+      "target_subs": [
         "抢包山?"
-      ],
-      "two": "抢包山？"
+      ]
     },
     "answer": {
-      "output": "抢包山？"
+      "target_sub_punctuated": "抢包山？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "年轻观众可能不知「抢包山」何物",
+      "target_subs": [
         "年轻嘅观众可能唔知乜嘢系抢包山呀"
-      ],
-      "two": "年轻观众可能不知「抢包山」何物"
+      ]
     },
     "answer": {
-      "output": "年轻嘅观众可能唔知乜嘢系「抢包山」呀"
+      "target_sub_punctuated": "年轻嘅观众可能唔知乜嘢系「抢包山」呀"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "什么是包山呢？",
+      "target_subs": [
         "噉乜嘢系包山呢?"
-      ],
-      "two": "什么是包山呢？"
+      ]
     },
     "answer": {
-      "output": "噉乜嘢系包山呢？"
+      "target_sub_punctuated": "噉乜嘢系包山呢？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "顾名思义⋯",
+      "target_subs": [
         "顾名思义"
-      ],
-      "two": "顾名思义⋯"
+      ]
     },
     "answer": {
-      "output": "顾名思义⋯"
+      "target_sub_punctuated": "顾名思义⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "包山就是一座由好多好多包砌起的山！",
+      "target_subs": [
         "包山就系一座由好多",
         "好多",
         "好多包砌起嘅山"
-      ],
-      "two": "包山就是一座由好多好多包砌起的山！"
+      ]
     },
     "answer": {
-      "output": "包山就系一座由好多好多好多包砌起嘅山！"
+      "target_sub_punctuated": "包山就系一座由好多好多好多包砌起嘅山！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "一座包山，起码六、七层楼高⋯",
+      "target_subs": [
         "一座包山起码六七层楼高"
-      ],
-      "two": "一座包山，起码六、七层楼高⋯"
+      ]
     },
     "answer": {
-      "output": "一座包山，起码六、七层楼高⋯"
+      "target_sub_punctuated": "一座包山，起码六、七层楼高⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "你可以想像一下包山有多高了吧？",
+      "target_subs": [
         "噉你可以想像一下嗰度有几多包喇"
-      ],
-      "two": "你可以想像一下包山有多高了吧？"
+      ]
     },
     "answer": {
-      "output": "噉你可以想像一下嗰度有几多包喇？"
+      "target_sub_punctuated": "噉你可以想像一下嗰度有几多包喇？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "抢包山，就是要把包山上的包抢到手！",
+      "target_subs": [
         "噉抢包山",
         "自然就系要将包山嘅包抢到手"
-      ],
-      "two": "抢包山，就是要把包山上的包抢到手！"
+      ]
     },
     "answer": {
-      "output": "噉抢包山，自然就系要将包山嘅包抢到手！"
+      "target_sub_punctuated": "噉抢包山，自然就系要将包山嘅包抢到手！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "抢得位置愈高的包，就是愈大的祝福",
+      "target_subs": [
         "抢到位置越高嘅包",
         "就代表越大嘅祝福"
-      ],
-      "two": "抢得位置愈高的包，就是愈大的祝福"
+      ]
     },
     "answer": {
-      "output": "抢到位置越高嘅包，就代表越大嘅祝福"
+      "target_sub_punctuated": "抢到位置越高嘅包，就代表越大嘅祝福"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "在1978年两座包山忽然倒下，多人重伤",
+      "target_subs": [
         "但喺1978年",
         "两座包山突然塌咗",
         "都去抢包山"
-      ],
-      "two": "在1978年两座包山忽然倒下，多人重伤"
+      ]
     },
     "answer": {
-      "output": "但喺1978年两座包山突然塌咗，都去抢包山"
+      "target_sub_punctuated": "但喺1978年两座包山突然塌咗，都去抢包山"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「抢包山」从此被禁！",
+      "target_subs": [
         "而长洲特有嘅传统亦占备为榜"
-      ],
-      "two": "「抢包山」从此被禁！"
+      ]
     },
     "answer": {
-      "output": "而长洲特有嘅传统亦占备为榜！"
+      "target_sub_punctuated": "而长洲特有嘅传统亦占备为榜！"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "而长洲独有的传统，亦渐被遗忘",
+      "target_subs": [
         "长洲特有嘅传统亦占备为榜"
-      ],
-      "two": "而长洲独有的传统，亦渐被遗忘"
+      ]
     },
     "answer": {
-      "output": "长洲特有嘅传统，亦占备为榜"
+      "target_sub_punctuated": "长洲特有嘅传统，亦占备为榜"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "奥运金牌⋯这一世是没有机会的了",
+      "target_subs": [
         "奥运金牌",
         "我谂呢一世都唔会攞到"
-      ],
-      "two": "奥运金牌⋯这一世是没有机会的了"
+      ]
     },
     "answer": {
-      "output": "奥运金牌⋯我谂呢一世都唔会攞到"
+      "target_sub_punctuated": "奥运金牌⋯我谂呢一世都唔会攞到"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "每个星期六我都搭船过长洲",
+      "target_subs": [
         "每个礼拜六",
         "我都会搭船过长洲"
-      ],
-      "two": "每个星期六我都搭船过长洲"
+      ]
     },
     "answer": {
-      "output": "每个礼拜六我都会搭船过长洲"
+      "target_sub_punctuated": "每个礼拜六我都会搭船过长洲"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "去学抢包山⋯",
+      "target_subs": [
         "去学抢包山"
-      ],
-      "two": "去学抢包山⋯"
+      ]
     },
     "answer": {
-      "output": "去学抢包山⋯"
+      "target_sub_punctuated": "去学抢包山⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "一项没有奖牌，没有对手，没有比赛⋯",
+      "target_subs": [
         "一日冇奖牌",
         "冇对手",
         "冇比赛"
-      ],
-      "two": "一项没有奖牌，没有对手，没有比赛⋯"
+      ]
     },
     "answer": {
-      "output": "一日冇奖牌，冇对手，冇比赛⋯"
+      "target_sub_punctuated": "一日冇奖牌，冇对手，冇比赛⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "更坏的是，连包山也没有！",
+      "target_subs": [
         "更衰嘅系",
         "连包山都冇"
-      ],
-      "two": "更坏的是，连包山也没有！"
+      ]
     },
     "answer": {
-      "output": "更衰嘅系，连包山都冇！"
+      "target_sub_punctuated": "更衰嘅系，连包山都冇！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "师傅只是叫我去他的家⋯",
+      "target_subs": [
         "师傅净系叫我去佢屋企"
-      ],
-      "two": "师傅只是叫我去他的家⋯"
+      ]
     },
     "answer": {
-      "output": "师傅净系叫我去佢屋企⋯"
+      "target_sub_punctuated": "师傅净系叫我去佢屋企⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "碰！三番！",
+      "target_subs": [
         "通",
         "三番"
-      ],
-      "two": "碰！三番！"
+      ]
     },
     "answer": {
-      "output": "通！三番！"
+      "target_sub_punctuated": "通！三番！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "别躲懒！继续练！",
+      "target_subs": [
         "冇偷懒",
         "继续练"
-      ],
-      "two": "别躲懒！继续练！"
+      ]
     },
     "answer": {
-      "output": "冇偷懒！继续练！"
+      "target_sub_punctuated": "冇偷懒！继续练！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "一天，珊珊到了师传家！",
+      "target_subs": [
         "有一日",
         "山伞嚟咗师傅屋企"
-      ],
-      "two": "一天，珊珊到了师传家！"
+      ]
     },
     "answer": {
-      "output": "有一日，山伞嚟咗师傅屋企！"
+      "target_sub_punctuated": "有一日，山伞嚟咗师傅屋企！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "珊珊！我的师姐珊珊！",
+      "target_subs": [
         "山伞",
         "我个师仔山伞啊"
-      ],
-      "two": "珊珊！我的师姐珊珊！"
+      ]
     },
     "answer": {
-      "output": "山伞！我个师仔山伞啊！"
+      "target_sub_punctuated": "山伞！我个师仔山伞啊！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "可以看见珊珊⋯",
+      "target_subs": [
         "可以见到山伞"
-      ],
-      "two": "可以看见珊珊⋯"
+      ]
     },
     "answer": {
-      "output": "可以见到山伞⋯"
+      "target_sub_punctuated": "可以见到山伞⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "这几个星期爬得再辛苦也是值得的！",
+      "target_subs": [
         "爬得咁辛苦",
         "都系值得㗎"
-      ],
-      "two": "这几个星期爬得再辛苦也是值得的！"
+      ]
     },
     "answer": {
-      "output": "爬得咁辛苦都系值得㗎！"
+      "target_sub_punctuated": "爬得咁辛苦都系值得㗎！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "珊珊！",
+      "target_subs": [
         "山伞"
-      ],
-      "two": "珊珊！"
+      ]
     },
     "answer": {
-      "output": "山伞！"
+      "target_sub_punctuated": "山伞！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "珊你个头！继续练习！",
+      "target_subs": [
         "伞你个头啊",
         "继续练习"
-      ],
-      "two": "珊你个头！继续练习！"
+      ]
     },
     "answer": {
-      "output": "伞你个头啊！继续练习！"
+      "target_sub_punctuated": "伞你个头啊！继续练习！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "还不去？",
+      "target_subs": [
         "仲唔系"
-      ],
-      "two": "还不去？"
+      ]
     },
     "answer": {
-      "output": "仲唔系？"
+      "target_sub_punctuated": "仲唔系？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我咁大个仔，什么「头」也给骂过⋯",
+      "target_subs": [
         "我咁大个仔",
         "乜嘢头都畀人闹过"
-      ],
-      "two": "我咁大个仔，什么「头」也给骂过⋯"
+      ]
     },
     "answer": {
-      "output": "我咁大个仔，乜嘢「头」都畀人闹过⋯"
+      "target_sub_punctuated": "我咁大个仔，乜嘢「头」都畀人闹过⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "不知道为什么「珊你个头」却特别刺耳",
+      "target_subs": [
         "但系山呢个头唔知点解特别瘾"
-      ],
-      "two": "不知道为什么「珊你个头」却特别刺耳"
+      ]
     },
     "answer": {
-      "output": "但系「山呢个头」唔知点解特别瘾"
+      "target_sub_punctuated": "但系「山呢个头」唔知点解特别瘾"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我⋯我⋯",
+      "target_subs": [
         "我",
         "我"
-      ],
-      "two": "我⋯我⋯"
+      ]
     },
     "answer": {
-      "output": "我⋯我⋯"
+      "target_sub_punctuated": "我⋯我⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我唔学抢包山了！",
+      "target_subs": [
         "我唔好抢包纱嘞",
         "字幕由纱友提供"
-      ],
-      "two": "我唔学抢包山了！"
+      ]
     },
     "answer": {
-      "output": "我唔好抢包纱嘞！字幕由纱友提供"
+      "target_sub_punctuated": "我唔好抢包纱嘞！字幕由纱友提供"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "鸡尾包！新鲜出炉！",
+      "target_subs": [
         "鸡尾包",
         "啱啱出炉嘅"
-      ],
-      "two": "鸡尾包！新鲜出炉！"
+      ]
     },
     "answer": {
-      "output": "鸡尾包！啱啱出炉嘅！"
+      "target_sub_punctuated": "鸡尾包！啱啱出炉嘅！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "其实鸡尾包呢⋯",
+      "target_subs": [
         "其实鸡尾爆呢"
-      ],
-      "two": "其实鸡尾包呢⋯"
+      ]
     },
     "answer": {
-      "output": "其实鸡尾爆呢⋯"
+      "target_sub_punctuated": "其实鸡尾爆呢⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "你说这似不似鸡尾？",
+      "target_subs": [
         "吓",
         "你话噉样似唔似鸡尾呀",
         "哈哈哈哈"
-      ],
-      "two": "你说这似不似鸡尾？"
+      ]
     },
     "answer": {
-      "output": "吓，你话噉样似唔似鸡尾呀？哈哈哈哈"
+      "target_sub_punctuated": "吓，你话噉样似唔似鸡尾呀？哈哈哈哈"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "麦兜他学东西⋯还可以",
+      "target_subs": [
         "麦兜嘅学嘢呢都仲可以"
-      ],
-      "two": "麦兜他学东西⋯还可以"
+      ]
     },
     "answer": {
-      "output": "麦兜嘅学嘢呢⋯都仲可以"
+      "target_sub_punctuated": "麦兜嘅学嘢呢⋯都仲可以"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "黎根接著说了一大堆话⋯",
+      "target_subs": [
         "跟住黎根讲咗一大堆说话"
-      ],
-      "two": "黎根接著说了一大堆话⋯"
+      ]
     },
     "answer": {
-      "output": "跟住黎根讲咗一大堆说话⋯"
+      "target_sub_punctuated": "跟住黎根讲咗一大堆说话⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "他的抱负，他对麦兜的期望",
+      "target_subs": [
         "讲下佢嘅抱负",
         "佢对麦兜嘅期望"
-      ],
-      "two": "他的抱负，他对麦兜的期望"
+      ]
     },
     "answer": {
-      "output": "讲下佢嘅抱负，佢对麦兜嘅期望"
+      "target_sub_punctuated": "讲下佢嘅抱负，佢对麦兜嘅期望"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "黎根越说越兴奋，直到双眼发光",
+      "target_subs": [
         "黎根越讲越兴奋"
-      ],
-      "two": "黎根越说越兴奋，直到双眼发光"
+      ]
     },
     "answer": {
-      "output": "黎根越讲越兴奋"
+      "target_sub_punctuated": "黎根越讲越兴奋"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "神功戏和现代器械操",
+      "target_subs": [
         "神功气",
         "现代气蟹粗"
-      ],
-      "two": "神功戏和现代器械操"
+      ]
     },
     "answer": {
-      "output": "神功气现代气蟹粗"
+      "target_sub_punctuated": "神功气现代气蟹粗"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "缩脚，唔该！",
+      "target_subs": [
         "缩嗰只脚唔该"
-      ],
-      "two": "缩脚，唔该！"
+      ]
     },
     "answer": {
-      "output": "缩嗰只脚，唔该！"
+      "target_sub_punctuated": "缩嗰只脚，唔该！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "你看！",
+      "target_subs": [
         "你睇下"
-      ],
-      "two": "你看！"
+      ]
     },
     "answer": {
-      "output": "你睇下！"
+      "target_sub_punctuated": "你睇下！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "这脚瓜⋯好粗好大！比一节瓜还要大！",
+      "target_subs": [
         "哗",
         "呢节",
         "呢节脚瓜好粗好大呀",
         "仲大过节瓜"
-      ],
-      "two": "这脚瓜⋯好粗好大！比一节瓜还要大！"
+      ]
     },
     "answer": {
-      "output": "哗，呢节⋯呢节脚瓜好粗好大呀！仲大过节瓜！"
+      "target_sub_punctuated": "哗，呢节⋯呢节脚瓜好粗好大呀！仲大过节瓜！"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "脚瓜的肌肉非常结实⋯",
+      "target_subs": [
         "脚瓜嘅肌肉非常结实"
-      ],
-      "two": "脚瓜的肌肉非常结实⋯"
+      ]
     },
     "answer": {
-      "output": "脚瓜嘅肌肉非常结实⋯"
+      "target_sub_punctuated": "脚瓜嘅肌肉非常结实⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "脚趾甲有一寸厚，究竟⋯",
+      "target_subs": [
         "脚趾弓啲脚夹成串咁厚",
         "究竟"
-      ],
-      "two": "脚趾甲有一寸厚，究竟⋯"
+      ]
     },
     "answer": {
-      "output": "脚趾弓啲脚夹成串咁厚，究竟⋯"
+      "target_sub_punctuated": "脚趾弓啲脚夹成串咁厚，究竟⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "要走过几多座山",
+      "target_subs": [
         "要行个几度呢?",
         "几多座山"
-      ],
-      "two": "要走过几多座山"
+      ]
     },
     "answer": {
-      "output": "要行个几度呢?几多座山?"
+      "target_sub_punctuated": "要行个几度呢?几多座山?"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "才可以练成这举世无双的脚瓜？",
+      "target_subs": [
         "先至可以练成呢一只举细无伤嘅脚瓜"
-      ],
-      "two": "才可以练成这举世无双的脚瓜？"
+      ]
     },
     "answer": {
-      "output": "先至可以练成呢一只举细无伤嘅脚瓜？"
+      "target_sub_punctuated": "先至可以练成呢一只举细无伤嘅脚瓜？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我个仔⋯",
+      "target_subs": [
         "我个仔"
-      ],
-      "two": "我个仔⋯"
+      ]
     },
     "answer": {
-      "output": "我个仔⋯"
+      "target_sub_punctuated": "我个仔⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "你个仔，他日都会有这只大脚瓜",
+      "target_subs": [
         "你个仔",
         "第时都会有我咁大只脚瓜"
-      ],
-      "two": "你个仔，他日都会有这只大脚瓜"
+      ]
     },
     "answer": {
-      "output": "你个仔，第时都会有我咁大只脚瓜"
+      "target_sub_punctuated": "你个仔，第时都会有我咁大只脚瓜"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "其实我也不知道个仔要这么粗的脚瓜⋯",
+      "target_subs": [
         "其实",
         "我都唔知我仔要咁粗嘅脚瓜"
-      ],
-      "two": "其实我也不知道个仔要这么粗的脚瓜⋯"
+      ]
     },
     "answer": {
-      "output": "其实我都唔知我仔要咁粗嘅脚瓜⋯"
+      "target_sub_punctuated": "其实我都唔知我仔要咁粗嘅脚瓜⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "可是看见那些凸现的青筋，不知怎样⋯",
+      "target_subs": [
         "但系见到佢一条条凸起嘅青筋",
         "唔知点解"
-      ],
-      "two": "可是看见那些凸现的青筋，不知怎样⋯"
+      ]
     },
     "answer": {
-      "output": "但系见到佢一条条凸起嘅青筋，唔知点解⋯"
+      "target_sub_punctuated": "但系见到佢一条条凸起嘅青筋，唔知点解⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我想起麦兜的爸爸，阿炳",
+      "target_subs": [
         "我",
         "我谂起麦兜嘅爸爸",
         "阿炳"
-      ],
-      "two": "我想起麦兜的爸爸，阿炳"
+      ]
     },
     "answer": {
-      "output": "我⋯我谂起麦兜嘅爸爸，阿炳"
+      "target_sub_punctuated": "我⋯我谂起麦兜嘅爸爸，阿炳"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我找来找去也找不到那部电子英文辞典",
+      "target_subs": [
         "我揾完成间屋",
         "都揾唔到部电子英文词典"
-      ],
-      "two": "我找来找去也找不到那部电子英文辞典"
+      ]
     },
     "answer": {
-      "output": "我揾完成间屋都揾唔到部电子英文词典"
+      "target_sub_punctuated": "我揾完成间屋都揾唔到部电子英文词典"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "跑哪去了？",
+      "target_subs": [
         "去咗边呢"
-      ],
-      "two": "跑哪去了？"
+      ]
     },
     "answer": {
-      "output": "去咗边呢？"
+      "target_sub_punctuated": "去咗边呢？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "难道⋯　不会吧？",
+      "target_subs": [
         "唔通",
         "冇理由㗎"
-      ],
-      "two": "难道⋯　不会吧？"
+      ]
     },
     "answer": {
-      "output": "唔通⋯　冇理由㗎？"
+      "target_sub_punctuated": "唔通⋯　冇理由㗎？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "想不到真的让妈妈拿去了．吓得我！",
+      "target_subs": [
         "咦",
         "估唔到真系妈妈攞咗㖞",
         "嚇得我啊"
-      ],
-      "two": "想不到真的让妈妈拿去了．吓得我！"
+      ]
     },
     "answer": {
-      "output": "咦，估唔到真系妈妈攞咗㖞．嚇得我啊！"
+      "target_sub_punctuated": "咦，估唔到真系妈妈攞咗㖞．嚇得我啊！"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈怎么会写起英文信？",
+      "target_subs": [
         "点解妈妈会用英文写信嘅"
-      ],
-      "two": "妈妈怎么会写起英文信？"
+      ]
     },
     "answer": {
-      "output": "点解妈妈会用英文写信嘅？"
+      "target_sub_punctuated": "点解妈妈会用英文写信嘅？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我猜是妈妈用电子辞典逐个字译成英文",
+      "target_subs": [
         "我谂妈妈佢系好辛苦用电子词典",
         "逐个逐个字译做英文"
-      ],
-      "two": "我猜是妈妈用电子辞典逐个字译成英文"
+      ]
     },
     "answer": {
-      "output": "我谂妈妈佢系好辛苦用电子词典逐个逐个字译做英文"
+      "target_sub_punctuated": "我谂妈妈佢系好辛苦用电子词典逐个逐个字译做英文"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "于是我又用电子辞典把信译回中文",
+      "target_subs": [
         "于是我让返电子词典",
         "将封信译返做中文"
-      ],
-      "two": "于是我又用电子辞典把信译回中文"
+      ]
     },
     "answer": {
-      "output": "于是我让返电子词典将封信译返做中文"
+      "target_sub_punctuated": "于是我让返电子词典将封信译返做中文"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "信，是妈妈写给奥委会主席的",
+      "target_subs": [
         "封信原来系妈妈写畀奥委会主席㗎"
-      ],
-      "two": "信，是妈妈写给奥委会主席的"
+      ]
     },
     "answer": {
-      "output": "封信，原来系妈妈写畀奥委会主席㗎"
+      "target_sub_punctuated": "封信，原来系妈妈写畀奥委会主席㗎"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「亲爱的主席：」",
+      "target_subs": [
         "亲爱的主席"
-      ],
-      "two": "「亲爱的主席：」"
+      ]
     },
     "answer": {
-      "output": "「亲爱的主席：」"
+      "target_sub_punctuated": "「亲爱的主席：」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「你好吗？我很好！」",
+      "target_subs": [
         "你好吗",
         "我很好"
-      ],
-      "two": "「你好吗？我很好！」"
+      ]
     },
     "answer": {
-      "output": "「你好吗？我很好！」"
+      "target_sub_punctuated": "「你好吗？我很好！」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「你吃包吗？我吃包！」",
+      "target_subs": [
         "你吃包吗",
         "我吃包"
-      ],
-      "two": "「你吃包吗？我吃包！」"
+      ]
     },
     "answer": {
-      "output": "「你吃包吗？我吃包！」"
+      "target_sub_punctuated": "「你吃包吗？我吃包！」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「我们居住在香港这里的人，很爱吃包」",
+      "target_subs": [
         "我门居住在香港这类的人",
         "肯爱吃包"
-      ],
-      "two": "「我们居住在香港这里的人，很爱吃包」"
+      ]
     },
     "answer": {
-      "output": "「我门居住在香港这类的人，肯爱吃包」"
+      "target_sub_punctuated": "「我门居住在香港这类的人，肯爱吃包」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「小笼包，上海包，广东包，莲蓉包」",
+      "target_subs": [
         "小笼包",
         "上海包",
         "广东包",
         "联融包"
-      ],
-      "two": "「小笼包，上海包，广东包，莲蓉包」"
+      ]
     },
     "answer": {
-      "output": "「小笼包，上海包，广东包，联融包」"
+      "target_sub_punctuated": "「小笼包，上海包，广东包，联融包」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「好朋友，我认为",
+      "target_subs": [
         "好朋友",
         "我认为"
-      ],
-      "two": "「好朋友，我认为"
+      ]
     },
     "answer": {
-      "output": "「好朋友，我认为"
+      "target_sub_punctuated": "「好朋友，我认为"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "抢劫那些包，十分重要」",
+      "target_subs": [
         "抢劫嗰些包十分重要"
-      ],
-      "two": "抢劫那些包，十分重要」"
+      ]
     },
     "answer": {
-      "output": "抢劫嗰些包，十分重要」"
+      "target_sub_punctuated": "抢劫嗰些包，十分重要」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「也算是运动，就真！」",
+      "target_subs": [
         "也算是运动就真"
-      ],
-      "two": "「也算是运动，就真！」"
+      ]
     },
     "answer": {
-      "output": "「也算是运动，就真！」"
+      "target_sub_punctuated": "「也算是运动，就真！」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「要大力！大吃晚上的粥，和大节瓜！」",
+      "target_subs": [
         "要大力",
         "大吃",
         "吻上的粥",
         "和大字瓜"
-      ],
-      "two": "「要大力！大吃晚上的粥，和大节瓜！」"
+      ]
     },
     "answer": {
-      "output": "「要大力！大吃吻上的粥，和大字瓜！」"
+      "target_sub_punctuated": "「要大力！大吃吻上的粥，和大字瓜！」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「按照我愚蠢的见解⋯」",
+      "target_subs": [
         "按照我愚蠢的见解"
-      ],
-      "two": "「按照我愚蠢的见解⋯」"
+      ]
     },
     "answer": {
-      "output": "「按照我愚蠢的见解⋯」"
+      "target_sub_punctuated": "「按照我愚蠢的见解⋯」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「抢劫那些包，是奥运会比赛」",
+      "target_subs": [
         "抢劫嗰些包",
         "系奥运会比赛"
-      ],
-      "two": "「抢劫那些包，是奥运会比赛」"
+      ]
     },
     "answer": {
-      "output": "「抢劫嗰些包，系奥运会比赛」"
+      "target_sub_punctuated": "「抢劫嗰些包，系奥运会比赛」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「让全世界的体育家，抢过！」",
+      "target_subs": [
         "让全世界嘅体育家抢过"
-      ],
-      "two": "「让全世界的体育家，抢过！」"
+      ]
     },
     "answer": {
-      "output": "「让全世界嘅体育家，抢过！」"
+      "target_sub_punctuated": "「让全世界嘅体育家，抢过！」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「世界便和平！」",
+      "target_subs": [
         "世界变和平"
-      ],
-      "two": "「世界便和平！」"
+      ]
     },
     "answer": {
-      "output": "「世界变和平！」"
+      "target_sub_punctuated": "「世界变和平！」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「你有孩子吗？」",
+      "target_subs": [
         "你有孩子吗"
-      ],
-      "two": "「你有孩子吗？」"
+      ]
     },
     "answer": {
-      "output": "「你有孩子吗？」"
+      "target_sub_punctuated": "「你有孩子吗？」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「我有一个孩子，麦兜」",
+      "target_subs": [
         "我有一个孩子",
         "麦兜"
-      ],
-      "two": "「我有一个孩子，麦兜」"
+      ]
     },
     "answer": {
-      "output": "「我有一个孩子，麦兜」"
+      "target_sub_punctuated": "「我有一个孩子，麦兜」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "终于讲到我了！",
+      "target_subs": [
         "终于讲到我啦"
-      ],
-      "two": "终于讲到我了！"
+      ]
     },
     "answer": {
-      "output": "终于讲到我啦！"
+      "target_sub_punctuated": "终于讲到我啦！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「他是一个好男孩」",
+      "target_subs": [
         "她系一个好男孩"
-      ],
-      "two": "「他是一个好男孩」"
+      ]
     },
     "answer": {
-      "output": "「她系一个好男孩」"
+      "target_sub_punctuated": "「她系一个好男孩」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「他非常懂得抢劫那些包」",
+      "target_subs": [
         "她非常懂得抢劫嗰些包"
-      ],
-      "two": "「他非常懂得抢劫那些包」"
+      ]
     },
     "answer": {
-      "output": "「她非常懂得抢劫嗰些包」"
+      "target_sub_punctuated": "「她非常懂得抢劫嗰些包」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「有一天，我看见他，抢劫包⋯」",
+      "target_subs": [
         "有一天我看见她抢劫包"
-      ],
-      "two": "「有一天，我看见他，抢劫包⋯」"
+      ]
     },
     "answer": {
-      "output": "「有一天，我看见她抢劫包⋯」"
+      "target_sub_punctuated": "「有一天，我看见她抢劫包⋯」"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「抢了一个奥运金牌」",
+      "target_subs": [
         "抢了一个奥运金牌"
-      ],
-      "two": "「抢了一个奥运金牌」"
+      ]
     },
     "answer": {
-      "output": "「抢了一个奥运金牌」"
+      "target_sub_punctuated": "「抢了一个奥运金牌」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「那便是一个母亲能够有的最大的安慰」",
+      "target_subs": [
         "哪便是一个母亲能够有的最好的",
         "最大的安慰"
-      ],
-      "two": "「那便是一个母亲能够有的最大的安慰」"
+      ]
     },
     "answer": {
-      "output": "「哪便是一个母亲能够有的最好的最大的安慰」"
+      "target_sub_punctuated": "「哪便是一个母亲能够有的最好的最大的安慰」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「孩子的才干，得到了世界人类的知道」",
+      "target_subs": [
         "孩子的才干得到了世界人类的知道"
-      ],
-      "two": "「孩子的才干，得到了世界人类的知道」"
+      ]
     },
     "answer": {
-      "output": "「孩子的才干，得到了世界人类的知道」"
+      "target_sub_punctuated": "「孩子的才干，得到了世界人类的知道」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「父母愿意做什么的东西都得」",
+      "target_subs": [
         "父母愿意做什么的东西都得"
-      ],
-      "two": "「父母愿意做什么的东西都得」"
+      ]
     },
     "answer": {
-      "output": "「父母愿意做什么的东西都得」"
+      "target_sub_punctuated": "「父母愿意做什么的东西都得」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「于是我写了这忽然间的信给你」",
+      "target_subs": [
         "于是我写了这忽然间的信给你"
-      ],
-      "two": "「于是我写了这忽然间的信给你」"
+      ]
     },
     "answer": {
-      "output": "「于是我写了这忽然间的信给你」"
+      "target_sub_punctuated": "「于是我写了这忽然间的信给你」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「虽然你不知道我是什么微细的东西」",
+      "target_subs": [
         "虽然你不知道我是什么微细的东西"
-      ],
-      "two": "「虽然你不知道我是什么微细的东西」"
+      ]
     },
     "answer": {
-      "output": "「虽然你不知道我是什么微细的东西」"
+      "target_sub_punctuated": "「虽然你不知道我是什么微细的东西」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「但我的孩子很大，很大！」",
+      "target_subs": [
         "但我的孩子很大很大"
-      ],
-      "two": "「但我的孩子很大，很大！」"
+      ]
     },
     "answer": {
-      "output": "「但我的孩子很大，很大！」"
+      "target_sub_punctuated": "「但我的孩子很大，很大！」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「有一天，你都会知道」",
+      "target_subs": [
         "有一天你都会知道"
-      ],
-      "two": "「有一天，你都会知道」"
+      ]
     },
     "answer": {
-      "output": "「有一天，你都会知道」"
+      "target_sub_punctuated": "「有一天，你都会知道」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「多谢合作！」",
+      "target_subs": [
         "多谢合作"
-      ],
-      "two": "「多谢合作！」"
+      ]
     },
     "answer": {
-      "output": "「多谢合作！」"
+      "target_sub_punctuated": "「多谢合作！」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「你忠实的，麦太」",
+      "target_subs": [
         "你忠实的",
         "麦太"
-      ],
-      "two": "「你忠实的，麦太」"
+      ]
     },
     "answer": {
-      "output": "「你忠实的，麦太」"
+      "target_sub_punctuated": "「你忠实的，麦太」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "可是，我依然努力练习抢包山",
+      "target_subs": [
         "但系",
         "我依然努力练习抢包生"
-      ],
-      "two": "可是，我依然努力练习抢包山"
+      ]
     },
     "answer": {
-      "output": "但系，我依然努力练习抢包生"
+      "target_sub_punctuated": "但系，我依然努力练习抢包生"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "因为，我爱我妈妈",
+      "target_subs": [
         "因为我爱我妈妈"
-      ],
-      "two": "因为，我爱我妈妈"
+      ]
     },
     "answer": {
-      "output": "因为，我爱我妈妈"
+      "target_sub_punctuated": "因为，我爱我妈妈"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "师傅说我攀爬功夫已经不错",
+      "target_subs": [
         "师傅话",
         "我嘅攀爬功夫已经唔错"
-      ],
-      "two": "师傅说我攀爬功夫已经不错"
+      ]
     },
     "answer": {
-      "output": "师傅话我嘅攀爬功夫已经唔错"
+      "target_sub_punctuated": "师傅话我嘅攀爬功夫已经唔错"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "可以开始教我「十二路抢包手」",
+      "target_subs": [
         "可以开始教我十二路抢包手"
-      ],
-      "two": "可以开始教我「十二路抢包手」"
+      ]
     },
     "answer": {
-      "output": "可以开始教我「十二路抢包手」"
+      "target_sub_punctuated": "可以开始教我「十二路抢包手」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "师傅说当年师祖耍出这套",
+      "target_subs": [
         "师傅话",
         "当年师祖使出呢套"
-      ],
-      "two": "师傅说当年师祖耍出这套"
+      ]
     },
     "answer": {
-      "output": "师傅话当年师祖使出呢套"
+      "target_sub_punctuated": "师傅话当年师祖使出呢套"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「十二路抢包手」⋯",
+      "target_subs": [
         "十二路抢包手"
-      ],
-      "two": "「十二路抢包手」⋯"
+      ]
     },
     "answer": {
-      "output": "「十二路抢包手」⋯"
+      "target_sub_punctuated": "「十二路抢包手」⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "后来麦唛告诉我⋯",
+      "target_subs": [
         "后来",
         "默默话我知"
-      ],
-      "two": "后来麦唛告诉我⋯"
+      ]
     },
     "answer": {
-      "output": "后来默默话我知⋯"
+      "target_sub_punctuated": "后来默默话我知⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "林世荣即是猪肉荣，是黄飞鸿的徒弟",
+      "target_subs": [
         "林世荣即系猪肉荣",
         "系黄飞鸿嘅徒弟"
-      ],
-      "two": "林世荣即是猪肉荣，是黄飞鸿的徒弟"
+      ]
     },
     "answer": {
-      "output": "林世荣即系猪肉荣，系黄飞鸿嘅徒弟"
+      "target_sub_punctuated": "林世荣即系猪肉荣，系黄飞鸿嘅徒弟"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我一边练习，一边胡思乱想；始终⋯",
+      "target_subs": [
         "我一边练习",
         "一边乱练",
         "一边谂嘢",
         "始终"
-      ],
-      "two": "我一边练习，一边胡思乱想；始终⋯"
+      ]
     },
     "answer": {
-      "output": "我一边练习，一边乱练，一边谂嘢；始终⋯"
+      "target_sub_punctuated": "我一边练习，一边乱练，一边谂嘢；始终⋯"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "于是我咬实牙根⋯",
+      "target_subs": [
         "于是我咬细牙根"
-      ],
-      "two": "于是我咬实牙根⋯"
+      ]
     },
     "answer": {
-      "output": "于是我咬细牙根⋯"
+      "target_sub_punctuated": "于是我咬细牙根⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "一步一步，一爪一爪⋯",
+      "target_subs": [
         "一步一步",
         "一爪一爪"
-      ],
-      "two": "一步一步，一爪一爪⋯"
+      ]
     },
     "answer": {
-      "output": "一步一步，一爪一爪⋯"
+      "target_sub_punctuated": "一步一步，一爪一爪⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我最后终于练成「十二路抢包手」",
+      "target_subs": [
         "最后",
         "我终于练成十二路抢包手啦"
-      ],
-      "two": "我最后终于练成「十二路抢包手」"
+      ]
     },
     "answer": {
-      "output": "最后我终于练成「十二路抢包手」啦"
+      "target_sub_punctuated": "最后我终于练成「十二路抢包手」啦"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "喂，我是麦兜",
+      "target_subs": [
         "喂",
         "我系麦兜啊"
-      ],
-      "two": "喂，我是麦兜"
+      ]
     },
     "answer": {
-      "output": "喂，我系麦兜啊"
+      "target_sub_punctuated": "喂，我系麦兜啊"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "刚才的是小朋友麦兜，我是大个佬麦兜",
+      "target_subs": [
         "正话嗰个系细路仔麦兜",
         "我系大个佬麦兜"
-      ],
-      "two": "刚才的是小朋友麦兜，我是大个佬麦兜"
+      ]
     },
     "answer": {
-      "output": "正话嗰个系细路仔麦兜，我系大个佬麦兜"
+      "target_sub_punctuated": "正话嗰个系细路仔麦兜，我系大个佬麦兜"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "小朋友麦兜和大个佬麦兜除了声音不同⋯",
+      "target_subs": [
         "细路仔麦兜同大个佬麦兜除咗把声唔同之外"
-      ],
-      "two": "小朋友麦兜和大个佬麦兜除了声音不同⋯"
+      ]
     },
     "answer": {
-      "output": "细路仔麦兜同大个佬麦兜除咗把声唔同之外⋯"
+      "target_sub_punctuated": "细路仔麦兜同大个佬麦兜除咗把声唔同之外⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "希望⋯失望⋯",
+      "target_subs": [
         "希望",
         "失望"
-      ],
-      "two": "希望⋯失望⋯"
+      ]
     },
     "answer": {
-      "output": "希望⋯失望⋯"
+      "target_sub_punctuated": "希望⋯失望⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "希望⋯",
+      "target_subs": [
         "希望"
-      ],
-      "two": "希望⋯"
+      ]
     },
     "answer": {
-      "output": "希望⋯"
+      "target_sub_punctuated": "希望⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "久而久之，就变成大个佬麦兜",
+      "target_subs": [
         "搞咗一轮",
         "就变咗大个佬麦兜"
-      ],
-      "two": "久而久之，就变成大个佬麦兜"
+      ]
     },
     "answer": {
-      "output": "搞咗一轮，就变咗大个佬麦兜"
+      "target_sub_punctuated": "搞咗一轮，就变咗大个佬麦兜"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我现在还是多说点小朋友麦兜",
+      "target_subs": [
         "不过",
         "而家我都系想讲返细路仔麦兜"
-      ],
-      "two": "我现在还是多说点小朋友麦兜"
+      ]
     },
     "answer": {
-      "output": "不过，而家我都系想讲返细路仔麦兜"
+      "target_sub_punctuated": "不过，而家我都系想讲返细路仔麦兜"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "小朋友麦兜仍然希望希望⋯",
+      "target_subs": [
         "细路仔麦兜仲系希望希望"
-      ],
-      "two": "小朋友麦兜仍然希望希望⋯"
+      ]
     },
     "answer": {
-      "output": "细路仔麦兜仲系希望希望⋯"
+      "target_sub_punctuated": "细路仔麦兜仲系希望希望⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "对，那时我还没吃过火鸡",
+      "target_subs": [
         "系啊",
         "我嗰阵",
         "我真系仲未食过火鸡"
-      ],
-      "two": "对，那时我还没吃过火鸡"
+      ]
     },
     "answer": {
-      "output": "系啊，我嗰阵我真系仲未食过火鸡"
+      "target_sub_punctuated": "系啊，我嗰阵我真系仲未食过火鸡"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "关于火鸡的一切⋯",
+      "target_subs": [
         "所有关于火鸡嘅嘢"
-      ],
-      "two": "关于火鸡的一切⋯"
+      ]
     },
     "answer": {
-      "output": "所有关于火鸡嘅嘢⋯"
+      "target_sub_punctuated": "所有关于火鸡嘅嘢⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "一片片比外边的雪还要白的鸡胸肉⋯",
+      "target_subs": [
         "一片一片",
         "比窗外面嘅雪仲要白嘅鸡胸肉"
-      ],
-      "two": "一片片比外边的雪还要白的鸡胸肉⋯"
+      ]
     },
     "answer": {
-      "output": "一片一片比窗外面嘅雪仲要白嘅鸡胸肉⋯"
+      "target_sub_punctuated": "一片一片比窗外面嘅雪仲要白嘅鸡胸肉⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "香气直入灵魂⋯",
+      "target_subs": [
         "香气直入灵魂"
-      ],
-      "two": "香气直入灵魂⋯"
+      ]
     },
     "answer": {
-      "output": "香气直入灵魂⋯"
+      "target_sub_punctuated": "香气直入灵魂⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "围住这香而圣洁的肉⋯",
+      "target_subs": [
         "围住呢一嚿好香好香又好盛洁嘅肉"
-      ],
-      "two": "围住这香而圣洁的肉⋯"
+      ]
     },
     "answer": {
-      "output": "围住呢一嚿好香好香又好盛洁嘅肉⋯"
+      "target_sub_punctuated": "围住呢一嚿好香好香又好盛洁嘅肉⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "在圣诞夜中飞呀，飞⋯",
+      "target_subs": [
         "喺圣诞夜里面",
         "飞呀",
         "飞呀"
-      ],
-      "two": "在圣诞夜中飞呀，飞⋯"
+      ]
     },
     "answer": {
-      "output": "喺圣诞夜里面飞呀，飞呀⋯"
+      "target_sub_punctuated": "喺圣诞夜里面飞呀，飞呀⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "这关于火鸡的一切，不过是我的想像",
+      "target_subs": [
         "但系呢一切一切关于火鸡嘅嘢",
         "都不过系我嘅想像"
-      ],
-      "two": "这关于火鸡的一切，不过是我的想像"
+      ]
     },
     "answer": {
-      "output": "但系呢一切一切关于火鸡嘅嘢，都不过系我嘅想像"
+      "target_sub_punctuated": "但系呢一切一切关于火鸡嘅嘢，都不过系我嘅想像"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我从来没吃过火鸡⋯",
+      "target_subs": [
         "因为我从来都未食过火鸡"
-      ],
-      "two": "我从来没吃过火鸡⋯"
+      ]
     },
     "answer": {
-      "output": "因为我从来都未食过火鸡⋯"
+      "target_sub_punctuated": "因为我从来都未食过火鸡⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我们一家两口，吃不下",
+      "target_subs": [
         "我哋一家两口点食都食唔晒"
-      ],
-      "two": "我们一家两口，吃不下"
+      ]
     },
     "answer": {
-      "output": "我哋一家两口，点食都食唔晒"
+      "target_sub_punctuated": "我哋一家两口，点食都食唔晒"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "有年圣诞节妈妈买了半只烧鸭庆祝",
+      "target_subs": [
         "有一年圣诞节",
         "妈妈买咗半边烧鸭庆祝"
-      ],
-      "two": "有年圣诞节妈妈买了半只烧鸭庆祝"
+      ]
     },
     "answer": {
-      "output": "有一年圣诞节妈妈买咗半边烧鸭庆祝"
+      "target_sub_punctuated": "有一年圣诞节妈妈买咗半边烧鸭庆祝"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "当时的我，十分十分失望",
+      "target_subs": [
         "当时我真系十分十分之失望"
-      ],
-      "two": "当时的我，十分十分失望"
+      ]
     },
     "answer": {
-      "output": "当时我，真系十分十分之失望"
+      "target_sub_punctuated": "当时我，真系十分十分之失望"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "又有一年，一间百货公司结业",
+      "target_subs": [
         "又有一年",
         "有间大薄货公司倒闭"
-      ],
-      "two": "又有一年，一间百货公司结业"
+      ]
     },
     "answer": {
-      "output": "又有一年，有间大薄货公司倒闭"
+      "target_sub_punctuated": "又有一年，有间大薄货公司倒闭"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那日妈妈竟然跟我说⋯",
+      "target_subs": [
         "嗰日妈妈竟然同我讲",
         "佢话"
-      ],
-      "two": "那日妈妈竟然跟我说⋯"
+      ]
     },
     "answer": {
-      "output": "嗰日妈妈竟然同我讲⋯佢话⋯"
+      "target_sub_punctuated": "嗰日妈妈竟然同我讲⋯佢话⋯"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我跟妈妈把火鸡揪回家的路上⋯",
+      "target_subs": [
         "我同妈妈抽住只火鸡行返屋企嗰阵",
         "喺嗰阵时"
-      ],
-      "two": "我跟妈妈把火鸡揪回家的路上⋯"
+      ]
     },
     "answer": {
-      "output": "我同妈妈抽住只火鸡行返屋企嗰阵，喺嗰阵时⋯"
+      "target_sub_punctuated": "我同妈妈抽住只火鸡行返屋企嗰阵，喺嗰阵时⋯"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我学著妈妈，把双手涂满盐⋯",
+      "target_subs": [
         "我同妈妈噉双手查满盐"
-      ],
-      "two": "我学著妈妈，把双手涂满盐⋯"
+      ]
     },
     "answer": {
-      "output": "我同妈妈，噉双手查满盐⋯"
+      "target_sub_punctuated": "我同妈妈，噉双手查满盐⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "在火鸡丰厚的鸡胸上擦呀，擦",
+      "target_subs": [
         "喺火鸡封口嘅鸡胸度",
         "起细噉啫啫"
-      ],
-      "two": "在火鸡丰厚的鸡胸上擦呀，擦"
+      ]
     },
     "answer": {
-      "output": "喺火鸡封口嘅鸡胸度，起细噉啫啫"
+      "target_sub_punctuated": "喺火鸡封口嘅鸡胸度，起细噉啫啫"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "联火鸡时⋯",
+      "target_subs": [
         "联火鸡时"
-      ],
-      "two": "联火鸡时⋯"
+      ]
     },
     "answer": {
-      "output": "联火鸡时⋯"
+      "target_sub_punctuated": "联火鸡时⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈不留神漏出了火鸡内的洋葱粒",
+      "target_subs": [
         "妈妈一个唔觉意",
         "畀酿喺火鸡里面嘅火鸡内脏洋葱粒"
-      ],
-      "two": "妈妈不留神漏出了火鸡内的洋葱粒"
+      ]
     },
     "answer": {
-      "output": "妈妈一个唔觉意畀酿喺火鸡里面嘅火鸡内脏洋葱粒"
+      "target_sub_punctuated": "妈妈一个唔觉意畀酿喺火鸡里面嘅火鸡内脏洋葱粒"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我说：火鸡「屙烂煮」！",
+      "target_subs": [
         "我话",
         "火鸡我能住呀"
-      ],
-      "two": "我说：火鸡「屙烂煮」！"
+      ]
     },
     "answer": {
-      "output": "我话：火鸡「我能住」呀！"
+      "target_sub_punctuated": "我话：火鸡「我能住」呀！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "焗炉戚戚恻恻，戚戚恻恻⋯",
+      "target_subs": [
         "个焗炉叱叱叱叱",
         "叱叱叱咁"
-      ],
-      "two": "焗炉戚戚恻恻，戚戚恻恻⋯"
+      ]
     },
     "answer": {
-      "output": "个焗炉叱叱叱叱，叱叱叱咁⋯"
+      "target_sub_punctuated": "个焗炉叱叱叱叱，叱叱叱咁⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "好靓的晚上啊！",
+      "target_subs": [
         "好靓嘅夜晚呀"
-      ],
-      "two": "好靓的晚上啊！"
+      ]
     },
     "answer": {
-      "output": "好靓嘅夜晚呀！"
+      "target_sub_punctuated": "好靓嘅夜晚呀！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "点点灯光在海面走来走去⋯",
+      "target_subs": [
         "点点点点嘅灯光喺海上面走来走去"
-      ],
-      "two": "点点灯光在海面走来走去⋯"
+      ]
     },
     "answer": {
-      "output": "点点点点嘅灯光喺海上面走来走去⋯"
+      "target_sub_punctuated": "点点点点嘅灯光喺海上面走来走去⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "美丽又温柔",
+      "target_subs": [
         "又靓",
         "又温柔"
-      ],
-      "two": "美丽又温柔"
+      ]
     },
     "answer": {
-      "output": "又靓又温柔"
+      "target_sub_punctuated": "又靓又温柔"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "真的好靓！",
+      "target_subs": [
         "真系好靓"
-      ],
-      "two": "真的好靓！"
+      ]
     },
     "answer": {
-      "output": "真系好靓！"
+      "target_sub_punctuated": "真系好靓！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "什至杯面，烧鸭的味道也没有这么浓",
+      "target_subs": [
         "连烧鸭连杯面都冇咁浓嘅味道"
-      ],
-      "two": "什至杯面，烧鸭的味道也没有这么浓"
+      ]
     },
     "answer": {
-      "output": "连烧鸭连杯面都冇咁浓嘅味道"
+      "target_sub_punctuated": "连烧鸭连杯面都冇咁浓嘅味道"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "火鸡的味道把我每一个味蕾缠住⋯",
+      "target_subs": [
         "火鸡嘅味道喺我嘅每一个味蕾度缠住"
-      ],
-      "two": "火鸡的味道把我每一个味蕾缠住⋯"
+      ]
     },
     "answer": {
-      "output": "火鸡嘅味道喺我嘅每一个味蕾度缠住⋯"
+      "target_sub_punctuated": "火鸡嘅味道喺我嘅每一个味蕾度缠住⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "爆发⋯缠住⋯爆发⋯",
+      "target_subs": [
         "爆发",
         "缠住",
         "爆发"
-      ],
-      "two": "爆发⋯缠住⋯爆发⋯"
+      ]
     },
     "answer": {
-      "output": "爆发⋯缠住⋯爆发⋯"
+      "target_sub_punctuated": "爆发⋯缠住⋯爆发⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "最靓最靓，最犀利，而且最温柔",
+      "target_subs": [
         "最靓",
         "最靓",
         "最犀利",
         "亦都系最温柔"
-      ],
-      "two": "最靓最靓，最犀利，而且最温柔"
+      ]
     },
     "answer": {
-      "output": "最靓最靓，最犀利，亦都系最温柔"
+      "target_sub_punctuated": "最靓最靓，最犀利，亦都系最温柔"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "第二天我睡得很晏⋯",
+      "target_subs": [
         "第二日我瞓到好硬"
-      ],
-      "two": "第二天我睡得很晏⋯"
+      ]
     },
     "answer": {
-      "output": "第二日我瞓到好硬⋯"
+      "target_sub_punctuated": "第二日我瞓到好硬⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "刷过牙我还感觉到火鸡的美味",
+      "target_subs": [
         "测完牙",
         "我仲感觉到火鸡嘅美味"
-      ],
-      "two": "刷过牙我还感觉到火鸡的美味"
+      ]
     },
     "answer": {
-      "output": "测完牙我仲感觉到火鸡嘅美味"
+      "target_sub_punctuated": "测完牙我仲感觉到火鸡嘅美味"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "因为早餐吃得晚⋯",
+      "target_subs": [
         "因为早餐食得硬"
-      ],
-      "two": "因为早餐吃得晚⋯"
+      ]
     },
     "answer": {
-      "output": "因为早餐食得硬⋯"
+      "target_sub_punctuated": "因为早餐食得硬⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "不用说，那夜就是我渴望了⋯",
+      "target_subs": [
         "嗰晚唔使讲",
         "当然系食我限咗"
-      ],
-      "two": "不用说，那夜就是我渴望了⋯"
+      ]
     },
     "answer": {
-      "output": "嗰晚唔使讲，当然系食我限咗⋯"
+      "target_sub_punctuated": "嗰晚唔使讲，当然系食我限咗⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "很久很久很久的⋯圣诞火鸡大餐！",
+      "target_subs": [
         "好耐好耐好耐好耐嘅圣诞火鸡大餐"
-      ],
-      "two": "很久很久很久的⋯圣诞火鸡大餐！"
+      ]
     },
     "answer": {
-      "output": "好耐好耐好耐好耐嘅⋯圣诞火鸡大餐！"
+      "target_sub_punctuated": "好耐好耐好耐好耐嘅⋯圣诞火鸡大餐！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "一片片的火鸡肉和伴碟的薯仔和节瓜⋯",
+      "target_subs": [
         "一片一片嘅火鸡肉",
         "半碟嘅有薯仔同节瓜"
-      ],
-      "two": "一片片的火鸡肉和伴碟的薯仔和节瓜⋯"
+      ]
     },
     "answer": {
-      "output": "一片一片嘅火鸡肉半碟嘅有薯仔同节瓜⋯"
+      "target_sub_punctuated": "一片一片嘅火鸡肉半碟嘅有薯仔同节瓜⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我们真的好兴奋，好满足",
+      "target_subs": [
         "我哋真系好兴奋",
         "好满足"
-      ],
-      "two": "我们真的好兴奋，好满足"
+      ]
     },
     "answer": {
-      "output": "我哋真系好兴奋，好满足"
+      "target_sub_punctuated": "我哋真系好兴奋，好满足"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "之后，我们吃了一个星期的⋯",
+      "target_subs": [
         "之后我哋仲食咗一个礼拜嘅"
-      ],
-      "two": "之后，我们吃了一个星期的⋯"
+      ]
     },
     "answer": {
-      "output": "之后，我哋仲食咗一个礼拜嘅⋯"
+      "target_sub_punctuated": "之后，我哋仲食咗一个礼拜嘅⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我大着胆跟妈妈说：不如去饮茶吖",
+      "target_subs": [
         "我嘅记心肝同妈妈讲",
         "不如饮茶"
-      ],
-      "two": "我大着胆跟妈妈说：不如去饮茶吖"
+      ]
     },
     "answer": {
-      "output": "我嘅记心肝同妈妈讲：不如饮茶"
+      "target_sub_punctuated": "我嘅记心肝同妈妈讲：不如饮茶"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈骂我「冇衣食」⋯",
+      "target_subs": [
         "妈妈闹我冇意食"
-      ],
-      "two": "妈妈骂我「冇衣食」⋯"
+      ]
     },
     "answer": {
-      "output": "妈妈闹我「冇意食」⋯"
+      "target_sub_punctuated": "妈妈闹我「冇意食」⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "之后，妈妈又有计⋯",
+      "target_subs": [
         "之后妈妈又有计"
-      ],
-      "two": "之后，妈妈又有计⋯"
+      ]
     },
     "answer": {
-      "output": "之后，妈妈又有计⋯"
+      "target_sub_punctuated": "之后，妈妈又有计⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "她把冰箱内剩下来的火鸡肉撕呀撕",
+      "target_subs": [
         "佢将雪柜净返嘅火鸡肉",
         "系噉撕系噉撕"
-      ],
-      "two": "她把冰箱内剩下来的火鸡肉撕呀撕"
+      ]
     },
     "answer": {
-      "output": "佢将雪柜净返嘅火鸡肉系噉撕系噉撕"
+      "target_sub_punctuated": "佢将雪柜净返嘅火鸡肉系噉撕系噉撕"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "银芽火鸡丝炒米，好味道",
+      "target_subs": [
         "银牙火鸡丝炒米好味道噉"
-      ],
-      "two": "银芽火鸡丝炒米，好味道"
+      ]
     },
     "answer": {
-      "output": "银牙火鸡丝炒米，好味道噉"
+      "target_sub_punctuated": "银牙火鸡丝炒米，好味道噉"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "唉，我好后悔讲过一句「火鸡屙烂煮」",
+      "target_subs": [
         "唉",
         "我后悔讲过火鸡阿宁处呢句嘢"
-      ],
-      "two": "唉，我好后悔讲过一句「火鸡屙烂煮」"
+      ]
     },
     "answer": {
-      "output": "唉，我后悔讲过「火鸡阿宁处」呢句嘢"
+      "target_sub_punctuated": "唉，我后悔讲过「火鸡阿宁处」呢句嘢"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "端午节，当我翻开我最喜欢吃的裹蒸粽⋯",
+      "target_subs": [
         "到端午节",
         "当我督开我最钟意食嘅果精粽嘅时候"
-      ],
-      "two": "端午节，当我翻开我最喜欢吃的裹蒸粽⋯"
+      ]
     },
     "answer": {
-      "output": "到端午节，当我督开我最钟意食嘅果精粽嘅时候⋯"
+      "target_sub_punctuated": "到端午节，当我督开我最钟意食嘅果精粽嘅时候⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "发现咸蛋旁边是一件火鸡背的时候⋯",
+      "target_subs": [
         "发现宿喺咸蛋旁边嘅系一件火鸡背脊"
-      ],
-      "two": "发现咸蛋旁边是一件火鸡背的时候⋯"
+      ]
     },
     "answer": {
-      "output": "发现宿喺咸蛋旁边嘅系一件火鸡背脊⋯"
+      "target_sub_punctuated": "发现宿喺咸蛋旁边嘅系一件火鸡背脊⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我脑部一时想唔通，哭起来",
+      "target_subs": [
         "我脑部一时想唔通",
         "喊咗起上嚟"
-      ],
-      "two": "我脑部一时想唔通，哭起来"
+      ]
     },
     "answer": {
-      "output": "我脑部一时想唔通，喊咗起上嚟"
+      "target_sub_punctuated": "我脑部一时想唔通，喊咗起上嚟"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "救命呀！",
+      "target_subs": [
         "救命啊"
-      ],
-      "two": "救命呀！"
+      ]
     },
     "answer": {
-      "output": "救命啊！"
+      "target_sub_punctuated": "救命啊！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我的美梦跟恶梦亦同时完结",
+      "target_subs": [
         "我嘅美梦同噩梦",
         "都同时完结"
-      ],
-      "two": "我的美梦跟恶梦亦同时完结"
+      ]
     },
     "answer": {
-      "output": "我嘅美梦同噩梦都同时完结"
+      "target_sub_punctuated": "我嘅美梦同噩梦都同时完结"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "后来我才知道⋯",
+      "target_subs": [
         "后来我先知道"
-      ],
-      "two": "后来我才知道⋯"
+      ]
     },
     "answer": {
-      "output": "后来我先知道⋯"
+      "target_sub_punctuated": "后来我先知道⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "即是说，火鸡死掉后跟我们一起的日子",
+      "target_subs": [
         "即系话",
         "只火鸡死咗之后",
         "同我哋一齐嘅日子"
-      ],
-      "two": "即是说，火鸡死掉后跟我们一起的日子"
+      ]
     },
     "answer": {
-      "output": "即系话，只火鸡死咗之后同我哋一齐嘅日子"
+      "target_sub_punctuated": "即系话，只火鸡死咗之后同我哋一齐嘅日子"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我还发觉，火鸡的味道⋯",
+      "target_subs": [
         "我仲发觉到",
         "火鸡嘅味道"
-      ],
-      "two": "我还发觉，火鸡的味道⋯"
+      ]
     },
     "answer": {
-      "output": "我仲发觉到，火鸡嘅味道⋯"
+      "target_sub_punctuated": "我仲发觉到，火鸡嘅味道⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "将吃未吃和第一口之间已经是最高峰",
+      "target_subs": [
         "味食同食第一啖之间",
         "已经系佢嘅最高峰"
-      ],
-      "two": "将吃未吃和第一口之间已经是最高峰"
+      ]
     },
     "answer": {
-      "output": "味食同食第一啖之间已经系佢嘅最高峰"
+      "target_sub_punctuated": "味食同食第一啖之间已经系佢嘅最高峰"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "之后的，不过是开始了也就吃下去",
+      "target_subs": [
         "之后",
         "不过都系食开就食埋落去噉解"
-      ],
-      "two": "之后的，不过是开始了也就吃下去"
+      ]
     },
     "answer": {
-      "output": "之后，不过都系食开就食埋落去噉解"
+      "target_sub_punctuated": "之后，不过都系食开就食埋落去噉解"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我没有哲学家的头脑⋯",
+      "target_subs": [
         "我冇知学家嘅头脑"
-      ],
-      "two": "我没有哲学家的头脑⋯"
+      ]
     },
     "answer": {
-      "output": "我冇知学家嘅头脑⋯"
+      "target_sub_punctuated": "我冇知学家嘅头脑⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "不知道两件事情应该得出什么道理",
+      "target_subs": [
         "唔知呢两样嘢要得起嘅呢个",
         "得出啲咩道理"
-      ],
-      "two": "不知道两件事情应该得出什么道理"
+      ]
     },
     "answer": {
-      "output": "唔知呢两样嘢要得起嘅呢个得出啲咩道理"
+      "target_sub_punctuated": "唔知呢两样嘢要得起嘅呢个得出啲咩道理"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "可是这些想法⋯",
+      "target_subs": [
         "但系呢啲谂法"
-      ],
-      "two": "可是这些想法⋯"
+      ]
     },
     "answer": {
-      "output": "但系呢啲谂法⋯"
+      "target_sub_punctuated": "但系呢啲谂法⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "在我长大后⋯",
+      "target_subs": [
         "喺我长大之后"
-      ],
-      "two": "在我长大后⋯"
+      ]
     },
     "answer": {
-      "output": "喺我长大之后⋯"
+      "target_sub_punctuated": "喺我长大之后⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "在一些跟圣诞节无关的日子⋯",
+      "target_subs": [
         "系一啲同圣诞节无关嘅日子"
-      ],
-      "two": "在一些跟圣诞节无关的日子⋯"
+      ]
     },
     "answer": {
-      "output": "系一啲同圣诞节无关嘅日子⋯"
+      "target_sub_punctuated": "系一啲同圣诞节无关嘅日子⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "毫无因由的在我脑中出现过三两次",
+      "target_subs": [
         "无端端噉喺我脑部",
         "出现过两三次"
-      ],
-      "two": "毫无因由的在我脑中出现过三两次"
+      ]
     },
     "answer": {
-      "output": "无端端噉喺我脑部出现过两三次"
+      "target_sub_punctuated": "无端端噉喺我脑部出现过两三次"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "一次，是在我自己的婚宴上",
+      "target_subs": [
         "一次",
         "喺我自己嘅婚宴上"
-      ],
-      "two": "一次，是在我自己的婚宴上"
+      ]
     },
     "answer": {
-      "output": "一次，喺我自己嘅婚宴上"
+      "target_sub_punctuated": "一次，喺我自己嘅婚宴上"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "一次⋯",
+      "target_subs": [
         "一次"
-      ],
-      "two": "一次⋯"
+      ]
     },
     "answer": {
-      "output": "一次⋯"
+      "target_sub_punctuated": "一次⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那天，我看着天空几缕灰色的烟",
+      "target_subs": [
         "嗰日",
         "我望住天东几条灰色嘅烟"
-      ],
-      "two": "那天，我看着天空几缕灰色的烟"
+      ]
     },
     "answer": {
-      "output": "嗰日，我望住天东几条灰色嘅烟"
+      "target_sub_punctuated": "嗰日，我望住天东几条灰色嘅烟"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我好后悔要妈妈扔掉最后几件火鸡",
+      "target_subs": [
         "我后悔",
         "要妈妈劈咗个忌廉",
         "火鸡"
-      ],
-      "two": "我好后悔要妈妈扔掉最后几件火鸡"
+      ]
     },
     "answer": {
-      "output": "我后悔要妈妈劈咗个忌廉火鸡"
+      "target_sub_punctuated": "我后悔要妈妈劈咗个忌廉火鸡"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "向全世界人再次证明⋯",
+      "target_subs": [
         "向全世界人再次证明"
-      ],
-      "two": "向全世界人再次证明⋯"
+      ]
     },
     "answer": {
-      "output": "向全世界人再次证明⋯"
+      "target_sub_punctuated": "向全世界人再次证明⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "另方面⋯",
+      "target_subs": [
         "另一方面"
-      ],
-      "two": "另方面⋯"
+      ]
     },
     "answer": {
-      "output": "另一方面⋯"
+      "target_sub_punctuated": "另一方面⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "香港体运总会霍震霆⋯",
+      "target_subs": [
         "中国香港体育协会企奥委会会长霍振庭"
-      ],
-      "two": "香港体运总会霍震霆⋯"
+      ]
     },
     "answer": {
-      "output": "中国香港体育协会企奥委会会长霍振庭⋯"
+      "target_sub_punctuated": "中国香港体育协会企奥委会会长霍振庭⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "其中港九新界竹战联谊会⋯",
+      "target_subs": [
         "其中港狗新界足战联谊会"
-      ],
-      "two": "其中港九新界竹战联谊会⋯"
+      ]
     },
     "answer": {
-      "output": "其中港狗新界足战联谊会⋯"
+      "target_sub_punctuated": "其中港狗新界足战联谊会⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "另外，全港茶餐厅员工协会⋯",
+      "target_subs": [
         "另外",
         "全港茶餐厅联工协会"
-      ],
-      "two": "另外，全港茶餐厅员工协会⋯"
+      ]
     },
     "answer": {
-      "output": "另外，全港茶餐厅联工协会⋯"
+      "target_sub_punctuated": "另外，全港茶餐厅联工协会⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "经已发动所有会员⋯",
+      "target_subs": [
         "经热发动所有会员"
-      ],
-      "two": "经已发动所有会员⋯"
+      ]
     },
     "answer": {
-      "output": "经热发动所有会员⋯"
+      "target_sub_punctuated": "经热发动所有会员⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "争取「掷蛋挞」成为亚运比赛项目",
+      "target_subs": [
         "争取掟蛋挞成为亚运会比赛项目"
-      ],
-      "two": "争取「掷蛋挞」成为亚运比赛项目"
+      ]
     },
     "answer": {
-      "output": "争取「掟蛋挞」成为亚运会比赛项目"
+      "target_sub_punctuated": "争取「掟蛋挞」成为亚运会比赛项目"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "港九烧味卤味腊味同业会",
+      "target_subs": [
         "港狗烧尾",
         "掳尾",
         "立尾同业会"
-      ],
-      "two": "港九烧味卤味腊味同业会"
+      ]
     },
     "answer": {
-      "output": "港狗烧尾掳尾立尾同业会"
+      "target_sub_punctuated": "港狗烧尾掳尾立尾同业会"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "亦向霍主席当面提出⋯",
+      "target_subs": [
         "亦都向霍主席当面提出"
-      ],
-      "two": "亦向霍主席当面提出⋯"
+      ]
     },
     "answer": {
-      "output": "亦都向霍主席当面提出⋯"
+      "target_sub_punctuated": "亦都向霍主席当面提出⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「挂腊鸭」可以成为亚运比赛项目",
+      "target_subs": [
         "挂立鸭可以成为亚运比赛项目"
-      ],
-      "two": "「挂腊鸭」可以成为亚运比赛项目"
+      ]
     },
     "answer": {
-      "output": "「挂立鸭」可以成为亚运比赛项目"
+      "target_sub_punctuated": "「挂立鸭」可以成为亚运比赛项目"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "较为特别的是，CIC保险营业员联同⋯",
+      "target_subs": [
         "较为特别嘅系",
         "CIC保险营业员联同"
-      ],
-      "two": "较为特别的是，CIC保险营业员联同⋯"
+      ]
     },
     "answer": {
-      "output": "较为特别嘅系，CIC保险营业员联同⋯"
+      "target_sub_punctuated": "较为特别嘅系，CIC保险营业员联同⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "大角咀春田花花幼稚园⋯",
+      "target_subs": [
         "大角嘴春田花花",
         "幼稚园"
-      ],
-      "two": "大角咀春田花花幼稚园⋯"
+      ]
     },
     "answer": {
-      "output": "大角嘴春田花花幼稚园⋯"
+      "target_sub_punctuated": "大角嘴春田花花幼稚园⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "附属小学一班小朋友⋯",
+      "target_subs": [
         "附属小学嘅一班小朋友"
-      ],
-      "two": "附属小学一班小朋友⋯"
+      ]
     },
     "answer": {
-      "output": "附属小学嘅一班小朋友⋯"
+      "target_sub_punctuated": "附属小学嘅一班小朋友⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "争取「抢包山」",
+      "target_subs": [
         "争取抢包山"
-      ],
-      "two": "争取「抢包山」"
+      ]
     },
     "answer": {
-      "output": "争取「抢包山」"
+      "target_sub_punctuated": "争取「抢包山」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "一项几乎绝迹的运动⋯",
+      "target_subs": [
         "一项几乎绝迹嘅运动"
-      ],
-      "two": "一项几乎绝迹的运动⋯"
+      ]
     },
     "answer": {
-      "output": "一项几乎绝迹嘅运动⋯"
+      "target_sub_punctuated": "一项几乎绝迹嘅运动⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "最后⋯",
+      "target_subs": [
         "最后"
-      ],
-      "two": "最后⋯"
+      ]
     },
     "answer": {
-      "output": "最后⋯"
+      "target_sub_punctuated": "最后⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "最后，一切成烟",
+      "target_subs": [
         "最后全部都系banana"
-      ],
-      "two": "最后，一切成烟"
+      ]
     },
     "answer": {
-      "output": "最后，全部都系banana"
+      "target_sub_punctuated": "最后，全部都系banana"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "最后，他们选了「掷蛋挞」做推介项目",
+      "target_subs": [
         "最后佢哋选咗定蛋挞做推介项目"
-      ],
-      "two": "最后，他们选了「掷蛋挞」做推介项目"
+      ]
     },
     "answer": {
-      "output": "最后，佢哋选咗「定蛋挞」做推介项目"
+      "target_sub_punctuated": "最后，佢哋选咗「定蛋挞」做推介项目"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "至于香港争取申办亚运的口号⋯",
+      "target_subs": [
         "至于香港争取申办亚运嘅口号"
-      ],
-      "two": "至于香港争取申办亚运的口号⋯"
+      ]
     },
     "answer": {
-      "output": "至于香港争取申办亚运嘅口号⋯"
+      "target_sub_punctuated": "至于香港争取申办亚运嘅口号⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "亦顺理成章叫成「香港一蛋挞」",
+      "target_subs": [
         "亦都顺理成章噉叫做香港一蛋挞"
-      ],
-      "two": "亦顺理成章叫成「香港一蛋挞」"
+      ]
     },
     "answer": {
-      "output": "亦都顺理成章噉叫做「香港一蛋挞」"
+      "target_sub_punctuated": "亦都顺理成章噉叫做「香港一蛋挞」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "之后李丽珊蝉联失败⋯",
+      "target_subs": [
         "之后李利山丧乱失败"
-      ],
-      "two": "之后李丽珊蝉联失败⋯"
+      ]
     },
     "answer": {
-      "output": "之后李利山丧乱失败⋯"
+      "target_sub_punctuated": "之后李利山丧乱失败⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "亚运主办权⋯",
+      "target_subs": [
         "亚运主办权"
-      ],
-      "two": "亚运主办权⋯"
+      ]
     },
     "answer": {
-      "output": "亚运主办权⋯"
+      "target_sub_punctuated": "亚运主办权⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "想着转行当运动员的茶餐厅伙记⋯",
+      "target_subs": [
         "谂住可以转行做运动员嘅茶餐厅夥计"
-      ],
-      "two": "想着转行当运动员的茶餐厅伙记⋯"
+      ]
     },
     "answer": {
-      "output": "谂住可以转行做运动员嘅茶餐厅夥计⋯"
+      "target_sub_punctuated": "谂住可以转行做运动员嘅茶餐厅夥计⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "上中学后，我再没有练习抢包手",
+      "target_subs": [
         "上个中学",
         "我已经再冇练习抢包手"
-      ],
-      "two": "上中学后，我再没有练习抢包手"
+      ]
     },
     "answer": {
-      "output": "上个中学，我已经再冇练习抢包手"
+      "target_sub_punctuated": "上个中学，我已经再冇练习抢包手"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "有时候跟妈妈饮茶⋯",
+      "target_subs": [
         "间中同妈妈饮茶"
-      ],
-      "two": "有时候跟妈妈饮茶⋯"
+      ]
     },
     "answer": {
-      "output": "间中同妈妈饮茶⋯"
+      "target_sub_punctuated": "间中同妈妈饮茶⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "之后，茶楼再不卖大包了",
+      "target_subs": [
         "之后茶楼都冇埋大包"
-      ],
-      "two": "之后，茶楼再不卖大包了"
+      ]
     },
     "answer": {
-      "output": "之后，茶楼都冇埋大包"
+      "target_sub_punctuated": "之后，茶楼都冇埋大包"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "每次看见师傅⋯",
+      "target_subs": [
         "每次见到师傅"
-      ],
-      "two": "每次看见师傅⋯"
+      ]
     },
     "answer": {
-      "output": "每次见到师傅⋯"
+      "target_sub_punctuated": "每次见到师傅⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "因为环保⋯",
+      "target_subs": [
         "因为环保"
-      ],
-      "two": "因为环保⋯"
+      ]
     },
     "answer": {
-      "output": "因为环保⋯"
+      "target_sub_punctuated": "因为环保⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "师傅说，那阵胶气，相当臭",
+      "target_subs": [
         "师傅话嗰阵胶气都几丑下"
-      ],
-      "two": "师傅说，那阵胶气，相当臭"
+      ]
     },
     "answer": {
-      "output": "师傅话，嗰阵胶气，都几丑下"
+      "target_sub_punctuated": "师傅话，嗰阵胶气，都几丑下"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "因为我练过抢包手，身手比较灵活⋯",
+      "target_subs": [
         "因为我练过抢包手",
         "身手比较灵活"
-      ],
-      "two": "因为我练过抢包手，身手比较灵活⋯"
+      ]
     },
     "answer": {
-      "output": "因为我练过抢包手，身手比较灵活⋯"
+      "target_sub_punctuated": "因为我练过抢包手，身手比较灵活⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "同学们叫我爬进去看看，说不定会发达",
+      "target_subs": [
         "班同我叫我爬佢睇下",
         "话唔定会发达"
-      ],
-      "two": "同学们叫我爬进去看看，说不定会发达"
+      ]
     },
     "answer": {
-      "output": "班同我叫我爬佢睇下，话唔定会发达"
+      "target_sub_punctuated": "班同我叫我爬佢睇下，话唔定会发达"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "于是我就向着这个又黑又窄的洞⋯",
+      "target_subs": [
         "于是我就向住呢一个又黑又窄嘅洞"
-      ],
-      "two": "于是我就向着这个又黑又窄的洞⋯"
+      ]
     },
     "answer": {
-      "output": "于是我就向住呢一个又黑又窄嘅洞⋯"
+      "target_sub_punctuated": "于是我就向住呢一个又黑又窄嘅洞⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "一直爬",
+      "target_subs": [
         "系噉爬",
         "爬"
-      ],
-      "two": "一直爬"
+      ]
     },
     "answer": {
-      "output": "系噉爬爬"
+      "target_sub_punctuated": "系噉爬爬"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "洞里面什么也没有，只有一个盒子",
+      "target_subs": [
         "洞里面乜都冇",
         "净系有一个盒"
-      ],
-      "two": "洞里面什么也没有，只有一个盒子"
+      ]
     },
     "answer": {
-      "output": "洞里面乜都冇，净系有一个盒"
+      "target_sub_punctuated": "洞里面乜都冇，净系有一个盒"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我小心揭开盒子⋯",
+      "target_subs": [
         "我好小心揭开呢个盒"
-      ],
-      "two": "我小心揭开盒子⋯"
+      ]
     },
     "answer": {
-      "output": "我好小心揭开呢个盒⋯"
+      "target_sub_punctuated": "我好小心揭开呢个盒⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "是不是张保仔吃过的呢？",
+      "target_subs": [
         "唔知系咪张宝仔食净㗎啦"
-      ],
-      "two": "是不是张保仔吃过的呢？"
+      ]
     },
     "answer": {
-      "output": "唔知系咪张宝仔食净㗎啦？"
+      "target_sub_punctuated": "唔知系咪张宝仔食净㗎啦？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "揸住个包，我忽然明白⋯",
+      "target_subs": [
         "揸住个包",
         "我忽然明白"
-      ],
-      "two": "揸住个包，我忽然明白⋯"
+      ]
     },
     "answer": {
-      "output": "揸住个包，我忽然明白⋯"
+      "target_sub_punctuated": "揸住个包，我忽然明白⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "原来有些事情，没有就是没有",
+      "target_subs": [
         "原来有啲嘢冇",
         "就真系冇"
-      ],
-      "two": "原来有些事情，没有就是没有"
+      ]
     },
     "answer": {
-      "output": "原来有啲嘢，冇就真系冇"
+      "target_sub_punctuated": "原来有啲嘢，冇就真系冇"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "唔得，就是唔得",
+      "target_subs": [
         "唔得",
         "就真系唔得"
-      ],
-      "two": "唔得，就是唔得"
+      ]
     },
     "answer": {
-      "output": "唔得，就真系唔得"
+      "target_sub_punctuated": "唔得，就真系唔得"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "没有鱼蛋没有粗面没去成马尔代夫⋯",
+      "target_subs": [
         "冇鱼蛋",
         "冇粗面",
         "冇去买义大夫"
-      ],
-      "two": "没有鱼蛋没有粗面没去成马尔代夫⋯"
+      ]
     },
     "answer": {
-      "output": "冇鱼蛋冇粗面冇去买义大夫⋯"
+      "target_sub_punctuated": "冇鱼蛋冇粗面冇去买义大夫⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "而张保仔，也没有咬过那个包",
+      "target_subs": [
         "而张宝仔亦都冇咬过个包"
-      ],
-      "two": "而张保仔，也没有咬过那个包"
+      ]
     },
     "answer": {
-      "output": "而张宝仔，亦都冇咬过个包"
+      "target_sub_punctuated": "而张宝仔，亦都冇咬过个包"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "原来蠢，并不那么好笑",
+      "target_subs": [
         "原来",
         "唔系咁好笑"
-      ],
-      "two": "原来蠢，并不那么好笑"
+      ]
     },
     "answer": {
-      "output": "原来，唔系咁好笑"
+      "target_sub_punctuated": "原来，唔系咁好笑"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "蠢会失败⋯",
+      "target_subs": [
         "会失败"
-      ],
-      "two": "蠢会失败⋯"
+      ]
     },
     "answer": {
-      "output": "会失败⋯"
+      "target_sub_punctuated": "会失败⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "失望，并不那么好笑",
+      "target_subs": [
         "失望",
         "唔系咁好笑"
-      ],
-      "two": "失望，并不那么好笑"
+      ]
     },
     "answer": {
-      "output": "失望，唔系咁好笑"
+      "target_sub_punctuated": "失望，唔系咁好笑"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "肥，都不一定好笑",
+      "target_subs": [
         "肥",
         "都未必好笑"
-      ],
-      "two": "肥，都不一定好笑"
+      ]
     },
     "answer": {
-      "output": "肥，都未必好笑"
+      "target_sub_punctuated": "肥，都未必好笑"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "肥，不一定大力",
+      "target_subs": [
         "肥",
         "唔一定大力"
-      ],
-      "two": "肥，不一定大力"
+      ]
     },
     "answer": {
-      "output": "肥，唔一定大力"
+      "target_sub_punctuated": "肥，唔一定大力"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "大力，亦不一定得",
+      "target_subs": [
         "大力",
         "亦都唔一定得"
-      ],
-      "two": "大力，亦不一定得"
+      ]
     },
     "answer": {
-      "output": "大力，亦都唔一定得"
+      "target_sub_punctuated": "大力，亦都唔一定得"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "揸住个包，我忽然想⋯",
+      "target_subs": [
         "揸住个包",
         "我忽然喺度谂"
-      ],
-      "two": "揸住个包，我忽然想⋯"
+      ]
     },
     "answer": {
-      "output": "揸住个包，我忽然喺度谂⋯"
+      "target_sub_punctuated": "揸住个包，我忽然喺度谂⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "长大了，到我要面对这个实掘掘⋯",
+      "target_subs": [
         "大个咗到我要面对呢一个实角局"
-      ],
-      "two": "长大了，到我要面对这个实掘掘⋯"
+      ]
     },
     "answer": {
-      "output": "大个咗，到我要面对呢一个实角局⋯"
+      "target_sub_punctuated": "大个咗，到我要面对呢一个实角局⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "未必可以发梦，未必那么好笑的⋯",
+      "target_subs": [
         "未必到你发梦",
         "又未必咁好笑嘅"
-      ],
-      "two": "未必可以发梦，未必那么好笑的⋯"
+      ]
     },
     "answer": {
-      "output": "未必到你发梦，又未必咁好笑嘅⋯"
+      "target_sub_punctuated": "未必到你发梦，又未必咁好笑嘅⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "世界的时候，我会怎么样？",
+      "target_subs": [
         "世界嘅时候",
         "我会系点㗎呢"
-      ],
-      "two": "世界的时候，我会怎么样？"
+      ]
     },
     "answer": {
-      "output": "世界嘅时候，我会系点㗎呢？"
+      "target_sub_punctuated": "世界嘅时候，我会系点㗎呢？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「⋯无力挽回！」",
+      "target_subs": [
         "无泪弯"
-      ],
-      "two": "「⋯无力挽回！」"
+      ]
     },
     "answer": {
-      "output": "「⋯无泪弯！」"
+      "target_sub_punctuated": "「⋯无泪弯！」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "是的，我就是大个佬麦兜",
+      "target_subs": [
         "系呀",
         "我就系大个佬麦豆喇"
-      ],
-      "two": "是的，我就是大个佬麦兜"
+      ]
     },
     "answer": {
-      "output": "系呀，我就系大个佬麦豆喇"
+      "target_sub_punctuated": "系呀，我就系大个佬麦豆喇"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "肥，算大力",
+      "target_subs": [
         "肥啰",
         "算大力啦"
-      ],
-      "two": "肥，算大力"
+      ]
     },
     "answer": {
-      "output": "肥啰，算大力啦"
+      "target_sub_punctuated": "肥啰，算大力啦"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "脚瓜是真的大，比一节瓜还要大",
+      "target_subs": [
         "脚瓜真系几大",
         "仲大过个折瓜"
-      ],
-      "two": "脚瓜是真的大，比一节瓜还要大"
+      ]
     },
     "answer": {
-      "output": "脚瓜真系几大，仲大过个折瓜"
+      "target_sub_punctuated": "脚瓜真系几大，仲大过个折瓜"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "脚瓜上的肌肉非常结实⋯",
+      "target_subs": [
         "脚瓜上面个肌肉非常结实"
-      ],
-      "two": "脚瓜上的肌肉非常结实⋯"
+      ]
     },
     "answer": {
-      "output": "脚瓜上面个肌肉非常结实⋯"
+      "target_sub_punctuated": "脚瓜上面个肌肉非常结实⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "青筋一条条凸出来，似钢筋",
+      "target_subs": [
         "啲青筋一条一条凸下凸下",
         "好似钢筋"
-      ],
-      "two": "青筋一条条凸出来，似钢筋"
+      ]
     },
     "answer": {
-      "output": "啲青筋一条一条凸下凸下，好似钢筋"
+      "target_sub_punctuated": "啲青筋一条一条凸下凸下，好似钢筋"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "至于脚趾甲⋯",
+      "target_subs": [
         "至于脚趾弓啲脚甲"
-      ],
-      "two": "至于脚趾甲⋯"
+      ]
     },
     "answer": {
-      "output": "至于脚趾弓啲脚甲⋯"
+      "target_sub_punctuated": "至于脚趾弓啲脚甲⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "有次我无无聊聊真的量了一下⋯",
+      "target_subs": [
         "有次我无无聊聊真系走去卡下佢"
-      ],
-      "two": "有次我无无聊聊真的量了一下⋯"
+      ]
     },
     "answer": {
-      "output": "有次我无无聊聊真系走去卡下佢⋯"
+      "target_sub_punctuated": "有次我无无聊聊真系走去卡下佢⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "足有一寸厚",
+      "target_subs": [
         "哗",
         "粥粥成串咁厚"
-      ],
-      "two": "足有一寸厚"
+      ]
     },
     "answer": {
-      "output": "哗，粥粥成串咁厚"
+      "target_sub_punctuated": "哗，粥粥成串咁厚"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "是的，故事讲完了",
+      "target_subs": [
         "系呀",
         "故事讲完喇"
-      ],
-      "two": "是的，故事讲完了"
+      ]
     },
     "answer": {
-      "output": "系呀，故事讲完喇"
+      "target_sub_punctuated": "系呀，故事讲完喇"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "失败⋯尝试⋯",
+      "target_subs": [
         "失败",
         "尝试"
-      ],
-      "two": "失败⋯尝试⋯"
+      ]
     },
     "answer": {
-      "output": "失败⋯尝试⋯"
+      "target_sub_punctuated": "失败⋯尝试⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "好多包⋯可是没有包保成功的故事",
+      "target_subs": [
         "好多包",
         "但系冇包补成功嘅故事"
-      ],
-      "two": "好多包⋯可是没有包保成功的故事"
+      ]
     },
     "answer": {
-      "output": "好多包⋯但系冇包补成功嘅故事"
+      "target_sub_punctuated": "好多包⋯但系冇包补成功嘅故事"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "故事说了一轮⋯",
+      "target_subs": [
         "故事讲咗一轮"
-      ],
-      "two": "故事说了一轮⋯"
+      ]
     },
     "answer": {
-      "output": "故事讲咗一轮⋯"
+      "target_sub_punctuated": "故事讲咗一轮⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "什么也没有？也不是",
+      "target_subs": [
         "乜都冇",
         "又唔系噃"
-      ],
-      "two": "什么也没有？也不是"
+      ]
     },
     "answer": {
-      "output": "乜都冇？又唔系噃"
+      "target_sub_punctuated": "乜都冇？又唔系噃"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "可是楝一双脚瓜站这儿⋯",
+      "target_subs": [
         "但系冻住两个脚瓜企喺度"
-      ],
-      "two": "可是楝一双脚瓜站这儿⋯"
+      ]
     },
     "answer": {
-      "output": "但系冻住两个脚瓜企喺度⋯"
+      "target_sub_punctuated": "但系冻住两个脚瓜企喺度⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "当浪打过来⋯",
+      "target_subs": [
         "当啲浪打埋嚟"
-      ],
-      "two": "当浪打过来⋯"
+      ]
     },
     "answer": {
-      "output": "当啲浪打埋嚟⋯"
+      "target_sub_punctuated": "当啲浪打埋嚟⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "你知道我麻麻地叻佬，不懂得⋯",
+      "target_subs": [
         "你知我麻麻地叻佬",
         "唔识得"
-      ],
-      "two": "你知道我麻麻地叻佬，不懂得⋯"
+      ]
     },
     "answer": {
-      "output": "你知我麻麻地叻佬，唔识得⋯"
+      "target_sub_punctuated": "你知我麻麻地叻佬，唔识得⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "替自己的故事加点教训呀锦囊呀那些",
+      "target_subs": [
         "帮自己嘅故事加啲教训呀",
         "锦囊呀嗰啲嘢"
-      ],
-      "two": "替自己的故事加点教训呀锦囊呀那些"
+      ]
     },
     "answer": {
-      "output": "帮自己嘅故事加啲教训呀锦囊呀嗰啲嘢"
+      "target_sub_punctuated": "帮自己嘅故事加啲教训呀锦囊呀嗰啲嘢"
     },
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "可是，浸一双脚瓜站水中⋯",
+      "target_subs": [
         "但系冻住两个脚瓜企喺水嗰度"
-      ],
-      "two": "可是，浸一双脚瓜站水中⋯"
+      ]
     },
     "answer": {
-      "output": "但系，冻住两个脚瓜企喺水嗰度⋯"
+      "target_sub_punctuated": "但系，冻住两个脚瓜企喺水嗰度⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "当风吹向我的脑，我会想⋯",
+      "target_subs": [
         "当风",
         "吹喺我个脑部",
         "我会谂"
-      ],
-      "two": "当风吹向我的脑，我会想⋯"
+      ]
     },
     "answer": {
-      "output": "当风吹喺我个脑部，我会谂⋯"
+      "target_sub_punctuated": "当风吹喺我个脑部，我会谂⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "如果妈妈看见我这个大脚瓜⋯",
+      "target_subs": [
         "如果妈妈见到我呢个大脚瓜"
-      ],
-      "two": "如果妈妈看见我这个大脚瓜⋯"
+      ]
     },
     "answer": {
-      "output": "如果妈妈见到我呢个大脚瓜⋯"
+      "target_sub_punctuated": "如果妈妈见到我呢个大脚瓜⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "我猜，她会好开心",
+      "target_subs": [
         "我谂佢会好开心"
-      ],
-      "two": "我猜，她会好开心"
+      ]
     },
     "answer": {
-      "output": "我谂，佢会好开心"
+      "target_sub_punctuated": "我谂，佢会好开心"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "不成，还是出个锦囊！",
+      "target_subs": [
         "都系唔好呀",
         "都系出返个锦囊先得"
-      ],
-      "two": "不成，还是出个锦囊！"
+      ]
     },
     "answer": {
-      "output": "都系唔好呀，都系出返个锦囊先得！"
+      "target_sub_punctuated": "都系唔好呀，都系出返个锦囊先得！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈的 dot com 散掉后，她又有计",
+      "target_subs": [
         "妈妈个Doccom散咗之后",
         "佢又有计喇"
-      ],
-      "two": "妈妈的 dot com 散掉后，她又有计"
+      ]
     },
     "answer": {
-      "output": "妈妈个 Doccom 散咗之后，佢又有计喇"
+      "target_sub_punctuated": "妈妈个 Doccom 散咗之后，佢又有计喇"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "她出版了一本教烹饪的食谱",
+      "target_subs": [
         "佢出咗半教主送嘅食谱",
         "谂住捞返扎沙"
-      ],
-      "two": "她出版了一本教烹饪的食谱"
+      ]
     },
     "answer": {
-      "output": "佢出咗半教主送嘅食谱，谂住捞返扎沙"
+      "target_sub_punctuated": "佢出咗半教主送嘅食谱，谂住捞返扎沙"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "方法简单，人人可学",
+      "target_subs": [
         "方法简单",
         "人人都学得识"
-      ],
-      "two": "方法简单，人人可学"
+      ]
     },
     "answer": {
-      "output": "方法简单，人人都学得识"
+      "target_sub_punctuated": "方法简单，人人都学得识"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "「烧鸡」",
+      "target_subs": [
         "烧鸡"
-      ],
-      "two": "「烧鸡」"
+      ]
     },
     "answer": {
-      "output": "「烧鸡」"
+      "target_sub_punctuated": "「烧鸡」"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "材料是⋯鸡",
+      "target_subs": [
         "材料系",
         "鸡"
-      ],
-      "two": "材料是⋯鸡"
+      ]
     },
     "answer": {
-      "output": "材料系⋯鸡"
+      "target_sub_punctuated": "材料系⋯鸡"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "方法：把鸡烧几烧",
+      "target_subs": [
         "方法",
         "攞只鸡",
         "去烧佢几烧"
-      ],
-      "two": "方法：把鸡烧几烧"
+      ]
     },
     "answer": {
-      "output": "方法：攞只鸡去烧佢几烧"
+      "target_sub_punctuated": "方法：攞只鸡去烧佢几烧"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "就这样，一味「烧鸡」大功告成",
+      "target_subs": [
         "就噉",
         "一味烧鸡",
         "就大功告成喇"
-      ],
-      "two": "就这样，一味「烧鸡」大功告成"
+      ]
     },
     "answer": {
-      "output": "就噉，一味「烧鸡」就大功告成喇"
+      "target_sub_punctuated": "就噉，一味「烧鸡」就大功告成喇"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "食谱里面补充说：",
+      "target_subs": [
         "食谱度又补充噉话"
-      ],
-      "two": "食谱里面补充说："
+      ]
     },
     "answer": {
-      "output": "食谱度又补充噉话："
+      "target_sub_punctuated": "食谱度又补充噉话："
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "如果你想把鸡烧得美味可口⋯",
+      "target_subs": [
         "如果想你个鸡烧得美味可口"
-      ],
-      "two": "如果你想把鸡烧得美味可口⋯"
+      ]
     },
     "answer": {
-      "output": "如果想你个鸡烧得美味可口⋯"
+      "target_sub_punctuated": "如果想你个鸡烧得美味可口⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "秘诀是：拜托，把鸡烧好一点⋯",
+      "target_subs": [
         "个秘诀系唔该",
         "烧得佢好啲啰"
-      ],
-      "two": "秘诀是：拜托，把鸡烧好一点⋯"
+      ]
     },
     "answer": {
-      "output": "个秘诀系：唔该，烧得佢好啲啰⋯"
+      "target_sub_punctuated": "个秘诀系：唔该，烧得佢好啲啰⋯"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "多谢合作！",
+      "target_subs": [
         "多谢合作"
-      ],
-      "two": "多谢合作！"
+      ]
     },
     "answer": {
-      "output": "多谢合作！"
+      "target_sub_punctuated": "多谢合作！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "麻烦你，一客常餐",
+      "target_subs": [
         "唔该",
         "我要一个常餐啦"
-      ],
-      "two": "麻烦你，一客常餐"
+      ]
     },
     "answer": {
-      "output": "唔该，我要一个常餐啦"
+      "target_sub_punctuated": "唔该，我要一个常餐啦"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "常餐？　常餐有什么吃？",
+      "target_subs": [
         "常餐",
         "常餐有咩食㗎"
-      ],
-      "two": "常餐？　常餐有什么吃？"
+      ]
     },
     "answer": {
-      "output": "常餐？　常餐有咩食㗎？"
+      "target_sub_punctuated": "常餐？　常餐有咩食㗎？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "特餐是什么？",
+      "target_subs": [
         "噉特餐系咩嚟㗎"
-      ],
-      "two": "特餐是什么？"
+      ]
     },
     "answer": {
-      "output": "噉特餐系咩嚟㗎？"
+      "target_sub_punctuated": "噉特餐系咩嚟㗎？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "快餐又是什么？",
+      "target_subs": [
         "噉快餐又系咩嚟㗎"
-      ],
-      "two": "快餐又是什么？"
+      ]
     },
     "answer": {
-      "output": "噉快餐又系咩嚟㗎？"
+      "target_sub_punctuated": "噉快餐又系咩嚟㗎？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "午餐吃什么？",
+      "target_subs": [
         "午餐食咩㗎"
-      ],
-      "two": "午餐吃什么？"
+      ]
     },
     "answer": {
-      "output": "午餐食咩㗎？"
+      "target_sub_punctuated": "午餐食咩㗎？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "晚餐又吃什么？",
+      "target_subs": [
         "噉晚餐又食啲咩呀"
-      ],
-      "two": "晚餐又吃什么？"
+      ]
     },
     "answer": {
-      "output": "噉晚餐又食啲咩呀？"
+      "target_sub_punctuated": "噉晚餐又食啲咩呀？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那么，两客常餐吧",
+      "target_subs": [
         "噉呀",
         "我要两个常餐啦"
-      ],
-      "two": "那么，两客常餐吧"
+      ]
     },
     "answer": {
-      "output": "噉呀，我要两个常餐啦"
+      "target_sub_punctuated": "噉呀，我要两个常餐啦"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "今天常餐精采呀！",
+      "target_subs": [
         "好嘢呀",
         "我哋今日啲常餐"
-      ],
-      "two": "今天常餐精采呀！"
+      ]
     },
     "answer": {
-      "output": "好嘢呀，我哋今日啲常餐！"
+      "target_sub_punctuated": "好嘢呀，我哋今日啲常餐！"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "对不起，常餐卖光了",
+      "target_subs": [
         "唔好意思",
         "上餐卖晒"
-      ],
-      "two": "对不起，常餐卖光了"
+      ]
     },
     "answer": {
-      "output": "唔好意思，上餐卖晒"
+      "target_sub_punctuated": "唔好意思，上餐卖晒"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "特餐？特餐有什么吃？",
+      "target_subs": [
         "特餐",
         "特餐有咩食㗎"
-      ],
-      "two": "特餐？特餐有什么吃？"
+      ]
     },
     "answer": {
-      "output": "特餐？特餐有咩食㗎？"
+      "target_sub_punctuated": "特餐？特餐有咩食㗎？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "午餐又吃什么呢？",
+      "target_subs": [
         "午餐食乜嘢㗎"
-      ],
-      "two": "午餐又吃什么呢？"
+      ]
     },
     "answer": {
-      "output": "午餐食乜嘢㗎？"
+      "target_sub_punctuated": "午餐食乜嘢㗎？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "什么是晚餐？",
+      "target_subs": [
         "咁乜嘢系晚餐呀"
-      ],
-      "two": "什么是晚餐？"
+      ]
     },
     "answer": {
-      "output": "咁乜嘢系晚餐呀？"
+      "target_sub_punctuated": "咁乜嘢系晚餐呀？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "快餐吃什么？",
+      "target_subs": [
         "咁快餐食咩㗎"
-      ],
-      "two": "快餐吃什么？"
+      ]
     },
     "answer": {
-      "output": "咁快餐食咩㗎？"
+      "target_sub_punctuated": "咁快餐食咩㗎？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "唉，快餐不就是常餐",
+      "target_subs": [
         "系",
         "快餐就即系上餐啰"
-      ],
-      "two": "唉，快餐不就是常餐"
+      ]
     },
     "answer": {
-      "output": "系，快餐就即系上餐啰"
+      "target_sub_punctuated": "系，快餐就即系上餐啰"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "常餐不是卖光了吗？",
+      "target_subs": [
         "咁你头先又话冇上餐"
-      ],
-      "two": "常餐不是卖光了吗？"
+      ]
     },
     "answer": {
-      "output": "咁你头先又话冇上餐？"
+      "target_sub_punctuated": "咁你头先又话冇上餐？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "对，常餐卖光了，要吃特餐吗？",
+      "target_subs": [
         "系呀",
         "上餐就系卖晒呀",
         "咁你试唔试下特餐啦"
-      ],
-      "two": "对，常餐卖光了，要吃特餐吗？"
+      ]
     },
     "answer": {
-      "output": "系呀，上餐就系卖晒呀，咁你试唔试下特餐啦？"
+      "target_sub_punctuated": "系呀，上餐就系卖晒呀，咁你试唔试下特餐啦？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "对不起，特餐卖光了",
+      "target_subs": [
         "唔好意思",
         "特餐卖晒嘅"
-      ],
-      "two": "对不起，特餐卖光了"
+      ]
     },
     "answer": {
-      "output": "唔好意思，特餐卖晒嘅"
+      "target_sub_punctuated": "唔好意思，特餐卖晒嘅"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "妈妈，改快餐吧",
+      "target_subs": [
         "妈妈",
         "不如改快餐啦"
-      ],
-      "two": "妈妈，改快餐吧"
+      ]
     },
     "answer": {
-      "output": "妈妈，不如改快餐啦"
+      "target_sub_punctuated": "妈妈，不如改快餐啦"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "快餐有什么？",
+      "target_subs": [
         "快餐有咩㗎"
-      ],
-      "two": "快餐有什么？"
+      ]
     },
     "answer": {
-      "output": "快餐有咩㗎？"
+      "target_sub_punctuated": "快餐有咩㗎？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "常餐又有什么呢？",
+      "target_subs": [
         "咁上餐有咩㗎"
-      ],
-      "two": "常餐又有什么呢？"
+      ]
     },
     "answer": {
-      "output": "咁上餐有咩㗎？"
+      "target_sub_punctuated": "咁上餐有咩㗎？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "那么午餐又有什么吃？",
+      "target_subs": [
         "哎呀",
         "咁午餐有咩食呀"
-      ],
-      "two": "那么午餐又有什么吃？"
+      ]
     },
     "answer": {
-      "output": "哎呀，咁午餐有咩食呀？"
+      "target_sub_punctuated": "哎呀，咁午餐有咩食呀？"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "晚餐呢？",
+      "target_subs": [
         "咁晚餐呢"
-      ],
-      "two": "晚餐呢？"
+      ]
     },
     "answer": {
-      "output": "咁晚餐呢？"
+      "target_sub_punctuated": "咁晚餐呢？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "不是说特餐卖光了吗？",
+      "target_subs": [
         "咁你头先又话冇特餐"
-      ],
-      "two": "不是说特餐卖光了吗？"
+      ]
     },
     "answer": {
-      "output": "咁你头先又话冇特餐？"
+      "target_sub_punctuated": "咁你头先又话冇特餐？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "特餐卖光了，要试试快餐吗？都一样的",
+      "target_subs": [
         "系呀",
         "特餐系卖晒呀",
         "咁你试唔试下个快餐啦",
         "一样嘅啫"
-      ],
-      "two": "特餐卖光了，要试试快餐吗？都一样的"
+      ]
     },
     "answer": {
-      "output": "系呀，特餐系卖晒呀，咁你试唔试下个快餐啦？一样嘅啫"
+      "target_sub_punctuated": "系呀，特餐系卖晒呀，咁你试唔试下个快餐啦？一样嘅啫"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "对不起，没快餐了",
+      "target_subs": [
         "唔好意思冇快餐呀"
-      ],
-      "two": "对不起，没快餐了"
+      ]
     },
     "answer": {
-      "output": "唔好意思，冇快餐呀"
+      "target_sub_punctuated": "唔好意思，冇快餐呀"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "太过份了吧？你们究竟有吃的没？",
+      "target_subs": [
         "嚟唔嚟普啲呀",
         "噉你哋究竟有啲咩餐呀"
-      ],
-      "two": "太过份了吧？你们究竟有吃的没？"
+      ]
     },
     "answer": {
-      "output": "嚟唔嚟普啲呀？噉你哋究竟有啲咩餐呀？"
+      "target_sub_punctuated": "嚟唔嚟普啲呀？噉你哋究竟有啲咩餐呀？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "午餐吧，午餐精采呀",
+      "target_subs": [
         "午餐啦",
         "午餐好嘢呀"
-      ],
-      "two": "午餐吧，午餐精采呀"
+      ]
     },
     "answer": {
-      "output": "午餐啦，午餐好嘢呀"
+      "target_sub_punctuated": "午餐啦，午餐好嘢呀"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "怎么个精采法？",
+      "target_subs": [
         "点好嘢法呀"
-      ],
-      "two": "怎么个精采法？"
+      ]
     },
     "answer": {
-      "output": "点好嘢法呀？"
+      "target_sub_punctuated": "点好嘢法呀？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "晚餐又怎样呢？",
+      "target_subs": [
         "噉晚餐又点好嘢法呀"
-      ],
-      "two": "晚餐又怎样呢？"
+      ]
     },
     "answer": {
-      "output": "噉晚餐又点好嘢法呀？"
+      "target_sub_punctuated": "噉晚餐又点好嘢法呀？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "常餐又怎样呢？",
+      "target_subs": [
         "噉上餐又点好嘢法呀"
-      ],
-      "two": "常餐又怎样呢？"
+      ]
     },
     "answer": {
-      "output": "噉上餐又点好嘢法呀？"
+      "target_sub_punctuated": "噉上餐又点好嘢法呀？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "常餐早卖光了，你说精采不？",
+      "target_subs": [
         "上餐",
         "上餐一早卖晒啦",
         "你话好唔好嘢"
-      ],
-      "two": "常餐早卖光了，你说精采不？"
+      ]
     },
     "answer": {
-      "output": "上餐，上餐一早卖晒啦，你话好唔好嘢？"
+      "target_sub_punctuated": "上餐，上餐一早卖晒啦，你话好唔好嘢？"
     },
     "difficulty": 2,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "好吧好吧！两份午餐好了",
+      "target_subs": [
         "好啦好啦",
         "要两份午餐啦"
-      ],
-      "two": "好吧好吧！两份午餐好了"
+      ]
     },
     "answer": {
-      "output": "好啦好啦！要两份午餐啦"
+      "target_sub_punctuated": "好啦好啦！要两份午餐啦"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "对不起，午餐卖光了",
+      "target_subs": [
         "唔好意思",
         "午餐卖晒"
-      ],
-      "two": "对不起，午餐卖光了"
+      ]
     },
     "answer": {
-      "output": "唔好意思，午餐卖晒"
+      "target_sub_punctuated": "唔好意思，午餐卖晒"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "要试试我们的晚餐吗？都一样的",
+      "target_subs": [
         "试唔试下我哋嘅晚餐啦",
         "一样嘅啫"
-      ],
-      "two": "要试试我们的晚餐吗？都一样的"
+      ]
     },
     "answer": {
-      "output": "试唔试下我哋嘅晚餐啦？一样嘅啫"
+      "target_sub_punctuated": "试唔试下我哋嘅晚餐啦？一样嘅啫"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "光天白日，吃什么鬼晚餐？",
+      "target_subs": [
         "日光日白食乜鬼嘢晚餐啊"
-      ],
-      "two": "光天白日，吃什么鬼晚餐？"
+      ]
     },
     "answer": {
-      "output": "日光日白，食乜鬼嘢晚餐啊？"
+      "target_sub_punctuated": "日光日白，食乜鬼嘢晚餐啊？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "唉，说是说晚餐，还不就是午餐？",
+      "target_subs": [
         "系",
         "个名叫晚餐啫",
         "其实唔系真系午餐"
-      ],
-      "two": "唉，说是说晚餐，还不就是午餐？"
+      ]
     },
     "answer": {
-      "output": "系，个名叫晚餐啫，其实唔系真系午餐？"
+      "target_sub_punctuated": "系，个名叫晚餐啫，其实唔系真系午餐？"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "好吧好吧，拜托！两份晚餐！快！",
+      "target_subs": [
         "好啦好啦",
         "怕咗你啦",
         "要两份晚餐啦",
         "快啲手啊"
-      ],
-      "two": "好吧好吧，拜托！两份晚餐！快！"
+      ]
     },
     "answer": {
-      "output": "好啦好啦，怕咗你啦！要两份晚餐啦！快啲手啊！"
+      "target_sub_punctuated": "好啦好啦，怕咗你啦！要两份晚餐啦！快啲手啊！"
     },
     "difficulty": 1,
     "verified": true
   },
   {
     "query": {
-      "one": [
+      "ref_sub": "要快吗？那得吃快餐了！",
+      "target_subs": [
         "想快",
         "想快就要快餐啊"
-      ],
-      "two": "要快吗？那得吃快餐了！"
+      ]
     },
     "answer": {
-      "output": "想快？想快就要快餐啊！"
+      "target_sub_punctuated": "想快？想快就要快餐啊！"
     },
     "difficulty": 1,
     "verified": true

--- a/test/lang/transcription/test_punctuation_alignment.py
+++ b/test/lang/transcription/test_punctuation_alignment.py
@@ -18,9 +18,9 @@ from scinoephile.lang.transcription.alignment import TranscriptionAlignment
 from scinoephile.llms.punctuation import PunctuationPrompt, PunctuationTestCase
 
 _LOCALIZED_PROMPT = PunctuationPrompt(
-    src_1="zimu",
-    src_2="cankao",
-    output="jieguo",
+    ref_sub="cankao",
+    target_subs="zimu",
+    target_sub_punctuated="jieguo",
 )
 """Punctuation prompt using non-default correspondence field names."""
 
@@ -64,12 +64,12 @@ def test_alignment_constructs_semantic_fields_with_configured_prompt():
     assert isinstance(test_case, PunctuationTestCase)
     assert test_case.prompt is _LOCALIZED_PROMPT
     assert test_case.query.model_dump() == {
-        "subtitles": ["你好"],
         "guide": "你好！",
+        "subtitles": ["你好"],
     }
     assert test_case.query.model_dump(by_alias=True) == {
-        "zimu": ["你好"],
         "cankao": "你好！",
+        "zimu": ["你好"],
     }
 
 

--- a/test/llms/test_punctuation.py
+++ b/test/llms/test_punctuation.py
@@ -31,21 +31,23 @@ from test.helpers import test_data_root
 
 _LOCALIZED_PROMPT = PunctuationPrompt(
     language=Language.zho_hant,
-    src_1="zimu",
-    src_1_desc="要加標點嘅字幕行",
-    src_2="cankao",
-    src_2_desc="標點參考字幕",
-    output="jieguo",
-    output_desc="加標點後嘅字幕",
+    ref_sub="cankao",
+    ref_sub_desc="標點參考字幕",
+    target_subs="zimu",
+    target_subs_desc="要加標點嘅字幕行",
+    target_sub_punctuated="jieguo",
+    target_sub_punctuated_desc="加標點後嘅字幕",
 )
 """Punctuation prompt with Chinese correspondence field names."""
 
-_PUNCTUATION_PATHS = tuple(
+_MLAMD_PUNCTUATION_PATHS = tuple(
     sorted(
-        test_data_root.glob("*/output/*/lang/yue_zho/transcription/punctuation/*.json")
+        test_data_root.glob(
+            "mlamd/output/*/lang/yue_zho/transcription/punctuation/*.json"
+        )
     )
 )
-"""Tracked punctuation test-case JSON paths."""
+"""Tracked MLAMD punctuation test-case JSON paths."""
 
 
 def test_prompt_aliases_are_used_for_llm_correspondence():
@@ -59,12 +61,12 @@ def test_prompt_aliases_are_used_for_llm_correspondence():
     )
 
     assert test_case.query.model_dump() == {
-        "subtitles": ["原文一", "原文二"],
         "guide": "參考",
+        "subtitles": ["原文一", "原文二"],
     }
     assert test_case.query.model_dump(by_alias=True) == {
-        "zimu": ["原文一", "原文二"],
         "cankao": "參考",
+        "zimu": ["原文一", "原文二"],
     }
     assert test_case.answer is not None
     assert test_case.answer.model_dump() == {"output": "原文一原文二"}
@@ -73,7 +75,7 @@ def test_prompt_aliases_are_used_for_llm_correspondence():
     query_schema = test_case_cls.query_cls.model_json_schema(by_alias=True)
     answer_schema = test_case_cls.answer_cls.model_json_schema(by_alias=True)
     assert query_schema["title"] == f"PunctuationQuery_{_LOCALIZED_PROMPT.name}"
-    assert list(query_schema["properties"]) == ["zimu", "cankao"]
+    assert list(query_schema["properties"]) == ["cankao", "zimu"]
     assert query_schema["properties"]["zimu"]["description"] == "要加標點嘅字幕行"
     assert query_schema["properties"]["cankao"]["description"] == "標點參考字幕"
     assert answer_schema["title"] == f"PunctuationAnswer_{_LOCALIZED_PROMPT.name}"
@@ -98,8 +100,8 @@ def test_queryer_corresponds_using_prompt_aliases():
     messages, answer_cls, _ = provider.chat_completion.call_args.args
     assert answer_cls is test_case_cls.answer_cls
     assert json.loads(messages[1]["content"]) == {
-        "zimu": ["原文"],
         "cankao": "參考",
+        "zimu": ["原文"],
     }
 
 
@@ -129,7 +131,7 @@ def test_queryer_localizes_test_case_validation_retry():
     assert messages[-1]["content"] == "\n".join(
         (
             prompt.test_case_invalid_pre,
-            prompt.src_1_chars_changed_err(
+            prompt.target_chars_changed_err(
                 "".join(subtitles),
                 "係洋文嚟嘅蝦即係有鬥心",
             ),
@@ -143,11 +145,14 @@ def test_query_and_answer_require_nonempty_fields():
     query_cls = PunctuationManager.get_query_cls(_LOCALIZED_PROMPT)
     answer_cls = PunctuationManager.get_answer_cls(_LOCALIZED_PROMPT)
 
-    with raises(ValidationError, match=_LOCALIZED_PROMPT.src_1_missing_err):
+    with raises(ValidationError, match=_LOCALIZED_PROMPT.target_subs_missing_err):
         query_cls.model_validate({"subtitles": [], "guide": "參考"})
-    with raises(ValidationError, match=_LOCALIZED_PROMPT.src_2_missing_err):
+    with raises(ValidationError, match=_LOCALIZED_PROMPT.ref_sub_missing_err):
         query_cls.model_validate({"subtitles": ["原文"], "guide": ""})
-    with raises(ValidationError, match=_LOCALIZED_PROMPT.output_missing_err):
+    with raises(
+        ValidationError,
+        match=_LOCALIZED_PROMPT.target_sub_punctuated_missing_err,
+    ):
         answer_cls.model_validate({"output": ""})
 
 
@@ -208,14 +213,14 @@ def test_persistence_uses_base_prompt_aliases(tmp_path: Path):
 
     assert json.loads(output_path.read_text(encoding="utf-8")) == [
         {
-            "query": {"one": ["原文"], "two": "參考"},
-            "answer": {"output": "原文"},
+            "query": {"ref_sub": "參考", "target_subs": ["原文"]},
+            "answer": {"target_sub_punctuated": "原文"},
             "verified": True,
         }
     ]
     persisted = PersistedTestCase.from_test_case(test_case, PunctuationManager)
-    assert persisted.query == {"one": ["原文"], "two": "參考"}
-    assert persisted.answer == {"output": "原文"}
+    assert persisted.query == {"ref_sub": "參考", "target_subs": ["原文"]}
+    assert persisted.answer == {"target_sub_punctuated": "原文"}
 
     loaded = load_test_cases_from_json(
         output_path,
@@ -223,30 +228,30 @@ def test_persistence_uses_base_prompt_aliases(tmp_path: Path):
         _LOCALIZED_PROMPT,
     )
     assert loaded[0].query.model_dump(by_alias=True) == {
-        "zimu": ["原文"],
         "cankao": "參考",
+        "zimu": ["原文"],
     }
     assert loaded[0].answer is not None
     assert loaded[0].answer.model_dump(by_alias=True) == {"jieguo": "原文"}
 
 
 def test_tracked_fixture_count():
-    """All four tracked punctuation files should contain 2,973 test cases."""
+    """Both tracked MLAMD punctuation files should contain 1,288 test cases."""
     counts = [
         len(json.loads(input_path.read_text(encoding="utf-8")))
-        for input_path in _PUNCTUATION_PATHS
+        for input_path in _MLAMD_PUNCTUATION_PATHS
     ]
 
-    assert len(_PUNCTUATION_PATHS) == 4
-    assert sum(counts) == 2973
+    assert len(_MLAMD_PUNCTUATION_PATHS) == 2
+    assert sum(counts) == 1288
 
 
 @mark.parametrize(
     "input_path",
-    _PUNCTUATION_PATHS,
+    _MLAMD_PUNCTUATION_PATHS,
     ids=[
         input_path.relative_to(test_data_root).as_posix()
-        for input_path in _PUNCTUATION_PATHS
+        for input_path in _MLAMD_PUNCTUATION_PATHS
     ],
 )
 def test_tracked_fixture_round_trips_without_migration(

--- a/test/optimization/persistence/test_cases/test_optimization_test_cases_sync.py
+++ b/test/optimization/persistence/test_cases/test_optimization_test_cases_sync.py
@@ -419,10 +419,10 @@ def test_sync_round_trips_unbounded_lists(tmp_path: Path):
             [
                 {
                     "query": {
-                        "one": lines,
-                        "two": "reference",
+                        "ref_sub": "reference",
+                        "target_subs": lines,
                     },
-                    "answer": {"output": "".join(lines)},
+                    "answer": {"target_sub_punctuated": "".join(lines)},
                 }
             ]
         ),
@@ -442,7 +442,7 @@ def test_sync_round_trips_unbounded_lists(tmp_path: Path):
 
     list_lengths: list[int] = []
     for test_case in loaded:
-        value = test_case.query.get("one")
+        value = test_case.query.get("target_subs")
         if isinstance(value, list):
             list_lengths.append(len(value))
     assert max(list_lengths) >= 36


### PR DESCRIPTION
## Summary

- rename punctuation prompt fields from generic source/output terminology to explicit reference/target terminology
- update punctuation managers, models, localized Cantonese prompts, persistence tests, and alignment tests to use the semantic names
- mechanically migrate the two MLAMD punctuation JSON fixtures while preserving every case and all metadata

## Why

The previous `src_1`, `src_2`, and `output` names obscured the distinct roles of the reference subtitle, target subtitle fragments, and punctuated target. Semantic names make prompt configuration, validation, and persisted data easier to understand while preserving runtime behavior.

## Impact

The base persisted punctuation aliases now use `ref_sub`, `target_subs`, and `target_sub_punctuated`. The localized LLM-facing aliases remain unchanged (`zhongwen`, `yuewen_to_punctuate`, and `yuewen_punctuated`).

Legacy KOB Yue-Hans punctuation fixtures are intentionally outside this PR. Both focused and repository-wide fixture contracts temporarily select only MLAMD punctuation fixtures. U12 will replace the KOB corpus and restore its coverage. The migration deliberately retains existing `few_shot`, difficulty, and verification metadata rather than carrying unrelated generated-fixture churn from the source branch.

## Checks

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format` on the nine changed Python files
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix` on the nine changed Python files
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check` on the nine changed Python files
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto core/llms/test_manager.py core/llms/test_test_case_json_fixtures.py lang/transcription/test_punctuation_alignment.py llms/test_punctuation.py optimization/persistence/test_cases/test_optimization_test_cases_sync.py` (120 passed)
- validated both JSON files with `jq empty`
- reverse-transformed both migrated JSON files and confirmed byte-for-byte equality with their `master` versions