### PR TITLE
Let guided reviews delete spurious subtitles

### DIFF
--- a/scinoephile/lang/eng/review.py
+++ b/scinoephile/lang/eng/review.py
@@ -31,8 +31,9 @@ GuidedReviewPromptEng = GuidedReviewPrompt(
         Do not improve style, grammar, tone, or phrasing unless the target is clearly
         erroneous. Include a revision only when a target subtitle requires a change.
         Each revision must include the target's index, its full revised text, and a
-        short English note. If no revisions are needed, return an empty revisions
-        list."""),
+        short English note. To delete a spurious target subtitle, use the single
+        replacement character "�" as its revised text. If no revisions are needed,
+        return an empty revisions list."""),
     targets="english",
     targets_desc="English target subtitles to review, in order.",
     guides="references",
@@ -43,7 +44,9 @@ GuidedReviewPromptEng = GuidedReviewPrompt(
     ),
     target_text_desc="English target subtitle text to review.",
     guide_text_desc="Reference subtitle text.",
-    revision_text_desc="Full revised English target subtitle text.",
+    revision_text_desc=(
+        'Full revised English target subtitle text, or "�" to delete the target.'
+    ),
     note_desc="English note explaining the target subtitle revision.",
 )
 """LLM correspondence text for guided review of English subtitles."""

--- a/scinoephile/lang/yue/review.py
+++ b/scinoephile/lang/yue/review.py
@@ -35,7 +35,8 @@ GuidedReviewPromptYueHant = GuidedReviewPrompt(
         唔好翻譯參考字幕，亦唔好為咗貼近參考字幕而改寫本來正確嘅粵文。
         唔好潤色或者改動語氣、文法、助詞、量詞同措辭。
         只有確實需要修改嘅粵文字幕先加入修改列表。每項修改必須包含字幕序號、
-        完整修訂後文本同粵文備註。如果全部字幕都唔需要修改，請返回空嘅修改列表。"""),
+        完整修訂後文本同粵文備註。如果要刪除多餘嘅目標字幕，修訂文本只填「�」。
+        如果全部字幕都唔需要修改，請返回空嘅修改列表。"""),
     targets="yuewen",
     targets_desc="按順序排列、需要審核嘅粵文字幕",
     guides="cankao",
