### PR TITLE
Stabilize iterative transcription delineation

### DIFF
--- a/scinoephile/lang/transcription/aligner.py
+++ b/scinoephile/lang/transcription/aligner.py
@@ -80,9 +80,21 @@ class TranscriptionAligner:
         """
         alignment = TranscriptionAlignment(reference_subs, transcription_subs)
 
-        delineation_in_progress = True
-        while delineation_in_progress:
-            delineation_in_progress = self._delineate(alignment)
+        seen_delineation_states = set()
+        while True:
+            delineation_state = (
+                tuple(
+                    (tuple(reference_idxs), tuple(transcription_idxs))
+                    for reference_idxs, transcription_idxs in alignment.sync_groups
+                ),
+                tuple(subtitle.text for subtitle in alignment.transcription),
+            )
+            if delineation_state in seen_delineation_states:
+                logger.warning("Stopping delineation after a repeated alignment state")
+                break
+            seen_delineation_states.add(delineation_state)
+            if not self._delineate(alignment):
+                break
 
         self._punctuate(alignment)
         return alignment
@@ -207,7 +219,7 @@ class TranscriptionAligner:
                 remaining_chars -= len(subtitle.text)
                 if remaining_chars == 0:
                     alignment._sync_groups_override = nascent_sync_groups
-                    return False
+                    return True
 
         if len(transcription_two) < len(shifted_two):
             text_to_shift = shifted_two[: len(shifted_two) - len(transcription_two)]
@@ -230,7 +242,7 @@ class TranscriptionAligner:
                 remaining_chars -= len(subtitle.text)
                 if remaining_chars == 0:
                     alignment._sync_groups_override = nascent_sync_groups
-                    return False
+                    return True
 
         raise ScinoephileError(
             f"Unexpected case:\nQuery:\n{query}\n with Answer:\n{answer}\n"

--- a/test/lang/transcription/test_delineation_alignment.py
+++ b/test/lang/transcription/test_delineation_alignment.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from pydub import AudioSegment
 
@@ -94,5 +94,84 @@ def test_aligner_uses_queryer_prompt_and_semantic_shift_output():
 
     encountered = delineation_queryer.call_args.args[0]
     assert encountered.prompt is _LOCALIZED_PROMPT
-    assert not restart_required
+    assert restart_required
     assert alignment.sync_groups == [([0], [0, 1]), ([1], [])]
+
+
+def test_aligner_restarts_to_propagate_text_across_multiple_boundaries():
+    """Aligner should revisit earlier boundaries after shifting whole subtitles."""
+    reference = Series(
+        events=[
+            Subtitle(start=0, end=1000, text="參考一"),
+            Subtitle(start=1000, end=2000, text="參考二"),
+            Subtitle(start=2000, end=3000, text="參考三"),
+        ],
+    )
+    transcription = AudioSeries(
+        audio=AudioSegment.silent(duration=3000),
+        events=[
+            AudioSubtitle(start=0, end=1000, text="甲"),
+            AudioSubtitle(start=1000, end=2000, text="乙"),
+            AudioSubtitle(start=2000, end=3000, text="丙"),
+        ],
+    )
+    alignment = TranscriptionAlignment(reference, transcription)
+    alignment._sync_groups_override = [([0], [0]), ([1], [1]), ([2], [2])]
+    delineation_queryer = Mock(spec=Queryer)
+    delineation_queryer.prompt = _LOCALIZED_PROMPT
+
+    def shift_left(test_case: DelineationTestCase) -> DelineationTestCase:
+        """Move text leftward until all targets reach the first group."""
+        answer: dict[str, str] = {}
+        if test_case.query.target_one == "乙":
+            answer = {"output_one": "乙丙"}
+        elif test_case.query.target_two == "乙丙":
+            answer = {"output_one": "甲乙丙"}
+        return type(test_case).model_validate(
+            {
+                **test_case.model_dump(),
+                "answer": answer,
+            }
+        )
+
+    delineation_queryer.side_effect = shift_left
+    aligner = TranscriptionAligner(
+        delineation_queryer=delineation_queryer,
+        punctuation_queryer=Mock(spec=Queryer),
+    )
+
+    while aligner._delineate(alignment):
+        pass
+
+    assert alignment.sync_groups == [([0], [0, 1, 2]), ([1], []), ([2], [])]
+
+
+def test_aligner_stops_when_delineation_states_repeat():
+    """Aligner should stop when neighboring decisions form a cycle."""
+    alignment = _get_alignment()
+    delineation_queryer = Mock(spec=Queryer)
+    delineation_queryer.prompt = _LOCALIZED_PROMPT
+
+    def oscillate(test_case: DelineationTestCase) -> DelineationTestCase:
+        """Move the second target left, then move it back right."""
+        answer = {"output_one": "甲乙"}
+        if not test_case.query.target_two:
+            answer = {"output_one": "甲", "output_two": "乙"}
+        return type(test_case).model_validate(
+            {
+                **test_case.model_dump(),
+                "answer": answer,
+            }
+        )
+
+    delineation_queryer.side_effect = oscillate
+    aligner = TranscriptionAligner(
+        delineation_queryer=delineation_queryer,
+        punctuation_queryer=Mock(spec=Queryer),
+    )
+
+    with patch.object(aligner, "_punctuate") as punctuate:
+        aligner.align(alignment.reference, alignment.transcription)
+
+    assert delineation_queryer.call_count == 2
+    punctuate.assert_called_once()


### PR DESCRIPTION
## Summary

Restarts delineation after moving a complete subtitle between synchronization groups, so the updated boundary can propagate. Stops safely if a provider response cycles the alignment state.

## Root cause

A whole-subtitle move previously reported that no restart was necessary, leaving earlier boundaries stale; repeated opposing decisions could loop indefinitely.

## Validation

- `uv run ruff format`
- `uv run ruff check --fix`
- `uv run ty check`
- `cd test && uv run pytest -n auto lang/transcription/test_delineation_alignment.py`