### PR TITLE
Add transcription delineation and punctuation audits

### DIFF
--- a/scinoephile/__init__.py
+++ b/scinoephile/__init__.py
@@ -5,7 +5,8 @@
 Package hierarchy (modules may import from any above):
 * common
 * core
-* analysis / image / llms
+* image / llms
+* analysis
 * media
 * audio
 * lang

--- a/scinoephile/analysis/audit/__init__.py
+++ b/scinoephile/analysis/audit/__init__.py
@@ -4,6 +4,6 @@
 
 Package hierarchy (modules may import from any above):
 * utils
-* ocr_fusion / review
+* delineation / ocr_fusion / punctuation / review
 * guided_review
 """

--- a/scinoephile/analysis/audit/delineation.py
+++ b/scinoephile/analysis/audit/delineation.py
@@ -13,13 +13,13 @@ from scinoephile.core.subtitles import Series
 from scinoephile.llms.delineation import DelineationTestCase
 
 from .utils import (
-    _AuditResult,
-    _get_contextual_index,
-    _get_superseded_keys,
+    AuditResult,
     escape_table_cell,
     format_block_range,
     format_index_range,
+    get_contextual_index,
     get_selected_event_indexes,
+    get_superseded_keys,
     validate_block_range,
     validate_index_range,
 )
@@ -113,19 +113,19 @@ def audit_delineation(
         if answer is None:
             output = "(unanswered)"
             unanswered += 1
-            result = _AuditResult.unanswered
+            result = AuditResult.unanswered
         elif answer.output_one or answer.output_two:
             output = _format_pair(answer.output_one, answer.output_two)
             shifts += 1
-            result = _AuditResult.changed
+            result = AuditResult.changed
         else:
             output = ""
             no_shifts += 1
-            result = _AuditResult.unchanged
+            result = AuditResult.unchanged
 
         if (
             row_filter is DelineationAuditFilter.changes
-            and result is not _AuditResult.changed
+            and result is not AuditResult.changed
         ) or (row_filter is DelineationAuditFilter.unverified and test_case.verified):
             continue
 
@@ -214,7 +214,7 @@ def _get_case_index(
     if direct_index is not None:
         return direct_index
 
-    contextual_index = _get_contextual_index(
+    contextual_index = get_contextual_index(
         candidate_indexes,
         direct_indexes,
         test_case_index - 1,
@@ -257,7 +257,7 @@ def _get_case_indexes(
         reference_pair = (query.reference_one, query.reference_two)
         target_pair = (query.target_one, query.target_two)
         target_pairs_by_reference_pair[reference_pair].add(target_pair)
-    superseded_pairs = _get_superseded_keys(
+    superseded_pairs = get_superseded_keys(
         pair_indexes,
         target_pairs_by_reference_pair,
     )

--- a/scinoephile/analysis/audit/delineation.py
+++ b/scinoephile/analysis/audit/delineation.py
@@ -1,0 +1,292 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Audit transcription delineation decisions and format them as Markdown."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Collection, Sequence
+from enum import StrEnum
+
+from scinoephile.core.exceptions import ScinoephileError
+from scinoephile.core.subtitles import Series
+from scinoephile.llms.delineation import DelineationTestCase
+
+from .utils import (
+    _AuditResult,
+    _get_contextual_index,
+    _get_superseded_keys,
+    escape_table_cell,
+    format_block_range,
+    format_index_range,
+    get_selected_event_indexes,
+    validate_block_range,
+    validate_index_range,
+)
+
+__all__ = [
+    "DelineationAuditFilter",
+    "audit_delineation",
+]
+
+
+class DelineationAuditFilter(StrEnum):
+    """Row filters supported by a transcription delineation audit."""
+
+    all = "all"
+    """Include every logged boundary decision."""
+
+    changes = "changes"
+    """Include only decisions that shifted the target boundary."""
+
+    unverified = "unverified"
+    """Include only decisions not marked as verified."""
+
+
+def audit_delineation(
+    reference: Series,
+    test_cases: Sequence[DelineationTestCase],
+    *,
+    row_filter: DelineationAuditFilter = DelineationAuditFilter.all,
+    first_index: int | None = None,
+    last_index: int | None = None,
+    first_block: int | None = None,
+    last_block: int | None = None,
+) -> str:
+    """Audit logged transcription boundary decisions against their reference.
+
+    Arguments:
+        reference: reference subtitle series used to guide transcription
+        test_cases: logged delineation test cases
+        row_filter: row status filter
+        first_index: first 1-indexed reference subtitle number to include
+        last_index: last 1-indexed reference subtitle number to include
+        first_block: first 1-indexed reference block number to include
+        last_block: last 1-indexed reference block number to include
+    Returns:
+        Markdown audit report
+    Raises:
+        ScinoephileError: if a logged reference pair cannot be matched uniquely
+    """
+    validate_index_range(first_index, last_index)
+    validate_block_range(first_block, last_block)
+
+    pair_indexes: dict[tuple[str, str], list[int]] = defaultdict(list)
+    for index in range(len(reference) - 1):
+        pair = (reference[index].text, reference[index + 1].text)
+        pair_indexes[pair].append(index)
+
+    selected_reference_indexes = get_selected_event_indexes(
+        reference,
+        first_index=first_index,
+        last_index=last_index,
+        first_block=first_block,
+        last_block=last_block,
+    )
+    candidate_indexes_by_case, direct_indexes = _get_case_indexes(
+        pair_indexes,
+        test_cases,
+        selected_reference_indexes=selected_reference_indexes,
+    )
+
+    rows: list[tuple[int, str]] = []
+    shifts = 0
+    no_shifts = 0
+    unanswered = 0
+    logged_cases = 0
+    for test_case_index, test_case in enumerate(test_cases, 1):
+        candidate_indexes = candidate_indexes_by_case[test_case_index - 1]
+        if not candidate_indexes:
+            continue
+        index = _get_case_index(
+            candidate_indexes,
+            direct_indexes,
+            test_case_index=test_case_index,
+        )
+        query = test_case.query
+        first_subtitle_index = index + 1
+        second_subtitle_index = index + 2
+        logged_cases += 1
+
+        input_target = (query.target_one, query.target_two)
+        answer = test_case.answer
+        if answer is None:
+            output = "(unanswered)"
+            unanswered += 1
+            result = _AuditResult.unanswered
+        elif answer.output_one or answer.output_two:
+            output = _format_pair(answer.output_one, answer.output_two)
+            shifts += 1
+            result = _AuditResult.changed
+        else:
+            output = ""
+            no_shifts += 1
+            result = _AuditResult.unchanged
+
+        if (
+            row_filter is DelineationAuditFilter.changes
+            and result is not _AuditResult.changed
+        ) or (row_filter is DelineationAuditFilter.unverified and test_case.verified):
+            continue
+
+        cells = (
+            f"{first_subtitle_index}\n{second_subtitle_index}",
+            _format_pair(query.reference_one, query.reference_two),
+            _format_pair(*input_target),
+            output,
+            "",
+            "✓" if test_case.verified else "",
+        )
+        rows.append(
+            (
+                first_subtitle_index,
+                f"| {' | '.join(escape_table_cell(cell) for cell in cells)} |",
+            )
+        )
+
+    rows.sort(key=lambda item: item[0])
+
+    lines = [
+        "# Transcription Delineation Audit",
+        "",
+        "## Summary",
+        "",
+        f"- logged cases: {logged_cases}",
+        f"- boundary shifts: {shifts}",
+        f"- no-shift answers: {no_shifts}",
+        f"- unanswered cases: {unanswered}",
+        f"- row filter: {row_filter.value}",
+    ]
+    range_summary = format_index_range(
+        first_index,
+        last_index,
+        track_name="reference",
+    )
+    if range_summary is not None:
+        lines.append(range_summary)
+    block_range_summary = format_block_range(first_block, last_block)
+    if block_range_summary is not None:
+        lines.append(block_range_summary)
+    lines.extend(
+        (
+            f"- table rows: {len(rows)}",
+            "",
+            "## Audit Table",
+            "",
+            "| Indexes | Reference | Input | Output | Notes | Verified |",
+            "|---:|---|---|---|---|:---:|",
+            *(row for _, row in rows),
+        )
+    )
+    return "\n".join(lines) + "\n"
+
+
+def _format_pair(one: str, two: str) -> str:
+    """Stack a pair of subtitle texts for one table cell.
+
+    Arguments:
+        one: first subtitle text
+        two: second subtitle text
+    Returns:
+        subtitle texts separated by a newline
+    """
+    return f"{one or '—'}\n{two or '—'}"
+
+
+def _get_case_index(
+    candidate_indexes: Sequence[int],
+    direct_indexes: list[int | None],
+    *,
+    test_case_index: int,
+) -> int:
+    """Resolve one delineation case's reference-pair index.
+
+    Arguments:
+        candidate_indexes: possible zero-indexed reference-pair positions
+        direct_indexes: directly resolved indexes for every logged case
+        test_case_index: one-indexed test case position
+    Returns:
+        uniquely resolved zero-indexed reference-pair position
+    Raises:
+        ScinoephileError: if a case remains ambiguous
+    """
+    direct_index = direct_indexes[test_case_index - 1]
+    if direct_index is not None:
+        return direct_index
+
+    contextual_index = _get_contextual_index(
+        candidate_indexes,
+        direct_indexes,
+        test_case_index - 1,
+    )
+    if contextual_index is not None:
+        direct_indexes[test_case_index - 1] = contextual_index
+        return contextual_index
+
+    indexes = ", ".join(str(index + 1) for index in candidate_indexes)
+    raise ScinoephileError(
+        "Unable to audit transcription delineation: "
+        f"test case {test_case_index} reference pair is ambiguous; "
+        f"it begins at subtitle indexes {indexes}"
+    )
+
+
+def _get_case_indexes(
+    pair_indexes: dict[tuple[str, str], list[int]],
+    test_cases: Sequence[DelineationTestCase],
+    *,
+    selected_reference_indexes: Collection[int],
+) -> tuple[list[list[int]], list[int | None]]:
+    """Get candidate and directly resolved indexes for logged cases.
+
+    Arguments:
+        pair_indexes: reference-pair positions keyed by subtitle text
+        test_cases: logged delineation test cases
+        selected_reference_indexes: selected zero-based reference subtitle indexes
+    Returns:
+        candidate and directly resolved indexes for every logged case
+    Raises:
+        ScinoephileError: if a logged reference pair is absent
+    """
+    target_pairs_by_reference_pair: dict[
+        tuple[str, str],
+        set[tuple[str, str]],
+    ] = defaultdict(set)
+    for test_case in test_cases:
+        query = test_case.query
+        reference_pair = (query.reference_one, query.reference_two)
+        target_pair = (query.target_one, query.target_two)
+        target_pairs_by_reference_pair[reference_pair].add(target_pair)
+    superseded_pairs = _get_superseded_keys(
+        pair_indexes,
+        target_pairs_by_reference_pair,
+    )
+    candidate_indexes_by_case: list[list[int]] = []
+    direct_indexes: list[int | None] = []
+    for test_case_index, test_case in enumerate(test_cases, 1):
+        query = test_case.query
+        pair = (query.reference_one, query.reference_two)
+        matches = pair_indexes.get(pair, [])
+        if not matches:
+            if pair in superseded_pairs:
+                candidate_indexes_by_case.append([])
+                direct_indexes.append(None)
+                continue
+            raise ScinoephileError(
+                "Unable to audit transcription delineation: "
+                f"test case {test_case_index} reference pair was not found in "
+                "reference subtitles"
+            )
+
+        candidate_indexes = [
+            index
+            for index in matches
+            if index in selected_reference_indexes
+            and index + 1 in selected_reference_indexes
+        ]
+        candidate_indexes_by_case.append(candidate_indexes)
+        direct_index = None
+        if len(candidate_indexes) == 1:
+            direct_index = candidate_indexes[0]
+        direct_indexes.append(direct_index)
+    return candidate_indexes_by_case, direct_indexes

--- a/scinoephile/analysis/audit/delineation.py
+++ b/scinoephile/analysis/audit/delineation.py
@@ -86,7 +86,6 @@ def audit_delineation(
     candidate_indexes_by_case, direct_indexes = _get_case_indexes(
         pair_indexes,
         test_cases,
-        selected_reference_indexes=selected_reference_indexes,
     )
 
     rows: list[tuple[int, str]] = []
@@ -95,14 +94,15 @@ def audit_delineation(
     unanswered = 0
     logged_cases = 0
     for test_case_index, test_case in enumerate(test_cases, 1):
-        candidate_indexes = candidate_indexes_by_case[test_case_index - 1]
-        if not candidate_indexes:
-            continue
-        index = _get_case_index(
-            candidate_indexes,
+        # Resolve against all occurrences before filtering to the requested range
+        index = _get_selected_case_index(
+            candidate_indexes_by_case[test_case_index - 1],
             direct_indexes,
+            selected_reference_indexes,
             test_case_index=test_case_index,
         )
+        if index is None:
+            continue
         query = test_case.query
         first_subtitle_index = index + 1
         second_subtitle_index = index + 2
@@ -234,15 +234,12 @@ def _get_case_index(
 def _get_case_indexes(
     pair_indexes: dict[tuple[str, str], list[int]],
     test_cases: Sequence[DelineationTestCase],
-    *,
-    selected_reference_indexes: Collection[int],
 ) -> tuple[list[list[int]], list[int | None]]:
     """Get candidate and directly resolved indexes for logged cases.
 
     Arguments:
         pair_indexes: reference-pair positions keyed by subtitle text
         test_cases: logged delineation test cases
-        selected_reference_indexes: selected zero-based reference subtitle indexes
     Returns:
         candidate and directly resolved indexes for every logged case
     Raises:
@@ -278,15 +275,46 @@ def _get_case_indexes(
                 "reference subtitles"
             )
 
-        candidate_indexes = [
-            index
-            for index in matches
-            if index in selected_reference_indexes
-            and index + 1 in selected_reference_indexes
-        ]
+        candidate_indexes = list(matches)
         candidate_indexes_by_case.append(candidate_indexes)
         direct_index = None
         if len(candidate_indexes) == 1:
             direct_index = candidate_indexes[0]
         direct_indexes.append(direct_index)
     return candidate_indexes_by_case, direct_indexes
+
+
+def _get_selected_case_index(
+    candidate_indexes: Sequence[int],
+    direct_indexes: list[int | None],
+    selected_reference_indexes: Collection[int],
+    *,
+    test_case_index: int,
+) -> int | None:
+    """Resolve one case globally and retain it only when selected.
+
+    Arguments:
+        candidate_indexes: possible zero-indexed reference-pair positions
+        direct_indexes: directly resolved indexes for every logged case
+        selected_reference_indexes: selected zero-based reference subtitle indexes
+        test_case_index: one-indexed test case position
+    Returns:
+        selected reference-pair position, or None if outside the requested range
+    """
+    selected_candidate_indexes = {
+        index
+        for index in candidate_indexes
+        if index in selected_reference_indexes
+        and index + 1 in selected_reference_indexes
+    }
+    if not selected_candidate_indexes:
+        return None
+
+    index = _get_case_index(
+        candidate_indexes,
+        direct_indexes,
+        test_case_index=test_case_index,
+    )
+    if index not in selected_candidate_indexes:
+        return None
+    return index

--- a/scinoephile/analysis/audit/delineation.py
+++ b/scinoephile/analysis/audit/delineation.py
@@ -6,20 +6,19 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Collection, Sequence
-from enum import StrEnum
 
 from scinoephile.core.exceptions import ScinoephileError
 from scinoephile.core.subtitles import Series
 from scinoephile.llms.delineation import DelineationTestCase
 
 from .utils import (
+    AuditFilter,
     AuditResult,
     escape_table_cell,
-    format_block_range,
-    format_index_range,
-    get_contextual_index,
+    format_audit_report,
     get_selected_event_indexes,
     get_superseded_keys,
+    resolve_contextual_index,
     validate_block_range,
     validate_index_range,
 )
@@ -30,17 +29,8 @@ __all__ = [
 ]
 
 
