### PR TITLE
Allow optional Whisper imports in ty

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,10 @@ convention = 'google'
 allowed-unresolved-imports = [
     "chrome_lens_py",
     "chrome_lens_py.**",
+    "huggingface_hub",
+    "huggingface_hub.**",
     "paddleocr",
+    "whisper_timestamped",
 ]
 
 [tool.setuptools]

--- a/scinoephile/audio/transcription/whisper_transcriber.py
+++ b/scinoephile/audio/transcription/whisper_transcriber.py
@@ -337,7 +337,7 @@ class WhisperTranscriber:
     def _get_huggingface_repo_validation() -> tuple[type[Exception], Any]:
         """Import HuggingFace repo validation helpers on demand."""
         try:
-            from huggingface_hub.utils import (  # ty: ignore[unresolved-import]  # noqa: E501, PLC0415
+            from huggingface_hub.utils import (  # noqa: E501, PLC0415
                 HFValidationError,
                 validate_repo_id,
             )
@@ -349,7 +349,7 @@ class WhisperTranscriber:
     def _get_snapshot_download() -> Any:
         """Import HuggingFace snapshot downloader on demand."""
         try:
-            from huggingface_hub import (  # ty: ignore[unresolved-import]  # noqa: PLC0415
+            from huggingface_hub import (  # noqa: PLC0415
                 snapshot_download,
             )
         except ImportError as exc:
@@ -360,7 +360,7 @@ class WhisperTranscriber:
     def _get_whisper_module() -> Any:
         """Import whisper-timestamped on demand."""
         try:
-            import whisper_timestamped as whisper  # ty: ignore[unresolved-import]  # noqa: E501, PLC0415
+            import whisper_timestamped as whisper  # noqa: E501, PLC0415
         except ImportError as exc:
             raise ImportError(_TRANSCRIPTION_EXTRA_MESSAGE) from exc
         return whisper


### PR DESCRIPTION
## Summary

- declare the optional Hugging Face and whisper-timestamped modules as unresolved imports permitted by `ty`
- remove the corresponding inline `ty: ignore` directives from the lazy Whisper imports

## Why

These imports are deliberately optional at runtime and already raise a clear transcription-extra installation error when unavailable. Centralizing the type-checker configuration keeps that policy in one place and makes the lazy import sites easier to read.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/audio/transcription/whisper_transcriber.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/audio/transcription/whisper_transcriber.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/audio/transcription/whisper_transcriber.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest audio/transcription/test_whisper_transcriber.py -n auto`