### PR TITLE
Use explicit transcription test-case JSON paths

### DIFF
--- a/scinoephile/cli/transcribe_cli.py
+++ b/scinoephile/cli/transcribe_cli.py
@@ -70,6 +70,12 @@ TRANSCRIBE_LOCALIZATIONS: dict[str, dict[str, str]] = {
         (
             "Whisper model identifier override (uses language-pair default if omitted)"
         ): "Whisper 模型标识符覆盖值（省略时使用语言对默认值）",
+        "delineation test-case JSON file to load and update": (
+            "要加载和更新的断句测试用例 JSON 文件"
+        ),
+        "punctuation test-case JSON file to load and update": (
+            "要加载和更新的标点测试用例 JSON 文件"
+        ),
         "subtitle outfile path (default: stdout)": (
             "字幕输出文件路径（默认：标准输出）"
         ),
@@ -102,6 +108,12 @@ TRANSCRIBE_LOCALIZATIONS: dict[str, dict[str, str]] = {
         (
             "Whisper model identifier override (uses language-pair default if omitted)"
         ): "Whisper 模型識別碼覆寫值（省略時使用語言對預設值）",
+        "delineation test-case JSON file to load and update": (
+            "要載入和更新的斷句測試案例 JSON 檔案"
+        ),
+        "punctuation test-case JSON file to load and update": (
+            "要載入和更新的標點測試案例 JSON 檔案"
+        ),
         "subtitle outfile path (default: stdout)": ("字幕輸出檔路徑（預設：標準輸出）"),
         "transcribe audio using reference subtitles": "使用參考字幕轉寫音訊",
     },

--- a/scinoephile/cli/transcribe_cli.py
+++ b/scinoephile/cli/transcribe_cli.py
@@ -24,7 +24,7 @@ from scinoephile.common.file import get_temp_file_path
 from scinoephile.core import Language, ScinoephileError
 from scinoephile.core.cli import ScinoephileCliBase
 from scinoephile.core.cli.localization import merge_localizations
-from scinoephile.lang.transcription.processor import (
+from scinoephile.lang.transcription.transcriber import (
     DemucsMode,
     VADMode,
 )

--- a/scinoephile/cli/transcribe_cli.py
+++ b/scinoephile/cli/transcribe_cli.py
@@ -24,10 +24,7 @@ from scinoephile.common.file import get_temp_file_path
 from scinoephile.core import Language, ScinoephileError
 from scinoephile.core.cli import ScinoephileCliBase
 from scinoephile.core.cli.localization import merge_localizations
-from scinoephile.lang.transcription.transcriber import (
-    DemucsMode,
-    VADMode,
-)
+from scinoephile.lang.transcription.transcriber import DemucsMode, VADMode
 from scinoephile.llms.providers.registry import get_provider
 from scinoephile.workflows.transcription import transcribe_series_guided
 

--- a/scinoephile/cli/transcribe_cli.py
+++ b/scinoephile/cli/transcribe_cli.py
@@ -36,6 +36,7 @@ from .helpers.llms import (
     LLM_LOCALIZATIONS,
     LlmArguments,
     add_llm_provider_args,
+    add_llm_test_case_json_arg,
     read_llm_additional_context,
 )
 
@@ -203,6 +204,18 @@ class TranscribeCli(ScinoephileCliBase):
         add_llm_provider_args(
             arg_groups["llm arguments"], arg_groups["additional help"]
         )
+        add_llm_test_case_json_arg(
+            arg_groups["llm arguments"],
+            "--delineation-json",
+            dest="delineation_json_path",
+            help_text="delineation test-case JSON file to load and update",
+        )
+        add_llm_test_case_json_arg(
+            arg_groups["llm arguments"],
+            "--punctuation-json",
+            dest="punctuation_json_path",
+            help_text="punctuation test-case JSON file to load and update",
+        )
 
         # Output arguments
         arg_groups["output arguments"].add_argument(
@@ -233,6 +246,8 @@ class TranscribeCli(ScinoephileCliBase):
         vad_mode: VADMode,
         model_name: str | None,
         llm_args: LlmArguments,
+        delineation_json_path: Path | None,
+        punctuation_json_path: Path | None,
         outfile_path: Path | None,
         overwrite: bool,
     ):
@@ -288,6 +303,8 @@ class TranscribeCli(ScinoephileCliBase):
                     parser,
                     llm_args.additional_context_file_path,
                 ),
+                delineation_json_path=delineation_json_path,
+                punctuation_json_path=punctuation_json_path,
             )
         except ScinoephileError as exc:
             parser.error(str(exc))

--- a/scinoephile/core/llms/processor.py
+++ b/scinoephile/core/llms/processor.py
@@ -8,7 +8,6 @@ from abc import ABC
 from pathlib import Path
 from typing import TypedDict
 
-from scinoephile.common.validation import val_output_path
 from scinoephile.core.paths import get_runtime_cache_dir_path
 
 from .llm_provider import LLMProvider
@@ -84,11 +83,7 @@ class Processor(ABC):
             raise ValueError("manager_cls must be set on Processor subclasses.")
         self.test_case_cls = self.manager_cls.get_test_case_cls(self.prompt)
 