-class DelineationAuditFilter(StrEnum):
-    """Row filters supported by a transcription delineation audit."""
-
-    all = "all"
-    """Include every logged boundary decision."""
-
-    changes = "changes"
-    """Include only decisions that shifted the target boundary."""
-
-    unverified = "unverified"
-    """Include only decisions not marked as verified."""
+DelineationAuditFilter = AuditFilter
+"""Row filters supported by a transcription delineation audit."""
 
 
 def audit_delineation(
@@ -146,39 +136,31 @@ def audit_delineation(
 
     rows.sort(key=lambda item: item[0])
 
-    lines = [
-        "# Transcription Delineation Audit",
-        "",
-        "## Summary",
-        "",
-        f"- logged cases: {logged_cases}",
-        f"- boundary shifts: {shifts}",
-        f"- no-shift answers: {no_shifts}",
-        f"- unanswered cases: {unanswered}",
-        f"- row filter: {row_filter.value}",
-    ]
-    range_summary = format_index_range(
-        first_index,
-        last_index,
-        track_name="reference",
+    return format_audit_report(
+        title="Transcription Delineation Audit",
+        summary_lines=(
+            f"- logged cases: {logged_cases}",
+            f"- boundary shifts: {shifts}",
+            f"- no-shift answers: {no_shifts}",
+            f"- unanswered cases: {unanswered}",
+            f"- row filter: {row_filter.value}",
+        ),
+        column_labels=(
+            "Indexes",
+            "Reference",
+            "Input",
+            "Output",
+            "Notes",
+            "Verified",
+        ),
+        column_separators=("---:", "---", "---", "---", "---", ":---:"),
+        rows=[row for _, row in rows],
+        first_index=first_index,
+        last_index=last_index,
+        index_track_name="reference",
+        first_block=first_block,
+        last_block=last_block,
     )
-    if range_summary is not None:
-        lines.append(range_summary)
-    block_range_summary = format_block_range(first_block, last_block)
-    if block_range_summary is not None:
-        lines.append(block_range_summary)
-    lines.extend(
-        (
-            f"- table rows: {len(rows)}",
-            "",
-            "## Audit Table",
-            "",
-            "| Indexes | Reference | Input | Output | Notes | Verified |",
-            "|---:|---|---|---|---|:---:|",
-            *(row for _, row in rows),
-        )
-    )
-    return "\n".join(lines) + "\n"
 
 
 def _format_pair(one: str, two: str) -> str:
@@ -210,18 +192,13 @@ def _get_case_index(
     Raises:
         ScinoephileError: if a case remains ambiguous
     """
-    direct_index = direct_indexes[test_case_index - 1]
-    if direct_index is not None:
-        return direct_index
-
-    contextual_index = get_contextual_index(
+    index = resolve_contextual_index(
         candidate_indexes,
         direct_indexes,
         test_case_index - 1,
     )
-    if contextual_index is not None:
-        direct_indexes[test_case_index - 1] = contextual_index
-        return contextual_index
+    if index is not None:
+        return index
 
     indexes = ", ".join(str(index + 1) for index in candidate_indexes)
     raise ScinoephileError(

--- a/scinoephile/analysis/audit/delineation.py
+++ b/scinoephile/analysis/audit/delineation.py
@@ -23,21 +23,14 @@ from .utils import (
     validate_index_range,
 )
 
-__all__ = [
-    "DelineationAuditFilter",
-    "audit_delineation",
-]
-
-
-DelineationAuditFilter = AuditFilter
-"""Row filters supported by a transcription delineation audit."""
+__all__ = ["audit_delineation"]
 
 
 def audit_delineation(
     reference: Series,
     test_cases: Sequence[DelineationTestCase],
     *,
-    row_filter: DelineationAuditFilter = DelineationAuditFilter.all,
+    row_filter: AuditFilter = AuditFilter.all,
     first_index: int | None = None,
     last_index: int | None = None,
     first_block: int | None = None,
@@ -114,9 +107,8 @@ def audit_delineation(
             result = AuditResult.unchanged
 
         if (
-            row_filter is DelineationAuditFilter.changes
-            and result is not AuditResult.changed
-        ) or (row_filter is DelineationAuditFilter.unverified and test_case.verified):
+            row_filter is AuditFilter.changes and result is not AuditResult.changed
+        ) or (row_filter is AuditFilter.unverified and test_case.verified):
             continue
 
         cells = (

--- a/scinoephile/analysis/audit/guided_review.py
+++ b/scinoephile/analysis/audit/guided_review.py
@@ -15,8 +15,8 @@ from scinoephile.core.subtitles import Series
 from scinoephile.core.synchronization import get_sync_groups
 from scinoephile.core.text import remove_punc_and_whitespace
 
-from .review import ReviewAuditFilter
 from .utils import (
+    AuditFilter,
     AuditResult,
     escape_table_cell,
     format_audit_report,
@@ -156,7 +156,7 @@ def audit_guided_review(
     guide: Series,
     test_cases: Sequence[_GuidedReviewTestCase],
     *,
-    row_filter: ReviewAuditFilter = ReviewAuditFilter.all,
+    row_filter: AuditFilter = AuditFilter.all,
     first_index: int | None = None,
     last_index: int | None = None,
     first_block: int | None = None,
@@ -265,10 +265,9 @@ def audit_guided_review(
         row
         for row in all_rows
         if not (
-            row_filter is ReviewAuditFilter.changes
-            and row.result is not AuditResult.changed
+            row_filter is AuditFilter.changes and row.result is not AuditResult.changed
         )
-        and not (row_filter is ReviewAuditFilter.unverified and row.verified)
+        and not (row_filter is AuditFilter.unverified and row.verified)
     ]
     subtitles = len(all_rows)
     unchanged_subtitles = subtitles - revised_subtitles - unanswered_subtitles

--- a/scinoephile/analysis/audit/guided_review.py
+++ b/scinoephile/analysis/audit/guided_review.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Sequence
 from dataclasses import dataclass
-from enum import StrEnum
 from typing import Protocol
 
 from scinoephile.core.exceptions import ScinoephileError
@@ -18,27 +17,14 @@ from scinoephile.core.text import remove_punc_and_whitespace
 
 from .review import ReviewAuditFilter
 from .utils import (
+    AuditResult,
     escape_table_cell,
-    format_block_range,
-    format_index_range,
+    format_audit_report,
     is_block_in_range,
     validate_audit_range,
 )
 
 __all__ = ["audit_guided_review"]
-
-
-class _AuditResult(StrEnum):
-    """Result of one logged guided-review answer."""
-
-    changed = "changed"
-    """The logged answer changed its input."""
-
-    unchanged = "unchanged"
-    """The logged answer explicitly retained its input."""
-
-    unanswered = "unanswered"
-    """The logged case has no answer."""
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -67,7 +53,7 @@ class _GuidedReviewRow:
     """One-based position of the source test case in the JSON."""
     markdown: str
     """Formatted Markdown table row."""
-    result: _AuditResult
+    result: AuditResult
     """Result of the logged answer for this subtitle."""
     verified: bool
     """Whether the source test case is verified."""
@@ -240,12 +226,12 @@ def audit_guided_review(
             target_revision = query_target.text
             if answer is None:
                 target_revision = f"{query_target.text}\n(unanswered)"
-                result = _AuditResult.unanswered
+                result = AuditResult.unanswered
             elif revision is not None:
                 target_revision = f"{query_target.text}\n{revision.text}"
-                result = _AuditResult.changed
+                result = AuditResult.changed
             else:
-                result = _AuditResult.unchanged
+                result = AuditResult.unchanged
 
             guide_text = "\n".join(guide_texts)
             if not guide_texts:
@@ -272,58 +258,48 @@ def audit_guided_review(
         rows_by_subtitle_index.values(),
         key=lambda row: (row.subtitle_index, row.test_case_index),
     )
-    revised_subtitles = sum(row.result is _AuditResult.changed for row in all_rows)
-    unanswered_subtitles = sum(
-        row.result is _AuditResult.unanswered for row in all_rows
-    )
+    revised_subtitles = sum(row.result is AuditResult.changed for row in all_rows)
+    unanswered_subtitles = sum(row.result is AuditResult.unanswered for row in all_rows)
     verified_subtitles = sum(row.verified for row in all_rows)
     rows = [
         row
         for row in all_rows
         if not (
             row_filter is ReviewAuditFilter.changes
-            and row.result is not _AuditResult.changed
+            and row.result is not AuditResult.changed
         )
         and not (row_filter is ReviewAuditFilter.unverified and row.verified)
     ]
     subtitles = len(all_rows)
     unchanged_subtitles = subtitles - revised_subtitles - unanswered_subtitles
     unverified_subtitles = subtitles - verified_subtitles
-    lines = [
-        "# Guided Subtitle Review Audit",
-        "",
-        "## Summary",
-        "",
-        f"- subtitles: {subtitles}",
-        f"- revised subtitles: {revised_subtitles}",
-        f"- unchanged subtitles: {unchanged_subtitles}",
-        f"- unanswered subtitles: {unanswered_subtitles}",
-        f"- verified subtitles: {verified_subtitles}",
-        f"- unverified subtitles: {unverified_subtitles}",
-        f"- row filter: {row_filter.value}",
-    ]
-    range_summary = format_index_range(
-        first_index,
-        last_index,
-        track_name="target",
+    return format_audit_report(
+        title="Guided Subtitle Review Audit",
+        summary_lines=(
+            f"- subtitles: {subtitles}",
+            f"- revised subtitles: {revised_subtitles}",
+            f"- unchanged subtitles: {unchanged_subtitles}",
+            f"- unanswered subtitles: {unanswered_subtitles}",
+            f"- verified subtitles: {verified_subtitles}",
+            f"- unverified subtitles: {unverified_subtitles}",
+            f"- row filter: {row_filter.value}",
+        ),
+        column_labels=(
+            "Index",
+            "Block",
+            "Guide",
+            "Target / revision",
+            "Notes",
+            "Verified",
+        ),
+        column_separators=("---:", "---:", "---", "---", "---", ":---:"),
+        rows=[row.markdown for row in rows],
+        first_index=first_index,
+        last_index=last_index,
+        index_track_name="target",
+        first_block=first_block,
+        last_block=last_block,
     )
-    if range_summary is not None:
-        lines.append(range_summary)
-    block_range_summary = format_block_range(first_block, last_block)
-    if block_range_summary is not None:
-        lines.append(block_range_summary)
-    lines.extend(
-        (
-            f"- table rows: {len(rows)}",
-            "",
-            "## Audit Table",
-            "",
-            "| Index | Block | Guide | Target / revision | Notes | Verified |",
-            "|---:|---:|---|---|---|:---:|",
-            *(row.markdown for row in rows),
-        )
-    )
-    return "\n".join(lines) + "\n"
 
 
 def _get_blocks_by_key(

--- a/scinoephile/analysis/audit/ocr_fusion.py
+++ b/scinoephile/analysis/audit/ocr_fusion.py
@@ -15,8 +15,7 @@ from scinoephile.core.synchronization import are_series_one_to_one
 
 from .utils import (
     escape_table_cell,
-    format_block_range,
-    format_index_range,
+    format_audit_report,
     get_selected_event_indexes,
 )
 
@@ -227,11 +226,7 @@ def audit_ocr_fusion(
 
     rows = _filter_rows(all_rows, row_filter)
     llm_rows = [row for row in all_rows if row.requires_llm]
-    lines = [
-        "# OCR Fusion Audit",
-        "",
-        "## Summary",
-        "",
+    summary_lines = [
         f"- subtitles: {len(all_rows)}",
         f"- source disagreements: {sum(row.changed for row in all_rows)}",
         f"- validated track: {'included' if validated is not None else 'omitted'}",
@@ -241,7 +236,7 @@ def audit_ocr_fusion(
     if has_decision_log:
         verified_llm_rows = sum(row.verified for row in llm_rows)
         unverified_llm_rows = sum(not row.verified for row in llm_rows)
-        lines.extend(
+        summary_lines.extend(
             (
                 f"- LLM decisions: {len(llm_rows)}",
                 f"- verified LLM decisions: {verified_llm_rows}",
@@ -249,22 +244,12 @@ def audit_ocr_fusion(
             )
         )
     else:
-        lines.extend(
+        summary_lines.extend(
             (
                 f"- LLM-required rows: {len(llm_rows)}",
                 "- decision log: omitted",
             )
         )
-    range_summary = format_index_range(
-        first_index,
-        last_index,
-        track_name="fused",
-    )
-    if range_summary is not None:
-        lines.append(range_summary)
-    block_range_summary = format_block_range(first_block, last_block)
-    if block_range_summary is not None:
-        lines.append(block_range_summary)
     column_labels = [
         "Subtitle",
         "Case",
@@ -278,18 +263,18 @@ def audit_ocr_fusion(
     if has_decision_log:
         column_labels.extend(("Notes", "Verified"))
         column_separators.extend(("---", ":---:"))
-    lines.extend(
-        (
-            f"- table rows: {len(rows)}",
-            "",
-            "## Audit Table",
-            "",
-            f"| {' | '.join(column_labels)} |",
-            f"|{'|'.join(column_separators)}|",
-            *(row.markdown for row in rows),
-        )
+    return format_audit_report(
+        title="OCR Fusion Audit",
+        summary_lines=summary_lines,
+        column_labels=column_labels,
+        column_separators=column_separators,
+        rows=[row.markdown for row in rows],
+        first_index=first_index,
+        last_index=last_index,
+        index_track_name="fused",
+        first_block=first_block,
+        last_block=last_block,
     )
-    return "\n".join(lines) + "\n"
 
 
 def _filter_rows(

--- a/scinoephile/analysis/audit/punctuation.py
+++ b/scinoephile/analysis/audit/punctuation.py
@@ -24,14 +24,7 @@ from .utils import (
     validate_index_range,
 )
 
-__all__ = [
-    "PunctuationAuditFilter",
-    "audit_punctuation",
-]
-
-
-PunctuationAuditFilter = AuditFilter
-"""Row filters supported by a transcription punctuation audit."""
+__all__ = ["audit_punctuation"]
 
 
 def audit_punctuation(
@@ -39,7 +32,7 @@ def audit_punctuation(
     target: Series,
     test_cases: Sequence[PunctuationTestCase],
     *,
-    row_filter: PunctuationAuditFilter = PunctuationAuditFilter.all,
+    row_filter: AuditFilter = AuditFilter.all,
     first_index: int | None = None,
     last_index: int | None = None,
     first_block: int | None = None,
@@ -116,9 +109,8 @@ def audit_punctuation(
             changes += 1
 
         if (
-            row_filter is PunctuationAuditFilter.changes
-            and result is not AuditResult.changed
-        ) or (row_filter is PunctuationAuditFilter.unverified and test_case.verified):
+            row_filter is AuditFilter.changes and result is not AuditResult.changed
+        ) or (row_filter is AuditFilter.unverified and test_case.verified):
             continue
         rows.append((index, test_case_index, row))
 

--- a/scinoephile/analysis/audit/punctuation.py
+++ b/scinoephile/analysis/audit/punctuation.py
@@ -1,0 +1,338 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Audit transcription punctuation decisions and format them as Markdown."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Sequence
+from enum import StrEnum
+
+from scinoephile.core.exceptions import ScinoephileError
+from scinoephile.core.subtitles import Series
+from scinoephile.core.text import remove_punc_and_whitespace
+from scinoephile.llms.punctuation import PunctuationTestCase
+
+from .utils import (
+    _AuditResult,
+    _get_contextual_index,
+    _get_superseded_keys,
+    escape_table_cell,
+    format_block_range,
+    format_index_range,
+    get_selected_event_indexes,
+    validate_block_range,
+    validate_index_range,
+)
+
+__all__ = [
+    "PunctuationAuditFilter",
+    "audit_punctuation",
+]
+
+
+class PunctuationAuditFilter(StrEnum):
+    """Row filters supported by a transcription punctuation audit."""
+
+    all = "all"
+    """Include every logged punctuation decision."""
+
+    changes = "changes"
+    """Include only decisions that changed punctuation or whitespace."""
+
+    unverified = "unverified"
+    """Include only decisions not marked as verified."""
+
+
+def audit_punctuation(
+    reference: Series,
+    target: Series,
+    test_cases: Sequence[PunctuationTestCase],
+    *,
+    row_filter: PunctuationAuditFilter = PunctuationAuditFilter.all,
+    first_index: int | None = None,
+    last_index: int | None = None,
+    first_block: int | None = None,
+    last_block: int | None = None,
+) -> str:
+    """Audit logged punctuation decisions against their reference subtitles.
+
+    The target series is used only to disambiguate repeated reference text.
+
+    Arguments:
+        reference: reference subtitle series used to guide punctuation
+        target: punctuated target series aligned to the reference by timing
+        test_cases: logged punctuation test cases
+        row_filter: row status filter
+        first_index: first 1-indexed reference subtitle number to include
+        last_index: last 1-indexed reference subtitle number to include
+        first_block: first 1-indexed reference block number to include
+        last_block: last 1-indexed reference block number to include
+    Returns:
+        Markdown audit report
+    Raises:
+        ScinoephileError: if a logged case cannot be matched uniquely
+    """
+    validate_index_range(first_index, last_index)
+    validate_block_range(first_block, last_block)
+
+    reference_indexes_by_text: dict[str, list[int]] = defaultdict(list)
+    for index, subtitle in enumerate(reference):
+        reference_indexes_by_text[subtitle.text].append(index)
+
+    target_text_by_reference_index = _get_target_text_by_reference_index(
+        reference,
+        target,
+    )
+    candidate_indexes_by_case, direct_indexes = _get_case_indexes(
+        reference_indexes_by_text,
+        target_text_by_reference_index,
+        test_cases,
+    )
+    selected_reference_indexes = get_selected_event_indexes(
+        reference,
+        first_index=first_index,
+        last_index=last_index,
+        first_block=first_block,
+        last_block=last_block,
+    )
+
+    rows: list[tuple[int, int, str]] = []
+    changes = 0
+    unchanged = 0
+    unanswered = 0
+    logged_cases = 0
+    for test_case_index, test_case in enumerate(test_cases, 1):
+        candidates = candidate_indexes_by_case[test_case_index - 1]
+        if not candidates:
+            continue
+        if selected_reference_indexes.isdisjoint(candidates):
+            continue
+        index = _get_case_index(
+            candidates,
+            direct_indexes,
+            test_case_index=test_case_index,
+        )
+        if index not in selected_reference_indexes:
+            continue
+
+        logged_cases += 1
+        row, result = _format_case_row(test_case, index)
+        if result is _AuditResult.unanswered:
+            unanswered += 1
+        elif result is _AuditResult.unchanged:
+            unchanged += 1
+        else:
+            changes += 1
+
+        if (
+            row_filter is PunctuationAuditFilter.changes
+            and result is not _AuditResult.changed
+        ) or (row_filter is PunctuationAuditFilter.unverified and test_case.verified):
+            continue
+        rows.append((index, test_case_index, row))
+
+    rows.sort(key=lambda item: (item[0], item[1]))
+    lines = [
+        "# Transcription Punctuation Audit",
+        "",
+        "## Summary",
+        "",
+        f"- logged cases: {logged_cases}",
+        f"- punctuation changes: {changes}",
+        f"- unchanged answers: {unchanged}",
+        f"- unanswered cases: {unanswered}",
+        f"- row filter: {row_filter.value}",
+    ]
+    range_summary = format_index_range(
+        first_index,
+        last_index,
+        track_name="reference",
+    )
+    if range_summary is not None:
+        lines.append(range_summary)
+    block_range_summary = format_block_range(first_block, last_block)
+    if block_range_summary is not None:
+        lines.append(block_range_summary)
+    lines.extend(
+        (
+            f"- table rows: {len(rows)}",
+            "",
+            "## Audit Table",
+            "",
+            "| Index | Reference | Input | Output | Notes | Verified |",
+            "|---:|---|---|---|---|:---:|",
+            *(row for _, _, row in rows),
+        )
+    )
+    return "\n".join(lines) + "\n"
+
+
+def _format_case_row(
+    test_case: PunctuationTestCase,
+    index: int,
+) -> tuple[str, _AuditResult]:
+    """Format one punctuation case as a Markdown table row.
+
+    Arguments:
+        test_case: punctuation case to format
+        index: zero-indexed reference subtitle position
+    Returns:
+        Markdown row and its result type
+    """
+    input_text = "".join(test_case.query.subtitles)
+    answer = test_case.answer
+    if answer is None:
+        output = "(unanswered)"
+        result = _AuditResult.unanswered
+    elif answer.output == input_text:
+        output = ""
+        result = _AuditResult.unchanged
+    else:
+        output = answer.output
+        result = _AuditResult.changed
+
+    cells = (
+        str(index + 1),
+        test_case.query.guide,
+        "\n".join(test_case.query.subtitles),
+        output,
+        "",
+        "✓" if test_case.verified else "",
+    )
+    row = f"| {' | '.join(escape_table_cell(cell) for cell in cells)} |"
+    return row, result
+
+
+def _get_case_index(
+    candidates: Sequence[int],
+    direct_indexes: list[int | None],
+    *,
+    test_case_index: int,
+) -> int:
+    """Resolve the reference index for one punctuation test case.
+
+    Arguments:
+        candidates: possible zero-indexed reference subtitle positions
+        direct_indexes: indexes resolved directly for all logged cases
+        test_case_index: one-indexed position of the case being resolved
+    Returns:
+        resolved zero-indexed reference subtitle position
+    Raises:
+        ScinoephileError: if the case remains ambiguous
+    """
+    index = direct_indexes[test_case_index - 1]
+    if index is None:
+        index = _get_contextual_index(
+            candidates,
+            direct_indexes,
+            test_case_index - 1,
+        )
+        if index is not None:
+            direct_indexes[test_case_index - 1] = index
+    if index is not None:
+        return index
+
+    indexes = ", ".join(str(candidate + 1) for candidate in candidates)
+    raise ScinoephileError(
+        "Unable to audit transcription punctuation: "
+        f"test case {test_case_index} is ambiguous; it matches subtitle "
+        f"indexes {indexes}"
+    )
+
+
+def _get_case_indexes(
+    reference_indexes_by_text: dict[str, list[int]],
+    target_text_by_reference_index: dict[int, str],
+    test_cases: Sequence[PunctuationTestCase],
+) -> tuple[list[list[int]], list[int | None]]:
+    """Get candidate and directly resolved reference indexes for all cases.
+
+    Arguments:
+        reference_indexes_by_text: reference positions keyed by subtitle text
+        target_text_by_reference_index: target text aligned to reference positions
+        test_cases: logged punctuation test cases
+    Returns:
+        candidate indexes and directly resolved indexes for each case
+    Raises:
+        ScinoephileError: if a case's reference subtitle is absent
+    """
+    inputs_by_guide: dict[str, set[tuple[str, ...]]] = defaultdict(set)
+    for test_case in test_cases:
+        inputs_by_guide[test_case.query.guide].add(tuple(test_case.query.subtitles))
+    superseded_guides = _get_superseded_keys(
+        reference_indexes_by_text,
+        inputs_by_guide,
+    )
+    candidate_indexes_by_case: list[list[int]] = []
+    direct_indexes: list[int | None] = []
+    for test_case_index, test_case in enumerate(test_cases, 1):
+        matches = reference_indexes_by_text.get(test_case.query.guide, [])
+        if not matches:
+            if test_case.query.guide in superseded_guides:
+                candidate_indexes_by_case.append([])
+                direct_indexes.append(None)
+                continue
+            raise ScinoephileError(
+                "Unable to audit transcription punctuation: "
+                f"test case {test_case_index} reference subtitle was not found"
+            )
+        candidates = list(matches)
+        candidate_indexes_by_case.append(candidates)
+
+        direct_index = None
+        if len(candidates) == 1:
+            direct_index = candidates[0]
+        elif candidates:
+            input_chars = remove_punc_and_whitespace("".join(test_case.query.subtitles))
+            target_chars_by_index = {
+                index: remove_punc_and_whitespace(
+                    target_text_by_reference_index.get(index, "")
+                )
+                for index in candidates
+            }
+            target_matches = [
+                index
+                for index, target_chars in target_chars_by_index.items()
+                if target_chars == input_chars
+            ]
+            if len(target_matches) == 1:
+                direct_index = target_matches[0]
+            else:
+                contained_target_lengths = {
+                    index: len(target_chars)
+                    for index, target_chars in target_chars_by_index.items()
+                    if target_chars and target_chars in input_chars
+                }
+                if contained_target_lengths:
+                    maximum_length = max(contained_target_lengths.values())
+                    longest_matches = [
+                        index
+                        for index, length in contained_target_lengths.items()
+                        if length == maximum_length
+                    ]
+                    if len(longest_matches) == 1:
+                        direct_index = longest_matches[0]
+        direct_indexes.append(direct_index)
+    return candidate_indexes_by_case, direct_indexes
+
+
+def _get_target_text_by_reference_index(
+    reference: Series,
+    target: Series,
+) -> dict[int, str]:
+    """Align target text to reference indexes by exact timing.
+
+    Arguments:
+        reference: reference subtitle series
+        target: punctuated target subtitle series
+    Returns:
+        concatenated target text keyed by zero-indexed reference position
+    """
+    target_texts_by_timing: dict[tuple[int, int], list[str]] = defaultdict(list)
+    for subtitle in target:
+        target_texts_by_timing[(subtitle.start, subtitle.end)].append(subtitle.text)
+    return {
+        index: "".join(target_texts_by_timing.get((subtitle.start, subtitle.end), []))
+        for index, subtitle in enumerate(reference)
+    }

--- a/scinoephile/analysis/audit/punctuation.py
+++ b/scinoephile/analysis/audit/punctuation.py
@@ -14,13 +14,13 @@ from scinoephile.core.text import remove_punc_and_whitespace
 from scinoephile.llms.punctuation import PunctuationTestCase
 
 from .utils import (
-    _AuditResult,
-    _get_contextual_index,
-    _get_superseded_keys,
+    AuditResult,
     escape_table_cell,
     format_block_range,
     format_index_range,
+    get_contextual_index,
     get_selected_event_indexes,
+    get_superseded_keys,
     validate_block_range,
     validate_index_range,
 )
@@ -118,16 +118,16 @@ def audit_punctuation(
 
         logged_cases += 1
         row, result = _format_case_row(test_case, index)
-        if result is _AuditResult.unanswered:
+        if result is AuditResult.unanswered:
             unanswered += 1
-        elif result is _AuditResult.unchanged:
+        elif result is AuditResult.unchanged:
             unchanged += 1
         else:
             changes += 1
 
         if (
             row_filter is PunctuationAuditFilter.changes
-            and result is not _AuditResult.changed
+            and result is not AuditResult.changed
         ) or (row_filter is PunctuationAuditFilter.unverified and test_case.verified):
             continue
         rows.append((index, test_case_index, row))
@@ -171,7 +171,7 @@ def audit_punctuation(
 def _format_case_row(
     test_case: PunctuationTestCase,
     index: int,
-) -> tuple[str, _AuditResult]:
+) -> tuple[str, AuditResult]:
     """Format one punctuation case as a Markdown table row.
 
     Arguments:
@@ -184,13 +184,13 @@ def _format_case_row(
     answer = test_case.answer
     if answer is None:
         output = "(unanswered)"
-        result = _AuditResult.unanswered
+        result = AuditResult.unanswered
     elif answer.output == input_text:
         output = ""
-        result = _AuditResult.unchanged
+        result = AuditResult.unchanged
     else:
         output = answer.output
-        result = _AuditResult.changed
+        result = AuditResult.changed
 
     cells = (
         str(index + 1),
@@ -223,7 +223,7 @@ def _get_case_index(
     """
     index = direct_indexes[test_case_index - 1]
     if index is None:
-        index = _get_contextual_index(
+        index = get_contextual_index(
             candidates,
             direct_indexes,
             test_case_index - 1,
@@ -260,7 +260,7 @@ def _get_case_indexes(
     inputs_by_guide: dict[str, set[tuple[str, ...]]] = defaultdict(set)
     for test_case in test_cases:
         inputs_by_guide[test_case.query.guide].add(tuple(test_case.query.subtitles))
-    superseded_guides = _get_superseded_keys(
+    superseded_guides = get_superseded_keys(
         reference_indexes_by_text,
         inputs_by_guide,
     )

--- a/scinoephile/analysis/audit/punctuation.py
+++ b/scinoephile/analysis/audit/punctuation.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Sequence
-from enum import StrEnum
 
 from scinoephile.core.exceptions import ScinoephileError
 from scinoephile.core.subtitles import Series
@@ -14,13 +13,13 @@ from scinoephile.core.text import remove_punc_and_whitespace
 from scinoephile.llms.punctuation import PunctuationTestCase
 
 from .utils import (
+    AuditFilter,
     AuditResult,
     escape_table_cell,
-    format_block_range,
-    format_index_range,
-    get_contextual_index,
+    format_audit_report,
     get_selected_event_indexes,
     get_superseded_keys,
+    resolve_contextual_index,
     validate_block_range,
     validate_index_range,
 )
@@ -31,17 +30,8 @@ __all__ = [
 ]
 
 
-class PunctuationAuditFilter(StrEnum):
-    """Row filters supported by a transcription punctuation audit."""
-
-    all = "all"
-    """Include every logged punctuation decision."""
-
-    changes = "changes"
-    """Include only decisions that changed punctuation or whitespace."""
-
-    unverified = "unverified"
-    """Include only decisions not marked as verified."""
+PunctuationAuditFilter = AuditFilter
+"""Row filters supported by a transcription punctuation audit."""
 
 
 def audit_punctuation(
@@ -133,39 +123,31 @@ def audit_punctuation(
         rows.append((index, test_case_index, row))
 
     rows.sort(key=lambda item: (item[0], item[1]))
-    lines = [
-        "# Transcription Punctuation Audit",
-        "",
-        "## Summary",
-        "",
-        f"- logged cases: {logged_cases}",
-        f"- punctuation changes: {changes}",
-        f"- unchanged answers: {unchanged}",
-        f"- unanswered cases: {unanswered}",
-        f"- row filter: {row_filter.value}",
-    ]
-    range_summary = format_index_range(
-        first_index,
-        last_index,
-        track_name="reference",
+    return format_audit_report(
+        title="Transcription Punctuation Audit",
+        summary_lines=(
+            f"- logged cases: {logged_cases}",
+            f"- punctuation changes: {changes}",
+            f"- unchanged answers: {unchanged}",
+            f"- unanswered cases: {unanswered}",
+            f"- row filter: {row_filter.value}",
+        ),
+        column_labels=(
+            "Index",
+            "Reference",
+            "Input",
+            "Output",
+            "Notes",
+            "Verified",
+        ),
+        column_separators=("---:", "---", "---", "---", "---", ":---:"),
+        rows=[row for _, _, row in rows],
+        first_index=first_index,
+        last_index=last_index,
+        index_track_name="reference",
+        first_block=first_block,
+        last_block=last_block,
     )
-    if range_summary is not None:
-        lines.append(range_summary)
-    block_range_summary = format_block_range(first_block, last_block)
-    if block_range_summary is not None:
-        lines.append(block_range_summary)
-    lines.extend(
-        (
-            f"- table rows: {len(rows)}",
-            "",
-            "## Audit Table",
-            "",
-            "| Index | Reference | Input | Output | Notes | Verified |",
-            "|---:|---|---|---|---|:---:|",
-            *(row for _, _, row in rows),
-        )
-    )
-    return "\n".join(lines) + "\n"
 
 
 def _format_case_row(
@@ -221,15 +203,11 @@ def _get_case_index(
     Raises:
         ScinoephileError: if the case remains ambiguous
     """
-    index = direct_indexes[test_case_index - 1]
-    if index is None:
-        index = get_contextual_index(
-            candidates,
-            direct_indexes,
-            test_case_index - 1,
-        )
-        if index is not None:
-            direct_indexes[test_case_index - 1] = index
+    index = resolve_contextual_index(
+        candidates,
+        direct_indexes,
+        test_case_index - 1,
+    )
     if index is not None:
         return index
 

--- a/scinoephile/analysis/audit/review.py
+++ b/scinoephile/analysis/audit/review.py
@@ -14,9 +14,9 @@ from scinoephile.core.llms import TestCase
 from scinoephile.core.subtitles import Series
 
 from .utils import (
+    AuditFilter,
     escape_table_cell,
-    format_block_range,
-    format_index_range,
+    format_audit_report,
     get_selected_event_indexes,
 )
 
@@ -46,17 +46,8 @@ class ComparativeReviewAuditFilter(StrEnum):
     """Include only subtitles from unverified logged cases."""
 
 
-class ReviewAuditFilter(StrEnum):
-    """Row filters supported by review audits without final comparisons."""
-
-    all = "all"
-    """Include every subtitle row."""
-
-    changes = "changes"
-    """Include changed subtitle rows."""
-
-    unverified = "unverified"
-    """Include only subtitles from unverified logged cases."""
+ReviewAuditFilter = AuditFilter
+"""Row filters supported by review audits without final comparisons."""
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -374,17 +365,11 @@ def _format_markdown(
         cells.append("\n".join(note_lines))
         row_lines.append(f"| {' | '.join(escape_table_cell(cell) for cell in cells)} |")
 
-    lines = [
-        "# Review Audit",
-        "",
-        "## Summary",
-        "",
-    ]
-    lines.extend(
+    summary_lines = [
         f"- {review.label.lower()} review edits: {len(changed_indexes)}"
         for review, changed_indexes in zip(reviews, review_changes, strict=True)
-    )
-    lines.extend(
+    ]
+    summary_lines.extend(
         f"- {comparison.summary_label.lower()} discrepancies: {len(changed_indexes)}"
         for comparison, changed_indexes in zip(
             comparisons,
@@ -392,32 +377,25 @@ def _format_markdown(
             strict=True,
         )
     )
-    lines.append(f"- row filter: {row_filter.value}")
+    summary_lines.append(f"- row filter: {row_filter.value}")
     if characters:
-        lines.append(f"- character filter: {', '.join(characters)}")
-    index_range = format_index_range(first_index, last_index)
-    if index_range is not None:
-        lines.append(index_range)
-    block_range = format_block_range(first_block, last_block)
-    if block_range is not None:
-        lines.append(block_range)
+        summary_lines.append(f"- character filter: {', '.join(characters)}")
 
     column_labels = ["Subtitle"]
     column_labels.extend(review.label for review in reviews)
     column_labels.extend(comparison.column_label for comparison in comparisons)
     column_labels.append("Notes")
-    lines.extend(
-        (
-            f"- table rows: {len(row_lines)}",
-            "",
-            "## Audit Table",
-            "",
-            f"| {' | '.join(column_labels)} |",
-            f"|---:|{'|'.join('---' for _ in column_labels[1:])}|",
-            *row_lines,
-        )
+    return format_audit_report(
+        title="Review Audit",
+        summary_lines=summary_lines,
+        column_labels=column_labels,
+        column_separators=["---:", *("---" for _ in column_labels[1:])],
+        rows=row_lines,
+        first_index=first_index,
+        last_index=last_index,
+        first_block=first_block,
+        last_block=last_block,
     )
-    return "\n".join(lines) + "\n"
 
 
 def _format_review_cell(

--- a/scinoephile/analysis/audit/review.py
+++ b/scinoephile/analysis/audit/review.py
@@ -23,7 +23,6 @@ from .utils import (
 __all__ = [
     "ComparativeReviewAuditFilter",
     "ReviewAuditComparison",
-    "ReviewAuditFilter",
     "ReviewAuditPair",
     "audit_review_workflow",
     "audit_reviews",
@@ -44,10 +43,6 @@ class ComparativeReviewAuditFilter(StrEnum):
 
     unverified = "unverified"
     """Include only subtitles from unverified logged cases."""
-
-
-ReviewAuditFilter = AuditFilter
-"""Row filters supported by review audits without final comparisons."""
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -167,9 +162,7 @@ def audit_review_workflow(
     *,
     reviews: Sequence[ReviewAuditPair],
     comparisons: Sequence[ReviewAuditComparison] = (),
-    row_filter: ReviewAuditFilter | ComparativeReviewAuditFilter = (
-        ReviewAuditFilter.changes
-    ),
+    row_filter: AuditFilter | ComparativeReviewAuditFilter = AuditFilter.changes,
     characters: Sequence[str] = (),
     first_index: int | None = None,
     last_index: int | None = None,
@@ -240,7 +233,7 @@ def audit_review_workflow(
             )
         )
         unverified_indexes = frozenset()
-        if row_filter.value == ReviewAuditFilter.unverified.value:
+        if row_filter.value == AuditFilter.unverified.value:
             unverified_indexes = frozenset(
                 index
                 for review, (original, reviewed) in zip(
@@ -311,7 +304,7 @@ def _format_markdown(
     comparison_series: Sequence[tuple[Sequence[str], Sequence[str]]],
     comparison_changes: Sequence[set[int]],
     indexes: Sequence[int],
-    row_filter: ReviewAuditFilter | ComparativeReviewAuditFilter,
+    row_filter: AuditFilter | ComparativeReviewAuditFilter,
     characters: Sequence[str],
     first_index: int | None,
     last_index: int | None,
@@ -442,7 +435,7 @@ def _get_filtered_indexes(
     review_changes: Sequence[set[int]],
     comparison_changes: Sequence[set[int]],
     indexes: Iterable[int],
-    row_filter: ReviewAuditFilter | ComparativeReviewAuditFilter,
+    row_filter: AuditFilter | ComparativeReviewAuditFilter,
     unverified_indexes: frozenset[int],
     characters: Sequence[str],
 ) -> list[int]:
@@ -459,9 +452,9 @@ def _get_filtered_indexes(
     Returns:
         selected subtitle indexes
     """
-    if row_filter.value == ReviewAuditFilter.all.value:
+    if row_filter.value == AuditFilter.all.value:
         selected_indexes = set(indexes)
-    elif row_filter.value == ReviewAuditFilter.changes.value:
+    elif row_filter.value == AuditFilter.changes.value:
         selected_indexes = {
             index
             for changed_indexes in (*review_changes, *comparison_changes)

--- a/scinoephile/analysis/audit/utils.py
+++ b/scinoephile/analysis/audit/utils.py
@@ -4,25 +4,41 @@
 
 from __future__ import annotations
 
-from collections.abc import Collection, Hashable, Mapping, Sequence
+from collections.abc import Collection, Hashable, Mapping, MutableSequence, Sequence
 from enum import StrEnum
 
 from scinoephile.core.exceptions import ScinoephileError
 from scinoephile.core.subtitles import Series
 
 __all__ = [
+    "AuditFilter",
     "AuditResult",
     "escape_table_cell",
+    "format_audit_report",
     "format_block_range",
     "format_index_range",
     "get_contextual_index",
     "get_selected_event_indexes",
     "get_superseded_keys",
     "is_block_in_range",
+    "resolve_contextual_index",
     "validate_audit_range",
     "validate_block_range",
     "validate_index_range",
 ]
+
+
+class AuditFilter(StrEnum):
+    """Row filters shared by audit reports without final comparisons."""
+
+    all = "all"
+    """Include every eligible row."""
+
+    changes = "changes"
+    """Include only changed rows."""
+
+    unverified = "unverified"
+    """Include only rows from unverified logged cases."""
 
 
 class AuditResult(StrEnum):
@@ -47,6 +63,71 @@ def escape_table_cell(value: str) -> str:
         escaped cell text
     """
     return value.replace("\\N", "\n").replace("\n", "<br>").replace("|", "\\|")
+
+
+def format_audit_report(
+    *,
+    title: str,
+    summary_lines: Sequence[str],
+    column_labels: Sequence[str],
+    column_separators: Sequence[str],
+    rows: Sequence[str],
+    first_index: int | None = None,
+    last_index: int | None = None,
+    index_track_name: str | None = None,
+    first_block: int | None = None,
+    last_block: int | None = None,
+) -> str:
+    """Format the shared structure of a Markdown audit report.
+
+    Arguments:
+        title: report title without the Markdown heading marker
+        summary_lines: report-specific Markdown summary list items
+        column_labels: audit table column labels
+        column_separators: Markdown alignment separators for the columns
+        rows: formatted Markdown table rows
+        first_index: first included one-based subtitle index
+        last_index: last included one-based subtitle index
+        index_track_name: optional name of the indexed subtitle track
+        first_block: first included one-based block number
+        last_block: last included one-based block number
+    Returns:
+        formatted Markdown audit report
+    Raises:
+        ValueError: if the table labels and separators have different lengths
+    """
+    if len(column_labels) != len(column_separators):
+        raise ValueError("Table labels and separators must have the same length")
+
+    lines = [
+        f"# {title}",
+        "",
+        "## Summary",
+        "",
+        *summary_lines,
+    ]
+    index_range = format_index_range(
+        first_index,
+        last_index,
+        track_name=index_track_name,
+    )
+    if index_range is not None:
+        lines.append(index_range)
+    block_range = format_block_range(first_block, last_block)
+    if block_range is not None:
+        lines.append(block_range)
+    lines.extend(
+        (
+            f"- table rows: {len(rows)}",
+            "",
+            "## Audit Table",
+            "",
+            f"| {' | '.join(column_labels)} |",
+            f"|{'|'.join(column_separators)}|",
+            *rows,
+        )
+    )
+    return "\n".join(lines) + "\n"
 
 
 def format_block_range(
@@ -266,6 +347,34 @@ def is_block_in_range(
     return (first_block is None or block_number >= first_block) and (
         last_block is None or block_number <= last_block
     )
+
+
+def resolve_contextual_index(
+    candidate_indexes: Sequence[int],
+    resolved_indexes: MutableSequence[int | None],
+    test_case_index: int,
+) -> int | None:
+    """Resolve and memoize one logged case's source index.
+
+    Arguments:
+        candidate_indexes: possible zero-indexed source positions
+        resolved_indexes: resolved indexes for every logged case
+        test_case_index: zero-indexed test case position
+    Returns:
+        resolved source position, or None if ambiguity remains
+    """
+    index = resolved_indexes[test_case_index]
+    if index is not None:
+        return index
+
+    index = get_contextual_index(
+        candidate_indexes,
+        resolved_indexes,
+        test_case_index,
+    )
+    if index is not None:
+        resolved_indexes[test_case_index] = index
+    return index
 
 
 def validate_audit_range(

--- a/scinoephile/analysis/audit/utils.py
+++ b/scinoephile/analysis/audit/utils.py
@@ -11,10 +11,13 @@ from scinoephile.core.exceptions import ScinoephileError
 from scinoephile.core.subtitles import Series
 
 __all__ = [
+    "AuditResult",
     "escape_table_cell",
     "format_block_range",
     "format_index_range",
+    "get_contextual_index",
     "get_selected_event_indexes",
+    "get_superseded_keys",
     "is_block_in_range",
     "validate_audit_range",
     "validate_block_range",
@@ -22,7 +25,7 @@ __all__ = [
 ]
 
 
-class _AuditResult(StrEnum):
+class AuditResult(StrEnum):
     """Result types shared by decision-log audit rows."""
 
     changed = "changed"
@@ -94,6 +97,77 @@ def format_index_range(
     return f"- {range_name} range: {first_index} through {last_index}"
 
 
+def get_contextual_index(
+    candidate_indexes: Sequence[int],
+    direct_indexes: Sequence[int | None],
+    test_case_index: int,
+) -> int | None:
+    """Resolve a repeated source key from neighboring logged cases.
+
+    Arguments:
+        candidate_indexes: possible zero-indexed source positions
+        direct_indexes: directly resolved indexes for every logged case
+        test_case_index: zero-indexed test case position
+    Returns:
+        uniquely resolved source position, or None if ambiguity remains
+    """
+    previous_index = next(
+        (
+            index
+            for index in reversed(direct_indexes[:test_case_index])
+            if index is not None
+        ),
+        None,
+    )
+    next_index = next(
+        (index for index in direct_indexes[test_case_index + 1 :] if index is not None),
+        None,
+    )
+    if previous_index is None and next_index is None:
+        return None
+
+    narrowed_candidates = list(candidate_indexes)
+    if (
+        previous_index is not None
+        and next_index is not None
+        and previous_index <= next_index
+    ):
+        candidates_between_anchors = [
+            candidate
+            for candidate in candidate_indexes
+            if previous_index <= candidate <= next_index
+        ]
+        if len(candidates_between_anchors) == 1:
+            return candidates_between_anchors[0]
+        if candidates_between_anchors:
+            narrowed_candidates = candidates_between_anchors
+
+    scores: dict[int, tuple[int, int]] = {}
+    for candidate in narrowed_candidates:
+        distances = []
+        if previous_index is not None:
+            distances.append(abs(candidate - previous_index))
+        if next_index is not None:
+            distances.append(abs(candidate - next_index))
+        if previous_index is not None and next_index is not None:
+            primary_score = sum(distances)
+        else:
+            primary_score = distances[0]
+
+        previous_distance = 0
+        if previous_index is not None:
+            previous_distance = abs(candidate - previous_index)
+        scores[candidate] = (primary_score, previous_distance)
+
+    minimum_score = min(scores.values())
+    best_candidates = [
+        candidate for candidate, score in scores.items() if score == minimum_score
+    ]
+    if len(best_candidates) == 1:
+        return best_candidates[0]
+    return None
+
+
 def get_selected_event_indexes(
     series: Series,
     *,
@@ -147,6 +221,32 @@ def get_selected_event_indexes(
         for event_index in range(block_start, block_stop)
     }
     return frozenset(selected_block_indexes)
+
+
+def get_superseded_keys[KeyT: Hashable, ValueT: Hashable](
+    current_keys: Collection[KeyT],
+    values_by_key: Mapping[KeyT, Collection[ValueT]],
+) -> set[KeyT]:
+    """Get historical keys directly replaced by current logged cases.
+
+    A historical key is superseded only when one of its logged values also
+    appears under a current key. Avoid transitive propagation because a reused
+    historical key may otherwise connect unrelated cases.
+
+    Arguments:
+        current_keys: keys present in the current source data
+        values_by_key: logged target values grouped by source key
+    Returns:
+        absent keys directly connected to a current key by a shared value
+    """
+    current_values = {
+        value for key in current_keys for value in values_by_key.get(key, ())
+    }
+    return {
+        key
+        for key, values in values_by_key.items()
+        if key not in current_keys and not current_values.isdisjoint(values)
+    }
 
 
 def is_block_in_range(
@@ -242,100 +342,3 @@ def validate_index_range(first_index: int | None, last_index: int | None):
         raise ScinoephileError("Last index must be at least 1")
     if first_index is not None and last_index is not None and first_index > last_index:
         raise ScinoephileError("First index must be less than or equal to last index")
-
-
-def _get_contextual_index(
-    candidate_indexes: Sequence[int],
-    direct_indexes: Sequence[int | None],
-    test_case_index: int,
-) -> int | None:
-    """Resolve a repeated source key from neighboring logged cases.
-
-    Arguments:
-        candidate_indexes: possible zero-indexed source positions
-        direct_indexes: directly resolved indexes for every logged case
-        test_case_index: zero-indexed test case position
-    Returns:
-        uniquely resolved source position, or None if ambiguity remains
-    """
-    previous_index = next(
-        (
-            index
-            for index in reversed(direct_indexes[:test_case_index])
-            if index is not None
-        ),
-        None,
-    )
-    next_index = next(
-        (index for index in direct_indexes[test_case_index + 1 :] if index is not None),
-        None,
-    )
-    if previous_index is None and next_index is None:
-        return None
-
-    narrowed_candidates = list(candidate_indexes)
-    if (
-        previous_index is not None
-        and next_index is not None
-        and previous_index <= next_index
-    ):
-        candidates_between_anchors = [
-            candidate
-            for candidate in candidate_indexes
-            if previous_index <= candidate <= next_index
-        ]
-        if len(candidates_between_anchors) == 1:
-            return candidates_between_anchors[0]
-        if candidates_between_anchors:
-            narrowed_candidates = candidates_between_anchors
-
-    scores: dict[int, tuple[int, int]] = {}
-    for candidate in narrowed_candidates:
-        distances = []
-        if previous_index is not None:
-            distances.append(abs(candidate - previous_index))
-        if next_index is not None:
-            distances.append(abs(candidate - next_index))
-        if previous_index is not None and next_index is not None:
-            primary_score = sum(distances)
-        else:
-            primary_score = distances[0]
-
-        previous_distance = 0
-        if previous_index is not None:
-            previous_distance = abs(candidate - previous_index)
-        scores[candidate] = (primary_score, previous_distance)
-
-    minimum_score = min(scores.values())
-    best_candidates = [
-        candidate for candidate, score in scores.items() if score == minimum_score
-    ]
-    if len(best_candidates) == 1:
-        return best_candidates[0]
-    return None
-
-
-def _get_superseded_keys[KeyT: Hashable, ValueT: Hashable](
-    current_keys: Collection[KeyT],
-    values_by_key: Mapping[KeyT, Collection[ValueT]],
-) -> set[KeyT]:
-    """Get historical keys directly replaced by current logged cases.
-
-    A historical key is superseded only when one of its logged values also
-    appears under a current key. Avoid transitive propagation because a reused
-    historical key may otherwise connect unrelated cases.
-
-    Arguments:
-        current_keys: keys present in the current source data
-        values_by_key: logged target values grouped by source key
-    Returns:
-        absent keys directly connected to a current key by a shared value
-    """
-    current_values = {
-        value for key in current_keys for value in values_by_key.get(key, ())
-    }
-    return {
-        key
-        for key, values in values_by_key.items()
-        if key not in current_keys and not current_values.isdisjoint(values)
-    }

--- a/scinoephile/analysis/audit/utils.py
+++ b/scinoephile/analysis/audit/utils.py
@@ -4,6 +4,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Collection, Hashable, Mapping, Sequence
+from enum import StrEnum
+
 from scinoephile.core.exceptions import ScinoephileError
 from scinoephile.core.subtitles import Series
 
@@ -17,6 +20,19 @@ __all__ = [
     "validate_block_range",
     "validate_index_range",
 ]
+
+
+class _AuditResult(StrEnum):
+    """Result types shared by decision-log audit rows."""
+
+    changed = "changed"
+    """The logged answer changed its input."""
+
+    unchanged = "unchanged"
+    """The logged answer explicitly retained its input."""
+
+    unanswered = "unanswered"
+    """The logged case has no answer."""
 
 
 def escape_table_cell(value: str) -> str:
@@ -226,3 +242,100 @@ def validate_index_range(first_index: int | None, last_index: int | None):
         raise ScinoephileError("Last index must be at least 1")
     if first_index is not None and last_index is not None and first_index > last_index:
         raise ScinoephileError("First index must be less than or equal to last index")
+
+
+def _get_contextual_index(
+    candidate_indexes: Sequence[int],
+    direct_indexes: Sequence[int | None],
+    test_case_index: int,
+) -> int | None:
+    """Resolve a repeated source key from neighboring logged cases.
+
+    Arguments:
+        candidate_indexes: possible zero-indexed source positions
+        direct_indexes: directly resolved indexes for every logged case
+        test_case_index: zero-indexed test case position
+    Returns:
+        uniquely resolved source position, or None if ambiguity remains
+    """
+    previous_index = next(
+        (
+            index
+            for index in reversed(direct_indexes[:test_case_index])
+            if index is not None
+        ),
+        None,
+    )
+    next_index = next(
+        (index for index in direct_indexes[test_case_index + 1 :] if index is not None),
+        None,
+    )
+    if previous_index is None and next_index is None:
+        return None
+
+    narrowed_candidates = list(candidate_indexes)
+    if (
+        previous_index is not None
+        and next_index is not None
+        and previous_index <= next_index
+    ):
+        candidates_between_anchors = [
+            candidate
+            for candidate in candidate_indexes
+            if previous_index <= candidate <= next_index
+        ]
+        if len(candidates_between_anchors) == 1:
+            return candidates_between_anchors[0]
+        if candidates_between_anchors:
+            narrowed_candidates = candidates_between_anchors
+
+    scores: dict[int, tuple[int, int]] = {}
+    for candidate in narrowed_candidates:
+        distances = []
+        if previous_index is not None:
+            distances.append(abs(candidate - previous_index))
+        if next_index is not None:
+            distances.append(abs(candidate - next_index))
+        if previous_index is not None and next_index is not None:
+            primary_score = sum(distances)
+        else:
+            primary_score = distances[0]
+
+        previous_distance = 0
+        if previous_index is not None:
+            previous_distance = abs(candidate - previous_index)
+        scores[candidate] = (primary_score, previous_distance)
+
+    minimum_score = min(scores.values())
+    best_candidates = [
+        candidate for candidate, score in scores.items() if score == minimum_score
+    ]
+    if len(best_candidates) == 1:
+        return best_candidates[0]
+    return None
+
+
+def _get_superseded_keys[KeyT: Hashable, ValueT: Hashable](
+    current_keys: Collection[KeyT],
+    values_by_key: Mapping[KeyT, Collection[ValueT]],
+) -> set[KeyT]:
+    """Get historical keys directly replaced by current logged cases.
+
+    A historical key is superseded only when one of its logged values also
+    appears under a current key. Avoid transitive propagation because a reused
+    historical key may otherwise connect unrelated cases.
+
+    Arguments:
+        current_keys: keys present in the current source data
+        values_by_key: logged target values grouped by source key
+    Returns:
+        absent keys directly connected to a current key by a shared value
+    """
+    current_values = {
+        value for key in current_keys for value in values_by_key.get(key, ())
+    }
+    return {
+        key
+        for key, values in values_by_key.items()
+        if key not in current_keys and not current_values.isdisjoint(values)
+    }

--- a/scinoephile/cli/audit/__init__.py
+++ b/scinoephile/cli/audit/__init__.py
@@ -4,7 +4,7 @@
 
 Package hierarchy (modules may import from any above):
 * audit_cli_base
-* audit_ocr_fusion_cli / utils
+* audit_delineation_cli / audit_ocr_fusion_cli / audit_punctuation_cli / utils
 * audit_review_cli / audit_review_dual_cli
 / audit_review_trad_cli
 * audit_cli

--- a/scinoephile/cli/audit/audit_cli.py
+++ b/scinoephile/cli/audit/audit_cli.py
@@ -10,7 +10,9 @@ from typing import Any
 from scinoephile.common import CommandLineInterface
 from scinoephile.core.cli import ScinoephileCliBase
 
+from .audit_delineation_cli import AuditDelineationCli
 from .audit_ocr_fusion_cli import AuditOcrFusionCli
+from .audit_punctuation_cli import AuditPunctuationCli
 from .audit_review_cli import AuditReviewCli
 from .audit_review_dual_cli import AuditReviewDualCli
 from .audit_review_trad_cli import AuditReviewTradCli
@@ -59,7 +61,9 @@ class AuditCli(ScinoephileCliBase):
             mapping of subcommand names to CLI classes
         """
         return {
+            AuditDelineationCli.name(): AuditDelineationCli,
             AuditOcrFusionCli.name(): AuditOcrFusionCli,
+            AuditPunctuationCli.name(): AuditPunctuationCli,
             AuditReviewCli.name(): AuditReviewCli,
             AuditReviewDualCli.name(): AuditReviewDualCli,
             AuditReviewTradCli.name(): AuditReviewTradCli,

--- a/scinoephile/cli/audit/audit_cli_base.py
+++ b/scinoephile/cli/audit/audit_cli_base.py
@@ -63,6 +63,10 @@ AUDIT_CLI_LOCALIZATIONS: dict[str, dict[str, str]] = {
 class AuditCliBase(ScinoephileCliBase):
     """Shared command-line support for subtitle audits."""
 
+    first_index_help = "first 1-indexed subtitle number to include, inclusive"
+    """Help text describing the first selected subtitle index."""
+    last_index_help = "last 1-indexed subtitle number to include, inclusive"
+    """Help text describing the last selected subtitle index."""
     localizations = AUDIT_CLI_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
@@ -84,12 +88,12 @@ class AuditCliBase(ScinoephileCliBase):
         arg_groups["operation arguments"].add_argument(
             "--first-index",
             type=int_arg(min_value=1),
-            help="first 1-indexed subtitle number to include, inclusive",
+            help=cls.first_index_help,
         )
         arg_groups["operation arguments"].add_argument(
             "--last-index",
             type=int_arg(min_value=1),
-            help="last 1-indexed subtitle number to include, inclusive",
+            help=cls.last_index_help,
         )
         add_block_range_args(
             arg_groups["operation arguments"],

--- a/scinoephile/cli/audit/audit_cli_base.py
+++ b/scinoephile/cli/audit/audit_cli_base.py
@@ -63,10 +63,6 @@ AUDIT_CLI_LOCALIZATIONS: dict[str, dict[str, str]] = {
 class AuditCliBase(ScinoephileCliBase):
     """Shared command-line support for subtitle audits."""
 
-    first_index_help = "first 1-indexed subtitle number to include, inclusive"
-    """Help text describing the first selected subtitle index."""
-    last_index_help = "last 1-indexed subtitle number to include, inclusive"
-    """Help text describing the last selected subtitle index."""
     localizations = AUDIT_CLI_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 
@@ -88,12 +84,12 @@ class AuditCliBase(ScinoephileCliBase):
         arg_groups["operation arguments"].add_argument(
             "--first-index",
             type=int_arg(min_value=1),
-            help=cls.first_index_help,
+            help="first 1-indexed subtitle number to include, inclusive",
         )
         arg_groups["operation arguments"].add_argument(
             "--last-index",
             type=int_arg(min_value=1),
-            help=cls.last_index_help,
+            help="last 1-indexed subtitle number to include, inclusive",
         )
         add_block_range_args(
             arg_groups["operation arguments"],

--- a/scinoephile/cli/audit/audit_delineation_cli.py
+++ b/scinoephile/cli/audit/audit_delineation_cli.py
@@ -1,0 +1,162 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Command-line interface for transcription delineation audits."""
+
+from __future__ import annotations
+
+from argparse import ArgumentParser
+from pathlib import Path
+
+from scinoephile.analysis.audit.delineation import (
+    DelineationAuditFilter,
+    audit_delineation,
+)
+from scinoephile.cli.helpers.io import read_series
+from scinoephile.common.argument_parsing import (
+    enum_arg,
+    get_arg_groups_by_name,
+    input_file_arg,
+)
+from scinoephile.core import ScinoephileError
+from scinoephile.llms.delineation import DelineationManager
+
+from .audit_cli_base import AuditCliBase
+
+__all__ = ["AuditDelineationCli"]
+
+AUDIT_DELINEATION_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "audit transcription delineation decisions": "审核转写字幕边界决策",
+        "reference subtitle SRT file used to guide transcription": (
+            "用于指导转写的参考字幕 SRT 文件"
+        ),
+        "delineation test-case JSON file": "字幕边界测试用例 JSON 文件",
+        "first 1-indexed reference subtitle number to include, inclusive": (
+            "要包含的第一个字幕编号（从 1 开始，包含该编号）"
+        ),
+        "last 1-indexed reference subtitle number to include, inclusive": (
+            "要包含的最后一个字幕编号（从 1 开始，包含该编号）"
+        ),
+        "rows to include: all, changes, or unverified (default: all)": (
+            "要包含的行：all 表示全部，changes 表示边界调整，unverified "
+            "表示未验证（默认：all）"
+        ),
+    },
+    "zh-hant": {
+        "audit transcription delineation decisions": "稽核轉寫字幕邊界決策",
+        "reference subtitle SRT file used to guide transcription": (
+            "用於指導轉寫的參考字幕 SRT 檔"
+        ),
+        "delineation test-case JSON file": "字幕邊界測試案例 JSON 檔",
+        "first 1-indexed reference subtitle number to include, inclusive": (
+            "要包含的第一個字幕編號（從 1 開始，包含該編號）"
+        ),
+        "last 1-indexed reference subtitle number to include, inclusive": (
+            "要包含的最後一個字幕編號（從 1 開始，包含該編號）"
+        ),
+        "rows to include: all, changes, or unverified (default: all)": (
+            "要包含的列：all 表示全部，changes 表示邊界調整，unverified "
+            "表示未驗證（預設：all）"
+        ),
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
+
+class AuditDelineationCli(AuditCliBase):
+    """Audit transcription delineation decisions."""
+
+    first_index_help = "first 1-indexed reference subtitle number to include, inclusive"
+    """Help text describing the first selected reference index."""
+    last_index_help = "last 1-indexed reference subtitle number to include, inclusive"
+    """Help text describing the last selected reference index."""
+    localizations = AUDIT_DELINEATION_LOCALIZATIONS
+    """Localized help text keyed by locale and English source text."""
+
+    @classmethod
+    def add_arguments_to_argparser(cls, parser: ArgumentParser):
+        """Add arguments to a nascent argument parser.
+
+        Arguments:
+            parser: nascent argument parser
+        """
+        super().add_arguments_to_argparser(parser)
+        arg_groups = get_arg_groups_by_name(
+            parser,
+            "input arguments",
+            "operation arguments",
+            "output arguments",
+            optional_arguments_name="additional arguments",
+        )
+        arg_groups["input arguments"].add_argument(
+            "--reference",
+            dest="reference_path",
+            required=True,
+            type=input_file_arg(),
+            help="reference subtitle SRT file used to guide transcription",
+        )
+        arg_groups["input arguments"].add_argument(
+            "--json",
+            dest="json_path",
+            required=True,
+            type=input_file_arg(),
+            help="delineation test-case JSON file",
+        )
+        arg_groups["operation arguments"].add_argument(
+            "--filter",
+            choices=tuple(DelineationAuditFilter),
+            default=DelineationAuditFilter.all,
+            dest="row_filter",
+            metavar="{all,changes,unverified}",
+            type=enum_arg(DelineationAuditFilter),
+            help="rows to include: all, changes, or unverified (default: all)",
+        )
+
+    @classmethod
+    def name(cls) -> str:
+        """Name of this tool used to define it when it is a subparser."""
+        return "delineation"
+
+    @classmethod
+    def _main(
+        cls,
+        *,
+        _parser: ArgumentParser | None = None,
+        reference_path: Path,
+        json_path: Path,
+        row_filter: DelineationAuditFilter,
+        first_index: int | None,
+        last_index: int | None,
+        first_block: int | None,
+        last_block: int | None,
+        outfile_path: Path | None,
+        overwrite: bool,
+    ):
+        """Execute with provided keyword arguments."""
+        parser = _parser or cls.argparser()
+        reference = read_series(parser, reference_path)
+        test_cases = cls.load_test_cases(
+            parser,
+            json_path,
+            DelineationManager,
+            workflow_name="delineation",
+        )
+
+        try:
+            report = audit_delineation(
+                reference,
+                test_cases,
+                row_filter=row_filter,
+                first_index=first_index,
+                last_index=last_index,
+                first_block=first_block,
+                last_block=last_block,
+            )
+        except ScinoephileError as exc:
+            parser.error(str(exc))
+
+        cls.write_report(parser, report, outfile_path, overwrite)
+
+
+if __name__ == "__main__":
+    AuditDelineationCli.main()

--- a/scinoephile/cli/audit/audit_delineation_cli.py
+++ b/scinoephile/cli/audit/audit_delineation_cli.py
@@ -7,10 +7,8 @@ from __future__ import annotations
 from argparse import ArgumentParser
 from pathlib import Path
 
-from scinoephile.analysis.audit.delineation import (
-    DelineationAuditFilter,
-    audit_delineation,
-)
+from scinoephile.analysis.audit.delineation import audit_delineation
+from scinoephile.analysis.audit.utils import AuditFilter
 from scinoephile.cli.helpers.io import read_series
 from scinoephile.common.argument_parsing import (
     enum_arg,
@@ -92,11 +90,11 @@ class AuditDelineationCli(AuditCliBase):
         # Operation arguments
         arg_groups["operation arguments"].add_argument(
             "--filter",
-            choices=tuple(DelineationAuditFilter),
-            default=DelineationAuditFilter.all,
+            choices=tuple(AuditFilter),
+            default=AuditFilter.all,
             dest="row_filter",
             metavar="{all,changes,unverified}",
-            type=enum_arg(DelineationAuditFilter),
+            type=enum_arg(AuditFilter),
             help="rows to include: all, changes, or unverified (default: all)",
         )
 
@@ -112,7 +110,7 @@ class AuditDelineationCli(AuditCliBase):
         _parser: ArgumentParser | None = None,
         reference_path: Path,
         json_path: Path,
-        row_filter: DelineationAuditFilter,
+        row_filter: AuditFilter,
         first_index: int | None,
         last_index: int | None,
         first_block: int | None,

--- a/scinoephile/cli/audit/audit_delineation_cli.py
+++ b/scinoephile/cli/audit/audit_delineation_cli.py
@@ -31,12 +31,6 @@ AUDIT_DELINEATION_LOCALIZATIONS: dict[str, dict[str, str]] = {
             "用于指导转写的参考字幕 SRT 文件"
         ),
         "delineation test-case JSON file": "字幕边界测试用例 JSON 文件",
-        "first 1-indexed reference subtitle number to include, inclusive": (
-            "要包含的第一个字幕编号（从 1 开始，包含该编号）"
-        ),
-        "last 1-indexed reference subtitle number to include, inclusive": (
-            "要包含的最后一个字幕编号（从 1 开始，包含该编号）"
-        ),
         "rows to include: all, changes, or unverified (default: all)": (
             "要包含的行：all 表示全部，changes 表示边界调整，unverified "
             "表示未验证（默认：all）"
@@ -48,12 +42,6 @@ AUDIT_DELINEATION_LOCALIZATIONS: dict[str, dict[str, str]] = {
             "用於指導轉寫的參考字幕 SRT 檔"
         ),
         "delineation test-case JSON file": "字幕邊界測試案例 JSON 檔",
-        "first 1-indexed reference subtitle number to include, inclusive": (
-            "要包含的第一個字幕編號（從 1 開始，包含該編號）"
-        ),
-        "last 1-indexed reference subtitle number to include, inclusive": (
-            "要包含的最後一個字幕編號（從 1 開始，包含該編號）"
-        ),
         "rows to include: all, changes, or unverified (default: all)": (
             "要包含的列：all 表示全部，changes 表示邊界調整，unverified "
             "表示未驗證（預設：all）"
@@ -66,10 +54,6 @@ AUDIT_DELINEATION_LOCALIZATIONS: dict[str, dict[str, str]] = {
 class AuditDelineationCli(AuditCliBase):
     """Audit transcription delineation decisions."""
 
-    first_index_help = "first 1-indexed reference subtitle number to include, inclusive"
-    """Help text describing the first selected reference index."""
-    last_index_help = "last 1-indexed reference subtitle number to include, inclusive"
-    """Help text describing the last selected reference index."""
     localizations = AUDIT_DELINEATION_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 

--- a/scinoephile/cli/audit/audit_delineation_cli.py
+++ b/scinoephile/cli/audit/audit_delineation_cli.py
@@ -88,6 +88,8 @@ class AuditDelineationCli(AuditCliBase):
             "output arguments",
             optional_arguments_name="additional arguments",
         )
+
+        # Input arguments
         arg_groups["input arguments"].add_argument(
             "--reference",
             dest="reference_path",
@@ -102,6 +104,8 @@ class AuditDelineationCli(AuditCliBase):
             type=input_file_arg(),
             help="delineation test-case JSON file",
         )
+
+        # Operation arguments
         arg_groups["operation arguments"].add_argument(
             "--filter",
             choices=tuple(DelineationAuditFilter),
@@ -133,6 +137,7 @@ class AuditDelineationCli(AuditCliBase):
         overwrite: bool,
     ):
         """Execute with provided keyword arguments."""
+        # Read inputs
         parser = _parser or cls.argparser()
         reference = read_series(parser, reference_path)
         test_cases = cls.load_test_cases(
@@ -142,6 +147,7 @@ class AuditDelineationCli(AuditCliBase):
             workflow_name="delineation",
         )
 
+        # Perform operation
         try:
             report = audit_delineation(
                 reference,
@@ -155,6 +161,7 @@ class AuditDelineationCli(AuditCliBase):
         except ScinoephileError as exc:
             parser.error(str(exc))
 
+        # Write output
         cls.write_report(parser, report, outfile_path, overwrite)
 
 

--- a/scinoephile/cli/audit/audit_punctuation_cli.py
+++ b/scinoephile/cli/audit/audit_punctuation_cli.py
@@ -90,6 +90,8 @@ class AuditPunctuationCli(AuditCliBase):
             "output arguments",
             optional_arguments_name="additional arguments",
         )
+
+        # Input arguments
         arg_groups["input arguments"].add_argument(
             "--reference",
             dest="reference_path",
@@ -111,6 +113,8 @@ class AuditPunctuationCli(AuditCliBase):
             type=input_file_arg(),
             help="punctuation test-case JSON file",
         )
+
+        # Operation arguments
         arg_groups["operation arguments"].add_argument(
             "--filter",
             choices=tuple(PunctuationAuditFilter),
@@ -143,6 +147,7 @@ class AuditPunctuationCli(AuditCliBase):
         overwrite: bool,
     ):
         """Execute with provided keyword arguments."""
+        # Read inputs
         parser = _parser or cls.argparser()
         reference = read_series(parser, reference_path)
         target = read_series(parser, target_path)
@@ -153,6 +158,7 @@ class AuditPunctuationCli(AuditCliBase):
             workflow_name="punctuation",
         )
 
+        # Perform operation
         try:
             report = audit_punctuation(
                 reference,
@@ -167,6 +173,7 @@ class AuditPunctuationCli(AuditCliBase):
         except ScinoephileError as exc:
             parser.error(str(exc))
 
+        # Write output
         cls.write_report(parser, report, outfile_path, overwrite)
 
 

--- a/scinoephile/cli/audit/audit_punctuation_cli.py
+++ b/scinoephile/cli/audit/audit_punctuation_cli.py
@@ -32,12 +32,6 @@ AUDIT_PUNCTUATION_LOCALIZATIONS: dict[str, dict[str, str]] = {
         ),
         "punctuated target subtitle SRT file": "已加标点的目标字幕 SRT 文件",
         "punctuation test-case JSON file": "字幕标点测试用例 JSON 文件",
-        "first 1-indexed reference subtitle number to include, inclusive": (
-            "要包含的第一个字幕编号（从 1 开始，包含该编号）"
-        ),
-        "last 1-indexed reference subtitle number to include, inclusive": (
-            "要包含的最后一个字幕编号（从 1 开始，包含该编号）"
-        ),
         "rows to include: all, changes, or unverified (default: all)": (
             "要包含的行：all 表示全部，changes 表示标点调整，unverified "
             "表示未验证（默认：all）"
@@ -50,12 +44,6 @@ AUDIT_PUNCTUATION_LOCALIZATIONS: dict[str, dict[str, str]] = {
         ),
         "punctuated target subtitle SRT file": "已加標點的目標字幕 SRT 檔",
         "punctuation test-case JSON file": "字幕標點測試案例 JSON 檔",
-        "first 1-indexed reference subtitle number to include, inclusive": (
-            "要包含的第一個字幕編號（從 1 開始，包含該編號）"
-        ),
-        "last 1-indexed reference subtitle number to include, inclusive": (
-            "要包含的最後一個字幕編號（從 1 開始，包含該編號）"
-        ),
         "rows to include: all, changes, or unverified (default: all)": (
             "要包含的列：all 表示全部，changes 表示標點調整，unverified "
             "表示未驗證（預設：all）"
@@ -68,10 +56,6 @@ AUDIT_PUNCTUATION_LOCALIZATIONS: dict[str, dict[str, str]] = {
 class AuditPunctuationCli(AuditCliBase):
     """Audit transcription punctuation decisions."""
 
-    first_index_help = "first 1-indexed reference subtitle number to include, inclusive"
-    """Help text describing the first selected reference index."""
-    last_index_help = "last 1-indexed reference subtitle number to include, inclusive"
-    """Help text describing the last selected reference index."""
     localizations = AUDIT_PUNCTUATION_LOCALIZATIONS
     """Localized help text keyed by locale and English source text."""
 

--- a/scinoephile/cli/audit/audit_punctuation_cli.py
+++ b/scinoephile/cli/audit/audit_punctuation_cli.py
@@ -1,0 +1,174 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Command-line interface for transcription punctuation audits."""
+
+from __future__ import annotations
+
+from argparse import ArgumentParser
+from pathlib import Path
+
+from scinoephile.analysis.audit.punctuation import (
+    PunctuationAuditFilter,
+    audit_punctuation,
+)
+from scinoephile.cli.helpers.io import read_series
+from scinoephile.common.argument_parsing import (
+    enum_arg,
+    get_arg_groups_by_name,
+    input_file_arg,
+)
+from scinoephile.core import ScinoephileError
+from scinoephile.llms.punctuation import PunctuationManager
+
+from .audit_cli_base import AuditCliBase
+
+__all__ = ["AuditPunctuationCli"]
+
+AUDIT_PUNCTUATION_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "audit transcription punctuation decisions": "审核转写字幕标点决策",
+        "reference subtitle SRT file used to guide punctuation": (
+            "用于指导标点的参考字幕 SRT 文件"
+        ),
+        "punctuated target subtitle SRT file": "已加标点的目标字幕 SRT 文件",
+        "punctuation test-case JSON file": "字幕标点测试用例 JSON 文件",
+        "first 1-indexed reference subtitle number to include, inclusive": (
+            "要包含的第一个字幕编号（从 1 开始，包含该编号）"
+        ),
+        "last 1-indexed reference subtitle number to include, inclusive": (
+            "要包含的最后一个字幕编号（从 1 开始，包含该编号）"
+        ),
+        "rows to include: all, changes, or unverified (default: all)": (
+            "要包含的行：all 表示全部，changes 表示标点调整，unverified "
+            "表示未验证（默认：all）"
+        ),
+    },
+    "zh-hant": {
+        "audit transcription punctuation decisions": "稽核轉寫字幕標點決策",
+        "reference subtitle SRT file used to guide punctuation": (
+            "用於指導標點的參考字幕 SRT 檔"
+        ),
+        "punctuated target subtitle SRT file": "已加標點的目標字幕 SRT 檔",
+        "punctuation test-case JSON file": "字幕標點測試案例 JSON 檔",
+        "first 1-indexed reference subtitle number to include, inclusive": (
+            "要包含的第一個字幕編號（從 1 開始，包含該編號）"
+        ),
+        "last 1-indexed reference subtitle number to include, inclusive": (
+            "要包含的最後一個字幕編號（從 1 開始，包含該編號）"
+        ),
+        "rows to include: all, changes, or unverified (default: all)": (
+            "要包含的列：all 表示全部，changes 表示標點調整，unverified "
+            "表示未驗證（預設：all）"
+        ),
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
+
+class AuditPunctuationCli(AuditCliBase):
+    """Audit transcription punctuation decisions."""
+
+    first_index_help = "first 1-indexed reference subtitle number to include, inclusive"
+    """Help text describing the first selected reference index."""
+    last_index_help = "last 1-indexed reference subtitle number to include, inclusive"
+    """Help text describing the last selected reference index."""
+    localizations = AUDIT_PUNCTUATION_LOCALIZATIONS
+    """Localized help text keyed by locale and English source text."""
+
+    @classmethod
+    def add_arguments_to_argparser(cls, parser: ArgumentParser):
+        """Add arguments to a nascent argument parser.
+
+        Arguments:
+            parser: nascent argument parser
+        """
+        super().add_arguments_to_argparser(parser)
+        arg_groups = get_arg_groups_by_name(
+            parser,
+            "input arguments",
+            "operation arguments",
+            "output arguments",
+            optional_arguments_name="additional arguments",
+        )
+        arg_groups["input arguments"].add_argument(
+            "--reference",
+            dest="reference_path",
+            required=True,
+            type=input_file_arg(),
+            help="reference subtitle SRT file used to guide punctuation",
+        )
+        arg_groups["input arguments"].add_argument(
+            "--target",
+            dest="target_path",
+            required=True,
+            type=input_file_arg(),
+            help="punctuated target subtitle SRT file",
+        )
+        arg_groups["input arguments"].add_argument(
+            "--json",
+            dest="json_path",
+            required=True,
+            type=input_file_arg(),
+            help="punctuation test-case JSON file",
+        )
+        arg_groups["operation arguments"].add_argument(
+            "--filter",
+            choices=tuple(PunctuationAuditFilter),
+            default=PunctuationAuditFilter.all,
+            dest="row_filter",
+            metavar="{all,changes,unverified}",
+            type=enum_arg(PunctuationAuditFilter),
+            help="rows to include: all, changes, or unverified (default: all)",
+        )
+
+    @classmethod
+    def name(cls) -> str:
+        """Name of this tool used to define it when it is a subparser."""
+        return "punctuation"
+
+    @classmethod
+    def _main(
+        cls,
+        *,
+        _parser: ArgumentParser | None = None,
+        reference_path: Path,
+        target_path: Path,
+        json_path: Path,
+        row_filter: PunctuationAuditFilter,
+        first_index: int | None,
+        last_index: int | None,
+        first_block: int | None,
+        last_block: int | None,
+        outfile_path: Path | None,
+        overwrite: bool,
+    ):
+        """Execute with provided keyword arguments."""
+        parser = _parser or cls.argparser()
+        reference = read_series(parser, reference_path)
+        target = read_series(parser, target_path)
+        test_cases = cls.load_test_cases(
+            parser,
+            json_path,
+            PunctuationManager,
+            workflow_name="punctuation",
+        )
+
+        try:
+            report = audit_punctuation(
+                reference,
+                target,
+                test_cases,
+                row_filter=row_filter,
+                first_index=first_index,
+                last_index=last_index,
+                first_block=first_block,
+                last_block=last_block,
+            )
+        except ScinoephileError as exc:
+            parser.error(str(exc))
+
+        cls.write_report(parser, report, outfile_path, overwrite)
+
+
+if __name__ == "__main__":
+    AuditPunctuationCli.main()

--- a/scinoephile/cli/audit/audit_punctuation_cli.py
+++ b/scinoephile/cli/audit/audit_punctuation_cli.py
@@ -7,10 +7,8 @@ from __future__ import annotations
 from argparse import ArgumentParser
 from pathlib import Path
 
-from scinoephile.analysis.audit.punctuation import (
-    PunctuationAuditFilter,
-    audit_punctuation,
-)
+from scinoephile.analysis.audit.punctuation import audit_punctuation
+from scinoephile.analysis.audit.utils import AuditFilter
 from scinoephile.cli.helpers.io import read_series
 from scinoephile.common.argument_parsing import (
     enum_arg,
@@ -101,11 +99,11 @@ class AuditPunctuationCli(AuditCliBase):
         # Operation arguments
         arg_groups["operation arguments"].add_argument(
             "--filter",
-            choices=tuple(PunctuationAuditFilter),
-            default=PunctuationAuditFilter.all,
+            choices=tuple(AuditFilter),
+            default=AuditFilter.all,
             dest="row_filter",
             metavar="{all,changes,unverified}",
-            type=enum_arg(PunctuationAuditFilter),
+            type=enum_arg(AuditFilter),
             help="rows to include: all, changes, or unverified (default: all)",
         )
 
@@ -122,7 +120,7 @@ class AuditPunctuationCli(AuditCliBase):
         reference_path: Path,
         target_path: Path,
         json_path: Path,
-        row_filter: PunctuationAuditFilter,
+        row_filter: AuditFilter,
         first_index: int | None,
         last_index: int | None,
         first_block: int | None,

--- a/scinoephile/cli/audit/audit_review_cli.py
+++ b/scinoephile/cli/audit/audit_review_cli.py
@@ -10,10 +10,10 @@ from pathlib import Path
 
 from scinoephile.analysis.audit.guided_review import audit_guided_review
 from scinoephile.analysis.audit.review import (
-    ReviewAuditFilter,
     ReviewAuditPair,
     audit_review_workflow,
 )
+from scinoephile.analysis.audit.utils import AuditFilter
 from scinoephile.cli.helpers.io import read_series
 from scinoephile.common.argument_parsing import (
     enum_arg,
@@ -145,12 +145,12 @@ class AuditReviewCli(AuditCliBase):
         # Operation arguments
         arg_groups["operation arguments"].add_argument(
             "--filter",
-            default=ReviewAuditFilter.changes,
+            default=AuditFilter.changes,
             dest="row_filter",
-            metavar=enum_metavar(ReviewAuditFilter),
-            type=enum_arg(ReviewAuditFilter),
+            metavar=enum_metavar(AuditFilter),
+            type=enum_arg(AuditFilter),
             help=(
-                f"rows to include: {enum_options_list_str(ReviewAuditFilter)} "
+                f"rows to include: {enum_options_list_str(AuditFilter)} "
                 "(default: %(default)s)"
             ),
         )
@@ -183,7 +183,7 @@ class AuditReviewCli(AuditCliBase):
         guide_path: Path,
         json_path: Path,
         *,
-        row_filter: ReviewAuditFilter,
+        row_filter: AuditFilter,
         first_index: int | None,
         last_index: int | None,
         first_block: int | None,
@@ -234,7 +234,7 @@ class AuditReviewCli(AuditCliBase):
         reviewed_path: Path,
         json_path: Path | None,
         *,
-        row_filter: ReviewAuditFilter,
+        row_filter: AuditFilter,
         characters: Sequence[str],
         first_index: int | None,
         last_index: int | None,
@@ -304,7 +304,7 @@ class AuditReviewCli(AuditCliBase):
         reviewed_path: Path | None,
         guide_path: Path | None,
         json_path: Path | None,
-        row_filter: ReviewAuditFilter,
+        row_filter: AuditFilter,
         characters: Sequence[str],
         first_index: int | None,
         last_index: int | None,
@@ -332,7 +332,7 @@ class AuditReviewCli(AuditCliBase):
         """
         # Validate arguments
         parser = _parser or cls.argparser()
-        if row_filter is ReviewAuditFilter.unverified and json_path is None:
+        if row_filter is AuditFilter.unverified and json_path is None:
             parser.error("--filter unverified requires --json")
         if guide_path is not None:
             if json_path is None:

--- a/scinoephile/cli/audit/audit_review_trad_cli.py
+++ b/scinoephile/cli/audit/audit_review_trad_cli.py
@@ -9,10 +9,10 @@ from collections.abc import Sequence
 from pathlib import Path
 
 from scinoephile.analysis.audit.review import (
-    ReviewAuditFilter,
     ReviewAuditPair,
     audit_review_workflow,
 )
+from scinoephile.analysis.audit.utils import AuditFilter
 from scinoephile.cli.helpers.io import read_series
 from scinoephile.common.argument_parsing import (
     enum_arg,
@@ -176,12 +176,12 @@ class AuditReviewTradCli(AuditCliBase):
         # Operation arguments
         arg_groups["operation arguments"].add_argument(
             "--filter",
-            default=ReviewAuditFilter.changes,
+            default=AuditFilter.changes,
             dest="row_filter",
-            metavar=enum_metavar(ReviewAuditFilter),
-            type=enum_arg(ReviewAuditFilter),
+            metavar=enum_metavar(AuditFilter),
+            type=enum_arg(AuditFilter),
             help=(
-                f"rows to include: {enum_options_list_str(ReviewAuditFilter)} "
+                f"rows to include: {enum_options_list_str(AuditFilter)} "
                 "(default: %(default)s)"
             ),
         )
@@ -218,7 +218,7 @@ class AuditReviewTradCli(AuditCliBase):
         traditional_simplified_reviewed_path: Path,
         traditional_json_path: Path | None,
         traditional_simplified_json_path: Path | None,
-        row_filter: ReviewAuditFilter,
+        row_filter: AuditFilter,
         characters: Sequence[str],
         first_index: int | None,
         last_index: int | None,
@@ -250,7 +250,7 @@ class AuditReviewTradCli(AuditCliBase):
         """
         # Validate arguments
         parser = _parser or cls.argparser()
-        if row_filter is ReviewAuditFilter.unverified and (
+        if row_filter is AuditFilter.unverified and (
             traditional_json_path is None or traditional_simplified_json_path is None
         ):
             parser.error(

--- a/scinoephile/cli/scinoephile_cli.py
+++ b/scinoephile/cli/scinoephile_cli.py
@@ -29,7 +29,7 @@ SCINOEPHILE_LOCALIZATIONS: dict[str, dict[str, str]] = {
     "zh-hans": {
         "additional help": "附加帮助",
         "Available subcommands:": "可用子命令：",
-        "audit subtitle review workflows": "审核字幕校对工作流",
+        "audit subtitle workflows": "审核字幕工作流",
         "build or search Chinese dictionaries": "构建或查询中文词典",
         "calculate the Character Error Rate (CER) of one series relative to "
         "another": "计算一个序列相对于另一个序列的字符错误率（CER）",
@@ -62,7 +62,7 @@ SCINOEPHILE_LOCALIZATIONS: dict[str, dict[str, str]] = {
     "zh-hant": {
         "additional help": "附加說明",
         "Available subcommands:": "可用子命令：",
-        "audit subtitle review workflows": "稽核字幕校對工作流程",
+        "audit subtitle workflows": "稽核字幕工作流程",
         "build or search Chinese dictionaries": "建置或查詢中文詞典",
         "calculate the Character Error Rate (CER) of one series relative to "
         "another": "計算一個序列相對於另一個序列的字元錯誤率（CER）",

--- a/skills/audit-transcription-delineation/SKILL.md
+++ b/skills/audit-transcription-delineation/SKILL.md
@@ -83,8 +83,8 @@ The report summary labels these bounds as the reference subtitle range.
 
 Use `--first-block` and `--last-block` for an inclusive, one-based range of
 reference blocks. A boundary is included only when both reference subtitles
-belong to selected blocks. Block and subtitle bounds may be combined, in which
-case both selections apply. Omit either block bound for an open-ended range.
+belong to selected blocks. Block and subtitle bounds are mutually exclusive.
+Omit either block bound for an open-ended range.
 
 Each table cell stacks the first and second subtitle with `<br>`. A blank line
 is displayed as `—`. Sort rows by their matched subtitle indexes. Preserve the

--- a/skills/audit-transcription-delineation/SKILL.md
+++ b/skills/audit-transcription-delineation/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: audit-transcription-delineation
+description: Audit Scinoephile transcription delineation logs by matching JSON reference pairs to their guide SRT subtitle indexes and judging whether target boundary shifts or no-shift answers align fixed target text appropriately. Use when inspecting transcription delineation mps.json or cuda.json files or identifying incorrect boundary decisions. Do not assess transcription accuracy.
+---
+
+# Audit Transcription Delineation
+
+Run commands from the repository root. A delineation audit assesses whether
+target text was divided appropriately across each pair of adjacent guide
+subtitles. Treat the provided target text as fixed input, even when it appears
+incorrect. Do not assess or comment on transcription accuracy, punctuation,
+wording, or character choice; those are reviewed later in a separate workflow.
+
+## Required report file
+
+Always save the complete six-column Markdown report under `local/`. After
+auditing every row, add each concise audit note directly to that file's `Notes`
+cell. Do not leave notes only in commentary, tool output, or the final response.
+
+- Keep the table at exactly these columns: `Indexes`, `Reference`, `Input`,
+  `Output`, `Notes`, and `Verified`.
+- Leave `Notes` blank when a row needs no note.
+- Preserve the generated `Verified` cell: `✓` means the JSON test case is
+  verified, and an empty cell means it is not verified.
+- Do not add a separate findings section; keep each observation beside the row
+  it describes.
+- Validate the saved report after adding notes, then provide a clickable link
+  to it in the final response. Do not paste the table inline unless the user
+  explicitly requests it.
+
+## Protect source data
+
+- Never edit files under `test/data/<dataset>/input/`.
+- For an audit-only request, do not edit delineation JSON, guide subtitles,
+  transcription output, or validation sources.
+- When corrections are requested, apply model-answer corrections to the
+  relevant delineation JSON and regenerate downstream outputs.
+- Treat guide or transcription-source corrections as separate changes and make
+  them only when the user explicitly requests them.
+
+## Locate artifacts
+
+Find the exact guide SRT used during transcription and the logged delineation
+JSON. Do not substitute a similarly named subtitle track. Transcription outputs
+normally place delineation logs below a directory named `delineation`, with
+provider-specific names such as `mps.json` or `cuda.json`.
+
+The guide SRT is required because delineation JSON stores reference text but not
+subtitle numbers. The CLI matches each logged reference pair to consecutive
+guide subtitles and rejects absent or ambiguous matches rather than displaying
+misleading indexes.
+
+An official target-language subtitle track may be consulted only to determine
+which utterance owns text near a boundary. It is not an input to the CLI and
+does not belong in the report as a separate column. Never use it to evaluate or
+comment on the accuracy of the target transcription.
+
+## Generate the report
+
+Always set `UV_CACHE_DIR=/tmp/uv-cache`:
+
+```shell
+UV_CACHE_DIR=/tmp/uv-cache uv run scinoephile audit delineation \
+  --reference <guide.srt> \
+  --json <delineation.json> \
+  --first-index <first> \
+  --last-index <last> \
+  --filter all \
+  --outfile local/<dataset>_delineation_audit_<first>-<last>.md \
+  --overwrite
+```
+
+On PowerShell, configure UTF-8 as directed by the repository `AGENTS.md` before
+printing subtitles.
+
+The index bounds are inclusive and retain only pairs wholly contained in the
+requested range. Omit either bound for an open-ended range. The default
+`--filter all` includes shifts, no-shift answers, and unanswered cases; use
+`--filter changes` to show only decisions that moved the target boundary, or
+`--filter unverified` when continuing verification of a partly audited file. A
+complete audit must use `all`, because `changes` cannot reveal missed shifts.
+The report summary labels these bounds as the reference subtitle range.
+
+Use `--first-block` and `--last-block` for an inclusive, one-based range of
+reference blocks. A boundary is included only when both reference subtitles
+belong to selected blocks. Block and subtitle bounds may be combined, in which
+case both selections apply. Omit either block bound for an open-ended range.
+
+Each table cell stacks the first and second subtitle with `<br>`. A blank line
+is displayed as `—`. Sort rows by their matched subtitle indexes. Preserve the
+original log order among repeated cases for the same boundary because they may
+record successive decisions. An empty JSON answer (`{}`) means no boundary
+shift was made; leave the output cell blank instead of repeating the input
+pair. The CLI leaves `Notes` cells blank for interpretation during the audit.
+
+## Audit every row
+
+Read the saved report from beginning to end and judge every row independently.
+The target characters may move across the boundary, but their concatenation
+must remain unchanged. Assess whether the output divides the target speech more
+faithfully between the meanings and utterances represented by the two guide
+subtitles.
+
+Judge only alignment. Ignore misspellings, mistranscriptions, Mandarinisms,
+punctuation, omissions, repetitions, and other defects in the target text except
+as fixed evidence for deciding which side of the boundary owns each phrase. Do
+not mention these defects in Notes. Leave Notes blank when the shift or no-shift
+answer is appropriate.
+
+Use semantic and discourse alignment rather than literal word matching:
+
+- Keep a phrase together when splitting it would damage its meaning or grammar.
+- Do not move a Cantonese sentence-final particle solely because the guide lacks
+  an equivalent token; attach it to the utterance it pragmatically completes.
+- Treat vocatives, discourse markers, repetitions, and other speech absent from
+  the guide according to their role in the target-language dialogue.
+- Accept a no-shift answer when the input division is already the best available
+  alignment; a change is not required merely because the two languages segment
+  an idea differently.
+- Flag a shift that makes alignment worse, and flag a no-shift answer when a
+  clear phrase belongs on the other side of the boundary.
+
+Classify alignment notes precisely:
+
+- **Delineation error:** the model chose the wrong boundary or failed to shift a
+  clearly misplaced phrase.
+- **Uncertain:** the appropriateness of the boundary cannot be determined from
+  the provided target text, guide pair, and available context.
+
+After reviewing every row, fill the saved report's `Notes` cells wherever you
+have an alignment observation. Begin each note with `Delineation error;` or
+`Uncertain;`, followed by a concise explanation focused only on boundary
+ownership. Leave the cell blank when the row needs no note. Validate that the
+edited file retains every generated row and the exact six-column shape. Do not
+claim the audit is complete until every row has been reviewed, all notes have
+been written to the saved report, and its link is ready for the final response.
+
+## Correct and verify cases
+
+When the user requests corrections, update the delineation JSON answer rather
+than a generated SRT:
+
+- Correct the boundary output before marking the case verified.
+- Mark a case `verified: true` only after auditing the entire boundary case and
+  correcting its answer where necessary.
+- Leave unanswered, unaudited, or partially audited cases unverified. Do not
+  treat an empty no-shift answer as unanswered; only a missing answer is
+  unanswered.
+
+After corrections, regenerate the transcription output and downstream
+artifacts through the dataset workflow. Rerun the audit over the corrected
+range, confirm the JSON remains canonical, and confirm corrected cases no
+longer appear with `--filter unverified` before linking the complete interpreted
+report.

--- a/skills/audit-transcription-delineation/agents/openai.yaml
+++ b/skills/audit-transcription-delineation/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Audit Transcription Delineation"
+  short_description: "Audit transcription boundary decisions"
+  default_prompt: "Use $audit-transcription-delineation to audit the logged transcription delineation decisions for this dataset."

--- a/skills/audit-transcription-punctuation/SKILL.md
+++ b/skills/audit-transcription-punctuation/SKILL.md
@@ -61,8 +61,8 @@ verification of a partly audited file. The report summary labels the requested
 bounds as the reference subtitle range. The report has exactly these columns:
 
 Use `--first-block` and `--last-block` for an inclusive, one-based range of
-reference blocks. Block and subtitle bounds may be combined; their intersection
-determines the eligible cases. Omit either block bound for an open-ended range.
+reference blocks. Block and subtitle bounds are mutually exclusive. Omit either
+block bound for an open-ended range.
 
 | Index | Reference | Input | Output | Notes | Verified |
 |---:|---|---|---|---|:---:|

--- a/skills/audit-transcription-punctuation/SKILL.md
+++ b/skills/audit-transcription-punctuation/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: audit-transcription-punctuation
+description: Audit Scinoephile transcription punctuation logs by matching JSON guide text and target fragments to reference and punctuated target SRTs, then judging whether punctuation and whitespace are appropriate without assessing transcription accuracy. Use when inspecting punctuation mps.json or cuda.json files, identifying punctuation errors, or verifying corrected punctuation test cases.
+---
+
+# Audit Transcription Punctuation
+
+Audit the punctuation and whitespace added to fixed transcription text. Produce a
+Markdown report, inspect every requested row, and record concise findings in its
+Notes column.
+
+## Scope
+
+Assess only whether the punctuation operation appropriately combined and
+punctuated the supplied target fragments. Treat the target characters as fixed.
+
+Do not assess transcription accuracy, translation accuracy, wording, character
+choice, Mandarinisms, omissions, or repetitions. Those belong to later review
+stages. Do not criticize the delineation of the input fragments except where the
+punctuation answer itself joins or separates them incorrectly.
+
+## Protect the source data
+
+Generating and annotating an audit is read-only with respect to the source JSON
+and SRT files. Do not modify them unless the user explicitly asks for fixes or
+verification. When asked to fix a case, update its JSON answer and propagate the
+correction to any derived output required by the repository workflow.
+
+## Locate the inputs
+
+Find these three inputs for the requested dataset:
+
+- the reference or guide SRT used during punctuation
+- the punctuated target SRT, normally `transcribe.srt`
+- the punctuation test-case JSON, normally `mps.json` or `cuda.json`
+
+The target SRT is used only to distinguish repeated reference subtitles. Do not
+use it as evidence that the transcription is accurate.
+
+## Generate the report
+
+Write the report to a Markdown file under `local/`; do not print the full table
+in the conversation. Use the inclusive reference-subtitle range requested by the
+user:
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache uv run scinoephile audit punctuation \
+  --reference <reference.srt> \
+  --target <transcribe.srt> \
+  --json <punctuation/mps.json> \
+  --first-index <first> \
+  --last-index <last> \
+  --filter all \
+  --outfile local/<dataset>_punctuation_audit_<first>-<last>.md \
+  --overwrite
+```
+
+Use `--filter changes` only when the user explicitly wants cases whose answers
+changed punctuation or whitespace. Use `--filter unverified` when continuing
+verification of a partly audited file. The report summary labels the requested
+bounds as the reference subtitle range. The report has exactly these columns:
+
+Use `--first-block` and `--last-block` for an inclusive, one-based range of
+reference blocks. Block and subtitle bounds may be combined; their intersection
+determines the eligible cases. Omit either block bound for an open-ended range.
+
+| Index | Reference | Input | Output | Notes | Verified |
+|---:|---|---|---|---|:---:|
+
+The Input column stacks the query fragments with `<br>`. Output is blank when
+the answer made no punctuation or whitespace change and `(unanswered)` when no
+answer is present. Verified contains `✓` for verified JSON cases and is otherwise
+blank. Rows are sorted by subtitle index; repeated logged cases remain separate.
+
+## Audit every row
+
+Open the Markdown file and inspect every requested row. The reference
+punctuation is useful context, but it does not dictate the target punctuation:
+Cantonese phrasing and sentence boundaries may differ from the guide.
+
+Consider:
+
+- question marks, exclamation marks, full stops, commas, colons, ellipses, and
+  quotation marks
+- spaces and the joining of the supplied fragments
+- particles, vocatives, interjections, and discourse markers
+- whether punctuation splits a grammatical phrase or implies the wrong
+  relationship between clauses
+
+Enter a note only when there is an actionable issue or genuine ambiguity. Use
+one of these exact prefixes:
+
+- `Punctuation error;` for a clear punctuation or whitespace error
+- `Uncertain;` when the audio or broader context is needed to judge the choice
+
+Leave Notes blank for acceptable answers. Replace generated/source notes with
+your own interpretation rather than copying them mechanically.
+
+## Correct and verify cases
+
+When the user requests corrections, update the punctuation JSON answer rather
+than the generated target SRT:
+
+- Correct the punctuation or whitespace output before marking the case
+  verified.
+- Mark a case `verified: true` only after auditing the entire punctuation case
+  and correcting its answer where necessary.
+- Leave unanswered, unaudited, or partially audited cases unverified.
+
+After corrections, regenerate the punctuated target SRT and downstream
+artifacts through the dataset workflow. Rerun the audit over the corrected
+range, confirm the JSON remains canonical, and confirm corrected cases no
+longer appear with `--filter unverified` before linking the complete interpreted
+report.
+
+## Validate and deliver
+
+After annotating the Markdown file:
+
+1. Confirm every requested row was inspected.
+2. Confirm the table still has exactly six columns and valid Markdown escaping.
+3. Confirm notes discuss punctuation only.
+4. Link the report file to the user and summarize the number and indexes of
+   clear errors and uncertain cases.

--- a/skills/audit-transcription-punctuation/agents/openai.yaml
+++ b/skills/audit-transcription-punctuation/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Audit Transcription Punctuation"
+  short_description: "Audit transcription punctuation decisions"
+  default_prompt: "Use $audit-transcription-punctuation to audit the logged transcription punctuation decisions for this dataset."

--- a/test/analysis/test_audit_utils.py
+++ b/test/analysis/test_audit_utils.py
@@ -1,0 +1,97 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests for shared audit-report helpers."""
+
+from __future__ import annotations
+
+from pytest import raises
+
+from scinoephile.analysis.audit.delineation import DelineationAuditFilter
+from scinoephile.analysis.audit.punctuation import PunctuationAuditFilter
+from scinoephile.analysis.audit.review import ReviewAuditFilter
+from scinoephile.analysis.audit.utils import (
+    AuditFilter,
+    format_audit_report,
+    resolve_contextual_index,
+)
+
+
+def test_workflow_audit_filters_share_one_enum():
+    """Test compatible workflow filter exports reuse the shared enum."""
+    assert DelineationAuditFilter is AuditFilter
+    assert PunctuationAuditFilter is AuditFilter
+    assert ReviewAuditFilter is AuditFilter
+
+
+def test_format_audit_report_formats_ranges_and_table():
+    """Test shared report framing includes optional ranges and table rows."""
+    report = format_audit_report(
+        title="Example Audit",
+        summary_lines=("- cases: 1",),
+        column_labels=("Index", "Text"),
+        column_separators=("---:", "---"),
+        rows=("| 2 | example |",),
+        first_index=2,
+        last_index=3,
+        index_track_name="target",
+        first_block=4,
+    )
+
+    assert report == (
+        "# Example Audit\n"
+        "\n"
+        "## Summary\n"
+        "\n"
+        "- cases: 1\n"
+        "- target subtitle range: 2 through 3\n"
+        "- block range: from 4\n"
+        "- table rows: 1\n"
+        "\n"
+        "## Audit Table\n"
+        "\n"
+        "| Index | Text |\n"
+        "|---:|---|\n"
+        "| 2 | example |\n"
+    )
+
+
+def test_format_audit_report_rejects_mismatched_table_columns():
+    """Test table labels and separators must describe the same columns."""
+    with raises(ValueError, match="same length"):
+        format_audit_report(
+            title="Example Audit",
+            summary_lines=(),
+            column_labels=("Index", "Text"),
+            column_separators=("---:",),
+            rows=(),
+        )
+
+
+def test_resolve_contextual_index_returns_direct_index():
+    """Test a directly resolved index is returned without modification."""
+    resolved_indexes = [2, None]
+
+    index = resolve_contextual_index((1, 2), resolved_indexes, 0)
+
+    assert index == 2
+    assert resolved_indexes == [2, None]
+
+
+def test_resolve_contextual_index_memoizes_contextual_match():
+    """Test a contextual match is retained for resolving later cases."""
+    resolved_indexes = [0, None, 4]
+
+    index = resolve_contextual_index((1, 3), resolved_indexes, 1)
+
+    assert index == 1
+    assert resolved_indexes == [0, 1, 4]
+
+
+def test_resolve_contextual_index_retains_ambiguity_without_anchors():
+    """Test repeated candidates remain unresolved without neighboring anchors."""
+    resolved_indexes = [None, None, None]
+
+    index = resolve_contextual_index((1, 3), resolved_indexes, 1)
+
+    assert index is None
+    assert resolved_indexes == [None, None, None]

--- a/test/analysis/test_audit_utils.py
+++ b/test/analysis/test_audit_utils.py
@@ -6,9 +6,6 @@ from __future__ import annotations
 
 from pytest import raises
 
-from scinoephile.analysis.audit.delineation import DelineationAuditFilter
-from scinoephile.analysis.audit.punctuation import PunctuationAuditFilter
-from scinoephile.analysis.audit.review import ReviewAuditFilter
 from scinoephile.analysis.audit.utils import (
     AuditFilter,
     format_audit_report,
@@ -16,11 +13,13 @@ from scinoephile.analysis.audit.utils import (
 )
 
 
-def test_workflow_audit_filters_share_one_enum():
-    """Test compatible workflow filter exports reuse the shared enum."""
-    assert DelineationAuditFilter is AuditFilter
-    assert PunctuationAuditFilter is AuditFilter
-    assert ReviewAuditFilter is AuditFilter
+def test_audit_filter_has_common_options():
+    """Test the shared audit filter exposes the common row options."""
+    assert tuple(AuditFilter) == (
+        AuditFilter.all,
+        AuditFilter.changes,
+        AuditFilter.unverified,
+    )
 
 
 def test_format_audit_report_formats_ranges_and_table():

--- a/test/analysis/test_delineation_audit.py
+++ b/test/analysis/test_delineation_audit.py
@@ -207,6 +207,13 @@ def test_audit_delineation_rejects_invalid_range():
         audit_delineation(_get_series("參考一", "參考二"), (), first_index=0)
     with raises(ScinoephileError, match="First block must be at least 1"):
         audit_delineation(_get_series("參考一", "參考二"), (), first_block=0)
+    with raises(ScinoephileError, match="ranges are mutually exclusive"):
+        audit_delineation(
+            _get_series("參考一", "參考二"),
+            (),
+            first_index=1,
+            first_block=1,
+        )
 
 
 def test_audit_delineation_rejects_unmatched_reference_pair():
@@ -469,8 +476,8 @@ def test_audit_delineation_rejects_ambiguous_reference_pair():
         )
 
 
-def test_audit_delineation_scopes_ambiguity_to_subtitle_range():
-    """Test repeated pairs are resolved only within the requested range."""
+def test_audit_delineation_rejects_range_based_disambiguation():
+    """Test a range cannot force an ambiguous pair onto one occurrence."""
     reference = _get_series("參考一", "參考二", "參考一", "參考二")
     test_case = DelineationTestCase(
         query=DelineationQuery(
@@ -481,12 +488,13 @@ def test_audit_delineation_scopes_ambiguity_to_subtitle_range():
         answer=DelineationAnswer(),
     )
 
-    first_report = audit_delineation(
-        reference,
-        (test_case,),
-        first_index=1,
-        last_index=2,
-    )
+    with raises(ScinoephileError, match="reference pair is ambiguous.*1, 3"):
+        audit_delineation(
+            reference,
+            (test_case,),
+            first_index=1,
+            last_index=2,
+        )
     excluded_report = audit_delineation(
         reference,
         (test_case,),
@@ -494,9 +502,43 @@ def test_audit_delineation_scopes_ambiguity_to_subtitle_range():
         last_index=6,
     )
 
-    assert "| 1<br>2 |" in first_report
     assert "- logged cases: 0" in excluded_report
     assert "- table rows: 0" in excluded_report
+
+
+def test_audit_delineation_resolves_repeated_pair_before_range_filtering():
+    """Test a range cannot reassign a contextually resolved pair."""
+    reference = _get_series("重複一", "重複二", "之前", "重複一", "重複二", "之後")
+    test_cases = (
+        DelineationTestCase(
+            query=DelineationQuery(
+                reference_one="之前",
+                reference_two="重複一",
+                target_one="前",
+            ),
+            answer=DelineationAnswer(),
+        ),
+        DelineationTestCase(
+            query=DelineationQuery(
+                reference_one="重複一",
+                reference_two="重複二",
+                target_one="中",
+            ),
+            answer=DelineationAnswer(),
+        ),
+    )
+
+    report = audit_delineation(reference, test_cases)
+    ranged_report = audit_delineation(
+        reference,
+        test_cases,
+        first_index=1,
+        last_index=2,
+    )
+
+    assert "| 4<br>5 | 重複一<br>重複二 | 中<br>— |" in report
+    assert "- logged cases: 0" in ranged_report
+    assert "- table rows: 0" in ranged_report
 
 
 def _get_series(*texts: str) -> Series:

--- a/test/analysis/test_delineation_audit.py
+++ b/test/analysis/test_delineation_audit.py
@@ -6,10 +6,8 @@ from __future__ import annotations
 
 from pytest import raises
 
-from scinoephile.analysis.audit.delineation import (
-    DelineationAuditFilter,
-    audit_delineation,
-)
+from scinoephile.analysis.audit.delineation import audit_delineation
+from scinoephile.analysis.audit.utils import AuditFilter
 from scinoephile.core import ScinoephileError
 from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.llms.delineation import (
@@ -130,12 +128,12 @@ def test_audit_delineation_filters_rows_and_subtitle_range():
     changed_report = audit_delineation(
         reference,
         test_cases,
-        row_filter=DelineationAuditFilter.changes,
+        row_filter=AuditFilter.changes,
     )
     unverified_report = audit_delineation(
         reference,
         test_cases,
-        row_filter=DelineationAuditFilter.unverified,
+        row_filter=AuditFilter.unverified,
     )
     ranged_report = audit_delineation(
         reference,

--- a/test/analysis/test_delineation_audit.py
+++ b/test/analysis/test_delineation_audit.py
@@ -1,0 +1,515 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests for transcription delineation audit reports."""
+
+from __future__ import annotations
+
+from pytest import raises
+
+from scinoephile.analysis.audit.delineation import (
+    DelineationAuditFilter,
+    audit_delineation,
+)
+from scinoephile.core import ScinoephileError
+from scinoephile.core.subtitles import Series, Subtitle
+from scinoephile.llms.delineation import (
+    DelineationAnswer,
+    DelineationQuery,
+    DelineationTestCase,
+)
+
+
+def test_audit_delineation_formats_shift_and_no_shift_rows():
+    """Test shifted and unchanged boundaries are rendered as stacked pairs."""
+    reference = _get_series("參|考一", "參考二", "參考三")
+    test_cases = (
+        DelineationTestCase(
+            query=DelineationQuery(
+                reference_one="參|考一",
+                reference_two="參考二",
+                target_one="甲乙",
+                target_two="丙",
+            ),
+            answer=DelineationAnswer(output_one="甲", output_two="乙丙"),
+            verified=True,
+        ),
+        DelineationTestCase(
+            query=DelineationQuery(
+                reference_one="參考二",
+                reference_two="參考三",
+                target_one="丁",
+            ),
+            answer=DelineationAnswer(),
+        ),
+    )
+
+    report = audit_delineation(reference, test_cases)
+
+    assert "- logged cases: 2" in report
+    assert "- boundary shifts: 1" in report
+    assert "- no-shift answers: 1" in report
+    assert "- unanswered cases: 0" in report
+    assert "| Indexes | Reference | Input | Output | Notes | Verified |" in report
+    assert "| 1<br>2 | 參\\|考一<br>參考二 | 甲乙<br>丙 | 甲<br>乙丙 |  | ✓ |" in report
+    assert "| 2<br>3 | 參考二<br>參考三 | 丁<br>— |  |  |  |" in report
+
+
+def test_audit_delineation_sorts_rows_and_omits_unchanged_output():
+    """Test rows are index-sorted and unchanged output is omitted."""
+    reference = _get_series("參考一", "參考二", "參考三")
+    test_cases = (
+        DelineationTestCase(
+            query=DelineationQuery(
+                reference_one="參考二",
+                reference_two="參考三",
+                target_one="丙",
+                target_two="丁",
+            ),
+            answer=DelineationAnswer(),
+        ),
+        DelineationTestCase(
+            query=DelineationQuery(
+                reference_one="參考一",
+                reference_two="參考二",
+                target_one="甲",
+                target_two="乙",
+            ),
+            answer=DelineationAnswer(),
+        ),
+    )
+
+    report = audit_delineation(reference, test_cases)
+
+    first_row = "| 1<br>2 | 參考一<br>參考二 | 甲<br>乙 |  |  |  |"
+    second_row = "| 2<br>3 | 參考二<br>參考三 | 丙<br>丁 |  |  |  |"
+    assert report.index(first_row) < report.index(second_row)
+    assert "- boundary shifts: 0" in report
+    assert "- no-shift answers: 2" in report
+
+
+def test_audit_delineation_formats_unanswered_case():
+    """Test an unanswered logged case is identified without inventing output."""
+    test_case = DelineationTestCase(
+        query=DelineationQuery(
+            reference_one="參考一",
+            reference_two="參考二",
+            target_one="甲",
+        )
+    )
+
+    report = audit_delineation(_get_series("參考一", "參考二"), (test_case,))
+
+    assert "- unanswered cases: 1" in report
+    assert "| 1<br>2 | 參考一<br>參考二 | 甲<br>— | (unanswered) |  |  |" in report
+
+
+def test_audit_delineation_filters_rows_and_subtitle_range():
+    """Test row status and inclusive subtitle-range filters."""
+    reference = _get_series("參考一", "參考二", "參考三")
+    test_cases = (
+        DelineationTestCase(
+            query=DelineationQuery(
+                reference_one="參考一",
+                reference_two="參考二",
+                target_one="甲乙",
+                target_two="丙",
+            ),
+            answer=DelineationAnswer(output_one="甲", output_two="乙丙"),
+        ),
+        DelineationTestCase(
+            query=DelineationQuery(
+                reference_one="參考二",
+                reference_two="參考三",
+                target_one="丁",
+            ),
+            answer=DelineationAnswer(),
+            verified=True,
+        ),
+    )
+
+    changed_report = audit_delineation(
+        reference,
+        test_cases,
+        row_filter=DelineationAuditFilter.changes,
+    )
+    unverified_report = audit_delineation(
+        reference,
+        test_cases,
+        row_filter=DelineationAuditFilter.unverified,
+    )
+    ranged_report = audit_delineation(
+        reference,
+        test_cases,
+        first_index=1,
+        last_index=2,
+    )
+
+    assert "- logged cases: 2" in changed_report
+    assert "- row filter: changes" in changed_report
+    assert "- table rows: 1" in changed_report
+    assert "| 1<br>2 |" in changed_report
+    assert "| 2<br>3 |" not in changed_report
+    assert "- logged cases: 1" in ranged_report
+    assert "- reference subtitle range: 1 through 2" in ranged_report
+    assert "- table rows: 1" in ranged_report
+    assert "| 1<br>2 |" in ranged_report
+    assert "| 2<br>3 |" not in ranged_report
+    assert "- row filter: unverified" in unverified_report
+    assert "- table rows: 1" in unverified_report
+    assert "| 1<br>2 |" in unverified_report
+    assert "| 2<br>3 |" not in unverified_report
+
+
+def test_audit_delineation_filters_reference_blocks():
+    """Test block bounds select only boundaries within matching guide blocks."""
+    reference = Series(
+        events=[
+            Subtitle(start=0, end=1000, text="一"),
+            Subtitle(start=1000, end=2000, text="二"),
+            Subtitle(start=6000, end=7000, text="三"),
+            Subtitle(start=7000, end=8000, text="四"),
+        ]
+    )
+    test_cases = (
+        DelineationTestCase(
+            query=DelineationQuery(
+                reference_one="一",
+                reference_two="二",
+                target_one="甲",
+            ),
+            answer=DelineationAnswer(),
+        ),
+        DelineationTestCase(
+            query=DelineationQuery(
+                reference_one="三",
+                reference_two="四",
+                target_one="乙",
+            ),
+            answer=DelineationAnswer(),
+        ),
+    )
+
+    report = audit_delineation(
+        reference,
+        test_cases,
+        first_block=2,
+        last_block=2,
+    )
+
+    assert "- block range: 2 through 2" in report
+    assert "| 1<br>2 |" not in report
+    assert "| 3<br>4 |" in report
+
+
+def test_audit_delineation_rejects_invalid_range():
+    """Test direct callers receive a domain error for an invalid range."""
+    with raises(ScinoephileError, match="First index must be at least 1"):
+        audit_delineation(_get_series("參考一", "參考二"), (), first_index=0)
+    with raises(ScinoephileError, match="First block must be at least 1"):
+        audit_delineation(_get_series("參考一", "參考二"), (), first_block=0)
+
+
+def test_audit_delineation_rejects_unmatched_reference_pair():
+    """Test a logged pair absent from the reference cannot be indexed."""
+    test_case = DelineationTestCase(
+        query=DelineationQuery(
+            reference_one="不同一",
+            reference_two="不同二",
+            target_one="甲",
+        )
+    )
+
+    with raises(ScinoephileError, match="test case 1 reference pair was not found"):
+        audit_delineation(_get_series("參考一", "參考二"), (test_case,))
+
+
+def test_audit_delineation_ignores_superseded_reference_revision():
+    """Test retained cases using corrected reference text are ignored."""
+    reference = _get_series("參考一", "更正參考二", "參考三")
+    historical_case = DelineationTestCase(
+        query=DelineationQuery(
+            reference_one="參考一",
+            reference_two="舊參考二",
+            target_one="舊甲",
+            target_two="舊乙",
+        ),
+        answer=DelineationAnswer(),
+    )
+    later_historical_case = DelineationTestCase(
+        query=DelineationQuery(
+            reference_one="參考一",
+            reference_two="舊參考二",
+            target_one="甲",
+            target_two="乙",
+        ),
+        answer=DelineationAnswer(),
+    )
+    current_case = DelineationTestCase(
+        query=DelineationQuery(
+            reference_one="參考一",
+            reference_two="更正參考二",
+            target_one="甲",
+            target_two="乙",
+        ),
+        answer=DelineationAnswer(),
+    )
+    test_cases = (historical_case, later_historical_case, current_case)
+
+    report = audit_delineation(reference, test_cases)
+    excluded_report = audit_delineation(
+        reference,
+        test_cases,
+        first_index=3,
+        last_index=3,
+    )
+
+    assert "- logged cases: 1" in report
+    assert "舊參考二" not in report
+    assert "| 1<br>2 | 參考一<br>更正參考二 | 甲<br>乙 |" in report
+    assert "- logged cases: 0" in excluded_report
+
+
+def test_audit_delineation_resolves_repeated_reference_pair_from_context():
+    """Test neighboring cases resolve a repeated reference pair."""
+    reference = _get_series("之前", "重複一", "重複二", "之後", "重複一", "重複二")
+    test_cases = (
+        DelineationTestCase(
+            query=DelineationQuery(
+                reference_one="之前",
+                reference_two="重複一",
+                target_one="甲",
+                target_two="乙",
+            ),
+            answer=DelineationAnswer(),
+        ),
+        DelineationTestCase(
+            query=DelineationQuery(
+                reference_one="重複一",
+                reference_two="重複二",
+                target_one="乙",
+                target_two="丙",
+            ),
+            answer=DelineationAnswer(),
+        ),
+        DelineationTestCase(
+            query=DelineationQuery(
+                reference_one="重複二",
+                reference_two="之後",
+                target_one="丙",
+                target_two="丁",
+            ),
+            answer=DelineationAnswer(),
+        ),
+    )
+
+    report = audit_delineation(reference, test_cases)
+
+    assert "| 2<br>3 | 重複一<br>重複二 | 乙<br>丙 |" in report
+    assert "| 5<br>6 | 重複一<br>重複二 | 乙<br>丙 |" not in report
+
+
+def test_audit_delineation_progressively_resolves_repeated_sequence():
+    """Test contextual resolutions disambiguate later repeated pairs."""
+    reference = _get_series("之前", "乙", "甲", "乙", "甲", "乙", "之後")
+    test_cases = (
+        DelineationTestCase(
+            query=DelineationQuery(
+                reference_one="之前",
+                reference_two="乙",
+                target_one="前",
+            ),
+            answer=DelineationAnswer(),
+        ),
+        DelineationTestCase(
+            query=DelineationQuery(
+                reference_one="甲",
+                reference_two="乙",
+                target_one="一",
+            ),
+            answer=DelineationAnswer(),
+        ),
+        DelineationTestCase(
+            query=DelineationQuery(
+                reference_one="甲",
+                reference_two="乙",
+                target_one="二",
+            ),
+            answer=DelineationAnswer(),
+        ),
+        DelineationTestCase(
+            query=DelineationQuery(
+                reference_one="乙",
+                reference_two="甲",
+                target_one="三",
+            ),
+            answer=DelineationAnswer(),
+        ),
+        DelineationTestCase(
+            query=DelineationQuery(
+                reference_one="甲",
+                reference_two="乙",
+                target_one="四",
+            ),
+            answer=DelineationAnswer(),
+        ),
+        DelineationTestCase(
+            query=DelineationQuery(
+                reference_one="乙",
+                reference_two="之後",
+                target_one="後",
+            ),
+            answer=DelineationAnswer(),
+        ),
+    )
+
+    report = audit_delineation(reference, test_cases)
+
+    assert report.count("| 3<br>4 | 甲<br>乙 |") == 2
+    assert "| 4<br>5 | 乙<br>甲 |" in report
+    assert "| 5<br>6 | 甲<br>乙 |" in report
+
+
+def test_audit_delineation_resolves_context_before_logged_restart():
+    """Test a later case is resolved before a logged traversal restart."""
+    reference = _get_series("之前", "甲", "乙", "甲", "乙", "之後")
+    test_cases = (
+        DelineationTestCase(
+            query=DelineationQuery(
+                reference_one="之前",
+                reference_two="甲",
+                target_one="前",
+            ),
+            answer=DelineationAnswer(),
+        ),
+        DelineationTestCase(
+            query=DelineationQuery(
+                reference_one="甲",
+                reference_two="乙",
+                target_one="中",
+            ),
+            answer=DelineationAnswer(),
+        ),
+        DelineationTestCase(
+            query=DelineationQuery(
+                reference_one="之前",
+                reference_two="甲",
+                target_one="重啟",
+            ),
+            answer=DelineationAnswer(),
+        ),
+    )
+
+    report = audit_delineation(reference, test_cases)
+
+    assert "| 2<br>3 | 甲<br>乙 | 中<br>— |" in report
+    assert "| 4<br>5 | 甲<br>乙 | 中<br>— |" not in report
+
+
+def test_audit_delineation_resolves_reverse_traversal_before_restart():
+    """Test adjacent reverse traversal is resolved before an earlier restart."""
+    reference = _get_series("之前", "乙", "甲", "乙", "甲", "乙", "之後")
+    test_cases = (
+        DelineationTestCase(
+            query=DelineationQuery(
+                reference_one="之前",
+                reference_two="乙",
+                target_one="前",
+            ),
+            answer=DelineationAnswer(),
+        ),
+        DelineationTestCase(
+            query=DelineationQuery(
+                reference_one="甲",
+                reference_two="乙",
+                target_one="右",
+            ),
+            answer=DelineationAnswer(),
+        ),
+        DelineationTestCase(
+            query=DelineationQuery(
+                reference_one="乙",
+                reference_two="甲",
+                target_one="左",
+            ),
+            answer=DelineationAnswer(),
+        ),
+        DelineationTestCase(
+            query=DelineationQuery(
+                reference_one="之前",
+                reference_two="乙",
+                target_one="重啟",
+            ),
+            answer=DelineationAnswer(),
+        ),
+    )
+
+    report = audit_delineation(reference, test_cases)
+
+    assert "| 2<br>3 | 乙<br>甲 | 左<br>— |" in report
+    assert "| 4<br>5 | 乙<br>甲 | 左<br>— |" not in report
+
+
+def test_audit_delineation_rejects_ambiguous_reference_pair():
+    """Test a repeated reference pair cannot be assigned misleading indexes."""
+    test_case = DelineationTestCase(
+        query=DelineationQuery(
+            reference_one="參考一",
+            reference_two="參考二",
+            target_one="甲",
+        )
+    )
+
+    with raises(
+        ScinoephileError,
+        match="test case 1 reference pair is ambiguous.*1, 3",
+    ):
+        audit_delineation(
+            _get_series("參考一", "參考二", "參考一", "參考二"),
+            (test_case,),
+        )
+
+
+def test_audit_delineation_scopes_ambiguity_to_subtitle_range():
+    """Test repeated pairs are resolved only within the requested range."""
+    reference = _get_series("參考一", "參考二", "參考一", "參考二")
+    test_case = DelineationTestCase(
+        query=DelineationQuery(
+            reference_one="參考一",
+            reference_two="參考二",
+            target_one="甲",
+        ),
+        answer=DelineationAnswer(),
+    )
+
+    first_report = audit_delineation(
+        reference,
+        (test_case,),
+        first_index=1,
+        last_index=2,
+    )
+    excluded_report = audit_delineation(
+        reference,
+        (test_case,),
+        first_index=5,
+        last_index=6,
+    )
+
+    assert "| 1<br>2 |" in first_report
+    assert "- logged cases: 0" in excluded_report
+    assert "- table rows: 0" in excluded_report
+
+
+def _get_series(*texts: str) -> Series:
+    """Construct a subtitle series with the provided text.
+
+    Arguments:
+        *texts: subtitle text by event
+    Returns:
+        constructed subtitle series
+    """
+    return Series(
+        events=[
+            Subtitle(start=index * 1000, end=(index + 1) * 1000, text=text)
+            for index, text in enumerate(texts)
+        ]
+    )

--- a/test/analysis/test_guided_review_audit.py
+++ b/test/analysis/test_guided_review_audit.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from pytest import raises
 
 from scinoephile.analysis.audit.guided_review import audit_guided_review
-from scinoephile.analysis.audit.review import ReviewAuditFilter
+from scinoephile.analysis.audit.utils import AuditFilter
 from scinoephile.core import ScinoephileError
 from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.llms.guided_review import GuidedReviewTestCase
@@ -173,13 +173,13 @@ def test_audit_guided_review_filters_rows_and_target_range():
         target,
         guide,
         test_cases,
-        row_filter=ReviewAuditFilter.changes,
+        row_filter=AuditFilter.changes,
     )
     unverified_report = audit_guided_review(
         target,
         guide,
         test_cases,
-        row_filter=ReviewAuditFilter.unverified,
+        row_filter=AuditFilter.unverified,
     )
     ranged_report = audit_guided_review(
         target,

--- a/test/analysis/test_punctuation_audit.py
+++ b/test/analysis/test_punctuation_audit.py
@@ -1,0 +1,388 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests for transcription punctuation audit reports."""
+
+from __future__ import annotations
+
+from pytest import raises
+
+from scinoephile.analysis.audit.punctuation import (
+    PunctuationAuditFilter,
+    audit_punctuation,
+)
+from scinoephile.core.exceptions import ScinoephileError
+from scinoephile.core.subtitles import Series, Subtitle
+from scinoephile.llms.punctuation import (
+    PunctuationAnswer,
+    PunctuationQuery,
+    PunctuationTestCase,
+)
+
+
+def test_audit_punctuation_formats_changed_and_unchanged_rows():
+    """Test changed and unchanged answers are rendered consistently."""
+    reference = _get_series("參|考一", "參考二")
+    target = _get_series("甲，乙丙", "丁")
+    test_cases = (
+        PunctuationTestCase(
+            query=PunctuationQuery(
+                guide="參|考一",
+                subtitles=["甲", "乙丙"],
+            ),
+            answer=PunctuationAnswer(output="甲，乙丙"),
+            verified=True,
+        ),
+        PunctuationTestCase(
+            query=PunctuationQuery(guide="參考二", subtitles=["丁"]),
+            answer=PunctuationAnswer(output="丁"),
+        ),
+    )
+
+    report = audit_punctuation(reference, target, test_cases)
+
+    assert "- logged cases: 2" in report
+    assert "- punctuation changes: 1" in report
+    assert "- unchanged answers: 1" in report
+    assert "- unanswered cases: 0" in report
+    assert "| Index | Reference | Input | Output | Notes | Verified |" in report
+    assert "| 1 | 參\\|考一 | 甲<br>乙丙 | 甲，乙丙 |  | ✓ |" in report
+    assert "| 2 | 參考二 | 丁 |  |  |  |" in report
+
+
+def test_audit_punctuation_formats_unanswered_case():
+    """Test an unanswered logged case is identified without inventing output."""
+    test_case = PunctuationTestCase(
+        query=PunctuationQuery(guide="參考", subtitles=["原文"])
+    )
+
+    report = audit_punctuation(
+        _get_series("參考"),
+        _get_series("原文"),
+        (test_case,),
+    )
+
+    assert "- unanswered cases: 1" in report
+    assert "| 1 | 參考 | 原文 | (unanswered) |  |  |" in report
+
+
+def test_audit_punctuation_filters_rows_and_subtitle_range():
+    """Test row status and inclusive subtitle-range filters."""
+    reference = _get_series("參考一", "參考二", "參考三")
+    target = _get_series("甲，乙", "丙", "丁")
+    test_cases = (
+        PunctuationTestCase(
+            query=PunctuationQuery(guide="參考一", subtitles=["甲", "乙"]),
+            answer=PunctuationAnswer(output="甲，乙"),
+        ),
+        PunctuationTestCase(
+            query=PunctuationQuery(guide="參考二", subtitles=["丙"]),
+            answer=PunctuationAnswer(output="丙"),
+            verified=True,
+        ),
+    )
+
+    changed_report = audit_punctuation(
+        reference,
+        target,
+        test_cases,
+        row_filter=PunctuationAuditFilter.changes,
+    )
+    unverified_report = audit_punctuation(
+        reference,
+        target,
+        test_cases,
+        row_filter=PunctuationAuditFilter.unverified,
+    )
+    ranged_report = audit_punctuation(
+        reference,
+        target,
+        test_cases,
+        first_index=2,
+        last_index=3,
+    )
+
+    assert "- logged cases: 2" in changed_report
+    assert "- row filter: changes" in changed_report
+    assert "- table rows: 1" in changed_report
+    assert "| 1 |" in changed_report
+    assert "| 2 |" not in changed_report
+    assert "- logged cases: 1" in ranged_report
+    assert "- reference subtitle range: 2 through 3" in ranged_report
+    assert "- table rows: 1" in ranged_report
+    assert "| 1 |" not in ranged_report
+    assert "| 2 |" in ranged_report
+    assert "- row filter: unverified" in unverified_report
+    assert "- table rows: 1" in unverified_report
+    assert "| 1 |" in unverified_report
+    assert "| 2 |" not in unverified_report
+
+
+def test_audit_punctuation_filters_reference_blocks():
+    """Test block bounds select punctuation cases from matching guide blocks."""
+    reference = Series(
+        events=[
+            Subtitle(start=0, end=1000, text="一"),
+            Subtitle(start=6000, end=7000, text="二"),
+        ]
+    )
+    target = Series(
+        events=[
+            Subtitle(start=0, end=1000, text="甲"),
+            Subtitle(start=6000, end=7000, text="乙"),
+        ]
+    )
+    test_cases = (
+        PunctuationTestCase(
+            query=PunctuationQuery(guide="一", subtitles=["甲"]),
+            answer=PunctuationAnswer(output="甲"),
+        ),
+        PunctuationTestCase(
+            query=PunctuationQuery(guide="二", subtitles=["乙"]),
+            answer=PunctuationAnswer(output="乙"),
+        ),
+    )
+
+    report = audit_punctuation(
+        reference,
+        target,
+        test_cases,
+        first_block=2,
+        last_block=2,
+    )
+
+    assert "- block range: 2 through 2" in report
+    assert "| 1 | 一 |" not in report
+    assert "| 2 | 二 |" in report
+
+
+def test_audit_punctuation_rejects_invalid_range():
+    """Test direct callers receive a domain error for an invalid range."""
+    with raises(ScinoephileError, match="First index must be at least 1"):
+        audit_punctuation(
+            _get_series("參考"),
+            _get_series("甲"),
+            (),
+            first_index=0,
+        )
+    with raises(ScinoephileError, match="First block must be at least 1"):
+        audit_punctuation(
+            _get_series("參考"),
+            _get_series("甲"),
+            (),
+            first_block=0,
+        )
+
+
+def test_audit_punctuation_resolves_repeated_reference_from_target():
+    """Test target characters disambiguate repeated reference text."""
+    reference = _get_series("重複", "其他", "重複")
+    target = _get_series("甲", "中", "乙！")
+    test_case = PunctuationTestCase(
+        query=PunctuationQuery(guide="重複", subtitles=["乙"]),
+        answer=PunctuationAnswer(output="乙！"),
+    )
+
+    report = audit_punctuation(reference, target, (test_case,))
+
+    assert "| 3 | 重複 | 乙 | 乙！ |" in report
+
+
+def test_audit_punctuation_resolves_repeated_reference_from_longest_target():
+    """Test the longest contained target text resolves a repeated reference."""
+    reference = _get_series("開始", "開始")
+    target = _get_series("開始啊", "開始")
+    test_case = PunctuationTestCase(
+        query=PunctuationQuery(guide="開始", subtitles=["啊", "開始啊"]),
+        answer=PunctuationAnswer(output="啊，開始啊。"),
+    )
+
+    report = audit_punctuation(reference, target, (test_case,))
+
+    assert "| 1 | 開始 | 啊<br>開始啊 | 啊，開始啊。 |" in report
+
+
+def test_audit_punctuation_resolves_repeated_reference_from_context():
+    """Test neighboring cases disambiguate repeated reference text."""
+    reference = _get_series("之前", "重複", "之後", "重複")
+    target = _get_series("前", "同", "後", "同")
+    test_cases = (
+        PunctuationTestCase(
+            query=PunctuationQuery(guide="之前", subtitles=["前"]),
+            answer=PunctuationAnswer(output="前"),
+        ),
+        PunctuationTestCase(
+            query=PunctuationQuery(guide="重複", subtitles=["同"]),
+            answer=PunctuationAnswer(output="同"),
+        ),
+        PunctuationTestCase(
+            query=PunctuationQuery(guide="之後", subtitles=["後"]),
+            answer=PunctuationAnswer(output="後"),
+        ),
+    )
+
+    report = audit_punctuation(reference, target, test_cases)
+
+    assert "| 2 | 重複 | 同 |" in report
+    assert "| 4 | 重複 | 同 |" not in report
+
+
+def test_audit_punctuation_resolves_repeated_reference_before_range_filtering():
+    """Test a range cannot force a repeated case onto the wrong subtitle."""
+    reference = _get_series("前一", "重複", "中間", "之前", "重複", "之後")
+    target = _get_series("甲", "同", "乙", "前", "同", "後")
+    test_cases = (
+        PunctuationTestCase(
+            query=PunctuationQuery(guide="之前", subtitles=["前"]),
+            answer=PunctuationAnswer(output="前"),
+        ),
+        PunctuationTestCase(
+            query=PunctuationQuery(guide="重複", subtitles=["同"]),
+            answer=PunctuationAnswer(output="同"),
+        ),
+        PunctuationTestCase(
+            query=PunctuationQuery(guide="之後", subtitles=["後"]),
+            answer=PunctuationAnswer(output="後"),
+        ),
+    )
+
+    report = audit_punctuation(
+        reference,
+        target,
+        test_cases,
+        first_index=1,
+        last_index=2,
+    )
+
+    assert "- logged cases: 0" in report
+    assert "- table rows: 0" in report
+    assert "| 2 | 重複 | 同 |" not in report
+
+
+def test_audit_punctuation_ignores_ambiguity_outside_range():
+    """Test repeated references wholly outside the range need not be resolved."""
+    reference = _get_series("範圍內", "重複", "重複")
+    target = _get_series("乙", "甲", "甲")
+    test_case = PunctuationTestCase(
+        query=PunctuationQuery(guide="重複", subtitles=["甲"]),
+        answer=PunctuationAnswer(output="甲"),
+    )
+
+    report = audit_punctuation(
+        reference,
+        target,
+        (test_case,),
+        first_index=1,
+        last_index=1,
+    )
+
+    assert "- logged cases: 0" in report
+    assert "- table rows: 0" in report
+
+
+def test_audit_punctuation_rejects_unmatched_reference():
+    """Test a logged reference absent from the series cannot be indexed."""
+    test_case = PunctuationTestCase(
+        query=PunctuationQuery(guide="不同", subtitles=["甲"])
+    )
+
+    with raises(ScinoephileError, match="test case 1 reference subtitle was not found"):
+        audit_punctuation(
+            _get_series("參考"),
+            _get_series("甲"),
+            (test_case,),
+        )
+
+
+def test_audit_punctuation_ignores_superseded_reference_revision():
+    """Test a retained case using corrected reference text is ignored."""
+    reference = _get_series("更正參考")
+    target = _get_series("甲，乙")
+    historical_case = PunctuationTestCase(
+        query=PunctuationQuery(guide="舊參考", subtitles=["甲", "乙"]),
+        answer=PunctuationAnswer(output="甲，乙"),
+    )
+    current_case = PunctuationTestCase(
+        query=PunctuationQuery(guide="更正參考", subtitles=["甲", "乙"]),
+        answer=PunctuationAnswer(output="甲，乙"),
+    )
+    test_cases = (historical_case, current_case)
+
+    report = audit_punctuation(reference, target, test_cases)
+    excluded_report = audit_punctuation(
+        reference,
+        target,
+        test_cases,
+        first_index=2,
+        last_index=2,
+    )
+
+    assert "- logged cases: 1" in report
+    assert "舊參考" not in report
+    assert "| 1 | 更正參考 | 甲<br>乙 | 甲，乙 |" in report
+    assert "- logged cases: 0" in excluded_report
+
+
+def test_audit_punctuation_does_not_transitively_ignore_unmatched_reference():
+    """Test one stale key cannot connect an unrelated unmatched reference."""
+    test_cases = (
+        PunctuationTestCase(
+            query=PunctuationQuery(guide="目前參考", subtitles=["共用"]),
+            answer=PunctuationAnswer(output="共用"),
+        ),
+        PunctuationTestCase(
+            query=PunctuationQuery(guide="過渡參考", subtitles=["共用"]),
+            answer=PunctuationAnswer(output="共用"),
+        ),
+        PunctuationTestCase(
+            query=PunctuationQuery(guide="過渡參考", subtitles=["其他"]),
+            answer=PunctuationAnswer(output="其他"),
+        ),
+        PunctuationTestCase(
+            query=PunctuationQuery(guide="無關參考", subtitles=["其他"]),
+            answer=PunctuationAnswer(output="其他"),
+        ),
+    )
+
+    with raises(
+        ScinoephileError,
+        match="test case 4 reference subtitle was not found",
+    ):
+        audit_punctuation(
+            _get_series("目前參考"),
+            _get_series("共用"),
+            test_cases,
+        )
+
+
+def test_audit_punctuation_rejects_ambiguous_reference():
+    """Test repeated references without distinguishing context are rejected."""
+    test_case = PunctuationTestCase(
+        query=PunctuationQuery(guide="重複", subtitles=["甲"]),
+        answer=PunctuationAnswer(output="甲"),
+    )
+
+    with raises(
+        ScinoephileError,
+        match="test case 1 is ambiguous.*1, 3",
+    ):
+        audit_punctuation(
+            _get_series("重複", "其他", "重複"),
+            _get_series("甲", "中", "甲"),
+            (test_case,),
+        )
+
+
+def _get_series(*texts: str) -> Series:
+    """Construct a subtitle series with the provided text.
+
+    Arguments:
+        *texts: subtitle text by event
+    Returns:
+        constructed subtitle series
+    """
+    return Series(
+        events=[
+            Subtitle(start=index * 1000, end=(index + 1) * 1000, text=text)
+            for index, text in enumerate(texts)
+        ]
+    )

--- a/test/analysis/test_punctuation_audit.py
+++ b/test/analysis/test_punctuation_audit.py
@@ -6,10 +6,8 @@ from __future__ import annotations
 
 from pytest import raises
 
-from scinoephile.analysis.audit.punctuation import (
-    PunctuationAuditFilter,
-    audit_punctuation,
-)
+from scinoephile.analysis.audit.punctuation import audit_punctuation
+from scinoephile.analysis.audit.utils import AuditFilter
 from scinoephile.core.exceptions import ScinoephileError
 from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.llms.punctuation import (
@@ -85,13 +83,13 @@ def test_audit_punctuation_filters_rows_and_subtitle_range():
         reference,
         target,
         test_cases,
-        row_filter=PunctuationAuditFilter.changes,
+        row_filter=AuditFilter.changes,
     )
     unverified_report = audit_punctuation(
         reference,
         target,
         test_cases,
-        row_filter=PunctuationAuditFilter.unverified,
+        row_filter=AuditFilter.unverified,
     )
     ranged_report = audit_punctuation(
         reference,

--- a/test/analysis/test_punctuation_audit.py
+++ b/test/analysis/test_punctuation_audit.py
@@ -171,6 +171,14 @@ def test_audit_punctuation_rejects_invalid_range():
             (),
             first_block=0,
         )
+    with raises(ScinoephileError, match="ranges are mutually exclusive"):
+        audit_punctuation(
+            _get_series("參考"),
+            _get_series("甲"),
+            (),
+            first_index=1,
+            first_block=1,
+        )
 
 
 def test_audit_punctuation_resolves_repeated_reference_from_target():

--- a/test/analysis/test_review_audit.py
+++ b/test/analysis/test_review_audit.py
@@ -12,11 +12,11 @@ from pytest import raises
 
 from scinoephile.analysis.audit.review import (
     ComparativeReviewAuditFilter,
-    ReviewAuditFilter,
     ReviewAuditPair,
     audit_review_workflow,
     audit_reviews,
 )
+from scinoephile.analysis.audit.utils import AuditFilter
 from scinoephile.core import ScinoephileError
 from scinoephile.core.llms import TestCase
 from scinoephile.core.llms.utils import load_test_cases_from_json
@@ -143,7 +143,7 @@ def test_audit_review_workflow_filters_unverified_cases():
                 review_cases=(unverified_case, verified_case),
             ),
         ),
-        row_filter=ReviewAuditFilter.unverified,
+        row_filter=AuditFilter.unverified,
     )
 
     assert "- row filter: unverified" in report
@@ -220,7 +220,7 @@ def test_audit_review_workflow_selects_blocks():
 
     report = audit_review_workflow(
         reviews=reviews,
-        row_filter=ReviewAuditFilter.all,
+        row_filter=AuditFilter.all,
         first_block=2,
         last_block=2,
     )

--- a/test/cli/test_audit_cli.py
+++ b/test/cli/test_audit_cli.py
@@ -15,7 +15,9 @@ from scinoephile.analysis.audit.review import (
 )
 from scinoephile.cli.audit import AuditCli
 from scinoephile.cli.audit.audit_cli_base import AuditCliBase
+from scinoephile.cli.audit.audit_delineation_cli import AuditDelineationCli
 from scinoephile.cli.audit.audit_ocr_fusion_cli import AuditOcrFusionCli
+from scinoephile.cli.audit.audit_punctuation_cli import AuditPunctuationCli
 from scinoephile.cli.audit.audit_review_cli import AuditReviewCli
 from scinoephile.cli.audit.audit_review_dual_cli import AuditReviewDualCli
 from scinoephile.cli.audit.audit_review_trad_cli import AuditReviewTradCli
@@ -175,12 +177,16 @@ def test_audit_review_dual_cli_stdout_outfile_and_validation(
 
 def test_audit_cli_subcommands():
     """Test the audit CLI and its workflow subcommands are registered."""
+    assert issubclass(AuditDelineationCli, AuditCliBase)
+    assert issubclass(AuditPunctuationCli, AuditCliBase)
     assert issubclass(AuditReviewCli, AuditCliBase)
     assert issubclass(AuditReviewDualCli, AuditCliBase)
     assert issubclass(AuditReviewTradCli, AuditCliBase)
     assert ScinoephileCli.subcommands()["audit"] is AuditCli
     assert AuditCli.subcommands() == {
+        "delineation": AuditDelineationCli,
         "ocr-fusion": AuditOcrFusionCli,
+        "punctuation": AuditPunctuationCli,
         "review": AuditReviewCli,
         "review-dual": AuditReviewDualCli,
         "review-trad": AuditReviewTradCli,

--- a/test/cli/test_audit_cli.py
+++ b/test/cli/test_audit_cli.py
@@ -193,17 +193,19 @@ def test_audit_cli_subcommands():
     }
 
 
-def test_transcription_audit_cli_help_uses_reference_indexes():
-    """Test transcription audit range help identifies the reference track."""
+def test_transcription_audit_cli_help_describes_subtitle_indexes():
+    """Test transcription audit range help describes subtitle indexes."""
     for cli_class in (AuditDelineationCli, AuditPunctuationCli):
         actions = {
             action.dest: action
             for action in cli_class.argparser()._actions  # noqa: SLF001
         }
-        assert actions["first_index"].help == cli_class.first_index_help
-        assert actions["last_index"].help == cli_class.last_index_help
-        assert "reference subtitle" in cli_class.first_index_help
-        assert "reference subtitle" in cli_class.last_index_help
+        assert actions["first_index"].help == (
+            "first 1-indexed subtitle number to include, inclusive"
+        )
+        assert actions["last_index"].help == (
+            "last 1-indexed subtitle number to include, inclusive"
+        )
 
 
 def test_audit_review_cli_help_is_consistent():

--- a/test/cli/test_audit_cli.py
+++ b/test/cli/test_audit_cli.py
@@ -193,6 +193,19 @@ def test_audit_cli_subcommands():
     }
 
 
+def test_transcription_audit_cli_help_uses_reference_indexes():
+    """Test transcription audit range help identifies the reference track."""
+    for cli_class in (AuditDelineationCli, AuditPunctuationCli):
+        actions = {
+            action.dest: action
+            for action in cli_class.argparser()._actions  # noqa: SLF001
+        }
+        assert actions["first_index"].help == cli_class.first_index_help
+        assert actions["last_index"].help == cli_class.last_index_help
+        assert "reference subtitle" in cli_class.first_index_help
+        assert "reference subtitle" in cli_class.last_index_help
+
+
 def test_audit_review_cli_help_is_consistent():
     """Test review audit help documents JSON inputs and option defaults."""
     for cli_class in (AuditReviewCli, AuditReviewDualCli, AuditReviewTradCli):

--- a/test/cli/test_audit_cli.py
+++ b/test/cli/test_audit_cli.py
@@ -9,10 +9,8 @@ from pathlib import Path
 
 from pytest import CaptureFixture, mark, raises
 
-from scinoephile.analysis.audit.review import (
-    ComparativeReviewAuditFilter,
-    ReviewAuditFilter,
-)
+from scinoephile.analysis.audit.review import ComparativeReviewAuditFilter
+from scinoephile.analysis.audit.utils import AuditFilter
 from scinoephile.cli.audit import AuditCli
 from scinoephile.cli.audit.audit_cli_base import AuditCliBase
 from scinoephile.cli.audit.audit_delineation_cli import AuditDelineationCli
@@ -218,7 +216,7 @@ def test_audit_review_cli_help_is_consistent():
         if cli_class is AuditReviewCli:
             assert "mode" not in actions
             assert actions["original_path"].option_strings == ["--original"]
-        filter_type = ReviewAuditFilter
+        filter_type = AuditFilter
         if cli_class is AuditReviewDualCli:
             filter_type = ComparativeReviewAuditFilter
         filter_action = actions["row_filter"]


### PR DESCRIPTION
## Summary

- add Markdown audit engines for transcription delineation and punctuation decision logs
- expose the engines through `scinoephile audit delineation` and `scinoephile audit punctuation`
- add localized CLI help, reusable audit workflow skills, and focused test coverage
- resolve repeated delineation pairs globally before applying range filters
- generalize shared audit filters, result types, contextual index resolution, and Markdown report framing

## Why

These audit tools were developed on #1110 but are independently useful and reviewable. Extracting them keeps the reusable audit functionality separate from the KOB transcription and fixture changes.

## Impact

Users gain two new audit subcommands for matching logged decisions back to reference subtitle indexes, filtering report rows and ranges, and writing Markdown reports. Repeated delineation pairs cannot be reassigned by a narrow range, shared range help is defined directly on its CLI arguments, and the skills document index and block ranges as mutually exclusive. Applicable audit engines and CLIs consume the shared `AuditFilter` directly, while common report construction is centralized.

## Validation

- Ruff formatting on changed Python files
- Ruff checks with automatic fixes on changed Python files
- `ty check` on changed Python files
- focused audit and CLI tests: 67 passed
- full parallel suite from `test/`: 1929 passed, 9 skipped