### PR TITLE
Expose raw aligned line diff text

### DIFF
--- a/scinoephile/analysis/diff/line_diff.py
+++ b/scinoephile/analysis/diff/line_diff.py
@@ -83,6 +83,22 @@ class LineDiff:
             f"{one_text_repr} -> {two_text_repr}"
         )
 
+    def get_aligned_texts(self) -> tuple[str, str]:
+        """Get the two character-aligned text rows without display markup.
+
+        Returns:
+            first- and second-side aligned text
+        """
+        if self.kind == LineDiffKind.DELETE:
+            return self._join_texts(self.one_texts or ()), ""
+        if self.kind == LineDiffKind.INSERT:
+            return "", self._join_texts(self.two_texts or ())
+        if self.kind == LineDiffKind.EQUAL:
+            one_text = self._join_texts(self.one_texts or ())
+            two_text = self._join_texts(self.two_texts or ())
+            return one_text, two_text
+        return self._get_edit_aligned_texts(color=False)
+
     def get_stacked_str(
         self, *, color: bool = True, three_texts: tuple[str, ...] | None = None
     ) -> str:
@@ -123,14 +139,65 @@ class LineDiff:
                 three_texts=three_texts,
             )
 
-        return self._get_edit_stacked_str(
-            one_range=one_range,
-            two_range=two_range,
-            one_texts=self.one_texts or (),
-            two_texts=self.two_texts or (),
-            color=color,
-            three_texts=three_texts,
-        )
+        header = f"{one_range} {two_range}".rstrip()
+        one_text, two_text = self._get_edit_aligned_texts(color=color)
+        if three_texts is None:
+            return f"{header}\n{one_text}\n{two_text}\n"
+        three_text = self._join_texts(three_texts)
+        return f"{header}\n{one_text}\n{two_text}\n{three_text}\n"
+
+    def _get_edit_aligned_texts(self, *, color: bool) -> tuple[str, str]:
+        """Character-align text for an edit-like diff.
+
+        Arguments:
+            color: whether to emit ANSI color escapes
+        Returns:
+            first- and second-side aligned text
+        """
+        one_text = self._join_texts(self.one_texts or ())
+        two_text = self._join_texts(self.two_texts or ())
+        alignment = LineAlignment(one_text, two_text).alignment_pairs
+
+        one_out: list[str] = []
+        two_out: list[str] = []
+        for column in alignment:
+            if column.operation == LineAlignmentOperation.MATCH:
+                one_char = column.one or ""
+                two_char = column.two or ""
+                if color:
+                    one_char = colorize(one_char, AnsiColor.GREEN)
+                    two_char = colorize(two_char, AnsiColor.GREEN)
+                one_out.append(one_char)
+                two_out.append(two_char)
+                continue
+
+            if column.operation == LineAlignmentOperation.SUBSTITUTE:
+                one_char = column.one or ""
+                two_char = column.two or ""
+                if color:
+                    one_char = colorize(one_char, AnsiColor.PURPLE)
+                    two_char = colorize(two_char, AnsiColor.PURPLE)
+                one_out.append(one_char)
+                two_out.append(two_char)
+                continue
+
+            if column.operation == LineAlignmentOperation.DELETE:
+                assert column.one is not None
+                one_char = column.one
+                if color:
+                    one_char = colorize(one_char, AnsiColor.RED)
+                one_out.append(one_char)
+                two_out.append(self._get_placeholder(column.one))
+                continue
+
+            assert column.two is not None
+            one_out.append(self._get_placeholder(column.two))
+            two_char = column.two
+            if color:
+                two_char = colorize(two_char, AnsiColor.BLUE)
+            two_out.append(two_char)
+
+        return "".join(one_out), "".join(two_out)
 
     @staticmethod
     def _format_idxs(idxs: tuple[int, ...]) -> str:
@@ -232,77 +299,6 @@ class LineDiff:
             return f"{header}\n{one_text}\n{two_text}\n"
         three_text = LineDiff._join_texts(three_texts)
         return f"{header}\n{one_text}\n{two_text}\n{three_text}\n"
