### PR TITLE
Avoid constructing block pairs to count them

### DIFF
--- a/scinoephile/cli/proofread_cli.py
+++ b/scinoephile/cli/proofread_cli.py
@@ -20,7 +20,7 @@ from scinoephile.common.argument_parsing import (
 from scinoephile.core import Language, ScinoephileError
 from scinoephile.core.cli import ScinoephileCliBase
 from scinoephile.core.cli.localization import merge_localizations
-from scinoephile.core.pairs import get_block_pairs_by_pause
+from scinoephile.core.pairs import get_block_pair_indexes_by_pause
 from scinoephile.llms.providers.registry import get_provider
 from scinoephile.workflows.review import (
     review_series,
@@ -185,7 +185,7 @@ class ProofreadCli(ScinoephileCliBase):
         guide = None
         if guide_infile_path is not None:
             guide = read_series(parser, guide_infile_path)
-            block_count = len(get_block_pairs_by_pause(series, guide))
+            block_count = len(get_block_pair_indexes_by_pause(series, guide))
         else:
             block_count = len(series.blocks)
         start_at_idx, stop_at_idx = get_block_range_indexes(

--- a/scinoephile/cli/translate_cli.py
+++ b/scinoephile/cli/translate_cli.py
@@ -21,7 +21,7 @@ from scinoephile.common.argument_parsing import (
 from scinoephile.core import Language, ScinoephileError
 from scinoephile.core.cli import ScinoephileCliBase
 from scinoephile.core.cli.localization import merge_localizations
-from scinoephile.core.pairs import get_block_pairs_by_pause
+from scinoephile.core.pairs import get_block_pair_indexes_by_pause
 from scinoephile.llms.providers.registry import get_provider
 from scinoephile.workflows.translation import (
     translate_series,
@@ -217,10 +217,10 @@ class TranslateCli(ScinoephileCliBase):
         guide = None
         if gapped_infile_path is not None:
             target = read_series(parser, gapped_infile_path)
-            block_count = len(get_block_pairs_by_pause(source, target))
+            block_count = len(get_block_pair_indexes_by_pause(source, target))
         elif guide_infile_path is not None:
             guide = read_series(parser, guide_infile_path)
-            block_count = len(get_block_pairs_by_pause(source, guide))
+            block_count = len(get_block_pair_indexes_by_pause(source, guide))
         else:
             block_count = len(source.blocks)
         start_at_idx, stop_at_idx = get_block_range_indexes(

--- a/scinoephile/core/pairs.py
+++ b/scinoephile/core/pairs.py
@@ -10,10 +10,69 @@ from .exceptions import ScinoephileError
 from .subtitles import Series
 
 __all__ = [
+    "get_block_pair_indexes_by_pause",
     "get_block_pairs_by_pause",
     "get_pair_with_zero_start",
     "get_pair_strings",
 ]
+
+
+def get_block_pair_indexes_by_pause(
+    one: Series,
+    two: Series,
+    pause_length: int = 3000,
+) -> list[tuple[tuple[int, int], tuple[int, int]]]:
+    """Get indexes of paired blocks split by pauses without text in either series.
+
+    Arguments:
+        one: first series
+        two: second series
+        pause_length: split whenever a pause of this length is encountered
+    Returns:
+        start and end indexes of each paired block in both series
+    """
+    block_indexes = []
+    one_idx = 0
+    two_idx = 0
+
+    while one_idx < len(one) or two_idx < len(two):
+        one_start_idx = one_idx
+        two_start_idx = two_idx
+
+        def get_cutoff() -> int:
+            """Get the latest event end plus the selected pause length."""
+            cutoff = 0
+            if one_idx > one_start_idx:
+                cutoff = max(cutoff, one[one_idx - 1].end)
+            if two_idx > two_start_idx:
+                cutoff = max(cutoff, two[two_idx - 1].end)
+            return cutoff + pause_length
+
+        # Start a new block with the earlier event
+        if one_idx < len(one) and two_idx < len(two):
+            if one[one_idx].start <= two[two_idx].start:
+                one_idx += 1
+            else:
+                two_idx += 1
+        elif one_idx < len(one):
+            one_idx += 1
+        else:
+            two_idx += 1
+
+        # Extend the block until both series reach a long enough pause
+        changed = True
+        while changed:
+            changed = False
+            while one_idx < len(one) and one[one_idx].start < get_cutoff():
+                one_idx += 1
+                changed = True
+            while two_idx < len(two) and two[two_idx].start < get_cutoff():
+                two_idx += 1
+                changed = True
+
+        block_indexes.append(((one_start_idx, one_idx), (two_start_idx, two_idx)))
+
+    return block_indexes
 
 
 def get_block_pairs_by_pause(
@@ -24,60 +83,22 @@ def get_block_pairs_by_pause(
     """Split a pair of series into blocks using pauses without text in either.
 
     Arguments:
-        one: First series
-        two: Second series
-        pause_length: Split whenever a pause of this length is encountered
+        one: first series
+        two: second series
+        pause_length: split whenever a pause of this length is encountered
     Returns:
-        Pairs of series split into blocks
+        pairs of series split into blocks
     """
     blocks = []
-    source_one = deepcopy(one.events)
-    source_two = deepcopy(two.events)
-
-    def get_nascent_block_cutoff() -> int:
-        """Get latest acceptable start for an event to be added to the nascent block."""
-        cutoff = 0
-        if nascent_block_one:
-            cutoff = max(cutoff, nascent_block_one[-1].end)
-        if nascent_block_two:
-            cutoff = max(cutoff, nascent_block_two[-1].end)
-        cutoff += pause_length
-
-        return cutoff
-
-    # Split into blocks
-    while source_one or source_two:
-        # Start a new block, with one event from the earlier of the two sources
-        nascent_block_one = []
-        nascent_block_two = []
-        if source_one and source_two:
-            if source_one[0].start <= source_two[0].start:
-                nascent_block_one.append(source_one.pop(0))
-            else:
-                nascent_block_two.append(source_two.pop(0))
-        elif source_one:
-            nascent_block_one.append(source_one.pop(0))
-        else:
-            nascent_block_two.append(source_two.pop(0))
-
-        # Extend block until a long enough pause is hit or sources are empty
-        changed = True
-        while changed:
-            changed = False
-            # Extend nascent_block_one until a pause is encountered in source_one
-            while source_one and source_one[0].start < get_nascent_block_cutoff():
-                nascent_block_one.append(source_one.pop(0))
-                changed = True
-            # Extend nascent_block_two until a pause is encountered in source_two
-            while source_two and source_two[0].start < get_nascent_block_cutoff():
-                nascent_block_two.append(source_two.pop(0))
-                changed = True
-
-        # Store block
+    for one_indexes, two_indexes in get_block_pair_indexes_by_pause(
+        one,
+        two,
+        pause_length,
+    ):
         block_one = one.__class__()
         block_two = two.__class__()
-        block_one.events = nascent_block_one
-        block_two.events = nascent_block_two
+        block_one.events = deepcopy(one.events[slice(*one_indexes)])
+        block_two.events = deepcopy(two.events[slice(*two_indexes)])
         blocks.append((block_one, block_two))
 
     return blocks
@@ -91,10 +112,10 @@ def get_pair_with_zero_start(one: Series, two: Series) -> tuple[Series, Series]:
     later will be shifted by the same amount.
 
     Arguments:
-        one: First series
-        two: Second series
+        one: first series
+        two: second series
     Returns:
-        Pair with their start times shifted to zero
+        pair with their start times shifted to zero
     """
     if one.events and two.events:
         start_time = min(one.events[0].start, two.events[0].start)
@@ -117,10 +138,10 @@ def get_pair_strings(one: Series, two: Series) -> tuple[str, str]:
     """Get string representations of two series.
 
     Arguments:
-        one: First series
-        two: Second series
+        one: first series
+        two: second series
     Returns:
-        Strings of each series
+        strings of each series
     """
     one, two = get_pair_with_zero_start(one, two)
     if one.events and two.events:

--- a/test/core/pairs/test_get_block_pairs_by_pause.py
+++ b/test/core/pairs/test_get_block_pairs_by_pause.py
@@ -1,10 +1,13 @@
 #  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
-"""Tests of scinoephile.core.pairs.get_block_pairs_by_pause."""
+"""Tests of paired subtitle block construction."""
 
 from __future__ import annotations
 
-from scinoephile.core.pairs import get_block_pairs_by_pause
+from scinoephile.core.pairs import (
+    get_block_pair_indexes_by_pause,
+    get_block_pairs_by_pause,
+)
 from scinoephile.core.subtitles import Series
 
 
@@ -16,8 +19,12 @@ def test_get_block_pairs_by_pause_kob(kob_yue_hans: Series, kob_eng: Series):
         kob_eng: KOB English series fixture
     """
     block_pairs = get_block_pairs_by_pause(kob_yue_hans, kob_eng)
+    block_pair_indexes = get_block_pair_indexes_by_pause(kob_yue_hans, kob_eng)
 
     assert len(block_pairs) == 193
+    assert len(block_pair_indexes) == len(block_pairs)
+    assert block_pair_indexes[0] == ((0, 1), (0, 1))
+    assert block_pair_indexes[-1] == ((1459, 1461), (1448, 1450))
     first_one_block, first_two_block = block_pairs[0]
     assert len(first_one_block) == 1
     assert len(first_two_block) == 1


### PR DESCRIPTION
The translation and proofreading CLIs only need a paired-block count to validate selected ranges. This adds an index-based block splitter so those checks avoid constructing and deep-copying temporary subtitle blocks.

`get_block_pairs_by_pause` now builds its existing public result from the shared index ranges, preserving its behavior.

Validated with Ruff, ty, and focused paired-block/CLI tests.