### PR TITLE
Load standalone WAV audio directly

### DIFF
--- a/scinoephile/audio/subtitles/series.py
+++ b/scinoephile/audio/subtitles/series.py
@@ -244,15 +244,23 @@ class AudioSeries(Series):
             validated_subtitle_path = val_input_path(subtitle_path)
             text_series = Series.load(validated_subtitle_path, **kwargs)
 
-            with get_temp_directory_path() as temp_dir_path:
-                full_audio_path = temp_dir_path / "full_audio.wav"
-                extract_audio(
-                    validated_media_path,
-                    full_audio_path,
-                    stream_index=stream_index,
-                )
-                logger.info(f"Loading full audio from {full_audio_path}")
-                full_audio = AudioSegment.from_wav(full_audio_path)
+            if validated_media_path.suffix.lower() == ".wav":
+                if stream_index not in (None, 0):
+                    raise ScinoephileError(
+                        "A standalone WAV infile only supports stream index 0"
+                    )
+                logger.info(f"Loading full audio from {validated_media_path}")
+                full_audio = AudioSegment.from_wav(validated_media_path)
+            else:
+                with get_temp_directory_path() as temp_dir_path:
+                    full_audio_path = temp_dir_path / "full_audio.wav"
+                    extract_audio(
+                        validated_media_path,
+                        full_audio_path,
+                        stream_index=stream_index,
+                    )
+                    logger.info(f"Loading full audio from {full_audio_path}")
+                    full_audio = AudioSegment.from_wav(full_audio_path)
 
             return cls.build_series(text_series, full_audio, buffer)
         except (OSError, PydubException, UnicodeError, ValueError) as exc:

--- a/test/audio/subtitles/test_audio_series_load_from_media.py
+++ b/test/audio/subtitles/test_audio_series_load_from_media.py
@@ -154,28 +154,44 @@ def test_audio_series_load_from_media_rejects_invalid_stream_index():
                     )
 
 
-def test_audio_series_load_from_media_normalizes_wav_through_extraction():
-    """Test a standalone WAV is normalized through audio extraction."""
+def test_audio_series_load_from_media_loads_wav_without_extraction():
+    """Test a standalone WAV is loaded directly without ffmpeg extraction."""
     with get_temp_file_path(".srt") as subtitle_path:
         subtitle_path.write_text(
             "1\n00:00:00,000 --> 00:00:01,000\n你好\n", encoding="utf-8"
         )
         with get_temp_file_path(".wav") as media_path:
             AudioSegment.silent(duration=2000).export(media_path, format="wav")
-            with patch(
-                "scinoephile.audio.subtitles.series.extract_audio",
-                side_effect=_write_selected_audio,
-            ) as extract:
+            with patch("scinoephile.audio.subtitles.series.extract_audio") as extract:
                 series = AudioSeries.load_from_media(
                     media_path=media_path,
                     subtitle_path=subtitle_path,
                 )
 
-    extract.assert_called_once()
-    assert extract.call_args.args[0].resolve() == media_path.resolve()
-    assert extract.call_args.args[1].name == "full_audio.wav"
-    assert extract.call_args.kwargs == {"stream_index": None}
-    assert len(series.audio) == 3012
+    extract.assert_not_called()
+    assert len(series.audio) == 2000
+
+
+def test_audio_series_load_from_media_rejects_nonzero_wav_stream_index():
+    """Test a standalone WAV supports only its single audio stream."""
+    with get_temp_file_path(".srt") as subtitle_path:
+        subtitle_path.write_text(
+            "1\n00:00:00,000 --> 00:00:01,000\n你好\n", encoding="utf-8"
+        )
+        with get_temp_file_path(".wav") as media_path:
+            AudioSegment.silent(duration=2000).export(media_path, format="wav")
+            with patch("scinoephile.audio.subtitles.series.extract_audio") as extract:
+                with raises(
+                    ScinoephileError,
+                    match="A standalone WAV infile only supports stream index 0",
+                ):
+                    AudioSeries.load_from_media(
+                        media_path=media_path,
+                        subtitle_path=subtitle_path,
+                        stream_index=1,
+                    )
+
+    extract.assert_not_called()
 
 
 def test_audio_series_load_from_media_rejects_non_audio_stream_index():


### PR DESCRIPTION
`AudioSeries.load_from_media` now reads a standalone WAV directly instead of sending it through ffmpeg for extraction and normalization.

Standalone WAV files have exactly one audio stream, so nonzero stream indexes are rejected explicitly. Other media formats retain the existing extraction path.

Validated with Ruff, ty, and the focused audio-series tests.