### PR TITLE
Bound SeriesDiff one-sided spans

### DIFF
--- a/scinoephile/analysis/diff/series_diff.py
+++ b/scinoephile/analysis/diff/series_diff.py
@@ -304,6 +304,8 @@ class SeriesDiff:
         Returns:
             updated first- and second-side local line positions
         """
+        one_line_stop = max(one_line_pos, min(one_line_stop, len(one_side.lines)))
+        two_line_stop = max(two_line_pos, min(two_line_stop, len(two_side.lines)))
         one_local_idxs = tuple(range(one_line_pos, one_line_stop))
         two_local_idxs = tuple(range(two_line_pos, two_line_stop))
         matcher = difflib.SequenceMatcher(

--- a/test/analysis/character_error_rate/test_character_error_rate.py
+++ b/test/analysis/character_error_rate/test_character_error_rate.py
@@ -217,3 +217,21 @@ def test_series_cer_string_uses_na_for_empty_reference():
         "Deletions: 0 (N/A)\n"
         "Reference length: 0"
     )
+
+
+def test_series_cer_handles_one_sided_span_after_shorter_side_is_exhausted():
+    """A trailing one-sided span should not overrun the shorter series."""
+    reference = get_text_series(
+        "係嗰度呀⋯⋯",
+        "係嗰邊呀，快點去⋯⋯",
+        "呢度仲有一隻",
+        "呢隻細隻啲",
+    )
+    candidate = get_text_series(
+        "係嗰邊呀，快點去⋯⋯",
+        "呢度仲有一隻",
+    )
+
+    result = SeriesCER(reference, candidate)
+
+    assert result.reference_length > 0


### PR DESCRIPTION
## Summary

Clamps equal-line span bounds to the available lines before constructing a `SequenceMatcher` input.

## Root cause

A trailing one-sided span could calculate a stop index beyond the shorter side and attempt to read a nonexistent line.

## Validation

- `uv run ruff format`
- `uv run ruff check --fix`
- `uv run ty check`
- `cd test && uv run pytest -n auto analysis/diff/test_series_diff.py analysis/character_error_rate/test_character_error_rate.py`