-
-    @staticmethod
-    def _get_edit_stacked_str(
-        *,
-        one_range: str,
-        two_range: str,
-        one_texts: tuple[str, ...],
-        two_texts: tuple[str, ...],
-        color: bool,
-        three_texts: tuple[str, ...] | None,
-    ) -> str:
-        """Format an edit-like diff as stacked output.
-
-        Arguments:
-            one_range: formatted index range for the first side
-            two_range: formatted index range for the second side
-            one_texts: first-side text lines
-            two_texts: second-side text lines
-            color: whether to emit ANSI color escapes
-            three_texts: optional unaligned third-side text lines
-        Returns:
-            formatted edit diff chunk
-        """
-        one_text = LineDiff._join_texts(one_texts)
-        two_text = LineDiff._join_texts(two_texts)
-        header = f"{one_range} {two_range}".rstrip()
-        alignment = LineAlignment(one_text, two_text).alignment_pairs
-
-        one_out: list[str] = []
-        two_out: list[str] = []
-        for column in alignment:
-            if column.operation == LineAlignmentOperation.MATCH:
-                one_text = column.one or ""
-                two_text = column.two or ""
-                if color:
-                    one_text = colorize(one_text, AnsiColor.GREEN)
-                    two_text = colorize(two_text, AnsiColor.GREEN)
-                one_out.append(one_text)
-                two_out.append(two_text)
-                continue
-
-            if column.operation == LineAlignmentOperation.SUBSTITUTE:
-                one_text = column.one or ""
-                two_text = column.two or ""
-                if color:
-                    one_text = colorize(one_text, AnsiColor.PURPLE)
-                    two_text = colorize(two_text, AnsiColor.PURPLE)
-                one_out.append(one_text)
-                two_out.append(two_text)
-                continue
-
-            if column.operation == LineAlignmentOperation.DELETE:
-                assert column.one is not None
-                one_text = column.one
-                if color:
-                    one_text = colorize(one_text, AnsiColor.RED)
-                one_out.append(one_text)
-                two_out.append(LineDiff._get_placeholder(column.one))
-                continue
-
-            assert column.two is not None
-            one_out.append(LineDiff._get_placeholder(column.two))
-            two_text = column.two
-            if color:
-                two_text = colorize(two_text, AnsiColor.BLUE)
-            two_out.append(two_text)
-
-        if three_texts is None:
-            return f"{header}\n{''.join(one_out)}\n{''.join(two_out)}\n"
-        three_text = LineDiff._join_texts(three_texts)
-        return f"{header}\n{''.join(one_out)}\n{''.join(two_out)}\n{three_text}\n"
 
     @staticmethod
     def _get_insert_stacked_str(

--- a/test/analysis/diff/test_line_diff.py
+++ b/test/analysis/diff/test_line_diff.py
@@ -7,6 +7,52 @@ from __future__ import annotations
 from scinoephile.analysis.diff import LineDiff, LineDiffKind
 
 
+def test_line_diff_get_aligned_texts_without_display_markup():
+    """Test raw aligned text includes width-aware placeholders."""
+    message = LineDiff(
+        kind=LineDiffKind.EDIT,
+        one_lbl="one",
+        two_lbl="two",
+        one_idxs=(0,),
+        two_idxs=(0,),
+        one_texts=("廣東話",),
+        two_texts=("廣東　話",),
+    )
+
+    assert message.get_aligned_texts() == ("廣東　話", "廣東　話")
+
+
+def test_line_diff_get_aligned_texts_for_non_edit_kinds():
+    """Test equal, insert, and delete text alignment."""
+    cases = [
+        (
+            LineDiff(
+                kind=LineDiffKind.EQUAL,
+                one_texts=("same", "lines"),
+                two_texts=("same", "lines"),
+            ),
+            ("same lines", "same lines"),
+        ),
+        (
+            LineDiff(
+                kind=LineDiffKind.INSERT,
+                two_texts=("new", "line"),
+            ),
+            ("", "new line"),
+        ),
+        (
+            LineDiff(
+                kind=LineDiffKind.DELETE,
+                one_texts=("廣東", "話"),
+            ),
+            ("廣東　話", ""),
+        ),
+    ]
+
+    for message, expected in cases:
+        assert message.get_aligned_texts() == expected
+
+
 def test_line_diff_get_stacked_str_no_color_full_width_placeholder():
     """Test full-width placeholder selection with color=False."""
     msg = LineDiff(


### PR DESCRIPTION
## Summary

- add `LineDiff.get_aligned_texts()` for markup-free character-aligned rows
- reuse one instance-level alignment implementation for structured and stacked output
- keep edit rendering inline instead of retaining a single-use formatting wrapper
- cover edit, equal, insert, and delete results, including width-aware joining and placeholders

## Why

Structured diff consumers need the aligned text itself without parsing headers or ANSI display markup.

## Impact

Existing stacked diff formatting is unchanged. The implementation now operates directly on the `LineDiff` record without class-qualified helper calls or redundant text parameters.

## Validation

- `ruff format`
- `ruff check --fix`
- `ty check`
- 36 focused diff tests passed