### PR TITLE
Skip rejected Whisper cache decodes

### DIFF
--- a/scinoephile/lang/transcription/processor.py
+++ b/scinoephile/lang/transcription/processor.py
@@ -292,7 +292,8 @@ class GuidedTranscriptionProcessor:
                 audio_duration=audio_duration,
             ):
                 return cached_segments, rejected_transcribers
-            rejected_transcribers.add(transcriber)
+            if transcriber is not self.recovery_transcriber:
+                rejected_transcribers.add(transcriber)
         return None, rejected_transcribers
 
     def _get_standard_transcribers(

--- a/scinoephile/lang/transcription/processor.py
+++ b/scinoephile/lang/transcription/processor.py
@@ -269,27 +269,31 @@ class GuidedTranscriptionProcessor:
         cache_audio: AudioSegment,
         *,
         audio_duration: float,
-    ) -> list[TranscribedSegment] | None:
+    ) -> tuple[list[TranscribedSegment] | None, set[WhisperTranscriber]]:
         """Get cached block transcription before expensive preprocessing.
 
         Arguments:
             cache_audio: original block audio used for cache-key generation
             audio_duration: original block audio duration in seconds
         Returns:
-            cached transcription, if present
+            cached transcription, if usable, and transcribers with unusable caches
         """
+        rejected_transcribers: set[WhisperTranscriber] = set()
         transcribers = list(self._get_standard_transcribers())
         if self.demucs_mode == DemucsMode.AUTO:
             transcribers.extend(self._get_standard_transcribers(unseparated=True))
         transcribers.append(self.recovery_transcriber)
         for transcriber in transcribers:
             cached_segments = transcriber.get_cached_transcription(cache_audio)
-            if cached_segments is not None and self._segments_are_usable(
+            if cached_segments is None:
+                continue
+            if self._segments_are_usable(
                 cached_segments,
                 audio_duration=audio_duration,
             ):
-                return cached_segments
-        return None
+                return cached_segments, rejected_transcribers
+            rejected_transcribers.add(transcriber)
+        return None, rejected_transcribers
 
     def _get_standard_transcribers(
         self,
@@ -391,14 +395,18 @@ class GuidedTranscriptionProcessor:
         """
         cache_audio = audio
         audio_duration = len(cache_audio) / 1000
-        segments = self._get_cached_block_transcription(
+        segments, rejected_transcribers = self._get_cached_block_transcription(
             cache_audio,
             audio_duration=audio_duration,
         )
         if segments is None:
             primary_audio = self._get_primary_transcription_audio(audio)
             if primary_audio is not None:
-                for transcriber in self._get_standard_transcribers():
+                for transcriber in (
+                    candidate
+                    for candidate in self._get_standard_transcribers()
+                    if candidate not in rejected_transcribers
+                ):
                     segments = self._transcribe_with_candidate(
                         transcriber,
                         primary_audio,
@@ -414,7 +422,11 @@ class GuidedTranscriptionProcessor:
                         "Retrying block transcription with original audio after "
                         "unusable Demucs result"
                     )
-                for transcriber in self._get_standard_transcribers(unseparated=True):
+                for transcriber in (
+                    candidate
+                    for candidate in self._get_standard_transcribers(unseparated=True)
+                    if candidate not in rejected_transcribers
+                ):
                     segments = self._transcribe_with_candidate(
                         transcriber,
                         audio,
@@ -424,7 +436,10 @@ class GuidedTranscriptionProcessor:
                     if segments is not None:
                         break
 
-            if segments is None:
+            if (
+                segments is None
+                and self.recovery_transcriber not in rejected_transcribers
+            ):
                 logger.info(
                     "Retrying block transcription with defensive Whisper decoding"
                 )

--- a/test/lang/transcription/test_processor.py
+++ b/test/lang/transcription/test_processor.py
@@ -276,6 +276,32 @@ def test_rejected_cached_result_skips_repeated_decode():
     )
 
 
+def test_rejected_cached_recovery_is_decoded():
+    """Test a rejected cached recovery transcription is retried."""
+    processor, _ = _get_processor(vad_mode=VADMode.OFF)
+    repetitive_segments = [_get_segment(compression_ratio=16.24, with_words=True)]
+    usable_segments = [_get_segment(compression_ratio=1.0, with_words=True)]
+    processor.no_vad_transcriber = Mock()
+    processor.no_vad_transcriber.get_cached_transcription.return_value = (
+        repetitive_segments
+    )
+    processor.recovery_transcriber = Mock(return_value=usable_segments)
+    processor.recovery_transcriber.get_cached_transcription.return_value = (
+        repetitive_segments
+    )
+    audio = AudioSegment.silent(duration=1000)
+
+    output = processor._transcribe_block_audio(audio)
+
+    assert output == usable_segments
+    processor.no_vad_transcriber.assert_not_called()
+    processor.recovery_transcriber.assert_called_once_with(
+        audio,
+        cache_audio=audio,
+        use_cache=False,
+    )
+
+
 def test_auto_vad_retries_without_vad_after_repetitive_new_result():
     """Test automatic VAD retries without VAD after a repetitive new result."""
     processor, _ = _get_processor(vad_mode=VADMode.AUTO)

--- a/test/lang/transcription/test_processor.py
+++ b/test/lang/transcription/test_processor.py
@@ -252,23 +252,24 @@ def test_auto_vad_uses_cached_non_vad_result_after_repetitive_vad_result():
     processor.no_vad_transcriber.assert_not_called()
 
 
-def test_rejected_cached_result_is_bypassed_for_fresh_retry():
-    """Test a rejected cache entry does not prevent a fresh Whisper attempt."""
+def test_rejected_cached_result_skips_repeated_decode():
+    """Test a rejected cache entry is not decoded again on a later run."""
     processor, _ = _get_processor(vad_mode=VADMode.OFF)
     repetitive_segments = [_get_segment(compression_ratio=16.24, with_words=True)]
     usable_segments = [_get_segment(compression_ratio=1.0, with_words=True)]
-    processor.no_vad_transcriber = Mock(return_value=usable_segments)
+    processor.no_vad_transcriber = Mock()
     processor.no_vad_transcriber.get_cached_transcription.return_value = (
         repetitive_segments
     )
-    processor.recovery_transcriber = Mock()
+    processor.recovery_transcriber = Mock(return_value=usable_segments)
     processor.recovery_transcriber.get_cached_transcription.return_value = None
     audio = AudioSegment.silent(duration=1000)
 
     output = processor._transcribe_block_audio(audio)
 
     assert output == usable_segments
-    processor.no_vad_transcriber.assert_called_once_with(
+    processor.no_vad_transcriber.assert_not_called()
+    processor.recovery_transcriber.assert_called_once_with(
         audio,
         cache_audio=audio,
         use_cache=False,


### PR DESCRIPTION
## Summary

Tracks transcribers whose cached segments are unusable and skips re-running those same configurations during fallback.

## Why

A rejected cache result already proves that configuration's cached output is not suitable for the block. Retrying it only repeats failed work before reaching the recovery decoder.

## Validation

- `uv run ruff format`
- `uv run ruff check --fix`
- `uv run ty check`
- `cd test && uv run pytest -n auto lang/transcription/test_processor.py`