### PR TITLE
Resume guided transcription by block range

### DIFF
--- a/scinoephile/cli/transcribe_cli.py
+++ b/scinoephile/cli/transcribe_cli.py
@@ -31,6 +31,11 @@ from scinoephile.lang.transcription.processor import (
 from scinoephile.llms.providers.registry import get_provider
 from scinoephile.workflows.transcription import transcribe_series_guided
 
+from .helpers.blocks import (
+    BLOCK_LOCALIZATIONS,
+    add_block_range_args,
+    get_block_range_indexes,
+)
 from .helpers.io import read_series, write_series
 from .helpers.llms import (
     LLM_LOCALIZATIONS,
@@ -112,6 +117,7 @@ class TranscribeCli(ScinoephileCliBase):
     """Transcribe audio using reference subtitles."""
 
     localizations = merge_localizations(
+        BLOCK_LOCALIZATIONS,
         LLM_LOCALIZATIONS,
         TRANSCRIBE_LOCALIZATIONS,
     )
@@ -171,6 +177,7 @@ class TranscribeCli(ScinoephileCliBase):
             type=enum_arg(Language),
             help="reference language tag (detected from infile if omitted)",
         )
+        add_block_range_args(arg_groups["operation arguments"])
         arg_groups["operation arguments"].add_argument(
             "--demucs",
             default=DemucsMode.AUTO,
@@ -229,6 +236,8 @@ class TranscribeCli(ScinoephileCliBase):
         stream_index: int | None,
         language: Language,
         reference_language: Language | None,
+        first_block: int | None,
+        last_block: int | None,
         demucs_mode: DemucsMode,
         vad_mode: VADMode,
         model_name: str | None,
@@ -246,6 +255,12 @@ class TranscribeCli(ScinoephileCliBase):
 
         # Read inputs
         reference = read_series(parser, reference_infile_path, allow_stdin=True)
+        start_at_idx, stop_at_idx = get_block_range_indexes(
+            parser,
+            first_block,
+            last_block,
+            len(reference.blocks),
+        )
         try:
             if reference_infile_path == "-":
                 with get_temp_file_path(suffix=".srt") as temp_reference_path:
@@ -288,6 +303,8 @@ class TranscribeCli(ScinoephileCliBase):
                     parser,
                     llm_args.additional_context_file_path,
                 ),
+                start_at_idx=start_at_idx,
+                stop_at_idx=stop_at_idx,
             )
         except ScinoephileError as exc:
             parser.error(str(exc))

--- a/scinoephile/lang/transcription/processor.py
+++ b/scinoephile/lang/transcription/processor.py
@@ -17,6 +17,7 @@ from scinoephile.audio.transcription import (
     TranscribedSegment,
     WhisperTranscriber,
 )
+from scinoephile.common.validation import val_index_range
 from scinoephile.core import Language, ScinoephileError
 from scinoephile.core.paths import get_runtime_cache_dir_path
 from scinoephile.core.subtitles import Series
@@ -178,18 +179,21 @@ class GuidedTranscriptionProcessor:
         audio_series: AudioSeries,
         reference_series: Series,
         stop_at_idx: int | None = None,
+        *,
+        start_at_idx: int = 0,
     ) -> AudioSeries:
         """Transcribe all audio blocks and align them with reference subtitles.
 
         Arguments:
             audio_series: audio divided into subtitle-timed blocks
             reference_series: reference subtitles corresponding to audio blocks
-            stop_at_idx: exclusive block index at which to stop processing
+            stop_at_idx: exclusive zero-based block index at which to stop processing
+            start_at_idx: inclusive zero-based block index at which to start processing
         Returns:
             transcribed and aligned audio subtitle series
         Raises:
             ScinoephileError: if audio and reference block counts differ
-            ValueError: if stop_at_idx is negative
+            ValueError: if the processing range is invalid
         """
         audio_blocks = audio_series.blocks
         reference_blocks = reference_series.blocks
@@ -198,17 +202,12 @@ class GuidedTranscriptionProcessor:
                 f"Audio has {len(audio_blocks)} blocks but reference subtitles have "
                 f"{len(reference_blocks)} blocks."
             )
