### PR TITLE
Avoid redundant focused tail recovery

### DIFF
--- a/scinoephile/lang/transcription/processor.py
+++ b/scinoephile/lang/transcription/processor.py
@@ -537,12 +537,18 @@ class GuidedTranscriptionProcessor:
         tail_segments = self.tail_recovery_transcriber.get_cached_transcription(
             normalized_tail_audio
         )
-        if tail_segments is not None and not self._segments_are_usable(
-            tail_segments,
-            audio_duration=tail_audio_duration,
-        ):
-            logger.info("Retrying focused tail transcription after unusable cache")
-            tail_segments = None
+        unusable_cached_tail = (
+            tail_segments is not None
+            and not self._segments_are_usable(
+                tail_segments,
+                audio_duration=tail_audio_duration,
+            )
+        )
+        if unusable_cached_tail:
+            logger.info(
+                f"Keeping valid base Whisper transcription ending at "
+                f"{last_word_end:.2f}s after unusable cached focused tail recovery"
+            )
 
         recovery_failed_with_assertion = False
         if tail_segments is None:
@@ -563,8 +569,8 @@ class GuidedTranscriptionProcessor:
                     audio_duration=tail_audio_duration,
                 ):
                     tail_segments = candidate_tail_segments
-        if tail_segments is None:
-            if not recovery_failed_with_assertion:
+        if tail_segments is None or unusable_cached_tail:
+            if not recovery_failed_with_assertion and not unusable_cached_tail:
                 logger.info(
                     f"Keeping valid base Whisper transcription ending at "
                     f"{last_word_end:.2f}s after unusable focused tail recovery"

--- a/test/lang/transcription/test_processor.py
+++ b/test/lang/transcription/test_processor.py
@@ -169,26 +169,16 @@ def test_missing_guided_tail_runs_focused_recovery():
     assert normalized_tail_audio.max_dBFS == approx(-1.0, abs=0.01)
 
 
-def test_missing_guided_tail_bypasses_unusable_cached_recovery():
-    """Test an unusable focused-tail cache does not prevent fresh recovery."""
+def test_missing_guided_tail_keeps_base_after_unusable_cached_recovery():
+    """Test an unusable focused-tail cache prevents redundant recovery."""
     processor, _ = _get_processor(vad_mode=VADMode.OFF)
     initial_segments = [_get_segment(end=4.0, compression_ratio=1.0, with_words=True)]
     repetitive_segments = [_get_segment(compression_ratio=16.24, with_words=True)]
-    recovered_segments = [
-        _get_segment(
-            start=0.2,
-            end=0.8,
-            text="tail",
-            compression_ratio=1.0,
-            with_words=True,
-        )
-    ]
-    recovered_segments[0].no_speech_prob = 0.1
     processor.no_vad_transcriber = Mock()
     processor.no_vad_transcriber.get_cached_transcription.return_value = (
         initial_segments
     )
-    processor.tail_recovery_transcriber = Mock(return_value=recovered_segments)
+    processor.tail_recovery_transcriber = Mock()
     processor.tail_recovery_transcriber.get_cached_transcription.return_value = (
         repetitive_segments
     )
@@ -196,16 +186,16 @@ def test_missing_guided_tail_bypasses_unusable_cached_recovery():
 
     output = processor._transcribe_block_audio(audio, expected_last_start=8.0)
 
-    assert output[:1] == initial_segments
-    assert output[1].text == "tail"
-    normalized_tail_audio = processor.tail_recovery_transcriber.call_args.args[0]
+    assert output == initial_segments
+    normalized_tail_audio = (
+        processor.tail_recovery_transcriber.get_cached_transcription.call_args.args[0]
+    )
+    assert len(normalized_tail_audio) == 5000
+    assert normalized_tail_audio.max_dBFS == approx(-1.0, abs=0.01)
     processor.tail_recovery_transcriber.get_cached_transcription.assert_called_once_with(
         normalized_tail_audio
     )
-    processor.tail_recovery_transcriber.assert_called_once_with(
-        normalized_tail_audio,
-        use_cache=False,
-    )
+    processor.tail_recovery_transcriber.assert_not_called()
 
 
 def test_missing_guided_tail_keeps_valid_base_without_credible_recovery():


### PR DESCRIPTION
## Summary

- preserve a valid base transcription when the cached focused-tail result is unusable
- avoid rerunning the expensive focused-tail recovery in that case
- cover the cached-tail path and retain assertions on the normalized tail audio

## Why

An unusable cached tail cannot be made usable by rerunning the same focused recovery. Retaining the valid base result avoids redundant work while preserving the existing fallback behavior.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/lang/transcription/processor.py test/lang/transcription/test_processor.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check scinoephile/lang/transcription/processor.py test/lang/transcription/test_processor.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/lang/transcription/processor.py test/lang/transcription/test_processor.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto`