### PR TITLE
Reuse Whisper models across transcribers

### DIFF
--- a/scinoephile/audio/transcription/whisper_transcriber.py
+++ b/scinoephile/audio/transcription/whisper_transcriber.py
@@ -9,7 +9,7 @@ import json
 from collections.abc import Sequence
 from logging import getLogger
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from scinoephile.common.file import get_temp_file_path
 from scinoephile.common.validation import val_output_dir_path
@@ -33,6 +33,9 @@ logger = getLogger(__name__)
 
 class WhisperTranscriber:
     """Transcribes audio using Whisper."""
+
+    _models: ClassVar[dict[tuple[str, str], Any]] = {}
+    """Loaded models shared by model name and device within the current process."""
 
     def __init__(
         self,
@@ -97,11 +100,15 @@ class WhisperTranscriber:
             loaded Whisper model
         """
         if self._model is None:
+            device = get_torch_device()
+            model_key = (self.model_name, device)
+            if model_key in self._models:
+                self._model = self._models[model_key]
+                return self._model
+
             whisper = self._get_whisper_module()
             try:
-                self._model = whisper.load_model(
-                    self.model_name, device=get_torch_device()
-                )
+                self._model = whisper.load_model(self.model_name, device=device)
             except FileNotFoundError:
                 if not self._model_name_is_huggingface_repo_id():
                     raise
@@ -111,9 +118,8 @@ class WhisperTranscriber:
                 )
                 snapshot_download = self._get_snapshot_download()
                 snapshot_download(repo_id=self.model_name)
-                self._model = whisper.load_model(
-                    self.model_name, device=get_torch_device()
-                )
+                self._model = whisper.load_model(self.model_name, device=device)
+            self._models[model_key] = self._model
         return self._model
 
     def get_cached_transcription(

--- a/test/audio/transcription/test_whisper_transcriber.py
+++ b/test/audio/transcription/test_whisper_transcriber.py
@@ -133,6 +133,38 @@ def test_transcribe_forwards_recovery_decoding_options(monkeypatch: MonkeyPatch)
     assert whisper.transcribe.call_args.kwargs["condition_on_previous_text"] is False
 
 
+def test_model_is_shared_across_decoding_configurations(monkeypatch: MonkeyPatch):
+    """Reuse one loaded model across fallback transcription configurations."""
+    whisper = Mock()
+    loaded_model = Mock()
+    whisper.load_model.return_value = loaded_model
+    monkeypatch.setattr(
+        WhisperTranscriber,
+        "_get_whisper_module",
+        Mock(return_value=whisper),
+    )
+    monkeypatch.setattr(
+        "scinoephile.audio.transcription.whisper_transcriber.get_torch_device",
+        Mock(return_value="cpu"),
+    )
+    WhisperTranscriber._models.clear()
+    vad_transcriber = WhisperTranscriber(
+        model_name="custom/model",
+        use_vad=True,
+    )
+    no_vad_transcriber = WhisperTranscriber(
+        model_name="custom/model",
+        use_vad=False,
+    )
+
+    try:
+        assert vad_transcriber.model is loaded_model
+        assert no_vad_transcriber.model is loaded_model
+        whisper.load_model.assert_called_once()
+    finally:
+        WhisperTranscriber._models.clear()
+
+
 def test_transcribe_bypasses_cache_when_requested(monkeypatch: MonkeyPatch):
     """Test an explicit uncached transcription does not reload rejected output."""
     whisper = Mock()


### PR DESCRIPTION
## Summary

Caches loaded Whisper models by model name and Torch device for the process lifetime.

## Why

Fallback transcription configurations differ in decoding behavior but use the same model. Reusing that model avoids redundant loading and GPU/CPU memory allocation.

## Validation

- `uv run ruff format`
- `uv run ruff check --fix`
- `uv run ty check`
- `cd test && uv run pytest -n auto audio/transcription/test_whisper_transcriber.py`