### PR TITLE
Rename proofreading CLI to review

### DIFF
--- a/scinoephile/cli/__init__.py
+++ b/scinoephile/cli/__init__.py
@@ -4,7 +4,7 @@
 
 Package hierarchy (modules may import from any above):
 * helpers
-* audit / dictionary / media / multi / ocr / process_cli / proofread_cli
+* audit / dictionary / media / multi / ocr / process_cli / review_cli
   / transcribe_cli / translate_cli / utility
 * scinoephile_cli
 """

--- a/scinoephile/cli/review_cli.py
+++ b/scinoephile/cli/review_cli.py
@@ -1,8 +1,8 @@
 #  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
-"""Command-line interface for subtitle proofreading.
+"""Command-line interface for subtitle review.
 
-Proofread subtitles using an LLM.
+Review subtitles using an LLM.
 """
 
 from __future__ import annotations
@@ -41,50 +41,50 @@ from .helpers.llms import (
     read_llm_additional_context,
 )
 
-__all__ = ["ProofreadCli"]
+__all__ = ["ReviewCli"]
 
-PROOFREAD_LOCALIZATIONS: dict[str, dict[str, str]] = {
+REVIEW_LOCALIZATIONS: dict[str, dict[str, str]] = {
     "zh-hans": {
-        "command-line interface for subtitle proofreading": "字幕校对命令行界面",
+        "command-line interface for subtitle review": "字幕审校命令行界面",
         'subtitle infile or "-" for stdin': '字幕输入文件，或使用 "-" 表示标准输入',
         "guide subtitle infile for guided review": "用于引导校对的字幕输入文件",
         "subtitle language tag (detected from infile if omitted)": (
             "字幕语言标签（省略时从输入文件检测）"
         ),
-        "reference or guide language tag (detected from its infile if omitted)": (
-            "参考或引导字幕语言标签（省略时从相应输入文件检测）"
+        "guide language tag (detected from guide infile if omitted)": (
+            "引导字幕语言标签（省略时从引导输入文件检测）"
         ),
         "subtitle outfile path (default: stdout)": (
             "字幕输出文件路径（默认：标准输出）"
         ),
-        "proofread subtitles using an LLM": "使用大语言模型校对字幕",
-        "Proofread subtitles using an LLM.": "使用大语言模型校对字幕。",
+        "review subtitles using an LLM": "使用大语言模型审校字幕",
+        "Review subtitles using an LLM.": "使用大语言模型审校字幕。",
     },
     "zh-hant": {
-        "command-line interface for subtitle proofreading": "字幕校對命令列介面",
+        "command-line interface for subtitle review": "字幕審校命令列介面",
         'subtitle infile or "-" for stdin': '字幕輸入檔，或使用 "-" 代表標準輸入',
         "guide subtitle infile for guided review": "用於引導校對的字幕輸入檔",
         "subtitle language tag (detected from infile if omitted)": (
             "字幕語言標籤（省略時從輸入檔偵測）"
         ),
-        "reference or guide language tag (detected from its infile if omitted)": (
-            "參考或引導字幕語言標籤（省略時從相應輸入檔偵測）"
+        "guide language tag (detected from guide infile if omitted)": (
+            "引導字幕語言標籤（省略時從引導輸入檔偵測）"
         ),
         "subtitle outfile path (default: stdout)": ("字幕輸出檔路徑（預設：標準輸出）"),
-        "proofread subtitles using an LLM": "使用大型語言模型校對字幕",
-        "Proofread subtitles using an LLM.": "使用大型語言模型校對字幕。",
+        "review subtitles using an LLM": "使用大型語言模型審校字幕",
+        "Review subtitles using an LLM.": "使用大型語言模型審校字幕。",
     },
 }
 """Localized help text keyed by locale and English source text."""
 
 
-class ProofreadCli(ScinoephileCliBase):
-    """Proofread subtitles using an LLM."""
+class ReviewCli(ScinoephileCliBase):
+    """Review subtitles using an LLM."""
 
     localizations = merge_localizations(
         BLOCK_LOCALIZATIONS,
         LLM_LOCALIZATIONS,
-        PROOFREAD_LOCALIZATIONS,
+        REVIEW_LOCALIZATIONS,
     )
     """Localized help text keyed by locale and English source text."""
 
@@ -128,12 +128,10 @@ class ProofreadCli(ScinoephileCliBase):
             help="subtitle language tag (detected from infile if omitted)",
         )
         arg_groups["operation arguments"].add_argument(
-            "--reference-language",
+            "--guide-language",
             metavar=enum_metavar(Language),
             type=enum_arg(Language),
-            help=(
-                "reference or guide language tag (detected from its infile if omitted)"
-            ),
+            help="guide language tag (detected from guide infile if omitted)",
         )
         add_block_range_args(arg_groups["operation arguments"])
         add_llm_provider_args(
@@ -164,7 +162,7 @@ class ProofreadCli(ScinoephileCliBase):
         infile_path: Path | str,
         guide_infile_path: Path | None,
         language: Language | None,
-        reference_language: Language | None,
+        guide_language: Language | None,
         first_block: int | None,
         last_block: int | None,
         llm_args: LlmArguments,
@@ -177,8 +175,8 @@ class ProofreadCli(ScinoephileCliBase):
         parser = _parser or cls.argparser()
         if overwrite and outfile_path is None:
             parser.error("--overwrite may only be used with --outfile")
-        if reference_language is not None and guide_infile_path is None:
-            parser.error("--reference-language requires --guide-infile")
+        if guide_language is not None and guide_infile_path is None:
+            parser.error("--guide-language requires --guide-infile")
 
         # Read input
         series = read_series(parser, infile_path, allow_stdin=True)
@@ -206,7 +204,7 @@ class ProofreadCli(ScinoephileCliBase):
                     series,
                     guide,
                     language=language,
-                    guide_language=reference_language,
+                    guide_language=guide_language,
                     provider=provider,
                     additional_context=additional_context,
                     test_case_path=json_path,
@@ -233,4 +231,4 @@ class ProofreadCli(ScinoephileCliBase):
 
 
 if __name__ == "__main__":
-    ProofreadCli.main()
+    ReviewCli.main()

--- a/scinoephile/cli/scinoephile_cli.py
+++ b/scinoephile/cli/scinoephile_cli.py
@@ -18,7 +18,7 @@ from .media import MediaCli
 from .multi import MultiCli
 from .ocr import OcrCli
 from .process_cli import ProcessCli
-from .proofread_cli import ProofreadCli
+from .review_cli import ReviewCli
 from .transcribe_cli import TranscribeCli
 from .translate_cli import TranslateCli
 from .utility import UtilityCli
@@ -40,7 +40,7 @@ SCINOEPHILE_LOCALIZATIONS: dict[str, dict[str, str]] = {
         "list all subcommands and exit": "列出所有子命令并退出",
         "operate on multiple subtitle series": "处理多个字幕序列",
         "process subtitles": "处理字幕",
-        "proofread subtitles using an LLM": "使用大语言模型校对字幕",
+        "review subtitles using an LLM": "使用大语言模型审校字幕",
         "recognize text from image-based subtitles": "识别图像字幕中的文本",
         "run utility commands": "运行实用工具命令",
         (
@@ -73,7 +73,7 @@ SCINOEPHILE_LOCALIZATIONS: dict[str, dict[str, str]] = {
         "list all subcommands and exit": "列出所有子命令並結束",
         "operate on multiple subtitle series": "處理多個字幕序列",
         "process subtitles": "處理字幕",
-        "proofread subtitles using an LLM": "使用大型語言模型校對字幕",
+        "review subtitles using an LLM": "使用大型語言模型審校字幕",
         "recognize text from image-based subtitles": "識別影像字幕中的文字",
         "run utility commands": "執行實用工具命令",
         (
@@ -150,7 +150,7 @@ class ScinoephileCli(ScinoephileCliBase):
             MultiCli.name(): MultiCli,
             OcrCli.name(): OcrCli,
             ProcessCli.name(): ProcessCli,
-            ProofreadCli.name(): ProofreadCli,
+            ReviewCli.name(): ReviewCli,
             TranscribeCli.name(): TranscribeCli,
             TranslateCli.name(): TranslateCli,
             UtilityCli.name(): UtilityCli,

--- a/test/cli/test_review_cli.py
+++ b/test/cli/test_review_cli.py
@@ -1,6 +1,6 @@
 #  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
-"""Tests of scinoephile.cli.ProofreadCli."""
+"""Tests of scinoephile.cli.ReviewCli."""
 
 from __future__ import annotations
 
@@ -10,11 +10,28 @@ from unittest.mock import patch
 
 from pytest import raises
 
-from scinoephile.cli.proofread_cli import ProofreadCli
+from scinoephile.cli.review_cli import ReviewCli
+from scinoephile.cli.scinoephile_cli import ScinoephileCli
 from scinoephile.common.file import get_temp_file_path
 from scinoephile.common.testing import run_cli_with_args
 from scinoephile.core.subtitles import Series
 from test.helpers import assert_series_equal, parametrize, test_data_root
+
+
+def test_review_cli_is_top_level_command():
+    """Test review replaces proofread as the top-level command."""
+    assert ReviewCli.name() == "review"
+    assert ScinoephileCli.subcommands()["review"] is ReviewCli
+    assert "proofread" not in ScinoephileCli.subcommands()
+
+
+def test_review_cli_uses_guide_terminology():
+    """Test guided review arguments consistently use guide terminology."""
+    help_text = ReviewCli.argparser().format_help()
+
+    assert "--guide-infile" in help_text
+    assert "--guide-language" in help_text
+    assert "--reference-language" not in help_text
 
 
 @parametrize(
@@ -27,8 +44,8 @@ from test.helpers import assert_series_equal, parametrize, test_data_root
         ),
     ],
 )
-def test_proofread_cli(input_path: str, args: str, expected_path: str):
-    """Test proofread CLI with file arguments.
+def test_review_cli(input_path: str, args: str, expected_path: str):
+    """Test review CLI with file arguments.
 
     Arguments:
         input_path: path to input subtitle fixture
@@ -40,7 +57,7 @@ def test_proofread_cli(input_path: str, args: str, expected_path: str):
 
     with get_temp_file_path(".srt") as output_path:
         run_cli_with_args(
-            ProofreadCli,
+            ReviewCli,
             f"{full_input_path} {args} --outfile {output_path}",
         )
         output = Series.load(output_path)
@@ -59,8 +76,8 @@ def test_proofread_cli(input_path: str, args: str, expected_path: str):
         ),
     ],
 )
-def test_proofread_cli_pipe(input_path: str, args: str, expected_path: str):
-    """Test proofread CLI via stdin/stdout.
+def test_review_cli_pipe(input_path: str, args: str, expected_path: str):
+    """Test review CLI via stdin/stdout.
 
     Arguments:
         input_path: path to input subtitle fixture
@@ -75,7 +92,7 @@ def test_proofread_cli_pipe(input_path: str, args: str, expected_path: str):
     stdout_stream = StringIO()
     with patch("scinoephile.cli.helpers.io.stdin", stdin_stream):
         with patch("scinoephile.cli.helpers.io.stdout", stdout_stream):
-            run_cli_with_args(ProofreadCli, f"- {args}".strip())
+            run_cli_with_args(ReviewCli, f"- {args}".strip())
 
     output = Series.from_string(stdout_stream.getvalue(), format_="srt")
     expected = Series.load(full_expected_path)
@@ -90,12 +107,12 @@ def test_proofread_cli_pipe(input_path: str, args: str, expected_path: str):
         ("review_series_guided", "--guide-infile"),
     ],
 )
