### PR TITLE
Type LLM managers by test case

### DIFF
--- a/scinoephile/cli/audit/audit_cli_base.py
+++ b/scinoephile/cli/audit/audit_cli_base.py
@@ -111,13 +111,13 @@ class AuditCliBase(ScinoephileCliBase):
         parser.set_defaults(_parser=parser)
 
     @staticmethod
-    def load_test_cases(
+    def load_test_cases[TTestCase: TestCase](
         parser: ArgumentParser,
         json_path: Path,
-        manager_cls: type[Manager],
+        manager_cls: type[Manager[TTestCase]],
         *,
         workflow_name: str,
-    ) -> list[TestCase]:
+    ) -> list[TTestCase]:
         """Load test cases from workflow JSON.
 
         Arguments:

--- a/scinoephile/core/llms/manager.py
+++ b/scinoephile/core/llms/manager.py
@@ -9,7 +9,7 @@ from collections.abc import Mapping
 from copy import copy
 from dataclasses import dataclass
 from functools import cache
-from typing import Any, ClassVar
+from typing import Any, ClassVar, cast
 
 from pydantic import create_model
 
@@ -37,7 +37,7 @@ class PromptModelField:
     """JSON schema description, or None to retain the semantic description."""
 
 
-class Manager(ABC):
+class Manager[TTestCase: TestCase](ABC):
     """ABC for LLM managers."""
 
     operation: ClassVar[str]
@@ -121,7 +121,7 @@ class Manager(ABC):
 
     @classmethod
     @cache
-    def get_test_case_cls(cls, prompt: Prompt) -> type[TestCase]:
+    def get_test_case_cls(cls, prompt: Prompt) -> type[TTestCase]:
         """Get concrete test case class with provided configuration.
 
         Arguments:
@@ -149,4 +149,4 @@ class Manager(ABC):
         )
         model.query_cls = query_cls
         model.answer_cls = answer_cls
-        return model
+        return cast("type[TTestCase]", model)

--- a/scinoephile/core/llms/utils.py
+++ b/scinoephile/core/llms/utils.py
@@ -25,13 +25,13 @@ __all__ = [
 ]
 
 
-def load_test_cases(
-    manager_cls: type[Manager],
+def load_test_cases[TTestCase: TestCase](
+    manager_cls: type[Manager[TTestCase]],
     prompt: Prompt,
     *,
-    test_cases: Iterable[TestCase] | None = None,
+    test_cases: Iterable[TTestCase] | None = None,
     test_case_path: Path | None = None,
-) -> tuple[list[TestCase], Path | None]:
+) -> tuple[list[TTestCase], Path | None]:
     """Load test cases from supplied cases and an optional JSON file.
 
     Test cases loaded from the JSON file replace supplied cases with matching queries.
@@ -61,11 +61,11 @@ def load_test_cases(
     return list(test_cases_by_query_key.values()), test_case_path
 
 
-def load_test_cases_from_json(
+def load_test_cases_from_json[TTestCase: TestCase](
     input_path: Path,
-    manager_cls: type[Manager],
+    manager_cls: type[Manager[TTestCase]],
     prompt: Prompt,
-) -> list[TestCase]:
+) -> list[TTestCase]:
     """Load test cases from JSON file.
 
     Arguments:
@@ -84,9 +84,7 @@ def load_test_cases_from_json(
         raw_test_cases: object = json.load(input_file)
 
     # Validate using the base-prompt schema
-    base_test_case_list_type = (
-        list[base_test_case_cls]  # ty: ignore[invalid-type-form]
-    )
+    base_test_case_list_type = list[base_test_case_cls]
     base_test_case_adapter = TypeAdapter(base_test_case_list_type)
     validated_base_test_cases = base_test_case_adapter.validate_python(
         raw_test_cases,
@@ -96,10 +94,10 @@ def load_test_cases_from_json(
         extra="forbid",
         context={"alias_only": True},
     )
-    base_test_cases = cast("list[TestCase]", validated_base_test_cases)
+    base_test_cases = cast("list[TTestCase]", validated_base_test_cases)
 
     # Convert to the requested prompt schema
-    test_cases: list[TestCase] = []
+    test_cases: list[TTestCase] = []
     for base_test_case in base_test_cases:
         test_case_data = base_test_case.model_dump(mode="json")
         test_case = test_case_cls.model_validate(test_case_data)
@@ -108,10 +106,10 @@ def load_test_cases_from_json(
     return test_cases
 
 
-def save_test_cases_to_json(
+def save_test_cases_to_json[TTestCase: TestCase](
     output_path: Path,
-    test_cases: Iterable[TestCase],
-    manager_cls: type[Manager],
+    test_cases: Iterable[TTestCase],
+    manager_cls: type[Manager[TTestCase]],
     *,
     prune: bool = False,
 ):

--- a/scinoephile/llms/delineation/manager.py
+++ b/scinoephile/llms/delineation/manager.py
@@ -21,7 +21,7 @@ from .prompt import DelineationPrompt
 __all__ = ["DelineationManager"]
 
 
-class DelineationManager(Manager):
+class DelineationManager(Manager[DelineationTestCase]):
     """Factories for prompt-specific delineation LLM classes."""
 
     operation: ClassVar[str] = "delineation"

--- a/scinoephile/llms/gap_translation/manager.py
+++ b/scinoephile/llms/gap_translation/manager.py
@@ -26,7 +26,7 @@ from .prompt import GapTranslationPrompt
 __all__ = ["GapTranslationManager"]
 
 
-class GapTranslationManager(Manager):
+class GapTranslationManager(Manager[GapTranslationTestCase]):
     """Factories for prompt-specific gap-translation LLM classes."""
 
     operation: ClassVar[str] = "gap-translation"

--- a/scinoephile/llms/guided_review/manager.py
+++ b/scinoephile/llms/guided_review/manager.py
@@ -23,7 +23,7 @@ from .prompt import GuidedReviewPrompt
 __all__ = ["GuidedReviewManager"]
 
 
-class GuidedReviewManager(Manager):
+class GuidedReviewManager(Manager[GuidedReviewTestCase]):
     """Factories for prompt-specific guided-review LLM classes."""
 
     operation: ClassVar[str] = "guided-review"

--- a/scinoephile/llms/guided_translation/manager.py
+++ b/scinoephile/llms/guided_translation/manager.py
@@ -26,7 +26,7 @@ from .prompt import GuidedTranslationPrompt
 __all__ = ["GuidedTranslationManager"]
 
 
-class GuidedTranslationManager(Manager):
+class GuidedTranslationManager(Manager[GuidedTranslationTestCase]):
     """Factories for prompt-specific guided-translation LLM classes."""
 
     operation: ClassVar[str] = "guided-translation"

--- a/scinoephile/llms/ocr_fusion/manager.py
+++ b/scinoephile/llms/ocr_fusion/manager.py
@@ -21,7 +21,7 @@ from .prompt import OcrFusionPrompt
 __all__ = ["OcrFusionManager"]
 
 
-class OcrFusionManager(Manager):
+class OcrFusionManager(Manager[OcrFusionTestCase]):
     """Factories for OCR fusion LLM classes."""
 
     operation: ClassVar[str] = "ocr-fusion"

--- a/scinoephile/llms/punctuation/manager.py
+++ b/scinoephile/llms/punctuation/manager.py
@@ -21,7 +21,7 @@ from .prompt import PunctuationPrompt
 __all__ = ["PunctuationManager"]
 
 
-class PunctuationManager(Manager):
+class PunctuationManager(Manager[PunctuationTestCase]):
     """Factories for punctuation LLM classes."""
 
     operation: ClassVar[str] = "punctuation"

--- a/scinoephile/llms/review/manager.py
+++ b/scinoephile/llms/review/manager.py
@@ -23,7 +23,7 @@ from .prompt import ReviewPrompt
 __all__ = ["ReviewManager"]
 
 
-class ReviewManager(Manager):
+class ReviewManager(Manager[ReviewTestCase]):
     """Factories for prompt-specific review LLM classes."""
 
     operation: ClassVar[str] = "review"

--- a/scinoephile/llms/translation/manager.py
+++ b/scinoephile/llms/translation/manager.py
@@ -27,7 +27,7 @@ from .prompt import TranslationPrompt
 __all__ = ["TranslationManager"]
 
 
-class TranslationManager(Manager):
+class TranslationManager(Manager[TranslationTestCase]):
     """Factories for prompt-specific translation LLM classes."""
 
     operation: ClassVar[str] = "translation"


### PR DESCRIPTION
## Summary

- parameterize `Manager` with its semantic test-case type
- preserve that type through test-case JSON loading, persistence, and audit CLI helpers
- declare each concrete manager's test-case type and remove an obsolete type-checker suppression

## Why

Managers already identify their semantic test-case model at runtime, but the shared helpers erased that information in their type signatures. This makes the relationship explicit without changing runtime behavior.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format …`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix …`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto core/llms/test_manager.py core/llms/test_utils.py cli/test_audit_cli.py`