@@ -47,7 +48,7 @@ GuidedReviewPromptYueHant = GuidedReviewPrompt(
     text="wenben",
     target_text_desc="需要審核嘅粵文字幕文本",
     guide_text_desc="參考字幕文本",
-    revision_text_desc="修改後嘅完整粵文字幕文本",
+    revision_text_desc="修改後嘅完整粵文字幕文本；如果要刪除字幕就只填「�」",
     note="beizhu",
     note_desc="關於粵文字幕修改嘅粵文備註",
     target_indices_err="查詢目標字幕序號必須由 1 開始、連續並按順序排列。",

--- a/scinoephile/lang/yue_zho/review.py
+++ b/scinoephile/lang/yue_zho/review.py
@@ -34,6 +34,7 @@ YueZhoGuidedReviewPromptYueHant = GuidedReviewPrompt(
         中文字幕只係參考，唔需要同粵文逐字對應。
         只有當一條粵文字幕確實需要修改時，先將佢加入修改列表。
         每項修改必須包含字幕序號、修訂後嘅完整粵文字幕，同埋一段粵文備註説明改動。
+        如果要刪除同音訊及中文字幕都冇對應嘅多餘字幕，修訂文本只填「�」。
         如果全部粵文字幕都唔需要修改，請回傳空嘅修改列表。"""),
     targets="yuewen",
     targets_desc="按順序排列、需要審核嘅粵文字幕轉寫",
@@ -46,7 +47,7 @@ YueZhoGuidedReviewPromptYueHant = GuidedReviewPrompt(
     text="wenben",
     target_text_desc="需要審核嘅粵文字幕轉寫",
     guide_text_desc="中文字幕指引文本",
-    revision_text_desc="修改後嘅完整粵文字幕文本",
+    revision_text_desc="修改後嘅完整粵文字幕文本；如果要刪除字幕就只填「�」",
     note="beizhu",
     note_desc="關於粵文字幕修改嘅粵文備註",
     target_indices_err="查詢粵文字幕序號必須由 1 開始、連續並按順序排列。",

--- a/scinoephile/lang/zho/review.py
+++ b/scinoephile/lang/zho/review.py
@@ -35,7 +35,8 @@ GuidedReviewPromptZhoHant = GuidedReviewPrompt(
         不要翻譯參考字幕，也不要為了貼近參考字幕而改寫原本正確的中文。
         不要潤色或改動語氣、文法與措辭。
         只有確實需要修改的中文字幕才加入修改列表。每項修改必須包含字幕序號、
-        完整修訂後文本與簡短中文備註。如果全部字幕都不需要修改，請返回空的修改列表。"""),
+        完整修訂後文本與簡短中文備註。如果要刪除多餘的目標字幕，修訂文本只填「�」。
+        如果全部字幕都不需要修改，請返回空的修改列表。"""),
     targets="zhongwen",
     targets_desc="按順序排列、需要審核的中文字幕",
     guides="cankao",
@@ -47,7 +48,7 @@ GuidedReviewPromptZhoHant = GuidedReviewPrompt(
     text="wenben",
     target_text_desc="需要審核的中文字幕文本",
     guide_text_desc="參考字幕文本",
-    revision_text_desc="修改後的完整中文字幕文本",
+    revision_text_desc="修改後的完整中文字幕文本；如果要刪除字幕就只填「�」",
     note="beizhu",
     note_desc="關於中文字幕修改的簡短中文備註",
     target_indices_err="查詢目標字幕序號必須從 1 開始、連續並按順序排列。",

--- a/scinoephile/llms/guided_review/processor.py
+++ b/scinoephile/llms/guided_review/processor.py
@@ -21,6 +21,8 @@ __all__ = ["GuidedReviewProcessor"]
 
 logger = getLogger(__name__)
 
+_DELETION_MARKER = "�"
+
 
 class GuidedReviewProcessor(Processor):
     """Processes guided review."""
@@ -95,8 +97,10 @@ class GuidedReviewProcessor(Processor):
             }
             output_block = Series()
             for idx, subtitle in enumerate(target_block, 1):
-                output_subtitle = type(subtitle)(**subtitle.as_dict())
                 output_text = revision_text_by_index.get(idx)
+                if output_text == _DELETION_MARKER:
+                    continue
+                output_subtitle = type(subtitle)(**subtitle.as_dict())
                 if output_text:
                     output_subtitle.text = replace_control_characters(output_text)
                 output_block.append(output_subtitle)

--- a/scinoephile/llms/guided_review/processor.py
+++ b/scinoephile/llms/guided_review/processor.py
@@ -61,12 +61,6 @@ class GuidedReviewProcessor(Processor):
             if not target_block:
                 output_blocks[block_idx] = Series()
                 continue
-            if not guide_block:
-                output_block = Series()
-                for subtitle in target_block:
-                    output_block.append(type(subtitle)(**subtitle.as_dict()))
-                output_blocks[block_idx] = output_block
-                continue
 
             test_case_cls = self.test_case_cls
             query_cls = test_case_cls.query_cls

--- a/scinoephile/llms/guided_review/prompt.py
+++ b/scinoephile/llms/guided_review/prompt.py
@@ -53,7 +53,9 @@ class GuidedReviewPrompt(Prompt):
     guide_text_desc: str = "Guide subtitle text."
     """Description of text field in guide items."""
 
-    revision_text_desc: str = "Full revised target subtitle text."
+    revision_text_desc: str = (
+        'Full revised target subtitle text, or "�" to delete the target.'
+    )
     """Description of text field in revision items."""
 
     note: str = "note"

--- a/test/llms/test_guided_review_models.py
+++ b/test/llms/test_guided_review_models.py
@@ -128,6 +128,28 @@ def test_processor_deletes_target_with_replacement_character_revision():
     assert [subtitle.text for subtitle in output] == ["保留"]
 
 
+def test_processor_reviews_target_only_blocks_for_deletion():
+    """Target-only blocks should be reviewed with an empty guide list."""
+    provider = Mock(spec=LLMProvider)
+    provider.chat_completion.return_value = json.dumps(
+        {"xiugai": [{"xuhao": 1, "wenben": "�", "beizhu": "刪除多餘字幕"}]},
+        ensure_ascii=False,
+    )
+    processor = GuidedReviewProcessor(_LOCALIZED_PROMPT, provider=provider)
+    processor.queryer.cache_dir_path = None
+    target = Series(events=[Subtitle(start=0, end=1000, text="多餘")])
+    guide = Series(events=[Subtitle(start=5000, end=6000, text="參考")])
+
+    output = processor.process(target, guide)
+
+    assert output == Series()
+    messages = provider.chat_completion.call_args.args[0]
+    assert json.loads(messages[1]["content"]) == {
+        "mubiao": [{"xuhao": 1, "wenben": "多餘"}],
+        "zhinan": [],
+    }
+
+
 def test_query_lists_require_items_and_consecutive_ordered_indexes():
     """Targets should be nonempty and both lists should use ordered indexes."""
     query_cls = GuidedReviewManager.get_query_cls(GuidedReviewManager.base_prompt)

--- a/test/llms/test_guided_review_models.py
+++ b/test/llms/test_guided_review_models.py
@@ -106,6 +106,28 @@ def test_queryer_corresponds_using_prompt_aliases():
     }
 
 
+def test_processor_deletes_target_with_replacement_character_revision():
+    """The replacement-character revision should remove its target subtitle."""
+    provider = Mock(spec=LLMProvider)
+    provider.chat_completion.return_value = json.dumps(
+        {"xiugai": [{"xuhao": 1, "wenben": "�", "beizhu": "刪除多餘字幕"}]},
+        ensure_ascii=False,
+    )
+    processor = GuidedReviewProcessor(_LOCALIZED_PROMPT, provider=provider)
+    processor.queryer.cache_dir_path = None
+    target = Series(
+        events=[
+            Subtitle(start=0, end=1000, text="多餘"),
+            Subtitle(start=1100, end=2000, text="保留"),
+        ]
+    )
+    guide = Series(events=[Subtitle(start=1100, end=2000, text="參考")])
+
+    output = processor.process(target, guide)
+
+    assert [subtitle.text for subtitle in output] == ["保留"]
+
+
 def test_query_lists_require_items_and_consecutive_ordered_indexes():
     """Targets should be nonempty and both lists should use ordered indexes."""
     query_cls = GuidedReviewManager.get_query_cls(GuidedReviewManager.base_prompt)


### PR DESCRIPTION
## Summary

- allow guided-review answers to mark spurious target subtitles for deletion
- document the replacement-character deletion marker in the localized prompts
- cover deletion while preserving remaining subtitle timing and text

## Validation

- `uv run ruff format`
- `uv run ruff check --fix`
- `uv run ty check`
- `cd test && uv run pytest llms/test_guided_review_models.py lang/yue_zho/test_guided_review.py -n auto`