### PR TITLE
Centralize media audio extraction

### DIFF
--- a/scinoephile/audio/subtitles/series.py
+++ b/scinoephile/audio/subtitles/series.py
@@ -12,7 +12,6 @@ from os import PathLike
 from pathlib import Path
 from typing import Any, Self, TypedDict, override
 
-import ffmpeg
 from pydub import AudioSegment
 from pydub.exceptions import PydubException
 
@@ -24,9 +23,8 @@ from scinoephile.common.validation import (
     val_output_path,
 )
 from scinoephile.core import ScinoephileError
-from scinoephile.core.media import AudioStream
 from scinoephile.core.subtitles import Series, Subtitle
-from scinoephile.media.probe import get_streams
+from scinoephile.media.audio import extract_audio
 
 from .subtitle import AudioSubtitle
 
@@ -246,27 +244,26 @@ class AudioSeries(Series):
             validated_subtitle_path = val_input_path(subtitle_path)
             text_series = Series.load(validated_subtitle_path, **kwargs)
 
-            stream = cls._get_audio_stream(validated_media_path, stream_index)
-            if stream.channels is None:
-                raise ScinoephileError(
-                    f"Audio stream {stream.index} in {validated_media_path} "
-                    "cannot be used for transcription."
-                )
-            channel_count = stream.channels
-
-            with get_temp_directory_path() as temp_dir_path:
-                full_audio_path = temp_dir_path / "full_audio.wav"
-                cls.extract_audio_track(
-                    validated_media_path,
-                    full_audio_path,
-                    stream.index,
-                    channel_count,
-                )
-                logger.info(f"Loading full audio from {full_audio_path}")
-                full_audio = AudioSegment.from_wav(full_audio_path)
+            if validated_media_path.suffix.lower() == ".wav":
+                if stream_index not in (None, 0):
+                    raise ScinoephileError(
+                        "A standalone WAV infile only supports stream index 0"
+                    )
+                logger.info(f"Loading full audio from {validated_media_path}")
+                full_audio = AudioSegment.from_wav(validated_media_path)
+            else:
+                with get_temp_directory_path() as temp_dir_path:
+                    full_audio_path = temp_dir_path / "full_audio.wav"
+                    extract_audio(
+                        validated_media_path,
+                        full_audio_path,
+                        stream_index=stream_index,
+                    )
+                    logger.info(f"Loading full audio from {full_audio_path}")
+                    full_audio = AudioSegment.from_wav(full_audio_path)
 
             return cls.build_series(text_series, full_audio, buffer)
-        except (ffmpeg.Error, OSError, PydubException, UnicodeError, ValueError) as exc:
+        except (OSError, PydubException, UnicodeError, ValueError) as exc:
             raise ScinoephileError(
                 f"Unable to load {cls.__name__} from media {media_path}: {exc}"
             ) from exc
@@ -329,54 +326,6 @@ class AudioSeries(Series):
 
         return series
 
