### PR TITLE
Set minimum difficulty for gap translations

### DIFF
--- a/scinoephile/llms/gap_translation/models.py
+++ b/scinoephile/llms/gap_translation/models.py
@@ -94,6 +94,19 @@ class GapTranslationTestCase(TestCase):
     answer: GapTranslationAnswer | None = None
     """Translations for target gaps, if available."""
 
+    def get_min_difficulty(self) -> int:
+        """Get minimum difficulty based on whether target text is generated.
+
+        Returns:
+            minimum difficulty
+        """
+        min_difficulty = super().get_min_difficulty()
+        if self.answer is not None and any(
+            output.text for output in self.answer.outputs
+        ):
+            min_difficulty = max(min_difficulty, 1)
+        return min_difficulty
+
     @model_validator(mode="after")
     def validate_output_correspondence(self) -> Self:
         """Ensure outputs exactly fill the guide indexes absent from targets.

--- a/test/llms/test_gap_translation.py
+++ b/test/llms/test_gap_translation.py
@@ -227,6 +227,47 @@ def test_gap_translation_preserves_unbounded_text():
 
 
 @mark.parametrize(
+    ("outputs", "explicit_difficulty", "expected_difficulty"),
+    [
+        (None, 0, 0),
+        (((2, ""),), 0, 0),
+        (((2, "translated"),), 0, 1),
+        (((2, "translated"),), 3, 3),
+    ],
+)
+def test_minimum_difficulty_tracks_generated_text(
+    outputs: tuple[tuple[int, str], ...] | None,
+    explicit_difficulty: int,
+    expected_difficulty: int,
+):
+    """Nonempty generated text should require at least difficulty one.
+
+    Arguments:
+        outputs: optional output indexes and texts
+        explicit_difficulty: requested test-case difficulty
+        expected_difficulty: enforced minimum difficulty
+    """
+    data: dict[str, object] = {
+        "query": {
+            "targets": [{"index": 1, "text": "existing"}],
+            "guides": [
+                {"index": 1, "text": "guide one"},
+                {"index": 2, "text": "guide two"},
+            ],
+        },
+        "difficulty": explicit_difficulty,
+    }
+    if outputs is not None:
+        data["answer"] = {
+            "outputs": [{"index": index, "text": text} for index, text in outputs]
+        }
+
+    test_case = GapTranslationTestCase.model_validate(data)
+
+    assert test_case.difficulty == expected_difficulty
+
+
+@mark.parametrize(
     "test_case_cls",
     [
         GapTranslationTestCase,
@@ -300,6 +341,7 @@ def test_json_persistence_uses_base_prompt_fields(tmp_path: Path):
                 ],
             },
             "answer": {"outputs": [{"index": 2, "text": "翻譯"}]},
+            "difficulty": 1,
             "verified": True,
         }
     ]


### PR DESCRIPTION
## Summary

- require gap-translation cases with nonempty generated output to have difficulty at least one
- preserve difficulty zero for cases with no output or only empty output
- verify the derived difficulty is persisted in the standard JSON fixture format

## Why

Generated translations require review, so they must not be classified as difficulty-zero test cases.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/llms/gap_translation/models.py test/llms/test_gap_translation.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/llms/gap_translation/models.py test/llms/test_gap_translation.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/llms/gap_translation/models.py test/llms/test_gap_translation.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest llms/test_gap_translation.py -n auto`