### PR TITLE
Bound Whisper decoding by clip duration

### DIFF
--- a/scinoephile/audio/transcription/whisper_transcriber.py
+++ b/scinoephile/audio/transcription/whisper_transcriber.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 from collections.abc import Sequence
 from logging import getLogger
+from math import ceil
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -20,6 +21,15 @@ from .transcribed_segment import TranscribedSegment
 __all__ = ["WhisperTranscriber"]
 
 _LOCAL_MODEL_PATH_PREFIXES = {"checkpoint", "checkpoints", "model", "models"}
+_MAX_SAMPLE_LEN = 224
+"""Maximum token budget supported by the configured Whisper models."""
+
+_MAX_TOKENS_PER_SECOND = 16
+"""Generous decode budget per second of source audio."""
+
+_MIN_SAMPLE_LEN = 32
+"""Minimum token budget for very short source audio."""
+
 _TRANSCRIPTION_EXTRA_MESSAGE = (
     "Whisper transcription support requires optional transcription dependencies. "
     "Install scinoephile with the 'transcription' extra."
@@ -169,6 +179,11 @@ class WhisperTranscriber:
         whisper = self._get_whisper_module()
         with get_temp_file_path(suffix=".wav") as temp_audio_path:
             audio.export(temp_audio_path, format="wav")
+            sample_len = self._get_sample_len(audio)
+            logger.info(
+                f"Limiting Whisper decoding to {sample_len} tokens for "
+                f"{len(audio) / 1000:.2f}s of audio"
+            )
             result = whisper.transcribe(
                 self.model,
                 str(temp_audio_path),
@@ -176,6 +191,7 @@ class WhisperTranscriber:
                 vad=self.use_vad,
                 temperature=self.temperature,
                 condition_on_previous_text=self.condition_on_previous_text,
+                sample_len=sample_len,
             )
         segments = [TranscribedSegment(**s) for s in result["segments"]]
         segments = self._normalize_transcription_segments(
@@ -193,6 +209,25 @@ class WhisperTranscriber:
                 logger.info(f"Saved transcription to cache: {cache_path}")
 
         return segments
+
+    @staticmethod
+    def _get_sample_len(audio: AudioSegment) -> int:
+        """Get a bounded token budget for one Whisper decode.
+
+        The timestamped Whisper implementation retains decoder attention maps for
+        word alignment. Repetitive decoding can otherwise run to the model-wide
+        token limit even for a very short clip, consuming excessive time and memory.
+
+        Arguments:
+            audio: audio to be transcribed
+        Returns:
+            maximum number of tokens Whisper may decode
+        """
+        duration_seconds = len(audio) / 1000
+        return min(
+            _MAX_SAMPLE_LEN,
+            max(_MIN_SAMPLE_LEN, ceil(duration_seconds * _MAX_TOKENS_PER_SECOND)),
+        )
 
     def _model_name_is_huggingface_repo_id(self) -> bool:
         """Determine whether model name looks like a HuggingFace repo ID.

--- a/test/audio/transcription/test_whisper_transcriber.py
+++ b/test/audio/transcription/test_whisper_transcriber.py
@@ -131,6 +131,32 @@ def test_transcribe_forwards_recovery_decoding_options(monkeypatch: MonkeyPatch)
     whisper.transcribe.assert_called_once()
     assert whisper.transcribe.call_args.kwargs["temperature"] == temperatures
     assert whisper.transcribe.call_args.kwargs["condition_on_previous_text"] is False
+    assert whisper.transcribe.call_args.kwargs["sample_len"] == 32
+
+
+@parametrize(
+    ("duration_ms", "expected"),
+    [
+        (100, 32),
+        (1000, 32),
+        (6530, 105),
+        (14000, 224),
+        (30000, 224),
+    ],
+)
+def test_get_sample_len_bounds_decode_by_audio_duration(
+    duration_ms: int,
+    expected: int,
+):
+    """Bound the decode token budget while leaving room for dense speech.
+
+    Arguments:
+        duration_ms: source audio duration in milliseconds
+        expected: expected Whisper token budget
+    """
+    audio = AudioSegment.silent(duration=duration_ms)
+
+    assert WhisperTranscriber._get_sample_len(audio) == expected
 
 
 def test_transcribe_bypasses_cache_when_requested(monkeypatch: MonkeyPatch):


### PR DESCRIPTION
## Summary

Sets Whisper's decode token budget from source-audio duration, with conservative minimum and maximum bounds.

## Why

Timestamped Whisper retains decoder attention maps for word alignment. Very short clips could otherwise consume time and memory decoding toward the model-wide token limit.

## Validation

- `uv run ruff format`
- `uv run ruff check --fix`
- `uv run ty check`
- `cd test && uv run pytest -n auto audio/transcription/test_whisper_transcriber.py`