-    @staticmethod
-    def extract_audio_track(
-        video_input_path: Path,
-        audio_output_path: Path,
-        audio_track: int,
-        channels: int,
-    ):
-        """Extract a mono audio track from a video file.
-
-        Arguments:
-            video_input_path: Path to input video file
-            audio_output_path: Path to output audio file
-            audio_track: media stream index of an audio stream
-            channels: Number of channels in audio track
-        """
-        try:
-            if channels >= 6:
-                logger.info(
-                    "Extracting center channel of audio stream "
-                    f"{audio_track} from {video_input_path} to {audio_output_path}"
-                )
-                ffmpeg.input(str(video_input_path)).output(
-                    str(audio_output_path),
-                    format="wav",
-                    ar=16000,
-                    **{
-                        "filter_complex": f"[0:{audio_track}]pan=mono|c0=c2[out]",
-                        "map": "[out]",
-                    },
-                ).run(quiet=False, overwrite_output=True)
-            else:
-                logger.info(
-                    f"Downmixing audio stream {audio_track} from {video_input_path} "
-                    f"to {audio_output_path}"
-                )
-                ffmpeg.input(str(video_input_path)).output(
-                    str(audio_output_path),
-                    format="wav",
-                    ar=16000,
-                    map=f"0:{audio_track}",
-                    ac=1,
-                ).run(quiet=False, overwrite_output=True)
-        except (ffmpeg.Error, OSError) as exc:
-            raise ScinoephileError(
-                f"Could not extract audio stream {audio_track} from "
-                f"{video_input_path} to {audio_output_path}"
-            ) from exc
-
     @override
     def _copy_with_events(self, events: Sequence[Subtitle]) -> Self:
         """Copy this audio series with a selected collection of events.
@@ -399,33 +348,6 @@ class AudioSeries(Series):
         copied = type(self)(audio=audio, events=audio_events)
         self._copy_metadata_to(copied)
         return copied
-
-    @staticmethod
-    def _get_audio_stream(media_path: Path, stream_index: int | None) -> AudioStream:
-        """Get the selected audio stream from a media file.
-
-        Arguments:
-            media_path: media input path
-            stream_index: audio stream index, or None to use the first audio stream
-        Returns:
-            selected audio stream
-        """
-        streams = get_streams(media_path)
-        if stream_index is None:
-            for stream in streams:
-                if isinstance(stream, AudioStream):
-                    return stream
-            raise ScinoephileError(f"No audio streams found in {media_path}")
-
-        for stream in streams:
-            if stream.index != stream_index:
-                continue
-            if not isinstance(stream, AudioStream):
-                raise ScinoephileError(
-                    f"Stream index {stream_index} is not an audio stream"
-                )
-            return stream
-        raise ScinoephileError(f"No stream index {stream_index} found in {media_path}")
 
     @override
     def _init_blocks(self):

--- a/scinoephile/audio/subtitles/series.py
+++ b/scinoephile/audio/subtitles/series.py
@@ -244,23 +244,15 @@ class AudioSeries(Series):
             validated_subtitle_path = val_input_path(subtitle_path)
             text_series = Series.load(validated_subtitle_path, **kwargs)
 
-            if validated_media_path.suffix.lower() == ".wav":
-                if stream_index not in (None, 0):
-                    raise ScinoephileError(
-                        "A standalone WAV infile only supports stream index 0"
-                    )
-                logger.info(f"Loading full audio from {validated_media_path}")
-                full_audio = AudioSegment.from_wav(validated_media_path)
-            else:
-                with get_temp_directory_path() as temp_dir_path:
-                    full_audio_path = temp_dir_path / "full_audio.wav"
-                    extract_audio(
-                        validated_media_path,
-                        full_audio_path,
-                        stream_index=stream_index,
-                    )
-                    logger.info(f"Loading full audio from {full_audio_path}")
-                    full_audio = AudioSegment.from_wav(full_audio_path)
+            with get_temp_directory_path() as temp_dir_path:
+                full_audio_path = temp_dir_path / "full_audio.wav"
+                extract_audio(
+                    validated_media_path,
+                    full_audio_path,
+                    stream_index=stream_index,
+                )
+                logger.info(f"Loading full audio from {full_audio_path}")
+                full_audio = AudioSegment.from_wav(full_audio_path)
 
             return cls.build_series(text_series, full_audio, buffer)
         except (OSError, PydubException, UnicodeError, ValueError) as exc:

--- a/scinoephile/media/__init__.py
+++ b/scinoephile/media/__init__.py
@@ -4,5 +4,6 @@
 
 Package hierarchy (modules may import from any above):
 * constants / offset / probe
+* audio
 * subtitles
 """