-        if stop_at_idx is None:
-            stop_at_idx = len(audio_blocks)
-        elif stop_at_idx < 0:
-            raise ValueError("stop_at_idx must be greater than or equal to 0")
+        block_range = val_index_range(len(audio_blocks), start_at_idx, stop_at_idx)
 
         output_events = []
-        for block_idx, (audio_block, reference_block) in enumerate(
-            zip(audio_blocks, reference_blocks, strict=True)
-        ):
-            if block_idx >= stop_at_idx:
-                break
+        for block_idx in block_range:
+            audio_block = audio_blocks[block_idx]
+            reference_block = reference_blocks[block_idx]
             output_block = self.process_block(audio_block, reference_block)
             logger.info(
                 f"BLOCK {block_idx + 1}:\n"

--- a/scinoephile/workflows/transcription.py
+++ b/scinoephile/workflows/transcription.py
@@ -41,6 +41,7 @@ def transcribe_series_guided(
     delineation_test_cases: list[TestCase] | None = None,
     punctuation_test_cases: list[TestCase] | None = None,
     transcriber: GuidedTranscriptionProcessor | None = None,
+    start_at_idx: int = 0,
     stop_at_idx: int | None = None,
 ) -> AudioSeries:
     """Transcribe audio using reference subtitles.
@@ -61,7 +62,8 @@ def transcribe_series_guided(
         delineation_test_cases: preloaded delineation test cases
         punctuation_test_cases: preloaded punctuation test cases
         transcriber: guided transcription processor, or None to construct one
-        stop_at_idx: exclusive block index at which to stop processing
+        start_at_idx: inclusive zero-based block index at which to start processing
+        stop_at_idx: exclusive zero-based block index at which to stop processing
     Returns:
         transcribed and reference-aligned audio subtitle series
     Raises:
@@ -91,4 +93,5 @@ def transcribe_series_guided(
         audio_series,
         reference_series,
         stop_at_idx=stop_at_idx,
+        start_at_idx=start_at_idx,
     )

--- a/test/cli/test_transcribe_cli.py
+++ b/test/cli/test_transcribe_cli.py
@@ -63,6 +63,8 @@ def test_transcribe_help_lists_generic_options():
     assert "--reference-infile REFERENCE_INFILE_PATH" in help_text
     assert "--language" in help_text
     assert "--reference-language" in help_text
+    assert "--first-block FIRST_BLOCK" in help_text
+    assert "--last-block LAST_BLOCK" in help_text
     assert "--script" not in normalized_help_text
     assert "--convert" not in normalized_help_text
     assert "--demucs {auto,on,off}" in help_text
@@ -185,6 +187,8 @@ def test_transcribe_cli_passes_generic_configuration(
         vad_mode: VADMode,
         provider: object,
         additional_context: str | None,
+        start_at_idx: int,
+        stop_at_idx: int | None,
     ) -> Series:
         """Validate transcription options passed by the CLI."""
         assert input_audio_series is audio_series
@@ -196,6 +200,8 @@ def test_transcribe_cli_passes_generic_configuration(
         assert vad_mode is VADMode.OFF
         assert provider is not None
         assert additional_context is None
+        assert start_at_idx == 1
+        assert stop_at_idx == 3
         return expected_series
 
     with patch(
@@ -211,7 +217,8 @@ def test_transcribe_cli_passes_generic_configuration(
                 f"{_MEDIA_INFILE_PATH} "
                 f"--reference-infile {_REFERENCE_INFILE_PATH} "
                 "--language yue-Hant --reference-language zho-Hans "
-                "--whisper-model custom/whisper --demucs on --vad off",
+                "--whisper-model custom/whisper --demucs on --vad off "
+                "--first-block 2 --last-block 3",
             )
 
 
@@ -227,6 +234,8 @@ def test_transcribe_cli_passes_generic_configuration(
         f"{_MEDIA_INFILE_PATH} --reference-infile {_REFERENCE_INFILE_PATH} "
         "--language yue-Hans --overwrite",
         f"{_MEDIA_INFILE_PATH} --reference-infile {_REFERENCE_INFILE_PATH} "
+        "--language yue-Hans --first-block 3 --last-block 2",
+        f"{_MEDIA_INFILE_PATH} --reference-infile {_REFERENCE_INFILE_PATH} "
         "--language yue-Hans --script traditional",
     ),
     ids=(
@@ -235,6 +244,7 @@ def test_transcribe_cli_passes_generic_configuration(
         "missing media infile",
         "two stdin infiles",
         "overwrite without outfile",
+        "reversed block range",
         "language-specific option",
     ),
 )
@@ -246,6 +256,24 @@ def test_transcribe_cli_rejects_invalid_arguments(args: str):
     """
     with raises(SystemExit, match="2"):
         run_cli_with_args(TranscribeCli, args)
+
+
+def test_transcribe_cli_rejects_oversized_last_block_before_loading_audio():
+    """Test an oversized last block fails before media audio is extracted."""
+    block_count = len(Series.load(_REFERENCE_INFILE_PATH).blocks)
+
+    with patch(
+        "scinoephile.cli.transcribe_cli.AudioSeries.load_from_media"
+    ) as load_from_media:
+        with raises(SystemExit, match="2"):
+            run_cli_with_args(
+                TranscribeCli,
+                f"{_MEDIA_INFILE_PATH} "
+                f"--reference-infile {_REFERENCE_INFILE_PATH} "
+                f"--language yue-Hans --last-block {block_count + 1}",
+            )
+
+    load_from_media.assert_not_called()
 
 
 def test_transcribe_cli_stream_errors_are_user_facing():

--- a/test/lang/transcription/test_processor.py
+++ b/test/lang/transcription/test_processor.py
@@ -527,6 +527,46 @@ def test_process_uses_exclusive_stop_index(caplog: LogCaptureFixture):
     assert "BLOCK 0:" not in caplog.text
 
 
+def test_process_uses_inclusive_start_index(caplog: LogCaptureFixture):
+    """Test start_at_idx excludes earlier blocks while preserving global numbering.
+
+    Arguments:
+        caplog: captured log records
+    """
+    processor, _ = _get_processor()
+    caplog.set_level(INFO, logger="scinoephile.lang.transcription.processor")
+    audio_series = AudioSeries(
+        audio=AudioSegment.silent(duration=6000),
+        events=[
+            AudioSubtitle(start=0, end=1000, text="one"),
+            AudioSubtitle(start=5000, end=6000, text="two"),
+        ],
+    )
+    reference_series = Series(
+        events=[
+            Subtitle(start=0, end=1000, text="one"),
+            Subtitle(start=5000, end=6000, text="two"),
+        ]
+    )
+
+    with patch.object(
+        processor,
+        "process_block",
+        side_effect=lambda audio_block, reference_block: audio_block,
+    ) as process_block:
+        output = processor.process(
+            audio_series,
+            reference_series,
+            start_at_idx=1,
+        )
+
+    assert process_block.call_count == 1
+    assert len(output) == 1
+    assert output[0].text == "two"
+    assert "BLOCK 2:" in caplog.text
+    assert "BLOCK 1:" not in caplog.text
+
+
 def test_process_rejects_mismatched_block_counts():
     """Test guided transcription requires corresponding block structures."""
     processor, _ = _get_processor()

--- a/test/workflows/test_transcription.py
+++ b/test/workflows/test_transcription.py
@@ -36,6 +36,7 @@ def test_transcribe_series_guided_constructs_processor_for_language_pair():
             reference_series,
             language=Language.yue_hant,
             reference_language=Language.zho_hans,
+            start_at_idx=1,
             stop_at_idx=2,
         )
 
@@ -50,4 +51,5 @@ def test_transcribe_series_guided_constructs_processor_for_language_pair():
         audio_series,
         reference_series,
         stop_at_idx=2,
+        start_at_idx=1,
     )


### PR DESCRIPTION
## Summary

Adds `--first-block` and `--last-block` to guided transcription and carries the resulting range through the CLI, workflow, and processor.

## Why

Long transcription jobs can resume a selected range without reprocessing completed blocks. Range validation happens before audio extraction.

## Validation

- `uv run ruff format`
- `uv run ruff check --fix`
- `uv run ty check`
- `cd test && uv run pytest -n auto lang/transcription/test_processor.py workflows/test_transcription.py cli/test_transcribe_cli.py`