### PR TITLE
Rename shared prompt localization fields

### DIFF
--- a/scinoephile/core/llms/__init__.py
+++ b/scinoephile/core/llms/__init__.py
@@ -18,7 +18,7 @@ from .llm_provider import ChatCompletionKwargs, LLMProvider
 from .manager import Manager, PromptModelField
 from .openai_provider_base import OpenAIProviderBase
 from .processor import Processor, ProcessorKwargs
-from .prompt import Prompt, PromptLocalizationFields
+from .prompt import Prompt, SharedPromptLocalizationFields
 from .query import Query
 from .queryer import Queryer
 from .test_case import TestCase
@@ -36,10 +36,10 @@ __all__ = [
     "Processor",
     "ProcessorKwargs",
     "Prompt",
-    "PromptLocalizationFields",
     "PromptModelField",
     "Query",
     "Queryer",
+    "SharedPromptLocalizationFields",
     "TestCase",
     "TestCaseSubtitle",
     "Tool",

--- a/scinoephile/core/llms/prompt.py
+++ b/scinoephile/core/llms/prompt.py
@@ -14,11 +14,11 @@ from scinoephile.core.language import Language
 
 __all__ = [
     "Prompt",
-    "PromptLocalizationFields",
+    "SharedPromptLocalizationFields",
 ]
 
 
-class PromptLocalizationFields(TypedDict):
+class SharedPromptLocalizationFields(TypedDict):
     """Shared localization fields accepted by all prompt types."""
 
     few_shot_intro: str

--- a/scinoephile/lang/eng/prompts.py
+++ b/scinoephile/lang/eng/prompts.py
@@ -6,12 +6,12 @@ from __future__ import annotations
 
 from typing import Final
 
-from scinoephile.core.llms import PromptLocalizationFields
+from scinoephile.core.llms import SharedPromptLocalizationFields
 
 __all__ = ["ENG_PROMPT_FIELDS"]
 
 
-ENG_PROMPT_FIELDS: Final[PromptLocalizationFields] = {
+ENG_PROMPT_FIELDS: Final[SharedPromptLocalizationFields] = {
     "few_shot_intro": "Here are some examples of queries and expected answers:",
     "few_shot_query_intro": "Example query:",
     "few_shot_answer_intro": "Expected answer:",

--- a/scinoephile/lang/yue/prompts.py
+++ b/scinoephile/lang/yue/prompts.py
@@ -6,12 +6,12 @@ from __future__ import annotations
 
 from typing import Final
 
-from scinoephile.core.llms import PromptLocalizationFields
+from scinoephile.core.llms import SharedPromptLocalizationFields
 
 __all__ = ["YUE_HANT_PROMPT_FIELDS"]
 
 
-YUE_HANT_PROMPT_FIELDS: Final[PromptLocalizationFields] = {
+YUE_HANT_PROMPT_FIELDS: Final[SharedPromptLocalizationFields] = {
     "few_shot_intro": "下面係一啲查詢同埋佢哋預期答案嘅例子：",
     "few_shot_query_intro": "例子查詢：",
     "few_shot_answer_intro": "預期答案：",

--- a/scinoephile/lang/zho/prompts.py
+++ b/scinoephile/lang/zho/prompts.py
@@ -6,12 +6,12 @@ from __future__ import annotations
 
 from typing import Final
 
-from scinoephile.core.llms import PromptLocalizationFields
+from scinoephile.core.llms import SharedPromptLocalizationFields
 
 __all__ = ["ZHO_HANT_PROMPT_FIELDS"]
 
 
-ZHO_HANT_PROMPT_FIELDS: Final[PromptLocalizationFields] = {
+ZHO_HANT_PROMPT_FIELDS: Final[SharedPromptLocalizationFields] = {
     "few_shot_intro": "下面是一些查詢及其預期答案的示例：",
     "few_shot_query_intro": "示例查詢：",
     "few_shot_answer_intro": "預期答案：",


### PR DESCRIPTION
## Summary

- rename `PromptLocalizationFields` to `SharedPromptLocalizationFields`
- update the public LLM facade and English, Cantonese, and Chinese shared prompt-field declarations
- preserve the existing `TypedDict` shape and static validation

## Why

The longer name makes clear that this type describes only the localization fields shared by every prompt type, while retaining the typing guarantees provided by the existing declaration.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format` on the five changed files
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix` on the five changed files
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check` on the five changed files
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q test/core/llms test/workflows/test_prompt_catalog.py test/test_module_hierarchy.py` (159 passed)