--- a/scinoephile/media/audio.py
+++ b/scinoephile/media/audio.py
@@ -1,0 +1,152 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Audio stream selection and extraction utilities."""
+
+from __future__ import annotations
+
+from logging import getLogger
+from pathlib import Path
+
+import ffmpeg
+
+from scinoephile.common.validation import val_input_path, val_output_path
+from scinoephile.core.exceptions import ScinoephileError
+from scinoephile.core.media.audio_stream import AudioStream
+
+from .probe import get_streams
+
+__all__ = ["extract_audio"]
+
+logger = getLogger(__name__)
+
+
+def extract_audio(
+    infile_path: Path,
+    outfile_path: Path,
+    *,
+    stream_index: int | None = None,
+    overwrite: bool = False,
+) -> AudioStream:
+    """Extract a selected audio stream as a transcription-ready mono WAV file.
+
+    Multichannel streams with a center channel use that channel; other streams are
+    downmixed to mono. Output is sampled at 16 kHz.
+
+    Arguments:
+        infile_path: media input file
+        outfile_path: WAV output file
+        stream_index: absolute media stream index, or None for the first audio stream
+        overwrite: whether to overwrite an existing output file
+    Returns:
+        selected audio stream metadata
+    Raises:
+        ScinoephileError: if paths, stream selection, or extraction are invalid
+    """
+    try:
+        validated_infile_path = val_input_path(infile_path)
+        validated_outfile_path = val_output_path(outfile_path, exist_ok=True)
+    except (OSError, TypeError, ValueError) as exc:
+        raise ScinoephileError(f"Unable to extract audio: {exc}") from exc
+
+    if validated_outfile_path.suffix.lower() != ".wav":
+        raise ScinoephileError("Audio outfile must have a .wav extension")
+    if validated_infile_path == validated_outfile_path:
+        raise ScinoephileError("Audio infile and outfile must be different files")
+    if validated_outfile_path.exists() and not overwrite:
+        raise ScinoephileError(
+            f"Audio outfile already exists: {validated_outfile_path}; "
+            "use --overwrite to replace it"
+        )
+
+    stream = _get_audio_stream(validated_infile_path, stream_index)
+    if stream.channels is None:
+        raise ScinoephileError(
+            f"Audio stream {stream.index} in {validated_infile_path} has no "
+            "channel count"
+        )
+    _extract_audio_track(
+        validated_infile_path,
+        validated_outfile_path,
+        stream.index,
+        stream.channels,
+    )
+    return stream
+
+
+def _extract_audio_track(
+    infile_path: Path,
+    outfile_path: Path,
+    stream_index: int,
+    channels: int,
+):
+    """Extract a known media audio stream as a mono 16 kHz WAV file.
+
+    Arguments:
+        infile_path: media input file
+        outfile_path: WAV output file
+        stream_index: absolute media stream index
+        channels: number of channels in the selected stream
+    Raises:
+        ScinoephileError: if ffmpeg cannot extract the stream
+    """
+    try:
+        if channels >= 6:
+            logger.info(
+                f"Extracting center channel of audio stream {stream_index} from "
+                f"{infile_path} to {outfile_path}"
+            )
+            ffmpeg.input(str(infile_path)).output(
+                str(outfile_path),
+                format="wav",
+                ar=16000,
+                **{
+                    "filter_complex": f"[0:{stream_index}]pan=mono|c0=c2[out]",
+                    "map": "[out]",
+                },
+            ).run(quiet=False, overwrite_output=True)
+        else:
+            logger.info(
+                f"Downmixing audio stream {stream_index} from {infile_path} to "
+                f"{outfile_path}"
+            )
+            ffmpeg.input(str(infile_path)).output(
+                str(outfile_path),
+                format="wav",
+                ar=16000,
+                map=f"0:{stream_index}",
+                ac=1,
+            ).run(quiet=False, overwrite_output=True)
+    except (ffmpeg.Error, OSError) as exc:
+        raise ScinoephileError(
+            f"Could not extract audio stream {stream_index} from {infile_path} "
+            f"to {outfile_path}"
+        ) from exc
+
+
+def _get_audio_stream(infile_path: Path, stream_index: int | None) -> AudioStream:
+    """Get a selected audio stream from a media file.
+
+    Arguments:
+        infile_path: media input file
+        stream_index: absolute media stream index, or None for the first audio stream
+    Returns:
+        selected audio stream
+    Raises:
+        ScinoephileError: if no matching audio stream exists
+    """
+    streams = get_streams(infile_path)
+    if stream_index is None:
+        for stream in streams:
+            if isinstance(stream, AudioStream):
+                return stream
+        raise ScinoephileError(f"No audio streams found in {infile_path}")
+
+    for stream in streams:
+        if stream.index != stream_index:
+            continue
+        if not isinstance(stream, AudioStream):
+            raise ScinoephileError(
+                f"Stream index {stream_index} is not an audio stream"
+            )
+        return stream
+    raise ScinoephileError(f"No stream index {stream_index} found in {infile_path}")

--- a/scinoephile/media/audio.py
+++ b/scinoephile/media/audio.py
@@ -58,7 +58,28 @@ def extract_audio(
             "use --overwrite to replace it"
         )
 
-    stream = _get_audio_stream(validated_infile_path, stream_index)
+    stream: AudioStream | None = None
+    for candidate in get_streams(validated_infile_path):
+        if stream_index is None:
+            if isinstance(candidate, AudioStream):
+                stream = candidate
+                break
+            continue
+        if candidate.index != stream_index:
+            continue
+        if not isinstance(candidate, AudioStream):
+            raise ScinoephileError(
+                f"Stream index {stream_index} is not an audio stream"
+            )
+        stream = candidate
+        break
+
+    if stream is None:
+        if stream_index is None:
+            raise ScinoephileError(f"No audio streams found in {validated_infile_path}")
+        raise ScinoephileError(
+            f"No stream index {stream_index} found in {validated_infile_path}"
+        )
     if stream.channels is None:
         raise ScinoephileError(
             f"Audio stream {stream.index} in {validated_infile_path} has no "
@@ -121,32 +142,3 @@ def _extract_audio_track(
             f"Could not extract audio stream {stream_index} from {infile_path} "
             f"to {outfile_path}"
         ) from exc
-
-
-def _get_audio_stream(infile_path: Path, stream_index: int | None) -> AudioStream:
-    """Get a selected audio stream from a media file.
-
-    Arguments:
-        infile_path: media input file
-        stream_index: absolute media stream index, or None for the first audio stream
-    Returns:
-        selected audio stream
-    Raises:
-        ScinoephileError: if no matching audio stream exists
-    """
-    streams = get_streams(infile_path)
-    if stream_index is None:
-        for stream in streams:
-            if isinstance(stream, AudioStream):
-                return stream
-        raise ScinoephileError(f"No audio streams found in {infile_path}")
-
-    for stream in streams:
-        if stream.index != stream_index:
-            continue
-        if not isinstance(stream, AudioStream):
-            raise ScinoephileError(
-                f"Stream index {stream_index} is not an audio stream"
-            )
-        return stream
-    raise ScinoephileError(f"No stream index {stream_index} found in {infile_path}")

--- a/test/audio/subtitles/test_audio_series_load_from_media.py
+++ b/test/audio/subtitles/test_audio_series_load_from_media.py
@@ -154,22 +154,28 @@ def test_audio_series_load_from_media_rejects_invalid_stream_index():
                     )
 
 
-def test_audio_series_load_from_media_loads_wav_without_extraction():
-    """Test a standalone WAV is loaded directly without ffmpeg extraction."""
+def test_audio_series_load_from_media_normalizes_wav_through_extraction():
+    """Test a standalone WAV is normalized through audio extraction."""
     with get_temp_file_path(".srt") as subtitle_path:
         subtitle_path.write_text(
             "1\n00:00:00,000 --> 00:00:01,000\n你好\n", encoding="utf-8"
         )
         with get_temp_file_path(".wav") as media_path:
             AudioSegment.silent(duration=2000).export(media_path, format="wav")
-            with patch("scinoephile.audio.subtitles.series.extract_audio") as extract:
+            with patch(
+                "scinoephile.audio.subtitles.series.extract_audio",
+                side_effect=_write_selected_audio,
+            ) as extract:
                 series = AudioSeries.load_from_media(
                     media_path=media_path,
                     subtitle_path=subtitle_path,
                 )
 
-    extract.assert_not_called()
-    assert len(series.audio) == 2000
+    extract.assert_called_once()
+    assert extract.call_args.args[0].resolve() == media_path.resolve()
+    assert extract.call_args.args[1].name == "full_audio.wav"
+    assert extract.call_args.kwargs == {"stream_index": None}
+    assert len(series.audio) == 3012
 
 
 def test_audio_series_load_from_media_rejects_non_audio_stream_index():

--- a/test/audio/subtitles/test_audio_series_load_from_media.py
+++ b/test/audio/subtitles/test_audio_series_load_from_media.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import patch
 
-import ffmpeg
 from pydub import AudioSegment
 from pydub.exceptions import CouldntDecodeError
 from pytest import raises
@@ -15,105 +14,6 @@ from pytest import raises
 from scinoephile.audio.subtitles import AudioSeries
 from scinoephile.common.file import get_temp_file_path
 from scinoephile.core import ScinoephileError
-
-
-class FakeFfmpegInput:
-    """Fake ffmpeg input chain that records output arguments."""
-
-    def __init__(self, run_exception: Exception | None = None):
-        """Initialize."""
-        self.output_args: tuple[object, ...] | None = None
-        self.output_kwargs: dict[str, object] | None = None
-        self.run_kwargs: dict[str, object] | None = None
-        self.run_exception = run_exception
-        """Exception to raise when run."""
-
-    def output(self, *args: object, **kwargs: object) -> FakeFfmpegInput:
-        """Record ffmpeg output arguments.
-
-        Arguments:
-            *args: ffmpeg output positional arguments
-            **kwargs: ffmpeg output keyword arguments
-        Returns:
-            fake ffmpeg input chain
-        """
-        self.output_args = args
-        self.output_kwargs = kwargs
-        return self
-
-    def run(self, **kwargs: object):
-        """Record ffmpeg run arguments.
-
-        Arguments:
-            **kwargs: ffmpeg run keyword arguments
-        """
-        self.run_kwargs = kwargs
-        if self.run_exception is not None:
-            raise self.run_exception
-
-
-def test_audio_series_extract_audio_track_maps_overall_stream_index():
-    """Test audio extraction maps the absolute media stream index."""
-    fake_ffmpeg_input = FakeFfmpegInput()
-
-    with patch(
-        "scinoephile.audio.subtitles.series.ffmpeg.input",
-        return_value=fake_ffmpeg_input,
-    ):
-        AudioSeries.extract_audio_track(
-            Path("video.mkv"),
-            Path("audio.wav"),
-            12,
-            2,
-        )
-
-    assert fake_ffmpeg_input.output_kwargs is not None
-    assert fake_ffmpeg_input.output_kwargs["map"] == "0:12"
-
-
-def test_audio_series_extract_audio_track_filters_overall_stream_index():
-    """Test center-channel extraction filters the absolute media stream index."""
-    fake_ffmpeg_input = FakeFfmpegInput()
-
-    with patch(
-        "scinoephile.audio.subtitles.series.ffmpeg.input",
-        return_value=fake_ffmpeg_input,
-    ):
-        AudioSeries.extract_audio_track(
-            Path("video.mkv"),
-            Path("audio.wav"),
-            12,
-            6,
-        )
-
-    assert fake_ffmpeg_input.output_kwargs is not None
-    assert fake_ffmpeg_input.output_kwargs["filter_complex"] == (
-        "[0:12]pan=mono|c0=c2[out]"
-    )
-
-
-def test_audio_series_extract_audio_track_wraps_ffmpeg_errors():
-    """Test audio extraction errors are user-facing."""
-    fake_ffmpeg_input = FakeFfmpegInput(
-        ffmpeg.Error("ffmpeg", b"", b"failed"),
-    )
-
-    with patch(
-        "scinoephile.audio.subtitles.series.ffmpeg.input",
-        return_value=fake_ffmpeg_input,
-    ):
-        with raises(
-            ScinoephileError,
-            match="Could not extract audio stream 12 from video.mkv",
-        ) as excinfo:
-            AudioSeries.extract_audio_track(
-                Path("video.mkv"),
-                Path("audio.wav"),
-                12,
-                2,
-            )
-
-    assert isinstance(excinfo.value.__cause__, ffmpeg.Error)
 
 
 def test_audio_series_load_from_media_supports_stream_index():
@@ -135,7 +35,7 @@ def test_audio_series_load_from_media_supports_stream_index():
                 },
             ):
                 with patch(
-                    "scinoephile.audio.subtitles.series.AudioSeries.extract_audio_track",
+                    "scinoephile.audio.subtitles.series.extract_audio",
                     side_effect=_write_selected_audio,
                 ):
                     yuewen_series = AudioSeries.load_from_media(
@@ -170,7 +70,7 @@ def test_audio_series_load_from_media_defaults_to_first_audio_stream():
                 },
             ):
                 with patch(
-                    "scinoephile.audio.subtitles.series.AudioSeries.extract_audio_track",
+                    "scinoephile.audio.subtitles.series.extract_audio",
                     side_effect=_write_selected_audio,
                 ):
                     yuewen_series = AudioSeries.load_from_media(
@@ -215,9 +115,7 @@ def test_audio_series_load_from_media_wraps_decode_errors():
                     "streams": [{"index": 1, "codec_type": "audio", "channels": 2}]
                 },
             ):
-                with patch(
-                    "scinoephile.audio.subtitles.series.AudioSeries.extract_audio_track"
-                ):
+                with patch("scinoephile.audio.subtitles.series.extract_audio"):
                     with patch(
                         "scinoephile.audio.subtitles.series.AudioSegment.from_wav",
                         side_effect=CouldntDecodeError("invalid audio"),
@@ -256,6 +154,24 @@ def test_audio_series_load_from_media_rejects_invalid_stream_index():
                     )
 
 
+def test_audio_series_load_from_media_loads_wav_without_extraction():
+    """Test a standalone WAV is loaded directly without ffmpeg extraction."""
+    with get_temp_file_path(".srt") as subtitle_path:
+        subtitle_path.write_text(
+            "1\n00:00:00,000 --> 00:00:01,000\n你好\n", encoding="utf-8"
+        )
+        with get_temp_file_path(".wav") as media_path:
+            AudioSegment.silent(duration=2000).export(media_path, format="wav")
+            with patch("scinoephile.audio.subtitles.series.extract_audio") as extract:
+                series = AudioSeries.load_from_media(
+                    media_path=media_path,
+                    subtitle_path=subtitle_path,
+                )
+
+    extract.assert_not_called()
+    assert len(series.audio) == 2000
+
+
 def test_audio_series_load_from_media_rejects_non_audio_stream_index():
     """Test media loading rejects overall stream indexes that are not audio."""
     with get_temp_file_path(".srt") as subtitle_path:
@@ -284,21 +200,25 @@ def test_audio_series_load_from_media_rejects_non_audio_stream_index():
 
 
 def _write_selected_audio(
-    video_input_path: Path,
-    audio_output_path: Path,
-    audio_track: int,
-    channels: int,
+    infile_path: Path,
+    outfile_path: Path,
+    *,
+    stream_index: int | None = None,
+    overwrite: bool = False,
 ):
     """Write a WAV whose duration identifies the selected stream.
 
     Arguments:
