### PR TITLE
Reject invalid Whisper word timings

### DIFF
--- a/scinoephile/lang/transcription/processor.py
+++ b/scinoephile/lang/transcription/processor.py
@@ -679,6 +679,27 @@ class GuidedTranscriptionProcessor:
                     f"Rejecting Whisper segment {segment.id} without word timings"
                 )
                 return False
+            duration_error = None
+            if int(segment.end * 1000) <= int(segment.start * 1000):
+                duration_error = (
+                    f"Rejecting Whisper segment {segment.id} with non-positive "
+                    f"millisecond duration ({segment.start:.3f}s to "
+                    f"{segment.end:.3f}s)"
+                )
+            else:
+                for word in segment.words:
+                    if not word.text.strip():
+                        continue
+                    if int(word.end * 1000) <= int(word.start * 1000):
+                        duration_error = (
+                            f"Rejecting Whisper segment {segment.id} with word "
+                            f"{word.text!r} having non-positive millisecond duration "
+                            f"({word.start:.3f}s to {word.end:.3f}s)"
+                        )
+                        break
+            if duration_error is not None:
+                logger.warning(duration_error)
+                return False
             if (
                 segment.compression_ratio is not None
                 and segment.compression_ratio > _MAX_COMPRESSION_RATIO

--- a/test/lang/transcription/test_processor.py
+++ b/test/lang/transcription/test_processor.py
@@ -100,6 +100,22 @@ def test_segments_are_usable_rejects_repetitive_whisper_output():
     assert not GuidedTranscriptionProcessor._segments_are_usable(segments)
 
 
+def test_segments_are_usable_rejects_nonpositive_word_duration():
+    """Test text-bearing words must remain positive after ms conversion."""
+    segment = _get_segment(
+        start=4.02,
+        end=4.04,
+        text=" 啊",
+        compression_ratio=1.0,
+    )
+    segment.words = [
+        TranscribedWord(text=" ", start=4.02, end=4.04, confidence=1.0),
+        TranscribedWord(text="啊", start=4.04, end=4.04, confidence=1.0),
+    ]
+
+    assert not GuidedTranscriptionProcessor._segments_are_usable([segment])
+
+
 def test_segments_are_usable_rejects_timestamp_beyond_audio():
     """Test Whisper timestamps extending beyond source audio are unusable."""
     segments = [


### PR DESCRIPTION
## Summary

Rejects text-bearing Whisper segments and words that have non-positive duration after conversion to millisecond timing.

## Root cause

Zero-length timing spans cannot be represented safely in the audio subtitle pipeline and would otherwise fail during downstream alignment.

## Validation

- `uv run ruff format`
- `uv run ruff check --fix`
- `uv run ty check`
- `cd test && uv run pytest -n auto lang/transcription/test_processor.py`