### PR TITLE
Leave empty gaps after failed transcription

### DIFF
--- a/scinoephile/lang/transcription/processor.py
+++ b/scinoephile/lang/transcription/processor.py
@@ -386,8 +386,6 @@ class GuidedTranscriptionProcessor:
             expected_last_start: expected start of the final guided subtitle
         Returns:
             transcribed segments
-        Raises:
-            ScinoephileError: if all configured Whisper attempts are unusable
         """
         cache_audio = audio
         audio_duration = len(cache_audio) / 1000
@@ -439,10 +437,12 @@ class GuidedTranscriptionProcessor:
                     audio_duration=audio_duration,
                 )
         if segments is None:
-            raise ScinoephileError(
+            logger.warning(
                 "Whisper produced no usable transcription after all configured "
-                "recovery attempts."
+                "recovery attempts; leaving this block empty for downstream gap "
+                "translation"
             )
+            return []
         return self._transcribe_with_focused_tail_recovery(
             segments,
             cache_audio,

--- a/test/lang/transcription/test_processor.py
+++ b/test/lang/transcription/test_processor.py
@@ -327,8 +327,8 @@ def test_unusable_no_vad_result_uses_defensive_recovery():
     )
 
 
-def test_all_unusable_candidates_fail_before_alignment():
-    """Test unusable recovery output raises a transcription-domain error."""
+def test_all_unusable_candidates_leave_gap_for_translation():
+    """Test unusable recovery output leaves an empty transcription block."""
     processor, _ = _get_processor(vad_mode=VADMode.OFF)
     repetitive_segments = [_get_segment(compression_ratio=16.24, with_words=True)]
     processor.no_vad_transcriber = Mock(return_value=repetitive_segments)
@@ -336,8 +336,9 @@ def test_all_unusable_candidates_fail_before_alignment():
     processor.recovery_transcriber = Mock(return_value=repetitive_segments)
     processor.recovery_transcriber.get_cached_transcription.return_value = None
 
-    with raises(ScinoephileError, match="no usable transcription"):
-        processor._transcribe_block_audio(AudioSegment.silent(duration=1000))
+    output = processor._transcribe_block_audio(AudioSegment.silent(duration=1000))
+
+    assert output == []
 
 
 def test_auto_demucs_retries_unseparated_audio_after_unusable_result():


### PR DESCRIPTION
## Summary

Leaves an unrecoverable guided-transcription block empty instead of aborting the full workflow.

## Why

Downstream gap translation can recover an isolated missing block; failing the complete transcription discards usable work from every other block.

## Validation

- `uv run ruff format`
- `uv run ruff check --fix`
- `uv run ty check`
- `cd test && uv run pytest -n auto lang/transcription/test_processor.py`