-        video_input_path: input media path
-        audio_output_path: output WAV path
-        audio_track: selected audio stream index
-        channels: selected audio channel count
+        infile_path: input media path
+        outfile_path: output WAV path
+        stream_index: selected audio stream index
+        overwrite: whether an existing output may be replaced
     """
-    _ = video_input_path
-    AudioSegment.silent(duration=3000 + audio_track * 10 + channels).export(
-        audio_output_path,
+    _ = infile_path, overwrite
+    if stream_index is None:
+        stream_index = 1
+    channels = 6 if stream_index == 12 else 2
+    AudioSegment.silent(duration=3000 + stream_index * 10 + channels).export(
+        outfile_path,
         format="wav",
     )

--- a/test/media/test_audio.py
+++ b/test/media/test_audio.py
@@ -62,7 +62,7 @@ def test_extract_audio_selects_stream_and_extracts_track(tmp_path: Path):
     stream = AudioStream(index=3, codec_type="audio", channels=6)
 
     with (
-        patch("scinoephile.media.audio._get_audio_stream", return_value=stream),
+        patch("scinoephile.media.audio.get_streams", return_value=[stream]),
         patch("scinoephile.media.audio._extract_audio_track") as extract_track,
     ):
         selected = extract_audio(
@@ -92,8 +92,8 @@ def test_extract_audio_track_filters_overall_stream_index(tmp_path: Path):
 
     with (
         patch(
-            "scinoephile.media.audio._get_audio_stream",
-            return_value=AudioStream(index=12, codec_type="audio", channels=6),
+            "scinoephile.media.audio.get_streams",
+            return_value=[AudioStream(index=12, codec_type="audio", channels=6)],
         ),
         patch(
             "scinoephile.media.audio.ffmpeg.input",
@@ -120,8 +120,8 @@ def test_extract_audio_track_maps_overall_stream_index(tmp_path: Path):
 
     with (
         patch(
-            "scinoephile.media.audio._get_audio_stream",
-            return_value=AudioStream(index=12, codec_type="audio", channels=2),
+            "scinoephile.media.audio.get_streams",
+            return_value=[AudioStream(index=12, codec_type="audio", channels=2)],
         ),
         patch(
             "scinoephile.media.audio.ffmpeg.input",
@@ -148,8 +148,8 @@ def test_extract_audio_track_wraps_ffmpeg_errors(tmp_path: Path):
 
     with (
         patch(
-            "scinoephile.media.audio._get_audio_stream",
-            return_value=AudioStream(index=12, codec_type="audio", channels=2),
+            "scinoephile.media.audio.get_streams",
+            return_value=[AudioStream(index=12, codec_type="audio", channels=2)],
         ),
         patch(
             "scinoephile.media.audio.ffmpeg.input",

--- a/test/media/test_audio.py
+++ b/test/media/test_audio.py
@@ -1,0 +1,193 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests of media audio extraction utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import ffmpeg
+from pytest import raises
+
+from scinoephile.core.exceptions import ScinoephileError
+from scinoephile.core.media.audio_stream import AudioStream
+from scinoephile.media.audio import extract_audio
+
+
+class FakeFfmpegInput:
+    """Fake ffmpeg input chain that records output arguments."""
+
+    def __init__(self, run_exception: Exception | None = None):
+        """Initialize."""
+        self.output_args: tuple[object, ...] | None = None
+        self.output_kwargs: dict[str, object] | None = None
+        self.run_kwargs: dict[str, object] | None = None
+        self.run_exception = run_exception
+        """Exception to raise when run."""
+
+    def output(self, *args: object, **kwargs: object) -> FakeFfmpegInput:
+        """Record ffmpeg output arguments.
+
+        Arguments:
+            *args: ffmpeg output positional arguments
+            **kwargs: ffmpeg output keyword arguments
+        Returns:
+            fake ffmpeg input chain
+        """
+        self.output_args = args
+        self.output_kwargs = kwargs
+        return self
+
+    def run(self, **kwargs: object):
+        """Record ffmpeg run arguments.
+
+        Arguments:
+            **kwargs: ffmpeg run keyword arguments
+        """
+        self.run_kwargs = kwargs
+        if self.run_exception is not None:
+            raise self.run_exception
+
+
+def test_extract_audio_selects_stream_and_extracts_track(tmp_path: Path):
+    """Test extraction selects the requested stream and forwards its channel count.
+
+    Arguments:
+        tmp_path: temporary directory provided by pytest
+    """
+    infile_path = tmp_path / "movie.mkv"
+    infile_path.touch()
+    outfile_path = tmp_path / "audio.wav"
+    stream = AudioStream(index=3, codec_type="audio", channels=6)
+
+    with (
+        patch("scinoephile.media.audio._get_audio_stream", return_value=stream),
+        patch("scinoephile.media.audio._extract_audio_track") as extract_track,
+    ):
+        selected = extract_audio(
+            infile_path,
+            outfile_path,
+            stream_index=3,
+        )
+
+    assert selected is stream
+    extract_track.assert_called_once_with(
+        infile_path.resolve(),
+        outfile_path.resolve(),
+        3,
+        6,
+    )
+
+
+def test_extract_audio_track_filters_overall_stream_index(tmp_path: Path):
+    """Test center-channel extraction filters the absolute media stream index.
+
+    Arguments:
+        tmp_path: temporary directory provided by pytest
+    """
+    infile_path = tmp_path / "video.mkv"
+    infile_path.touch()
+    fake_ffmpeg_input = FakeFfmpegInput()
+
+    with (
+        patch(
+            "scinoephile.media.audio._get_audio_stream",
+            return_value=AudioStream(index=12, codec_type="audio", channels=6),
+        ),
+        patch(
+            "scinoephile.media.audio.ffmpeg.input",
+            return_value=fake_ffmpeg_input,
+        ),
+    ):
+        extract_audio(infile_path, tmp_path / "audio.wav")
+
+    assert fake_ffmpeg_input.output_kwargs is not None
+    assert fake_ffmpeg_input.output_kwargs["filter_complex"] == (
+        "[0:12]pan=mono|c0=c2[out]"
+    )
+
+
+def test_extract_audio_track_maps_overall_stream_index(tmp_path: Path):
+    """Test audio extraction maps the absolute media stream index.
+
+    Arguments:
+        tmp_path: temporary directory provided by pytest
+    """
+    infile_path = tmp_path / "video.mkv"
+    infile_path.touch()
+    fake_ffmpeg_input = FakeFfmpegInput()
+
+    with (
+        patch(
+            "scinoephile.media.audio._get_audio_stream",
+            return_value=AudioStream(index=12, codec_type="audio", channels=2),
+        ),
+        patch(
+            "scinoephile.media.audio.ffmpeg.input",
+            return_value=fake_ffmpeg_input,
+        ),
+    ):
+        extract_audio(infile_path, tmp_path / "audio.wav")
+
+    assert fake_ffmpeg_input.output_kwargs is not None
+    assert fake_ffmpeg_input.output_kwargs["map"] == "0:12"
+
+
+def test_extract_audio_track_wraps_ffmpeg_errors(tmp_path: Path):
+    """Test audio extraction errors are user-facing.
+
+    Arguments:
+        tmp_path: temporary directory provided by pytest
+    """
+    infile_path = tmp_path / "video.mkv"
+    infile_path.touch()
+    fake_ffmpeg_input = FakeFfmpegInput(
+        ffmpeg.Error("ffmpeg", b"", b"failed"),
+    )
+
+    with (
+        patch(
+            "scinoephile.media.audio._get_audio_stream",
+            return_value=AudioStream(index=12, codec_type="audio", channels=2),
+        ),
+        patch(
+            "scinoephile.media.audio.ffmpeg.input",
+            return_value=fake_ffmpeg_input,
+        ),
+        raises(
+            ScinoephileError,
+            match="Could not extract audio stream 12",
+        ) as excinfo,
+    ):
+        extract_audio(infile_path, tmp_path / "audio.wav")
+
+    assert isinstance(excinfo.value.__cause__, ffmpeg.Error)
+
+
+def test_extract_audio_requires_overwrite_for_existing_output(tmp_path: Path):
+    """Test extraction preserves an existing output unless overwrite is enabled.
+
+    Arguments:
+        tmp_path: temporary directory provided by pytest
+    """
+    infile_path = tmp_path / "movie.mkv"
+    infile_path.touch()
+    outfile_path = tmp_path / "audio.wav"
+    outfile_path.touch()
+
+    with raises(ScinoephileError, match="use --overwrite"):
+        extract_audio(infile_path, outfile_path)
+
+
+def test_extract_audio_requires_wav_output(tmp_path: Path):
+    """Test extraction rejects an output extension inconsistent with its format.
+
+    Arguments:
+        tmp_path: temporary directory provided by pytest
+    """
+    infile_path = tmp_path / "movie.mkv"
+    infile_path.touch()
+
+    with raises(ScinoephileError, match=r"\.wav extension"):
+        extract_audio(infile_path, tmp_path / "audio.mp3")


### PR DESCRIPTION
## Summary

- move generic audio-stream selection and WAV extraction into `scinoephile.media.audio`
- migrate `AudioSeries.load_from_media` to the shared helper
- load standalone WAV inputs directly, without an unnecessary extraction pass

## Validation

- `uv run ruff format`
- `uv run ruff check --fix`
- `uv run ty check`
- `cd test && uv run pytest media/test_audio.py audio/subtitles/test_audio_series_load_from_media.py test_module_hierarchy.py -n auto`