-def test_proofread_cli_passes_block_range(
+def test_review_cli_passes_block_range(
     workflow_name: str,
     guide_argument: str,
     tmp_path: Path,
 ):
-    """Test block ranges and JSON paths are forwarded through review modes.
+    """Test block ranges and JSON paths are forwarded through every review mode.
 
     Arguments:
         workflow_name: workflow function expected to be called
@@ -105,16 +122,16 @@ def test_proofread_cli_passes_block_range(
     input_path = test_data_root / "mnt/output/eng_ocr/fuse_clean_validate.srt"
     guide_args = ""
     if guide_argument:
-        guide_args = f"{guide_argument} {input_path}"
+        guide_args = f"{guide_argument} {input_path} --guide-language eng"
     json_path = tmp_path / "review.json"
 
     with patch(
-        f"scinoephile.cli.proofread_cli.{workflow_name}",
+        f"scinoephile.cli.review_cli.{workflow_name}",
         return_value=Series(),
     ) as workflow:
-        with patch("scinoephile.cli.proofread_cli.write_series"):
+        with patch("scinoephile.cli.review_cli.write_series"):
             run_cli_with_args(
-                ProofreadCli,
+                ReviewCli,
                 f"{input_path} {guide_args} --json {json_path} "
                 "--first-block 2 --last-block 3",
             )
@@ -122,15 +139,17 @@ def test_proofread_cli_passes_block_range(
     assert workflow.call_args.kwargs["test_case_path"] == json_path
     assert workflow.call_args.kwargs["start_at_idx"] == 1
     assert workflow.call_args.kwargs["stop_at_idx"] == 3
+    if guide_argument:
+        assert workflow.call_args.kwargs["guide_language"].code == "eng"
 
 
-def test_proofread_cli_rejects_reversed_block_range():
+def test_review_cli_rejects_reversed_block_range():
     """Test the first selected block cannot follow the last selected block."""
     input_path = test_data_root / "mnt/output/eng_ocr/fuse_clean_validate.srt"
 
     with raises(SystemExit, match="2"):
         run_cli_with_args(
-            ProofreadCli,
+            ReviewCli,
             f"{input_path} --first-block 3 --last-block 2",
         )
 
@@ -142,7 +161,7 @@ def test_proofread_cli_rejects_reversed_block_range():
         "--guide-infile {input_path}",
     ),
 )
-def test_proofread_cli_rejects_oversized_last_block(guide_args: str):
+def test_review_cli_rejects_oversized_last_block(guide_args: str):
     """Test the last selected block cannot exceed the available block count.
 
     Arguments:
@@ -154,6 +173,6 @@ def test_proofread_cli_rejects_oversized_last_block(guide_args: str):
 
     with raises(SystemExit, match="2"):
         run_cli_with_args(
-            ProofreadCli,
+            ReviewCli,
             f"{input_path} {guide_args} --last-block {block_count + 1}",
         )


### PR DESCRIPTION
## Summary

Renames the top-level `proofread` command and its implementation to `review`, and consistently refers to a guided-review language as `--guide-language`.

## Impact

This is an intentional CLI-breaking terminology cleanup: `proofread` and `--reference-language` are no longer accepted by this command.

## Validation

- `uv run ruff format`
- `uv run ruff check --fix`
- `uv run ty check`
- `cd test && uv run pytest -n auto cli/test_review_cli.py`