### PR TITLE
Fix series diff coverage around shifted spans

### DIFF
--- a/scinoephile/analysis/diff/series_diff.py
+++ b/scinoephile/analysis/diff/series_diff.py
@@ -304,17 +304,37 @@ class SeriesDiff:
         Returns:
             updated first- and second-side local line positions
         """
-        while one_line_pos < one_line_stop and two_line_pos < two_line_stop:
-            self._add_equal_message(
-                one_side=one_side,
-                two_side=two_side,
-                one_local_idxs=(one_line_pos,),
-                two_local_idxs=(two_line_pos,),
+        one_local_idxs = tuple(range(one_line_pos, one_line_stop))
+        two_local_idxs = tuple(range(two_line_pos, two_line_stop))
+        matcher = difflib.SequenceMatcher(
+            None,
+            tuple(one_side.normlines[idx] for idx in one_local_idxs),
+            tuple(two_side.normlines[idx] for idx in two_local_idxs),
+            autojunk=False,
+        )
+        for tag, one_start, one_end, two_start, two_end in matcher.get_opcodes():
+            matched_one_local_idxs = one_local_idxs[one_start:one_end]
+            matched_two_local_idxs = two_local_idxs[two_start:two_end]
+            if tag == "equal":
+                for one_local_idx, two_local_idx in zip(
+                    matched_one_local_idxs,
+                    matched_two_local_idxs,
+                    strict=True,
+                ):
+                    self._add_equal_message(
+                        one_side=one_side,
+                        two_side=two_side,
+                        one_local_idxs=(one_local_idx,),
+                        two_local_idxs=(two_local_idx,),
+                    )
+                continue
+            self._add_changed_span(
+                one_side,
+                two_side,
+                matched_one_local_idxs,
+                matched_two_local_idxs,
             )
-            one_line_pos += 1
-            two_line_pos += 1
-
-        return one_line_pos, two_line_pos
+        return one_line_stop, two_line_stop
 
     def _add_delete_messages(
         self,

--- a/test/analysis/diff/test_series_diff.py
+++ b/test/analysis/diff/test_series_diff.py
@@ -343,6 +343,50 @@ def test_series_diff_represents_line_before_one_sided_span():
     ]
 
 
+def test_series_diff_represents_line_before_shifted_changed_span():
+    """Test lines before a shifted changed span are not dropped."""
+    messages = SeriesDiff(
+        get_text_series("a", "b"),
+        get_text_series("a", "ab"),
+    ).get_messages(include_equal=True)
+
+    assert [
+        (message.kind, message.one_idxs, message.two_idxs) for message in messages
+    ] == [
+        (LineDiffKind.INSERT, None, (0,)),
+        (LineDiffKind.MERGE_EDIT, (0, 1), (1,)),
+    ]
+
+
+def test_series_diff_represents_deleted_repeated_line_before_equal_lines():
+    """Test repeated lines do not offset subsequent equal-line matches."""
+    messages = SeriesDiff(
+        get_text_series(
+            "pre",
+            "打賞⋯打賞",
+            "打賞⋯打賞",
+            "恭喜蘇翁生辰快樂",
+            "post",
+        ),
+        get_text_series(
+            "pre",
+            "打賞⋯打賞",
+            "恭喜蘇翁生辰快樂",
+            "post",
+        ),
+    ).get_messages(include_equal=True)
+
+    assert [
+        (message.kind, message.one_idxs, message.two_idxs) for message in messages
+    ] == [
+        (LineDiffKind.EQUAL, (0,), (0,)),
+        (LineDiffKind.EQUAL, (1,), (1,)),
+        (LineDiffKind.DELETE, (2,), None),
+        (LineDiffKind.EQUAL, (3,), (2,)),
+        (LineDiffKind.EQUAL, (4,), (3,)),
+    ]
+
+
 @parametrize(
     ("one_texts", "two_texts", "expected_message_indices"),
     [


### PR DESCRIPTION
## Summary

- align the line ranges before each changed span with `SequenceMatcher` instead of pairing them by position
- emit equal, inserted, deleted, and changed messages for the resulting opcodes
- cover a shifted changed span and a deleted repeated line followed by equal lines

## Why

The previous positional pairing could match the wrong surrounding lines after an insertion or deletion. This caused shifted and repeated lines to be misrepresented in stacked diff output.

## Simplification

The extracted fix relies on the existing equality handling in `_add_changed_span()`; it does not duplicate that logic in `_add_block_messages()`.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/analysis/diff/series_diff.py test/analysis/diff/test_series_diff.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/analysis/diff/series_diff.py test/analysis/diff/test_series_diff.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/analysis/diff/series_diff.py test/analysis/diff/test_series_diff.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest analysis/diff/test_series_diff.py -n auto`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto`