### PR TITLE
Expose structured series diff messages

### DIFF
--- a/scinoephile/analysis/diff/series_diff.py
+++ b/scinoephile/analysis/diff/series_diff.py
@@ -108,6 +108,7 @@ class SeriesDiff:
         self._stacked_messages: list[LineDiff] = []
         self._one = one
         self._one_line_event_idxs: tuple[int, ...] = ()
+        self._two_line_event_idxs: tuple[int, ...] = ()
         self._diff(one, two)
 
     def __iter__(self) -> Iterator[LineDiff]:
@@ -132,6 +133,39 @@ class SeriesDiff:
         )
         return f"[\n{formatted_messages}\n]"
 
+    def get_event_indices(
+        self,
+        message: LineDiff,
+    ) -> tuple[tuple[int, ...], tuple[int, ...]]:
+        """Get subtitle event indices represented by a line diff message.
+
+        Arguments:
+            message: line diff message
+        Returns:
+            first- and second-side zero-based subtitle event indices
+        """
+        one_event_idxs = self._get_message_event_indices(
+            message.one_idxs,
+            self._one_line_event_idxs,
+        )
+        two_event_idxs = self._get_message_event_indices(
+            message.two_idxs,
+            self._two_line_event_idxs,
+        )
+        return one_event_idxs, two_event_idxs
+
+    def get_messages(self, *, include_equal: bool = False) -> tuple[LineDiff, ...]:
+        """Get aligned line diff messages.
+
+        Arguments:
+            include_equal: whether to include unchanged aligned subtitles
+        Returns:
+            line diff messages in display order
+        """
+        if include_equal:
+            return tuple(self._stacked_messages)
+        return tuple(self.messages)
+
     def get_stacked_str(
         self,
         *,
@@ -150,7 +184,7 @@ class SeriesDiff:
         Raises:
             ScinoephileError: if one and three are not one-to-one matched
         """
-        messages = self._stacked_messages if include_equal else self.messages
+        messages = self.get_messages(include_equal=include_equal)
         if three is None:
             return "\n".join(
                 message.get_stacked_str(color=color) for message in messages
@@ -355,6 +389,11 @@ class SeriesDiff:
         self._one_line_event_idxs = tuple(
             record.event_idx
             for event_line_records in one_line_records
+            for record in event_line_records
+        )
+        self._two_line_event_idxs = tuple(
+            record.event_idx
+            for event_line_records in two_line_records
             for record in event_line_records
         )
         block_pairs = self._get_block_event_index_pairs_by_pause(one, two)
@@ -1402,15 +1441,10 @@ class SeriesDiff:
         Returns:
             third-side subtitle texts in first-side event order
         """
-        if not message.one_idxs:
-            return ()
-
-        event_idxs = []
-        for line_idx in message.one_idxs:
-            event_idx = self._one_line_event_idxs[line_idx]
-            if event_idxs and event_idxs[-1] == event_idx:
-                continue
-            event_idxs.append(event_idx)
+        event_idxs = self._get_message_event_indices(
+            message.one_idxs,
+            self._one_line_event_idxs,
+        )
 
         texts = []
         for event_idx in event_idxs:
@@ -1425,6 +1459,27 @@ class SeriesDiff:
                 texts.append("")
 
         return tuple(texts)
+
+    @staticmethod
+    def _get_message_event_indices(
+        line_idxs: tuple[int, ...] | None,
+        line_event_idxs: tuple[int, ...],
+    ) -> tuple[int, ...]:
+        """Map line indices to unique subtitle event indices in order.
+
+        Arguments:
+            line_idxs: zero-based flattened line indices
+            line_event_idxs: event index corresponding to each flattened line
+        Returns:
+            unique zero-based subtitle event indices
+        """
+        event_idxs = []
+        for line_idx in line_idxs or ():
+            event_idx = line_event_idxs[line_idx]
+            if event_idxs and event_idxs[-1] == event_idx:
+                continue
+            event_idxs.append(event_idx)
+        return tuple(event_idxs)
 
     @staticmethod
     def _join_normlines(

--- a/test/analysis/diff/test_series_diff.py
+++ b/test/analysis/diff/test_series_diff.py
@@ -146,6 +146,54 @@ def test_series_diff_empty_for_identical_series():
     assert str(diff) == "[]"
 
 
+def test_series_diff_get_event_indices():
+    """Test line indices map to unique event indices on both sides."""
+    cases = [
+        (
+            SeriesDiff(
+                get_text_series("first second"),
+                get_text_series("first\\Nsecond"),
+            ),
+            ((0,), (0,)),
+        ),
+        (
+            SeriesDiff(
+                get_text_series("same"),
+                get_text_series("same", "insert"),
+            ),
+            ((), (1,)),
+        ),
+        (
+            SeriesDiff(
+                get_text_series("same", "delete"),
+                get_text_series("same"),
+            ),
+            ((1,), ()),
+        ),
+    ]
+
+    for diff, expected in cases:
+        (message,) = diff.get_messages()
+        assert diff.get_event_indices(message) == expected
+
+
+def test_series_diff_get_messages_can_include_equal():
+    """Test structured messages optionally include equal lines."""
+    one = get_text_series("same", "first\\Nsecond")
+    two = get_text_series("same", "first\\Nedited")
+    diff = SeriesDiff(one, two)
+
+    changed_messages = diff.get_messages()
+    all_messages = diff.get_messages(include_equal=True)
+
+    assert [message.kind for message in changed_messages] == [LineDiffKind.EDIT]
+    assert [message.kind for message in all_messages] == [
+        LineDiffKind.EQUAL,
+        LineDiffKind.EQUAL,
+        LineDiffKind.EDIT,
+    ]
+
+
 def test_series_diff_get_stacked_str_appends_blank_third_line_for_insert():
     """Test third-series output is blank for second-side-only inserts."""
     one = get_text_series()


### PR DESCRIPTION
## Summary

- add `SeriesDiff.get_messages()` with optional equal-line inclusion
- add `SeriesDiff.get_event_indices()` to map flattened diff lines back to subtitle events
- reuse the event-index mapping helper for third-series rendering
- route stacked display through the new message accessor
- cover equal inclusion, multiline-event deduplication, and empty insert/delete sides

## Why

Structured consumers need complete aligned messages and their source event indices without reaching into private state.

## Impact

Existing iteration and stacked output remain unchanged. The new APIs expose already-computed alignment state while consolidating duplicated line-to-event mapping.

## Validation

- `ruff format`
- `ruff check --fix`
- `ty check`
- 46 focused series-diff tests passed