### PR TITLE
Add media audio extraction CLI

### DIFF
--- a/scinoephile/cli/media/__init__.py
+++ b/scinoephile/cli/media/__init__.py
@@ -3,19 +3,21 @@
 """Command-line interfaces for media operations.
 
 Package hierarchy (modules may import from any above):
-* media_extract_subs_cli / media_offset_cli / media_probe_cli
+* media_extract_audio_cli / media_extract_subs_cli / media_offset_cli / media_probe_cli
 * media_cli
 """
 
 from __future__ import annotations
 
 from .media_cli import MediaCli
+from .media_extract_audio_cli import MediaExtractAudioCli
 from .media_extract_subs_cli import MediaExtractSubsCli
 from .media_offset_cli import MediaOffsetCli
 from .media_probe_cli import MediaProbeCli
 
 __all__ = [
     "MediaCli",
+    "MediaExtractAudioCli",
     "MediaExtractSubsCli",
     "MediaOffsetCli",
     "MediaProbeCli",

--- a/scinoephile/cli/media/media_cli.py
+++ b/scinoephile/cli/media/media_cli.py
@@ -10,6 +10,7 @@ from typing import Any
 from scinoephile.common import CommandLineInterface
 from scinoephile.core.cli import ScinoephileCliBase
 
+from .media_extract_audio_cli import MediaExtractAudioCli
 from .media_extract_subs_cli import MediaExtractSubsCli
 from .media_offset_cli import MediaOffsetCli
 from .media_probe_cli import MediaProbeCli
@@ -22,6 +23,7 @@ MEDIA_LOCALIZATIONS: dict[str, dict[str, str]] = {
         "extract matching subtitle streams from a video file": (
             "从视频文件提取匹配的字幕流"
         ),
+        "extract an audio stream from a media file": "从媒体文件提取音频流",
         "estimate visual offset between two media files": (
             "估计两个媒体文件之间的视觉偏移"
         ),
@@ -33,6 +35,7 @@ MEDIA_LOCALIZATIONS: dict[str, dict[str, str]] = {
         "extract matching subtitle streams from a video file": (
             "從影片檔提取匹配的字幕流"
         ),
+        "extract an audio stream from a media file": "從媒體檔提取音訊流",
         "estimate visual offset between two media files": (
             "估計兩個媒體檔之間的視覺偏移"
         ),
@@ -75,6 +78,7 @@ class MediaCli(ScinoephileCliBase):
             mapping of subcommand names to CLI classes
         """
         return {
+            MediaExtractAudioCli.name(): MediaExtractAudioCli,
             MediaExtractSubsCli.name(): MediaExtractSubsCli,
             MediaOffsetCli.name(): MediaOffsetCli,
             MediaProbeCli.name(): MediaProbeCli,

--- a/scinoephile/cli/media/media_extract_audio_cli.py
+++ b/scinoephile/cli/media/media_extract_audio_cli.py
@@ -1,0 +1,127 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Command-line interface for extracting an audio stream from media."""
+
+from __future__ import annotations
+
+from argparse import ArgumentParser
+from pathlib import Path
+
+from scinoephile.common.argument_parsing import (
+    get_arg_groups_by_name,
+    input_file_arg,
+    int_arg,
+    output_file_arg,
+)
+from scinoephile.core import ScinoephileError
+from scinoephile.core.cli import ScinoephileCliBase
+from scinoephile.media.audio import extract_audio
+
+__all__ = ["MediaExtractAudioCli"]
+
+MEDIA_EXTRACT_AUDIO_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "audio outfile path in WAV format": "WAV 格式的音频输出文件路径",
+        "extract an audio stream from a media file": "从媒体文件提取音频流",
+        "media infile containing audio streams": "包含音频流的媒体输入文件",
+        "media stream index of audio stream (default: first audio stream)": (
+            "音频媒体流的媒体流索引（默认：第一个音频流）"
+        ),
+        "overwrite audio outfile if it exists": "若音频输出文件已存在则覆盖",
+    },
+    "zh-hant": {
+        "audio outfile path in WAV format": "WAV 格式的音訊輸出檔路徑",
+        "extract an audio stream from a media file": "從媒體檔提取音訊流",
+        "media infile containing audio streams": "包含音訊流的媒體輸入檔",
+        "media stream index of audio stream (default: first audio stream)": (
+            "音訊媒體流的媒體流索引（預設：第一個音訊流）"
+        ),
+        "overwrite audio outfile if it exists": "若音訊輸出檔已存在則覆寫",
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
+
+class MediaExtractAudioCli(ScinoephileCliBase):
+    """Extract an audio stream from a media file."""
+
+    localizations = MEDIA_EXTRACT_AUDIO_LOCALIZATIONS
+    """Localized help text keyed by locale and English source text."""
+
+    @classmethod
+    def add_arguments_to_argparser(cls, parser: ArgumentParser):
+        """Add arguments to a nascent argument parser.
+
+        Arguments:
+            parser: nascent argument parser
+        """
+        super().add_arguments_to_argparser(parser)
+        arg_groups = get_arg_groups_by_name(
+            parser,
+            "input arguments",
+            "operation arguments",
+            "output arguments",
+            optional_arguments_name="additional arguments",
+        )
+        arg_groups["input arguments"].add_argument(
+            "--infile",
+            dest="infile_path",
+            required=True,
+            type=input_file_arg(),
+            help="media infile containing audio streams",
+        )
+        arg_groups["operation arguments"].add_argument(
+            "--stream-index",
+            type=int_arg(min_value=0),
+            help=("media stream index of audio stream (default: first audio stream)"),
+        )
+        arg_groups["output arguments"].add_argument(
+            "-o",
+            "--outfile",
+            dest="outfile_path",
+            required=True,
+            type=output_file_arg(exist_ok=True),
+            help="audio outfile path in WAV format",
+        )
+        arg_groups["output arguments"].add_argument(
+            "--overwrite",
+            action="store_true",
+            help="overwrite audio outfile if it exists",
+        )
+        parser.set_defaults(_parser=parser)
+
+    @classmethod
+    def name(cls) -> str:
+        """Name of this tool used to define it when it is a subparser.
+
+        Returns:
+            subcommand name
+        """
+        return "extract-audio"
+
+    @classmethod
+    def _main(
+        cls,
+        *,
+        _parser: ArgumentParser | None = None,
+        infile_path: Path,
+        stream_index: int | None,
+        outfile_path: Path,
+        overwrite: bool,
+    ):
+        """Execute with provided keyword arguments."""
+        parser = _parser or cls.argparser()
+        try:
+            stream = extract_audio(
+                infile_path,
+                outfile_path,
+                stream_index=stream_index,
+                overwrite=overwrite,
+            )
+        except ScinoephileError as exc:
+            parser.error(str(exc))
+        print(f"Extracted audio: {stream.description} -> {outfile_path}")
+
+
+if __name__ == "__main__":
+    MediaExtractAudioCli.main()

--- a/test/cli/media/test_media_extract_audio_cli.py
+++ b/test/cli/media/test_media_extract_audio_cli.py
@@ -1,0 +1,84 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests of scinoephile.cli.media.MediaExtractAudioCli."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from pytest import CaptureFixture, raises
+
+from scinoephile.cli.media.media_extract_audio_cli import MediaExtractAudioCli
+from scinoephile.common.testing import run_cli_with_args
+from scinoephile.core.exceptions import ScinoephileError
+from scinoephile.core.media.audio_stream import AudioStream
+
+
+def test_media_extract_audio_cli_extracts_selected_stream(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+):
+    """Test extract-audio forwards its options and reports the output.
+
+    Arguments:
+        tmp_path: temporary directory provided by pytest
+        capsys: pytest output capture fixture
+    """
+    infile_path = tmp_path / "movie.mkv"
+    infile_path.touch()
+    outfile_path = tmp_path / "audio.wav"
+    stream = AudioStream(
+        index=3,
+        codec_type="audio",
+        codec_name="aac",
+        language="yue",
+        channels=6,
+    )
+
+    with patch(
+        "scinoephile.cli.media.media_extract_audio_cli.extract_audio",
+        return_value=stream,
+    ) as extract:
+        run_cli_with_args(
+            MediaExtractAudioCli,
+            f"--infile {infile_path} --stream-index 3 --outfile {outfile_path} "
+            "--overwrite",
+        )
+
+    extract.assert_called_once_with(
+        infile_path.resolve(),
+        outfile_path.resolve(),
+        stream_index=3,
+        overwrite=True,
+    )
+    assert capsys.readouterr().out.strip() == (
+        f"Extracted audio: {stream.description} -> {outfile_path.resolve()}"
+    )
+
+
+def test_media_extract_audio_cli_maps_extraction_errors_to_parser_errors(
+    tmp_path: Path,
+):
+    """Test extract-audio presents domain failures as argument errors.
+
+    Arguments:
+        tmp_path: temporary directory provided by pytest
+    """
+    infile_path = tmp_path / "movie.mkv"
+    infile_path.touch()
+    outfile_path = tmp_path / "audio.wav"
+
+    with (
+        patch(
+            "scinoephile.cli.media.media_extract_audio_cli.extract_audio",
+            side_effect=ScinoephileError("No audio streams found"),
+        ),
+        raises(SystemExit) as excinfo,
+    ):
+        run_cli_with_args(
+            MediaExtractAudioCli,
+            f"--infile {infile_path} --outfile {outfile_path}",
+        )
+
+    assert excinfo.value.code == 2


### PR DESCRIPTION
## Summary

Adds `scinoephile media extract-audio` to extract a selected media audio stream as a transcription-ready WAV.

## Why

Exposes the existing media-audio extraction capability as a focused command-line operation.

## Validation

- `uv run ruff format`
- `uv run ruff check --fix`
- `uv run ty check`
- `cd test && uv run pytest -n auto cli/media/test_media_extract_audio_cli.py`