-        if test_case_path is not None:
-            test_case_path = val_output_path(test_case_path, exist_ok=True)
-        if test_cases is None:
-            test_cases = []
-        test_cases = load_test_cases(
+        test_cases, test_case_path = load_test_cases(
             self.manager_cls,
             self.prompt,
             test_cases=test_cases,

--- a/scinoephile/core/llms/processor.py
+++ b/scinoephile/core/llms/processor.py
@@ -105,20 +105,13 @@ class Processor(ABC):
         )
         """LLM queryer."""
 
-    def save_test_cases(self, *, prune: bool | None = None):
-        """Persist encountered test cases.
-
-        Arguments:
-            prune: whether to remove unencountered cases, or None to use the
-                processor's configured behavior
-        """
+    def save_test_cases(self):
+        """Persist encountered test cases."""
         if self.test_case_path is None or self.manager_cls is None:
             return
-        if prune is None:
-            prune = self.prune_test_cases
         save_test_cases_to_json(
             self.test_case_path,
             self.queryer.encountered_test_cases.values(),
             self.manager_cls,
-            prune=prune,
+            prune=self.prune_test_cases,
         )

--- a/scinoephile/core/llms/processor.py
+++ b/scinoephile/core/llms/processor.py
@@ -17,7 +17,7 @@ from .prompt import Prompt
 from .queryer import Queryer
 from .test_case import TestCase
 from .tool_box import ToolBox
-from .utils import load_test_cases_from_json, save_test_cases_to_json
+from .utils import load_test_cases, save_test_cases_to_json
 
 __all__ = [
     "Processor",
@@ -84,19 +84,16 @@ class Processor(ABC):
             raise ValueError("manager_cls must be set on Processor subclasses.")
         self.test_case_cls = self.manager_cls.get_test_case_cls(self.prompt)
 
-        if test_cases is None:
-            test_cases = []
-
         if test_case_path is not None:
             test_case_path = val_output_path(test_case_path, exist_ok=True)
-            if test_case_path.exists():
-                test_cases.extend(
-                    load_test_cases_from_json(
-                        test_case_path,
-                        self.manager_cls,
-                        prompt=self.prompt,
-                    )
-                )
+        if test_cases is None:
+            test_cases = []
+        test_cases = load_test_cases(
+            self.manager_cls,
+            self.prompt,
+            test_cases=test_cases,
+            test_case_path=test_case_path,
+        )
         self.test_case_path = test_case_path
         """Path to file containing test cases."""
         self.prune_test_cases = prune_test_cases

--- a/scinoephile/core/llms/utils.py
+++ b/scinoephile/core/llms/utils.py
@@ -18,9 +18,42 @@ from .prompt import Prompt
 from .test_case import TestCase
 
 __all__ = [
+    "load_test_cases",
     "load_test_cases_from_json",
     "save_test_cases_to_json",
 ]
+
+
+def load_test_cases(
+    manager_cls: type[Manager],
+    prompt: Prompt,
+    *,
+    test_cases: Iterable[TestCase] = (),
+    test_case_path: Path | None = None,
+) -> list[TestCase]:
+    """Load test cases from supplied cases and an optional JSON file.
+
+    Test cases loaded from the JSON file replace supplied cases with matching queries.
+
+    Arguments:
+        manager_cls: manager used to load JSON test cases
+        prompt: prompt whose localized schema should be applied
+        test_cases: test cases to load before the JSON file
+        test_case_path: optional JSON file containing additional test cases
+    Returns:
+        test cases unique by query
+    """
+    test_cases_by_query_key = {
+        test_case.query.key: test_case for test_case in test_cases
+    }
+    if test_case_path is not None and test_case_path.exists():
+        for test_case in load_test_cases_from_json(
+            test_case_path,
+            manager_cls,
+            prompt,
+        ):
+            test_cases_by_query_key[test_case.query.key] = test_case
+    return list(test_cases_by_query_key.values())
 
 
 def load_test_cases_from_json(

--- a/scinoephile/core/llms/utils.py
+++ b/scinoephile/core/llms/utils.py
@@ -12,6 +12,7 @@ from typing import cast
 from pydantic import TypeAdapter
 
 from scinoephile.common.file import open_atomic_text_file
+from scinoephile.common.validation import val_output_path
 
 from .manager import Manager
 from .prompt import Prompt
@@ -28,9 +29,9 @@ def load_test_cases(
     manager_cls: type[Manager],
     prompt: Prompt,
     *,
-    test_cases: Iterable[TestCase] = (),
+    test_cases: Iterable[TestCase] | None = None,
     test_case_path: Path | None = None,
-) -> list[TestCase]:
+) -> tuple[list[TestCase], Path | None]:
     """Load test cases from supplied cases and an optional JSON file.
 
     Test cases loaded from the JSON file replace supplied cases with matching queries.
@@ -38,11 +39,15 @@ def load_test_cases(
     Arguments:
         manager_cls: manager used to load JSON test cases
         prompt: prompt whose localized schema should be applied
-        test_cases: test cases to load before the JSON file
+        test_cases: optional test cases to load before the JSON file
         test_case_path: optional JSON file containing additional test cases
     Returns:
-        test cases unique by query
+        test cases unique by query and normalized optional JSON path
     """
+    if test_case_path is not None:
+        test_case_path = val_output_path(test_case_path, exist_ok=True)
+    if test_cases is None:
+        test_cases = []
     test_cases_by_query_key = {
         test_case.query.key: test_case for test_case in test_cases
     }
@@ -53,7 +58,7 @@ def load_test_cases(
             prompt,
         ):
             test_cases_by_query_key[test_case.query.key] = test_case
-    return list(test_cases_by_query_key.values())
+    return list(test_cases_by_query_key.values()), test_case_path
 
 
 def load_test_cases_from_json(

--- a/scinoephile/lang/transcription/__init__.py
+++ b/scinoephile/lang/transcription/__init__.py
@@ -5,7 +5,7 @@
 Package hierarchy (modules may import from any above):
 * alignment
 * aligner
-* processor
+* transcriber
 * guided
 """
 
@@ -14,11 +14,11 @@ from __future__ import annotations
 from .aligner import TranscriptionAligner
 from .alignment import TranscriptionAlignment
 from .guided import GuidedTranscriptionSpec, TranscriptionLanguageSpec
-from .processor import DemucsMode, GuidedTranscriptionProcessor, VADMode
+from .transcriber import DemucsMode, GuidedTranscriber, VADMode
 
 __all__ = [
     "DemucsMode",
-    "GuidedTranscriptionProcessor",
+    "GuidedTranscriber",
     "GuidedTranscriptionSpec",
     "TranscriptionAligner",
     "TranscriptionAlignment",

--- a/scinoephile/lang/transcription/aligner.py
+++ b/scinoephile/lang/transcription/aligner.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 from copy import deepcopy
 from logging import getLogger
-from pathlib import Path
 from typing import cast
 
 from pydantic import ValidationError
@@ -17,20 +16,22 @@ from scinoephile.audio.subtitles import (
     get_series_with_sub_split_at_idx,
     get_sub_merged,
 )
-from scinoephile.common.validation import val_output_path
 from scinoephile.core import ScinoephileError
-from scinoephile.core.llms import Queryer
-from scinoephile.core.llms.utils import save_test_cases_to_json
 from scinoephile.core.subtitles import Series
 from scinoephile.core.synchronization import SyncGroup, get_sync_groups_string
 from scinoephile.core.text import remove_punc_and_whitespace
 from scinoephile.llms.delineation import (
     DelineationAnswer,
-    DelineationManager,
+    DelineationProcessor,
     DelineationPrompt,
     DelineationQuery,
+    DelineationTestCase,
 )
-from scinoephile.llms.punctuation import PunctuationManager, PunctuationPrompt
+from scinoephile.llms.punctuation import (
+    PunctuationProcessor,
+    PunctuationPrompt,
+    PunctuationTestCase,
+)
 
 from .alignment import TranscriptionAlignment
 
@@ -45,44 +46,19 @@ class TranscriptionAligner:
 
     def __init__(
         self,
-        delineation_queryer: Queryer,
-        punctuation_queryer: Queryer,
-        *,
-        delineation_json_path: Path | None = None,
-        punctuation_json_path: Path | None = None,
-        prune_delineation_test_cases: bool = False,
-        prune_punctuation_test_cases: bool = False,
+        delineation_processor: DelineationProcessor,
+        punctuation_processor: PunctuationProcessor,
     ):
         """Initialize.
 
         Arguments:
-            delineation_queryer: queryer for delineation
-            punctuation_queryer: queryer for punctuation
-            delineation_json_path: delineation test-case JSON file to update
-            punctuation_json_path: punctuation test-case JSON file to update
-            prune_delineation_test_cases: whether to remove unencountered
-                delineation test cases
-            prune_punctuation_test_cases: whether to remove unencountered punctuation
-                test cases
+            delineation_processor: processor for delineation LLM queries
+            punctuation_processor: processor for punctuation LLM queries
         """
-        self.delineation_queryer = delineation_queryer
+        self.delineation_processor = delineation_processor
         """Shift transcription text between adjacent reference subtitles."""
-        self.punctuation_queryer = punctuation_queryer
+        self.punctuation_processor = punctuation_processor
         """Punctuate transcription text using corresponding reference subtitles."""
-        self.delineation_json_path = (
-            val_output_path(delineation_json_path, exist_ok=True)
-            if delineation_json_path is not None
-            else None
-        )
-        self.punctuation_json_path = (
-            val_output_path(punctuation_json_path, exist_ok=True)
-            if punctuation_json_path is not None
-            else None
-        )
-        self.prune_delineation_test_cases = prune_delineation_test_cases
-        """Whether to remove unencountered delineation test cases when saving."""
-        self.prune_punctuation_test_cases = prune_punctuation_test_cases
-        """Whether to remove unencountered punctuation test cases when saving."""
 
     def align(
         self,
@@ -120,20 +96,8 @@ class TranscriptionAligner:
 
     def update_all_test_cases(self):
         """Update all test cases encountered during the current run."""
-        if self.delineation_json_path is not None:
-            save_test_cases_to_json(
-                self.delineation_json_path,
-                list(self.delineation_queryer.encountered_test_cases.values()),
-                DelineationManager,
-                prune=self.prune_delineation_test_cases,
-            )
-        if self.punctuation_json_path is not None:
-            save_test_cases_to_json(
-                self.punctuation_json_path,
-                list(self.punctuation_queryer.encountered_test_cases.values()),
-                PunctuationManager,
-                prune=self.prune_punctuation_test_cases,
-            )
+        self.delineation_processor.save_test_cases()
+        self.punctuation_processor.save_test_cases()
 
     def _delineate(self, alignment: TranscriptionAlignment) -> bool:
         """Delineate transcribed text.
@@ -143,7 +107,8 @@ class TranscriptionAligner:
         Returns:
             whether delineation must restart after splitting a subtitle
         """
-        delineation_prompt = cast(DelineationPrompt, self.delineation_queryer.prompt)
+        delineation_queryer = self.delineation_processor.queryer
+        delineation_prompt = cast(DelineationPrompt, delineation_queryer.prompt)
         for sync_group_one_idx in range(len(alignment.sync_groups) - 1):
             test_case = alignment.get_delineation_test_case(
                 sync_group_one_idx,
@@ -155,7 +120,10 @@ class TranscriptionAligner:
                     f"{sync_group_one_idx + 1} with no transcription"
                 )
                 continue
-            test_case = self.delineation_queryer(test_case)
+            test_case = cast(
+                DelineationTestCase,
+                delineation_queryer(test_case),
+            )
 
             query = test_case.query
             answer = test_case.answer
@@ -281,7 +249,8 @@ class TranscriptionAligner:
 
         nascent_transcription = AudioSeries(audio=alignment.transcription.audio)
         nascent_sync_groups: list[SyncGroup] = []
-        punctuation_prompt = cast(PunctuationPrompt, self.punctuation_queryer.prompt)
+        punctuation_queryer = self.punctuation_processor.queryer
+        punctuation_prompt = cast(PunctuationPrompt, punctuation_queryer.prompt)
         for sync_group_idx, sync_group in enumerate(alignment.sync_groups):
             reference_idx = sync_group[0][0]
             reference = alignment.reference[reference_idx]
@@ -314,7 +283,10 @@ class TranscriptionAligner:
                 nascent_sync_groups.append(([reference_idx], []))
                 continue
             try:
-                test_case = self.punctuation_queryer(test_case)
+                test_case = cast(
+                    PunctuationTestCase,
+                    punctuation_queryer(test_case),
+                )
             except ValidationError as exc:
                 logger.error(
                     f"Error punctuating sync group {sync_group_idx}; "

--- a/scinoephile/lang/transcription/aligner.py
+++ b/scinoephile/lang/transcription/aligner.py
@@ -119,7 +119,7 @@ class TranscriptionAligner:
         return alignment
 
     def update_all_test_cases(self):
-        """Update all test cases for the specified block."""
+        """Update all test cases encountered during the current run."""
         if self.delineation_json_path is not None:
             save_test_cases_to_json(
                 self.delineation_json_path,

--- a/scinoephile/lang/transcription/aligner.py
+++ b/scinoephile/lang/transcription/aligner.py
@@ -17,7 +17,7 @@ from scinoephile.audio.subtitles import (
     get_series_with_sub_split_at_idx,
     get_sub_merged,
 )
-from scinoephile.common.validation import val_input_dir_path
+from scinoephile.common.validation import val_input_dir_path, val_output_path
 from scinoephile.core import ScinoephileError
 from scinoephile.core.llms import Queryer
 from scinoephile.core.llms.utils import save_test_cases_to_json
@@ -49,6 +49,9 @@ class TranscriptionAligner:
         delineation_queryer: Queryer,
         punctuation_queryer: Queryer,
         test_case_dir_path: Path | None = None,
+        *,
+        delineation_json_path: Path | None = None,
+        punctuation_json_path: Path | None = None,
     ):
         """Initialize.
 
@@ -56,6 +59,8 @@ class TranscriptionAligner:
             delineation_queryer: queryer for delineation
             punctuation_queryer: queryer for punctuation
             test_case_dir_path: directory where encountered test cases are written
+            delineation_json_path: delineation test-case JSON file to update
+            punctuation_json_path: punctuation test-case JSON file to update
         """
         self.delineation_queryer = delineation_queryer
         """Shift transcription text between adjacent reference subtitles."""
@@ -64,6 +69,16 @@ class TranscriptionAligner:
         self.test_case_dir_path = None
         if test_case_dir_path is not None:
             self.test_case_dir_path = val_input_dir_path(test_case_dir_path)
+        self.delineation_json_path = (
+            val_output_path(delineation_json_path, exist_ok=True)
+            if delineation_json_path is not None
+            else None
+        )
+        self.punctuation_json_path = (
+            val_output_path(punctuation_json_path, exist_ok=True)
+            if punctuation_json_path is not None
+            else None
+        )
 
     def align(
         self,
@@ -89,25 +104,34 @@ class TranscriptionAligner:
 
     def update_all_test_cases(self):
         """Update all test cases for the specified block."""
-        if self.test_case_dir_path is None:
-            return
-
-        delineation_output_path = (
-            self.test_case_dir_path / "delineation" / f"{get_torch_device()}.json"
-        )
-        save_test_cases_to_json(
-            delineation_output_path,
-            list(self.delineation_queryer.encountered_test_cases.values()),
-            DelineationManager,
-        )
-        punctuation_output_path = (
-            self.test_case_dir_path / "punctuation" / f"{get_torch_device()}.json"
-        )
-        save_test_cases_to_json(
-            punctuation_output_path,
-            list(self.punctuation_queryer.encountered_test_cases.values()),
-            PunctuationManager,
-        )
+        delineation_json_path = self.delineation_json_path
+        punctuation_json_path = self.punctuation_json_path
+        if self.test_case_dir_path is not None and (
+            delineation_json_path is None or punctuation_json_path is None
+        ):
+            device = get_torch_device()
+            if delineation_json_path is None:
+                delineation_json_path = (
+                    self.test_case_dir_path / "delineation" / f"{device}.json"
+                )
+            if punctuation_json_path is None:
+                punctuation_json_path = (
+                    self.test_case_dir_path / "punctuation" / f"{device}.json"
+                )
+        if delineation_json_path is not None:
+            save_test_cases_to_json(
+                delineation_json_path,
+                list(self.delineation_queryer.encountered_test_cases.values()),
+                DelineationManager,
+                prune=True,
+            )
+        if punctuation_json_path is not None:
+            save_test_cases_to_json(
+                punctuation_json_path,
+                list(self.punctuation_queryer.encountered_test_cases.values()),
+                PunctuationManager,
+                prune=True,
+            )
 
     def _delineate(self, alignment: TranscriptionAlignment) -> bool:
         """Delineate transcribed text.

--- a/scinoephile/lang/transcription/aligner.py
+++ b/scinoephile/lang/transcription/aligner.py
@@ -106,6 +106,8 @@ class TranscriptionAligner:
         """Update all test cases for the specified block."""
         delineation_json_path = self.delineation_json_path
         punctuation_json_path = self.punctuation_json_path
+        prune_delineation_json = delineation_json_path is not None
+        prune_punctuation_json = punctuation_json_path is not None
         if self.test_case_dir_path is not None and (
             delineation_json_path is None or punctuation_json_path is None
         ):
@@ -123,14 +125,14 @@ class TranscriptionAligner:
                 delineation_json_path,
                 list(self.delineation_queryer.encountered_test_cases.values()),
                 DelineationManager,
-                prune=True,
+                prune=prune_delineation_json,
             )
         if punctuation_json_path is not None:
             save_test_cases_to_json(
                 punctuation_json_path,
                 list(self.punctuation_queryer.encountered_test_cases.values()),
                 PunctuationManager,
-                prune=True,
+                prune=prune_punctuation_json,
             )
 
     def _delineate(self, alignment: TranscriptionAlignment) -> bool:

--- a/scinoephile/lang/transcription/aligner.py
+++ b/scinoephile/lang/transcription/aligner.py
@@ -17,11 +17,10 @@ from scinoephile.audio.subtitles import (
     get_series_with_sub_split_at_idx,
     get_sub_merged,
 )
-from scinoephile.common.validation import val_input_dir_path, val_output_path
+from scinoephile.common.validation import val_output_path
 from scinoephile.core import ScinoephileError
 from scinoephile.core.llms import Queryer
 from scinoephile.core.llms.utils import save_test_cases_to_json
-from scinoephile.core.ml import get_torch_device
 from scinoephile.core.subtitles import Series
 from scinoephile.core.synchronization import SyncGroup, get_sync_groups_string
 from scinoephile.core.text import remove_punc_and_whitespace
@@ -48,27 +47,28 @@ class TranscriptionAligner:
         self,
         delineation_queryer: Queryer,
         punctuation_queryer: Queryer,
-        test_case_dir_path: Path | None = None,
         *,
         delineation_json_path: Path | None = None,
         punctuation_json_path: Path | None = None,
+        prune_delineation_test_cases: bool = False,
+        prune_punctuation_test_cases: bool = False,
     ):
         """Initialize.
 
         Arguments:
             delineation_queryer: queryer for delineation
             punctuation_queryer: queryer for punctuation
-            test_case_dir_path: directory where encountered test cases are written
             delineation_json_path: delineation test-case JSON file to update
             punctuation_json_path: punctuation test-case JSON file to update
+            prune_delineation_test_cases: whether to remove unencountered
+                delineation test cases
+            prune_punctuation_test_cases: whether to remove unencountered punctuation
+                test cases
         """
         self.delineation_queryer = delineation_queryer
         """Shift transcription text between adjacent reference subtitles."""
         self.punctuation_queryer = punctuation_queryer
         """Punctuate transcription text using corresponding reference subtitles."""
-        self.test_case_dir_path = None
-        if test_case_dir_path is not None:
-            self.test_case_dir_path = val_input_dir_path(test_case_dir_path)
         self.delineation_json_path = (
             val_output_path(delineation_json_path, exist_ok=True)
             if delineation_json_path is not None
@@ -79,6 +79,10 @@ class TranscriptionAligner:
             if punctuation_json_path is not None
             else None
         )
+        self.prune_delineation_test_cases = prune_delineation_test_cases
+        """Whether to remove unencountered delineation test cases when saving."""
+        self.prune_punctuation_test_cases = prune_punctuation_test_cases
+        """Whether to remove unencountered punctuation test cases when saving."""
 
     def align(
         self,
@@ -104,35 +108,19 @@ class TranscriptionAligner:
 
     def update_all_test_cases(self):
         """Update all test cases for the specified block."""
-        delineation_json_path = self.delineation_json_path
-        punctuation_json_path = self.punctuation_json_path
-        prune_delineation_json = delineation_json_path is not None
-        prune_punctuation_json = punctuation_json_path is not None
-        if self.test_case_dir_path is not None and (
-            delineation_json_path is None or punctuation_json_path is None
-        ):
-            device = get_torch_device()
-            if delineation_json_path is None:
-                delineation_json_path = (
-                    self.test_case_dir_path / "delineation" / f"{device}.json"
-                )
-            if punctuation_json_path is None:
-                punctuation_json_path = (
-                    self.test_case_dir_path / "punctuation" / f"{device}.json"
-                )
-        if delineation_json_path is not None:
+        if self.delineation_json_path is not None:
             save_test_cases_to_json(
-                delineation_json_path,
+                self.delineation_json_path,
                 list(self.delineation_queryer.encountered_test_cases.values()),
                 DelineationManager,
-                prune=prune_delineation_json,
+                prune=self.prune_delineation_test_cases,
             )
-        if punctuation_json_path is not None:
+        if self.punctuation_json_path is not None:
             save_test_cases_to_json(
-                punctuation_json_path,
+                self.punctuation_json_path,
                 list(self.punctuation_queryer.encountered_test_cases.values()),
                 PunctuationManager,
-                prune=prune_punctuation_json,
+                prune=self.prune_punctuation_test_cases,
             )
 
     def _delineate(self, alignment: TranscriptionAlignment) -> bool:

--- a/scinoephile/lang/transcription/guided.py
+++ b/scinoephile/lang/transcription/guided.py
@@ -11,8 +11,9 @@ from types import MappingProxyType
 
 from scinoephile.audio.transcription import get_segment_split_on_whitespace
 from scinoephile.core import Language, ScinoephileError
-from scinoephile.core.llms import LLMProvider, Manager, Prompt, Queryer, TestCase
-from scinoephile.core.llms.utils import load_test_cases_from_json
+from scinoephile.core.llms import LLMProvider, Queryer, TestCase
+from scinoephile.core.llms.utils import load_test_cases
+from scinoephile.core.ml import get_torch_device
 from scinoephile.core.paths import get_runtime_cache_dir_path
 from scinoephile.lang.yue_zho.transcription import (
     YueZhoDelineationPromptYueHans,
@@ -168,7 +169,6 @@ def get_guided_transcriber(
     additional_context: str | None = None,
     delineation_prompt: DelineationPrompt | None = None,
     punctuation_prompt: PunctuationPrompt | None = None,
-    test_case_dir_path: Path | None = None,
     delineation_json_path: Path | None = None,
     punctuation_json_path: Path | None = None,
     delineation_test_cases: list[TestCase] | None = None,
@@ -186,7 +186,6 @@ def get_guided_transcriber(
         additional_context: additional context to include in LLM prompts
         delineation_prompt: delineation prompt override
         punctuation_prompt: punctuation prompt override
-        test_case_dir_path: directory where encountered test cases are written
         delineation_json_path: delineation test-case JSON file to load and update
         punctuation_json_path: punctuation test-case JSON file to load and update
         delineation_test_cases: preloaded delineation test cases
@@ -211,29 +210,49 @@ def get_guided_transcriber(
         delineation_prompt = spec.delineation_prompt
     if punctuation_prompt is None:
         punctuation_prompt = spec.punctuation_prompt
-    if test_case_dir_path is None and (
-        delineation_json_path is None or punctuation_json_path is None
-    ):
-        test_case_dir_path = get_runtime_cache_dir_path("test_cases")
-        test_case_dir_path /= spec.test_case_dir_path
-    if test_case_dir_path is not None:
-        (test_case_dir_path / "delineation").mkdir(parents=True, exist_ok=True)
-        (test_case_dir_path / "punctuation").mkdir(parents=True, exist_ok=True)
-
+    prune_delineation_test_cases = delineation_json_path is not None
+    prune_punctuation_test_cases = punctuation_json_path is not None
+    if delineation_json_path is None or punctuation_json_path is None:
+        runtime_test_case_dir_path = (
+            get_runtime_cache_dir_path("test_cases") / spec.test_case_dir_path
+        )
+        device = get_torch_device()
+        if delineation_json_path is None:
+            delineation_json_path = (
+                runtime_test_case_dir_path / "delineation" / f"{device}.json"
+            )
+        if punctuation_json_path is None:
+            punctuation_json_path = (
+                runtime_test_case_dir_path / "punctuation" / f"{device}.json"
+            )
     if delineation_test_cases is None:
-        delineation_test_cases = _load_transcription_test_cases(
-            DelineationManager,
-            delineation_prompt,
-            spec.delineation_json_paths,
-            delineation_json_path,
+        delineation_test_cases = list(
+            load_default_test_cases(
+                DelineationManager,
+                delineation_prompt,
+                spec.delineation_json_paths,
+            )
         )
+    delineation_test_cases = load_test_cases(
+        DelineationManager,
+        delineation_prompt,
+        test_cases=delineation_test_cases,
+        test_case_path=delineation_json_path,
+    )
     if punctuation_test_cases is None:
-        punctuation_test_cases = _load_transcription_test_cases(
-            PunctuationManager,
-            punctuation_prompt,
-            spec.punctuation_json_paths,
-            punctuation_json_path,
+        punctuation_test_cases = list(
+            load_default_test_cases(
+                PunctuationManager,
+                punctuation_prompt,
+                spec.punctuation_json_paths,
+            )
         )
+    punctuation_test_cases = load_test_cases(
+        PunctuationManager,
+        punctuation_prompt,
+        test_cases=punctuation_test_cases,
+        test_case_path=punctuation_json_path,
+    )
     if provider is None:
         provider = get_provider()
 
@@ -258,9 +277,10 @@ def get_guided_transcriber(
     aligner = TranscriptionAligner(
         delineation_queryer=delineation_queryer,
         punctuation_queryer=punctuation_queryer,
-        test_case_dir_path=test_case_dir_path,
         delineation_json_path=delineation_json_path,
         punctuation_json_path=punctuation_json_path,
+        prune_delineation_test_cases=prune_delineation_test_cases,
+        prune_punctuation_test_cases=prune_punctuation_test_cases,
     )
     return GuidedTranscriptionProcessor(
         language=language,
@@ -272,33 +292,3 @@ def get_guided_transcriber(
         vad_mode=vad_mode,
         segment_splitter=language_spec.segment_splitter,
     )
-
-
-def _load_transcription_test_cases(
-    manager_cls: type[Manager],
-    prompt: Prompt,
-    default_json_paths: tuple[Path, ...],
-    json_path: Path | None,
-) -> list[TestCase]:
-    """Load bundled and workflow-local transcription test cases.
-
-    Workflow-local cases take precedence over bundled cases with the same query.
-
-    Arguments:
-        manager_cls: manager used to load test cases
-        prompt: prompt whose localized schema should be applied
-        default_json_paths: bundled test-case paths
-        json_path: optional workflow-local JSON path
-    Returns:
-        test cases unique by query
-    """
-    test_cases = list(load_default_test_cases(manager_cls, prompt, default_json_paths))
-    if json_path is not None and json_path.exists():
-        test_cases.extend(
-            load_test_cases_from_json(
-                json_path,
-                manager_cls,
-                prompt=prompt,
-            )
-        )
-    return list({test_case.query.key: test_case for test_case in test_cases}.values())

--- a/scinoephile/lang/transcription/guided.py
+++ b/scinoephile/lang/transcription/guided.py
@@ -27,9 +27,9 @@ from scinoephile.llms.providers.registry import get_provider
 from scinoephile.llms.punctuation import PunctuationManager, PunctuationPrompt
 
 from .aligner import TranscriptionAligner
-from .processor import (
+from .transcriber import (
     DemucsMode,
-    GuidedTranscriptionProcessor,
+    GuidedTranscriber,
     TranscribedSegmentSplitter,
     VADMode,
 )
@@ -174,7 +174,7 @@ def get_guided_transcriber(
     punctuation_json_path: Path | None = None,
     delineation_test_cases: list[TestCase] | None = None,
     punctuation_test_cases: list[TestCase] | None = None,
-) -> GuidedTranscriptionProcessor:
+) -> GuidedTranscriber:
     """Get a guided transcriber for a supported language pair.
 
     Arguments:
@@ -193,7 +193,7 @@ def get_guided_transcriber(
         delineation_test_cases: preloaded delineation test cases
         punctuation_test_cases: preloaded punctuation test cases
     Returns:
-        configured guided transcription processor
+        configured guided transcriber
     Raises:
         ScinoephileError: if guided transcription does not support the language pair
     """
@@ -282,7 +282,7 @@ def get_guided_transcriber(
         prune_delineation_test_cases=prune_test_cases,
         prune_punctuation_test_cases=prune_test_cases,
     )
-    return GuidedTranscriptionProcessor(
+    return GuidedTranscriber(
         language=language,
         reference_language=reference_language,
         model_name=model_name,

--- a/scinoephile/lang/transcription/guided.py
+++ b/scinoephile/lang/transcription/guided.py
@@ -11,8 +11,7 @@ from types import MappingProxyType
 
 from scinoephile.audio.transcription import get_segment_split_on_whitespace
 from scinoephile.core import Language, ScinoephileError
-from scinoephile.core.llms import LLMProvider, Queryer, TestCase
-from scinoephile.core.llms.utils import load_test_cases
+from scinoephile.core.llms import LLMProvider, TestCase
 from scinoephile.core.ml import get_torch_device
 from scinoephile.core.paths import get_runtime_cache_dir_path
 from scinoephile.lang.yue_zho.transcription import (
@@ -22,9 +21,17 @@ from scinoephile.lang.yue_zho.transcription import (
     YueZhoPunctuationPromptYueHant,
 )
 from scinoephile.llms import load_default_test_cases
-from scinoephile.llms.delineation import DelineationManager, DelineationPrompt
+from scinoephile.llms.delineation import (
+    DelineationManager,
+    DelineationProcessor,
+    DelineationPrompt,
+)
 from scinoephile.llms.providers.registry import get_provider
-from scinoephile.llms.punctuation import PunctuationManager, PunctuationPrompt
+from scinoephile.llms.punctuation import (
+    PunctuationManager,
+    PunctuationProcessor,
+    PunctuationPrompt,
+)
 
 from .aligner import TranscriptionAligner
 from .transcriber import (
@@ -233,11 +240,15 @@ def get_guided_transcriber(
                 spec.delineation_json_paths,
             )
         )
-    delineation_test_cases, delineation_json_path = load_test_cases(
-        DelineationManager,
+    if provider is None:
+        provider = get_provider()
+    delineation_processor = DelineationProcessor(
         delineation_prompt,
         test_cases=delineation_test_cases,
         test_case_path=delineation_json_path,
+        provider=provider,
+        additional_context=additional_context,
+        prune_test_cases=prune_test_cases,
     )
     if punctuation_test_cases is None:
         punctuation_test_cases = list(
@@ -247,40 +258,17 @@ def get_guided_transcriber(
                 spec.punctuation_json_paths,
             )
         )
-    punctuation_test_cases, punctuation_json_path = load_test_cases(
-        PunctuationManager,
+    punctuation_processor = PunctuationProcessor(
         punctuation_prompt,
         test_cases=punctuation_test_cases,
         test_case_path=punctuation_json_path,
-    )
-    if provider is None:
-        provider = get_provider()
-
-    delineation_queryer = Queryer(
-        DelineationManager.get_test_case_cls(delineation_prompt),
-        verified_test_cases=[
-            test_case for test_case in delineation_test_cases if test_case.verified
-        ],
         provider=provider,
-        cache_dir_path=get_runtime_cache_dir_path("llm"),
         additional_context=additional_context,
-    )
-    punctuation_queryer = Queryer(
-        PunctuationManager.get_test_case_cls(punctuation_prompt),
-        verified_test_cases=[
-            test_case for test_case in punctuation_test_cases if test_case.verified
-        ],
-        provider=provider,
-        cache_dir_path=get_runtime_cache_dir_path("llm"),
-        additional_context=additional_context,
+        prune_test_cases=prune_test_cases,
     )
     aligner = TranscriptionAligner(
-        delineation_queryer=delineation_queryer,
-        punctuation_queryer=punctuation_queryer,
-        delineation_json_path=delineation_json_path,
-        punctuation_json_path=punctuation_json_path,
-        prune_delineation_test_cases=prune_test_cases,
-        prune_punctuation_test_cases=prune_test_cases,
+        delineation_processor=delineation_processor,
+        punctuation_processor=punctuation_processor,
     )
     return GuidedTranscriber(
         language=language,

--- a/scinoephile/lang/transcription/guided.py
+++ b/scinoephile/lang/transcription/guided.py
@@ -11,7 +11,8 @@ from types import MappingProxyType
 
 from scinoephile.audio.transcription import get_segment_split_on_whitespace
 from scinoephile.core import Language, ScinoephileError
-from scinoephile.core.llms import LLMProvider, Queryer, TestCase
+from scinoephile.core.llms import LLMProvider, Manager, Prompt, Queryer, TestCase
+from scinoephile.core.llms.utils import load_test_cases_from_json
 from scinoephile.core.paths import get_runtime_cache_dir_path
 from scinoephile.lang.yue_zho.transcription import (
     YueZhoDelineationPromptYueHans,
@@ -168,6 +169,8 @@ def get_guided_transcriber(
     delineation_prompt: DelineationPrompt | None = None,
     punctuation_prompt: PunctuationPrompt | None = None,
     test_case_dir_path: Path | None = None,
+    delineation_json_path: Path | None = None,
+    punctuation_json_path: Path | None = None,
     delineation_test_cases: list[TestCase] | None = None,
     punctuation_test_cases: list[TestCase] | None = None,
 ) -> GuidedTranscriptionProcessor:
@@ -184,6 +187,8 @@ def get_guided_transcriber(
         delineation_prompt: delineation prompt override
         punctuation_prompt: punctuation prompt override
         test_case_dir_path: directory where encountered test cases are written
+        delineation_json_path: delineation test-case JSON file to load and update
+        punctuation_json_path: punctuation test-case JSON file to load and update
         delineation_test_cases: preloaded delineation test cases
         punctuation_test_cases: preloaded punctuation test cases
     Returns:
@@ -206,27 +211,28 @@ def get_guided_transcriber(
         delineation_prompt = spec.delineation_prompt
     if punctuation_prompt is None:
         punctuation_prompt = spec.punctuation_prompt
-    if test_case_dir_path is None:
+    if test_case_dir_path is None and (
+        delineation_json_path is None or punctuation_json_path is None
+    ):
         test_case_dir_path = get_runtime_cache_dir_path("test_cases")
         test_case_dir_path /= spec.test_case_dir_path
-    (test_case_dir_path / "delineation").mkdir(parents=True, exist_ok=True)
-    (test_case_dir_path / "punctuation").mkdir(parents=True, exist_ok=True)
+    if test_case_dir_path is not None:
+        (test_case_dir_path / "delineation").mkdir(parents=True, exist_ok=True)
+        (test_case_dir_path / "punctuation").mkdir(parents=True, exist_ok=True)
 
     if delineation_test_cases is None:
-        delineation_test_cases = list(
-            load_default_test_cases(
-                DelineationManager,
-                delineation_prompt,
-                spec.delineation_json_paths,
-            )
+        delineation_test_cases = _load_transcription_test_cases(
+            DelineationManager,
+            delineation_prompt,
+            spec.delineation_json_paths,
+            delineation_json_path,
         )
     if punctuation_test_cases is None:
-        punctuation_test_cases = list(
-            load_default_test_cases(
-                PunctuationManager,
-                punctuation_prompt,
-                spec.punctuation_json_paths,
-            )
+        punctuation_test_cases = _load_transcription_test_cases(
+            PunctuationManager,
+            punctuation_prompt,
+            spec.punctuation_json_paths,
+            punctuation_json_path,
         )
     if provider is None:
         provider = get_provider()
@@ -253,6 +259,8 @@ def get_guided_transcriber(
         delineation_queryer=delineation_queryer,
         punctuation_queryer=punctuation_queryer,
         test_case_dir_path=test_case_dir_path,
+        delineation_json_path=delineation_json_path,
+        punctuation_json_path=punctuation_json_path,
     )
     return GuidedTranscriptionProcessor(
         language=language,
@@ -264,3 +272,33 @@ def get_guided_transcriber(
         vad_mode=vad_mode,
         segment_splitter=language_spec.segment_splitter,
     )
+
+
+def _load_transcription_test_cases(
+    manager_cls: type[Manager],
+    prompt: Prompt,
+    default_json_paths: tuple[Path, ...],
+    json_path: Path | None,
+) -> list[TestCase]:
+    """Load bundled and workflow-local transcription test cases.
+
+    Workflow-local cases take precedence over bundled cases with the same query.
+
+    Arguments:
+        manager_cls: manager used to load test cases
+        prompt: prompt whose localized schema should be applied
+        default_json_paths: bundled test-case paths
+        json_path: optional workflow-local JSON path
+    Returns:
+        test cases unique by query
+    """
+    test_cases = list(load_default_test_cases(manager_cls, prompt, default_json_paths))
+    if json_path is not None and json_path.exists():
+        test_cases.extend(
+            load_test_cases_from_json(
+                json_path,
+                manager_cls,
+                prompt=prompt,
+            )
+        )
+    return list({test_case.query.key: test_case for test_case in test_cases}.values())

--- a/scinoephile/lang/transcription/guided.py
+++ b/scinoephile/lang/transcription/guided.py
@@ -167,6 +167,7 @@ def get_guided_transcriber(
     vad_mode: VADMode = VADMode.AUTO,
     provider: LLMProvider | None = None,
     additional_context: str | None = None,
+    prune_test_cases: bool = False,
     delineation_prompt: DelineationPrompt | None = None,
     punctuation_prompt: PunctuationPrompt | None = None,
     delineation_json_path: Path | None = None,
@@ -184,6 +185,7 @@ def get_guided_transcriber(
         vad_mode: Whisper VAD mode
         provider: provider to use for LLM queries
         additional_context: additional context to include in LLM prompts
+        prune_test_cases: whether to remove test cases not encountered in this run
         delineation_prompt: delineation prompt override
         punctuation_prompt: punctuation prompt override
         delineation_json_path: delineation test-case JSON file to load and update
@@ -210,8 +212,6 @@ def get_guided_transcriber(
         delineation_prompt = spec.delineation_prompt
     if punctuation_prompt is None:
         punctuation_prompt = spec.punctuation_prompt
-    prune_delineation_test_cases = delineation_json_path is not None
-    prune_punctuation_test_cases = punctuation_json_path is not None
     if delineation_json_path is None or punctuation_json_path is None:
         runtime_test_case_dir_path = (
             get_runtime_cache_dir_path("test_cases") / spec.test_case_dir_path
@@ -279,8 +279,8 @@ def get_guided_transcriber(
         punctuation_queryer=punctuation_queryer,
         delineation_json_path=delineation_json_path,
         punctuation_json_path=punctuation_json_path,
-        prune_delineation_test_cases=prune_delineation_test_cases,
-        prune_punctuation_test_cases=prune_punctuation_test_cases,
+        prune_delineation_test_cases=prune_test_cases,
+        prune_punctuation_test_cases=prune_test_cases,
     )
     return GuidedTranscriptionProcessor(
         language=language,

--- a/scinoephile/lang/transcription/guided.py
+++ b/scinoephile/lang/transcription/guided.py
@@ -233,7 +233,7 @@ def get_guided_transcriber(
                 spec.delineation_json_paths,
             )
         )
-    delineation_test_cases = load_test_cases(
+    delineation_test_cases, delineation_json_path = load_test_cases(
         DelineationManager,
         delineation_prompt,
         test_cases=delineation_test_cases,
@@ -247,7 +247,7 @@ def get_guided_transcriber(
                 spec.punctuation_json_paths,
             )
         )
-    punctuation_test_cases = load_test_cases(
+    punctuation_test_cases, punctuation_json_path = load_test_cases(
         PunctuationManager,
         punctuation_prompt,
         test_cases=punctuation_test_cases,

--- a/scinoephile/lang/transcription/processor.py
+++ b/scinoephile/lang/transcription/processor.py
@@ -203,6 +203,13 @@ class GuidedTranscriptionProcessor:
                 f"{len(reference_blocks)} blocks."
             )
         block_range = val_index_range(len(audio_blocks), start_at_idx, stop_at_idx)
+        if (
+            self.aligner.prune_delineation_test_cases
+            or self.aligner.prune_punctuation_test_cases
+        ) and block_range != range(len(audio_blocks)):
+            raise ValueError(
+                "Cannot prune test cases while processing only a subset of blocks."
+            )
 
         output_events = []
         for block_idx in block_range:
@@ -221,6 +228,7 @@ class GuidedTranscriptionProcessor:
         output_events.sort(key=lambda event: event.start)
         output = AudioSeries(audio=audio_series.audio, events=output_events)
         logger.info(f"Concatenated Series:\n{output.to_simple_string()}")
+        self.aligner.update_all_test_cases()
         return output
 
     def process_block(
@@ -260,7 +268,6 @@ class GuidedTranscriptionProcessor:
             offset=offset,
         )
         alignment = self.aligner.align(reference_block, transcription_block)
-        self.aligner.update_all_test_cases()
         return alignment.transcription
 
     def _get_cached_block_transcription(

--- a/scinoephile/lang/transcription/transcriber.py
+++ b/scinoephile/lang/transcription/transcriber.py
@@ -1,6 +1,6 @@
 #  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
-"""Reference-guided audio transcription processor."""
+"""Reference-guided audio transcriber."""
 
 from __future__ import annotations
 
@@ -26,7 +26,7 @@ from .aligner import TranscriptionAligner
 
 __all__ = [
     "DemucsMode",
-    "GuidedTranscriptionProcessor",
+    "GuidedTranscriber",
     "TranscribedSegmentSplitter",
     "VADMode",
 ]
@@ -87,7 +87,7 @@ class VADMode(StrEnum):
     """Never use VAD."""
 
 
-class GuidedTranscriptionProcessor:
+class GuidedTranscriber:
     """Transcribe audio and align it with reference subtitles."""
 
     def __init__(

--- a/scinoephile/lang/transcription/transcriber.py
+++ b/scinoephile/lang/transcription/transcriber.py
@@ -204,8 +204,8 @@ class GuidedTranscriber:
             )
         block_range = val_index_range(len(audio_blocks), start_at_idx, stop_at_idx)
         if (
-            self.aligner.prune_delineation_test_cases
-            or self.aligner.prune_punctuation_test_cases
+            self.aligner.delineation_processor.prune_test_cases
+            or self.aligner.punctuation_processor.prune_test_cases
         ) and block_range != range(len(audio_blocks)):
             raise ValueError(
                 "Cannot prune test cases while processing only a subset of blocks."

--- a/scinoephile/llms/delineation/__init__.py
+++ b/scinoephile/llms/delineation/__init__.py
@@ -6,17 +6,20 @@ Package hierarchy (modules may import from any above):
 * prompt
 * models
 * manager
+* processor
 """
 
 from __future__ import annotations
 
 from .manager import DelineationManager
 from .models import DelineationAnswer, DelineationQuery, DelineationTestCase
+from .processor import DelineationProcessor
 from .prompt import DelineationPrompt
 
 __all__ = [
     "DelineationAnswer",
     "DelineationManager",
+    "DelineationProcessor",
     "DelineationPrompt",
     "DelineationQuery",
     "DelineationTestCase",

--- a/scinoephile/llms/delineation/processor.py
+++ b/scinoephile/llms/delineation/processor.py
@@ -1,0 +1,22 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Processor for delineation LLM queries."""
+
+from __future__ import annotations
+
+from scinoephile.core.llms import Processor
+
+from .manager import DelineationManager
+from .prompt import DelineationPrompt
+
+__all__ = ["DelineationProcessor"]
+
+
+class DelineationProcessor(Processor):
+    """Processor for delineation LLM queries."""
+
+    prompt: DelineationPrompt
+    """Text for LLM correspondence."""
+
+    manager_cls = DelineationManager
+    """Manager class used to construct test case models."""

--- a/scinoephile/llms/punctuation/__init__.py
+++ b/scinoephile/llms/punctuation/__init__.py
@@ -6,17 +6,20 @@ Package hierarchy (modules may import from any above):
 * prompt
 * models
 * manager
+* processor
 """
 
 from __future__ import annotations
 
 from .manager import PunctuationManager
 from .models import PunctuationAnswer, PunctuationQuery, PunctuationTestCase
+from .processor import PunctuationProcessor
 from .prompt import PunctuationPrompt
 
 __all__ = [
     "PunctuationAnswer",
     "PunctuationManager",
+    "PunctuationProcessor",
     "PunctuationPrompt",
     "PunctuationQuery",
     "PunctuationTestCase",

--- a/scinoephile/llms/punctuation/processor.py
+++ b/scinoephile/llms/punctuation/processor.py
@@ -1,0 +1,22 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Processor for punctuation LLM queries."""
+
+from __future__ import annotations
+
+from scinoephile.core.llms import Processor
+
+from .manager import PunctuationManager
+from .prompt import PunctuationPrompt
+
+__all__ = ["PunctuationProcessor"]
+
+
+class PunctuationProcessor(Processor):
+    """Processor for punctuation LLM queries."""
+
+    prompt: PunctuationPrompt
+    """Text for LLM correspondence."""
+
+    manager_cls = PunctuationManager
+    """Manager class used to construct test case models."""

--- a/scinoephile/workflows/transcription.py
+++ b/scinoephile/workflows/transcription.py
@@ -11,9 +11,9 @@ from scinoephile.core import Language
 from scinoephile.core.llms import LLMProvider, TestCase
 from scinoephile.core.subtitles import Series
 from scinoephile.lang.transcription.guided import get_guided_transcriber
-from scinoephile.lang.transcription.processor import (
+from scinoephile.lang.transcription.transcriber import (
     DemucsMode,
-    GuidedTranscriptionProcessor,
+    GuidedTranscriber,
     VADMode,
 )
 from scinoephile.llms.delineation import DelineationPrompt
@@ -42,7 +42,7 @@ def transcribe_series_guided(
     punctuation_json_path: Path | None = None,
     delineation_test_cases: list[TestCase] | None = None,
     punctuation_test_cases: list[TestCase] | None = None,
-    transcriber: GuidedTranscriptionProcessor | None = None,
+    transcriber: GuidedTranscriber | None = None,
     start_at_idx: int = 0,
     stop_at_idx: int | None = None,
 ) -> AudioSeries:
@@ -65,7 +65,7 @@ def transcribe_series_guided(
         punctuation_json_path: punctuation test-case JSON file to load and update
         delineation_test_cases: preloaded delineation test cases
         punctuation_test_cases: preloaded punctuation test cases
-        transcriber: guided transcription processor, or None to construct one
+        transcriber: guided transcriber, or None to construct one
         start_at_idx: inclusive zero-based block index at which to start processing
         stop_at_idx: exclusive zero-based block index at which to stop processing
     Returns:

--- a/scinoephile/workflows/transcription.py
+++ b/scinoephile/workflows/transcription.py
@@ -38,6 +38,8 @@ def transcribe_series_guided(
     delineation_prompt: DelineationPrompt | None = None,
     punctuation_prompt: PunctuationPrompt | None = None,
     test_case_dir_path: Path | None = None,
+    delineation_json_path: Path | None = None,
+    punctuation_json_path: Path | None = None,
     delineation_test_cases: list[TestCase] | None = None,
     punctuation_test_cases: list[TestCase] | None = None,
     transcriber: GuidedTranscriptionProcessor | None = None,
@@ -58,6 +60,8 @@ def transcribe_series_guided(
         delineation_prompt: delineation prompt override
         punctuation_prompt: punctuation prompt override
         test_case_dir_path: directory where encountered test cases are written
+        delineation_json_path: delineation test-case JSON file to load and update
+        punctuation_json_path: punctuation test-case JSON file to load and update
         delineation_test_cases: preloaded delineation test cases
         punctuation_test_cases: preloaded punctuation test cases
         transcriber: guided transcription processor, or None to construct one
@@ -84,6 +88,8 @@ def transcribe_series_guided(
             delineation_prompt=delineation_prompt,
             punctuation_prompt=punctuation_prompt,
             test_case_dir_path=test_case_dir_path,
+            delineation_json_path=delineation_json_path,
+            punctuation_json_path=punctuation_json_path,
             delineation_test_cases=delineation_test_cases,
             punctuation_test_cases=punctuation_test_cases,
         )

--- a/scinoephile/workflows/transcription.py
+++ b/scinoephile/workflows/transcription.py
@@ -35,6 +35,7 @@ def transcribe_series_guided(
     vad_mode: VADMode = VADMode.AUTO,
     provider: LLMProvider | None = None,
     additional_context: str | None = None,
+    prune_test_cases: bool = False,
     delineation_prompt: DelineationPrompt | None = None,
     punctuation_prompt: PunctuationPrompt | None = None,
     delineation_json_path: Path | None = None,
@@ -57,6 +58,7 @@ def transcribe_series_guided(
         vad_mode: Whisper VAD mode
         provider: provider to use for LLM queries
         additional_context: additional context to include in LLM prompts
+        prune_test_cases: whether to remove test cases not encountered in this run
         delineation_prompt: delineation prompt override
         punctuation_prompt: punctuation prompt override
         delineation_json_path: delineation test-case JSON file to load and update
@@ -85,6 +87,7 @@ def transcribe_series_guided(
             vad_mode=vad_mode,
             provider=provider,
             additional_context=additional_context,
+            prune_test_cases=prune_test_cases,
             delineation_prompt=delineation_prompt,
             punctuation_prompt=punctuation_prompt,
             delineation_json_path=delineation_json_path,

--- a/scinoephile/workflows/transcription.py
+++ b/scinoephile/workflows/transcription.py
@@ -37,7 +37,6 @@ def transcribe_series_guided(
     additional_context: str | None = None,
     delineation_prompt: DelineationPrompt | None = None,
     punctuation_prompt: PunctuationPrompt | None = None,
-    test_case_dir_path: Path | None = None,
     delineation_json_path: Path | None = None,
     punctuation_json_path: Path | None = None,
     delineation_test_cases: list[TestCase] | None = None,
@@ -59,7 +58,6 @@ def transcribe_series_guided(
         additional_context: additional context to include in LLM prompts
         delineation_prompt: delineation prompt override
         punctuation_prompt: punctuation prompt override
-        test_case_dir_path: directory where encountered test cases are written
         delineation_json_path: delineation test-case JSON file to load and update
         punctuation_json_path: punctuation test-case JSON file to load and update
         delineation_test_cases: preloaded delineation test cases
@@ -87,7 +85,6 @@ def transcribe_series_guided(
             additional_context=additional_context,
             delineation_prompt=delineation_prompt,
             punctuation_prompt=punctuation_prompt,
-            test_case_dir_path=test_case_dir_path,
             delineation_json_path=delineation_json_path,
             punctuation_json_path=punctuation_json_path,
             delineation_test_cases=delineation_test_cases,

--- a/test/cli/test_transcribe_cli.py
+++ b/test/cli/test_transcribe_cli.py
@@ -18,7 +18,7 @@ from scinoephile.common.file import get_temp_file_path
 from scinoephile.common.testing import run_cli_with_args
 from scinoephile.core import Language, ScinoephileError
 from scinoephile.core.subtitles import Series
-from scinoephile.lang.transcription.processor import DemucsMode, VADMode
+from scinoephile.lang.transcription.transcriber import DemucsMode, VADMode
 from test.helpers import assert_series_equal, test_data_root
 
 _MEDIA_INFILE_PATH = "/tmp/test_media.mp4"

--- a/test/cli/test_transcribe_cli.py
+++ b/test/cli/test_transcribe_cli.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 from pytest import fixture, mark, raises
@@ -63,6 +64,8 @@ def test_transcribe_help_lists_generic_options():
     assert "--reference-infile REFERENCE_INFILE_PATH" in help_text
     assert "--language" in help_text
     assert "--reference-language" in help_text
+    assert "--delineation-json DELINEATION_JSON_PATH" in help_text
+    assert "--punctuation-json PUNCTUATION_JSON_PATH" in help_text
     assert "--script" not in normalized_help_text
     assert "--convert" not in normalized_help_text
     assert "--demucs {auto,on,off}" in help_text
@@ -166,12 +169,14 @@ def test_transcribe_cli_writes_stdout(
 def test_transcribe_cli_passes_generic_configuration(
     audio_series: Mock,
     expected_series: Series,
+    tmp_path: Path,
 ):
     """Test transcription CLI passes generic language and model configuration.
 
     Arguments:
         audio_series: mock audio subtitle series
         expected_series: expected transcribed subtitle series
+        tmp_path: temporary directory path
     """
 
     def transcribe(
@@ -185,6 +190,8 @@ def test_transcribe_cli_passes_generic_configuration(
         vad_mode: VADMode,
         provider: object,
         additional_context: str | None,
+        delineation_json_path: Path | None,
+        punctuation_json_path: Path | None,
     ) -> Series:
         """Validate transcription options passed by the CLI."""
         assert input_audio_series is audio_series
@@ -196,6 +203,8 @@ def test_transcribe_cli_passes_generic_configuration(
         assert vad_mode is VADMode.OFF
         assert provider is not None
         assert additional_context is None
+        assert delineation_json_path == tmp_path / "delineation.json"
+        assert punctuation_json_path == tmp_path / "punctuation.json"
         return expected_series
 
     with patch(
@@ -211,7 +220,9 @@ def test_transcribe_cli_passes_generic_configuration(
                 f"{_MEDIA_INFILE_PATH} "
                 f"--reference-infile {_REFERENCE_INFILE_PATH} "
                 "--language yue-Hant --reference-language zho-Hans "
-                "--whisper-model custom/whisper --demucs on --vad off",
+                "--whisper-model custom/whisper --demucs on --vad off "
+                f"--delineation-json {tmp_path / 'delineation.json'} "
+                f"--punctuation-json {tmp_path / 'punctuation.json'}",
             )
 
 

--- a/test/core/llms/test_utils.py
+++ b/test/core/llms/test_utils.py
@@ -142,7 +142,7 @@ def test_load_test_cases_prefers_json_cases(tmp_path: Path):
         _AliasedBaseReviewManager,
     )
 
-    test_cases = load_test_cases(
+    test_cases, normalized_test_case_path = load_test_cases(
         _AliasedBaseReviewManager,
         _LOCALIZED_REVIEW_PROMPT,
         test_cases=[supplied_test_case],
@@ -150,6 +150,22 @@ def test_load_test_cases_prefers_json_cases(tmp_path: Path):
     )
 
     assert test_cases == [json_test_case]
+    assert normalized_test_case_path == test_case_path.resolve()
+
+
+def test_load_test_cases_normalizes_optional_arguments(tmp_path: Path):
+    """Test optional cases and paths are normalized during loading."""
+    test_case_path = tmp_path / "new" / "test_cases.json"
+
+    test_cases, normalized_test_case_path = load_test_cases(
+        _AliasedBaseReviewManager,
+        _LOCALIZED_REVIEW_PROMPT,
+        test_case_path=test_case_path,
+    )
+
+    assert test_cases == []
+    assert normalized_test_case_path == test_case_path.resolve()
+    assert test_case_path.parent.is_dir()
 
 
 @mark.parametrize(

--- a/test/core/llms/test_utils.py
+++ b/test/core/llms/test_utils.py
@@ -14,6 +14,7 @@ from pytest import mark, raises
 
 from scinoephile.core import Language
 from scinoephile.core.llms.utils import (
+    load_test_cases,
     load_test_cases_from_json,
     save_test_cases_to_json,
 )
@@ -128,6 +129,27 @@ def test_json_uses_base_prompt_fields(tmp_path: Path):
     assert loaded[0].answer.model_dump(by_alias=True) == {
         "xiugai": [{"xuhao": 1, "wenben": "corrected", "beizhu": "typo"}]
     }
+
+
+def test_load_test_cases_prefers_json_cases(tmp_path: Path):
+    """Test JSON test cases replace supplied cases with matching queries."""
+    supplied_test_case = _get_test_case("original", "supplied correction")
+    json_test_case = _get_test_case("original", "JSON correction")
+    test_case_path = tmp_path / "test_cases.json"
+    save_test_cases_to_json(
+        test_case_path,
+        [json_test_case],
+        _AliasedBaseReviewManager,
+    )
+
+    test_cases = load_test_cases(
+        _AliasedBaseReviewManager,
+        _LOCALIZED_REVIEW_PROMPT,
+        test_cases=[supplied_test_case],
+        test_case_path=test_case_path,
+    )
+
+    assert test_cases == [json_test_case]
 
 
 @mark.parametrize(

--- a/test/data/mlamd/create_output.py
+++ b/test/data/mlamd/create_output.py
@@ -81,6 +81,7 @@ if "yue-Hans_transcribe" in actions:
         Language.yue_hans,
         Language.zho_hans,
         vad_mode=VADMode.ON,
+        prune_test_cases=True,
         delineation_json_path=test_case_dir_path / "delineation" / f"{device}.json",
         punctuation_json_path=test_case_dir_path / "punctuation" / f"{device}.json",
         delineation_test_cases=get_mlamd_yue_delineation_test_cases(),

--- a/test/data/mlamd/create_output.py
+++ b/test/data/mlamd/create_output.py
@@ -73,13 +73,16 @@ if "yue-Hans_transcribe" in actions:
 
     # Transcribe
     yue_hans = AudioSeries.load(audio_path)
+    test_case_dir_path = (
+        output_path / "yue-Hans_transcribe" / "lang/yue_zho/transcription"
+    )
+    device = get_torch_device()
     transcriber = get_guided_transcriber(
         Language.yue_hans,
         Language.zho_hans,
         vad_mode=VADMode.ON,
-        test_case_dir_path=(
-            output_path / "yue-Hans_transcribe" / "lang/yue_zho/transcription"
-        ),
+        delineation_json_path=test_case_dir_path / "delineation" / f"{device}.json",
+        punctuation_json_path=test_case_dir_path / "punctuation" / f"{device}.json",
         delineation_test_cases=get_mlamd_yue_delineation_test_cases(),
         punctuation_test_cases=get_mlamd_yue_punctuation_test_cases(),
     )

--- a/test/data/mlamd/create_output.py
+++ b/test/data/mlamd/create_output.py
@@ -14,7 +14,7 @@ from scinoephile.core.ml import get_torch_device
 from scinoephile.core.subtitles import Series, get_series_with_subs_merged
 from scinoephile.lang.review.guided import get_guided_reviewer
 from scinoephile.lang.transcription.guided import get_guided_transcriber
-from scinoephile.lang.transcription.processor import VADMode
+from scinoephile.lang.transcription.transcriber import VADMode
 from scinoephile.lang.translation.gap import get_gap_translator
 from scinoephile.workflows.review import review_series_guided
 from scinoephile.workflows.transcription import transcribe_series_guided

--- a/test/data/transcription.py
+++ b/test/data/transcription.py
@@ -306,9 +306,15 @@ def _load_or_transcribe_series_guided(
     transcription_kw = dict(transcription_kw or {})
     spec = DEFAULT_SPECS.get((language, guide_language))
     if spec is not None:
+        test_case_dir_path = output_path.parent / spec.test_case_dir_path
+        device = get_torch_device()
         transcription_kw.setdefault(
-            "test_case_dir_path",
-            output_path.parent / spec.test_case_dir_path,
+            "delineation_json_path",
+            test_case_dir_path / "delineation" / f"{device}.json",
+        )
+        transcription_kw.setdefault(
+            "punctuation_json_path",
+            test_case_dir_path / "punctuation" / f"{device}.json",
         )
     audio_transcription = transcribe_series_guided(
         audio,

--- a/test/lang/transcription/test_delineation_alignment.py
+++ b/test/lang/transcription/test_delineation_alignment.py
@@ -9,11 +9,15 @@ from unittest.mock import Mock, patch
 from pydub import AudioSegment
 
 from scinoephile.audio.subtitles import AudioSeries, AudioSubtitle
-from scinoephile.core.llms import Queryer
 from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.lang.transcription.aligner import TranscriptionAligner
 from scinoephile.lang.transcription.alignment import TranscriptionAlignment
-from scinoephile.llms.delineation import DelineationPrompt, DelineationTestCase
+from scinoephile.llms.delineation import (
+    DelineationProcessor,
+    DelineationPrompt,
+    DelineationTestCase,
+)
+from scinoephile.llms.punctuation import PunctuationProcessor
 
 _LOCALIZED_PROMPT = DelineationPrompt(
     ref_sub_1="cankao_yi",
@@ -72,8 +76,10 @@ def test_alignment_constructs_semantic_fields_with_configured_prompt():
 def test_aligner_uses_queryer_prompt_and_semantic_shift_output():
     """Aligner should propagate its prompt and consume semantic answer fields."""
     alignment = _get_alignment()
-    delineation_queryer = Mock(spec=Queryer)
+    delineation_queryer = Mock()
     delineation_queryer.prompt = _LOCALIZED_PROMPT
+    delineation_processor = Mock(spec=DelineationProcessor)
+    delineation_processor.queryer = delineation_queryer
 
     def add_answer(test_case: DelineationTestCase) -> DelineationTestCase:
         """Move the second target subtitle into the first sync group."""
@@ -86,8 +92,8 @@ def test_aligner_uses_queryer_prompt_and_semantic_shift_output():
 
     delineation_queryer.side_effect = add_answer
     aligner = TranscriptionAligner(
-        delineation_queryer=delineation_queryer,
-        punctuation_queryer=Mock(spec=Queryer),
+        delineation_processor=delineation_processor,
+        punctuation_processor=Mock(spec=PunctuationProcessor),
     )
 
     restart_required = aligner._delineate(alignment)
@@ -117,8 +123,10 @@ def test_aligner_restarts_to_propagate_text_across_multiple_boundaries():
     )
     alignment = TranscriptionAlignment(reference, transcription)
     alignment._sync_groups_override = [([0], [0]), ([1], [1]), ([2], [2])]
-    delineation_queryer = Mock(spec=Queryer)
+    delineation_queryer = Mock()
     delineation_queryer.prompt = _LOCALIZED_PROMPT
+    delineation_processor = Mock(spec=DelineationProcessor)
+    delineation_processor.queryer = delineation_queryer
 
     def shift_left(test_case: DelineationTestCase) -> DelineationTestCase:
         """Move text leftward until all targets reach the first group."""
@@ -136,8 +144,8 @@ def test_aligner_restarts_to_propagate_text_across_multiple_boundaries():
 
     delineation_queryer.side_effect = shift_left
     aligner = TranscriptionAligner(
-        delineation_queryer=delineation_queryer,
-        punctuation_queryer=Mock(spec=Queryer),
+        delineation_processor=delineation_processor,
+        punctuation_processor=Mock(spec=PunctuationProcessor),
     )
 
     while aligner._delineate(alignment):
@@ -149,8 +157,10 @@ def test_aligner_restarts_to_propagate_text_across_multiple_boundaries():
 def test_aligner_stops_when_delineation_states_repeat():
     """Aligner should stop when neighboring decisions form a cycle."""
     alignment = _get_alignment()
-    delineation_queryer = Mock(spec=Queryer)
+    delineation_queryer = Mock()
     delineation_queryer.prompt = _LOCALIZED_PROMPT
+    delineation_processor = Mock(spec=DelineationProcessor)
+    delineation_processor.queryer = delineation_queryer
 
     def oscillate(test_case: DelineationTestCase) -> DelineationTestCase:
         """Move the second target left, then move it back right."""
@@ -166,8 +176,8 @@ def test_aligner_stops_when_delineation_states_repeat():
 
     delineation_queryer.side_effect = oscillate
     aligner = TranscriptionAligner(
-        delineation_queryer=delineation_queryer,
-        punctuation_queryer=Mock(spec=Queryer),
+        delineation_processor=delineation_processor,
+        punctuation_processor=Mock(spec=PunctuationProcessor),
     )
 
     with patch.object(aligner, "_punctuate") as punctuate:

--- a/test/lang/transcription/test_guided.py
+++ b/test/lang/transcription/test_guided.py
@@ -68,14 +68,23 @@ def test_default_specs_are_read_only_and_cover_yue_zho_scripts():
 
 def test_get_guided_transcriber_uses_registered_language_configuration(tmp_path):
     """Test factory configures language-specific prompts and Whisper language."""
-    transcriber = get_guided_transcriber(
-        Language.yue_hant,
-        Language.zho_hans,
-        provider=Mock(spec=LLMProvider),
-        test_case_dir_path=tmp_path,
-        delineation_test_cases=[],
-        punctuation_test_cases=[],
-    )
+    with (
+        patch(
+            "scinoephile.lang.transcription.guided.get_runtime_cache_dir_path",
+            return_value=tmp_path,
+        ),
+        patch(
+            "scinoephile.lang.transcription.guided.get_torch_device",
+            return_value="test",
+        ),
+    ):
+        transcriber = get_guided_transcriber(
+            Language.yue_hant,
+            Language.zho_hans,
+            provider=Mock(spec=LLMProvider),
+            delineation_test_cases=[],
+            punctuation_test_cases=[],
+        )
 
     assert transcriber.language is Language.yue_hant
     assert transcriber.reference_language is Language.zho_hans
@@ -93,8 +102,13 @@ def test_get_guided_transcriber_uses_registered_language_configuration(tmp_path)
     assert transcriber.vad_transcriber.language == "yue"
     assert transcriber.no_vad_transcriber is not None
     assert transcriber.no_vad_transcriber.language == "yue"
-    assert (tmp_path / "delineation").is_dir()
-    assert (tmp_path / "punctuation").is_dir()
+    test_case_dir_path = tmp_path / "lang/yue_zho/transcription"
+    assert transcriber.aligner.delineation_json_path == (
+        test_case_dir_path / "delineation" / "test.json"
+    )
+    assert transcriber.aligner.punctuation_json_path == (
+        test_case_dir_path / "punctuation" / "test.json"
+    )
 
 
 def test_get_guided_transcriber_prunes_stale_cases_from_exact_json_paths(
@@ -155,20 +169,30 @@ def test_get_guided_transcriber_prunes_stale_cases_from_exact_json_paths(
     assert json.loads(punctuation_json_path.read_text(encoding="utf-8")) == []
 
 
-def test_get_guided_transcriber_preserves_cases_in_test_case_directory(
+def test_get_guided_transcriber_preserves_cases_in_default_json_paths(
     tmp_path: Path,
 ):
-    """Test directory-backed JSON test cases are preserved between runs."""
-    transcriber = get_guided_transcriber(
-        Language.yue_hant,
-        Language.zho_hans,
-        provider=Mock(spec=LLMProvider),
-        test_case_dir_path=tmp_path,
-        delineation_test_cases=[],
-        punctuation_test_cases=[],
-    )
-    delineation_json_path = tmp_path / "delineation" / "test.json"
-    punctuation_json_path = tmp_path / "punctuation" / "test.json"
+    """Test default JSON test cases are preserved between runs."""
+    with (
+        patch(
+            "scinoephile.lang.transcription.guided.get_runtime_cache_dir_path",
+            return_value=tmp_path,
+        ),
+        patch(
+            "scinoephile.lang.transcription.guided.get_torch_device",
+            return_value="test",
+        ),
+    ):
+        transcriber = get_guided_transcriber(
+            Language.yue_hant,
+            Language.zho_hans,
+            provider=Mock(spec=LLMProvider),
+            delineation_test_cases=[],
+            punctuation_test_cases=[],
+        )
+    test_case_dir_path = tmp_path / "lang/yue_zho/transcription"
+    delineation_json_path = test_case_dir_path / "delineation" / "test.json"
+    punctuation_json_path = test_case_dir_path / "punctuation" / "test.json"
     delineation_test_case_data = [
         {
             "query": {
@@ -199,11 +223,7 @@ def test_get_guided_transcriber_preserves_cases_in_test_case_directory(
         encoding="utf-8",
     )
 
-    with patch(
-        "scinoephile.lang.transcription.aligner.get_torch_device",
-        return_value="test",
-    ):
-        transcriber.aligner.update_all_test_cases()
+    transcriber.aligner.update_all_test_cases()
 
     assert json.loads(delineation_json_path.read_text(encoding="utf-8")) == (
         delineation_test_case_data

--- a/test/lang/transcription/test_guided.py
+++ b/test/lang/transcription/test_guided.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import cast
 from unittest.mock import Mock
 
@@ -11,6 +13,7 @@ from pytest import raises
 
 from scinoephile.core import Language, ScinoephileError
 from scinoephile.core.llms import LLMProvider
+from scinoephile.core.llms.utils import save_test_cases_to_json
 from scinoephile.lang.transcription.guided import (
     DEFAULT_SPECS,
     get_guided_transcriber,
@@ -94,8 +97,66 @@ def test_get_guided_transcriber_uses_registered_language_configuration(tmp_path)
     assert (tmp_path / "punctuation").is_dir()
 
 
-def test_get_guided_transcriber_uses_verified_cases_without_few_shot(tmp_path):
-    """Test verified cases bypass the provider without entering the prompt."""
+def test_get_guided_transcriber_prunes_stale_cases_from_exact_json_paths(
+    tmp_path: Path,
+):
+    """Test exact JSON paths retain only cases encountered by the current run."""
+    delineation_json_path = tmp_path / "custom" / "delineation.json"
+    punctuation_json_path = tmp_path / "other" / "punctuation.json"
+    transcriber = get_guided_transcriber(
+        Language.yue_hant,
+        Language.zho_hans,
+        provider=Mock(spec=LLMProvider),
+        delineation_json_path=delineation_json_path,
+        punctuation_json_path=punctuation_json_path,
+        delineation_test_cases=[],
+        punctuation_test_cases=[],
+    )
+
+    assert transcriber.aligner.delineation_json_path == delineation_json_path
+    assert transcriber.aligner.punctuation_json_path == punctuation_json_path
+
+    delineation_json_path.parent.mkdir(parents=True, exist_ok=True)
+    delineation_json_path.write_text(
+        json.dumps(
+            [
+                {
+                    "query": {
+                        "reference_one": "參考一",
+                        "reference_two": "參考二",
+                        "target_one": "目標一",
+                        "target_two": "目標二",
+                    },
+                    "answer": {},
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    punctuation_json_path.parent.mkdir(parents=True, exist_ok=True)
+    punctuation_json_path.write_text(
+        json.dumps(
+            [
+                {
+                    "query": {
+                        "ref_sub": "參考",
+                        "target_subs": ["目標"],
+                    },
+                    "answer": {"target_sub_punctuated": "目標。"},
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    transcriber.aligner.update_all_test_cases()
+
+    assert json.loads(delineation_json_path.read_text(encoding="utf-8")) == []
+    assert json.loads(punctuation_json_path.read_text(encoding="utf-8")) == []
+
+
+def test_get_guided_transcriber_loads_verified_cases_from_exact_json(tmp_path: Path):
+    """Test an exact JSON's verified cases bypass the provider and few-shot prompt."""
     test_case_cls = DelineationManager.get_test_case_cls(YueZhoDelineationPromptYueHant)
     verified_test_case = test_case_cls.model_validate(
         {
@@ -109,13 +170,19 @@ def test_get_guided_transcriber_uses_verified_cases_without_few_shot(tmp_path):
             "verified": True,
         }
     )
+    delineation_json_path = tmp_path / "delineation.json"
+    save_test_cases_to_json(
+        delineation_json_path,
+        [verified_test_case],
+        DelineationManager,
+    )
     provider = Mock(spec=LLMProvider)
     transcriber = get_guided_transcriber(
         Language.yue_hant,
         Language.zho_hant,
         provider=provider,
-        test_case_dir_path=tmp_path,
-        delineation_test_cases=[verified_test_case],
+        delineation_json_path=delineation_json_path,
+        punctuation_json_path=tmp_path / "punctuation.json",
         punctuation_test_cases=[],
     )
     queryer = transcriber.aligner.delineation_queryer
@@ -127,7 +194,8 @@ def test_get_guided_transcriber_uses_verified_cases_without_few_shot(tmp_path):
 
     assert result.answer == verified_test_case.answer
     assert result.verified is True
-    assert queryer.few_shot_test_cases == {}
+    assert result.few_shot is False
+    assert verified_test_case.query.key not in queryer.few_shot_test_cases
     provider.chat_completion.assert_not_called()
 
 

--- a/test/lang/transcription/test_guided.py
+++ b/test/lang/transcription/test_guided.py
@@ -24,7 +24,8 @@ from scinoephile.lang.yue_zho.transcription import (
     YueZhoDelineationPromptYueHant,
     YueZhoPunctuationPromptYueHant,
 )
-from scinoephile.llms.delineation import DelineationManager
+from scinoephile.llms.delineation import DelineationManager, DelineationProcessor
+from scinoephile.llms.punctuation import PunctuationProcessor
 
 
 def test_default_specs_are_read_only_and_cover_yue_zho_scripts():
@@ -92,10 +93,12 @@ def test_get_guided_transcriber_uses_registered_language_configuration(tmp_path)
     assert transcriber.vad_mode is VADMode.AUTO
     assert transcriber.whisper_language == "yue"
     assert transcriber.segment_splitter is not None
-    assert transcriber.aligner.delineation_queryer.prompt is (
+    assert isinstance(transcriber.aligner.delineation_processor, DelineationProcessor)
+    assert isinstance(transcriber.aligner.punctuation_processor, PunctuationProcessor)
+    assert transcriber.aligner.delineation_processor.prompt is (
         YueZhoDelineationPromptYueHant
     )
-    assert transcriber.aligner.punctuation_queryer.prompt is (
+    assert transcriber.aligner.punctuation_processor.prompt is (
         YueZhoPunctuationPromptYueHant
     )
     assert transcriber.vad_transcriber is not None
@@ -103,14 +106,14 @@ def test_get_guided_transcriber_uses_registered_language_configuration(tmp_path)
     assert transcriber.no_vad_transcriber is not None
     assert transcriber.no_vad_transcriber.language == "yue"
     test_case_dir_path = tmp_path / "lang/yue_zho/transcription"
-    assert transcriber.aligner.delineation_json_path == (
+    assert transcriber.aligner.delineation_processor.test_case_path == (
         test_case_dir_path / "delineation" / "test.json"
     )
-    assert transcriber.aligner.punctuation_json_path == (
+    assert transcriber.aligner.punctuation_processor.test_case_path == (
         test_case_dir_path / "punctuation" / "test.json"
     )
-    assert not transcriber.aligner.prune_delineation_test_cases
-    assert not transcriber.aligner.prune_punctuation_test_cases
+    assert not transcriber.aligner.delineation_processor.prune_test_cases
+    assert not transcriber.aligner.punctuation_processor.prune_test_cases
 
 
 def test_get_guided_transcriber_prunes_stale_cases_when_requested(
@@ -130,8 +133,12 @@ def test_get_guided_transcriber_prunes_stale_cases_when_requested(
         punctuation_test_cases=[],
     )
 
-    assert transcriber.aligner.delineation_json_path == delineation_json_path
-    assert transcriber.aligner.punctuation_json_path == punctuation_json_path
+    assert transcriber.aligner.delineation_processor.test_case_path == (
+        delineation_json_path
+    )
+    assert transcriber.aligner.punctuation_processor.test_case_path == (
+        punctuation_json_path
+    )
 
     delineation_json_path.parent.mkdir(parents=True, exist_ok=True)
     delineation_json_path.write_text(
@@ -266,9 +273,9 @@ def test_get_guided_transcriber_loads_verified_cases_from_exact_json(tmp_path: P
         punctuation_json_path=tmp_path / "punctuation.json",
         punctuation_test_cases=[],
     )
-    queryer = transcriber.aligner.delineation_queryer
-    assert not transcriber.aligner.prune_delineation_test_cases
-    assert not transcriber.aligner.prune_punctuation_test_cases
+    queryer = transcriber.aligner.delineation_processor.queryer
+    assert not transcriber.aligner.delineation_processor.prune_test_cases
+    assert not transcriber.aligner.punctuation_processor.prune_test_cases
     pending_test_case = test_case_cls.model_validate(
         {"query": verified_test_case.query.model_dump()}
     )

--- a/test/lang/transcription/test_guided.py
+++ b/test/lang/transcription/test_guided.py
@@ -18,7 +18,7 @@ from scinoephile.lang.transcription.guided import (
     DEFAULT_SPECS,
     get_guided_transcriber,
 )
-from scinoephile.lang.transcription.processor import DemucsMode, VADMode
+from scinoephile.lang.transcription.transcriber import DemucsMode, VADMode
 from scinoephile.lang.yue.prompts import YUE_HANT_PROMPT_FIELDS
 from scinoephile.lang.yue_zho.transcription import (
     YueZhoDelineationPromptYueHant,

--- a/test/lang/transcription/test_guided.py
+++ b/test/lang/transcription/test_guided.py
@@ -109,18 +109,21 @@ def test_get_guided_transcriber_uses_registered_language_configuration(tmp_path)
     assert transcriber.aligner.punctuation_json_path == (
         test_case_dir_path / "punctuation" / "test.json"
     )
+    assert not transcriber.aligner.prune_delineation_test_cases
+    assert not transcriber.aligner.prune_punctuation_test_cases
 
 
-def test_get_guided_transcriber_prunes_stale_cases_from_exact_json_paths(
+def test_get_guided_transcriber_prunes_stale_cases_when_requested(
     tmp_path: Path,
 ):
-    """Test exact JSON paths retain only cases encountered by the current run."""
+    """Test requested pruning retains only cases encountered by the current run."""
     delineation_json_path = tmp_path / "custom" / "delineation.json"
     punctuation_json_path = tmp_path / "other" / "punctuation.json"
     transcriber = get_guided_transcriber(
         Language.yue_hant,
         Language.zho_hans,
         provider=Mock(spec=LLMProvider),
+        prune_test_cases=True,
         delineation_json_path=delineation_json_path,
         punctuation_json_path=punctuation_json_path,
         delineation_test_cases=[],
@@ -264,6 +267,8 @@ def test_get_guided_transcriber_loads_verified_cases_from_exact_json(tmp_path: P
         punctuation_test_cases=[],
     )
     queryer = transcriber.aligner.delineation_queryer
+    assert not transcriber.aligner.prune_delineation_test_cases
+    assert not transcriber.aligner.prune_punctuation_test_cases
     pending_test_case = test_case_cls.model_validate(
         {"query": verified_test_case.query.model_dump()}
     )

--- a/test/lang/transcription/test_guided.py
+++ b/test/lang/transcription/test_guided.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import cast
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from pytest import raises
 
@@ -153,6 +153,64 @@ def test_get_guided_transcriber_prunes_stale_cases_from_exact_json_paths(
 
     assert json.loads(delineation_json_path.read_text(encoding="utf-8")) == []
     assert json.loads(punctuation_json_path.read_text(encoding="utf-8")) == []
+
+
+def test_get_guided_transcriber_preserves_cases_in_test_case_directory(
+    tmp_path: Path,
+):
+    """Test directory-backed JSON test cases are preserved between runs."""
+    transcriber = get_guided_transcriber(
+        Language.yue_hant,
+        Language.zho_hans,
+        provider=Mock(spec=LLMProvider),
+        test_case_dir_path=tmp_path,
+        delineation_test_cases=[],
+        punctuation_test_cases=[],
+    )
+    delineation_json_path = tmp_path / "delineation" / "test.json"
+    punctuation_json_path = tmp_path / "punctuation" / "test.json"
+    delineation_test_case_data = [
+        {
+            "query": {
+                "ref_sub_1": "參考一",
+                "ref_sub_2": "參考二",
+                "target_sub_1": "目標一",
+                "target_sub_2": "目標二",
+            },
+            "answer": {},
+        }
+    ]
+    punctuation_test_case_data = [
+        {
+            "query": {
+                "ref_sub": "參考",
+                "target_subs": ["目標"],
+            },
+            "answer": {"target_sub_punctuated": "目標。"},
+            "difficulty": 2,
+        }
+    ]
+    delineation_json_path.write_text(
+        json.dumps(delineation_test_case_data),
+        encoding="utf-8",
+    )
+    punctuation_json_path.write_text(
+        json.dumps(punctuation_test_case_data),
+        encoding="utf-8",
+    )
+
+    with patch(
+        "scinoephile.lang.transcription.aligner.get_torch_device",
+        return_value="test",
+    ):
+        transcriber.aligner.update_all_test_cases()
+
+    assert json.loads(delineation_json_path.read_text(encoding="utf-8")) == (
+        delineation_test_case_data
+    )
+    assert json.loads(punctuation_json_path.read_text(encoding="utf-8")) == (
+        punctuation_test_case_data
+    )
 
 
 def test_get_guided_transcriber_loads_verified_cases_from_exact_json(tmp_path: Path):

--- a/test/lang/transcription/test_processor.py
+++ b/test/lang/transcription/test_processor.py
@@ -39,6 +39,8 @@ def _get_processor(
     """
     aligner = Mock(spec=TranscriptionAligner)
     aligner.align.side_effect = TranscriptionAlignment
+    aligner.prune_delineation_test_cases = False
+    aligner.prune_punctuation_test_cases = False
     return (
         GuidedTranscriptionProcessor(
             language=Language.eng,
@@ -476,7 +478,7 @@ def test_process_block_preserves_raw_segments_and_uses_buffered_offset():
         audio_block.audio,
         expected_last_start=0.75,
     )
-    aligner.update_all_test_cases.assert_called_once_with()
+    aligner.update_all_test_cases.assert_not_called()
 
 
 def test_process_block_applies_configured_segment_splitter():
@@ -514,7 +516,7 @@ def test_process_uses_exclusive_stop_index(caplog: LogCaptureFixture):
     Arguments:
         caplog: captured log records
     """
-    processor, _ = _get_processor()
+    processor, aligner = _get_processor()
     caplog.set_level(INFO, logger="scinoephile.lang.transcription.processor")
     audio_series = AudioSeries(
         audio=AudioSegment.silent(duration=6000),
@@ -542,6 +544,7 @@ def test_process_uses_exclusive_stop_index(caplog: LogCaptureFixture):
     assert output[0].text == "one"
     assert "BLOCK 1:" in caplog.text
     assert "BLOCK 0:" not in caplog.text
+    aligner.update_all_test_cases.assert_called_once_with()
 
 
 def test_process_uses_inclusive_start_index(caplog: LogCaptureFixture):
@@ -600,6 +603,52 @@ def test_process_rejects_mismatched_block_counts():
 
     with raises(ScinoephileError, match="Audio has 1 blocks"):
         processor.process(audio_series, reference_series)
+
+
+def test_process_rejects_partial_range_when_pruning_test_cases():
+    """Test pruning requires processing every block."""
+    processor, aligner = _get_processor()
+    aligner.prune_delineation_test_cases = True
+    audio_series = AudioSeries(
+        audio=AudioSegment.silent(duration=6000),
+        events=[
+            AudioSubtitle(start=0, end=1000, text="one"),
+            AudioSubtitle(start=5000, end=6000, text="two"),
+        ],
+    )
+    reference_series = Series(
+        events=[
+            Subtitle(start=0, end=1000, text="one"),
+            Subtitle(start=5000, end=6000, text="two"),
+        ]
+    )
+
+    with raises(ValueError, match="Cannot prune test cases"):
+        processor.process(audio_series, reference_series, stop_at_idx=1)
+
+    aligner.update_all_test_cases.assert_not_called()
+
+
+def test_process_does_not_save_test_cases_after_failure():
+    """Test test cases are not persisted when processing fails."""
+    processor, aligner = _get_processor()
+    audio_series = AudioSeries(
+        audio=AudioSegment.silent(duration=1000),
+        events=[AudioSubtitle(start=0, end=1000, text="one")],
+    )
+    reference_series = Series(events=[Subtitle(start=0, end=1000, text="one")])
+
+    with (
+        patch.object(
+            processor,
+            "process_block",
+            side_effect=ScinoephileError("transcription failed"),
+        ),
+        raises(ScinoephileError, match="transcription failed"),
+    ):
+        processor.process(audio_series, reference_series)
+
+    aligner.update_all_test_cases.assert_not_called()
 
 
 def test_process_rejects_negative_stop_index():

--- a/test/lang/transcription/test_punctuation_alignment.py
+++ b/test/lang/transcription/test_punctuation_alignment.py
@@ -10,12 +10,16 @@ from pydub import AudioSegment
 from pytest import MonkeyPatch
 
 from scinoephile.audio.subtitles import AudioSeries, AudioSubtitle
-from scinoephile.core.llms import Queryer
 from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.lang.transcription import aligner as aligner_module
 from scinoephile.lang.transcription.aligner import TranscriptionAligner
 from scinoephile.lang.transcription.alignment import TranscriptionAlignment
-from scinoephile.llms.punctuation import PunctuationPrompt, PunctuationTestCase
+from scinoephile.llms.delineation import DelineationProcessor
+from scinoephile.llms.punctuation import (
+    PunctuationProcessor,
+    PunctuationPrompt,
+    PunctuationTestCase,
+)
 
 _LOCALIZED_PROMPT = PunctuationPrompt(
     ref_sub="cankao",
@@ -76,8 +80,10 @@ def test_alignment_constructs_semantic_fields_with_configured_prompt():
 def test_aligner_uses_queryer_prompt_and_semantic_output(monkeypatch: MonkeyPatch):
     """Aligner should propagate its prompt and consume semantic answer output."""
     alignment = _get_alignment()
-    punctuation_queryer = Mock(spec=Queryer)
+    punctuation_queryer = Mock()
     punctuation_queryer.prompt = _LOCALIZED_PROMPT
+    punctuation_processor = Mock(spec=PunctuationProcessor)
+    punctuation_processor.queryer = punctuation_queryer
 
     def add_answer(
         test_case: PunctuationTestCase,
@@ -94,8 +100,8 @@ def test_aligner_uses_queryer_prompt_and_semantic_output(monkeypatch: MonkeyPatc
     punctuation_queryer.side_effect = add_answer
     monkeypatch.setattr(aligner_module, "get_sub_merged", _get_merged_subtitle)
     aligner = TranscriptionAligner(
-        delineation_queryer=Mock(spec=Queryer),
-        punctuation_queryer=punctuation_queryer,
+        delineation_processor=Mock(spec=DelineationProcessor),
+        punctuation_processor=punctuation_processor,
     )
 
     aligner._punctuate(alignment)
@@ -110,8 +116,10 @@ def test_aligner_falls_back_to_concatenation_after_invalid_answer(
 ):
     """A rejected answer should retain the existing concatenation fallback."""
     alignment = _get_alignment()
-    punctuation_queryer = Mock(spec=Queryer)
+    punctuation_queryer = Mock()
     punctuation_queryer.prompt = _LOCALIZED_PROMPT
+    punctuation_processor = Mock(spec=PunctuationProcessor)
+    punctuation_processor.queryer = punctuation_queryer
 
     def reject_answer(
         test_case: PunctuationTestCase,
@@ -128,8 +136,8 @@ def test_aligner_falls_back_to_concatenation_after_invalid_answer(
     punctuation_queryer.side_effect = reject_answer
     monkeypatch.setattr(aligner_module, "get_sub_merged", _get_merged_subtitle)
     aligner = TranscriptionAligner(
-        delineation_queryer=Mock(spec=Queryer),
-        punctuation_queryer=punctuation_queryer,
+        delineation_processor=Mock(spec=DelineationProcessor),
+        punctuation_processor=punctuation_processor,
     )
 
     aligner._punctuate(alignment)

--- a/test/lang/transcription/test_transcriber.py
+++ b/test/lang/transcription/test_transcriber.py
@@ -39,8 +39,10 @@ def _get_transcriber(
     """
     aligner = Mock(spec=TranscriptionAligner)
     aligner.align.side_effect = TranscriptionAlignment
-    aligner.prune_delineation_test_cases = False
-    aligner.prune_punctuation_test_cases = False
+    aligner.delineation_processor = Mock()
+    aligner.delineation_processor.prune_test_cases = False
+    aligner.punctuation_processor = Mock()
+    aligner.punctuation_processor.prune_test_cases = False
     return (
         GuidedTranscriber(
             language=Language.eng,
@@ -610,7 +612,7 @@ def test_process_rejects_mismatched_block_counts():
 def test_process_rejects_partial_range_when_pruning_test_cases():
     """Test pruning requires processing every block."""
     transcriber, aligner = _get_transcriber()
-    aligner.prune_delineation_test_cases = True
+    aligner.delineation_processor.prune_test_cases = True
     audio_series = AudioSeries(
         audio=AudioSegment.silent(duration=6000),
         events=[

--- a/test/lang/transcription/test_transcriber.py
+++ b/test/lang/transcription/test_transcriber.py
@@ -17,32 +17,32 @@ from scinoephile.core import Language, ScinoephileError
 from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.lang.transcription.aligner import TranscriptionAligner
 from scinoephile.lang.transcription.alignment import TranscriptionAlignment
-from scinoephile.lang.transcription.processor import (
+from scinoephile.lang.transcription.transcriber import (
     DemucsMode,
-    GuidedTranscriptionProcessor,
+    GuidedTranscriber,
     VADMode,
 )
 
 
-def _get_processor(
+def _get_transcriber(
     *,
     demucs_mode: DemucsMode = DemucsMode.OFF,
     vad_mode: VADMode = VADMode.OFF,
-) -> tuple[GuidedTranscriptionProcessor, Mock]:
-    """Get a processor with a passthrough alignment mock.
+) -> tuple[GuidedTranscriber, Mock]:
+    """Get a transcriber with a passthrough alignment mock.
 
     Arguments:
         demucs_mode: Demucs preprocessing mode
         vad_mode: Whisper VAD mode
     Returns:
-        processor and alignment mock
+        transcriber and alignment mock
     """
     aligner = Mock(spec=TranscriptionAligner)
     aligner.align.side_effect = TranscriptionAlignment
     aligner.prune_delineation_test_cases = False
     aligner.prune_punctuation_test_cases = False
     return (
-        GuidedTranscriptionProcessor(
+        GuidedTranscriber(
             language=Language.eng,
             reference_language=Language.zho_hans,
             model_name="test/model",
@@ -99,7 +99,7 @@ def test_segments_are_usable_rejects_repetitive_whisper_output():
         )
     ]
 
-    assert not GuidedTranscriptionProcessor._segments_are_usable(segments)
+    assert not GuidedTranscriber._segments_are_usable(segments)
 
 
 def test_segments_are_usable_rejects_nonpositive_word_duration():
@@ -115,7 +115,7 @@ def test_segments_are_usable_rejects_nonpositive_word_duration():
         TranscribedWord(text="啊", start=4.04, end=4.04, confidence=1.0),
     ]
 
-    assert not GuidedTranscriptionProcessor._segments_are_usable([segment])
+    assert not GuidedTranscriber._segments_are_usable([segment])
 
 
 def test_segments_are_usable_rejects_timestamp_beyond_audio():
@@ -128,7 +128,7 @@ def test_segments_are_usable_rejects_timestamp_beyond_audio():
         )
     ]
 
-    assert not GuidedTranscriptionProcessor._segments_are_usable(
+    assert not GuidedTranscriber._segments_are_usable(
         segments,
         audio_duration=10.0,
     )
@@ -144,7 +144,7 @@ def test_segments_are_usable_accepts_partial_guided_tail():
         )
     ]
 
-    assert GuidedTranscriptionProcessor._segments_are_usable(
+    assert GuidedTranscriber._segments_are_usable(
         segments,
         audio_duration=10.0,
     )
@@ -152,7 +152,7 @@ def test_segments_are_usable_accepts_partial_guided_tail():
 
 def test_missing_guided_tail_runs_focused_recovery():
     """Test a missing guided tail triggers normalized focused recovery."""
-    processor, _ = _get_processor(vad_mode=VADMode.OFF)
+    transcriber, _ = _get_transcriber(vad_mode=VADMode.OFF)
     initial_segments = [_get_segment(end=4.0, compression_ratio=1.0, with_words=True)]
     recovered_segments = [
         _get_segment(
@@ -164,22 +164,22 @@ def test_missing_guided_tail_runs_focused_recovery():
         )
     ]
     recovered_segments[0].no_speech_prob = 0.1
-    processor.no_vad_transcriber = Mock()
-    processor.no_vad_transcriber.get_cached_transcription.return_value = (
+    transcriber.no_vad_transcriber = Mock()
+    transcriber.no_vad_transcriber.get_cached_transcription.return_value = (
         initial_segments
     )
-    processor.tail_recovery_transcriber = Mock(return_value=recovered_segments)
-    processor.tail_recovery_transcriber.get_cached_transcription.return_value = None
+    transcriber.tail_recovery_transcriber = Mock(return_value=recovered_segments)
+    transcriber.tail_recovery_transcriber.get_cached_transcription.return_value = None
     audio = Sine(440).to_audio_segment(duration=10000).apply_gain(-20.0)
 
-    output = processor._transcribe_block_audio(audio, expected_last_start=8.0)
+    output = transcriber._transcribe_block_audio(audio, expected_last_start=8.0)
 
     assert output[:1] == initial_segments
     assert output[1].text == "tail"
     assert output[1].start == 5.2
     assert output[1].end == 5.8
-    normalized_tail_audio = processor.tail_recovery_transcriber.call_args.args[0]
-    processor.tail_recovery_transcriber.assert_called_once_with(
+    normalized_tail_audio = transcriber.tail_recovery_transcriber.call_args.args[0]
+    transcriber.tail_recovery_transcriber.assert_called_once_with(
         normalized_tail_audio,
         use_cache=False,
     )
@@ -189,36 +189,36 @@ def test_missing_guided_tail_runs_focused_recovery():
 
 def test_missing_guided_tail_keeps_base_after_unusable_cached_recovery():
     """Test an unusable focused-tail cache prevents redundant recovery."""
-    processor, _ = _get_processor(vad_mode=VADMode.OFF)
+    transcriber, _ = _get_transcriber(vad_mode=VADMode.OFF)
     initial_segments = [_get_segment(end=4.0, compression_ratio=1.0, with_words=True)]
     repetitive_segments = [_get_segment(compression_ratio=16.24, with_words=True)]
-    processor.no_vad_transcriber = Mock()
-    processor.no_vad_transcriber.get_cached_transcription.return_value = (
+    transcriber.no_vad_transcriber = Mock()
+    transcriber.no_vad_transcriber.get_cached_transcription.return_value = (
         initial_segments
     )
-    processor.tail_recovery_transcriber = Mock()
-    processor.tail_recovery_transcriber.get_cached_transcription.return_value = (
+    transcriber.tail_recovery_transcriber = Mock()
+    transcriber.tail_recovery_transcriber.get_cached_transcription.return_value = (
         repetitive_segments
     )
     audio = Sine(440).to_audio_segment(duration=10000).apply_gain(-20.0)
 
-    output = processor._transcribe_block_audio(audio, expected_last_start=8.0)
+    output = transcriber._transcribe_block_audio(audio, expected_last_start=8.0)
 
     assert output == initial_segments
     normalized_tail_audio = (
-        processor.tail_recovery_transcriber.get_cached_transcription.call_args.args[0]
+        transcriber.tail_recovery_transcriber.get_cached_transcription.call_args.args[0]
     )
     assert len(normalized_tail_audio) == 5000
     assert normalized_tail_audio.max_dBFS == approx(-1.0, abs=0.01)
-    processor.tail_recovery_transcriber.get_cached_transcription.assert_called_once_with(
+    transcriber.tail_recovery_transcriber.get_cached_transcription.assert_called_once_with(
         normalized_tail_audio
     )
-    processor.tail_recovery_transcriber.assert_not_called()
+    transcriber.tail_recovery_transcriber.assert_not_called()
 
 
 def test_missing_guided_tail_keeps_valid_base_without_credible_recovery():
     """Test implausible tail recovery does not invalidate a valid base transcript."""
-    processor, _ = _get_processor(vad_mode=VADMode.OFF)
+    transcriber, _ = _get_transcriber(vad_mode=VADMode.OFF)
     initial_segments = [_get_segment(end=4.0, compression_ratio=1.0, with_words=True)]
     stretched_segment = _get_segment(
         end=5.0,
@@ -236,57 +236,59 @@ def test_missing_guided_tail_keeps_valid_base_without_credible_recovery():
         with_words=True,
     )
     no_speech_segment.no_speech_prob = 0.9
-    processor.no_vad_transcriber = Mock()
-    processor.no_vad_transcriber.get_cached_transcription.return_value = (
+    transcriber.no_vad_transcriber = Mock()
+    transcriber.no_vad_transcriber.get_cached_transcription.return_value = (
         initial_segments
     )
-    processor.tail_recovery_transcriber = Mock(
+    transcriber.tail_recovery_transcriber = Mock(
         return_value=[stretched_segment, no_speech_segment]
     )
-    processor.tail_recovery_transcriber.get_cached_transcription.return_value = None
+    transcriber.tail_recovery_transcriber.get_cached_transcription.return_value = None
     audio = Sine(440).to_audio_segment(duration=10000).apply_gain(-20.0)
 
-    output = processor._transcribe_block_audio(audio, expected_last_start=8.0)
+    output = transcriber._transcribe_block_audio(audio, expected_last_start=8.0)
 
     assert output == initial_segments
 
 
 def test_auto_vad_uses_cached_non_vad_result_after_repetitive_vad_result():
     """Test automatic VAD skips a repetitive cached result."""
-    processor, _ = _get_processor(vad_mode=VADMode.AUTO)
+    transcriber, _ = _get_transcriber(vad_mode=VADMode.AUTO)
     repetitive_segments = [_get_segment(compression_ratio=16.24, with_words=True)]
     usable_segments = [_get_segment(compression_ratio=1.0, with_words=True)]
-    processor.vad_transcriber = Mock()
-    processor.vad_transcriber.get_cached_transcription.return_value = (
+    transcriber.vad_transcriber = Mock()
+    transcriber.vad_transcriber.get_cached_transcription.return_value = (
         repetitive_segments
     )
-    processor.no_vad_transcriber = Mock()
-    processor.no_vad_transcriber.get_cached_transcription.return_value = usable_segments
+    transcriber.no_vad_transcriber = Mock()
+    transcriber.no_vad_transcriber.get_cached_transcription.return_value = (
+        usable_segments
+    )
 
-    output = processor._transcribe_block_audio(AudioSegment.silent(duration=1000))
+    output = transcriber._transcribe_block_audio(AudioSegment.silent(duration=1000))
 
     assert output == usable_segments
-    processor.vad_transcriber.assert_not_called()
-    processor.no_vad_transcriber.assert_not_called()
+    transcriber.vad_transcriber.assert_not_called()
+    transcriber.no_vad_transcriber.assert_not_called()
 
 
 def test_rejected_cached_result_is_bypassed_for_fresh_retry():
     """Test a rejected cache entry does not prevent a fresh Whisper attempt."""
-    processor, _ = _get_processor(vad_mode=VADMode.OFF)
+    transcriber, _ = _get_transcriber(vad_mode=VADMode.OFF)
     repetitive_segments = [_get_segment(compression_ratio=16.24, with_words=True)]
     usable_segments = [_get_segment(compression_ratio=1.0, with_words=True)]
-    processor.no_vad_transcriber = Mock(return_value=usable_segments)
-    processor.no_vad_transcriber.get_cached_transcription.return_value = (
+    transcriber.no_vad_transcriber = Mock(return_value=usable_segments)
+    transcriber.no_vad_transcriber.get_cached_transcription.return_value = (
         repetitive_segments
     )
-    processor.recovery_transcriber = Mock()
-    processor.recovery_transcriber.get_cached_transcription.return_value = None
+    transcriber.recovery_transcriber = Mock()
+    transcriber.recovery_transcriber.get_cached_transcription.return_value = None
     audio = AudioSegment.silent(duration=1000)
 
-    output = processor._transcribe_block_audio(audio)
+    output = transcriber._transcribe_block_audio(audio)
 
     assert output == usable_segments
-    processor.no_vad_transcriber.assert_called_once_with(
+    transcriber.no_vad_transcriber.assert_called_once_with(
         audio,
         cache_audio=audio,
         use_cache=False,
@@ -295,24 +297,24 @@ def test_rejected_cached_result_is_bypassed_for_fresh_retry():
 
 def test_auto_vad_retries_without_vad_after_repetitive_new_result():
     """Test automatic VAD retries without VAD after a repetitive new result."""
-    processor, _ = _get_processor(vad_mode=VADMode.AUTO)
+    transcriber, _ = _get_transcriber(vad_mode=VADMode.AUTO)
     repetitive_segments = [_get_segment(compression_ratio=16.24, with_words=True)]
     usable_segments = [_get_segment(compression_ratio=1.0, with_words=True)]
-    processor.vad_transcriber = Mock(return_value=repetitive_segments)
-    processor.vad_transcriber.get_cached_transcription.return_value = None
-    processor.no_vad_transcriber = Mock(return_value=usable_segments)
-    processor.no_vad_transcriber.get_cached_transcription.return_value = None
+    transcriber.vad_transcriber = Mock(return_value=repetitive_segments)
+    transcriber.vad_transcriber.get_cached_transcription.return_value = None
+    transcriber.no_vad_transcriber = Mock(return_value=usable_segments)
+    transcriber.no_vad_transcriber.get_cached_transcription.return_value = None
     audio = AudioSegment.silent(duration=1000)
 
-    output = processor._transcribe_block_audio(audio)
+    output = transcriber._transcribe_block_audio(audio)
 
     assert output == usable_segments
-    processor.vad_transcriber.assert_called_once_with(
+    transcriber.vad_transcriber.assert_called_once_with(
         audio,
         cache_audio=audio,
         use_cache=False,
     )
-    processor.no_vad_transcriber.assert_called_once_with(
+    transcriber.no_vad_transcriber.assert_called_once_with(
         audio,
         cache_audio=audio,
         use_cache=False,
@@ -321,24 +323,24 @@ def test_auto_vad_retries_without_vad_after_repetitive_new_result():
 
 def test_unusable_no_vad_result_uses_defensive_recovery():
     """Test unusable non-VAD output is validated before defensive recovery."""
-    processor, _ = _get_processor(vad_mode=VADMode.OFF)
+    transcriber, _ = _get_transcriber(vad_mode=VADMode.OFF)
     repetitive_segments = [_get_segment(compression_ratio=16.24, with_words=True)]
     usable_segments = [_get_segment(compression_ratio=1.0, with_words=True)]
-    processor.no_vad_transcriber = Mock(return_value=repetitive_segments)
-    processor.no_vad_transcriber.get_cached_transcription.return_value = None
-    processor.recovery_transcriber = Mock(return_value=usable_segments)
-    processor.recovery_transcriber.get_cached_transcription.return_value = None
+    transcriber.no_vad_transcriber = Mock(return_value=repetitive_segments)
+    transcriber.no_vad_transcriber.get_cached_transcription.return_value = None
+    transcriber.recovery_transcriber = Mock(return_value=usable_segments)
+    transcriber.recovery_transcriber.get_cached_transcription.return_value = None
     audio = AudioSegment.silent(duration=1000)
 
-    output = processor._transcribe_block_audio(audio)
+    output = transcriber._transcribe_block_audio(audio)
 
     assert output == usable_segments
-    processor.no_vad_transcriber.assert_called_once_with(
+    transcriber.no_vad_transcriber.assert_called_once_with(
         audio,
         cache_audio=audio,
         use_cache=False,
     )
-    processor.recovery_transcriber.assert_called_once_with(
+    transcriber.recovery_transcriber.assert_called_once_with(
         audio,
         cache_audio=audio,
         use_cache=False,
@@ -347,114 +349,114 @@ def test_unusable_no_vad_result_uses_defensive_recovery():
 
 def test_all_unusable_candidates_leave_gap_for_translation():
     """Test unusable recovery output leaves an empty transcription block."""
-    processor, _ = _get_processor(vad_mode=VADMode.OFF)
+    transcriber, _ = _get_transcriber(vad_mode=VADMode.OFF)
     repetitive_segments = [_get_segment(compression_ratio=16.24, with_words=True)]
-    processor.no_vad_transcriber = Mock(return_value=repetitive_segments)
-    processor.no_vad_transcriber.get_cached_transcription.return_value = None
-    processor.recovery_transcriber = Mock(return_value=repetitive_segments)
-    processor.recovery_transcriber.get_cached_transcription.return_value = None
+    transcriber.no_vad_transcriber = Mock(return_value=repetitive_segments)
+    transcriber.no_vad_transcriber.get_cached_transcription.return_value = None
+    transcriber.recovery_transcriber = Mock(return_value=repetitive_segments)
+    transcriber.recovery_transcriber.get_cached_transcription.return_value = None
 
-    output = processor._transcribe_block_audio(AudioSegment.silent(duration=1000))
+    output = transcriber._transcribe_block_audio(AudioSegment.silent(duration=1000))
 
     assert output == []
 
 
 def test_auto_demucs_retries_unseparated_audio_after_unusable_result():
     """Test automatic Demucs retries the original audio before recovery decoding."""
-    processor, _ = _get_processor(
+    transcriber, _ = _get_transcriber(
         demucs_mode=DemucsMode.AUTO,
         vad_mode=VADMode.OFF,
     )
     repetitive_segments = [_get_segment(compression_ratio=16.24, with_words=True)]
     usable_segments = [_get_segment(compression_ratio=1.0, with_words=True)]
-    processor.no_vad_transcriber = Mock(return_value=repetitive_segments)
-    processor.no_vad_transcriber.get_cached_transcription.return_value = None
-    processor.unseparated_no_vad_transcriber = Mock(return_value=usable_segments)
-    processor.unseparated_no_vad_transcriber.get_cached_transcription.return_value = (
+    transcriber.no_vad_transcriber = Mock(return_value=repetitive_segments)
+    transcriber.no_vad_transcriber.get_cached_transcription.return_value = None
+    transcriber.unseparated_no_vad_transcriber = Mock(return_value=usable_segments)
+    transcriber.unseparated_no_vad_transcriber.get_cached_transcription.return_value = (
         None
     )
-    processor.recovery_transcriber = Mock()
-    processor.recovery_transcriber.get_cached_transcription.return_value = None
+    transcriber.recovery_transcriber = Mock()
+    transcriber.recovery_transcriber.get_cached_transcription.return_value = None
     original_audio = AudioSegment.silent(duration=1000)
     separated_audio = AudioSegment.silent(duration=900)
-    processor.demucs_separator = Mock(return_value=separated_audio)
+    transcriber.demucs_separator = Mock(return_value=separated_audio)
 
-    output = processor._transcribe_block_audio(original_audio)
+    output = transcriber._transcribe_block_audio(original_audio)
 
     assert output == usable_segments
-    processor.demucs_separator.assert_called_once_with(original_audio)
-    processor.no_vad_transcriber.assert_called_once_with(
+    transcriber.demucs_separator.assert_called_once_with(original_audio)
+    transcriber.no_vad_transcriber.assert_called_once_with(
         separated_audio,
         cache_audio=original_audio,
         use_cache=False,
     )
-    processor.unseparated_no_vad_transcriber.assert_called_once_with(
+    transcriber.unseparated_no_vad_transcriber.assert_called_once_with(
         original_audio,
         cache_audio=original_audio,
         use_cache=False,
     )
-    processor.recovery_transcriber.assert_not_called()
+    transcriber.recovery_transcriber.assert_not_called()
 
 
 def test_auto_demucs_uses_original_audio_after_separation_failure():
     """Test automatic Demucs recovers when vocal separation fails."""
-    processor, _ = _get_processor(
+    transcriber, _ = _get_transcriber(
         demucs_mode=DemucsMode.AUTO,
         vad_mode=VADMode.OFF,
     )
     usable_segments = [_get_segment(compression_ratio=1.0, with_words=True)]
-    processor.no_vad_transcriber = Mock()
-    processor.no_vad_transcriber.get_cached_transcription.return_value = None
-    processor.unseparated_no_vad_transcriber = Mock(return_value=usable_segments)
-    processor.unseparated_no_vad_transcriber.get_cached_transcription.return_value = (
+    transcriber.no_vad_transcriber = Mock()
+    transcriber.no_vad_transcriber.get_cached_transcription.return_value = None
+    transcriber.unseparated_no_vad_transcriber = Mock(return_value=usable_segments)
+    transcriber.unseparated_no_vad_transcriber.get_cached_transcription.return_value = (
         None
     )
-    processor.recovery_transcriber = Mock()
-    processor.recovery_transcriber.get_cached_transcription.return_value = None
+    transcriber.recovery_transcriber = Mock()
+    transcriber.recovery_transcriber.get_cached_transcription.return_value = None
     original_audio = AudioSegment.silent(duration=1000)
-    processor.demucs_separator = Mock(
+    transcriber.demucs_separator = Mock(
         side_effect=ScinoephileError("Demucs separation failed.")
     )
 
-    output = processor._transcribe_block_audio(original_audio)
+    output = transcriber._transcribe_block_audio(original_audio)
 
     assert output == usable_segments
-    processor.demucs_separator.assert_called_once_with(original_audio)
-    processor.no_vad_transcriber.assert_not_called()
-    processor.unseparated_no_vad_transcriber.assert_called_once_with(
+    transcriber.demucs_separator.assert_called_once_with(original_audio)
+    transcriber.no_vad_transcriber.assert_not_called()
+    transcriber.unseparated_no_vad_transcriber.assert_called_once_with(
         original_audio,
         cache_audio=original_audio,
         use_cache=False,
     )
-    processor.recovery_transcriber.assert_not_called()
+    transcriber.recovery_transcriber.assert_not_called()
 
 
 def test_forced_demucs_surfaces_separation_failure():
     """Test forced Demucs does not hide vocal-separation failures."""
-    processor, _ = _get_processor(
+    transcriber, _ = _get_transcriber(
         demucs_mode=DemucsMode.ON,
         vad_mode=VADMode.OFF,
     )
-    processor.no_vad_transcriber = Mock()
-    processor.no_vad_transcriber.get_cached_transcription.return_value = None
-    processor.recovery_transcriber = Mock()
-    processor.recovery_transcriber.get_cached_transcription.return_value = None
+    transcriber.no_vad_transcriber = Mock()
+    transcriber.no_vad_transcriber.get_cached_transcription.return_value = None
+    transcriber.recovery_transcriber = Mock()
+    transcriber.recovery_transcriber.get_cached_transcription.return_value = None
     original_audio = AudioSegment.silent(duration=1000)
-    processor.demucs_separator = Mock(
+    transcriber.demucs_separator = Mock(
         side_effect=ScinoephileError("Demucs separation failed.")
     )
 
     with raises(ScinoephileError, match="Demucs separation failed"):
-        processor._transcribe_block_audio(original_audio)
+        transcriber._transcribe_block_audio(original_audio)
 
-    processor.demucs_separator.assert_called_once_with(original_audio)
-    processor.no_vad_transcriber.assert_not_called()
-    processor.recovery_transcriber.assert_not_called()
+    transcriber.demucs_separator.assert_called_once_with(original_audio)
+    transcriber.no_vad_transcriber.assert_not_called()
+    transcriber.recovery_transcriber.assert_not_called()
 
 
 def test_process_block_preserves_raw_segments_and_uses_buffered_offset():
     """Test generic processing preserves segments and anchors buffered audio."""
-    processor, aligner = _get_processor()
+    transcriber, aligner = _get_transcriber()
     audio_block = AudioSeries(
         audio=AudioSegment.silent(duration=1000),
         events=[AudioSubtitle(start=1000, end=1500, text="reference")],
@@ -464,11 +466,11 @@ def test_process_block_preserves_raw_segments_and_uses_buffered_offset():
     segment = _get_segment()
 
     with patch.object(
-        processor,
+        transcriber,
         "_transcribe_block_audio",
         return_value=[segment],
     ) as transcribe_block_audio:
-        output = processor.process_block(audio_block, reference_block)
+        output = transcriber.process_block(audio_block, reference_block)
 
     assert len(output) == 1
     assert output[0].text == "hello"
@@ -483,8 +485,8 @@ def test_process_block_preserves_raw_segments_and_uses_buffered_offset():
 
 def test_process_block_applies_configured_segment_splitter():
     """Test language specs may split raw Whisper segments."""
-    processor, aligner = _get_processor()
-    processor.segment_splitter = Mock(
+    transcriber, aligner = _get_transcriber()
+    transcriber.segment_splitter = Mock(
         return_value=[
             _get_segment(segment_id=0, end=0.15, text="one"),
             _get_segment(segment_id=1, start=0.15, text="two"),
@@ -499,13 +501,13 @@ def test_process_block_applies_configured_segment_splitter():
     segment = _get_segment()
 
     with patch.object(
-        processor,
+        transcriber,
         "_transcribe_block_audio",
         return_value=[segment],
     ):
-        processor.process_block(audio_block, reference_block)
+        transcriber.process_block(audio_block, reference_block)
 
-    processor.segment_splitter.assert_called_once_with(segment)
+    transcriber.segment_splitter.assert_called_once_with(segment)
     transcription = aligner.align.call_args.args[1]
     assert [subtitle.text for subtitle in transcription] == ["one", "two"]
 
@@ -516,8 +518,8 @@ def test_process_uses_exclusive_stop_index(caplog: LogCaptureFixture):
     Arguments:
         caplog: captured log records
     """
-    processor, aligner = _get_processor()
-    caplog.set_level(INFO, logger="scinoephile.lang.transcription.processor")
+    transcriber, aligner = _get_transcriber()
+    caplog.set_level(INFO, logger="scinoephile.lang.transcription.transcriber")
     audio_series = AudioSeries(
         audio=AudioSegment.silent(duration=6000),
         events=[
@@ -533,11 +535,11 @@ def test_process_uses_exclusive_stop_index(caplog: LogCaptureFixture):
     )
 
     with patch.object(
-        processor,
+        transcriber,
         "process_block",
         side_effect=lambda audio_block, reference_block: audio_block,
     ) as process_block:
-        output = processor.process(audio_series, reference_series, stop_at_idx=1)
+        output = transcriber.process(audio_series, reference_series, stop_at_idx=1)
 
     assert process_block.call_count == 1
     assert len(output) == 1
@@ -553,8 +555,8 @@ def test_process_uses_inclusive_start_index(caplog: LogCaptureFixture):
     Arguments:
         caplog: captured log records
     """
-    processor, _ = _get_processor()
-    caplog.set_level(INFO, logger="scinoephile.lang.transcription.processor")
+    transcriber, _ = _get_transcriber()
+    caplog.set_level(INFO, logger="scinoephile.lang.transcription.transcriber")
     audio_series = AudioSeries(
         audio=AudioSegment.silent(duration=6000),
         events=[
@@ -570,11 +572,11 @@ def test_process_uses_inclusive_start_index(caplog: LogCaptureFixture):
     )
 
     with patch.object(
-        processor,
+        transcriber,
         "process_block",
         side_effect=lambda audio_block, reference_block: audio_block,
     ) as process_block:
-        output = processor.process(
+        output = transcriber.process(
             audio_series,
             reference_series,
             start_at_idx=1,
@@ -589,7 +591,7 @@ def test_process_uses_inclusive_start_index(caplog: LogCaptureFixture):
 
 def test_process_rejects_mismatched_block_counts():
     """Test guided transcription requires corresponding block structures."""
-    processor, _ = _get_processor()
+    transcriber, _ = _get_transcriber()
     audio_series = AudioSeries(
         audio=AudioSegment.silent(duration=6000),
         events=[AudioSubtitle(start=0, end=1000, text="one")],
@@ -602,12 +604,12 @@ def test_process_rejects_mismatched_block_counts():
     )
 
     with raises(ScinoephileError, match="Audio has 1 blocks"):
-        processor.process(audio_series, reference_series)
+        transcriber.process(audio_series, reference_series)
 
 
 def test_process_rejects_partial_range_when_pruning_test_cases():
     """Test pruning requires processing every block."""
-    processor, aligner = _get_processor()
+    transcriber, aligner = _get_transcriber()
     aligner.prune_delineation_test_cases = True
     audio_series = AudioSeries(
         audio=AudioSegment.silent(duration=6000),
@@ -624,14 +626,14 @@ def test_process_rejects_partial_range_when_pruning_test_cases():
     )
 
     with raises(ValueError, match="Cannot prune test cases"):
-        processor.process(audio_series, reference_series, stop_at_idx=1)
+        transcriber.process(audio_series, reference_series, stop_at_idx=1)
 
     aligner.update_all_test_cases.assert_not_called()
 
 
 def test_process_does_not_save_test_cases_after_failure():
     """Test test cases are not persisted when processing fails."""
-    processor, aligner = _get_processor()
+    transcriber, aligner = _get_transcriber()
     audio_series = AudioSeries(
         audio=AudioSegment.silent(duration=1000),
         events=[AudioSubtitle(start=0, end=1000, text="one")],
@@ -640,20 +642,20 @@ def test_process_does_not_save_test_cases_after_failure():
 
     with (
         patch.object(
-            processor,
+            transcriber,
             "process_block",
             side_effect=ScinoephileError("transcription failed"),
         ),
         raises(ScinoephileError, match="transcription failed"),
     ):
-        processor.process(audio_series, reference_series)
+        transcriber.process(audio_series, reference_series)
 
     aligner.update_all_test_cases.assert_not_called()
 
 
 def test_process_rejects_negative_stop_index():
     """Test guided transcription rejects negative stop indexes."""
-    processor, _ = _get_processor()
+    transcriber, _ = _get_transcriber()
     audio_series = AudioSeries(
         audio=AudioSegment.silent(duration=1000),
         events=[AudioSubtitle(start=0, end=1000, text="one")],
@@ -661,4 +663,4 @@ def test_process_rejects_negative_stop_index():
     reference_series = Series(events=[Subtitle(start=0, end=1000, text="one")])
 
     with raises(ValueError, match="greater than or equal to 0"):
-        processor.process(audio_series, reference_series, stop_at_idx=-1)
+        transcriber.process(audio_series, reference_series, stop_at_idx=-1)

--- a/test/workflows/test_transcription.py
+++ b/test/workflows/test_transcription.py
@@ -12,22 +12,22 @@ from pydub import AudioSegment
 from scinoephile.audio.subtitles import AudioSeries
 from scinoephile.core import Language
 from scinoephile.core.subtitles import Series, Subtitle
-from scinoephile.lang.transcription.processor import (
+from scinoephile.lang.transcription.transcriber import (
     DemucsMode,
-    GuidedTranscriptionProcessor,
+    GuidedTranscriber,
     VADMode,
 )
 from scinoephile.workflows.transcription import transcribe_series_guided
 
 
-def test_transcribe_series_guided_constructs_processor_for_language_pair(
+def test_transcribe_series_guided_constructs_transcriber_for_language_pair(
     tmp_path: Path,
 ):
     """Test workflow resolves construction and delegates processing."""
     audio_series = Mock(spec=AudioSeries)
     reference_series = Series(events=[Subtitle(start=0, end=1000, text="你好")])
     expected = AudioSeries(audio=AudioSegment.silent(duration=1000))
-    transcriber = Mock(spec=GuidedTranscriptionProcessor)
+    transcriber = Mock(spec=GuidedTranscriber)
     transcriber.process.return_value = expected
     delineation_json_path = tmp_path / "delineation.json"
     punctuation_json_path = tmp_path / "punctuation.json"

--- a/test/workflows/test_transcription.py
+++ b/test/workflows/test_transcription.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 from pydub import AudioSegment
@@ -19,13 +20,17 @@ from scinoephile.lang.transcription.processor import (
 from scinoephile.workflows.transcription import transcribe_series_guided
 
 
-def test_transcribe_series_guided_constructs_processor_for_language_pair():
+def test_transcribe_series_guided_constructs_processor_for_language_pair(
+    tmp_path: Path,
+):
     """Test workflow resolves construction and delegates processing."""
     audio_series = Mock(spec=AudioSeries)
     reference_series = Series(events=[Subtitle(start=0, end=1000, text="你好")])
     expected = AudioSeries(audio=AudioSegment.silent(duration=1000))
     transcriber = Mock(spec=GuidedTranscriptionProcessor)
     transcriber.process.return_value = expected
+    delineation_json_path = tmp_path / "delineation.json"
+    punctuation_json_path = tmp_path / "punctuation.json"
 
     with patch(
         "scinoephile.workflows.transcription.get_guided_transcriber",
@@ -36,6 +41,8 @@ def test_transcribe_series_guided_constructs_processor_for_language_pair():
             reference_series,
             language=Language.yue_hant,
             reference_language=Language.zho_hans,
+            delineation_json_path=delineation_json_path,
+            punctuation_json_path=punctuation_json_path,
             stop_at_idx=2,
         )
 
@@ -46,6 +53,14 @@ def test_transcribe_series_guided_constructs_processor_for_language_pair():
     )
     assert get_transcriber.call_args.kwargs["demucs_mode"] is DemucsMode.AUTO
     assert get_transcriber.call_args.kwargs["vad_mode"] is VADMode.AUTO
+    assert (
+        get_transcriber.call_args.kwargs["delineation_json_path"]
+        == delineation_json_path
+    )
+    assert (
+        get_transcriber.call_args.kwargs["punctuation_json_path"]
+        == punctuation_json_path
+    )
     transcriber.process.assert_called_once_with(
         audio_series,
         reference_series,

--- a/test/workflows/test_transcription.py
+++ b/test/workflows/test_transcription.py
@@ -41,6 +41,7 @@ def test_transcribe_series_guided_constructs_processor_for_language_pair(
             reference_series,
             language=Language.yue_hant,
             reference_language=Language.zho_hans,
+            prune_test_cases=True,
             delineation_json_path=delineation_json_path,
             punctuation_json_path=punctuation_json_path,
             start_at_idx=1,
@@ -54,6 +55,7 @@ def test_transcribe_series_guided_constructs_processor_for_language_pair(
     )
     assert get_transcriber.call_args.kwargs["demucs_mode"] is DemucsMode.AUTO
     assert get_transcriber.call_args.kwargs["vad_mode"] is VADMode.AUTO
+    assert get_transcriber.call_args.kwargs["prune_test_cases"] is True
     assert (
         get_transcriber.call_args.kwargs["delineation_json_path"]
         == delineation_json_path


### PR DESCRIPTION
## Summary

Adds `--delineation-json` and `--punctuation-json` to guided transcription. The factory loads workflow-local cases after bundled cases, so local entries take precedence, and updates the exact files selected for the run.

Pruning is opt-in through `prune_test_cases=True` and is rejected for partial transcriptions, so routine and resumed runs preserve unencountered cases.

## Why

Fixture-generation and workflow runs need to evolve their own test-case corpora without relying on a shared runtime-cache directory. Routine runs must retain previously collected cases, while intentional full fixture regeneration can prune stale ones.

## Validation

- `uv run ruff format`
- `uv run ruff check --fix`
- `uv run ty check`
- `cd test && uv run pytest -n auto` — 1,861 passed, 9 skipped