### PR TITLE
Add translation audit CLI

### DIFF
--- a/scinoephile/analysis/audit/__init__.py
+++ b/scinoephile/analysis/audit/__init__.py
@@ -5,5 +5,5 @@
 Package hierarchy (modules may import from any above):
 * utils
 * delineation / ocr_fusion / punctuation / review / translation
-* gap_translation / guided_review / guided_translation
+* dual_review / gap_translation / guided_review / guided_translation
 """

--- a/scinoephile/analysis/audit/__init__.py
+++ b/scinoephile/analysis/audit/__init__.py
@@ -4,6 +4,6 @@
 
 Package hierarchy (modules may import from any above):
 * utils
-* delineation / gap_translation / ocr_fusion / punctuation / review / translation
-* guided_review
+* delineation / ocr_fusion / punctuation / review / translation
+* gap_translation / guided_review / guided_translation
 """

--- a/scinoephile/analysis/audit/__init__.py
+++ b/scinoephile/analysis/audit/__init__.py
@@ -4,6 +4,6 @@
 
 Package hierarchy (modules may import from any above):
 * utils
-* delineation / ocr_fusion / punctuation / review
+* delineation / gap_translation / ocr_fusion / punctuation / review / translation
 * guided_review
 """

--- a/scinoephile/analysis/audit/delineation.py
+++ b/scinoephile/analysis/audit/delineation.py
@@ -19,8 +19,6 @@ from .utils import (
     get_selected_event_indexes,
     get_superseded_keys,
     resolve_contextual_index,
-    validate_block_range,
-    validate_index_range,
 )
 
 __all__ = ["audit_delineation"]
@@ -51,9 +49,6 @@ def audit_delineation(
     Raises:
         ScinoephileError: if a logged reference pair cannot be matched uniquely
     """
-    validate_index_range(first_index, last_index)
-    validate_block_range(first_block, last_block)
-
     pair_indexes: dict[tuple[str, str], list[int]] = defaultdict(list)
     for index in range(len(reference) - 1):
         pair = (reference[index].text, reference[index + 1].text)

--- a/scinoephile/analysis/audit/delineation.py
+++ b/scinoephile/analysis/audit/delineation.py
@@ -14,7 +14,6 @@ from scinoephile.llms.delineation import DelineationTestCase
 from .utils import (
     AuditFilter,
     AuditResult,
-    escape_table_cell,
     format_audit_report,
     get_selected_event_indexes,
     get_superseded_keys,
@@ -66,7 +65,7 @@ def audit_delineation(
         test_cases,
     )
 
-    rows: list[tuple[int, str]] = []
+    rows: list[tuple[int, tuple[str, ...]]] = []
     shifts = 0
     no_shifts = 0
     unanswered = 0
@@ -106,41 +105,38 @@ def audit_delineation(
         ) or (row_filter is AuditFilter.unverified and test_case.verified):
             continue
 
+        verified_marker = ""
+        if test_case.verified:
+            verified_marker = "✓"
         cells = (
             f"{first_subtitle_index}\n{second_subtitle_index}",
             _format_pair(query.reference_one, query.reference_two),
             _format_pair(*input_target),
             output,
             "",
-            "✓" if test_case.verified else "",
+            verified_marker,
         )
-        rows.append(
-            (
-                first_subtitle_index,
-                f"| {' | '.join(escape_table_cell(cell) for cell in cells)} |",
-            )
-        )
+        rows.append((first_subtitle_index, cells))
 
     rows.sort(key=lambda item: item[0])
 
     return format_audit_report(
         title="Transcription Delineation Audit",
-        summary_lines=(
-            f"- logged cases: {logged_cases}",
-            f"- boundary shifts: {shifts}",
-            f"- no-shift answers: {no_shifts}",
-            f"- unanswered cases: {unanswered}",
-            f"- row filter: {row_filter.value}",
+        summary_items=(
+            f"logged cases: {logged_cases}",
+            f"boundary shifts: {shifts}",
+            f"no-shift answers: {no_shifts}",
+            f"unanswered cases: {unanswered}",
+            f"row filter: {row_filter.value}",
         ),
-        column_labels=(
-            "Indexes",
-            "Reference",
-            "Input",
-            "Output",
-            "Notes",
-            "Verified",
+        columns=(
+            ("Indexes", "right"),
+            ("Reference", "left"),
+            ("Input", "left"),
+            ("Output", "left"),
+            ("Notes", "left"),
+            ("Verified", "center"),
         ),
-        column_separators=("---:", "---", "---", "---", "---", ":---:"),
         rows=[row for _, row in rows],
         first_index=first_index,
         last_index=last_index,

--- a/scinoephile/analysis/audit/delineation.py
+++ b/scinoephile/analysis/audit/delineation.py
@@ -12,8 +12,8 @@ from scinoephile.core.subtitles import Series
 from scinoephile.llms.delineation import DelineationTestCase
 
 from .utils import (
-    AuditFilter,
     AuditResult,
+    ChangeAuditFilter,
     format_audit_report,
     format_verification_marker,
     get_selected_event_indexes,
@@ -28,7 +28,7 @@ def audit_delineation(
     reference: Series,
     test_cases: Sequence[DelineationTestCase],
     *,
-    row_filter: AuditFilter = AuditFilter.all,
+    row_filter: ChangeAuditFilter = ChangeAuditFilter.all,
     first_index: int | None = None,
     last_index: int | None = None,
     first_block: int | None = None,
@@ -102,8 +102,9 @@ def audit_delineation(
             result = AuditResult.unchanged
 
         if (
-            row_filter is AuditFilter.changes and result is not AuditResult.changed
-        ) or (row_filter is AuditFilter.unverified and test_case.verified):
+            row_filter is ChangeAuditFilter.changes
+            and result is not AuditResult.changed
+        ) or (row_filter is ChangeAuditFilter.unverified and test_case.verified):
             continue
 
         verified_marker = format_verification_marker(test_case.verified)

--- a/scinoephile/analysis/audit/delineation.py
+++ b/scinoephile/analysis/audit/delineation.py
@@ -15,6 +15,7 @@ from .utils import (
     AuditFilter,
     AuditResult,
     format_audit_report,
+    format_verification_marker,
     get_selected_event_indexes,
     get_superseded_keys,
     resolve_contextual_index,
@@ -105,9 +106,7 @@ def audit_delineation(
         ) or (row_filter is AuditFilter.unverified and test_case.verified):
             continue
 
-        verified_marker = ""
-        if test_case.verified:
-            verified_marker = "✓"
+        verified_marker = format_verification_marker(test_case.verified)
         cells = (
             f"{first_subtitle_index}\n{second_subtitle_index}",
             _format_pair(query.reference_one, query.reference_two),

--- a/scinoephile/analysis/audit/dual_review.py
+++ b/scinoephile/analysis/audit/dual_review.py
@@ -1,0 +1,96 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Audit parallel dual-script subtitle review workflows."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from scinoephile.core.llms import TestCase
+from scinoephile.core.subtitles import Series
+
+from .review import ReviewAuditComparison, ReviewAuditPair, audit_review
+from .utils import ExtendedAuditFilter
+
+__all__ = ["audit_dual_review"]
+
+
+def audit_dual_review(
+    *,
+    traditional: Series,
+    traditional_reviewed: Series,
+    traditional_simplified: Series,
+    traditional_simplified_reviewed: Series,
+    simplified: Series,
+    simplified_reviewed: Series,
+    traditional_review_cases: Sequence[TestCase] = (),
+    traditional_simplified_review_cases: Sequence[TestCase] = (),
+    simplified_review_cases: Sequence[TestCase] = (),
+    row_filter: ExtendedAuditFilter = ExtendedAuditFilter.changes,
+    characters: Sequence[str] = (),
+    first_index: int | None = None,
+    last_index: int | None = None,
+    first_block: int | None = None,
+    last_block: int | None = None,
+) -> str:
+    """Audit parallel simplified and traditional-to-simplified review paths.
+
+    Arguments:
+        traditional: traditional-script review input
+        traditional_reviewed: traditional-script reviewed subtitles
+        traditional_simplified: simplified traditional-script subtitles
+        traditional_simplified_reviewed: reviewed simplified traditional-script
+            subtitles
+        simplified: simplified-script review input
+        simplified_reviewed: simplified-script reviewed subtitles
+        traditional_review_cases: traditional review test cases
+        traditional_simplified_review_cases: traditional simplification review test
+            cases
+        simplified_review_cases: simplified review test cases
+        row_filter: row status filter
+        characters: individual characters whose occurrence limits included rows
+        first_index: first 1-indexed subtitle number to include, inclusive
+        last_index: last 1-indexed subtitle number to include, inclusive
+        first_block: first 1-indexed workflow block number to include, inclusive
+        last_block: last 1-indexed workflow block number to include, inclusive
+    Returns:
+        Markdown audit report
+    Raises:
+        ScinoephileError: if review test cases do not match the subtitle series
+    """
+    return audit_review(
+        reviews=(
+            ReviewAuditPair(
+                label="Simplified",
+                original=simplified,
+                reviewed=simplified_reviewed,
+                review_cases=simplified_review_cases,
+            ),
+            ReviewAuditPair(
+                label="Traditional",
+                original=traditional,
+                reviewed=traditional_reviewed,
+                review_cases=traditional_review_cases,
+            ),
+            ReviewAuditPair(
+                label="Traditional simplification",
+                original=traditional_simplified,
+                reviewed=traditional_simplified_reviewed,
+                review_cases=traditional_simplified_review_cases,
+            ),
+        ),
+        comparisons=(
+            ReviewAuditComparison(
+                column_label="Simplified vs Traditional->Simplified",
+                summary_label="Final text",
+                left=simplified_reviewed,
+                right=traditional_simplified_reviewed,
+            ),
+        ),
+        row_filter=row_filter,
+        characters=characters,
+        first_index=first_index,
+        last_index=last_index,
+        first_block=first_block,
+        last_block=last_block,
+    )

--- a/scinoephile/analysis/audit/gap_translation.py
+++ b/scinoephile/analysis/audit/gap_translation.py
@@ -18,6 +18,7 @@ from .translation import resolve_translation_audit_output
 from .utils import (
     VerificationAuditFilter,
     format_audit_report,
+    format_verification_marker,
     validate_audit_range,
 )
 
@@ -124,9 +125,7 @@ def audit_gap_translation(
             outputs_by_index = {
                 output.index: output.text for output in test_case.answer.outputs
             }
-        verified_marker = ""
-        if test_case.verified:
-            verified_marker = "✓"
+        verified_marker = format_verification_marker(test_case.verified)
         for local_index, (global_index, guide_text, target_text) in enumerate(
             zip(
                 block.guide_indexes,
@@ -350,21 +349,13 @@ def _get_active_test_case_blocks(
                 continue
             unmatched_cases.append((test_case_index, test_case))
             continue
-        if len(selected_matches) > 1:
-            block_numbers = ", ".join(
-                str(block.block_number) for block in selected_matches
+        # Reuse one deduplicated logged query for every exact current match
+        for block in selected_matches:
+            active_by_block_number[block.block_number] = (
+                test_case_index,
+                test_case,
+                block,
             )
-            raise ScinoephileError(
-                "Unable to audit gap translation: "
-                f"test case {test_case_index} is ambiguous; it matches blocks "
-                f"{block_numbers}"
-            )
-        block = selected_matches[0]
-        active_by_block_number[block.block_number] = (
-            test_case_index,
-            test_case,
-            block,
-        )
 
     # Reconcile unmatched historical cases against current guide blocks
     active_block_numbers = set(active_by_block_number)

--- a/scinoephile/analysis/audit/gap_translation.py
+++ b/scinoephile/analysis/audit/gap_translation.py
@@ -17,10 +17,8 @@ from scinoephile.llms.gap_translation import GapTranslationTestCase
 from .utils import (
     _get_paired_event_block_numbers,
     _get_validated_block_pairs_by_pause,
-    _is_block_in_range,
     escape_table_cell,
     format_block_range,
-    format_difficulty_filter,
     format_index_range,
     validate_block_range,
     validate_index_range,
@@ -55,8 +53,6 @@ class _GapTranslationRow:
 
     answered: bool
     """Whether the source test case has an answer."""
-    difficulty: int
-    """Difficulty level of the source test case."""
     empty: bool
     """Whether the answer deliberately emitted empty text."""
     global_index: int
@@ -84,7 +80,6 @@ def audit_gap_translation(
     guide: Series,
     test_cases: Sequence[GapTranslationTestCase],
     *,
-    difficulties: Sequence[int] = (),
     row_filter: GapTranslationAuditFilter = GapTranslationAuditFilter.all,
     first_index: int | None = None,
     last_index: int | None = None,
@@ -97,7 +92,6 @@ def audit_gap_translation(
         target: gapped target subtitle series provided for gap translation
         guide: complete guide subtitle series provided for gap translation
         test_cases: logged gap-translation test cases
-        difficulties: exact case difficulty levels to include, or all if empty
         row_filter: row verification filter
         first_index: first 1-indexed guide subtitle number to include
         last_index: last 1-indexed guide subtitle number to include
@@ -110,9 +104,6 @@ def audit_gap_translation(
     """
     validate_index_range(first_index, last_index)
     validate_block_range(first_block, last_block)
-    if any(difficulty < 0 for difficulty in difficulties):
-        raise ScinoephileError("Difficulty must be at least 0")
-    difficulty_filter = tuple(sorted(set(difficulties)))
 
     block_pairs = _get_validated_block_pairs_by_pause(
         target,
@@ -127,7 +118,6 @@ def audit_gap_translation(
         guide_block_numbers,
         test_cases,
         blocks,
-        difficulties=difficulty_filter,
         first_index=first_index,
         last_index=last_index,
         first_block=first_block,
@@ -176,7 +166,6 @@ def audit_gap_translation(
             all_rows.append(
                 _GapTranslationRow(
                     answered=answered,
-                    difficulty=test_case.difficulty,
                     empty=empty,
                     global_index=global_index,
                     markdown=(
@@ -211,7 +200,6 @@ def audit_gap_translation(
         f"- unverified gaps: {len(all_rows) - verified_gaps}",
         f"- row filter: {row_filter.value}",
     ]
-    lines.append(format_difficulty_filter(difficulty_filter))
     range_summary = format_index_range(
         first_index,
         last_index,
@@ -257,18 +245,18 @@ def _block_intersects_range(
     Returns:
         whether any target gap in the block is selected
     """
-    return _is_block_in_range(
-        block.block_number,
-        first_block,
-        last_block,
-    ) and any(
-        target_text is None
-        and (first_index is None or guide_index >= first_index)
-        and (last_index is None or guide_index <= last_index)
-        for guide_index, target_text in zip(
-            block.guide_indexes,
-            block.target_texts,
-            strict=True,
+    return (
+        (first_block is None or block.block_number >= first_block)
+        and (last_block is None or block.block_number <= last_block)
+        and any(
+            target_text is None
+            and (first_index is None or guide_index >= first_index)
+            and (last_index is None or guide_index <= last_index)
+            for guide_index, target_text in zip(
+                block.guide_indexes,
+                block.target_texts,
+                strict=True,
+            )
         )
     )
 
@@ -304,7 +292,6 @@ def _get_active_test_case_blocks(
     test_cases: Sequence[GapTranslationTestCase],
     blocks: Sequence[_GapTranslationBlock],
     *,
-    difficulties: Sequence[int],
     first_index: int | None,
     last_index: int | None,
     first_block: int | None,
@@ -317,7 +304,6 @@ def _get_active_test_case_blocks(
         guide_block_numbers: paired block number for every guide subtitle
         test_cases: logged gap-translation test cases
         blocks: current target and guide blocks containing gaps
-        difficulties: exact case difficulty levels to include, or all if empty
         first_index: first included guide subtitle number
         last_index: last included guide subtitle number
         first_block: first included paired block number
@@ -378,8 +364,6 @@ def _get_active_test_case_blocks(
             unmatched_cases.append((test_case_index, test_case))
             continue
         if len(selected_matches) > 1:
-            if difficulties and test_case.difficulty not in difficulties:
-                continue
             block_numbers = ", ".join(
                 str(block.block_number) for block in selected_matches
             )
@@ -397,8 +381,6 @@ def _get_active_test_case_blocks(
 
     active_block_numbers = set(active_by_block_number)
     for test_case_index, test_case in unmatched_cases:
-        if difficulties and test_case.difficulty not in difficulties:
-            continue
         guides = tuple(guide_subtitle.text for guide_subtitle in test_case.query.guides)
         matches = blocks_by_guides.get(guides, [])
         selected_matches = [
@@ -439,12 +421,10 @@ def _get_active_test_case_blocks(
             f"{selected_matches[0].block_number}"
         )
 
-    active_cases = [
-        item
-        for item in active_by_block_number.values()
-        if not difficulties or item[1].difficulty in difficulties
-    ]
-    return sorted(active_cases, key=lambda item: item[2].block_number)
+    return sorted(
+        active_by_block_number.values(),
+        key=lambda item: item[2].block_number,
+    )
 
 
 def _get_blocks(
@@ -540,10 +520,13 @@ def _is_test_case_outside_range(
             (
                 (first_index is not None and start + gap_index < first_index)
                 or (last_index is not None and start + gap_index > last_index)
-                or not _is_block_in_range(
-                    guide_block_numbers[start + gap_index - 1],
-                    first_block,
-                    last_block,
+                or (
+                    first_block is not None
+                    and guide_block_numbers[start + gap_index - 1] < first_block
+                )
+                or (
+                    last_block is not None
+                    and guide_block_numbers[start + gap_index - 1] > last_block
                 )
             )
             for gap_index in gap_indexes

--- a/scinoephile/analysis/audit/gap_translation.py
+++ b/scinoephile/analysis/audit/gap_translation.py
@@ -1,0 +1,552 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Audit gap-translation decisions and format them as Markdown."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+
+from scinoephile.core.exceptions import ScinoephileError
+from scinoephile.core.subtitles import Series
+from scinoephile.core.synchronization import get_sync_overlap_matrix
+from scinoephile.llms.gap_translation import GapTranslationTestCase
+
+from .utils import (
+    _get_paired_event_block_numbers,
+    _get_validated_block_pairs_by_pause,
+    _is_block_in_range,
+    escape_table_cell,
+    format_block_range,
+    format_difficulty_filter,
+    format_index_range,
+    validate_block_range,
+    validate_index_range,
+)
+
+__all__ = [
+    "GapTranslationAuditFilter",
+    "audit_gap_translation",
+]
+
+
+_GapTranslationKey = tuple[tuple[tuple[int, str], ...], tuple[str, ...]]
+
+
+@dataclass(frozen=True, kw_only=True)
+class _GapTranslationBlock:
+    """One target and guide block available for gap translation."""
+
+    block_number: int
+    """One-based position in the complete block alignment."""
+    guide_indexes: tuple[int, ...]
+    """One-based global guide subtitle indexes in the block."""
+    guide_texts: tuple[str, ...]
+    """Guide subtitle texts in query-local order."""
+    target_texts: tuple[str | None, ...]
+    """Existing target text by guide position, with gaps represented by None."""
+
+
+@dataclass(frozen=True, kw_only=True)
+class _GapTranslationRow:
+    """One translated gap displayed in the audit report."""
+
+    answered: bool
+    """Whether the source test case has an answer."""
+    difficulty: int
+    """Difficulty level of the source test case."""
+    empty: bool
+    """Whether the answer deliberately emitted empty text."""
+    global_index: int
+    """One-based global guide subtitle index."""
+    markdown: str
+    """Formatted Markdown table row."""
+    test_case_index: int
+    """One-based position of the source test case in the JSON."""
+    verified: bool
+    """Whether the source test case is verified."""
+
+
+class GapTranslationAuditFilter(StrEnum):
+    """Row filters supported by a gap-translation audit."""
+
+    all = "all"
+    """Include every translated or unanswered target gap."""
+
+    unverified = "unverified"
+    """Include only gaps from cases not marked as verified."""
+
+
+def audit_gap_translation(
+    target: Series,
+    guide: Series,
+    test_cases: Sequence[GapTranslationTestCase],
+    *,
+    difficulties: Sequence[int] = (),
+    row_filter: GapTranslationAuditFilter = GapTranslationAuditFilter.all,
+    first_index: int | None = None,
+    last_index: int | None = None,
+    first_block: int | None = None,
+    last_block: int | None = None,
+) -> str:
+    """Audit translations generated for gaps in a target subtitle series.
+
+    Arguments:
+        target: gapped target subtitle series provided for gap translation
+        guide: complete guide subtitle series provided for gap translation
+        test_cases: logged gap-translation test cases
+        difficulties: exact case difficulty levels to include, or all if empty
+        row_filter: row verification filter
+        first_index: first 1-indexed guide subtitle number to include
+        last_index: last 1-indexed guide subtitle number to include
+        first_block: first 1-indexed paired block number to include
+        last_block: last 1-indexed paired block number to include
+    Returns:
+        Markdown audit report
+    Raises:
+        ScinoephileError: if a logged case cannot be matched uniquely to source data
+    """
+    validate_index_range(first_index, last_index)
+    validate_block_range(first_block, last_block)
+    if any(difficulty < 0 for difficulty in difficulties):
+        raise ScinoephileError("Difficulty must be at least 0")
+    difficulty_filter = tuple(sorted(set(difficulties)))
+
+    block_pairs = _get_validated_block_pairs_by_pause(
+        target,
+        guide,
+        first_block,
+        last_block,
+    )
+    blocks = _get_blocks(block_pairs)
+    _, guide_block_numbers = _get_paired_event_block_numbers(block_pairs)
+    active_cases = _get_active_test_case_blocks(
+        guide,
+        guide_block_numbers,
+        test_cases,
+        blocks,
+        difficulties=difficulty_filter,
+        first_index=first_index,
+        last_index=last_index,
+        first_block=first_block,
+        last_block=last_block,
+    )
+    all_rows: list[_GapTranslationRow] = []
+    for test_case_index, test_case, block in active_cases:
+        outputs_by_index = (
+            {output.index: output.text for output in test_case.answer.outputs}
+            if test_case.answer is not None
+            else {}
+        )
+        for local_index, (global_index, guide_text, target_text) in enumerate(
+            zip(
+                block.guide_indexes,
+                block.guide_texts,
+                block.target_texts,
+                strict=True,
+            ),
+            1,
+        ):
+            if target_text is not None:
+                continue
+            if (first_index is not None and global_index < first_index) or (
+                last_index is not None and global_index > last_index
+            ):
+                continue
+
+            answered = test_case.answer is not None
+            output_text = outputs_by_index.get(local_index, "")
+            empty = answered and not output_text
+            if not answered:
+                output_text = "(unanswered)"
+            elif empty:
+                output_text = "(empty)"
+            cells = (
+                f"G {global_index}\nQ {local_index}",
+                f"C {test_case_index}\nB {block.block_number}",
+                str(test_case.difficulty),
+                guide_text,
+                _format_target_context(block, local_index - 1),
+                output_text,
+                "",
+                "✓" if test_case.verified else "",
+            )
+            all_rows.append(
+                _GapTranslationRow(
+                    answered=answered,
+                    difficulty=test_case.difficulty,
+                    empty=empty,
+                    global_index=global_index,
+                    markdown=(
+                        f"| {' | '.join(escape_table_cell(cell) for cell in cells)} |"
+                    ),
+                    test_case_index=test_case_index,
+                    verified=test_case.verified,
+                )
+            )
+
+    all_rows.sort(key=lambda row: (row.global_index, row.test_case_index))
+    translated_gaps = sum(row.answered and not row.empty for row in all_rows)
+    empty_translations = sum(row.empty for row in all_rows)
+    unanswered_gaps = sum(not row.answered for row in all_rows)
+    verified_gaps = sum(row.verified for row in all_rows)
+    rows = [
+        row
+        for row in all_rows
+        if not (row_filter is GapTranslationAuditFilter.unverified and row.verified)
+    ]
+    lines = [
+        "# Gap Translation Audit",
+        "",
+        "## Summary",
+        "",
+        f"- logged cases: {len({row.test_case_index for row in all_rows})}",
+        f"- gaps: {len(all_rows)}",
+        f"- translated gaps: {translated_gaps}",
+        f"- empty translations: {empty_translations}",
+        f"- unanswered gaps: {unanswered_gaps}",
+        f"- verified gaps: {verified_gaps}",
+        f"- unverified gaps: {len(all_rows) - verified_gaps}",
+        f"- row filter: {row_filter.value}",
+    ]
+    lines.append(format_difficulty_filter(difficulty_filter))
+    range_summary = format_index_range(
+        first_index,
+        last_index,
+        track_name="guide",
+    )
+    if range_summary is not None:
+        lines.append(range_summary)
+    block_range_summary = format_block_range(first_block, last_block)
+    if block_range_summary is not None:
+        lines.append(block_range_summary)
+    lines.extend(
+        (
+            f"- table rows: {len(rows)}",
+            "",
+            "## Audit Table",
+            "",
+            (
+                "| Indexes | Case / block | Difficulty | Guide | Target context | "
+                "Translation | Notes | Verified |"
+            ),
+            "|---:|---:|---:|---|---|---|---|:---:|",
+            *(row.markdown for row in rows),
+        )
+    )
+    return "\n".join(lines) + "\n"
+
+
+def _block_intersects_range(
+    block: _GapTranslationBlock,
+    first_index: int | None,
+    last_index: int | None,
+    first_block: int | None,
+    last_block: int | None,
+) -> bool:
+    """Check whether a block has a target gap within an audit range.
+
+    Arguments:
+        block: gap-translation block to check
+        first_index: first included guide subtitle number
+        last_index: last included guide subtitle number
+        first_block: first included paired block number
+        last_block: last included paired block number
+    Returns:
+        whether any target gap in the block is selected
+    """
+    return _is_block_in_range(
+        block.block_number,
+        first_block,
+        last_block,
+    ) and any(
+        target_text is None
+        and (first_index is None or guide_index >= first_index)
+        and (last_index is None or guide_index <= last_index)
+        for guide_index, target_text in zip(
+            block.guide_indexes,
+            block.target_texts,
+            strict=True,
+        )
+    )
+
+
+def _format_target_context(block: _GapTranslationBlock, position: int) -> str:
+    """Format the nearest existing target subtitles around one gap.
+
+    Arguments:
+        block: gap-translation block containing the gap
+        position: zero-based guide position of the gap within the block
+    Returns:
+        nearest preceding and following target texts, or an em dash
+    """
+    context: list[str] = []
+    for context_position in range(position - 1, -1, -1):
+        text = block.target_texts[context_position]
+        if text is not None:
+            context.append(f"G {block.guide_indexes[context_position]}: {text}")
+            break
+    for context_position in range(position + 1, len(block.target_texts)):
+        text = block.target_texts[context_position]
+        if text is not None:
+            context.append(f"G {block.guide_indexes[context_position]}: {text}")
+            break
+    if not context:
+        return "—"
+    return "\n".join(context)
+
+
+def _get_active_test_case_blocks(
+    guide: Series,
+    guide_block_numbers: Sequence[int],
+    test_cases: Sequence[GapTranslationTestCase],
+    blocks: Sequence[_GapTranslationBlock],
+    *,
+    difficulties: Sequence[int],
+    first_index: int | None,
+    last_index: int | None,
+    first_block: int | None,
+    last_block: int | None,
+) -> list[tuple[int, GapTranslationTestCase, _GapTranslationBlock]]:
+    """Match current cases to blocks while ignoring superseded history.
+
+    Arguments:
+        guide: complete guide subtitle series
+        guide_block_numbers: paired block number for every guide subtitle
+        test_cases: logged gap-translation test cases
+        blocks: current target and guide blocks containing gaps
+        difficulties: exact case difficulty levels to include, or all if empty
+        first_index: first included guide subtitle number
+        last_index: last included guide subtitle number
+        first_block: first included paired block number
+        last_block: last included paired block number
+    Returns:
+        current test cases paired with their unique blocks
+    Raises:
+        ScinoephileError: if a selected case is absent, stale, or ambiguous
+    """
+    blocks_by_key: dict[_GapTranslationKey, list[_GapTranslationBlock]] = defaultdict(
+        list
+    )
+    blocks_by_guides: dict[tuple[str, ...], list[_GapTranslationBlock]] = defaultdict(
+        list
+    )
+    for block in blocks:
+        targets = tuple(
+            (position, text)
+            for position, text in enumerate(block.target_texts, 1)
+            if text is not None
+        )
+        blocks_by_key[(targets, block.guide_texts)].append(block)
+        blocks_by_guides[block.guide_texts].append(block)
+
+    active_by_block_number: dict[
+        int,
+        tuple[int, GapTranslationTestCase, _GapTranslationBlock],
+    ] = {}
+    unmatched_cases: list[tuple[int, GapTranslationTestCase]] = []
+    for test_case_index, test_case in enumerate(test_cases, 1):
+        targets = tuple(
+            (target.index, target.text) for target in test_case.query.targets
+        )
+        guides = tuple(guide_subtitle.text for guide_subtitle in test_case.query.guides)
+        matches = blocks_by_key.get((targets, guides), [])
+        selected_matches = [
+            block
+            for block in matches
+            if _block_intersects_range(
+                block,
+                first_index,
+                last_index,
+                first_block,
+                last_block,
+            )
+        ]
+        if not selected_matches:
+            if matches or _is_test_case_outside_range(
+                test_case,
+                guide,
+                guide_block_numbers,
+                first_index=first_index,
+                last_index=last_index,
+                first_block=first_block,
+                last_block=last_block,
+            ):
+                continue
+            unmatched_cases.append((test_case_index, test_case))
+            continue
+        if len(selected_matches) > 1:
+            if difficulties and test_case.difficulty not in difficulties:
+                continue
+            block_numbers = ", ".join(
+                str(block.block_number) for block in selected_matches
+            )
+            raise ScinoephileError(
+                "Unable to audit gap translation: "
+                f"test case {test_case_index} is ambiguous; it matches blocks "
+                f"{block_numbers}"
+            )
+        block = selected_matches[0]
+        active_by_block_number[block.block_number] = (
+            test_case_index,
+            test_case,
+            block,
+        )
+
+    active_block_numbers = set(active_by_block_number)
+    for test_case_index, test_case in unmatched_cases:
+        if difficulties and test_case.difficulty not in difficulties:
+            continue
+        guides = tuple(guide_subtitle.text for guide_subtitle in test_case.query.guides)
+        matches = blocks_by_guides.get(guides, [])
+        selected_matches = [
+            block
+            for block in matches
+            if _block_intersects_range(
+                block,
+                first_index,
+                last_index,
+                first_block,
+                last_block,
+            )
+        ]
+        if not selected_matches:
+            if matches:
+                continue
+            raise ScinoephileError(
+                "Unable to audit gap translation: "
+                f"test case {test_case_index} was not found in the target and guide "
+                "subtitle blocks"
+            )
+        if all(
+            block.block_number in active_block_numbers for block in selected_matches
+        ):
+            continue
+        if len(selected_matches) > 1:
+            block_numbers = ", ".join(
+                str(block.block_number) for block in selected_matches
+            )
+            raise ScinoephileError(
+                "Unable to audit gap translation: "
+                f"test case {test_case_index} is ambiguous; its guide text matches "
+                f"blocks {block_numbers}"
+            )
+        raise ScinoephileError(
+            "Unable to audit gap translation: "
+            f"test case {test_case_index} target subtitles no longer match block "
+            f"{selected_matches[0].block_number}"
+        )
+
+    active_cases = [
+        item
+        for item in active_by_block_number.values()
+        if not difficulties or item[1].difficulty in difficulties
+    ]
+    return sorted(active_cases, key=lambda item: item[2].block_number)
+
+
+def _get_blocks(
+    block_pairs: Sequence[tuple[Series, Series]],
+) -> list[_GapTranslationBlock]:
+    """Reconstruct the target and guide blocks used for gap translation.
+
+    Arguments:
+        block_pairs: paired target and guide workflow blocks
+    Returns:
+        blocks containing one or more missing target positions
+    """
+    blocks: list[_GapTranslationBlock] = []
+    guide_offset = 0
+    for block_number, (target_block, guide_block) in enumerate(block_pairs, 1):
+        guide_indexes = tuple(
+            range(guide_offset + 1, guide_offset + len(guide_block) + 1)
+        )
+        guide_offset += len(guide_block)
+        if not guide_block:
+            continue
+
+        overlap = get_sync_overlap_matrix(target_block, guide_block)
+        occupied_positions = {int(row.argmax()) for row in overlap}
+        if len(occupied_positions) == len(guide_block):
+            continue
+
+        target_texts: list[str | None] = [None] * len(guide_block)
+        target_position = 0
+        for guide_position in range(len(guide_block)):
+            if guide_position not in occupied_positions:
+                continue
+            target_texts[guide_position] = target_block.events[
+                target_position
+            ].text_with_newline.strip()
+            target_position += 1
+        blocks.append(
+            _GapTranslationBlock(
+                block_number=block_number,
+                guide_indexes=guide_indexes,
+                guide_texts=tuple(
+                    subtitle.text_with_newline.strip() for subtitle in guide_block
+                ),
+                target_texts=tuple(target_texts),
+            )
+        )
+    return blocks
+
+
+def _is_test_case_outside_range(
+    test_case: GapTranslationTestCase,
+    guide: Series,
+    guide_block_numbers: Sequence[int],
+    *,
+    first_index: int | None,
+    last_index: int | None,
+    first_block: int | None,
+    last_block: int | None,
+) -> bool:
+    """Check whether an unmatched case is provably outside a bounded range.
+
+    Arguments:
+        test_case: unmatched gap-translation test case
+        guide: complete current guide subtitle series
+        guide_block_numbers: paired block number for every guide subtitle
+        first_index: first included guide subtitle number
+        last_index: last included guide subtitle number
+        first_block: first included paired block number
+        last_block: last included paired block number
+    Returns:
+        whether every matching guide span places all gaps outside the range
+    """
+    if all(
+        boundary is None
+        for boundary in (first_index, last_index, first_block, last_block)
+    ):
+        return False
+
+    query_guides = tuple(subtitle.text for subtitle in test_case.query.guides)
+    guide_texts = tuple(subtitle.text_with_newline.strip() for subtitle in guide)
+    gap_indexes = {subtitle.index for subtitle in test_case.query.guides} - {
+        subtitle.index for subtitle in test_case.query.targets
+    }
+    matching_starts = [
+        start
+        for start in range(len(guide_texts) - len(query_guides) + 1)
+        if guide_texts[start : start + len(query_guides)] == query_guides
+    ]
+    if not matching_starts:
+        return False
+    return all(
+        all(
+            (
+                (first_index is not None and start + gap_index < first_index)
+                or (last_index is not None and start + gap_index > last_index)
+                or not _is_block_in_range(
+                    guide_block_numbers[start + gap_index - 1],
+                    first_block,
+                    last_block,
+                )
+            )
+            for gap_index in gap_indexes
+        )
+        for start in matching_starts
+    )

--- a/scinoephile/analysis/audit/gap_translation.py
+++ b/scinoephile/analysis/audit/gap_translation.py
@@ -14,6 +14,7 @@ from scinoephile.core.subtitles import Series
 from scinoephile.core.synchronization import get_sync_overlap_matrix
 from scinoephile.llms.gap_translation import GapTranslationTestCase
 
+from .translation import resolve_translation_audit_output
 from .utils import (
     VerificationAuditFilter,
     format_audit_report,
@@ -118,7 +119,7 @@ def audit_gap_translation(
     # Format all selected gap rows before applying the row filter
     all_rows: list[_GapTranslationRow] = []
     for test_case_index, test_case, block in active_cases:
-        outputs_by_index = {}
+        outputs_by_index = None
         if test_case.answer is not None:
             outputs_by_index = {
                 output.index: output.text for output in test_case.answer.outputs
@@ -142,13 +143,10 @@ def audit_gap_translation(
             ):
                 continue
 
-            answered = test_case.answer is not None
-            output_text = outputs_by_index.get(local_index, "")
-            empty = answered and not output_text
-            if not answered:
-                output_text = "(unanswered)"
-            elif empty:
-                output_text = "(empty)"
+            output_text, answered, empty = resolve_translation_audit_output(
+                outputs_by_index,
+                local_index,
+            )
             cells = (
                 f"G {global_index}\nQ {local_index}",
                 f"C {test_case_index}\nB {block.block_number}",

--- a/scinoephile/analysis/audit/gap_translation.py
+++ b/scinoephile/analysis/audit/gap_translation.py
@@ -16,7 +16,6 @@ from scinoephile.llms.gap_translation import GapTranslationTestCase
 
 from .utils import (
     VerificationAuditFilter,
-    escape_table_cell,
     format_audit_report,
     validate_audit_range,
 )
@@ -51,8 +50,8 @@ class _GapTranslationRow:
     """Whether the answer deliberately emitted empty text."""
     global_index: int
     """One-based global guide subtitle index."""
-    markdown: str
-    """Formatted Markdown table row."""
+    cells: tuple[str, ...]
+    """Semantic audit table cell values."""
     test_case_index: int
     """One-based position of the source test case in the JSON."""
     verified: bool
@@ -163,11 +162,9 @@ def audit_gap_translation(
             all_rows.append(
                 _GapTranslationRow(
                     answered=answered,
+                    cells=cells,
                     empty=empty,
                     global_index=global_index,
-                    markdown=(
-                        f"| {' | '.join(escape_table_cell(cell) for cell in cells)} |"
-                    ),
                     test_case_index=test_case_index,
                     verified=test_case.verified,
                 )
@@ -188,28 +185,27 @@ def audit_gap_translation(
     # Format the report using the shared Markdown structure
     return format_audit_report(
         title="Gap Translation Audit",
-        summary_lines=(
-            f"- logged cases: {len({row.test_case_index for row in all_rows})}",
-            f"- gaps: {len(all_rows)}",
-            f"- translated gaps: {translated_gaps}",
-            f"- empty translations: {empty_translations}",
-            f"- unanswered gaps: {unanswered_gaps}",
-            f"- verified gaps: {verified_gaps}",
-            f"- unverified gaps: {len(all_rows) - verified_gaps}",
-            f"- row filter: {row_filter.value}",
+        summary_items=(
+            f"logged cases: {len({row.test_case_index for row in all_rows})}",
+            f"gaps: {len(all_rows)}",
+            f"translated gaps: {translated_gaps}",
+            f"empty translations: {empty_translations}",
+            f"unanswered gaps: {unanswered_gaps}",
+            f"verified gaps: {verified_gaps}",
+            f"unverified gaps: {len(all_rows) - verified_gaps}",
+            f"row filter: {row_filter.value}",
         ),
-        column_labels=(
-            "Indexes",
-            "Case / block",
-            "Difficulty",
-            "Guide",
-            "Target context",
-            "Translation",
-            "Notes",
-            "Verified",
+        columns=(
+            ("Indexes", "right"),
+            ("Case / block", "right"),
+            ("Difficulty", "right"),
+            ("Guide", "left"),
+            ("Target context", "left"),
+            ("Translation", "left"),
+            ("Notes", "left"),
+            ("Verified", "center"),
         ),
-        column_separators=("---:", "---:", "---:", "---", "---", "---", "---", ":---:"),
-        rows=[row.markdown for row in rows],
+        rows=[row.cells for row in rows],
         first_index=first_index,
         last_index=last_index,
         index_track_name="guide",

--- a/scinoephile/analysis/audit/gap_translation.py
+++ b/scinoephile/analysis/audit/gap_translation.py
@@ -7,26 +7,21 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Sequence
 from dataclasses import dataclass
-from enum import StrEnum
 
 from scinoephile.core.exceptions import ScinoephileError
+from scinoephile.core.pairs import get_block_pairs_by_pause
 from scinoephile.core.subtitles import Series
 from scinoephile.core.synchronization import get_sync_overlap_matrix
 from scinoephile.llms.gap_translation import GapTranslationTestCase
 
 from .utils import (
+    VerificationAuditFilter,
     escape_table_cell,
-    format_block_range,
-    format_index_range,
-    get_validated_block_pairs_by_pause,
-    validate_block_range,
-    validate_index_range,
+    format_audit_report,
+    validate_audit_range,
 )
 
-__all__ = [
-    "GapTranslationAuditFilter",
-    "audit_gap_translation",
-]
+__all__ = ["audit_gap_translation"]
 
 
 _GapTranslationKey = tuple[tuple[tuple[int, str], ...], tuple[str, ...]]
@@ -64,22 +59,12 @@ class _GapTranslationRow:
     """Whether the source test case is verified."""
 
 
-class GapTranslationAuditFilter(StrEnum):
-    """Row filters supported by a gap-translation audit."""
-
-    all = "all"
-    """Include every translated or unanswered target gap."""
-
-    unverified = "unverified"
-    """Include only gaps from cases not marked as verified."""
-
-
 def audit_gap_translation(
     target: Series,
     guide: Series,
     test_cases: Sequence[GapTranslationTestCase],
     *,
-    row_filter: GapTranslationAuditFilter = GapTranslationAuditFilter.all,
+    row_filter: VerificationAuditFilter = VerificationAuditFilter.all,
     first_index: int | None = None,
     last_index: int | None = None,
     first_block: int | None = None,
@@ -101,21 +86,25 @@ def audit_gap_translation(
     Raises:
         ScinoephileError: if a logged case cannot be matched uniquely to source data
     """
-    validate_index_range(first_index, last_index)
-    validate_block_range(first_block, last_block)
-
-    block_pairs = get_validated_block_pairs_by_pause(
-        target,
-        guide,
+    # Build paired workflow blocks and validate the selection
+    block_pairs = get_block_pairs_by_pause(target, guide)
+    validate_audit_range(
+        first_index,
+        last_index,
         first_block,
         last_block,
+        block_count=len(block_pairs),
     )
+
+    # Reconstruct current gap blocks and their global guide indexes
     blocks = _get_blocks(block_pairs)
     guide_block_numbers = tuple(
         block_number
         for block_number, (_, guide_block) in enumerate(block_pairs, 1)
         for _ in guide_block
     )
+
+    # Match logged cases to current selected gap blocks
     active_cases = _get_active_test_case_blocks(
         guide,
         guide_block_numbers,
@@ -126,13 +115,18 @@ def audit_gap_translation(
         first_block=first_block,
         last_block=last_block,
     )
+
+    # Format all selected gap rows before applying the row filter
     all_rows: list[_GapTranslationRow] = []
     for test_case_index, test_case, block in active_cases:
-        outputs_by_index = (
-            {output.index: output.text for output in test_case.answer.outputs}
-            if test_case.answer is not None
-            else {}
-        )
+        outputs_by_index = {}
+        if test_case.answer is not None:
+            outputs_by_index = {
+                output.index: output.text for output in test_case.answer.outputs
+            }
+        verified_marker = ""
+        if test_case.verified:
+            verified_marker = "✓"
         for local_index, (global_index, guide_text, target_text) in enumerate(
             zip(
                 block.guide_indexes,
@@ -164,7 +158,7 @@ def audit_gap_translation(
                 _format_target_context(block, local_index - 1),
                 output_text,
                 "",
-                "✓" if test_case.verified else "",
+                verified_marker,
             )
             all_rows.append(
                 _GapTranslationRow(
@@ -179,6 +173,7 @@ def audit_gap_translation(
                 )
             )
 
+    # Sort and filter rows while retaining complete selection statistics
     all_rows.sort(key=lambda row: (row.global_index, row.test_case_index))
     translated_gaps = sum(row.answered and not row.empty for row in all_rows)
     empty_translations = sum(row.empty for row in all_rows)
@@ -187,47 +182,40 @@ def audit_gap_translation(
     rows = [
         row
         for row in all_rows
-        if not (row_filter is GapTranslationAuditFilter.unverified and row.verified)
+        if not (row_filter is VerificationAuditFilter.unverified and row.verified)
     ]
-    lines = [
-        "# Gap Translation Audit",
-        "",
-        "## Summary",
-        "",
-        f"- logged cases: {len({row.test_case_index for row in all_rows})}",
-        f"- gaps: {len(all_rows)}",
-        f"- translated gaps: {translated_gaps}",
-        f"- empty translations: {empty_translations}",
-        f"- unanswered gaps: {unanswered_gaps}",
-        f"- verified gaps: {verified_gaps}",
-        f"- unverified gaps: {len(all_rows) - verified_gaps}",
-        f"- row filter: {row_filter.value}",
-    ]
-    range_summary = format_index_range(
-        first_index,
-        last_index,
-        track_name="guide",
+
+    # Format the report using the shared Markdown structure
+    return format_audit_report(
+        title="Gap Translation Audit",
+        summary_lines=(
+            f"- logged cases: {len({row.test_case_index for row in all_rows})}",
+            f"- gaps: {len(all_rows)}",
+            f"- translated gaps: {translated_gaps}",
+            f"- empty translations: {empty_translations}",
+            f"- unanswered gaps: {unanswered_gaps}",
+            f"- verified gaps: {verified_gaps}",
+            f"- unverified gaps: {len(all_rows) - verified_gaps}",
+            f"- row filter: {row_filter.value}",
+        ),
+        column_labels=(
+            "Indexes",
+            "Case / block",
+            "Difficulty",
+            "Guide",
+            "Target context",
+            "Translation",
+            "Notes",
+            "Verified",
+        ),
+        column_separators=("---:", "---:", "---:", "---", "---", "---", "---", ":---:"),
+        rows=[row.markdown for row in rows],
+        first_index=first_index,
+        last_index=last_index,
+        index_track_name="guide",
+        first_block=first_block,
+        last_block=last_block,
     )
-    if range_summary is not None:
-        lines.append(range_summary)
-    block_range_summary = format_block_range(first_block, last_block)
-    if block_range_summary is not None:
-        lines.append(block_range_summary)
-    lines.extend(
-        (
-            f"- table rows: {len(rows)}",
-            "",
-            "## Audit Table",
-            "",
-            (
-                "| Indexes | Case / block | Difficulty | Guide | Target context | "
-                "Translation | Notes | Verified |"
-            ),
-            "|---:|---:|---:|---|---|---|---|:---:|",
-            *(row.markdown for row in rows),
-        )
-    )
-    return "\n".join(lines) + "\n"
 
 
 def _block_intersects_range(
@@ -316,6 +304,7 @@ def _get_active_test_case_blocks(
     Raises:
         ScinoephileError: if a selected case is absent, stale, or ambiguous
     """
+    # Index current blocks by exact query content and guide-only content
     blocks_by_key: dict[_GapTranslationKey, list[_GapTranslationBlock]] = defaultdict(
         list
     )
@@ -331,6 +320,7 @@ def _get_active_test_case_blocks(
         blocks_by_key[(targets, block.guide_texts)].append(block)
         blocks_by_guides[block.guide_texts].append(block)
 
+    # Match exact current cases, retaining the latest case for each block
     active_by_block_number: dict[
         int,
         tuple[int, GapTranslationTestCase, _GapTranslationBlock],
@@ -382,6 +372,7 @@ def _get_active_test_case_blocks(
             block,
         )
 
+    # Reconcile unmatched historical cases against current guide blocks
     active_block_numbers = set(active_by_block_number)
     for test_case_index, test_case in unmatched_cases:
         guides = tuple(guide_subtitle.text for guide_subtitle in test_case.query.guides)
@@ -424,6 +415,27 @@ def _get_active_test_case_blocks(
             f"{selected_matches[0].block_number}"
         )
 
+    # Ensure every selected current gap block has a corresponding logged case
+    selected_block_numbers = {
+        block.block_number
+        for block in blocks
+        if _block_intersects_range(
+            block,
+            first_index,
+            last_index,
+            first_block,
+            last_block,
+        )
+    }
+    missing_block_numbers = sorted(selected_block_numbers - set(active_by_block_number))
+    if missing_block_numbers:
+        block_numbers = ", ".join(str(number) for number in missing_block_numbers)
+        raise ScinoephileError(
+            "Unable to audit gap translation: selected gap blocks have no matching "
+            f"logged test case: {block_numbers}"
+        )
+
+    # Return active cases in current workflow order
     return sorted(
         active_by_block_number.values(),
         key=lambda item: item[2].block_number,
@@ -440,6 +452,7 @@ def _get_blocks(
     Returns:
         blocks containing one or more missing target positions
     """
+    # Track global guide positions across every paired block
     blocks: list[_GapTranslationBlock] = []
     guide_offset = 0
     for block_number, (target_block, guide_block) in enumerate(block_pairs, 1):
@@ -450,6 +463,7 @@ def _get_blocks(
         if not guide_block:
             continue
 
+        # Reconstruct target gaps using the production alignment strategy
         overlap = get_sync_overlap_matrix(target_block, guide_block)
         occupied_positions = {int(row.argmax()) for row in overlap}
         if len(occupied_positions) == len(guide_block):
@@ -518,6 +532,8 @@ def _is_test_case_outside_range(
     ]
     if not matching_starts:
         return False
+
+    # Accept the stale case only when every possible span is outside the selection
     return all(
         all(
             (

--- a/scinoephile/analysis/audit/gap_translation.py
+++ b/scinoephile/analysis/audit/gap_translation.py
@@ -16,7 +16,7 @@ from scinoephile.llms.gap_translation import GapTranslationTestCase
 
 from .translation import resolve_translation_audit_output
 from .utils import (
-    VerificationAuditFilter,
+    AuditFilter,
     format_audit_report,
     format_verification_marker,
     validate_audit_range,
@@ -65,7 +65,7 @@ def audit_gap_translation(
     guide: Series,
     test_cases: Sequence[GapTranslationTestCase],
     *,
-    row_filter: VerificationAuditFilter = VerificationAuditFilter.all,
+    row_filter: AuditFilter = AuditFilter.all,
     first_index: int | None = None,
     last_index: int | None = None,
     first_block: int | None = None,
@@ -176,7 +176,7 @@ def audit_gap_translation(
     rows = [
         row
         for row in all_rows
-        if not (row_filter is VerificationAuditFilter.unverified and row.verified)
+        if not (row_filter is AuditFilter.unverified and row.verified)
     ]
 
     # Format the report using the shared Markdown structure

--- a/scinoephile/analysis/audit/gap_translation.py
+++ b/scinoephile/analysis/audit/gap_translation.py
@@ -304,6 +304,9 @@ def _get_active_test_case_blocks(
     blocks_by_guides: dict[tuple[str, ...], list[_GapTranslationBlock]] = defaultdict(
         list
     )
+    blocks_by_targets: dict[tuple[tuple[int, str], ...], list[_GapTranslationBlock]] = (
+        defaultdict(list)
+    )
     for block in blocks:
         targets = tuple(
             (position, text)
@@ -312,6 +315,7 @@ def _get_active_test_case_blocks(
         )
         blocks_by_key[(targets, block.guide_texts)].append(block)
         blocks_by_guides[block.guide_texts].append(block)
+        blocks_by_targets[targets].append(block)
 
     # Match exact current cases, retaining the latest case for each block
     active_by_block_number: dict[
@@ -360,6 +364,16 @@ def _get_active_test_case_blocks(
     # Reconcile unmatched historical cases against current guide blocks
     active_block_numbers = set(active_by_block_number)
     for test_case_index, test_case in unmatched_cases:
+        targets = tuple(
+            (target.index, target.text) for target in test_case.query.targets
+        )
+        if any(
+            block.block_number in active_block_numbers
+            for block in blocks_by_targets.get(targets, [])
+        ):
+            # A current case for the same target layout supersedes old guide text
+            continue
+
         guides = tuple(guide_subtitle.text for guide_subtitle in test_case.query.guides)
         matches = blocks_by_guides.get(guides, [])
         selected_matches = [

--- a/scinoephile/analysis/audit/gap_translation.py
+++ b/scinoephile/analysis/audit/gap_translation.py
@@ -15,11 +15,10 @@ from scinoephile.core.synchronization import get_sync_overlap_matrix
 from scinoephile.llms.gap_translation import GapTranslationTestCase
 
 from .utils import (
-    _get_paired_event_block_numbers,
-    _get_validated_block_pairs_by_pause,
     escape_table_cell,
     format_block_range,
     format_index_range,
+    get_validated_block_pairs_by_pause,
     validate_block_range,
     validate_index_range,
 )
@@ -105,14 +104,18 @@ def audit_gap_translation(
     validate_index_range(first_index, last_index)
     validate_block_range(first_block, last_block)
 
-    block_pairs = _get_validated_block_pairs_by_pause(
+    block_pairs = get_validated_block_pairs_by_pause(
         target,
         guide,
         first_block,
         last_block,
     )
     blocks = _get_blocks(block_pairs)
-    _, guide_block_numbers = _get_paired_event_block_numbers(block_pairs)
+    guide_block_numbers = tuple(
+        block_number
+        for block_number, (_, guide_block) in enumerate(block_pairs, 1)
+        for _ in guide_block
+    )
     active_cases = _get_active_test_case_blocks(
         guide,
         guide_block_numbers,

--- a/scinoephile/analysis/audit/guided_review.py
+++ b/scinoephile/analysis/audit/guided_review.py
@@ -16,8 +16,8 @@ from scinoephile.core.text import remove_punc_and_whitespace
 from scinoephile.llms.guided_review import GuidedReviewTestCase
 
 from .utils import (
-    AuditFilter,
     AuditResult,
+    ChangeAuditFilter,
     format_audit_report,
     format_verification_marker,
     is_block_in_range,
@@ -64,7 +64,7 @@ def audit_guided_review(
     guide: Series,
     test_cases: Sequence[GuidedReviewTestCase],
     *,
-    row_filter: AuditFilter = AuditFilter.changes,
+    row_filter: ChangeAuditFilter = ChangeAuditFilter.changes,
     first_index: int | None = None,
     last_index: int | None = None,
     first_block: int | None = None,
@@ -174,9 +174,10 @@ def audit_guided_review(
         row
         for row in all_rows
         if not (
-            row_filter is AuditFilter.changes and row.result is not AuditResult.changed
+            row_filter is ChangeAuditFilter.changes
+            and row.result is not AuditResult.changed
         )
-        and not (row_filter is AuditFilter.unverified and row.verified)
+        and not (row_filter is ChangeAuditFilter.unverified and row.verified)
     ]
     subtitles = len(all_rows)
     unchanged_subtitles = subtitles - revised_subtitles - unanswered_subtitles

--- a/scinoephile/analysis/audit/guided_review.py
+++ b/scinoephile/analysis/audit/guided_review.py
@@ -19,6 +19,7 @@ from .utils import (
     AuditFilter,
     AuditResult,
     format_audit_report,
+    format_verification_marker,
     is_block_in_range,
     validate_audit_range,
 )
@@ -145,9 +146,7 @@ def audit_guided_review(
             guide_text = "\n".join(guide_texts)
             if not guide_texts:
                 guide_text = "—"
-            verified_marker = ""
-            if test_case.verified:
-                verified_marker = "✓"
+            verified_marker = format_verification_marker(test_case.verified)
             cells = (
                 str(subtitle_index),
                 str(block.block_number),
@@ -210,51 +209,29 @@ def audit_guided_review(
     )
 
 
-def _get_blocks_by_key(
-    block_pairs: Sequence[tuple[Series, Series]],
-) -> dict[tuple[tuple[str, ...], tuple[str, ...]], list[_GuidedReviewBlock]]:
-    """Index eligible target and guide blocks by their logged text.
+def _block_intersects_range(
+    block: _GuidedReviewBlock,
+    first_index: int | None,
+    last_index: int | None,
+    first_block: int | None,
+    last_block: int | None,
+) -> bool:
+    """Check whether a guided-review block intersects an audit range.
 
     Arguments:
-        block_pairs: paired target and guide workflow blocks
+        block: guided-review block to check
+        first_index: first included target subtitle number
+        last_index: last included target subtitle number
+        first_block: first included paired block number
+        last_block: last included paired block number
     Returns:
-        guided-review blocks keyed by target and guide text
+        whether any target subtitle in the block is selected
     """
-    blocks_by_key: dict[
-        tuple[tuple[str, ...], tuple[str, ...]],
-        list[_GuidedReviewBlock],
-    ] = defaultdict(list)
-    target_offset = 0
-    for block_number, (target_block, guide_block) in enumerate(block_pairs, 1):
-        target_indexes = tuple(
-            range(target_offset + 1, target_offset + len(target_block) + 1)
-        )
-        target_offset += len(target_block)
-        if not target_block:
-            continue
-
-        target_texts = tuple(
-            subtitle.text_with_newline.strip() for subtitle in target_block
-        )
-        guide_texts = tuple(
-            subtitle.text_with_newline.strip() for subtitle in guide_block
-        )
-        aligned_guide_texts: list[tuple[str, ...]] = [()] * len(target_block)
-        for target_group, guide_group in get_sync_groups(target_block, guide_block):
-            group_guide_texts = tuple(guide_texts[index] for index in guide_group)
-            for target_index in target_group:
-                aligned_guide_texts[target_index] = group_guide_texts
-        key = (_normalize_texts(target_texts), guide_texts)
-        blocks_by_key[key].append(
-            _GuidedReviewBlock(
-                block_number=block_number,
-                target_indexes=target_indexes,
-                target_texts=target_texts,
-                guide_texts=guide_texts,
-                aligned_guide_texts=tuple(aligned_guide_texts),
-            )
-        )
-    return blocks_by_key
+    return (
+        is_block_in_range(block.block_number, first_block, last_block)
+        and (first_index is None or block.target_indexes[-1] >= first_index)
+        and (last_index is None or block.target_indexes[0] <= last_index)
+    )
 
 
 def _get_active_test_case_blocks(  # noqa: PLR0912
@@ -325,18 +302,12 @@ def _get_active_test_case_blocks(  # noqa: PLR0912
                 last_block,
             )
         ]
-        if len(selected_matches) == 1:
-            active_cases.append((test_case_index, test_case, selected_matches[0]))
+        if selected_matches:
+            # Reuse one deduplicated logged query for every exact current match
+            active_cases.extend(
+                (test_case_index, test_case, block) for block in selected_matches
+            )
             continue
-        if len(selected_matches) > 1:
-            block_numbers = ", ".join(
-                str(match.block_number) for match in selected_matches
-            )
-            raise ScinoephileError(
-                "Unable to audit guided review: "
-                f"test case {test_case_index} is ambiguous; it matches blocks "
-                f"{block_numbers}"
-            )
         if matches:
             continue
         unmatched_cases.append((test_case_index, test_case))
@@ -436,92 +407,51 @@ def _get_active_test_case_blocks(  # noqa: PLR0912
     return active_cases
 
 
-def _block_intersects_range(
-    block: _GuidedReviewBlock,
-    first_index: int | None,
-    last_index: int | None,
-    first_block: int | None,
-    last_block: int | None,
-) -> bool:
-    """Check whether a guided-review block intersects an audit range.
+def _get_blocks_by_key(
+    block_pairs: Sequence[tuple[Series, Series]],
+) -> dict[tuple[tuple[str, ...], tuple[str, ...]], list[_GuidedReviewBlock]]:
+    """Index eligible target and guide blocks by their logged text.
 
     Arguments:
-        block: guided-review block to check
-        first_index: first included target subtitle number
-        last_index: last included target subtitle number
-        first_block: first included paired block number
-        last_block: last included paired block number
+        block_pairs: paired target and guide workflow blocks
     Returns:
-        whether any target subtitle in the block is selected
+        guided-review blocks keyed by target and guide text
     """
-    return (
-        is_block_in_range(block.block_number, first_block, last_block)
-        and (first_index is None or block.target_indexes[-1] >= first_index)
-        and (last_index is None or block.target_indexes[0] <= last_index)
-    )
-
-
-def _validate_selected_targets(
-    test_case: GuidedReviewTestCase,
-    block: _GuidedReviewBlock,
-    *,
-    first_index: int | None,
-    last_index: int | None,
-    test_case_index: int,
-):
-    """Validate selected logged targets against the current target block.
-
-    This permits an audit of an unaffected prefix after later upstream
-    delineation changes while rejecting selected rows whose indexing changed.
-
-    Arguments:
-        test_case: guided-review test case to validate
-        block: current target and guide block matched to the case
-        first_index: first included target subtitle number
-        last_index: last included target subtitle number
-        test_case_index: one-based test case position used in errors
-    Raises:
-        ScinoephileError: if selected logged targets no longer match current indexes
-    """
-    query_targets = tuple(target.text for target in test_case.query.targets)
-    selected_positions = [
-        position
-        for position, subtitle_index in enumerate(block.target_indexes)
-        if (first_index is None or subtitle_index >= first_index)
-        and (last_index is None or subtitle_index <= last_index)
-    ]
-    if not selected_positions:
-        return
-
-    for position in selected_positions:
-        if position >= len(query_targets) or _normalize_texts(
-            (query_targets[position],)
-        ) != _normalize_texts((block.target_texts[position],)):
-            subtitle_index = block.target_indexes[position]
-            raise ScinoephileError(
-                "Unable to audit guided review: "
-                f"test case {test_case_index} target segmentation no longer "
-                f"matches subtitle index {subtitle_index}"
-            )
-
-    includes_block_end = last_index is None or last_index >= block.target_indexes[-1]
-    if len(query_targets) != len(block.target_texts) and includes_block_end:
-        raise ScinoephileError(
-            "Unable to audit guided review: "
-            f"test case {test_case_index} target block length changed from "
-            f"{len(query_targets)} to {len(block.target_texts)} subtitles"
+    blocks_by_key: dict[
+        tuple[tuple[str, ...], tuple[str, ...]],
+        list[_GuidedReviewBlock],
+    ] = defaultdict(list)
+    target_offset = 0
+    for block_number, (target_block, guide_block) in enumerate(block_pairs, 1):
+        target_indexes = tuple(
+            range(target_offset + 1, target_offset + len(target_block) + 1)
         )
+        target_offset += len(target_block)
+        if not target_block:
+            continue
 
-
-def _normalize_texts(texts: tuple[str, ...]) -> tuple[str, ...]:
-    """Normalize target texts for matching across punctuation-only changes.
-
-    Arguments:
-        texts: target subtitle texts
-    Returns:
-        texts without punctuation or whitespace
-    """
-    return tuple(remove_punc_and_whitespace(text) for text in texts)
+        target_texts = tuple(
+            subtitle.text_with_newline.strip() for subtitle in target_block
+        )
+        guide_texts = tuple(
+            subtitle.text_with_newline.strip() for subtitle in guide_block
+        )
+        aligned_guide_texts: list[tuple[str, ...]] = [()] * len(target_block)
+        for target_group, guide_group in get_sync_groups(target_block, guide_block):
+            group_guide_texts = tuple(guide_texts[index] for index in guide_group)
+            for target_index in target_group:
+                aligned_guide_texts[target_index] = group_guide_texts
+        key = (_normalize_texts(target_texts), guide_texts)
+        blocks_by_key[key].append(
+            _GuidedReviewBlock(
+                block_number=block_number,
+                target_indexes=target_indexes,
+                target_texts=target_texts,
+                guide_texts=guide_texts,
+                aligned_guide_texts=tuple(aligned_guide_texts),
+            )
+        )
+    return blocks_by_key
 
 
 def _is_test_case_outside_range(
@@ -597,3 +527,66 @@ def _is_test_case_outside_range(
         )
         outside_selected_ranges.append(outside_index_range or outside_block_range)
     return all(outside_selected_ranges)
+
+
+def _normalize_texts(texts: tuple[str, ...]) -> tuple[str, ...]:
+    """Normalize target texts for matching across punctuation-only changes.
+
+    Arguments:
+        texts: target subtitle texts
+    Returns:
+        texts without punctuation or whitespace
+    """
+    return tuple(remove_punc_and_whitespace(text) for text in texts)
+
+
+def _validate_selected_targets(
+    test_case: GuidedReviewTestCase,
+    block: _GuidedReviewBlock,
+    *,
+    first_index: int | None,
+    last_index: int | None,
+    test_case_index: int,
+):
+    """Validate selected logged targets against the current target block.
+
+    This permits an audit of an unaffected prefix after later upstream
+    delineation changes while rejecting selected rows whose indexing changed.
+
+    Arguments:
+        test_case: guided-review test case to validate
+        block: current target and guide block matched to the case
+        first_index: first included target subtitle number
+        last_index: last included target subtitle number
+        test_case_index: one-based test case position used in errors
+    Raises:
+        ScinoephileError: if selected logged targets no longer match current indexes
+    """
+    query_targets = tuple(target.text for target in test_case.query.targets)
+    selected_positions = [
+        position
+        for position, subtitle_index in enumerate(block.target_indexes)
+        if (first_index is None or subtitle_index >= first_index)
+        and (last_index is None or subtitle_index <= last_index)
+    ]
+    if not selected_positions:
+        return
+
+    for position in selected_positions:
+        if position >= len(query_targets) or _normalize_texts(
+            (query_targets[position],)
+        ) != _normalize_texts((block.target_texts[position],)):
+            subtitle_index = block.target_indexes[position]
+            raise ScinoephileError(
+                "Unable to audit guided review: "
+                f"test case {test_case_index} target segmentation no longer "
+                f"matches subtitle index {subtitle_index}"
+            )
+
+    includes_block_end = last_index is None or last_index >= block.target_indexes[-1]
+    if len(query_targets) != len(block.target_texts) and includes_block_end:
+        raise ScinoephileError(
+            "Unable to audit guided review: "
+            f"test case {test_case_index} target block length changed from "
+            f"{len(query_targets)} to {len(block.target_texts)} subtitles"
+        )

--- a/scinoephile/analysis/audit/guided_review.py
+++ b/scinoephile/analysis/audit/guided_review.py
@@ -64,7 +64,7 @@ def audit_guided_review(
     guide: Series,
     test_cases: Sequence[GuidedReviewTestCase],
     *,
-    row_filter: AuditFilter = AuditFilter.all,
+    row_filter: AuditFilter = AuditFilter.changes,
     first_index: int | None = None,
     last_index: int | None = None,
     first_block: int | None = None,

--- a/scinoephile/analysis/audit/guided_review.py
+++ b/scinoephile/analysis/audit/guided_review.py
@@ -7,13 +7,13 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Protocol
 
 from scinoephile.core.exceptions import ScinoephileError
 from scinoephile.core.pairs import get_block_pairs_by_pause
 from scinoephile.core.subtitles import Series
 from scinoephile.core.synchronization import get_sync_groups
 from scinoephile.core.text import remove_punc_and_whitespace
+from scinoephile.llms.guided_review import GuidedReviewTestCase
 
 from .utils import (
     AuditFilter,
@@ -58,111 +58,10 @@ class _GuidedReviewRow:
     """Whether the source test case is verified."""
 
 
-class _GuidedReviewSubtitle(Protocol):
-    """Subtitle fields required for guided-review audit reporting."""
-
-    @property
-    def text(self) -> str:
-        """Subtitle text.
-
-        Returns:
-            subtitle text
-        """
-        ...
-
-
-class _GuidedReviewRevision(_GuidedReviewSubtitle, Protocol):
-    """Revision fields required for guided-review audit reporting."""
-
-    @property
-    def index(self) -> int:
-        """One-based query-local target index.
-
-        Returns:
-            one-based query-local target index
-        """
-        ...
-
-    @property
-    def note(self) -> str:
-        """Explanation recorded for the revision.
-
-        Returns:
-            revision explanation
-        """
-        ...
-
-
-class _GuidedReviewAnswer(Protocol):
-    """Answer fields required for guided-review audit reporting."""
-
-    @property
-    def revisions(self) -> Sequence[_GuidedReviewRevision]:
-        """Sparse target revisions.
-
-        Returns:
-            sparse target revisions
-        """
-        ...
-
-
-class _GuidedReviewQuery(Protocol):
-    """Query fields required for guided-review audit reporting."""
-
-    @property
-    def guides(self) -> Sequence[_GuidedReviewSubtitle]:
-        """Guide subtitles.
-
-        Returns:
-            guide subtitles
-        """
-        ...
-
-    @property
-    def targets(self) -> Sequence[_GuidedReviewSubtitle]:
-        """Target subtitles.
-
-        Returns:
-            target subtitles
-        """
-        ...
-
-
-class _GuidedReviewTestCase(Protocol):
-    """Test-case fields required for guided-review audit reporting."""
-
-    @property
-    def answer(self) -> _GuidedReviewAnswer | None:
-        """Optional guided-review answer.
-
-        Returns:
-            guided-review answer, if present
-        """
-        ...
-
-    @property
-    def query(self) -> _GuidedReviewQuery:
-        """Guided-review query.
-
-        Returns:
-            guided-review query
-        """
-        ...
-
-    @property
-    def verified(self) -> bool:
-        """Whether the test case has been verified.
-
-        Returns:
-            whether the test case has been verified
-        """
-        ...
-
-
 def audit_guided_review(
     target: Series,
     guide: Series,
-    test_cases: Sequence[_GuidedReviewTestCase],
+    test_cases: Sequence[GuidedReviewTestCase],
     *,
     row_filter: AuditFilter = AuditFilter.all,
     first_index: int | None = None,
@@ -361,7 +260,7 @@ def _get_blocks_by_key(
 def _get_active_test_case_blocks(  # noqa: PLR0912
     target: Series,
     guide: Series,
-    test_cases: Sequence[_GuidedReviewTestCase],
+    test_cases: Sequence[GuidedReviewTestCase],
     blocks_by_key: dict[
         tuple[tuple[str, ...], tuple[str, ...]], list[_GuidedReviewBlock]
     ],
@@ -371,7 +270,7 @@ def _get_active_test_case_blocks(  # noqa: PLR0912
     last_index: int | None,
     first_block: int | None,
     last_block: int | None,
-) -> list[tuple[int, _GuidedReviewTestCase, _GuidedReviewBlock]]:
+) -> list[tuple[int, GuidedReviewTestCase, _GuidedReviewBlock]]:
     """Get current cases while ignoring superseded historical cases.
 
     Persisted guided-review cases are retained after their target block's
@@ -407,8 +306,8 @@ def _get_active_test_case_blocks(  # noqa: PLR0912
             blocks_by_guides[block.guide_texts].append(block)
             blocks_by_targets[_normalize_texts(block.target_texts)].append(block)
 
-    active_cases: list[tuple[int, _GuidedReviewTestCase, _GuidedReviewBlock]] = []
-    unmatched_cases: list[tuple[int, _GuidedReviewTestCase]] = []
+    active_cases: list[tuple[int, GuidedReviewTestCase, _GuidedReviewBlock]] = []
+    unmatched_cases: list[tuple[int, GuidedReviewTestCase]] = []
     for test_case_index, test_case in enumerate(test_cases, 1):
         key = (
             _normalize_texts(tuple(target.text for target in test_case.query.targets)),
@@ -448,7 +347,7 @@ def _get_active_test_case_blocks(  # noqa: PLR0912
         for block_number, (_, guide_block) in enumerate(block_pairs, 1)
         for _ in guide_block
     )
-    stale_cases: list[tuple[int, _GuidedReviewTestCase, list[_GuidedReviewBlock]]] = []
+    stale_cases: list[tuple[int, GuidedReviewTestCase, list[_GuidedReviewBlock]]] = []
     for test_case_index, test_case in unmatched_cases:
         key = (
             _normalize_texts(tuple(target.text for target in test_case.query.targets)),
@@ -563,7 +462,7 @@ def _block_intersects_range(
 
 
 def _validate_selected_targets(
-    test_case: _GuidedReviewTestCase,
+    test_case: GuidedReviewTestCase,
     block: _GuidedReviewBlock,
     *,
     first_index: int | None,
@@ -626,7 +525,7 @@ def _normalize_texts(texts: tuple[str, ...]) -> tuple[str, ...]:
 
 
 def _is_test_case_outside_range(
-    test_case: _GuidedReviewTestCase,
+    test_case: GuidedReviewTestCase,
     target: Series,
     guide: Series,
     guide_block_numbers: Sequence[int],

--- a/scinoephile/analysis/audit/guided_review.py
+++ b/scinoephile/analysis/audit/guided_review.py
@@ -18,7 +18,6 @@ from scinoephile.core.text import remove_punc_and_whitespace
 from .utils import (
     AuditFilter,
     AuditResult,
-    escape_table_cell,
     format_audit_report,
     is_block_in_range,
     validate_audit_range,
@@ -51,8 +50,8 @@ class _GuidedReviewRow:
     """One-based target subtitle index."""
     test_case_index: int
     """One-based position of the source test case in the JSON."""
-    markdown: str
-    """Formatted Markdown table row."""
+    cells: tuple[str, ...]
+    """Semantic audit table cell values."""
     result: AuditResult
     """Result of the logged answer for this subtitle."""
     verified: bool
@@ -81,6 +80,15 @@ class _GuidedReviewRevision(_GuidedReviewSubtitle, Protocol):
 
         Returns:
             one-based query-local target index
+        """
+        ...
+
+    @property
+    def note(self) -> str:
+        """Explanation recorded for the revision.
+
+        Returns:
+            revision explanation
         """
         ...
 
@@ -201,11 +209,11 @@ def audit_guided_review(
         last_block=last_block,
     ):
         answer = test_case.answer
-        revisions_by_index = (
-            {revision.index: revision for revision in answer.revisions}
-            if answer is not None
-            else {}
-        )
+        revisions_by_index = {}
+        if answer is not None:
+            revisions_by_index = {
+                revision.index: revision for revision in answer.revisions
+            }
 
         for local_index, (subtitle_index, query_target, guide_texts) in enumerate(
             zip(
@@ -224,11 +232,13 @@ def audit_guided_review(
             revision = revisions_by_index.get(local_index)
 
             target_revision = query_target.text
+            note = ""
             if answer is None:
                 target_revision = f"{query_target.text}\n(unanswered)"
                 result = AuditResult.unanswered
             elif revision is not None:
                 target_revision = f"{query_target.text}\n{revision.text}"
+                note = revision.note
                 result = AuditResult.changed
             else:
                 result = AuditResult.unchanged
@@ -236,20 +246,21 @@ def audit_guided_review(
             guide_text = "\n".join(guide_texts)
             if not guide_texts:
                 guide_text = "—"
+            verified_marker = ""
+            if test_case.verified:
+                verified_marker = "✓"
             cells = (
                 str(subtitle_index),
                 str(block.block_number),
                 guide_text,
                 target_revision,
-                "",
-                "✓" if test_case.verified else "",
+                note,
+                verified_marker,
             )
             rows_by_subtitle_index[subtitle_index] = _GuidedReviewRow(
+                cells=cells,
                 subtitle_index=subtitle_index,
                 test_case_index=test_case_index,
-                markdown=(
-                    f"| {' | '.join(escape_table_cell(cell) for cell in cells)} |"
-                ),
                 result=result,
                 verified=test_case.verified,
             )
@@ -274,25 +285,24 @@ def audit_guided_review(
     unverified_subtitles = subtitles - verified_subtitles
     return format_audit_report(
         title="Guided Subtitle Review Audit",
-        summary_lines=(
-            f"- subtitles: {subtitles}",
-            f"- revised subtitles: {revised_subtitles}",
-            f"- unchanged subtitles: {unchanged_subtitles}",
-            f"- unanswered subtitles: {unanswered_subtitles}",
-            f"- verified subtitles: {verified_subtitles}",
-            f"- unverified subtitles: {unverified_subtitles}",
-            f"- row filter: {row_filter.value}",
+        summary_items=(
+            f"subtitles: {subtitles}",
+            f"revised subtitles: {revised_subtitles}",
+            f"unchanged subtitles: {unchanged_subtitles}",
+            f"unanswered subtitles: {unanswered_subtitles}",
+            f"verified subtitles: {verified_subtitles}",
+            f"unverified subtitles: {unverified_subtitles}",
+            f"row filter: {row_filter.value}",
         ),
-        column_labels=(
-            "Index",
-            "Block",
-            "Guide",
-            "Target / revision",
-            "Notes",
-            "Verified",
+        columns=(
+            ("Index", "right"),
+            ("Block", "right"),
+            ("Guide", "left"),
+            ("Target / revision", "left"),
+            ("Notes", "left"),
+            ("Verified", "center"),
         ),
-        column_separators=("---:", "---:", "---", "---", "---", ":---:"),
-        rows=[row.markdown for row in rows],
+        rows=[row.cells for row in rows],
         first_index=first_index,
         last_index=last_index,
         index_track_name="target",
@@ -501,6 +511,28 @@ def _get_active_test_case_blocks(  # noqa: PLR0912
             test_case_index=test_case_index,
         )
         active_cases.append((test_case_index, test_case, selected_matches[0]))
+
+    # Ensure every selected current target block has a corresponding logged case
+    selected_block_numbers = {
+        block.block_number
+        for blocks in blocks_by_key.values()
+        for block in blocks
+        if _block_intersects_range(
+            block,
+            first_index,
+            last_index,
+            first_block,
+            last_block,
+        )
+    }
+    active_block_numbers = {block.block_number for _, _, block in active_cases}
+    missing_block_numbers = sorted(selected_block_numbers - active_block_numbers)
+    if missing_block_numbers:
+        block_numbers = ", ".join(str(number) for number in missing_block_numbers)
+        raise ScinoephileError(
+            "Unable to audit guided review: selected target blocks have no matching "
+            f"logged test case: {block_numbers}"
+        )
 
     return active_cases
 

--- a/scinoephile/analysis/audit/guided_translation.py
+++ b/scinoephile/analysis/audit/guided_translation.py
@@ -15,7 +15,7 @@ from .translation import (
     TranslationAuditCase,
     audit_translation_blocks,
 )
-from .utils import VerificationAuditFilter, validate_audit_range
+from .utils import AuditFilter, validate_audit_range
 
 __all__ = ["audit_guided_translation"]
 
@@ -25,7 +25,7 @@ def audit_guided_translation(
     guide: Series,
     test_cases: Sequence[GuidedTranslationTestCase],
     *,
-    row_filter: VerificationAuditFilter = VerificationAuditFilter.all,
+    row_filter: AuditFilter = AuditFilter.all,
     first_index: int | None = None,
     last_index: int | None = None,
     first_block: int | None = None,

--- a/scinoephile/analysis/audit/guided_translation.py
+++ b/scinoephile/analysis/audit/guided_translation.py
@@ -1,0 +1,138 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Audit guided translation decisions and format them as Markdown."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from scinoephile.core.pairs import get_block_pairs_by_pause
+from scinoephile.core.subtitles import Series
+from scinoephile.llms.guided_translation import GuidedTranslationTestCase
+
+from .translation import (
+    TranslationAuditBlock,
+    TranslationAuditCase,
+    audit_translation_blocks,
+)
+from .utils import VerificationAuditFilter, validate_audit_range
+
+__all__ = ["audit_guided_translation"]
+
+
+def audit_guided_translation(
+    source: Series,
+    guide: Series,
+    test_cases: Sequence[GuidedTranslationTestCase],
+    *,
+    row_filter: VerificationAuditFilter = VerificationAuditFilter.all,
+    first_index: int | None = None,
+    last_index: int | None = None,
+    first_block: int | None = None,
+    last_block: int | None = None,
+) -> str:
+    """Audit guided translations against their source and guide blocks.
+
+    Arguments:
+        source: source-language subtitle series provided for translation
+        guide: target-language guide subtitle series
+        test_cases: logged guided-translation test cases
+        row_filter: row verification filter
+        first_index: first 1-indexed source subtitle number to include
+        last_index: last 1-indexed source subtitle number to include
+        first_block: first 1-indexed paired block number to include
+        last_block: last 1-indexed paired block number to include
+    Returns:
+        Markdown audit report
+    Raises:
+        ScinoephileError: if a range or logged case is invalid
+    """
+    # Build paired workflow blocks and validate the selection
+    block_pairs = get_block_pairs_by_pause(source, guide)
+    validate_audit_range(
+        first_index,
+        last_index,
+        first_block,
+        last_block,
+        block_count=len(block_pairs),
+    )
+    blocks = _get_blocks(block_pairs)
+
+    # Adapt concrete test cases and run the shared audit engine
+    cases = _get_cases(test_cases)
+    return audit_translation_blocks(
+        blocks,
+        cases,
+        title="Guided Translation Audit",
+        row_filter=row_filter,
+        first_index=first_index,
+        last_index=last_index,
+        first_block=first_block,
+        last_block=last_block,
+    )
+
+
+def _get_blocks(
+    block_pairs: Sequence[tuple[Series, Series]],
+) -> list[TranslationAuditBlock]:
+    """Build current guided-translation blocks with global source indexes.
+
+    Arguments:
+        block_pairs: paired source and guide workflow blocks
+    Returns:
+        current nonempty source blocks
+    """
+    blocks = []
+    source_position = 0
+    for block_number, (source_block, guide_block) in enumerate(block_pairs, 1):
+        if not source_block:
+            continue
+        source_indexes = tuple(
+            range(source_position + 1, source_position + len(source_block) + 1)
+        )
+        source_position += len(source_block)
+        blocks.append(
+            TranslationAuditBlock(
+                block_number=block_number,
+                guide_texts=tuple(
+                    subtitle.text_with_newline.strip() for subtitle in guide_block
+                ),
+                source_indexes=source_indexes,
+                source_texts=tuple(
+                    subtitle.text_with_newline.strip() for subtitle in source_block
+                ),
+            )
+        )
+    return blocks
+
+
+def _get_cases(
+    test_cases: Sequence[GuidedTranslationTestCase],
+) -> list[TranslationAuditCase]:
+    """Adapt guided translation test cases to shared semantic data.
+
+    Arguments:
+        test_cases: concrete guided translation test cases
+    Returns:
+        semantic translation cases
+    """
+    cases = []
+    for case_index, test_case in enumerate(test_cases, 1):
+        outputs_by_index = None
+        if test_case.answer is not None:
+            outputs_by_index = {
+                output.index: output.text for output in test_case.answer.outputs
+            }
+        cases.append(
+            TranslationAuditCase(
+                case_index=case_index,
+                difficulty=test_case.difficulty,
+                key=(
+                    tuple(subtitle.text for subtitle in test_case.query.subtitles),
+                    tuple(guide.text for guide in test_case.query.guides),
+                ),
+                outputs_by_index=outputs_by_index,
+                verified=test_case.verified,
+            )
+        )
+    return cases

--- a/scinoephile/analysis/audit/ocr_fusion.py
+++ b/scinoephile/analysis/audit/ocr_fusion.py
@@ -7,15 +7,16 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Protocol
 
 from scinoephile.core.exceptions import ScinoephileError
 from scinoephile.core.subtitles import Series
 from scinoephile.core.synchronization import are_series_one_to_one
+from scinoephile.llms.ocr_fusion import OcrFusionTestCase
 
 from .utils import (
     AuditColumn,
     format_audit_report,
+    format_verification_marker,
     get_selected_event_indexes,
 )
 
@@ -57,58 +58,6 @@ class _OcrFusionDecision:
     """Whether the associated LLM case is verified."""
 
 
-class _OcrFusionAnswer(Protocol):
-    """OCR-fusion answer fields required for audit reporting."""
-
-    @property
-    def note(self) -> str:
-        """Note recorded for the fusion decision."""
-        ...
-
-    @property
-    def output(self) -> str:
-        """Selected fused subtitle text."""
-        ...
-
-
-class _OcrFusionQuery(Protocol):
-    """OCR-fusion query fields required for audit reporting."""
-
-    @property
-    def source_one(self) -> str:
-        """Text from the first OCR source."""
-        ...
-
-    @property
-    def source_two(self) -> str:
-        """Text from the second OCR source."""
-        ...
-
-
-class _OcrFusionTestCase(Protocol):
-    """OCR-fusion test-case fields required for audit reporting."""
-
-    @property
-    def answer(self) -> _OcrFusionAnswer | None:
-        """Optional decision answer."""
-        ...
-
-    @property
-    def difficulty(self) -> int:
-        """Decision difficulty."""
-        ...
-
-    @property
-    def query(self) -> _OcrFusionQuery:
-        """OCR source texts."""
-        ...
-
-    @property
-    def verified(self) -> bool:
-        """Whether the decision has been reviewed."""
-        ...
-
-
 class OcrFusionAuditFilter(StrEnum):
     """Row filters supported by an OCR-fusion audit."""
 
@@ -129,7 +78,7 @@ def audit_ocr_fusion(
     source_one: Series,
     source_two: Series,
     fused: Series,
-    test_cases: Sequence[_OcrFusionTestCase] | None = None,
+    test_cases: Sequence[OcrFusionTestCase] | None = None,
     *,
     validated: Series | None = None,
     row_filter: OcrFusionAuditFilter = OcrFusionAuditFilter.changes,
@@ -175,7 +124,7 @@ def audit_ocr_fusion(
         _validate_alignment(source_one, validated, "Validated")
 
     has_decision_log = test_cases is not None
-    cases_by_key: dict[tuple[str, str], tuple[int, _OcrFusionTestCase]] = {}
+    cases_by_key: dict[tuple[str, str], tuple[int, OcrFusionTestCase]] = {}
     for case_index, test_case in enumerate(test_cases or (), 1):
         key = (test_case.query.source_one, test_case.query.source_two)
         cases_by_key[key] = (case_index, test_case)
@@ -232,9 +181,10 @@ def audit_ocr_fusion(
         ("Source two", "left"),
         ("Fused", "left"),
         ("Validated", "left"),
+        ("Notes", "left"),
     ]
     if has_decision_log:
-        columns.extend((("Notes", "left"), ("Verified", "center")))
+        columns.append(("Verified", "center"))
     return format_audit_report(
         title="OCR Fusion Audit",
         summary_items=summary_items,
@@ -269,20 +219,6 @@ def _filter_rows(
     return [row for row in rows if row.requires_llm and not row.verified]
 
 
-def _get_automatic_output(source_one_text: str, source_two_text: str) -> str:
-    """Get the deterministic fusion output for a pair not sent to the LLM.
-
-    Arguments:
-        source_one_text: first source text
-        source_two_text: second source text
-    Returns:
-        automatic fused text
-    """
-    if source_one_text:
-        return source_one_text
-    return source_two_text
-
-
 def _get_automatic_note(source_one_text: str, source_two_text: str) -> str:
     """Describe the deterministic fusion decision for a source pair.
 
@@ -301,12 +237,26 @@ def _get_automatic_note(source_one_text: str, source_two_text: str) -> str:
     return "Source one empty"
 
 
+def _get_automatic_output(source_one_text: str, source_two_text: str) -> str:
+    """Get the deterministic fusion output for a pair not sent to the LLM.
+
+    Arguments:
+        source_one_text: first source text
+        source_two_text: second source text
+    Returns:
+        automatic fused text
+    """
+    if source_one_text:
+        return source_one_text
+    return source_two_text
+
+
 def _get_decision(
     index: int,
     source_one_text: str,
     source_two_text: str,
     fused_text: str,
-    cases_by_key: dict[tuple[str, str], tuple[int, _OcrFusionTestCase]],
+    cases_by_key: dict[tuple[str, str], tuple[int, OcrFusionTestCase]],
     *,
     has_decision_log: bool,
 ) -> _OcrFusionDecision:
@@ -379,7 +329,7 @@ def _get_row(
     source_one: Series,
     source_two: Series,
     fused: Series,
-    cases_by_key: dict[tuple[str, str], tuple[int, _OcrFusionTestCase]],
+    cases_by_key: dict[tuple[str, str], tuple[int, OcrFusionTestCase]],
     *,
     has_decision_log: bool,
     validated: Series | None,
@@ -423,7 +373,7 @@ def _get_row(
     if validated_text:
         validated_display = validated_text
 
-    # Keep verification unavailable for deterministic rows
+    # Keep the Notes column available even when no decision log was supplied
     cells = (
         str(index),
         case_index,
@@ -432,14 +382,14 @@ def _get_row(
         source_two_text or "—",
         fused_text or "—",
         validated_display,
+        decision.note,
     )
     if has_decision_log:
-        verified_marker = "—"
+        verified: bool | None = None
         if decision.requires_llm:
-            verified_marker = ""
-            if decision.verified:
-                verified_marker = "✓"
-        cells += (decision.note, verified_marker)
+            verified = decision.verified
+        verified_marker = format_verification_marker(verified)
+        cells += (verified_marker,)
 
     return _OcrFusionRow(
         changed=source_one_text != source_two_text,

--- a/scinoephile/analysis/audit/ocr_fusion.py
+++ b/scinoephile/analysis/audit/ocr_fusion.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
-from enum import StrEnum
 
 from scinoephile.core.exceptions import ScinoephileError
 from scinoephile.core.subtitles import Series
@@ -15,15 +14,13 @@ from scinoephile.llms.ocr_fusion import OcrFusionTestCase
 
 from .utils import (
     AuditColumn,
+    ComparisonAuditFilter,
     format_audit_report,
     format_verification_marker,
     get_selected_event_indexes,
 )
 
-__all__ = [
-    "OcrFusionAuditFilter",
-    "audit_ocr_fusion",
-]
+__all__ = ["audit_ocr_fusion"]
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -58,22 +55,6 @@ class _OcrFusionDecision:
     """Whether the associated LLM case is verified."""
 
 
-class OcrFusionAuditFilter(StrEnum):
-    """Row filters supported by an OCR-fusion audit."""
-
-    all = "all"
-    """Include every fused subtitle."""
-
-    changes = "changes"
-    """Include only subtitles whose OCR sources differ."""
-
-    discrepancies = "discrepancies"
-    """Include only subtitles that differ from the validated track."""
-
-    unverified = "unverified"
-    """Include only LLM decisions not marked as verified."""
-
-
 def audit_ocr_fusion(
     source_one: Series,
     source_two: Series,
@@ -81,7 +62,7 @@ def audit_ocr_fusion(
     test_cases: Sequence[OcrFusionTestCase] | None = None,
     *,
     validated: Series | None = None,
-    row_filter: OcrFusionAuditFilter = OcrFusionAuditFilter.changes,
+    row_filter: ComparisonAuditFilter = ComparisonAuditFilter.changes,
     first_index: int | None = None,
     last_index: int | None = None,
     first_block: int | None = None,
@@ -105,7 +86,7 @@ def audit_ocr_fusion(
     Raises:
         ScinoephileError: if ranges, series alignment, or logged decisions are invalid
     """
-    if row_filter is OcrFusionAuditFilter.discrepancies and validated is None:
+    if row_filter is ComparisonAuditFilter.discrepancies and validated is None:
         raise ScinoephileError(
             "OCR-fusion discrepancy filtering requires a validated subtitle track"
         )
@@ -200,7 +181,7 @@ def audit_ocr_fusion(
 
 def _filter_rows(
     rows: Sequence[_OcrFusionRow],
-    row_filter: OcrFusionAuditFilter,
+    row_filter: ComparisonAuditFilter,
 ) -> list[_OcrFusionRow]:
     """Filter OCR-fusion rows by their status.
 
@@ -210,11 +191,11 @@ def _filter_rows(
     Returns:
         filtered rows
     """
-    if row_filter is OcrFusionAuditFilter.all:
+    if row_filter is ComparisonAuditFilter.all:
         return list(rows)
-    if row_filter is OcrFusionAuditFilter.changes:
+    if row_filter is ComparisonAuditFilter.changes:
         return [row for row in rows if row.changed]
-    if row_filter is OcrFusionAuditFilter.discrepancies:
+    if row_filter is ComparisonAuditFilter.discrepancies:
         return [row for row in rows if row.discrepancy]
     return [row for row in rows if row.requires_llm and not row.verified]
 

--- a/scinoephile/analysis/audit/ocr_fusion.py
+++ b/scinoephile/analysis/audit/ocr_fusion.py
@@ -14,7 +14,7 @@ from scinoephile.llms.ocr_fusion import OcrFusionTestCase
 
 from .utils import (
     AuditColumn,
-    ComparisonAuditFilter,
+    ExtendedAuditFilter,
     format_audit_report,
     format_verification_marker,
     get_selected_event_indexes,
@@ -62,7 +62,7 @@ def audit_ocr_fusion(
     test_cases: Sequence[OcrFusionTestCase] | None = None,
     *,
     validated: Series | None = None,
-    row_filter: ComparisonAuditFilter = ComparisonAuditFilter.changes,
+    row_filter: ExtendedAuditFilter = ExtendedAuditFilter.changes,
     first_index: int | None = None,
     last_index: int | None = None,
     first_block: int | None = None,
@@ -86,7 +86,7 @@ def audit_ocr_fusion(
     Raises:
         ScinoephileError: if ranges, series alignment, or logged decisions are invalid
     """
-    if row_filter is ComparisonAuditFilter.discrepancies and validated is None:
+    if row_filter is ExtendedAuditFilter.discrepancies and validated is None:
         raise ScinoephileError(
             "OCR-fusion discrepancy filtering requires a validated subtitle track"
         )
@@ -181,7 +181,7 @@ def audit_ocr_fusion(
 
 def _filter_rows(
     rows: Sequence[_OcrFusionRow],
-    row_filter: ComparisonAuditFilter,
+    row_filter: ExtendedAuditFilter,
 ) -> list[_OcrFusionRow]:
     """Filter OCR-fusion rows by their status.
 
@@ -191,11 +191,11 @@ def _filter_rows(
     Returns:
         filtered rows
     """
-    if row_filter is ComparisonAuditFilter.all:
+    if row_filter is ExtendedAuditFilter.all:
         return list(rows)
-    if row_filter is ComparisonAuditFilter.changes:
+    if row_filter is ExtendedAuditFilter.changes:
         return [row for row in rows if row.changed]
-    if row_filter is ComparisonAuditFilter.discrepancies:
+    if row_filter is ExtendedAuditFilter.discrepancies:
         return [row for row in rows if row.discrepancy]
     return [row for row in rows if row.requires_llm and not row.verified]
 

--- a/scinoephile/analysis/audit/ocr_fusion.py
+++ b/scinoephile/analysis/audit/ocr_fusion.py
@@ -14,7 +14,7 @@ from scinoephile.core.subtitles import Series
 from scinoephile.core.synchronization import are_series_one_to_one
 
 from .utils import (
-    escape_table_cell,
+    AuditColumn,
     format_audit_report,
     get_selected_event_indexes,
 )
@@ -33,8 +33,8 @@ class _OcrFusionRow:
     """Whether the two OCR sources differ."""
     discrepancy: bool
     """Whether fused and validated text differ."""
-    markdown: str
-    """Formatted Markdown table row."""
+    cells: tuple[str, ...]
+    """Semantic audit table cell values."""
     requires_llm: bool
     """Whether the row required an OCR-fusion LLM decision."""
     verified: bool
@@ -180,95 +180,66 @@ def audit_ocr_fusion(
         key = (test_case.query.source_one, test_case.query.source_two)
         cases_by_key[key] = (case_index, test_case)
 
-    all_rows: list[_OcrFusionRow] = []
-    for position in sorted(selected_positions):
-        index = position + 1
-        source_one_text = source_one.events[position].text_with_newline
-        source_two_text = source_two.events[position].text_with_newline
-        fused_text = fused.events[position].text_with_newline
-        validated_text = None
-        if validated is not None:
-            validated_text = validated.events[position].text_with_newline
-
-        decision = _get_decision(
-            index,
-            source_one_text,
-            source_two_text,
-            fused_text,
+    # Resolve the semantic data for every selected subtitle row
+    all_rows = [
+        _get_row(
+            position,
+            source_one,
+            source_two,
+            fused,
             cases_by_key,
             has_decision_log=has_decision_log,
+            validated=validated,
         )
-        discrepancy = validated_text is not None and fused_text != validated_text
-        cells = (
-            str(index),
-            str(decision.case_index) if decision.case_index is not None else "—",
-            str(decision.difficulty) if decision.case_index is not None else "—",
-            source_one_text or "—",
-            source_two_text or "—",
-            fused_text or "—",
-            validated_text if validated_text else "—",
-        )
-        if has_decision_log:
-            cells += (
-                decision.note,
-                "✓" if decision.requires_llm and decision.verified else "",
-            )
-        markdown_cells = " | ".join(escape_table_cell(cell) for cell in cells)
-        all_rows.append(
-            _OcrFusionRow(
-                changed=source_one_text != source_two_text,
-                discrepancy=discrepancy,
-                markdown=f"| {markdown_cells} |",
-                requires_llm=decision.requires_llm,
-                verified=decision.verified,
-            )
-        )
+        for position in sorted(selected_positions)
+    ]
 
+    # Filter rows and summarize the complete selected data
     rows = _filter_rows(all_rows, row_filter)
     llm_rows = [row for row in all_rows if row.requires_llm]
-    summary_lines = [
-        f"- subtitles: {len(all_rows)}",
-        f"- source disagreements: {sum(row.changed for row in all_rows)}",
-        f"- validated track: {'included' if validated is not None else 'omitted'}",
-        f"- validated discrepancies: {sum(row.discrepancy for row in all_rows)}",
-        f"- row filter: {row_filter.value}",
+    validated_track = "omitted"
+    if validated is not None:
+        validated_track = "included"
+    summary_items = [
+        f"subtitles: {len(all_rows)}",
+        f"source disagreements: {sum(row.changed for row in all_rows)}",
+        f"validated track: {validated_track}",
+        f"validated discrepancies: {sum(row.discrepancy for row in all_rows)}",
+        f"row filter: {row_filter.value}",
     ]
     if has_decision_log:
         verified_llm_rows = sum(row.verified for row in llm_rows)
         unverified_llm_rows = sum(not row.verified for row in llm_rows)
-        summary_lines.extend(
+        summary_items.extend(
             (
-                f"- LLM decisions: {len(llm_rows)}",
-                f"- verified LLM decisions: {verified_llm_rows}",
-                f"- unverified LLM decisions: {unverified_llm_rows}",
+                f"LLM decisions: {len(llm_rows)}",
+                f"verified LLM decisions: {verified_llm_rows}",
+                f"unverified LLM decisions: {unverified_llm_rows}",
             )
         )
     else:
-        summary_lines.extend(
+        summary_items.extend(
             (
-                f"- LLM-required rows: {len(llm_rows)}",
-                "- decision log: omitted",
+                f"LLM-required rows: {len(llm_rows)}",
+                "decision log: omitted",
             )
         )
-    column_labels = [
-        "Subtitle",
-        "Case",
-        "Difficulty",
-        "Source one",
-        "Source two",
-        "Fused",
-        "Validated",
+    columns: list[AuditColumn] = [
+        ("Subtitle", "right"),
+        ("Case", "right"),
+        ("Difficulty", "right"),
+        ("Source one", "left"),
+        ("Source two", "left"),
+        ("Fused", "left"),
+        ("Validated", "left"),
     ]
-    column_separators = ["---:", "---:", "---:", "---", "---", "---", "---"]
     if has_decision_log:
-        column_labels.extend(("Notes", "Verified"))
-        column_separators.extend(("---", ":---:"))
+        columns.extend((("Notes", "left"), ("Verified", "center")))
     return format_audit_report(
         title="OCR Fusion Audit",
-        summary_lines=summary_lines,
-        column_labels=column_labels,
-        column_separators=column_separators,
-        rows=[row.markdown for row in rows],
+        summary_items=summary_items,
+        columns=columns,
+        rows=[row.cells for row in rows],
         first_index=first_index,
         last_index=last_index,
         index_track_name="fused",
@@ -400,6 +371,82 @@ def _get_decision(
         note=note,
         requires_llm=True,
         verified=test_case.verified,
+    )
+
+
+def _get_row(
+    position: int,
+    source_one: Series,
+    source_two: Series,
+    fused: Series,
+    cases_by_key: dict[tuple[str, str], tuple[int, _OcrFusionTestCase]],
+    *,
+    has_decision_log: bool,
+    validated: Series | None,
+) -> _OcrFusionRow:
+    """Resolve one OCR-fusion subtitle into semantic report data.
+
+    Arguments:
+        position: zero-based fused subtitle position
+        source_one: first OCR subtitle series
+        source_two: second OCR subtitle series
+        fused: OCR-fusion output subtitle series
+        cases_by_key: latest logged case keyed by source text pair
+        has_decision_log: whether a decision log was supplied
+        validated: optional validated subtitle series
+    Returns:
+        semantic audit row
+    """
+    index = position + 1
+    source_one_text = source_one.events[position].text_with_newline
+    source_two_text = source_two.events[position].text_with_newline
+    fused_text = fused.events[position].text_with_newline
+    validated_text = None
+    if validated is not None:
+        validated_text = validated.events[position].text_with_newline
+
+    # Resolve the automatic or logged decision and its display metadata
+    decision = _get_decision(
+        index,
+        source_one_text,
+        source_two_text,
+        fused_text,
+        cases_by_key,
+        has_decision_log=has_decision_log,
+    )
+    case_index = "—"
+    difficulty = "—"
+    if decision.case_index is not None:
+        case_index = str(decision.case_index)
+        difficulty = str(decision.difficulty)
+    validated_display = "—"
+    if validated_text:
+        validated_display = validated_text
+
+    # Keep verification unavailable for deterministic rows
+    cells = (
+        str(index),
+        case_index,
+        difficulty,
+        source_one_text or "—",
+        source_two_text or "—",
+        fused_text or "—",
+        validated_display,
+    )
+    if has_decision_log:
+        verified_marker = "—"
+        if decision.requires_llm:
+            verified_marker = ""
+            if decision.verified:
+                verified_marker = "✓"
+        cells += (decision.note, verified_marker)
+
+    return _OcrFusionRow(
+        changed=source_one_text != source_two_text,
+        cells=cells,
+        discrepancy=validated_text is not None and fused_text != validated_text,
+        requires_llm=decision.requires_llm,
+        verified=decision.verified,
     )
 
 

--- a/scinoephile/analysis/audit/punctuation.py
+++ b/scinoephile/analysis/audit/punctuation.py
@@ -16,6 +16,7 @@ from .utils import (
     AuditFilter,
     AuditResult,
     format_audit_report,
+    format_verification_marker,
     get_selected_event_indexes,
     get_superseded_keys,
     resolve_contextual_index,
@@ -159,9 +160,7 @@ def _format_case_row(
         output = answer.output
         result = AuditResult.changed
 
-    verified_marker = ""
-    if test_case.verified:
-        verified_marker = "✓"
+    verified_marker = format_verification_marker(test_case.verified)
     cells = (
         str(index + 1),
         test_case.query.guide,

--- a/scinoephile/analysis/audit/punctuation.py
+++ b/scinoephile/analysis/audit/punctuation.py
@@ -20,8 +20,6 @@ from .utils import (
     get_selected_event_indexes,
     get_superseded_keys,
     resolve_contextual_index,
-    validate_block_range,
-    validate_index_range,
 )
 
 __all__ = ["audit_punctuation"]
@@ -56,9 +54,6 @@ def audit_punctuation(
     Raises:
         ScinoephileError: if a logged case cannot be matched uniquely
     """
-    validate_index_range(first_index, last_index)
-    validate_block_range(first_block, last_block)
-
     reference_indexes_by_text: dict[str, list[int]] = defaultdict(list)
     for index, subtitle in enumerate(reference):
         reference_indexes_by_text[subtitle.text].append(index)

--- a/scinoephile/analysis/audit/punctuation.py
+++ b/scinoephile/analysis/audit/punctuation.py
@@ -15,7 +15,6 @@ from scinoephile.llms.punctuation import PunctuationTestCase
 from .utils import (
     AuditFilter,
     AuditResult,
-    escape_table_cell,
     format_audit_report,
     get_selected_event_indexes,
     get_superseded_keys,
@@ -75,7 +74,7 @@ def audit_punctuation(
         last_block=last_block,
     )
 
-    rows: list[tuple[int, int, str]] = []
+    rows: list[tuple[int, int, tuple[str, ...]]] = []
     changes = 0
     unchanged = 0
     unanswered = 0
@@ -112,22 +111,21 @@ def audit_punctuation(
     rows.sort(key=lambda item: (item[0], item[1]))
     return format_audit_report(
         title="Transcription Punctuation Audit",
-        summary_lines=(
-            f"- logged cases: {logged_cases}",
-            f"- punctuation changes: {changes}",
-            f"- unchanged answers: {unchanged}",
-            f"- unanswered cases: {unanswered}",
-            f"- row filter: {row_filter.value}",
+        summary_items=(
+            f"logged cases: {logged_cases}",
+            f"punctuation changes: {changes}",
+            f"unchanged answers: {unchanged}",
+            f"unanswered cases: {unanswered}",
+            f"row filter: {row_filter.value}",
         ),
-        column_labels=(
-            "Index",
-            "Reference",
-            "Input",
-            "Output",
-            "Notes",
-            "Verified",
+        columns=(
+            ("Index", "right"),
+            ("Reference", "left"),
+            ("Input", "left"),
+            ("Output", "left"),
+            ("Notes", "left"),
+            ("Verified", "center"),
         ),
-        column_separators=("---:", "---", "---", "---", "---", ":---:"),
         rows=[row for _, _, row in rows],
         first_index=first_index,
         last_index=last_index,
@@ -140,14 +138,14 @@ def audit_punctuation(
 def _format_case_row(
     test_case: PunctuationTestCase,
     index: int,
-) -> tuple[str, AuditResult]:
-    """Format one punctuation case as a Markdown table row.
+) -> tuple[tuple[str, ...], AuditResult]:
+    """Format one punctuation case as semantic table data.
 
     Arguments:
         test_case: punctuation case to format
         index: zero-indexed reference subtitle position
     Returns:
-        Markdown row and its result type
+        semantic table cells and their result type
     """
     input_text = "".join(test_case.query.subtitles)
     answer = test_case.answer
@@ -161,16 +159,18 @@ def _format_case_row(
         output = answer.output
         result = AuditResult.changed
 
+    verified_marker = ""
+    if test_case.verified:
+        verified_marker = "✓"
     cells = (
         str(index + 1),
         test_case.query.guide,
         "\n".join(test_case.query.subtitles),
         output,
         "",
-        "✓" if test_case.verified else "",
+        verified_marker,
     )
-    row = f"| {' | '.join(escape_table_cell(cell) for cell in cells)} |"
-    return row, result
+    return cells, result
 
 
 def _get_case_index(

--- a/scinoephile/analysis/audit/punctuation.py
+++ b/scinoephile/analysis/audit/punctuation.py
@@ -13,8 +13,8 @@ from scinoephile.core.text import remove_punc_and_whitespace
 from scinoephile.llms.punctuation import PunctuationTestCase
 
 from .utils import (
-    AuditFilter,
     AuditResult,
+    ChangeAuditFilter,
     format_audit_report,
     format_verification_marker,
     get_selected_event_indexes,
@@ -30,7 +30,7 @@ def audit_punctuation(
     target: Series,
     test_cases: Sequence[PunctuationTestCase],
     *,
-    row_filter: AuditFilter = AuditFilter.all,
+    row_filter: ChangeAuditFilter = ChangeAuditFilter.all,
     first_index: int | None = None,
     last_index: int | None = None,
     first_block: int | None = None,
@@ -104,8 +104,9 @@ def audit_punctuation(
             changes += 1
 
         if (
-            row_filter is AuditFilter.changes and result is not AuditResult.changed
-        ) or (row_filter is AuditFilter.unverified and test_case.verified):
+            row_filter is ChangeAuditFilter.changes
+            and result is not AuditResult.changed
+        ) or (row_filter is ChangeAuditFilter.unverified and test_case.verified):
             continue
         rows.append((index, test_case_index, row))
 

--- a/scinoephile/analysis/audit/review.py
+++ b/scinoephile/analysis/audit/review.py
@@ -14,8 +14,8 @@ from scinoephile.core.subtitles import Series
 
 from .utils import (
     AuditColumn,
-    AuditFilter,
-    ComparisonAuditFilter,
+    ChangeAuditFilter,
+    ExtendedAuditFilter,
     format_audit_report,
     format_verification_marker,
     get_selected_event_indexes,
@@ -77,7 +77,7 @@ def audit_review_workflow(
     *,
     reviews: Sequence[ReviewAuditPair],
     comparisons: Sequence[ReviewAuditComparison] = (),
-    row_filter: AuditFilter | ComparisonAuditFilter = AuditFilter.changes,
+    row_filter: ChangeAuditFilter | ExtendedAuditFilter = ChangeAuditFilter.changes,
     characters: Sequence[str] = (),
     first_index: int | None = None,
     last_index: int | None = None,
@@ -103,7 +103,7 @@ def audit_review_workflow(
     """
     if not reviews:
         raise ScinoephileError("Unable to audit subtitle reviews: no reviews provided")
-    if row_filter is ComparisonAuditFilter.discrepancies and not comparisons:
+    if row_filter is ExtendedAuditFilter.discrepancies and not comparisons:
         raise ScinoephileError(
             "Unable to audit subtitle reviews: discrepancy filtering requires at "
             "least one comparison"
@@ -218,7 +218,7 @@ def audit_reviews(
     traditional_review_cases: Sequence[TestCase] = (),
     traditional_simplified_review_cases: Sequence[TestCase] = (),
     simplified_review_cases: Sequence[TestCase] = (),
-    row_filter: ComparisonAuditFilter = ComparisonAuditFilter.changes,
+    row_filter: ExtendedAuditFilter = ExtendedAuditFilter.changes,
     characters: Sequence[str] = (),
     first_index: int | None = None,
     last_index: int | None = None,
@@ -300,7 +300,7 @@ def _format_report(
     covered_indexes: frozenset[int],
     has_review_cases: bool,
     indexes: Sequence[int],
-    row_filter: AuditFilter | ComparisonAuditFilter,
+    row_filter: ChangeAuditFilter | ExtendedAuditFilter,
     unverified_indexes: frozenset[int],
     characters: Sequence[str],
     first_index: int | None,
@@ -442,7 +442,7 @@ def _get_filtered_indexes(
     review_changes: Sequence[set[int]],
     comparison_changes: Sequence[set[int]],
     indexes: Iterable[int],
-    row_filter: AuditFilter | ComparisonAuditFilter,
+    row_filter: ChangeAuditFilter | ExtendedAuditFilter,
     unverified_indexes: frozenset[int],
     characters: Sequence[str],
 ) -> list[int]:
@@ -459,15 +459,15 @@ def _get_filtered_indexes(
     Returns:
         selected subtitle indexes
     """
-    if row_filter.value == AuditFilter.all.value:
+    if row_filter.value == ChangeAuditFilter.all.value:
         selected_indexes = set(indexes)
-    elif row_filter.value == AuditFilter.changes.value:
+    elif row_filter.value == ChangeAuditFilter.changes.value:
         selected_indexes = {
             index
             for changed_indexes in (*review_changes, *comparison_changes)
             for index in changed_indexes
         }
-    elif row_filter is ComparisonAuditFilter.discrepancies:
+    elif row_filter is ExtendedAuditFilter.discrepancies:
         selected_indexes = {
             index for changed_indexes in comparison_changes for index in changed_indexes
         }

--- a/scinoephile/analysis/audit/review.py
+++ b/scinoephile/analysis/audit/review.py
@@ -24,7 +24,6 @@ from .utils import (
 __all__ = [
     "ReviewAuditComparison",
     "ReviewAuditPair",
-    "audit_dual_review",
     "audit_review",
 ]
 
@@ -71,87 +70,6 @@ class _ReviewAuditMetadata:
     """Current revision notes keyed by zero-based subtitle index."""
     unverified_indexes: frozenset[int]
     """Covered subtitle indexes belonging to unverified cases."""
-
-
-def audit_dual_review(
-    *,
-    traditional: Series,
-    traditional_reviewed: Series,
-    traditional_simplified: Series,
-    traditional_simplified_reviewed: Series,
-    simplified: Series,
-    simplified_reviewed: Series,
-    traditional_review_cases: Sequence[TestCase] = (),
-    traditional_simplified_review_cases: Sequence[TestCase] = (),
-    simplified_review_cases: Sequence[TestCase] = (),
-    row_filter: ExtendedAuditFilter = ExtendedAuditFilter.changes,
-    characters: Sequence[str] = (),
-    first_index: int | None = None,
-    last_index: int | None = None,
-    first_block: int | None = None,
-    last_block: int | None = None,
-) -> str:
-    """Audit parallel simplified and traditional-to-simplified review paths.
-
-    Arguments:
-        traditional: traditional-script review input
-        traditional_reviewed: traditional-script reviewed subtitles
-        traditional_simplified: simplified traditional-script subtitles
-        traditional_simplified_reviewed: reviewed simplified traditional-script
-            subtitles
-        simplified: simplified-script review input
-        simplified_reviewed: simplified-script reviewed subtitles
-        traditional_review_cases: traditional review test cases
-        traditional_simplified_review_cases: traditional simplification review test
-            cases
-        simplified_review_cases: simplified review test cases
-        row_filter: row status filter
-        characters: individual characters whose occurrence limits included rows
-        first_index: first 1-indexed subtitle number to include, inclusive
-        last_index: last 1-indexed subtitle number to include, inclusive
-        first_block: first 1-indexed workflow block number to include, inclusive
-        last_block: last 1-indexed workflow block number to include, inclusive
-    Returns:
-        Markdown audit report
-    Raises:
-        ScinoephileError: if review test cases do not match the subtitle series
-    """
-    return audit_review(
-        reviews=(
-            ReviewAuditPair(
-                label="Simplified",
-                original=simplified,
-                reviewed=simplified_reviewed,
-                review_cases=simplified_review_cases,
-            ),
-            ReviewAuditPair(
-                label="Traditional",
-                original=traditional,
-                reviewed=traditional_reviewed,
-                review_cases=traditional_review_cases,
-            ),
-            ReviewAuditPair(
-                label="Traditional simplification",
-                original=traditional_simplified,
-                reviewed=traditional_simplified_reviewed,
-                review_cases=traditional_simplified_review_cases,
-            ),
-        ),
-        comparisons=(
-            ReviewAuditComparison(
-                column_label="Simplified vs Traditional->Simplified",
-                summary_label="Final text",
-                left=simplified_reviewed,
-                right=traditional_simplified_reviewed,
-            ),
-        ),
-        row_filter=row_filter,
-        characters=characters,
-        first_index=first_index,
-        last_index=last_index,
-        first_block=first_block,
-        last_block=last_block,
-    )
 
 
 def audit_review(

--- a/scinoephile/analysis/audit/review.py
+++ b/scinoephile/analysis/audit/review.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
-from enum import StrEnum
 from typing import cast
 
 from scinoephile.core import ScinoephileError
@@ -16,34 +15,18 @@ from scinoephile.core.subtitles import Series
 from .utils import (
     AuditColumn,
     AuditFilter,
+    ComparisonAuditFilter,
     format_audit_report,
     format_verification_marker,
     get_selected_event_indexes,
 )
 
 __all__ = [
-    "ComparativeReviewAuditFilter",
     "ReviewAuditComparison",
     "ReviewAuditPair",
     "audit_review_workflow",
     "audit_reviews",
 ]
-
-
-class ComparativeReviewAuditFilter(StrEnum):
-    """Row filters supported by review audits with final comparisons."""
-
-    all = "all"
-    """Include every subtitle row."""
-
-    changes = "changes"
-    """Include review edits and final discrepancies."""
-
-    discrepancies = "discrepancies"
-    """Include only final discrepancies."""
-
-    unverified = "unverified"
-    """Include only subtitles from unverified logged cases."""
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -78,11 +61,23 @@ class ReviewAuditComparison:
     """Right-hand subtitle series."""
 
 
+@dataclass(frozen=True, kw_only=True)
+class _ReviewAuditMetadata:
+    """Matched notes and verification state for one review decision log."""
+
+    covered_indexes: frozenset[int]
+    """Zero-based subtitle indexes covered by current logged cases."""
+    notes_by_index: Mapping[int, tuple[str, ...]]
+    """Current revision notes keyed by zero-based subtitle index."""
+    unverified_indexes: frozenset[int]
+    """Covered subtitle indexes belonging to unverified cases."""
+
+
 def audit_review_workflow(
     *,
     reviews: Sequence[ReviewAuditPair],
     comparisons: Sequence[ReviewAuditComparison] = (),
-    row_filter: AuditFilter | ComparativeReviewAuditFilter = AuditFilter.changes,
+    row_filter: AuditFilter | ComparisonAuditFilter = AuditFilter.changes,
     characters: Sequence[str] = (),
     first_index: int | None = None,
     last_index: int | None = None,
@@ -108,7 +103,7 @@ def audit_review_workflow(
     """
     if not reviews:
         raise ScinoephileError("Unable to audit subtitle reviews: no reviews provided")
-    if row_filter is ComparativeReviewAuditFilter.discrepancies and not comparisons:
+    if row_filter is ComparisonAuditFilter.discrepancies and not comparisons:
         raise ScinoephileError(
             "Unable to audit subtitle reviews: discrepancy filtering requires at "
             "least one comparison"
@@ -144,31 +139,22 @@ def audit_review_workflow(
 
     # Match block-based log data against the complete inputs
     try:
-        notes = tuple(
-            _get_review_notes(review.review_cases, original, reviewed)
+        review_metadata = tuple(
+            _get_review_metadata(review.review_cases, original, reviewed)
             for review, (original, reviewed) in zip(
                 reviews,
                 review_series,
                 strict=True,
             )
         )
-        verification_indexes = tuple(
-            _get_verification_indexes(
-                review.review_cases,
-                original,
-                reviewed,
-            )
-            for review, (original, reviewed) in zip(
-                reviews,
-                review_series,
-                strict=True,
-            )
-        )
+        notes = tuple(metadata.notes_by_index for metadata in review_metadata)
         covered_indexes = frozenset(
-            index for covered, _ in verification_indexes for index in covered
+            index for metadata in review_metadata for index in metadata.covered_indexes
         )
         unverified_indexes = frozenset(
-            index for _, unverified in verification_indexes for index in unverified
+            index
+            for metadata in review_metadata
+            for index in metadata.unverified_indexes
         )
         has_review_cases = any(review.review_cases for review in reviews)
     except ValueError as exc:
@@ -232,7 +218,7 @@ def audit_reviews(
     traditional_review_cases: Sequence[TestCase] = (),
     traditional_simplified_review_cases: Sequence[TestCase] = (),
     simplified_review_cases: Sequence[TestCase] = (),
-    row_filter: ComparativeReviewAuditFilter = ComparativeReviewAuditFilter.changes,
+    row_filter: ComparisonAuditFilter = ComparisonAuditFilter.changes,
     characters: Sequence[str] = (),
     first_index: int | None = None,
     last_index: int | None = None,
@@ -314,7 +300,7 @@ def _format_report(
     covered_indexes: frozenset[int],
     has_review_cases: bool,
     indexes: Sequence[int],
-    row_filter: AuditFilter | ComparativeReviewAuditFilter,
+    row_filter: AuditFilter | ComparisonAuditFilter,
     unverified_indexes: frozenset[int],
     characters: Sequence[str],
     first_index: int | None,
@@ -456,7 +442,7 @@ def _get_filtered_indexes(
     review_changes: Sequence[set[int]],
     comparison_changes: Sequence[set[int]],
     indexes: Iterable[int],
-    row_filter: AuditFilter | ComparativeReviewAuditFilter,
+    row_filter: AuditFilter | ComparisonAuditFilter,
     unverified_indexes: frozenset[int],
     characters: Sequence[str],
 ) -> list[int]:
@@ -481,7 +467,7 @@ def _get_filtered_indexes(
             for changed_indexes in (*review_changes, *comparison_changes)
             for index in changed_indexes
         }
-    elif row_filter is ComparativeReviewAuditFilter.discrepancies:
+    elif row_filter is ComparisonAuditFilter.discrepancies:
         selected_indexes = {
             index for changed_indexes in comparison_changes for index in changed_indexes
         }
@@ -540,101 +526,69 @@ def _get_review_case_data(
     return query_texts, revised_texts, revision_by_index
 
 
-def _get_review_notes(
+def _get_review_metadata(
     review_cases: Sequence[TestCase],
     original: tuple[str, ...],
     reviewed: tuple[str, ...],
-) -> dict[int, tuple[str, ...]]:
-    """Match review test-case notes to subtitle text.
+) -> _ReviewAuditMetadata:
+    """Match the latest current review cases to subtitle text.
 
     Arguments:
         review_cases: deserialized review test cases
         original: original subtitle text
         reviewed: reviewed subtitle text
     Returns:
-        review notes keyed by zero-based subtitle index
+        current notes and verification metadata
     Raises:
-        ValueError: if a review test case does not match the subtitles
+        ValueError: if a current query's answer does not match reviewed subtitles
     """
+    # Retain the latest logged decision for each deduplicated query
+    latest_cases_by_query = {
+        review_case.query.key: (case_index, review_case)
+        for case_index, review_case in enumerate(review_cases, 1)
+    }
+
+    # Match current cases once and derive all report metadata together
+    covered_indexes: set[int] = set()
     notes_by_index: dict[int, list[str]] = {}
-    for case_index, review_case in enumerate(review_cases, 1):
-        if review_case.answer is None:
-            continue
+    unverified_indexes: set[int] = set()
+    for case_index, review_case in latest_cases_by_query.values():
         query_texts, revised_texts, revision_by_index = _get_review_case_data(
             review_case
         )
-        note_fields = {
-            local_index: cast(str, revision["note"]).strip()
-            for local_index, revision in revision_by_index.items()
-        }
-        if not note_fields:
-            continue
-
         candidate_starts = [
             start
             for start in range(len(original) - len(query_texts) + 1)
             if original[start : start + len(query_texts)] == query_texts
         ]
         if not candidate_starts:
-            raise ValueError(
-                f"Review test case {case_index} does not match its subtitle pair"
-            )
-        matched_note_fields: set[int] = set()
-        for start in candidate_starts:
-            for local_index, note in note_fields.items():
-                if reviewed[start + local_index - 1] != revised_texts[local_index - 1]:
-                    continue
-                index = start + local_index - 1
-                notes = notes_by_index.setdefault(index, [])
-                if note not in notes:
-                    notes.append(note)
-                matched_note_fields.add(local_index)
-        unmatched_note_fields = sorted(note_fields.keys() - matched_note_fields)
-        if unmatched_note_fields:
-            formatted_fields = ", ".join(
-                f"revision {local_index}" for local_index in unmatched_note_fields
-            )
-            raise ValueError(
-                f"Review test case {case_index} fields {formatted_fields} do not "
-                "match reviewed subtitle text"
-            )
+            # Persisted logs retain historical queries after their input changes
+            continue
 
-    return {index: tuple(notes) for index, notes in notes_by_index.items()}
-
-
-def _get_verification_indexes(
-    review_cases: Sequence[TestCase],
-    original: tuple[str, ...],
-    reviewed: tuple[str, ...],
-) -> tuple[set[int], set[int]]:
-    """Get subtitle indexes covered by logged and unverified review cases.
-
-    Arguments:
-        review_cases: deserialized review test cases
-        original: original subtitle text
-        reviewed: reviewed subtitle text
-    Returns:
-        zero-based subtitle indexes covered by all and unverified cases
-    Raises:
-        ValueError: if a logged case does not match the subtitles
-    """
-    covered_indexes: set[int] = set()
-    unverified_indexes: set[int] = set()
-    for case_index, review_case in enumerate(review_cases, 1):
-        query_texts, revised_texts, _ = _get_review_case_data(review_case)
         matched_starts = [
             start
-            for start in range(len(original) - len(query_texts) + 1)
-            if original[start : start + len(query_texts)] == query_texts
-            and reviewed[start : start + len(revised_texts)] == revised_texts
+            for start in candidate_starts
+            if reviewed[start : start + len(revised_texts)] == revised_texts
         ]
         if not matched_starts:
             raise ValueError(
                 f"Review test case {case_index} does not match its subtitle pair"
             )
+
         for start in matched_starts:
             matched_indexes = set(range(start, start + len(query_texts)))
             covered_indexes.update(matched_indexes)
             if not review_case.verified:
                 unverified_indexes.update(matched_indexes)
-    return covered_indexes, unverified_indexes
+            for local_index, revision in revision_by_index.items():
+                index = start + local_index - 1
+                note = cast(str, revision["note"]).strip()
+                notes = notes_by_index.setdefault(index, [])
+                if note not in notes:
+                    notes.append(note)
+
+    return _ReviewAuditMetadata(
+        covered_indexes=frozenset(covered_indexes),
+        notes_by_index={index: tuple(notes) for index, notes in notes_by_index.items()},
+        unverified_indexes=frozenset(unverified_indexes),
+    )

--- a/scinoephile/analysis/audit/review.py
+++ b/scinoephile/analysis/audit/review.py
@@ -17,6 +17,7 @@ from .utils import (
     AuditColumn,
     AuditFilter,
     format_audit_report,
+    format_verification_marker,
     get_selected_event_indexes,
 )
 
@@ -75,87 +76,6 @@ class ReviewAuditComparison:
     """Left-hand subtitle series."""
     right: Series
     """Right-hand subtitle series."""
-
-
-def audit_reviews(
-    *,
-    traditional: Series,
-    traditional_reviewed: Series,
-    traditional_simplified: Series,
-    traditional_simplified_reviewed: Series,
-    simplified: Series,
-    simplified_reviewed: Series,
-    traditional_review_cases: Sequence[TestCase] = (),
-    traditional_simplified_review_cases: Sequence[TestCase] = (),
-    simplified_review_cases: Sequence[TestCase] = (),
-    row_filter: ComparativeReviewAuditFilter = ComparativeReviewAuditFilter.changes,
-    characters: Sequence[str] = (),
-    first_index: int | None = None,
-    last_index: int | None = None,
-    first_block: int | None = None,
-    last_block: int | None = None,
-) -> str:
-    """Audit parallel simplified and traditional-to-simplified review paths.
-
-    Arguments:
-        traditional: traditional-script review input
-        traditional_reviewed: traditional-script reviewed subtitles
-        traditional_simplified: simplified traditional-script subtitles
-        traditional_simplified_reviewed: reviewed simplified traditional-script
-            subtitles
-        simplified: simplified-script review input
-        simplified_reviewed: simplified-script reviewed subtitles
-        traditional_review_cases: traditional review test cases
-        traditional_simplified_review_cases: traditional simplification review test
-            cases
-        simplified_review_cases: simplified review test cases
-        row_filter: row status filter
-        characters: individual characters whose occurrence limits included rows
-        first_index: first 1-indexed subtitle number to include, inclusive
-        last_index: last 1-indexed subtitle number to include, inclusive
-        first_block: first 1-indexed workflow block number to include, inclusive
-        last_block: last 1-indexed workflow block number to include, inclusive
-    Returns:
-        Markdown audit report
-    Raises:
-        ScinoephileError: if review test cases do not match the subtitle series
-    """
-    return audit_review_workflow(
-        reviews=(
-            ReviewAuditPair(
-                label="Simplified",
-                original=simplified,
-                reviewed=simplified_reviewed,
-                review_cases=simplified_review_cases,
-            ),
-            ReviewAuditPair(
-                label="Traditional",
-                original=traditional,
-                reviewed=traditional_reviewed,
-                review_cases=traditional_review_cases,
-            ),
-            ReviewAuditPair(
-                label="Traditional simplification",
-                original=traditional_simplified,
-                reviewed=traditional_simplified_reviewed,
-                review_cases=traditional_simplified_review_cases,
-            ),
-        ),
-        comparisons=(
-            ReviewAuditComparison(
-                column_label="Simplified vs Traditional->Simplified",
-                summary_label="Final text",
-                left=simplified_reviewed,
-                right=traditional_simplified_reviewed,
-            ),
-        ),
-        row_filter=row_filter,
-        characters=characters,
-        first_index=first_index,
-        last_index=last_index,
-        first_block=first_block,
-        last_block=last_block,
-    )
 
 
 def audit_review_workflow(
@@ -301,6 +221,87 @@ def audit_review_workflow(
     )
 
 
+def audit_reviews(
+    *,
+    traditional: Series,
+    traditional_reviewed: Series,
+    traditional_simplified: Series,
+    traditional_simplified_reviewed: Series,
+    simplified: Series,
+    simplified_reviewed: Series,
+    traditional_review_cases: Sequence[TestCase] = (),
+    traditional_simplified_review_cases: Sequence[TestCase] = (),
+    simplified_review_cases: Sequence[TestCase] = (),
+    row_filter: ComparativeReviewAuditFilter = ComparativeReviewAuditFilter.changes,
+    characters: Sequence[str] = (),
+    first_index: int | None = None,
+    last_index: int | None = None,
+    first_block: int | None = None,
+    last_block: int | None = None,
+) -> str:
+    """Audit parallel simplified and traditional-to-simplified review paths.
+
+    Arguments:
+        traditional: traditional-script review input
+        traditional_reviewed: traditional-script reviewed subtitles
+        traditional_simplified: simplified traditional-script subtitles
+        traditional_simplified_reviewed: reviewed simplified traditional-script
+            subtitles
+        simplified: simplified-script review input
+        simplified_reviewed: simplified-script reviewed subtitles
+        traditional_review_cases: traditional review test cases
+        traditional_simplified_review_cases: traditional simplification review test
+            cases
+        simplified_review_cases: simplified review test cases
+        row_filter: row status filter
+        characters: individual characters whose occurrence limits included rows
+        first_index: first 1-indexed subtitle number to include, inclusive
+        last_index: last 1-indexed subtitle number to include, inclusive
+        first_block: first 1-indexed workflow block number to include, inclusive
+        last_block: last 1-indexed workflow block number to include, inclusive
+    Returns:
+        Markdown audit report
+    Raises:
+        ScinoephileError: if review test cases do not match the subtitle series
+    """
+    return audit_review_workflow(
+        reviews=(
+            ReviewAuditPair(
+                label="Simplified",
+                original=simplified,
+                reviewed=simplified_reviewed,
+                review_cases=simplified_review_cases,
+            ),
+            ReviewAuditPair(
+                label="Traditional",
+                original=traditional,
+                reviewed=traditional_reviewed,
+                review_cases=traditional_review_cases,
+            ),
+            ReviewAuditPair(
+                label="Traditional simplification",
+                original=traditional_simplified,
+                reviewed=traditional_simplified_reviewed,
+                review_cases=traditional_simplified_review_cases,
+            ),
+        ),
+        comparisons=(
+            ReviewAuditComparison(
+                column_label="Simplified vs Traditional->Simplified",
+                summary_label="Final text",
+                left=simplified_reviewed,
+                right=traditional_simplified_reviewed,
+            ),
+        ),
+        row_filter=row_filter,
+        characters=characters,
+        first_index=first_index,
+        last_index=last_index,
+        first_block=first_block,
+        last_block=last_block,
+    )
+
+
 def _format_report(
     *,
     reviews: Sequence[ReviewAuditPair],
@@ -370,11 +371,10 @@ def _format_report(
         )
         cells.append("\n".join(note_lines))
         if has_review_cases:
-            verified_marker = "—"
+            verified: bool | None = None
             if index in covered_indexes:
-                verified_marker = "✓"
-                if index in unverified_indexes:
-                    verified_marker = ""
+                verified = index not in unverified_indexes
+            verified_marker = format_verification_marker(verified)
             cells.append(verified_marker)
         rows.append(cells)
 

--- a/scinoephile/analysis/audit/review.py
+++ b/scinoephile/analysis/audit/review.py
@@ -24,7 +24,7 @@ from .utils import (
 __all__ = [
     "ReviewAuditComparison",
     "ReviewAuditPair",
-    "audit_review_workflow",
+    "audit_review",
     "audit_reviews",
 ]
 
@@ -73,7 +73,7 @@ class _ReviewAuditMetadata:
     """Covered subtitle indexes belonging to unverified cases."""
 
 
-def audit_review_workflow(
+def audit_review(
     *,
     reviews: Sequence[ReviewAuditPair],
     comparisons: Sequence[ReviewAuditComparison] = (),
@@ -250,7 +250,7 @@ def audit_reviews(
     Raises:
         ScinoephileError: if review test cases do not match the subtitle series
     """
-    return audit_review_workflow(
+    return audit_review(
         reviews=(
             ReviewAuditPair(
                 label="Simplified",

--- a/scinoephile/analysis/audit/review.py
+++ b/scinoephile/analysis/audit/review.py
@@ -14,8 +14,8 @@ from scinoephile.core.llms import TestCase
 from scinoephile.core.subtitles import Series
 
 from .utils import (
+    AuditColumn,
     AuditFilter,
-    escape_table_cell,
     format_audit_report,
     get_selected_event_indexes,
 )
@@ -232,21 +232,25 @@ def audit_review_workflow(
                 strict=True,
             )
         )
-        unverified_indexes = frozenset()
-        if row_filter.value == AuditFilter.unverified.value:
-            unverified_indexes = frozenset(
-                index
-                for review, (original, reviewed) in zip(
-                    reviews,
-                    review_series,
-                    strict=True,
-                )
-                for index in _get_unverified_indexes(
-                    review.review_cases,
-                    original,
-                    reviewed,
-                )
+        verification_indexes = tuple(
+            _get_verification_indexes(
+                review.review_cases,
+                original,
+                reviewed,
             )
+            for review, (original, reviewed) in zip(
+                reviews,
+                review_series,
+                strict=True,
+            )
+        )
+        covered_indexes = frozenset(
+            index for covered, _ in verification_indexes for index in covered
+        )
+        unverified_indexes = frozenset(
+            index for _, unverified in verification_indexes for index in unverified
+        )
+        has_review_cases = any(review.review_cases for review in reviews)
     except ValueError as exc:
         raise ScinoephileError(f"Unable to audit subtitle reviews: {exc}") from exc
 
@@ -276,7 +280,7 @@ def audit_review_workflow(
         unverified_indexes=unverified_indexes,
         characters=characters,
     )
-    return _format_markdown(
+    return _format_report(
         reviews=reviews,
         review_series=review_series,
         review_changes=review_changes,
@@ -284,8 +288,11 @@ def audit_review_workflow(
         comparisons=comparisons,
         comparison_series=comparison_series,
         comparison_changes=comparison_changes,
+        covered_indexes=covered_indexes,
+        has_review_cases=has_review_cases,
         indexes=selected_indexes,
         row_filter=row_filter,
+        unverified_indexes=unverified_indexes,
         characters=characters,
         first_index=first_index,
         last_index=last_index,
@@ -294,7 +301,7 @@ def audit_review_workflow(
     )
 
 
-def _format_markdown(
+def _format_report(
     *,
     reviews: Sequence[ReviewAuditPair],
     review_series: Sequence[tuple[Sequence[str], Sequence[str]]],
@@ -303,15 +310,18 @@ def _format_markdown(
     comparisons: Sequence[ReviewAuditComparison],
     comparison_series: Sequence[tuple[Sequence[str], Sequence[str]]],
     comparison_changes: Sequence[set[int]],
+    covered_indexes: frozenset[int],
+    has_review_cases: bool,
     indexes: Sequence[int],
     row_filter: AuditFilter | ComparativeReviewAuditFilter,
+    unverified_indexes: frozenset[int],
     characters: Sequence[str],
     first_index: int | None,
     last_index: int | None,
     first_block: int | None,
     last_block: int | None,
 ) -> str:
-    """Format a review audit as Markdown.
+    """Build semantic review data and format it with the shared renderer.
 
     Arguments:
         reviews: ordered review-pair specifications
@@ -321,8 +331,11 @@ def _format_markdown(
         comparisons: ordered comparison specifications
         comparison_series: left- and right-hand subtitle text for each comparison
         comparison_changes: changed subtitle indexes for each comparison
+        covered_indexes: subtitle indexes covered by logged cases
+        has_review_cases: whether any review decision log was supplied
         indexes: zero-based subtitle indexes to include
         row_filter: active row filter
+        unverified_indexes: subtitle indexes covered by unverified cases
         characters: active character filter
         first_index: first included 1-indexed subtitle number
         last_index: last included 1-indexed subtitle number
@@ -331,7 +344,7 @@ def _format_markdown(
     Returns:
         Markdown report
     """
-    row_lines: list[str] = []
+    rows: list[list[str]] = []
     for index in indexes:
         note_lines = [
             f"{review.label} review: {note}"
@@ -356,34 +369,42 @@ def _format_markdown(
             )
         )
         cells.append("\n".join(note_lines))
-        row_lines.append(f"| {' | '.join(escape_table_cell(cell) for cell in cells)} |")
+        if has_review_cases:
+            verified_marker = "—"
+            if index in covered_indexes:
+                verified_marker = "✓"
+                if index in unverified_indexes:
+                    verified_marker = ""
+            cells.append(verified_marker)
+        rows.append(cells)
 
-    summary_lines = [
-        f"- {review.label.lower()} review edits: {len(changed_indexes)}"
+    summary_items = [
+        f"{review.label.lower()} review edits: {len(changed_indexes)}"
         for review, changed_indexes in zip(reviews, review_changes, strict=True)
     ]
-    summary_lines.extend(
-        f"- {comparison.summary_label.lower()} discrepancies: {len(changed_indexes)}"
+    summary_items.extend(
+        f"{comparison.summary_label.lower()} discrepancies: {len(changed_indexes)}"
         for comparison, changed_indexes in zip(
             comparisons,
             comparison_changes,
             strict=True,
         )
     )
-    summary_lines.append(f"- row filter: {row_filter.value}")
+    summary_items.append(f"row filter: {row_filter.value}")
     if characters:
-        summary_lines.append(f"- character filter: {', '.join(characters)}")
+        summary_items.append(f"character filter: {', '.join(characters)}")
 
-    column_labels = ["Subtitle"]
-    column_labels.extend(review.label for review in reviews)
-    column_labels.extend(comparison.column_label for comparison in comparisons)
-    column_labels.append("Notes")
+    columns: list[AuditColumn] = [("Subtitle", "right")]
+    columns.extend((review.label, "left") for review in reviews)
+    columns.extend((comparison.column_label, "left") for comparison in comparisons)
+    columns.append(("Notes", "left"))
+    if has_review_cases:
+        columns.append(("Verified", "center"))
     return format_audit_report(
         title="Review Audit",
-        summary_lines=summary_lines,
-        column_labels=column_labels,
-        column_separators=["---:", *("---" for _ in column_labels[1:])],
-        rows=row_lines,
+        summary_items=summary_items,
+        columns=columns,
+        rows=rows,
         first_index=first_index,
         last_index=last_index,
         first_block=first_block,
@@ -499,24 +520,23 @@ def _get_review_case_data(
         list[dict[str, int | str]],
         review_case.query.model_dump()["subtitles"],
     )
-    answer_revisions = (
-        cast(
+    answer_revisions: list[dict[str, int | str]] = []
+    if answer is not None:
+        answer_revisions = cast(
             list[dict[str, int | str]],
             answer.model_dump()["revisions"],
         )
-        if answer is not None
-        else []
-    )
     query_texts = tuple(cast(str, subtitle["text"]) for subtitle in query_subtitles)
     revision_by_index = {
         cast(int, revision["index"]): revision for revision in answer_revisions
     }
-    revised_texts = tuple(
-        cast(str, revision_by_index[local_index]["text"])
-        if local_index in revision_by_index
-        else query_text
-        for local_index, query_text in enumerate(query_texts, 1)
-    )
+    revised_texts_list = []
+    for local_index, query_text in enumerate(query_texts, 1):
+        revised_text = query_text
+        if local_index in revision_by_index:
+            revised_text = cast(str, revision_by_index[local_index]["text"])
+        revised_texts_list.append(revised_text)
+    revised_texts = tuple(revised_texts_list)
     return query_texts, revised_texts, revision_by_index
 
 
@@ -582,26 +602,25 @@ def _get_review_notes(
     return {index: tuple(notes) for index, notes in notes_by_index.items()}
 
 
-def _get_unverified_indexes(
+def _get_verification_indexes(
     review_cases: Sequence[TestCase],
     original: tuple[str, ...],
     reviewed: tuple[str, ...],
-) -> set[int]:
-    """Get subtitle indexes covered by unverified review test cases.
+) -> tuple[set[int], set[int]]:
+    """Get subtitle indexes covered by logged and unverified review cases.
 
     Arguments:
         review_cases: deserialized review test cases
         original: original subtitle text
         reviewed: reviewed subtitle text
     Returns:
-        zero-based subtitle indexes covered by unverified cases
+        zero-based subtitle indexes covered by all and unverified cases
     Raises:
-        ValueError: if an unverified case does not match the subtitles
+        ValueError: if a logged case does not match the subtitles
     """
+    covered_indexes: set[int] = set()
     unverified_indexes: set[int] = set()
     for case_index, review_case in enumerate(review_cases, 1):
-        if review_case.verified:
-            continue
         query_texts, revised_texts, _ = _get_review_case_data(review_case)
         matched_starts = [
             start
@@ -614,5 +633,8 @@ def _get_unverified_indexes(
                 f"Review test case {case_index} does not match its subtitle pair"
             )
         for start in matched_starts:
-            unverified_indexes.update(range(start, start + len(query_texts)))
-    return unverified_indexes
+            matched_indexes = set(range(start, start + len(query_texts)))
+            covered_indexes.update(matched_indexes)
+            if not review_case.verified:
+                unverified_indexes.update(matched_indexes)
+    return covered_indexes, unverified_indexes

--- a/scinoephile/analysis/audit/review.py
+++ b/scinoephile/analysis/audit/review.py
@@ -24,8 +24,8 @@ from .utils import (
 __all__ = [
     "ReviewAuditComparison",
     "ReviewAuditPair",
+    "audit_dual_review",
     "audit_review",
-    "audit_reviews",
 ]
 
 
@@ -71,6 +71,87 @@ class _ReviewAuditMetadata:
     """Current revision notes keyed by zero-based subtitle index."""
     unverified_indexes: frozenset[int]
     """Covered subtitle indexes belonging to unverified cases."""
+
+
+def audit_dual_review(
+    *,
+    traditional: Series,
+    traditional_reviewed: Series,
+    traditional_simplified: Series,
+    traditional_simplified_reviewed: Series,
+    simplified: Series,
+    simplified_reviewed: Series,
+    traditional_review_cases: Sequence[TestCase] = (),
+    traditional_simplified_review_cases: Sequence[TestCase] = (),
+    simplified_review_cases: Sequence[TestCase] = (),
+    row_filter: ExtendedAuditFilter = ExtendedAuditFilter.changes,
+    characters: Sequence[str] = (),
+    first_index: int | None = None,
+    last_index: int | None = None,
+    first_block: int | None = None,
+    last_block: int | None = None,
+) -> str:
+    """Audit parallel simplified and traditional-to-simplified review paths.
+
+    Arguments:
+        traditional: traditional-script review input
+        traditional_reviewed: traditional-script reviewed subtitles
+        traditional_simplified: simplified traditional-script subtitles
+        traditional_simplified_reviewed: reviewed simplified traditional-script
+            subtitles
+        simplified: simplified-script review input
+        simplified_reviewed: simplified-script reviewed subtitles
+        traditional_review_cases: traditional review test cases
+        traditional_simplified_review_cases: traditional simplification review test
+            cases
+        simplified_review_cases: simplified review test cases
+        row_filter: row status filter
+        characters: individual characters whose occurrence limits included rows
+        first_index: first 1-indexed subtitle number to include, inclusive
+        last_index: last 1-indexed subtitle number to include, inclusive
+        first_block: first 1-indexed workflow block number to include, inclusive
+        last_block: last 1-indexed workflow block number to include, inclusive
+    Returns:
+        Markdown audit report
+    Raises:
+        ScinoephileError: if review test cases do not match the subtitle series
+    """
+    return audit_review(
+        reviews=(
+            ReviewAuditPair(
+                label="Simplified",
+                original=simplified,
+                reviewed=simplified_reviewed,
+                review_cases=simplified_review_cases,
+            ),
+            ReviewAuditPair(
+                label="Traditional",
+                original=traditional,
+                reviewed=traditional_reviewed,
+                review_cases=traditional_review_cases,
+            ),
+            ReviewAuditPair(
+                label="Traditional simplification",
+                original=traditional_simplified,
+                reviewed=traditional_simplified_reviewed,
+                review_cases=traditional_simplified_review_cases,
+            ),
+        ),
+        comparisons=(
+            ReviewAuditComparison(
+                column_label="Simplified vs Traditional->Simplified",
+                summary_label="Final text",
+                left=simplified_reviewed,
+                right=traditional_simplified_reviewed,
+            ),
+        ),
+        row_filter=row_filter,
+        characters=characters,
+        first_index=first_index,
+        last_index=last_index,
+        first_block=first_block,
+        last_block=last_block,
+    )
 
 
 def audit_review(
@@ -199,87 +280,6 @@ def audit_review(
         indexes=selected_indexes,
         row_filter=row_filter,
         unverified_indexes=unverified_indexes,
-        characters=characters,
-        first_index=first_index,
-        last_index=last_index,
-        first_block=first_block,
-        last_block=last_block,
-    )
-
-
-def audit_reviews(
-    *,
-    traditional: Series,
-    traditional_reviewed: Series,
-    traditional_simplified: Series,
-    traditional_simplified_reviewed: Series,
-    simplified: Series,
-    simplified_reviewed: Series,
-    traditional_review_cases: Sequence[TestCase] = (),
-    traditional_simplified_review_cases: Sequence[TestCase] = (),
-    simplified_review_cases: Sequence[TestCase] = (),
-    row_filter: ExtendedAuditFilter = ExtendedAuditFilter.changes,
-    characters: Sequence[str] = (),
-    first_index: int | None = None,
-    last_index: int | None = None,
-    first_block: int | None = None,
-    last_block: int | None = None,
-) -> str:
-    """Audit parallel simplified and traditional-to-simplified review paths.
-
-    Arguments:
-        traditional: traditional-script review input
-        traditional_reviewed: traditional-script reviewed subtitles
-        traditional_simplified: simplified traditional-script subtitles
-        traditional_simplified_reviewed: reviewed simplified traditional-script
-            subtitles
-        simplified: simplified-script review input
-        simplified_reviewed: simplified-script reviewed subtitles
-        traditional_review_cases: traditional review test cases
-        traditional_simplified_review_cases: traditional simplification review test
-            cases
-        simplified_review_cases: simplified review test cases
-        row_filter: row status filter
-        characters: individual characters whose occurrence limits included rows
-        first_index: first 1-indexed subtitle number to include, inclusive
-        last_index: last 1-indexed subtitle number to include, inclusive
-        first_block: first 1-indexed workflow block number to include, inclusive
-        last_block: last 1-indexed workflow block number to include, inclusive
-    Returns:
-        Markdown audit report
-    Raises:
-        ScinoephileError: if review test cases do not match the subtitle series
-    """
-    return audit_review(
-        reviews=(
-            ReviewAuditPair(
-                label="Simplified",
-                original=simplified,
-                reviewed=simplified_reviewed,
-                review_cases=simplified_review_cases,
-            ),
-            ReviewAuditPair(
-                label="Traditional",
-                original=traditional,
-                reviewed=traditional_reviewed,
-                review_cases=traditional_review_cases,
-            ),
-            ReviewAuditPair(
-                label="Traditional simplification",
-                original=traditional_simplified,
-                reviewed=traditional_simplified_reviewed,
-                review_cases=traditional_simplified_review_cases,
-            ),
-        ),
-        comparisons=(
-            ReviewAuditComparison(
-                column_label="Simplified vs Traditional->Simplified",
-                summary_label="Final text",
-                left=simplified_reviewed,
-                right=traditional_simplified_reviewed,
-            ),
-        ),
-        row_filter=row_filter,
         characters=characters,
         first_index=first_index,
         last_index=last_index,

--- a/scinoephile/analysis/audit/translation.py
+++ b/scinoephile/analysis/audit/translation.py
@@ -1,0 +1,403 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Audit standard and guided translation decisions as Markdown reports."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+
+from scinoephile.core.exceptions import ScinoephileError
+from scinoephile.core.subtitles import Series
+from scinoephile.llms.guided_translation import GuidedTranslationTestCase
+from scinoephile.llms.translation import TranslationTestCase
+
+from .utils import (
+    _get_validated_block_pairs_by_pause,
+    _is_block_in_range,
+    escape_table_cell,
+    format_block_range,
+    format_difficulty_filter,
+    format_index_range,
+    validate_block_range,
+    validate_index_range,
+)
+
+__all__ = [
+    "TranslationAuditFilter",
+    "audit_guided_translation",
+    "audit_translation",
+]
+
+type _TranslationCase = TranslationTestCase | GuidedTranslationTestCase
+type _TranslationKey = tuple[tuple[str, ...], tuple[str, ...]]
+
+
+@dataclass(frozen=True, kw_only=True)
+class _TranslationBlock:
+    """One current source block available for translation."""
+
+    block_number: int
+    """One-based position in the source or paired block sequence."""
+    guide_texts: tuple[str, ...]
+    """Guide texts supplied to guided translation, if any."""
+    source_indexes: tuple[int, ...]
+    """One-based global source subtitle indexes."""
+    source_texts: tuple[str, ...]
+    """Source subtitle texts in query order."""
+
+    @property
+    def key(self) -> _TranslationKey:
+        """Key matching this block to a logged test case."""
+        return self.source_texts, self.guide_texts
+
+
+@dataclass(frozen=True, kw_only=True)
+class _TranslationRow:
+    """One translated subtitle displayed in an audit report."""
+
+    markdown: str
+    """Formatted Markdown table row."""
+    verified: bool
+    """Whether the source test case is verified."""
+
+
+class TranslationAuditFilter(StrEnum):
+    """Row filters supported by standard and guided translation audits."""
+
+    all = "all"
+    """Include every translated or unanswered source subtitle."""
+
+    unverified = "unverified"
+    """Include only subtitles from cases not marked as verified."""
+
+
+def audit_guided_translation(
+    source: Series,
+    guide: Series,
+    test_cases: Sequence[GuidedTranslationTestCase],
+    *,
+    difficulties: Sequence[int] = (),
+    row_filter: TranslationAuditFilter = TranslationAuditFilter.all,
+    first_index: int | None = None,
+    last_index: int | None = None,
+    first_block: int | None = None,
+    last_block: int | None = None,
+) -> str:
+    """Audit guided translations against their source and guide blocks.
+
+    Arguments:
+        source: source-language subtitle series provided for translation
+        guide: target-language guide subtitle series
+        test_cases: logged guided-translation test cases
+        difficulties: exact case difficulty levels to include, or all if empty
+        row_filter: row verification filter
+        first_index: first 1-indexed source subtitle number to include
+        last_index: last 1-indexed source subtitle number to include
+        first_block: first 1-indexed paired block number to include
+        last_block: last 1-indexed paired block number to include
+    Returns:
+        Markdown audit report
+    Raises:
+        ScinoephileError: if a range, difficulty, or logged case is invalid
+    """
+    block_pairs = _get_validated_block_pairs_by_pause(
+        source,
+        guide,
+        first_block,
+        last_block,
+    )
+    blocks = _get_guided_blocks(block_pairs)
+    return _audit_translation_blocks(
+        blocks,
+        test_cases,
+        title="Guided Translation Audit",
+        difficulties=difficulties,
+        row_filter=row_filter,
+        first_index=first_index,
+        last_index=last_index,
+        first_block=first_block,
+        last_block=last_block,
+    )
+
+
+def audit_translation(
+    source: Series,
+    test_cases: Sequence[TranslationTestCase],
+    *,
+    difficulties: Sequence[int] = (),
+    row_filter: TranslationAuditFilter = TranslationAuditFilter.all,
+    first_index: int | None = None,
+    last_index: int | None = None,
+    first_block: int | None = None,
+    last_block: int | None = None,
+) -> str:
+    """Audit standard translations against their source blocks.
+
+    Arguments:
+        source: source-language subtitle series provided for translation
+        test_cases: logged standard-translation test cases
+        difficulties: exact case difficulty levels to include, or all if empty
+        row_filter: row verification filter
+        first_index: first 1-indexed source subtitle number to include
+        last_index: last 1-indexed source subtitle number to include
+        first_block: first 1-indexed source block number to include
+        last_block: last 1-indexed source block number to include
+    Returns:
+        Markdown audit report
+    Raises:
+        ScinoephileError: if a range, difficulty, or logged case is invalid
+    """
+    blocks = _get_standard_blocks(source)
+    validate_block_range(first_block, last_block, len(blocks))
+    return _audit_translation_blocks(
+        blocks,
+        test_cases,
+        title="Standard Translation Audit",
+        difficulties=difficulties,
+        row_filter=row_filter,
+        first_index=first_index,
+        last_index=last_index,
+        first_block=first_block,
+        last_block=last_block,
+    )
+
+
+def _audit_translation_blocks(
+    blocks: Sequence[_TranslationBlock],
+    test_cases: Sequence[_TranslationCase],
+    *,
+    title: str,
+    difficulties: Sequence[int],
+    row_filter: TranslationAuditFilter,
+    first_index: int | None,
+    last_index: int | None,
+    first_block: int | None,
+    last_block: int | None,
+) -> str:
+    """Audit matched standard or guided translation blocks.
+
+    Arguments:
+        blocks: current source blocks
+        test_cases: logged translation cases
+        title: report title
+        difficulties: exact case difficulty levels to include, or all if empty
+        row_filter: row verification filter
+        first_index: first included source subtitle number
+        last_index: last included source subtitle number
+        first_block: first included block number
+        last_block: last included block number
+    Returns:
+        Markdown audit report
+    Raises:
+        ScinoephileError: if a selected block lacks a logged test case
+    """
+    validate_index_range(first_index, last_index)
+    validate_block_range(first_block, last_block)
+    if any(difficulty < 0 for difficulty in difficulties):
+        raise ScinoephileError("Difficulty must be at least 0")
+    difficulty_filter = tuple(sorted(set(difficulties)))
+
+    cases_by_key: dict[_TranslationKey, tuple[int, _TranslationCase]] = {}
+    for case_index, test_case in enumerate(test_cases, 1):
+        cases_by_key[_get_case_key(test_case)] = (case_index, test_case)
+
+    all_rows: list[_TranslationRow] = []
+    selected_case_indexes: set[int] = set()
+    answered_subtitles = 0
+    unanswered_subtitles = 0
+    selected_blocks = (
+        block
+        for block in blocks
+        if _is_block_in_range(block.block_number, first_block, last_block)
+    )
+    for block in selected_blocks:
+        selected_positions = [
+            position
+            for position, source_index in enumerate(block.source_indexes)
+            if (first_index is None or source_index >= first_index)
+            and (last_index is None or source_index <= last_index)
+        ]
+        if not selected_positions:
+            continue
+
+        case_data = cases_by_key.get(block.key)
+        if case_data is None:
+            raise ScinoephileError(
+                f"Unable to audit translation: block {block.block_number} has no "
+                "matching logged test case"
+            )
+        case_index, test_case = case_data
+        if difficulty_filter and test_case.difficulty not in difficulty_filter:
+            continue
+        selected_case_indexes.add(case_index)
+
+        outputs_by_index = {}
+        if test_case.answer is not None:
+            outputs_by_index = {
+                output.index: output.text for output in test_case.answer.outputs
+            }
+        guide_text = _format_guide_text(block.guide_texts)
+        for position in selected_positions:
+            local_index = position + 1
+            output_text = "(unanswered)"
+            if test_case.answer is not None:
+                output_text = outputs_by_index[local_index]
+                answered_subtitles += 1
+            else:
+                unanswered_subtitles += 1
+            cells = (
+                f"S {block.source_indexes[position]}\nQ {local_index}",
+                f"C {case_index}\nB {block.block_number}",
+                str(test_case.difficulty),
+                block.source_texts[position],
+                guide_text,
+                output_text,
+                "",
+                "✓" if test_case.verified else "",
+            )
+            all_rows.append(
+                _TranslationRow(
+                    markdown=(
+                        f"| {' | '.join(escape_table_cell(cell) for cell in cells)} |"
+                    ),
+                    verified=test_case.verified,
+                )
+            )
+
+    rows = [
+        row
+        for row in all_rows
+        if not (row_filter is TranslationAuditFilter.unverified and row.verified)
+    ]
+    verified_subtitles = sum(row.verified for row in all_rows)
+    lines = [
+        f"# {title}",
+        "",
+        "## Summary",
+        "",
+        f"- logged cases: {len(selected_case_indexes)}",
+        f"- subtitles: {len(all_rows)}",
+        f"- translated subtitles: {answered_subtitles}",
+        f"- unanswered subtitles: {unanswered_subtitles}",
+        f"- verified subtitles: {verified_subtitles}",
+        f"- unverified subtitles: {len(all_rows) - verified_subtitles}",
+        f"- row filter: {row_filter.value}",
+    ]
+    lines.append(format_difficulty_filter(difficulty_filter))
+    range_summary = format_index_range(
+        first_index,
+        last_index,
+        track_name="source",
+    )
+    if range_summary is not None:
+        lines.append(range_summary)
+    block_range_summary = format_block_range(first_block, last_block)
+    if block_range_summary is not None:
+        lines.append(block_range_summary)
+    lines.extend(
+        (
+            f"- table rows: {len(rows)}",
+            "",
+            "## Audit Table",
+            "",
+            (
+                "| Indexes | Case / block | Difficulty | Source | Guide | "
+                "Translation | Notes | Verified |"
+            ),
+            "|---:|---:|---:|---|---|---|---|:---:|",
+            *(row.markdown for row in rows),
+        )
+    )
+    return "\n".join(lines) + "\n"
+
+
+def _format_guide_text(guide_texts: Sequence[str]) -> str:
+    """Format a guided-translation block for one table cell.
+
+    Arguments:
+        guide_texts: guide texts in query order
+    Returns:
+        indexed guide text, or an em dash when absent
+    """
+    if not guide_texts:
+        return "—"
+    return "\n".join(f"G {index}: {text}" for index, text in enumerate(guide_texts, 1))
+
+
+def _get_case_key(test_case: _TranslationCase) -> _TranslationKey:
+    """Get the source and guide text key for a translation test case.
+
+    Arguments:
+        test_case: standard or guided translation test case
+    Returns:
+        source and guide text tuples
+    """
+    source_texts = tuple(subtitle.text for subtitle in test_case.query.subtitles)
+    guide_texts: tuple[str, ...] = ()
+    if isinstance(test_case, GuidedTranslationTestCase):
+        guide_texts = tuple(guide.text for guide in test_case.query.guides)
+    return source_texts, guide_texts
+
+
+def _get_guided_blocks(
+    block_pairs: Sequence[tuple[Series, Series]],
+) -> list[_TranslationBlock]:
+    """Build current guided-translation blocks with global source indexes.
+
+    Arguments:
+        block_pairs: paired source and guide workflow blocks
+    Returns:
+        current nonempty source blocks
+    """
+    blocks = []
+    source_position = 0
+    for block_number, (source_block, guide_block) in enumerate(block_pairs, 1):
+        if not source_block:
+            continue
+        source_indexes = tuple(
+            range(source_position + 1, source_position + len(source_block) + 1)
+        )
+        source_position += len(source_block)
+        blocks.append(
+            _TranslationBlock(
+                block_number=block_number,
+                guide_texts=tuple(
+                    subtitle.text_with_newline.strip() for subtitle in guide_block
+                ),
+                source_indexes=source_indexes,
+                source_texts=tuple(
+                    subtitle.text_with_newline.strip() for subtitle in source_block
+                ),
+            )
+        )
+    return blocks
+
+
+def _get_standard_blocks(source: Series) -> list[_TranslationBlock]:
+    """Build current standard-translation blocks with global source indexes.
+
+    Arguments:
+        source: source-language subtitle series
+    Returns:
+        current source blocks
+    """
+    blocks = []
+    source_position = 0
+    for block_number, source_block in enumerate(source.blocks, 1):
+        source_indexes = tuple(
+            range(source_position + 1, source_position + len(source_block) + 1)
+        )
+        source_position += len(source_block)
+        blocks.append(
+            _TranslationBlock(
+                block_number=block_number,
+                guide_texts=(),
+                source_indexes=source_indexes,
+                source_texts=tuple(
+                    subtitle.text_with_newline.strip() for subtitle in source_block
+                ),
+            )
+        )
+    return blocks

--- a/scinoephile/analysis/audit/translation.py
+++ b/scinoephile/analysis/audit/translation.py
@@ -12,7 +12,7 @@ from scinoephile.core.subtitles import Series
 from scinoephile.llms.translation import TranslationTestCase
 
 from .utils import (
-    VerificationAuditFilter,
+    AuditFilter,
     format_audit_report,
     format_verification_marker,
     validate_audit_range,
@@ -83,7 +83,7 @@ def audit_translation(
     source: Series,
     test_cases: Sequence[TranslationTestCase],
     *,
-    row_filter: VerificationAuditFilter = VerificationAuditFilter.all,
+    row_filter: AuditFilter = AuditFilter.all,
     first_index: int | None = None,
     last_index: int | None = None,
     first_block: int | None = None,
@@ -133,7 +133,7 @@ def audit_translation_blocks(
     cases: Sequence[TranslationAuditCase],
     *,
     title: str,
-    row_filter: VerificationAuditFilter,
+    row_filter: AuditFilter,
     first_index: int | None,
     last_index: int | None,
     first_block: int | None,
@@ -217,7 +217,7 @@ def audit_translation_blocks(
     rows = [
         row
         for row in all_rows
-        if not (row_filter is VerificationAuditFilter.unverified and row.verified)
+        if not (row_filter is AuditFilter.unverified and row.verified)
     ]
     verified_subtitles = sum(row.verified for row in all_rows)
     return format_audit_report(

--- a/scinoephile/analysis/audit/translation.py
+++ b/scinoephile/analysis/audit/translation.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 
@@ -15,6 +14,7 @@ from scinoephile.llms.translation import TranslationTestCase
 from .utils import (
     VerificationAuditFilter,
     format_audit_report,
+    format_verification_marker,
     validate_audit_range,
 )
 
@@ -183,9 +183,7 @@ def audit_translation_blocks(
         selected_case_indexes.add(case.case_index)
 
         guide_text = _format_guide_text(block.guide_texts)
-        verified_marker = ""
-        if case.verified:
-            verified_marker = "✓"
+        verified_marker = format_verification_marker(case.verified)
         for position in selected_positions:
             local_index = position + 1
             output_text, answered, empty = resolve_translation_audit_output(
@@ -294,7 +292,7 @@ def _get_selected_block_data(
     first_block: int | None,
     last_block: int | None,
 ) -> list[tuple[TranslationAuditBlock, list[int]]]:
-    """Select block positions and reject indistinguishable repeated blocks.
+    """Select block positions within the requested range.
 
     Arguments:
         blocks: current source blocks
@@ -304,8 +302,6 @@ def _get_selected_block_data(
         last_block: last included block number
     Returns:
         selected blocks and their zero-based source positions
-    Raises:
-        ScinoephileError: if selected blocks have identical logged query keys
     """
     # Select current blocks and source positions within the requested range
     selected_block_data: list[tuple[TranslationAuditBlock, list[int]]] = []
@@ -323,22 +319,6 @@ def _get_selected_block_data(
         if selected_positions:
             selected_block_data.append((block, selected_positions))
 
-    # Reject repeated current blocks that cannot be matched uniquely to log cases
-    selected_blocks_by_key: dict[
-        _TranslationAuditKey,
-        list[TranslationAuditBlock],
-    ] = defaultdict(list)
-    for block, _ in selected_block_data:
-        selected_blocks_by_key[block.key].append(block)
-    for matching_blocks in selected_blocks_by_key.values():
-        if len(matching_blocks) < 2:
-            continue
-        block_numbers = ", ".join(str(block.block_number) for block in matching_blocks)
-        raise ScinoephileError(
-            "Unable to audit translation: "
-            f"blocks {block_numbers} have identical source and guide text and cannot "
-            "be matched uniquely to logged test cases"
-        )
     return selected_block_data
 
 

--- a/scinoephile/analysis/audit/translation.py
+++ b/scinoephile/analysis/audit/translation.py
@@ -16,7 +16,6 @@ from scinoephile.llms.translation import TranslationTestCase
 
 from .utils import (
     VerificationAuditFilter,
-    escape_table_cell,
     format_audit_report,
     validate_audit_range,
 )
@@ -53,8 +52,8 @@ class _TranslationBlock:
 class _TranslationRow:
     """One translated subtitle displayed in an audit report."""
 
-    markdown: str
-    """Formatted Markdown table row."""
+    cells: tuple[str, ...]
+    """Semantic audit table cell values."""
     verified: bool
     """Whether the source test case is verified."""
 
@@ -248,9 +247,7 @@ def _audit_translation_blocks(
             )
             all_rows.append(
                 _TranslationRow(
-                    markdown=(
-                        f"| {' | '.join(escape_table_cell(cell) for cell in cells)} |"
-                    ),
+                    cells=cells,
                     verified=test_case.verified,
                 )
             )
@@ -264,28 +261,27 @@ def _audit_translation_blocks(
     verified_subtitles = sum(row.verified for row in all_rows)
     return format_audit_report(
         title=title,
-        summary_lines=(
-            f"- logged cases: {len(selected_case_indexes)}",
-            f"- subtitles: {len(all_rows)}",
-            f"- translated subtitles: {translated_subtitles}",
-            f"- empty translations: {empty_translations}",
-            f"- unanswered subtitles: {unanswered_subtitles}",
-            f"- verified subtitles: {verified_subtitles}",
-            f"- unverified subtitles: {len(all_rows) - verified_subtitles}",
-            f"- row filter: {row_filter.value}",
+        summary_items=(
+            f"logged cases: {len(selected_case_indexes)}",
+            f"subtitles: {len(all_rows)}",
+            f"translated subtitles: {translated_subtitles}",
+            f"empty translations: {empty_translations}",
+            f"unanswered subtitles: {unanswered_subtitles}",
+            f"verified subtitles: {verified_subtitles}",
+            f"unverified subtitles: {len(all_rows) - verified_subtitles}",
+            f"row filter: {row_filter.value}",
         ),
-        column_labels=(
-            "Indexes",
-            "Case / block",
-            "Difficulty",
-            "Source",
-            "Guide",
-            "Translation",
-            "Notes",
-            "Verified",
+        columns=(
+            ("Indexes", "right"),
+            ("Case / block", "right"),
+            ("Difficulty", "right"),
+            ("Source", "left"),
+            ("Guide", "left"),
+            ("Translation", "left"),
+            ("Notes", "left"),
+            ("Verified", "center"),
         ),
-        column_separators=("---:", "---:", "---:", "---", "---", "---", "---", ":---:"),
-        rows=[row.markdown for row in rows],
+        rows=[row.cells for row in rows],
         first_index=first_index,
         last_index=last_index,
         index_track_name="source",

--- a/scinoephile/analysis/audit/translation.py
+++ b/scinoephile/analysis/audit/translation.py
@@ -14,10 +14,10 @@ from scinoephile.llms.guided_translation import GuidedTranslationTestCase
 from scinoephile.llms.translation import TranslationTestCase
 
 from .utils import (
-    _get_validated_block_pairs_by_pause,
     escape_table_cell,
     format_block_range,
     format_index_range,
+    get_validated_block_pairs_by_pause,
     validate_block_range,
     validate_index_range,
 )
@@ -98,7 +98,7 @@ def audit_guided_translation(
     Raises:
         ScinoephileError: if a range or logged case is invalid
     """
-    block_pairs = _get_validated_block_pairs_by_pause(
+    block_pairs = get_validated_block_pairs_by_pause(
         source,
         guide,
         first_block,

--- a/scinoephile/analysis/audit/translation.py
+++ b/scinoephile/analysis/audit/translation.py
@@ -4,26 +4,24 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
 from collections.abc import Sequence
 from dataclasses import dataclass
-from enum import StrEnum
 
 from scinoephile.core.exceptions import ScinoephileError
+from scinoephile.core.pairs import get_block_pairs_by_pause
 from scinoephile.core.subtitles import Series
 from scinoephile.llms.guided_translation import GuidedTranslationTestCase
 from scinoephile.llms.translation import TranslationTestCase
 
 from .utils import (
+    VerificationAuditFilter,
     escape_table_cell,
-    format_block_range,
-    format_index_range,
-    get_validated_block_pairs_by_pause,
-    validate_block_range,
-    validate_index_range,
+    format_audit_report,
+    validate_audit_range,
 )
 
 __all__ = [
-    "TranslationAuditFilter",
     "audit_guided_translation",
     "audit_translation",
 ]
@@ -61,22 +59,12 @@ class _TranslationRow:
     """Whether the source test case is verified."""
 
 
-class TranslationAuditFilter(StrEnum):
-    """Row filters supported by standard and guided translation audits."""
-
-    all = "all"
-    """Include every translated or unanswered source subtitle."""
-
-    unverified = "unverified"
-    """Include only subtitles from cases not marked as verified."""
-
-
 def audit_guided_translation(
     source: Series,
     guide: Series,
     test_cases: Sequence[GuidedTranslationTestCase],
     *,
-    row_filter: TranslationAuditFilter = TranslationAuditFilter.all,
+    row_filter: VerificationAuditFilter = VerificationAuditFilter.all,
     first_index: int | None = None,
     last_index: int | None = None,
     first_block: int | None = None,
@@ -98,13 +86,18 @@ def audit_guided_translation(
     Raises:
         ScinoephileError: if a range or logged case is invalid
     """
-    block_pairs = get_validated_block_pairs_by_pause(
-        source,
-        guide,
+    # Build paired workflow blocks and validate the selection
+    block_pairs = get_block_pairs_by_pause(source, guide)
+    validate_audit_range(
+        first_index,
+        last_index,
         first_block,
         last_block,
+        block_count=len(block_pairs),
     )
     blocks = _get_guided_blocks(block_pairs)
+
+    # Audit the current blocks against the logged cases
     return _audit_translation_blocks(
         blocks,
         test_cases,
@@ -121,7 +114,7 @@ def audit_translation(
     source: Series,
     test_cases: Sequence[TranslationTestCase],
     *,
-    row_filter: TranslationAuditFilter = TranslationAuditFilter.all,
+    row_filter: VerificationAuditFilter = VerificationAuditFilter.all,
     first_index: int | None = None,
     last_index: int | None = None,
     first_block: int | None = None,
@@ -142,8 +135,17 @@ def audit_translation(
     Raises:
         ScinoephileError: if a range or logged case is invalid
     """
+    # Build current workflow blocks and validate the selection
     blocks = _get_standard_blocks(source)
-    validate_block_range(first_block, last_block, len(blocks))
+    validate_audit_range(
+        first_index,
+        last_index,
+        first_block,
+        last_block,
+        block_count=len(blocks),
+    )
+
+    # Audit the current blocks against the logged cases
     return _audit_translation_blocks(
         blocks,
         test_cases,
@@ -161,7 +163,7 @@ def _audit_translation_blocks(
     test_cases: Sequence[_TranslationCase],
     *,
     title: str,
-    row_filter: TranslationAuditFilter,
+    row_filter: VerificationAuditFilter,
     first_index: int | None,
     last_index: int | None,
     first_block: int | None,
@@ -183,33 +185,27 @@ def _audit_translation_blocks(
     Raises:
         ScinoephileError: if a selected block lacks a logged test case
     """
-    validate_index_range(first_index, last_index)
-    validate_block_range(first_block, last_block)
-
+    # Retain the latest logged case for each query
     cases_by_key: dict[_TranslationKey, tuple[int, _TranslationCase]] = {}
     for case_index, test_case in enumerate(test_cases, 1):
         cases_by_key[_get_case_key(test_case)] = (case_index, test_case)
 
+    # Select current blocks and reject ambiguous repeated queries
+    selected_block_data = _get_selected_block_data(
+        blocks,
+        first_index=first_index,
+        last_index=last_index,
+        first_block=first_block,
+        last_block=last_block,
+    )
+
+    # Match selected blocks to cases and format their rows
     all_rows: list[_TranslationRow] = []
     selected_case_indexes: set[int] = set()
-    answered_subtitles = 0
+    translated_subtitles = 0
+    empty_translations = 0
     unanswered_subtitles = 0
-    selected_blocks = (
-        block
-        for block in blocks
-        if (first_block is None or block.block_number >= first_block)
-        and (last_block is None or block.block_number <= last_block)
-    )
-    for block in selected_blocks:
-        selected_positions = [
-            position
-            for position, source_index in enumerate(block.source_indexes)
-            if (first_index is None or source_index >= first_index)
-            and (last_index is None or source_index <= last_index)
-        ]
-        if not selected_positions:
-            continue
-
+    for block, selected_positions in selected_block_data:
         case_data = cases_by_key.get(block.key)
         if case_data is None:
             raise ScinoephileError(
@@ -225,12 +221,19 @@ def _audit_translation_blocks(
                 output.index: output.text for output in test_case.answer.outputs
             }
         guide_text = _format_guide_text(block.guide_texts)
+        verified_marker = ""
+        if test_case.verified:
+            verified_marker = "✓"
         for position in selected_positions:
             local_index = position + 1
             output_text = "(unanswered)"
             if test_case.answer is not None:
                 output_text = outputs_by_index[local_index]
-                answered_subtitles += 1
+                if output_text:
+                    translated_subtitles += 1
+                else:
+                    output_text = "(empty)"
+                    empty_translations += 1
             else:
                 unanswered_subtitles += 1
             cells = (
@@ -241,7 +244,7 @@ def _audit_translation_blocks(
                 guide_text,
                 output_text,
                 "",
-                "✓" if test_case.verified else "",
+                verified_marker,
             )
             all_rows.append(
                 _TranslationRow(
@@ -252,50 +255,43 @@ def _audit_translation_blocks(
                 )
             )
 
+    # Apply the row filter after calculating complete selection statistics
     rows = [
         row
         for row in all_rows
-        if not (row_filter is TranslationAuditFilter.unverified and row.verified)
+        if not (row_filter is VerificationAuditFilter.unverified and row.verified)
     ]
     verified_subtitles = sum(row.verified for row in all_rows)
-    lines = [
-        f"# {title}",
-        "",
-        "## Summary",
-        "",
-        f"- logged cases: {len(selected_case_indexes)}",
-        f"- subtitles: {len(all_rows)}",
-        f"- translated subtitles: {answered_subtitles}",
-        f"- unanswered subtitles: {unanswered_subtitles}",
-        f"- verified subtitles: {verified_subtitles}",
-        f"- unverified subtitles: {len(all_rows) - verified_subtitles}",
-        f"- row filter: {row_filter.value}",
-    ]
-    range_summary = format_index_range(
-        first_index,
-        last_index,
-        track_name="source",
+    return format_audit_report(
+        title=title,
+        summary_lines=(
+            f"- logged cases: {len(selected_case_indexes)}",
+            f"- subtitles: {len(all_rows)}",
+            f"- translated subtitles: {translated_subtitles}",
+            f"- empty translations: {empty_translations}",
+            f"- unanswered subtitles: {unanswered_subtitles}",
+            f"- verified subtitles: {verified_subtitles}",
+            f"- unverified subtitles: {len(all_rows) - verified_subtitles}",
+            f"- row filter: {row_filter.value}",
+        ),
+        column_labels=(
+            "Indexes",
+            "Case / block",
+            "Difficulty",
+            "Source",
+            "Guide",
+            "Translation",
+            "Notes",
+            "Verified",
+        ),
+        column_separators=("---:", "---:", "---:", "---", "---", "---", "---", ":---:"),
+        rows=[row.markdown for row in rows],
+        first_index=first_index,
+        last_index=last_index,
+        index_track_name="source",
+        first_block=first_block,
+        last_block=last_block,
     )
-    if range_summary is not None:
-        lines.append(range_summary)
-    block_range_summary = format_block_range(first_block, last_block)
-    if block_range_summary is not None:
-        lines.append(block_range_summary)
-    lines.extend(
-        (
-            f"- table rows: {len(rows)}",
-            "",
-            "## Audit Table",
-            "",
-            (
-                "| Indexes | Case / block | Difficulty | Source | Guide | "
-                "Translation | Notes | Verified |"
-            ),
-            "|---:|---:|---:|---|---|---|---|:---:|",
-            *(row.markdown for row in rows),
-        )
-    )
-    return "\n".join(lines) + "\n"
 
 
 def _format_guide_text(guide_texts: Sequence[str]) -> str:
@@ -358,6 +354,61 @@ def _get_guided_blocks(
             )
         )
     return blocks
+
+
+def _get_selected_block_data(
+    blocks: Sequence[_TranslationBlock],
+    *,
+    first_index: int | None,
+    last_index: int | None,
+    first_block: int | None,
+    last_block: int | None,
+) -> list[tuple[_TranslationBlock, list[int]]]:
+    """Select block positions and reject indistinguishable repeated blocks.
+
+    Arguments:
+        blocks: current source blocks
+        first_index: first included source subtitle number
+        last_index: last included source subtitle number
+        first_block: first included block number
+        last_block: last included block number
+    Returns:
+        selected blocks and their zero-based source positions
+    Raises:
+        ScinoephileError: if selected blocks have identical logged query keys
+    """
+    # Select current blocks and source positions within the requested range
+    selected_block_data: list[tuple[_TranslationBlock, list[int]]] = []
+    for block in blocks:
+        if first_block is not None and block.block_number < first_block:
+            continue
+        if last_block is not None and block.block_number > last_block:
+            continue
+        selected_positions = [
+            position
+            for position, source_index in enumerate(block.source_indexes)
+            if (first_index is None or source_index >= first_index)
+            and (last_index is None or source_index <= last_index)
+        ]
+        if selected_positions:
+            selected_block_data.append((block, selected_positions))
+
+    # Reject repeated current blocks that cannot be matched uniquely to log cases
+    selected_blocks_by_key: dict[_TranslationKey, list[_TranslationBlock]] = (
+        defaultdict(list)
+    )
+    for block, _ in selected_block_data:
+        selected_blocks_by_key[block.key].append(block)
+    for matching_blocks in selected_blocks_by_key.values():
+        if len(matching_blocks) < 2:
+            continue
+        block_numbers = ", ".join(str(block.block_number) for block in matching_blocks)
+        raise ScinoephileError(
+            "Unable to audit translation: "
+            f"blocks {block_numbers} have identical source and guide text and cannot "
+            "be matched uniquely to logged test cases"
+        )
+    return selected_block_data
 
 
 def _get_standard_blocks(source: Series) -> list[_TranslationBlock]:

--- a/scinoephile/analysis/audit/translation.py
+++ b/scinoephile/analysis/audit/translation.py
@@ -15,10 +15,8 @@ from scinoephile.llms.translation import TranslationTestCase
 
 from .utils import (
     _get_validated_block_pairs_by_pause,
-    _is_block_in_range,
     escape_table_cell,
     format_block_range,
-    format_difficulty_filter,
     format_index_range,
     validate_block_range,
     validate_index_range,
@@ -78,7 +76,6 @@ def audit_guided_translation(
     guide: Series,
     test_cases: Sequence[GuidedTranslationTestCase],
     *,
-    difficulties: Sequence[int] = (),
     row_filter: TranslationAuditFilter = TranslationAuditFilter.all,
     first_index: int | None = None,
     last_index: int | None = None,
@@ -91,7 +88,6 @@ def audit_guided_translation(
         source: source-language subtitle series provided for translation
         guide: target-language guide subtitle series
         test_cases: logged guided-translation test cases
-        difficulties: exact case difficulty levels to include, or all if empty
         row_filter: row verification filter
         first_index: first 1-indexed source subtitle number to include
         last_index: last 1-indexed source subtitle number to include
@@ -100,7 +96,7 @@ def audit_guided_translation(
     Returns:
         Markdown audit report
     Raises:
-        ScinoephileError: if a range, difficulty, or logged case is invalid
+        ScinoephileError: if a range or logged case is invalid
     """
     block_pairs = _get_validated_block_pairs_by_pause(
         source,
@@ -113,7 +109,6 @@ def audit_guided_translation(
         blocks,
         test_cases,
         title="Guided Translation Audit",
-        difficulties=difficulties,
         row_filter=row_filter,
         first_index=first_index,
         last_index=last_index,
@@ -126,7 +121,6 @@ def audit_translation(
     source: Series,
     test_cases: Sequence[TranslationTestCase],
     *,
-    difficulties: Sequence[int] = (),
     row_filter: TranslationAuditFilter = TranslationAuditFilter.all,
     first_index: int | None = None,
     last_index: int | None = None,
@@ -138,7 +132,6 @@ def audit_translation(
     Arguments:
         source: source-language subtitle series provided for translation
         test_cases: logged standard-translation test cases
-        difficulties: exact case difficulty levels to include, or all if empty
         row_filter: row verification filter
         first_index: first 1-indexed source subtitle number to include
         last_index: last 1-indexed source subtitle number to include
@@ -147,7 +140,7 @@ def audit_translation(
     Returns:
         Markdown audit report
     Raises:
-        ScinoephileError: if a range, difficulty, or logged case is invalid
+        ScinoephileError: if a range or logged case is invalid
     """
     blocks = _get_standard_blocks(source)
     validate_block_range(first_block, last_block, len(blocks))
@@ -155,7 +148,6 @@ def audit_translation(
         blocks,
         test_cases,
         title="Standard Translation Audit",
-        difficulties=difficulties,
         row_filter=row_filter,
         first_index=first_index,
         last_index=last_index,
@@ -169,7 +161,6 @@ def _audit_translation_blocks(
     test_cases: Sequence[_TranslationCase],
     *,
     title: str,
-    difficulties: Sequence[int],
     row_filter: TranslationAuditFilter,
     first_index: int | None,
     last_index: int | None,
@@ -182,7 +173,6 @@ def _audit_translation_blocks(
         blocks: current source blocks
         test_cases: logged translation cases
         title: report title
-        difficulties: exact case difficulty levels to include, or all if empty
         row_filter: row verification filter
         first_index: first included source subtitle number
         last_index: last included source subtitle number
@@ -195,9 +185,6 @@ def _audit_translation_blocks(
     """
     validate_index_range(first_index, last_index)
     validate_block_range(first_block, last_block)
-    if any(difficulty < 0 for difficulty in difficulties):
-        raise ScinoephileError("Difficulty must be at least 0")
-    difficulty_filter = tuple(sorted(set(difficulties)))
 
     cases_by_key: dict[_TranslationKey, tuple[int, _TranslationCase]] = {}
     for case_index, test_case in enumerate(test_cases, 1):
@@ -210,7 +197,8 @@ def _audit_translation_blocks(
     selected_blocks = (
         block
         for block in blocks
-        if _is_block_in_range(block.block_number, first_block, last_block)
+        if (first_block is None or block.block_number >= first_block)
+        and (last_block is None or block.block_number <= last_block)
     )
     for block in selected_blocks:
         selected_positions = [
@@ -229,8 +217,6 @@ def _audit_translation_blocks(
                 "matching logged test case"
             )
         case_index, test_case = case_data
-        if difficulty_filter and test_case.difficulty not in difficulty_filter:
-            continue
         selected_case_indexes.add(case_index)
 
         outputs_by_index = {}
@@ -285,7 +271,6 @@ def _audit_translation_blocks(
         f"- unverified subtitles: {len(all_rows) - verified_subtitles}",
         f"- row filter: {row_filter.value}",
     ]
-    lines.append(format_difficulty_filter(difficulty_filter))
     range_summary = format_index_range(
         first_index,
         last_index,

--- a/scinoephile/analysis/audit/translation.py
+++ b/scinoephile/analysis/audit/translation.py
@@ -1,17 +1,15 @@
 #  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
-"""Audit standard and guided translation decisions as Markdown reports."""
+"""Audit standard translations and provide shared translation-audit semantics."""
 
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 
 from scinoephile.core.exceptions import ScinoephileError
-from scinoephile.core.pairs import get_block_pairs_by_pause
 from scinoephile.core.subtitles import Series
-from scinoephile.llms.guided_translation import GuidedTranslationTestCase
 from scinoephile.llms.translation import TranslationTestCase
 
 from .utils import (
@@ -21,16 +19,19 @@ from .utils import (
 )
 
 __all__ = [
-    "audit_guided_translation",
+    "TranslationAuditBlock",
+    "TranslationAuditCase",
     "audit_translation",
+    "audit_translation_blocks",
+    "resolve_translation_audit_output",
 ]
 
-type _TranslationCase = TranslationTestCase | GuidedTranslationTestCase
-type _TranslationKey = tuple[tuple[str, ...], tuple[str, ...]]
+type _TranslationAuditKey = tuple[tuple[str, ...], tuple[str, ...]]
+"""Source and guide text identifying one translation workflow block."""
 
 
 @dataclass(frozen=True, kw_only=True)
-class _TranslationBlock:
+class TranslationAuditBlock:
     """One current source block available for translation."""
 
     block_number: int
@@ -43,70 +44,39 @@ class _TranslationBlock:
     """Source subtitle texts in query order."""
 
     @property
-    def key(self) -> _TranslationKey:
-        """Key matching this block to a logged test case."""
+    def key(self) -> _TranslationAuditKey:
+        """Get the key matching this block to a logged test case.
+
+        Returns:
+            source and guide text identifying the block
+        """
         return self.source_texts, self.guide_texts
 
 
 @dataclass(frozen=True, kw_only=True)
-class _TranslationRow:
+class TranslationAuditCase:
+    """Semantic data from one standard or guided translation test case."""
+
+    case_index: int
+    """One-based position of the test case in the JSON."""
+    difficulty: int
+    """Logged test-case difficulty."""
+    key: _TranslationAuditKey
+    """Source and guide text identifying the translated block."""
+    outputs_by_index: Mapping[int, str] | None
+    """Translated output by query-local index, or None when unanswered."""
+    verified: bool
+    """Whether the complete test case is verified."""
+
+
+@dataclass(frozen=True, kw_only=True)
+class _TranslationAuditRow:
     """One translated subtitle displayed in an audit report."""
 
     cells: tuple[str, ...]
     """Semantic audit table cell values."""
     verified: bool
     """Whether the source test case is verified."""
-
-
-def audit_guided_translation(
-    source: Series,
-    guide: Series,
-    test_cases: Sequence[GuidedTranslationTestCase],
-    *,
-    row_filter: VerificationAuditFilter = VerificationAuditFilter.all,
-    first_index: int | None = None,
-    last_index: int | None = None,
-    first_block: int | None = None,
-    last_block: int | None = None,
-) -> str:
-    """Audit guided translations against their source and guide blocks.
-
-    Arguments:
-        source: source-language subtitle series provided for translation
-        guide: target-language guide subtitle series
-        test_cases: logged guided-translation test cases
-        row_filter: row verification filter
-        first_index: first 1-indexed source subtitle number to include
-        last_index: last 1-indexed source subtitle number to include
-        first_block: first 1-indexed paired block number to include
-        last_block: last 1-indexed paired block number to include
-    Returns:
-        Markdown audit report
-    Raises:
-        ScinoephileError: if a range or logged case is invalid
-    """
-    # Build paired workflow blocks and validate the selection
-    block_pairs = get_block_pairs_by_pause(source, guide)
-    validate_audit_range(
-        first_index,
-        last_index,
-        first_block,
-        last_block,
-        block_count=len(block_pairs),
-    )
-    blocks = _get_guided_blocks(block_pairs)
-
-    # Audit the current blocks against the logged cases
-    return _audit_translation_blocks(
-        blocks,
-        test_cases,
-        title="Guided Translation Audit",
-        row_filter=row_filter,
-        first_index=first_index,
-        last_index=last_index,
-        first_block=first_block,
-        last_block=last_block,
-    )
 
 
 def audit_translation(
@@ -144,10 +114,11 @@ def audit_translation(
         block_count=len(blocks),
     )
 
-    # Audit the current blocks against the logged cases
-    return _audit_translation_blocks(
+    # Adapt concrete test cases to shared semantic data
+    cases = _get_standard_cases(test_cases)
+    return audit_translation_blocks(
         blocks,
-        test_cases,
+        cases,
         title="Standard Translation Audit",
         row_filter=row_filter,
         first_index=first_index,
@@ -157,9 +128,9 @@ def audit_translation(
     )
 
 
-def _audit_translation_blocks(
-    blocks: Sequence[_TranslationBlock],
-    test_cases: Sequence[_TranslationCase],
+def audit_translation_blocks(
+    blocks: Sequence[TranslationAuditBlock],
+    cases: Sequence[TranslationAuditCase],
     *,
     title: str,
     row_filter: VerificationAuditFilter,
@@ -168,11 +139,11 @@ def _audit_translation_blocks(
     first_block: int | None,
     last_block: int | None,
 ) -> str:
-    """Audit matched standard or guided translation blocks.
+    """Audit semantic standard or guided translation blocks.
 
     Arguments:
         blocks: current source blocks
-        test_cases: logged translation cases
+        cases: semantic logged translation cases
         title: report title
         row_filter: row verification filter
         first_index: first included source subtitle number
@@ -185,9 +156,7 @@ def _audit_translation_blocks(
         ScinoephileError: if a selected block lacks a logged test case
     """
     # Retain the latest logged case for each query
-    cases_by_key: dict[_TranslationKey, tuple[int, _TranslationCase]] = {}
-    for case_index, test_case in enumerate(test_cases, 1):
-        cases_by_key[_get_case_key(test_case)] = (case_index, test_case)
+    cases_by_key = {case.key: case for case in cases}
 
     # Select current blocks and reject ambiguous repeated queries
     selected_block_data = _get_selected_block_data(
@@ -198,47 +167,41 @@ def _audit_translation_blocks(
         last_block=last_block,
     )
 
-    # Match selected blocks to cases and format their rows
-    all_rows: list[_TranslationRow] = []
+    # Match selected blocks to cases and build their semantic rows
+    all_rows: list[_TranslationAuditRow] = []
     selected_case_indexes: set[int] = set()
     translated_subtitles = 0
     empty_translations = 0
     unanswered_subtitles = 0
     for block, selected_positions in selected_block_data:
-        case_data = cases_by_key.get(block.key)
-        if case_data is None:
+        case = cases_by_key.get(block.key)
+        if case is None:
             raise ScinoephileError(
                 f"Unable to audit translation: block {block.block_number} has no "
                 "matching logged test case"
             )
-        case_index, test_case = case_data
-        selected_case_indexes.add(case_index)
+        selected_case_indexes.add(case.case_index)
 
-        outputs_by_index = {}
-        if test_case.answer is not None:
-            outputs_by_index = {
-                output.index: output.text for output in test_case.answer.outputs
-            }
         guide_text = _format_guide_text(block.guide_texts)
         verified_marker = ""
-        if test_case.verified:
+        if case.verified:
             verified_marker = "✓"
         for position in selected_positions:
             local_index = position + 1
-            output_text = "(unanswered)"
-            if test_case.answer is not None:
-                output_text = outputs_by_index[local_index]
-                if output_text:
-                    translated_subtitles += 1
-                else:
-                    output_text = "(empty)"
-                    empty_translations += 1
-            else:
+            output_text, answered, empty = resolve_translation_audit_output(
+                case.outputs_by_index,
+                local_index,
+            )
+            if not answered:
                 unanswered_subtitles += 1
+            elif empty:
+                empty_translations += 1
+            else:
+                translated_subtitles += 1
             cells = (
                 f"S {block.source_indexes[position]}\nQ {local_index}",
-                f"C {case_index}\nB {block.block_number}",
-                str(test_case.difficulty),
+                f"C {case.case_index}\nB {block.block_number}",
+                str(case.difficulty),
                 block.source_texts[position],
                 guide_text,
                 output_text,
@@ -246,9 +209,9 @@ def _audit_translation_blocks(
                 verified_marker,
             )
             all_rows.append(
-                _TranslationRow(
+                _TranslationAuditRow(
                     cells=cells,
-                    verified=test_case.verified,
+                    verified=case.verified,
                 )
             )
 
@@ -290,6 +253,26 @@ def _audit_translation_blocks(
     )
 
 
+def resolve_translation_audit_output(
+    outputs_by_index: Mapping[int, str] | None,
+    local_index: int,
+) -> tuple[str, bool, bool]:
+    """Resolve one logged translation output for audit display.
+
+    Arguments:
+        outputs_by_index: output text by query-local index, or None when unanswered
+        local_index: query-local output index
+    Returns:
+        display text, whether answered, and whether the answer is empty
+    """
+    if outputs_by_index is None:
+        return "(unanswered)", False, False
+    output_text = outputs_by_index[local_index]
+    if not output_text:
+        return "(empty)", True, True
+    return output_text, True, False
+
+
 def _format_guide_text(guide_texts: Sequence[str]) -> str:
     """Format a guided-translation block for one table cell.
 
@@ -303,63 +286,14 @@ def _format_guide_text(guide_texts: Sequence[str]) -> str:
     return "\n".join(f"G {index}: {text}" for index, text in enumerate(guide_texts, 1))
 
 
-def _get_case_key(test_case: _TranslationCase) -> _TranslationKey:
-    """Get the source and guide text key for a translation test case.
-
-    Arguments:
-        test_case: standard or guided translation test case
-    Returns:
-        source and guide text tuples
-    """
-    source_texts = tuple(subtitle.text for subtitle in test_case.query.subtitles)
-    guide_texts: tuple[str, ...] = ()
-    if isinstance(test_case, GuidedTranslationTestCase):
-        guide_texts = tuple(guide.text for guide in test_case.query.guides)
-    return source_texts, guide_texts
-
-
-def _get_guided_blocks(
-    block_pairs: Sequence[tuple[Series, Series]],
-) -> list[_TranslationBlock]:
-    """Build current guided-translation blocks with global source indexes.
-
-    Arguments:
-        block_pairs: paired source and guide workflow blocks
-    Returns:
-        current nonempty source blocks
-    """
-    blocks = []
-    source_position = 0
-    for block_number, (source_block, guide_block) in enumerate(block_pairs, 1):
-        if not source_block:
-            continue
-        source_indexes = tuple(
-            range(source_position + 1, source_position + len(source_block) + 1)
-        )
-        source_position += len(source_block)
-        blocks.append(
-            _TranslationBlock(
-                block_number=block_number,
-                guide_texts=tuple(
-                    subtitle.text_with_newline.strip() for subtitle in guide_block
-                ),
-                source_indexes=source_indexes,
-                source_texts=tuple(
-                    subtitle.text_with_newline.strip() for subtitle in source_block
-                ),
-            )
-        )
-    return blocks
-
-
 def _get_selected_block_data(
-    blocks: Sequence[_TranslationBlock],
+    blocks: Sequence[TranslationAuditBlock],
     *,
     first_index: int | None,
     last_index: int | None,
     first_block: int | None,
     last_block: int | None,
-) -> list[tuple[_TranslationBlock, list[int]]]:
+) -> list[tuple[TranslationAuditBlock, list[int]]]:
     """Select block positions and reject indistinguishable repeated blocks.
 
     Arguments:
@@ -374,7 +308,7 @@ def _get_selected_block_data(
         ScinoephileError: if selected blocks have identical logged query keys
     """
     # Select current blocks and source positions within the requested range
-    selected_block_data: list[tuple[_TranslationBlock, list[int]]] = []
+    selected_block_data: list[tuple[TranslationAuditBlock, list[int]]] = []
     for block in blocks:
         if first_block is not None and block.block_number < first_block:
             continue
@@ -390,9 +324,10 @@ def _get_selected_block_data(
             selected_block_data.append((block, selected_positions))
 
     # Reject repeated current blocks that cannot be matched uniquely to log cases
-    selected_blocks_by_key: dict[_TranslationKey, list[_TranslationBlock]] = (
-        defaultdict(list)
-    )
+    selected_blocks_by_key: dict[
+        _TranslationAuditKey,
+        list[TranslationAuditBlock],
+    ] = defaultdict(list)
     for block, _ in selected_block_data:
         selected_blocks_by_key[block.key].append(block)
     for matching_blocks in selected_blocks_by_key.values():
@@ -407,7 +342,7 @@ def _get_selected_block_data(
     return selected_block_data
 
 
-def _get_standard_blocks(source: Series) -> list[_TranslationBlock]:
+def _get_standard_blocks(source: Series) -> list[TranslationAuditBlock]:
     """Build current standard-translation blocks with global source indexes.
 
     Arguments:
@@ -423,7 +358,7 @@ def _get_standard_blocks(source: Series) -> list[_TranslationBlock]:
         )
         source_position += len(source_block)
         blocks.append(
-            _TranslationBlock(
+            TranslationAuditBlock(
                 block_number=block_number,
                 guide_texts=(),
                 source_indexes=source_indexes,
@@ -433,3 +368,35 @@ def _get_standard_blocks(source: Series) -> list[_TranslationBlock]:
             )
         )
     return blocks
+
+
+def _get_standard_cases(
+    test_cases: Sequence[TranslationTestCase],
+) -> list[TranslationAuditCase]:
+    """Adapt standard translation test cases to shared semantic data.
+
+    Arguments:
+        test_cases: concrete standard translation test cases
+    Returns:
+        semantic translation cases
+    """
+    cases = []
+    for case_index, test_case in enumerate(test_cases, 1):
+        outputs_by_index = None
+        if test_case.answer is not None:
+            outputs_by_index = {
+                output.index: output.text for output in test_case.answer.outputs
+            }
+        cases.append(
+            TranslationAuditCase(
+                case_index=case_index,
+                difficulty=test_case.difficulty,
+                key=(
+                    tuple(subtitle.text for subtitle in test_case.query.subtitles),
+                    (),
+                ),
+                outputs_by_index=outputs_by_index,
+                verified=test_case.verified,
+            )
+        )
+    return cases

--- a/scinoephile/analysis/audit/utils.py
+++ b/scinoephile/analysis/audit/utils.py
@@ -8,6 +8,7 @@ from collections.abc import Collection, Hashable, Mapping, MutableSequence, Sequ
 from enum import StrEnum
 
 from scinoephile.core.exceptions import ScinoephileError
+from scinoephile.core.pairs import get_block_pairs_by_pause
 from scinoephile.core.subtitles import Series
 
 __all__ = [
@@ -16,6 +17,7 @@ __all__ = [
     "escape_table_cell",
     "format_audit_report",
     "format_block_range",
+    "format_difficulty_filter",
     "format_index_range",
     "get_contextual_index",
     "get_selected_event_indexes",
@@ -149,6 +151,19 @@ def format_block_range(
     if last_block is None:
         return f"- block range: from {first_block}"
     return f"- block range: {first_block} through {last_block}"
+
+
+def format_difficulty_filter(difficulties: Sequence[int]) -> str:
+    """Format an exact difficulty filter for a report summary.
+
+    Arguments:
+        difficulties: selected exact difficulty levels
+    Returns:
+        formatted difficulty-filter summary
+    """
+    if not difficulties:
+        return "- difficulty filter: all"
+    return f"- difficulty filter: {', '.join(str(value) for value in difficulties)}"
 
 
 def format_index_range(
@@ -451,3 +466,63 @@ def validate_index_range(first_index: int | None, last_index: int | None):
         raise ScinoephileError("Last index must be at least 1")
     if first_index is not None and last_index is not None and first_index > last_index:
         raise ScinoephileError("First index must be less than or equal to last index")
+
+
+def _get_paired_event_block_numbers(
+    block_pairs: Sequence[tuple[Series, Series]],
+) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    """Get paired workflow block numbers for two subtitle series.
+
+    Arguments:
+        block_pairs: paired subtitle workflow blocks
+    Returns:
+        one-based paired block number for every event in each series
+    """
+    one_block_numbers: list[int] = []
+    two_block_numbers: list[int] = []
+    for block_number, (one_block, two_block) in enumerate(block_pairs, 1):
+        one_block_numbers.extend([block_number] * len(one_block))
+        two_block_numbers.extend([block_number] * len(two_block))
+    return tuple(one_block_numbers), tuple(two_block_numbers)
+
+
+def _get_validated_block_pairs_by_pause(
+    one: Series,
+    two: Series,
+    first_block: int | None,
+    last_block: int | None,
+) -> list[tuple[Series, Series]]:
+    """Get paired workflow blocks and validate a range against their count.
+
+    Arguments:
+        one: first subtitle series
+        two: second subtitle series
+        first_block: first included one-based block number
+        last_block: last included one-based block number
+    Returns:
+        paired workflow blocks
+    Raises:
+        ScinoephileError: if the requested range exceeds the available blocks
+    """
+    block_pairs = get_block_pairs_by_pause(one, two)
+    validate_block_range(first_block, last_block, len(block_pairs))
+    return block_pairs
+
+
+def _is_block_in_range(
+    block_number: int,
+    first_block: int | None,
+    last_block: int | None,
+) -> bool:
+    """Check whether a one-based block number is selected.
+
+    Arguments:
+        block_number: one-based block number
+        first_block: first included block number
+        last_block: last included block number
+    Returns:
+        whether the block is selected
+    """
+    return (first_block is None or block_number >= first_block) and (
+        last_block is None or block_number <= last_block
+    )

--- a/scinoephile/analysis/audit/utils.py
+++ b/scinoephile/analysis/audit/utils.py
@@ -6,27 +6,27 @@ from __future__ import annotations
 
 from collections.abc import Collection, Hashable, Mapping, MutableSequence, Sequence
 from enum import StrEnum
+from typing import Literal
 
 from scinoephile.core.exceptions import ScinoephileError
 from scinoephile.core.subtitles import Series
 
 __all__ = [
+    "AuditColumn",
     "AuditFilter",
     "AuditResult",
     "VerificationAuditFilter",
-    "escape_table_cell",
     "format_audit_report",
-    "format_block_range",
-    "format_index_range",
     "get_contextual_index",
     "get_selected_event_indexes",
     "get_superseded_keys",
     "is_block_in_range",
     "resolve_contextual_index",
     "validate_audit_range",
-    "validate_block_range",
-    "validate_index_range",
 ]
+
+type AuditColumn = tuple[str, Literal["left", "right", "center"]]
+"""Semantic label and alignment for one audit report column."""
 
 
 class AuditFilter(StrEnum):
@@ -65,24 +65,12 @@ class VerificationAuditFilter(StrEnum):
     """Include only rows from cases not marked as verified."""
 
 
-def escape_table_cell(value: str) -> str:
-    """Escape one Markdown table cell.
-
-    Arguments:
-        value: cell text
-    Returns:
-        escaped cell text
-    """
-    return value.replace("\\N", "\n").replace("\n", "<br>").replace("|", "\\|")
-
-
 def format_audit_report(
     *,
     title: str,
-    summary_lines: Sequence[str],
-    column_labels: Sequence[str],
-    column_separators: Sequence[str],
-    rows: Sequence[str],
+    summary_items: Sequence[str],
+    columns: Sequence[AuditColumn],
+    rows: Sequence[Sequence[str]],
     first_index: int | None = None,
     last_index: int | None = None,
     index_track_name: str | None = None,
@@ -93,10 +81,9 @@ def format_audit_report(
 
     Arguments:
         title: report title without the Markdown heading marker
-        summary_lines: report-specific Markdown summary list items
-        column_labels: audit table column labels
-        column_separators: Markdown alignment separators for the columns
-        rows: formatted Markdown table rows
+        summary_items: report-specific summary text without Markdown list markers
+        columns: audit table labels and alignments
+        rows: raw audit table cell values
         first_index: first included one-based subtitle index
         last_index: last included one-based subtitle index
         index_track_name: optional name of the indexed subtitle track
@@ -105,88 +92,66 @@ def format_audit_report(
     Returns:
         formatted Markdown audit report
     Raises:
-        ValueError: if the table labels and separators have different lengths
+        ScinoephileError: if subtitle-index and block ranges are both provided
+        ValueError: if a column alignment or table row is invalid
     """
-    if len(column_labels) != len(column_separators):
-        raise ValueError("Table labels and separators must have the same length")
+    # Validate ranges at the shared output boundary
+    validate_audit_range(first_index, last_index, first_block, last_block)
 
+    # Format and validate the table schema
+    separators_by_alignment = {
+        "left": "---",
+        "right": "---:",
+        "center": ":---:",
+    }
+    column_labels = []
+    column_separators = []
+    for label, alignment in columns:
+        separator = separators_by_alignment.get(alignment)
+        if separator is None:
+            raise ValueError(f"Unsupported table column alignment: {alignment}")
+        column_labels.append(_escape_table_cell(label))
+        column_separators.append(separator)
+
+    # Escape raw cell values and verify every row matches the schema
+    table_rows = []
+    for row_number, row in enumerate(rows, 1):
+        if len(row) != len(columns):
+            raise ValueError(
+                f"Table row {row_number} has {len(row)} cells; expected {len(columns)}"
+            )
+        table_rows.append(f"| {' | '.join(_escape_table_cell(cell) for cell in row)} |")
+
+    # Format the report heading and summary
     lines = [
         f"# {title}",
         "",
         "## Summary",
         "",
-        *summary_lines,
+        *(f"- {item}" for item in summary_items),
     ]
-    index_range = format_index_range(
+    index_range = _format_index_range(
         first_index,
         last_index,
         track_name=index_track_name,
     )
     if index_range is not None:
-        lines.append(index_range)
-    block_range = format_block_range(first_block, last_block)
+        lines.append(f"- {index_range}")
+    block_range = _format_block_range(first_block, last_block)
     if block_range is not None:
-        lines.append(block_range)
+        lines.append(f"- {block_range}")
     lines.extend(
         (
-            f"- table rows: {len(rows)}",
+            f"- table rows: {len(table_rows)}",
             "",
             "## Audit Table",
             "",
             f"| {' | '.join(column_labels)} |",
             f"|{'|'.join(column_separators)}|",
-            *rows,
+            *table_rows,
         )
     )
     return "\n".join(lines) + "\n"
-
-
-def format_block_range(
-    first_block: int | None,
-    last_block: int | None,
-) -> str | None:
-    """Format an optional block range for a report summary.
-
-    Arguments:
-        first_block: first included one-based block number
-        last_block: last included one-based block number
-    Returns:
-        formatted block-range summary, or None if the range is unbounded
-    """
-    if first_block is None and last_block is None:
-        return None
-    if first_block is None:
-        return f"- block range: through {last_block}"
-    if last_block is None:
-        return f"- block range: from {first_block}"
-    return f"- block range: {first_block} through {last_block}"
-
-
-def format_index_range(
-    first_index: int | None,
-    last_index: int | None,
-    *,
-    track_name: str | None = None,
-) -> str | None:
-    """Format an optional subtitle range for a report summary.
-
-    Arguments:
-        first_index: first included one-based subtitle index
-        last_index: last included one-based subtitle index
-        track_name: optional name of the subtitle track whose indexes are selected
-    Returns:
-        formatted range summary, or None if the range is unbounded
-    """
-    if first_index is None and last_index is None:
-        return None
-    range_name = "subtitle"
-    if track_name is not None:
-        range_name = f"{track_name} subtitle"
-    if first_index is None:
-        return f"- {range_name} range: through {last_index}"
-    if last_index is None:
-        return f"- {range_name} range: from {first_index}"
-    return f"- {range_name} range: {first_index} through {last_index}"
 
 
 def get_contextual_index(
@@ -282,15 +247,18 @@ def get_selected_event_indexes(
         ScinoephileError: if selection ranges are invalid or mixed
     """
     has_block_range = first_block is not None or last_block is not None
-    block_indexes = (
-        Series.get_block_indexes_by_pause(series) if has_block_range else None
-    )
+    block_indexes = None
+    if has_block_range:
+        block_indexes = Series.get_block_indexes_by_pause(series)
+    block_count = None
+    if block_indexes is not None:
+        block_count = len(block_indexes)
     validate_audit_range(
         first_index,
         last_index,
         first_block,
         last_block,
-        block_count=len(block_indexes) if block_indexes is not None else None,
+        block_count=block_count,
     )
 
     if not has_block_range:
@@ -411,11 +379,70 @@ def validate_audit_range(
     has_block_range = first_block is not None or last_block is not None
     if has_index_range and has_block_range:
         raise ScinoephileError("Subtitle-index and block ranges are mutually exclusive")
-    validate_index_range(first_index, last_index)
-    validate_block_range(first_block, last_block, block_count)
+    _validate_index_range(first_index, last_index)
+    _validate_block_range(first_block, last_block, block_count)
 
 
-def validate_block_range(
+def _escape_table_cell(value: str) -> str:
+    """Escape one Markdown table cell.
+
+    Arguments:
+        value: cell text
+    Returns:
+        escaped cell text
+    """
+    return value.replace("\\N", "\n").replace("\n", "<br>").replace("|", "\\|")
+
+
+def _format_block_range(
+    first_block: int | None,
+    last_block: int | None,
+) -> str | None:
+    """Format an optional block range for a report summary.
+
+    Arguments:
+        first_block: first included one-based block number
+        last_block: last included one-based block number
+    Returns:
+        formatted block-range summary, or None if the range is unbounded
+    """
+    if first_block is None and last_block is None:
+        return None
+    if first_block is None:
+        return f"block range: through {last_block}"
+    if last_block is None:
+        return f"block range: from {first_block}"
+    return f"block range: {first_block} through {last_block}"
+
+
+def _format_index_range(
+    first_index: int | None,
+    last_index: int | None,
+    *,
+    track_name: str | None = None,
+) -> str | None:
+    """Format an optional subtitle range for a report summary.
+
+    Arguments:
+        first_index: first included one-based subtitle index
+        last_index: last included one-based subtitle index
+        track_name: optional name of the subtitle track whose indexes are selected
+    Returns:
+        formatted range summary, or None if the range is unbounded
+    """
+    if first_index is None and last_index is None:
+        return None
+    range_name = "subtitle"
+    if track_name is not None:
+        range_name = f"{track_name} subtitle"
+    if first_index is None:
+        return f"{range_name} range: through {last_index}"
+    if last_index is None:
+        return f"{range_name} range: from {first_index}"
+    return f"{range_name} range: {first_index} through {last_index}"
+
+
+def _validate_block_range(
     first_block: int | None,
     last_block: int | None,
     block_count: int | None = None,
@@ -447,7 +474,7 @@ def validate_block_range(
         )
 
 
-def validate_index_range(first_index: int | None, last_index: int | None):
+def _validate_index_range(first_index: int | None, last_index: int | None):
     """Validate optional one-based index boundaries.
 
     Arguments:

--- a/scinoephile/analysis/audit/utils.py
+++ b/scinoephile/analysis/audit/utils.py
@@ -15,6 +15,7 @@ __all__ = [
     "AuditColumn",
     "AuditFilter",
     "AuditResult",
+    "ComparisonAuditFilter",
     "VerificationAuditFilter",
     "format_audit_report",
     "format_verification_marker",
@@ -54,6 +55,22 @@ class AuditResult(StrEnum):
 
     unanswered = "unanswered"
     """The logged case has no answer."""
+
+
+class ComparisonAuditFilter(StrEnum):
+    """Row filters shared by audits with final comparisons."""
+
+    all = "all"
+    """Include every eligible row."""
+
+    changes = "changes"
+    """Include rows that the audit classifies as changed."""
+
+    discrepancies = "discrepancies"
+    """Include only final discrepancies."""
+
+    unverified = "unverified"
+    """Include only rows from unverified logged cases."""
 
 
 class VerificationAuditFilter(StrEnum):

--- a/scinoephile/analysis/audit/utils.py
+++ b/scinoephile/analysis/audit/utils.py
@@ -17,6 +17,7 @@ __all__ = [
     "AuditResult",
     "VerificationAuditFilter",
     "format_audit_report",
+    "format_verification_marker",
     "get_contextual_index",
     "get_selected_event_indexes",
     "get_superseded_keys",
@@ -152,6 +153,21 @@ def format_audit_report(
         )
     )
     return "\n".join(lines) + "\n"
+
+
+def format_verification_marker(verified: bool | None) -> str:
+    """Format semantic verification state for an audit table.
+
+    Arguments:
+        verified: verification state, or None when verification is unavailable
+    Returns:
+        check mark, blank text, or em dash
+    """
+    if verified is None:
+        return "—"
+    if verified:
+        return "✓"
+    return ""
 
 
 def get_contextual_index(

--- a/scinoephile/analysis/audit/utils.py
+++ b/scinoephile/analysis/audit/utils.py
@@ -8,12 +8,12 @@ from collections.abc import Collection, Hashable, Mapping, MutableSequence, Sequ
 from enum import StrEnum
 
 from scinoephile.core.exceptions import ScinoephileError
-from scinoephile.core.pairs import get_block_pairs_by_pause
 from scinoephile.core.subtitles import Series
 
 __all__ = [
     "AuditFilter",
     "AuditResult",
+    "VerificationAuditFilter",
     "escape_table_cell",
     "format_audit_report",
     "format_block_range",
@@ -21,7 +21,6 @@ __all__ = [
     "get_contextual_index",
     "get_selected_event_indexes",
     "get_superseded_keys",
-    "get_validated_block_pairs_by_pause",
     "is_block_in_range",
     "resolve_contextual_index",
     "validate_audit_range",
@@ -54,6 +53,16 @@ class AuditResult(StrEnum):
 
     unanswered = "unanswered"
     """The logged case has no answer."""
+
+
+class VerificationAuditFilter(StrEnum):
+    """Row filters for audits whose only row state is verification."""
+
+    all = "all"
+    """Include every eligible row."""
+
+    unverified = "unverified"
+    """Include only rows from cases not marked as verified."""
 
 
 def escape_table_cell(value: str) -> str:
@@ -330,29 +339,6 @@ def get_superseded_keys[KeyT: Hashable, ValueT: Hashable](
         for key, values in values_by_key.items()
         if key not in current_keys and not current_values.isdisjoint(values)
     }
-
-
-def get_validated_block_pairs_by_pause(
-    one: Series,
-    two: Series,
-    first_block: int | None,
-    last_block: int | None,
-) -> list[tuple[Series, Series]]:
-    """Get paired workflow blocks and validate a range against their count.
-
-    Arguments:
-        one: first subtitle series
-        two: second subtitle series
-        first_block: first included one-based block number
-        last_block: last included one-based block number
-    Returns:
-        paired workflow blocks
-    Raises:
-        ScinoephileError: if the requested range exceeds the available blocks
-    """
-    block_pairs = get_block_pairs_by_pause(one, two)
-    validate_block_range(first_block, last_block, len(block_pairs))
-    return block_pairs
 
 
 def is_block_in_range(

--- a/scinoephile/analysis/audit/utils.py
+++ b/scinoephile/analysis/audit/utils.py
@@ -21,6 +21,7 @@ __all__ = [
     "get_contextual_index",
     "get_selected_event_indexes",
     "get_superseded_keys",
+    "get_validated_block_pairs_by_pause",
     "is_block_in_range",
     "resolve_contextual_index",
     "validate_audit_range",
@@ -331,6 +332,29 @@ def get_superseded_keys[KeyT: Hashable, ValueT: Hashable](
     }
 
 
+def get_validated_block_pairs_by_pause(
+    one: Series,
+    two: Series,
+    first_block: int | None,
+    last_block: int | None,
+) -> list[tuple[Series, Series]]:
+    """Get paired workflow blocks and validate a range against their count.
+
+    Arguments:
+        one: first subtitle series
+        two: second subtitle series
+        first_block: first included one-based block number
+        last_block: last included one-based block number
+    Returns:
+        paired workflow blocks
+    Raises:
+        ScinoephileError: if the requested range exceeds the available blocks
+    """
+    block_pairs = get_block_pairs_by_pause(one, two)
+    validate_block_range(first_block, last_block, len(block_pairs))
+    return block_pairs
+
+
 def is_block_in_range(
     block_number: int,
     first_block: int | None,
@@ -452,44 +476,3 @@ def validate_index_range(first_index: int | None, last_index: int | None):
         raise ScinoephileError("Last index must be at least 1")
     if first_index is not None and last_index is not None and first_index > last_index:
         raise ScinoephileError("First index must be less than or equal to last index")
-
-
-def _get_paired_event_block_numbers(
-    block_pairs: Sequence[tuple[Series, Series]],
-) -> tuple[tuple[int, ...], tuple[int, ...]]:
-    """Get paired workflow block numbers for two subtitle series.
-
-    Arguments:
-        block_pairs: paired subtitle workflow blocks
-    Returns:
-        one-based paired block number for every event in each series
-    """
-    one_block_numbers: list[int] = []
-    two_block_numbers: list[int] = []
-    for block_number, (one_block, two_block) in enumerate(block_pairs, 1):
-        one_block_numbers.extend([block_number] * len(one_block))
-        two_block_numbers.extend([block_number] * len(two_block))
-    return tuple(one_block_numbers), tuple(two_block_numbers)
-
-
-def _get_validated_block_pairs_by_pause(
-    one: Series,
-    two: Series,
-    first_block: int | None,
-    last_block: int | None,
-) -> list[tuple[Series, Series]]:
-    """Get paired workflow blocks and validate a range against their count.
-
-    Arguments:
-        one: first subtitle series
-        two: second subtitle series
-        first_block: first included one-based block number
-        last_block: last included one-based block number
-    Returns:
-        paired workflow blocks
-    Raises:
-        ScinoephileError: if the requested range exceeds the available blocks
-    """
-    block_pairs = get_block_pairs_by_pause(one, two)
-    validate_block_range(first_block, last_block, len(block_pairs))
-    return block_pairs

--- a/scinoephile/analysis/audit/utils.py
+++ b/scinoephile/analysis/audit/utils.py
@@ -17,7 +17,6 @@ __all__ = [
     "escape_table_cell",
     "format_audit_report",
     "format_block_range",
-    "format_difficulty_filter",
     "format_index_range",
     "get_contextual_index",
     "get_selected_event_indexes",
@@ -151,19 +150,6 @@ def format_block_range(
     if last_block is None:
         return f"- block range: from {first_block}"
     return f"- block range: {first_block} through {last_block}"
-
-
-def format_difficulty_filter(difficulties: Sequence[int]) -> str:
-    """Format an exact difficulty filter for a report summary.
-
-    Arguments:
-        difficulties: selected exact difficulty levels
-    Returns:
-        formatted difficulty-filter summary
-    """
-    if not difficulties:
-        return "- difficulty filter: all"
-    return f"- difficulty filter: {', '.join(str(value) for value in difficulties)}"
 
 
 def format_index_range(
@@ -507,22 +493,3 @@ def _get_validated_block_pairs_by_pause(
     block_pairs = get_block_pairs_by_pause(one, two)
     validate_block_range(first_block, last_block, len(block_pairs))
     return block_pairs
-
-
-def _is_block_in_range(
-    block_number: int,
-    first_block: int | None,
-    last_block: int | None,
-) -> bool:
-    """Check whether a one-based block number is selected.
-
-    Arguments:
-        block_number: one-based block number
-        first_block: first included block number
-        last_block: last included block number
-    Returns:
-        whether the block is selected
-    """
-    return (first_block is None or block_number >= first_block) and (
-        last_block is None or block_number <= last_block
-    )

--- a/scinoephile/analysis/audit/utils.py
+++ b/scinoephile/analysis/audit/utils.py
@@ -15,8 +15,8 @@ __all__ = [
     "AuditColumn",
     "AuditFilter",
     "AuditResult",
-    "ComparisonAuditFilter",
-    "VerificationAuditFilter",
+    "ChangeAuditFilter",
+    "ExtendedAuditFilter",
     "format_audit_report",
     "format_verification_marker",
     "get_contextual_index",
@@ -32,16 +32,13 @@ type AuditColumn = tuple[str, Literal["left", "right", "center"]]
 
 
 class AuditFilter(StrEnum):
-    """Row filters shared by audit reports without final comparisons."""
+    """Row filters for audits whose only row state is verification."""
 
     all = "all"
     """Include every eligible row."""
 
-    changes = "changes"
-    """Include only changed rows."""
-
     unverified = "unverified"
-    """Include only rows from unverified logged cases."""
+    """Include only rows from cases not marked as verified."""
 
 
 class AuditResult(StrEnum):
@@ -57,8 +54,21 @@ class AuditResult(StrEnum):
     """The logged case has no answer."""
 
 
-class ComparisonAuditFilter(StrEnum):
-    """Row filters shared by audits with final comparisons."""
+class ChangeAuditFilter(StrEnum):
+    """Row filters shared by audit reports that identify changed rows."""
+
+    all = "all"
+    """Include every eligible row."""
+
+    changes = "changes"
+    """Include only changed rows."""
+
+    unverified = "unverified"
+    """Include only rows from unverified logged cases."""
+
+
+class ExtendedAuditFilter(StrEnum):
+    """Row filters for audits that also identify final discrepancies."""
 
     all = "all"
     """Include every eligible row."""
@@ -71,16 +81,6 @@ class ComparisonAuditFilter(StrEnum):
 
     unverified = "unverified"
     """Include only rows from unverified logged cases."""
-
-
-class VerificationAuditFilter(StrEnum):
-    """Row filters for audits whose only row state is verification."""
-
-    all = "all"
-    """Include every eligible row."""
-
-    unverified = "unverified"
-    """Include only rows from cases not marked as verified."""
 
 
 def format_audit_report(

--- a/scinoephile/cli/audit/__init__.py
+++ b/scinoephile/cli/audit/__init__.py
@@ -4,7 +4,8 @@
 
 Package hierarchy (modules may import from any above):
 * audit_cli_base
-* audit_delineation_cli / audit_ocr_fusion_cli / audit_punctuation_cli / utils
+* audit_delineation_cli / audit_ocr_fusion_cli / audit_punctuation_cli
+/ audit_translation_cli / utils
 * audit_review_cli / audit_review_dual_cli
 / audit_review_trad_cli
 * audit_cli

--- a/scinoephile/cli/audit/audit_cli.py
+++ b/scinoephile/cli/audit/audit_cli.py
@@ -16,6 +16,7 @@ from .audit_punctuation_cli import AuditPunctuationCli
 from .audit_review_cli import AuditReviewCli
 from .audit_review_dual_cli import AuditReviewDualCli
 from .audit_review_trad_cli import AuditReviewTradCli
+from .audit_translation_cli import AuditTranslationCli
 
 __all__ = ["AuditCli"]
 
@@ -67,6 +68,7 @@ class AuditCli(ScinoephileCliBase):
             AuditReviewCli.name(): AuditReviewCli,
             AuditReviewDualCli.name(): AuditReviewDualCli,
             AuditReviewTradCli.name(): AuditReviewTradCli,
+            AuditTranslationCli.name(): AuditTranslationCli,
         }
 
     @classmethod

--- a/scinoephile/cli/audit/audit_cli_base.py
+++ b/scinoephile/cli/audit/audit_cli_base.py
@@ -5,10 +5,14 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
+from enum import Enum
 from pathlib import Path
 
 from scinoephile.cli.helpers.blocks import add_block_range_args
 from scinoephile.common.argument_parsing import (
+    enum_arg,
+    enum_metavar,
+    enum_options_list_str,
     get_arg_groups_by_name,
     int_arg,
     output_file_arg,
@@ -109,6 +113,44 @@ class AuditCliBase(ScinoephileCliBase):
             help="overwrite outfile if it exists",
         )
         parser.set_defaults(_parser=parser)
+
+    @staticmethod
+    def add_row_filter_argument[TFilter: Enum](
+        parser: ArgumentParser,
+        filter_type: type[TFilter],
+        default: TFilter,
+        *,
+        description: str,
+    ):
+        """Add a consistently formatted row-filter argument.
+
+        Arguments:
+            parser: parser to which the argument is added
+            filter_type: enum defining accepted filter values
+            default: default filter value
+            description: semantic description of each accepted filter
+        """
+        # Locate the shared operation group created by the audit base parser
+        arg_groups = get_arg_groups_by_name(
+            parser,
+            "input arguments",
+            "operation arguments",
+            "output arguments",
+            optional_arguments_name="additional arguments",
+        )
+
+        # Parse the filter directly to its enum while keeping help text uniform
+        arg_groups["operation arguments"].add_argument(
+            "--filter",
+            default=default,
+            dest="row_filter",
+            metavar=enum_metavar(filter_type),
+            type=enum_arg(filter_type),
+            help=(
+                f"rows to include: {enum_options_list_str(filter_type)}; "
+                f"{description} (default: %(default)s)"
+            ),
+        )
 
     @staticmethod
     def load_test_cases[TTestCase: TestCase](

--- a/scinoephile/cli/audit/audit_delineation_cli.py
+++ b/scinoephile/cli/audit/audit_delineation_cli.py
@@ -12,6 +12,8 @@ from scinoephile.analysis.audit.utils import AuditFilter
 from scinoephile.cli.helpers.io import read_series
 from scinoephile.common.argument_parsing import (
     enum_arg,
+    enum_metavar,
+    enum_options_list_str,
     get_arg_groups_by_name,
     input_file_arg,
 )
@@ -29,9 +31,9 @@ AUDIT_DELINEATION_LOCALIZATIONS: dict[str, dict[str, str]] = {
             "用于指导转写的参考字幕 SRT 文件"
         ),
         "delineation test-case JSON file": "字幕边界测试用例 JSON 文件",
-        "rows to include: all, changes, or unverified (default: all)": (
+        "rows to include: all, changes, or unverified (default: %(default)s)": (
             "要包含的行：all 表示全部，changes 表示边界调整，unverified "
-            "表示未验证（默认：all）"
+            "表示未验证（默认：%(default)s）"
         ),
     },
     "zh-hant": {
@@ -40,9 +42,9 @@ AUDIT_DELINEATION_LOCALIZATIONS: dict[str, dict[str, str]] = {
             "用於指導轉寫的參考字幕 SRT 檔"
         ),
         "delineation test-case JSON file": "字幕邊界測試案例 JSON 檔",
-        "rows to include: all, changes, or unverified (default: all)": (
+        "rows to include: all, changes, or unverified (default: %(default)s)": (
             "要包含的列：all 表示全部，changes 表示邊界調整，unverified "
-            "表示未驗證（預設：all）"
+            "表示未驗證（預設：%(default)s）"
         ),
     },
 }
@@ -90,12 +92,14 @@ class AuditDelineationCli(AuditCliBase):
         # Operation arguments
         arg_groups["operation arguments"].add_argument(
             "--filter",
-            choices=tuple(AuditFilter),
             default=AuditFilter.all,
             dest="row_filter",
-            metavar="{all,changes,unverified}",
+            metavar=enum_metavar(AuditFilter),
             type=enum_arg(AuditFilter),
-            help="rows to include: all, changes, or unverified (default: all)",
+            help=(
+                f"rows to include: {enum_options_list_str(AuditFilter)} "
+                "(default: %(default)s)"
+            ),
         )
 
     @classmethod

--- a/scinoephile/cli/audit/audit_delineation_cli.py
+++ b/scinoephile/cli/audit/audit_delineation_cli.py
@@ -8,12 +8,9 @@ from argparse import ArgumentParser
 from pathlib import Path
 
 from scinoephile.analysis.audit.delineation import audit_delineation
-from scinoephile.analysis.audit.utils import AuditFilter
+from scinoephile.analysis.audit.utils import ChangeAuditFilter
 from scinoephile.cli.helpers.io import read_series
 from scinoephile.common.argument_parsing import (
-    enum_arg,
-    enum_metavar,
-    enum_options_list_str,
     get_arg_groups_by_name,
     input_file_arg,
 )
@@ -31,9 +28,13 @@ AUDIT_DELINEATION_LOCALIZATIONS: dict[str, dict[str, str]] = {
             "用于指导转写的参考字幕 SRT 文件"
         ),
         "delineation test-case JSON file": "字幕边界测试用例 JSON 文件",
-        "rows to include: all, changes, or unverified (default: %(default)s)": (
-            "要包含的行：all 表示全部，changes 表示边界调整，unverified "
-            "表示未验证（默认：%(default)s）"
+        (
+            "rows to include: all, changes, or unverified; all includes every "
+            "decision; changes includes boundary shifts; unverified includes cases "
+            "not marked verified (default: %(default)s)"
+        ): (
+            "要包含的行：all 表示每个决策，changes 表示边界调整，unverified "
+            "表示未标记为已验证的案例（默认：%(default)s）"
         ),
     },
     "zh-hant": {
@@ -42,9 +43,13 @@ AUDIT_DELINEATION_LOCALIZATIONS: dict[str, dict[str, str]] = {
             "用於指導轉寫的參考字幕 SRT 檔"
         ),
         "delineation test-case JSON file": "字幕邊界測試案例 JSON 檔",
-        "rows to include: all, changes, or unverified (default: %(default)s)": (
-            "要包含的列：all 表示全部，changes 表示邊界調整，unverified "
-            "表示未驗證（預設：%(default)s）"
+        (
+            "rows to include: all, changes, or unverified; all includes every "
+            "decision; changes includes boundary shifts; unverified includes cases "
+            "not marked verified (default: %(default)s)"
+        ): (
+            "要包含的列：all 表示每個決策，changes 表示邊界調整，unverified "
+            "表示未標記為已驗證的案例（預設：%(default)s）"
         ),
     },
 }
@@ -90,15 +95,13 @@ class AuditDelineationCli(AuditCliBase):
         )
 
         # Operation arguments
-        arg_groups["operation arguments"].add_argument(
-            "--filter",
-            default=AuditFilter.all,
-            dest="row_filter",
-            metavar=enum_metavar(AuditFilter),
-            type=enum_arg(AuditFilter),
-            help=(
-                f"rows to include: {enum_options_list_str(AuditFilter)} "
-                "(default: %(default)s)"
+        cls.add_row_filter_argument(
+            parser,
+            ChangeAuditFilter,
+            ChangeAuditFilter.all,
+            description=(
+                "all includes every decision; changes includes boundary shifts; "
+                "unverified includes cases not marked verified"
             ),
         )
 
@@ -118,7 +121,7 @@ class AuditDelineationCli(AuditCliBase):
         _parser: ArgumentParser | None = None,
         reference_path: Path,
         json_path: Path,
-        row_filter: AuditFilter,
+        row_filter: ChangeAuditFilter,
         first_index: int | None,
         last_index: int | None,
         first_block: int | None,

--- a/scinoephile/cli/audit/audit_delineation_cli.py
+++ b/scinoephile/cli/audit/audit_delineation_cli.py
@@ -104,7 +104,11 @@ class AuditDelineationCli(AuditCliBase):
 
     @classmethod
     def name(cls) -> str:
-        """Name of this tool used to define it when it is a subparser."""
+        """Name of this tool used to define it when it is a subparser.
+
+        Returns:
+            subcommand name
+        """
         return "delineation"
 
     @classmethod
@@ -122,7 +126,20 @@ class AuditDelineationCli(AuditCliBase):
         outfile_path: Path | None,
         overwrite: bool,
     ):
-        """Execute with provided keyword arguments."""
+        """Execute with provided keyword arguments.
+
+        Arguments:
+            _parser: parser used to report user-facing errors
+            reference_path: reference subtitle SRT path
+            json_path: delineation test-case JSON path
+            row_filter: rows to include in the report
+            first_index: first reference subtitle number to include
+            last_index: last reference subtitle number to include
+            first_block: first reference block number to include
+            last_block: last reference block number to include
+            outfile_path: optional Markdown output path
+            overwrite: whether to overwrite an existing output file
+        """
         # Read inputs
         parser = _parser or cls.argparser()
         reference = read_series(parser, reference_path)

--- a/scinoephile/cli/audit/audit_ocr_fusion_cli.py
+++ b/scinoephile/cli/audit/audit_ocr_fusion_cli.py
@@ -7,10 +7,8 @@ from __future__ import annotations
 from argparse import ArgumentParser
 from pathlib import Path
 
-from scinoephile.analysis.audit.ocr_fusion import (
-    OcrFusionAuditFilter,
-    audit_ocr_fusion,
-)
+from scinoephile.analysis.audit.ocr_fusion import audit_ocr_fusion
+from scinoephile.analysis.audit.utils import ComparisonAuditFilter
 from scinoephile.cli.helpers.io import read_series
 from scinoephile.common.argument_parsing import (
     enum_arg,
@@ -144,12 +142,12 @@ class AuditOcrFusionCli(AuditCliBase):
         # Operation arguments
         arg_groups["operation arguments"].add_argument(
             "--filter",
-            default=OcrFusionAuditFilter.changes,
+            default=ComparisonAuditFilter.changes,
             dest="row_filter",
-            metavar=enum_metavar(OcrFusionAuditFilter),
-            type=enum_arg(OcrFusionAuditFilter),
+            metavar=enum_metavar(ComparisonAuditFilter),
+            type=enum_arg(ComparisonAuditFilter),
             help=(
-                f"rows to include: {enum_options_list_str(OcrFusionAuditFilter)} "
+                f"rows to include: {enum_options_list_str(ComparisonAuditFilter)} "
                 "(default: %(default)s)"
             ),
         )
@@ -173,7 +171,7 @@ class AuditOcrFusionCli(AuditCliBase):
         fused_path: Path,
         validated_path: Path | None,
         json_path: Path | None,
-        row_filter: OcrFusionAuditFilter,
+        row_filter: ComparisonAuditFilter,
         first_index: int | None,
         last_index: int | None,
         first_block: int | None,
@@ -200,7 +198,7 @@ class AuditOcrFusionCli(AuditCliBase):
         """
         # Validate arguments
         parser = _parser or cls.argparser()
-        if row_filter is OcrFusionAuditFilter.discrepancies and validated_path is None:
+        if row_filter is ComparisonAuditFilter.discrepancies and validated_path is None:
             parser.error("--filter discrepancies requires --validated")
 
         # Read inputs

--- a/scinoephile/cli/audit/audit_ocr_fusion_cli.py
+++ b/scinoephile/cli/audit/audit_ocr_fusion_cli.py
@@ -40,8 +40,9 @@ AUDIT_OCR_FUSION_LOCALIZATIONS: dict[str, dict[str, str]] = {
             "with --filter discrepancies"
         ): ("用作真值的可选已验证字幕 SRT 文件；使用 --filter discrepancies 时为必需"),
         (
-            "optional OCR-fusion test-case JSON file; required with --filter unverified"
-        ): ("可选的 OCR 融合测试用例 JSON 文件；使用 --filter unverified 时为必需"),
+            "optional OCR-fusion test-case JSON file supplying notes and "
+            "verification state"
+        ): ("提供备注和验证状态的可选 OCR 融合测试用例 JSON 文件"),
         (
             "rows to include: all, changes, discrepancies, or unverified "
             "(default: %(default)s)"
@@ -63,8 +64,9 @@ AUDIT_OCR_FUSION_LOCALIZATIONS: dict[str, dict[str, str]] = {
             "with --filter discrepancies"
         ): ("用作真值的選用已驗證字幕 SRT 檔；使用 --filter discrepancies 時為必需"),
         (
-            "optional OCR-fusion test-case JSON file; required with --filter unverified"
-        ): ("選用的 OCR 融合測試案例 JSON 檔；使用 --filter unverified 時為必需"),
+            "optional OCR-fusion test-case JSON file supplying notes and "
+            "verification state"
+        ): ("提供備註和驗證狀態的選用 OCR 融合測試案例 JSON 檔"),
         (
             "rows to include: all, changes, discrepancies, or unverified "
             "(default: %(default)s)"
@@ -134,8 +136,8 @@ class AuditOcrFusionCli(AuditCliBase):
             dest="json_path",
             type=input_file_arg(),
             help=(
-                "optional OCR-fusion test-case JSON file; required with --filter "
-                "unverified"
+                "optional OCR-fusion test-case JSON file supplying notes and "
+                "verification state"
             ),
         )
 
@@ -198,8 +200,6 @@ class AuditOcrFusionCli(AuditCliBase):
         """
         # Validate arguments
         parser = _parser or cls.argparser()
-        if row_filter is OcrFusionAuditFilter.unverified and json_path is None:
-            parser.error("--filter unverified requires --json")
         if row_filter is OcrFusionAuditFilter.discrepancies and validated_path is None:
             parser.error("--filter discrepancies requires --validated")
 

--- a/scinoephile/cli/audit/audit_ocr_fusion_cli.py
+++ b/scinoephile/cli/audit/audit_ocr_fusion_cli.py
@@ -8,12 +8,9 @@ from argparse import ArgumentParser
 from pathlib import Path
 
 from scinoephile.analysis.audit.ocr_fusion import audit_ocr_fusion
-from scinoephile.analysis.audit.utils import ComparisonAuditFilter
+from scinoephile.analysis.audit.utils import ExtendedAuditFilter
 from scinoephile.cli.helpers.io import read_series
 from scinoephile.common.argument_parsing import (
-    enum_arg,
-    enum_metavar,
-    enum_options_list_str,
     get_arg_groups_by_name,
     input_file_arg,
 )
@@ -42,11 +39,15 @@ AUDIT_OCR_FUSION_LOCALIZATIONS: dict[str, dict[str, str]] = {
             "verification state"
         ): ("提供备注和验证状态的可选 OCR 融合测试用例 JSON 文件"),
         (
-            "rows to include: all, changes, discrepancies, or unverified "
+            "rows to include: all, changes, discrepancies, or unverified; all "
+            "includes every fused subtitle; changes includes source "
+            "disagreements; discrepancies includes differences from the validated "
+            "track; unverified includes LLM decisions not marked verified "
             "(default: %(default)s)"
         ): (
-            "要包含的行：all 表示全部，changes 表示来源差异，discrepancies "
-            "表示与已验证轨道不同，unverified 表示未验证（默认：%(default)s）"
+            "要包含的行：all 表示每个融合字幕，changes 表示来源差异，"
+            "discrepancies 表示与已验证轨道不同，unverified 表示未标记为"
+            "已验证的 LLM 决策（默认：%(default)s）"
         ),
     },
     "zh-hant": {
@@ -66,11 +67,15 @@ AUDIT_OCR_FUSION_LOCALIZATIONS: dict[str, dict[str, str]] = {
             "verification state"
         ): ("提供備註和驗證狀態的選用 OCR 融合測試案例 JSON 檔"),
         (
-            "rows to include: all, changes, discrepancies, or unverified "
+            "rows to include: all, changes, discrepancies, or unverified; all "
+            "includes every fused subtitle; changes includes source "
+            "disagreements; discrepancies includes differences from the validated "
+            "track; unverified includes LLM decisions not marked verified "
             "(default: %(default)s)"
         ): (
-            "要包含的列：all 表示全部，changes 表示來源差異，discrepancies "
-            "表示與已驗證軌道不同，unverified 表示未驗證（預設：%(default)s）"
+            "要包含的列：all 表示每個融合字幕，changes 表示來源差異，"
+            "discrepancies 表示與已驗證軌道不同，unverified 表示未標記為"
+            "已驗證的 LLM 決策（預設：%(default)s）"
         ),
     },
 }
@@ -140,15 +145,15 @@ class AuditOcrFusionCli(AuditCliBase):
         )
 
         # Operation arguments
-        arg_groups["operation arguments"].add_argument(
-            "--filter",
-            default=ComparisonAuditFilter.changes,
-            dest="row_filter",
-            metavar=enum_metavar(ComparisonAuditFilter),
-            type=enum_arg(ComparisonAuditFilter),
-            help=(
-                f"rows to include: {enum_options_list_str(ComparisonAuditFilter)} "
-                "(default: %(default)s)"
+        cls.add_row_filter_argument(
+            parser,
+            ExtendedAuditFilter,
+            ExtendedAuditFilter.changes,
+            description=(
+                "all includes every fused subtitle; changes includes source "
+                "disagreements; discrepancies includes differences from the "
+                "validated track; unverified includes LLM decisions not marked "
+                "verified"
             ),
         )
 
@@ -171,7 +176,7 @@ class AuditOcrFusionCli(AuditCliBase):
         fused_path: Path,
         validated_path: Path | None,
         json_path: Path | None,
-        row_filter: ComparisonAuditFilter,
+        row_filter: ExtendedAuditFilter,
         first_index: int | None,
         last_index: int | None,
         first_block: int | None,
@@ -198,7 +203,7 @@ class AuditOcrFusionCli(AuditCliBase):
         """
         # Validate arguments
         parser = _parser or cls.argparser()
-        if row_filter is ComparisonAuditFilter.discrepancies and validated_path is None:
+        if row_filter is ExtendedAuditFilter.discrepancies and validated_path is None:
             parser.error("--filter discrepancies requires --validated")
 
         # Read inputs

--- a/scinoephile/cli/audit/audit_punctuation_cli.py
+++ b/scinoephile/cli/audit/audit_punctuation_cli.py
@@ -12,6 +12,8 @@ from scinoephile.analysis.audit.utils import AuditFilter
 from scinoephile.cli.helpers.io import read_series
 from scinoephile.common.argument_parsing import (
     enum_arg,
+    enum_metavar,
+    enum_options_list_str,
     get_arg_groups_by_name,
     input_file_arg,
 )
@@ -30,9 +32,9 @@ AUDIT_PUNCTUATION_LOCALIZATIONS: dict[str, dict[str, str]] = {
         ),
         "punctuated target subtitle SRT file": "已加标点的目标字幕 SRT 文件",
         "punctuation test-case JSON file": "字幕标点测试用例 JSON 文件",
-        "rows to include: all, changes, or unverified (default: all)": (
+        "rows to include: all, changes, or unverified (default: %(default)s)": (
             "要包含的行：all 表示全部，changes 表示标点调整，unverified "
-            "表示未验证（默认：all）"
+            "表示未验证（默认：%(default)s）"
         ),
     },
     "zh-hant": {
@@ -42,9 +44,9 @@ AUDIT_PUNCTUATION_LOCALIZATIONS: dict[str, dict[str, str]] = {
         ),
         "punctuated target subtitle SRT file": "已加標點的目標字幕 SRT 檔",
         "punctuation test-case JSON file": "字幕標點測試案例 JSON 檔",
-        "rows to include: all, changes, or unverified (default: all)": (
+        "rows to include: all, changes, or unverified (default: %(default)s)": (
             "要包含的列：all 表示全部，changes 表示標點調整，unverified "
-            "表示未驗證（預設：all）"
+            "表示未驗證（預設：%(default)s）"
         ),
     },
 }
@@ -99,12 +101,14 @@ class AuditPunctuationCli(AuditCliBase):
         # Operation arguments
         arg_groups["operation arguments"].add_argument(
             "--filter",
-            choices=tuple(AuditFilter),
             default=AuditFilter.all,
             dest="row_filter",
-            metavar="{all,changes,unverified}",
+            metavar=enum_metavar(AuditFilter),
             type=enum_arg(AuditFilter),
-            help="rows to include: all, changes, or unverified (default: all)",
+            help=(
+                f"rows to include: {enum_options_list_str(AuditFilter)} "
+                "(default: %(default)s)"
+            ),
         )
 
     @classmethod

--- a/scinoephile/cli/audit/audit_punctuation_cli.py
+++ b/scinoephile/cli/audit/audit_punctuation_cli.py
@@ -113,7 +113,11 @@ class AuditPunctuationCli(AuditCliBase):
 
     @classmethod
     def name(cls) -> str:
-        """Name of this tool used to define it when it is a subparser."""
+        """Name of this tool used to define it when it is a subparser.
+
+        Returns:
+            subcommand name
+        """
         return "punctuation"
 
     @classmethod
@@ -132,7 +136,21 @@ class AuditPunctuationCli(AuditCliBase):
         outfile_path: Path | None,
         overwrite: bool,
     ):
-        """Execute with provided keyword arguments."""
+        """Execute with provided keyword arguments.
+
+        Arguments:
+            _parser: parser used to report user-facing errors
+            reference_path: reference subtitle SRT path
+            target_path: punctuated target subtitle SRT path
+            json_path: punctuation test-case JSON path
+            row_filter: rows to include in the report
+            first_index: first reference subtitle number to include
+            last_index: last reference subtitle number to include
+            first_block: first reference block number to include
+            last_block: last reference block number to include
+            outfile_path: optional Markdown output path
+            overwrite: whether to overwrite an existing output file
+        """
         # Read inputs
         parser = _parser or cls.argparser()
         reference = read_series(parser, reference_path)

--- a/scinoephile/cli/audit/audit_punctuation_cli.py
+++ b/scinoephile/cli/audit/audit_punctuation_cli.py
@@ -8,12 +8,9 @@ from argparse import ArgumentParser
 from pathlib import Path
 
 from scinoephile.analysis.audit.punctuation import audit_punctuation
-from scinoephile.analysis.audit.utils import AuditFilter
+from scinoephile.analysis.audit.utils import ChangeAuditFilter
 from scinoephile.cli.helpers.io import read_series
 from scinoephile.common.argument_parsing import (
-    enum_arg,
-    enum_metavar,
-    enum_options_list_str,
     get_arg_groups_by_name,
     input_file_arg,
 )
@@ -32,9 +29,13 @@ AUDIT_PUNCTUATION_LOCALIZATIONS: dict[str, dict[str, str]] = {
         ),
         "punctuated target subtitle SRT file": "已加标点的目标字幕 SRT 文件",
         "punctuation test-case JSON file": "字幕标点测试用例 JSON 文件",
-        "rows to include: all, changes, or unverified (default: %(default)s)": (
-            "要包含的行：all 表示全部，changes 表示标点调整，unverified "
-            "表示未验证（默认：%(default)s）"
+        (
+            "rows to include: all, changes, or unverified; all includes every "
+            "decision; changes includes punctuation or whitespace revisions; "
+            "unverified includes cases not marked verified (default: %(default)s)"
+        ): (
+            "要包含的行：all 表示每个决策，changes 表示标点或空白调整，"
+            "unverified 表示未标记为已验证的案例（默认：%(default)s）"
         ),
     },
     "zh-hant": {
@@ -44,9 +45,13 @@ AUDIT_PUNCTUATION_LOCALIZATIONS: dict[str, dict[str, str]] = {
         ),
         "punctuated target subtitle SRT file": "已加標點的目標字幕 SRT 檔",
         "punctuation test-case JSON file": "字幕標點測試案例 JSON 檔",
-        "rows to include: all, changes, or unverified (default: %(default)s)": (
-            "要包含的列：all 表示全部，changes 表示標點調整，unverified "
-            "表示未驗證（預設：%(default)s）"
+        (
+            "rows to include: all, changes, or unverified; all includes every "
+            "decision; changes includes punctuation or whitespace revisions; "
+            "unverified includes cases not marked verified (default: %(default)s)"
+        ): (
+            "要包含的列：all 表示每個決策，changes 表示標點或空白調整，"
+            "unverified 表示未標記為已驗證的案例（預設：%(default)s）"
         ),
     },
 }
@@ -99,15 +104,13 @@ class AuditPunctuationCli(AuditCliBase):
         )
 
         # Operation arguments
-        arg_groups["operation arguments"].add_argument(
-            "--filter",
-            default=AuditFilter.all,
-            dest="row_filter",
-            metavar=enum_metavar(AuditFilter),
-            type=enum_arg(AuditFilter),
-            help=(
-                f"rows to include: {enum_options_list_str(AuditFilter)} "
-                "(default: %(default)s)"
+        cls.add_row_filter_argument(
+            parser,
+            ChangeAuditFilter,
+            ChangeAuditFilter.all,
+            description=(
+                "all includes every decision; changes includes punctuation or "
+                "whitespace revisions; unverified includes cases not marked verified"
             ),
         )
 
@@ -128,7 +131,7 @@ class AuditPunctuationCli(AuditCliBase):
         reference_path: Path,
         target_path: Path,
         json_path: Path,
-        row_filter: AuditFilter,
+        row_filter: ChangeAuditFilter,
         first_index: int | None,
         last_index: int | None,
         first_block: int | None,

--- a/scinoephile/cli/audit/audit_review_cli.py
+++ b/scinoephile/cli/audit/audit_review_cli.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from scinoephile.analysis.audit.guided_review import audit_guided_review
 from scinoephile.analysis.audit.review import (
     ReviewAuditPair,
-    audit_review_workflow,
+    audit_review,
 )
 from scinoephile.analysis.audit.utils import ChangeAuditFilter
 from scinoephile.cli.helpers.io import read_series
@@ -283,7 +283,7 @@ class AuditReviewCli(AuditCliBase):
         language = detected_languages.pop()
 
         # Perform operation
-        return audit_review_workflow(
+        return audit_review(
             reviews=(
                 ReviewAuditPair(
                     label=_LANGUAGE_LABELS[language],

--- a/scinoephile/cli/audit/audit_review_cli.py
+++ b/scinoephile/cli/audit/audit_review_cli.py
@@ -13,12 +13,9 @@ from scinoephile.analysis.audit.review import (
     ReviewAuditPair,
     audit_review_workflow,
 )
-from scinoephile.analysis.audit.utils import AuditFilter
+from scinoephile.analysis.audit.utils import ChangeAuditFilter
 from scinoephile.cli.helpers.io import read_series
 from scinoephile.common.argument_parsing import (
-    enum_arg,
-    enum_metavar,
-    enum_options_list_str,
     get_arg_groups_by_name,
     input_file_arg,
 )
@@ -44,8 +41,13 @@ AUDIT_REVIEW_LOCALIZATIONS: dict[str, dict[str, str]] = {
         "test-case JSON file; required with --guide or --filter unverified": (
             "测试用例 JSON 文件；与 --guide 或 --filter unverified 一同使用时为必需"
         ),
-        "rows to include: all, changes, or unverified (default: %(default)s)": (
-            "要包含的行：all、changes 或 unverified（默认：%(default)s）"
+        (
+            "rows to include: all, changes, or unverified; all includes every "
+            "subtitle; changes includes review edits; unverified includes subtitles "
+            "in cases not marked verified (default: %(default)s)"
+        ): (
+            "要包含的行：all 表示每个字幕，changes 表示校对更改，unverified "
+            "表示未标记为已验证的案例中的字幕（默认：%(default)s）"
         ),
         (
             "characters to match in regular-review input; values may be separated "
@@ -66,8 +68,13 @@ AUDIT_REVIEW_LOCALIZATIONS: dict[str, dict[str, str]] = {
         "test-case JSON file; required with --guide or --filter unverified": (
             "測試案例 JSON 檔；與 --guide 或 --filter unverified 一同使用時為必需"
         ),
-        "rows to include: all, changes, or unverified (default: %(default)s)": (
-            "要包含的列：all、changes 或 unverified（預設：%(default)s）"
+        (
+            "rows to include: all, changes, or unverified; all includes every "
+            "subtitle; changes includes review edits; unverified includes subtitles "
+            "in cases not marked verified (default: %(default)s)"
+        ): (
+            "要包含的列：all 表示每個字幕，changes 表示校對變更，unverified "
+            "表示未標記為已驗證的案例中的字幕（預設：%(default)s）"
         ),
         (
             "characters to match in regular-review input; values may be separated "
@@ -143,15 +150,13 @@ class AuditReviewCli(AuditCliBase):
         )
 
         # Operation arguments
-        arg_groups["operation arguments"].add_argument(
-            "--filter",
-            default=AuditFilter.changes,
-            dest="row_filter",
-            metavar=enum_metavar(AuditFilter),
-            type=enum_arg(AuditFilter),
-            help=(
-                f"rows to include: {enum_options_list_str(AuditFilter)} "
-                "(default: %(default)s)"
+        cls.add_row_filter_argument(
+            parser,
+            ChangeAuditFilter,
+            ChangeAuditFilter.changes,
+            description=(
+                "all includes every subtitle; changes includes review edits; "
+                "unverified includes subtitles in cases not marked verified"
             ),
         )
         arg_groups["operation arguments"].add_argument(
@@ -183,7 +188,7 @@ class AuditReviewCli(AuditCliBase):
         guide_path: Path,
         json_path: Path,
         *,
-        row_filter: AuditFilter,
+        row_filter: ChangeAuditFilter,
         first_index: int | None,
         last_index: int | None,
         first_block: int | None,
@@ -234,7 +239,7 @@ class AuditReviewCli(AuditCliBase):
         reviewed_path: Path,
         json_path: Path | None,
         *,
-        row_filter: AuditFilter,
+        row_filter: ChangeAuditFilter,
         characters: Sequence[str],
         first_index: int | None,
         last_index: int | None,
@@ -304,7 +309,7 @@ class AuditReviewCli(AuditCliBase):
         reviewed_path: Path | None,
         guide_path: Path | None,
         json_path: Path | None,
-        row_filter: AuditFilter,
+        row_filter: ChangeAuditFilter,
         characters: Sequence[str],
         first_index: int | None,
         last_index: int | None,
@@ -332,7 +337,7 @@ class AuditReviewCli(AuditCliBase):
         """
         # Validate arguments
         parser = _parser or cls.argparser()
-        if row_filter is AuditFilter.unverified and json_path is None:
+        if row_filter is ChangeAuditFilter.unverified and json_path is None:
             parser.error("--filter unverified requires --json")
         if guide_path is not None:
             if json_path is None:

--- a/scinoephile/cli/audit/audit_review_dual_cli.py
+++ b/scinoephile/cli/audit/audit_review_dual_cli.py
@@ -8,7 +8,7 @@ from argparse import ArgumentParser
 from collections.abc import Sequence
 from pathlib import Path
 
-from scinoephile.analysis.audit.review import audit_dual_review
+from scinoephile.analysis.audit.dual_review import audit_dual_review
 from scinoephile.analysis.audit.utils import ExtendedAuditFilter
 from scinoephile.cli.helpers.io import read_series
 from scinoephile.common.argument_parsing import (

--- a/scinoephile/cli/audit/audit_review_dual_cli.py
+++ b/scinoephile/cli/audit/audit_review_dual_cli.py
@@ -8,10 +8,8 @@ from argparse import ArgumentParser
 from collections.abc import Sequence
 from pathlib import Path
 
-from scinoephile.analysis.audit.review import (
-    ComparativeReviewAuditFilter,
-    audit_reviews,
-)
+from scinoephile.analysis.audit.review import audit_reviews
+from scinoephile.analysis.audit.utils import ComparisonAuditFilter
 from scinoephile.cli.helpers.io import read_series
 from scinoephile.common.argument_parsing import (
     enum_arg,
@@ -252,13 +250,13 @@ class AuditReviewDualCli(AuditCliBase):
         # Operation arguments
         arg_groups["operation arguments"].add_argument(
             "--filter",
-            default=ComparativeReviewAuditFilter.changes,
+            default=ComparisonAuditFilter.changes,
             dest="row_filter",
-            metavar=enum_metavar(ComparativeReviewAuditFilter),
-            type=enum_arg(ComparativeReviewAuditFilter),
+            metavar=enum_metavar(ComparisonAuditFilter),
+            type=enum_arg(ComparisonAuditFilter),
             help=(
                 "rows to include: "
-                f"{enum_options_list_str(ComparativeReviewAuditFilter)}; changes "
+                f"{enum_options_list_str(ComparisonAuditFilter)}; changes "
                 "includes any review edit or final discrepancy; discrepancies "
                 "includes final discrepancies only; unverified includes subtitles "
                 "in unverified logged cases (default: %(default)s)"
@@ -301,7 +299,7 @@ class AuditReviewDualCli(AuditCliBase):
         simplified_json_path: Path | None,
         traditional_json_path: Path | None,
         traditional_simplified_json_path: Path | None,
-        row_filter: ComparativeReviewAuditFilter,
+        row_filter: ComparisonAuditFilter,
         characters: Sequence[str],
         first_index: int | None,
         last_index: int | None,
@@ -336,7 +334,7 @@ class AuditReviewDualCli(AuditCliBase):
         """
         # Validate arguments
         parser = _parser or cls.argparser()
-        if row_filter is ComparativeReviewAuditFilter.unverified and any(
+        if row_filter is ComparisonAuditFilter.unverified and any(
             json_path is None
             for json_path in (
                 simplified_json_path,

--- a/scinoephile/cli/audit/audit_review_dual_cli.py
+++ b/scinoephile/cli/audit/audit_review_dual_cli.py
@@ -8,7 +8,7 @@ from argparse import ArgumentParser
 from collections.abc import Sequence
 from pathlib import Path
 
-from scinoephile.analysis.audit.review import audit_reviews
+from scinoephile.analysis.audit.review import audit_dual_review
 from scinoephile.analysis.audit.utils import ExtendedAuditFilter
 from scinoephile.cli.helpers.io import read_series
 from scinoephile.common.argument_parsing import (
@@ -369,7 +369,7 @@ class AuditReviewDualCli(AuditCliBase):
 
         # Perform operation
         try:
-            report = audit_reviews(
+            report = audit_dual_review(
                 simplified=simplified,
                 simplified_reviewed=simplified_reviewed,
                 traditional=traditional,

--- a/scinoephile/cli/audit/audit_review_dual_cli.py
+++ b/scinoephile/cli/audit/audit_review_dual_cli.py
@@ -9,12 +9,9 @@ from collections.abc import Sequence
 from pathlib import Path
 
 from scinoephile.analysis.audit.review import audit_reviews
-from scinoephile.analysis.audit.utils import ComparisonAuditFilter
+from scinoephile.analysis.audit.utils import ExtendedAuditFilter
 from scinoephile.cli.helpers.io import read_series
 from scinoephile.common.argument_parsing import (
-    enum_arg,
-    enum_metavar,
-    enum_options_list_str,
     get_arg_groups_by_name,
     input_file_arg,
 )
@@ -66,14 +63,14 @@ AUDIT_REVIEW_DUAL_LOCALIZATIONS: dict[str, dict[str, str]] = {
         ),
         (
             "rows to include: all, changes, discrepancies, or unverified; "
-            "changes includes any review edit or final discrepancy; discrepancies "
-            "includes final discrepancies only; unverified includes subtitles in "
-            "unverified logged cases "
-            "(default: %(default)s)"
+            "all includes every subtitle; changes includes any review edit or final "
+            "discrepancy; discrepancies includes final discrepancies only; "
+            "unverified includes subtitles in cases not marked verified (default: "
+            "%(default)s)"
         ): (
-            "要包含的行：all、changes、discrepancies 或 unverified；changes 表示"
-            "任何校对更改或最终差异；discrepancies 仅表示最终差异；unverified "
-            "表示未验证日志案例中的字幕（默认：%(default)s）"
+            "要包含的行：all 表示每个字幕，changes 表示任何校对更改或最终差异，"
+            "discrepancies 仅表示最终差异，unverified 表示未标记为已验证的案例"
+            "中的字幕（默认：%(default)s）"
         ),
         (
             "further limit rows to those containing any listed character in any "
@@ -127,14 +124,14 @@ AUDIT_REVIEW_DUAL_LOCALIZATIONS: dict[str, dict[str, str]] = {
         ),
         (
             "rows to include: all, changes, discrepancies, or unverified; "
-            "changes includes any review edit or final discrepancy; discrepancies "
-            "includes final discrepancies only; unverified includes subtitles in "
-            "unverified logged cases "
-            "(default: %(default)s)"
+            "all includes every subtitle; changes includes any review edit or final "
+            "discrepancy; discrepancies includes final discrepancies only; "
+            "unverified includes subtitles in cases not marked verified (default: "
+            "%(default)s)"
         ): (
-            "要包含的列：all、changes、discrepancies 或 unverified；changes 表示"
-            "任何校對變更或最終差異；discrepancies 僅表示最終差異；unverified "
-            "表示未驗證日誌案例中的字幕（預設：%(default)s）"
+            "要包含的列：all 表示每個字幕，changes 表示任何校對變更或最終差異，"
+            "discrepancies 僅表示最終差異，unverified 表示未標記為已驗證的案例"
+            "中的字幕（預設：%(default)s）"
         ),
         (
             "further limit rows to those containing any listed character in any "
@@ -248,18 +245,14 @@ class AuditReviewDualCli(AuditCliBase):
         )
 
         # Operation arguments
-        arg_groups["operation arguments"].add_argument(
-            "--filter",
-            default=ComparisonAuditFilter.changes,
-            dest="row_filter",
-            metavar=enum_metavar(ComparisonAuditFilter),
-            type=enum_arg(ComparisonAuditFilter),
-            help=(
-                "rows to include: "
-                f"{enum_options_list_str(ComparisonAuditFilter)}; changes "
-                "includes any review edit or final discrepancy; discrepancies "
-                "includes final discrepancies only; unverified includes subtitles "
-                "in unverified logged cases (default: %(default)s)"
+        cls.add_row_filter_argument(
+            parser,
+            ExtendedAuditFilter,
+            ExtendedAuditFilter.changes,
+            description=(
+                "all includes every subtitle; changes includes any review edit or "
+                "final discrepancy; discrepancies includes final discrepancies only; "
+                "unverified includes subtitles in cases not marked verified"
             ),
         )
         arg_groups["operation arguments"].add_argument(
@@ -299,7 +292,7 @@ class AuditReviewDualCli(AuditCliBase):
         simplified_json_path: Path | None,
         traditional_json_path: Path | None,
         traditional_simplified_json_path: Path | None,
-        row_filter: ComparisonAuditFilter,
+        row_filter: ExtendedAuditFilter,
         characters: Sequence[str],
         first_index: int | None,
         last_index: int | None,
@@ -334,7 +327,7 @@ class AuditReviewDualCli(AuditCliBase):
         """
         # Validate arguments
         parser = _parser or cls.argparser()
-        if row_filter is ComparisonAuditFilter.unverified and any(
+        if row_filter is ExtendedAuditFilter.unverified and any(
             json_path is None
             for json_path in (
                 simplified_json_path,

--- a/scinoephile/cli/audit/audit_review_trad_cli.py
+++ b/scinoephile/cli/audit/audit_review_trad_cli.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from scinoephile.analysis.audit.review import (
     ReviewAuditPair,
-    audit_review_workflow,
+    audit_review,
 )
 from scinoephile.analysis.audit.utils import ChangeAuditFilter
 from scinoephile.cli.helpers.io import read_series
@@ -276,7 +276,7 @@ class AuditReviewTradCli(AuditCliBase):
 
         # Perform operation
         try:
-            report = audit_review_workflow(
+            report = audit_review(
                 reviews=(
                     ReviewAuditPair(
                         label="Traditional",

--- a/scinoephile/cli/audit/audit_review_trad_cli.py
+++ b/scinoephile/cli/audit/audit_review_trad_cli.py
@@ -12,12 +12,9 @@ from scinoephile.analysis.audit.review import (
     ReviewAuditPair,
     audit_review_workflow,
 )
-from scinoephile.analysis.audit.utils import AuditFilter
+from scinoephile.analysis.audit.utils import ChangeAuditFilter
 from scinoephile.cli.helpers.io import read_series
 from scinoephile.common.argument_parsing import (
-    enum_arg,
-    enum_metavar,
-    enum_options_list_str,
     get_arg_groups_by_name,
     input_file_arg,
 )
@@ -52,9 +49,13 @@ AUDIT_TRADITIONAL_SIMPLIFICATION_LOCALIZATIONS: dict[str, dict[str, str]] = {
         ): (
             "繁体字简化校对的可选测试用例 JSON 文件；使用 --filter unverified 时为必需"
         ),
-        "rows to include: all, changes, or unverified (default: %(default)s)": (
-            "要包含的行：all 表示全部，changes 表示校对更改，unverified 表示"
-            "未验证日志案例中的字幕（默认：%(default)s）"
+        (
+            "rows to include: all, changes, or unverified; all includes every "
+            "subtitle; changes includes review edits; unverified includes subtitles "
+            "in cases not marked verified (default: %(default)s)"
+        ): (
+            "要包含的行：all 表示每个字幕，changes 表示校对更改，unverified "
+            "表示未标记为已验证的案例中的字幕（默认：%(default)s）"
         ),
         (
             "further limit rows to those containing any listed character in any "
@@ -86,9 +87,13 @@ AUDIT_TRADITIONAL_SIMPLIFICATION_LOCALIZATIONS: dict[str, dict[str, str]] = {
             "optional test-case JSON file for the traditional simplification "
             "review; required with --filter unverified"
         ): ("繁體字簡化校對的選用測試案例 JSON 檔；使用 --filter unverified 時為必需"),
-        "rows to include: all, changes, or unverified (default: %(default)s)": (
-            "要包含的列：all 表示全部，changes 表示校對變更，unverified 表示"
-            "未驗證日誌案例中的字幕（預設：%(default)s）"
+        (
+            "rows to include: all, changes, or unverified; all includes every "
+            "subtitle; changes includes review edits; unverified includes subtitles "
+            "in cases not marked verified (default: %(default)s)"
+        ): (
+            "要包含的列：all 表示每個字幕，changes 表示校對變更，unverified "
+            "表示未標記為已驗證的案例中的字幕（預設：%(default)s）"
         ),
         (
             "further limit rows to those containing any listed character in any "
@@ -174,15 +179,13 @@ class AuditReviewTradCli(AuditCliBase):
         )
 
         # Operation arguments
-        arg_groups["operation arguments"].add_argument(
-            "--filter",
-            default=AuditFilter.changes,
-            dest="row_filter",
-            metavar=enum_metavar(AuditFilter),
-            type=enum_arg(AuditFilter),
-            help=(
-                f"rows to include: {enum_options_list_str(AuditFilter)} "
-                "(default: %(default)s)"
+        cls.add_row_filter_argument(
+            parser,
+            ChangeAuditFilter,
+            ChangeAuditFilter.changes,
+            description=(
+                "all includes every subtitle; changes includes review edits; "
+                "unverified includes subtitles in cases not marked verified"
             ),
         )
         arg_groups["operation arguments"].add_argument(
@@ -218,7 +221,7 @@ class AuditReviewTradCli(AuditCliBase):
         traditional_simplified_reviewed_path: Path,
         traditional_json_path: Path | None,
         traditional_simplified_json_path: Path | None,
-        row_filter: AuditFilter,
+        row_filter: ChangeAuditFilter,
         characters: Sequence[str],
         first_index: int | None,
         last_index: int | None,
@@ -250,7 +253,7 @@ class AuditReviewTradCli(AuditCliBase):
         """
         # Validate arguments
         parser = _parser or cls.argparser()
-        if row_filter is AuditFilter.unverified and (
+        if row_filter is ChangeAuditFilter.unverified and (
             traditional_json_path is None or traditional_simplified_json_path is None
         ):
             parser.error(

--- a/scinoephile/cli/audit/audit_translation_cli.py
+++ b/scinoephile/cli/audit/audit_translation_cli.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
-from collections.abc import Sequence
 from enum import StrEnum
 from pathlib import Path
 
@@ -23,7 +22,6 @@ from scinoephile.common.argument_parsing import (
     enum_arg,
     get_arg_groups_by_name,
     input_file_arg,
-    int_arg,
 )
 from scinoephile.core.exceptions import ScinoephileError
 from scinoephile.llms.gap_translation import GapTranslationManager
@@ -58,9 +56,6 @@ AUDIT_TRANSLATION_LOCALIZATIONS: dict[str, dict[str, str]] = {
         "rows to include: all or unverified (default: all)": (
             "要包含的行：all 表示全部，unverified 表示未验证（默认：all）"
         ),
-        "exact case difficulty levels to include (default: all)": (
-            "要包含的指定测试用例难度级别（默认：all）"
-        ),
     },
     "zh-hant": {
         "audit standard, gapped, or guided subtitle translations": (
@@ -84,9 +79,6 @@ AUDIT_TRANSLATION_LOCALIZATIONS: dict[str, dict[str, str]] = {
         ),
         "rows to include: all or unverified (default: all)": (
             "要包含的列：all 表示全部，unverified 表示未驗證（預設：all）"
-        ),
-        "exact case difficulty levels to include (default: all)": (
-            "要包含的指定測試案例難度級別（預設：all）"
         ),
     },
 }
@@ -124,6 +116,8 @@ class AuditTranslationCli(AuditCliBase):
             "operation arguments",
             optional_arguments_name="additional arguments",
         )
+
+        # Input arguments
         arg_groups["input arguments"].add_argument(
             "--source",
             dest="source_path",
@@ -149,6 +143,8 @@ class AuditTranslationCli(AuditCliBase):
             type=input_file_arg(),
             help="translation test-case JSON file for the selected workflow",
         )
+
+        # Operation arguments
         arg_groups["operation arguments"].add_argument(
             "--mode",
             choices=tuple(_TranslationAuditMode),
@@ -168,19 +164,14 @@ class AuditTranslationCli(AuditCliBase):
             type=enum_arg(TranslationAuditFilter),
             help="rows to include: all or unverified (default: all)",
         )
-        arg_groups["operation arguments"].add_argument(
-            "--difficulty",
-            default=(),
-            dest="difficulties",
-            metavar="LEVEL",
-            nargs="+",
-            type=int_arg(min_value=0),
-            help="exact case difficulty levels to include (default: all)",
-        )
 
     @classmethod
     def name(cls) -> str:
-        """Name of this tool used to define it when it is a subparser."""
+        """Name of this tool used to define it when it is a subparser.
+
+        Returns:
+            subcommand name
+        """
         return "translation"
 
     @classmethod
@@ -191,14 +182,28 @@ class AuditTranslationCli(AuditCliBase):
         guide_path: Path,
         json_path: Path,
         *,
-        difficulties: Sequence[int],
         row_filter: TranslationAuditFilter,
         first_index: int | None,
         last_index: int | None,
         first_block: int | None,
         last_block: int | None,
     ) -> str:
-        """Load and audit one gapped-translation workflow."""
+        """Load and audit one gapped-translation workflow.
+
+        Arguments:
+            parser: parser used to report user-facing errors
+            target_path: gapped target subtitle SRT path
+            guide_path: complete guide subtitle SRT path
+            json_path: gap-translation test-case JSON path
+            row_filter: rows to include in the report
+            first_index: first guide subtitle number to include
+            last_index: last guide subtitle number to include
+            first_block: first paired block number to include
+            last_block: last paired block number to include
+        Returns:
+            Markdown audit report
+        """
+        # Read inputs
         target = read_series(parser, target_path)
         guide = read_series(parser, guide_path)
         test_cases = cls.load_test_cases(
@@ -207,11 +212,12 @@ class AuditTranslationCli(AuditCliBase):
             GapTranslationManager,
             workflow_name="gapped translation",
         )
+
+        # Perform operation
         return audit_gap_translation(
             target,
             guide,
             test_cases,
-            difficulties=difficulties,
             row_filter=GapTranslationAuditFilter(row_filter.value),
             first_index=first_index,
             last_index=last_index,
@@ -227,14 +233,28 @@ class AuditTranslationCli(AuditCliBase):
         guide_path: Path,
         json_path: Path,
         *,
-        difficulties: Sequence[int],
         row_filter: TranslationAuditFilter,
         first_index: int | None,
         last_index: int | None,
         first_block: int | None,
         last_block: int | None,
     ) -> str:
-        """Load and audit one guided-translation workflow."""
+        """Load and audit one guided-translation workflow.
+
+        Arguments:
+            parser: parser used to report user-facing errors
+            source_path: source subtitle SRT path
+            guide_path: target-language guide subtitle SRT path
+            json_path: guided-translation test-case JSON path
+            row_filter: rows to include in the report
+            first_index: first source subtitle number to include
+            last_index: last source subtitle number to include
+            first_block: first paired block number to include
+            last_block: last paired block number to include
+        Returns:
+            Markdown audit report
+        """
+        # Read inputs
         source = read_series(parser, source_path)
         guide = read_series(parser, guide_path)
         test_cases = cls.load_test_cases(
@@ -243,11 +263,12 @@ class AuditTranslationCli(AuditCliBase):
             GuidedTranslationManager,
             workflow_name="guided translation",
         )
+
+        # Perform operation
         return audit_guided_translation(
             source,
             guide,
             test_cases,
-            difficulties=difficulties,
             row_filter=row_filter,
             first_index=first_index,
             last_index=last_index,
@@ -262,14 +283,27 @@ class AuditTranslationCli(AuditCliBase):
         source_path: Path,
         json_path: Path,
         *,
-        difficulties: Sequence[int],
         row_filter: TranslationAuditFilter,
         first_index: int | None,
         last_index: int | None,
         first_block: int | None,
         last_block: int | None,
     ) -> str:
-        """Load and audit one standard-translation workflow."""
+        """Load and audit one standard-translation workflow.
+
+        Arguments:
+            parser: parser used to report user-facing errors
+            source_path: source subtitle SRT path
+            json_path: translation test-case JSON path
+            row_filter: rows to include in the report
+            first_index: first source subtitle number to include
+            last_index: last source subtitle number to include
+            first_block: first source block number to include
+            last_block: last source block number to include
+        Returns:
+            Markdown audit report
+        """
+        # Read inputs
         source = read_series(parser, source_path)
         test_cases = cls.load_test_cases(
             parser,
@@ -277,10 +311,11 @@ class AuditTranslationCli(AuditCliBase):
             TranslationManager,
             workflow_name="standard translation",
         )
+
+        # Perform operation
         return audit_translation(
             source,
             test_cases,
-            difficulties=difficulties,
             row_filter=row_filter,
             first_index=first_index,
             last_index=last_index,
@@ -298,7 +333,6 @@ class AuditTranslationCli(AuditCliBase):
         guide_path: Path | None,
         json_path: Path,
         mode: _TranslationAuditMode,
-        difficulties: Sequence[int],
         row_filter: TranslationAuditFilter,
         first_index: int | None,
         last_index: int | None,
@@ -307,7 +341,24 @@ class AuditTranslationCli(AuditCliBase):
         outfile_path: Path | None,
         overwrite: bool,
     ):
-        """Execute with provided keyword arguments."""
+        """Execute with provided keyword arguments.
+
+        Arguments:
+            _parser: parser used to report user-facing errors
+            source_path: optional source subtitle SRT path
+            target_path: optional gapped target subtitle SRT path
+            guide_path: optional guide subtitle SRT path
+            json_path: translation test-case JSON path
+            mode: translation workflow to audit
+            row_filter: rows to include in the report
+            first_index: first workflow subtitle number to include
+            last_index: last workflow subtitle number to include
+            first_block: first workflow block number to include
+            last_block: last workflow block number to include
+            outfile_path: optional Markdown output path
+            overwrite: whether to overwrite an existing output file
+        """
+        # Validate arguments
         parser = _parser or cls.argparser()
         cls._validate_mode_inputs(
             parser,
@@ -317,6 +368,7 @@ class AuditTranslationCli(AuditCliBase):
             guide_path=guide_path,
         )
 
+        # Perform operation
         try:
             if mode is _TranslationAuditMode.standard:
                 assert source_path is not None
@@ -324,7 +376,6 @@ class AuditTranslationCli(AuditCliBase):
                     parser,
                     source_path,
                     json_path,
-                    difficulties=difficulties,
                     row_filter=row_filter,
                     first_index=first_index,
                     last_index=last_index,
@@ -338,7 +389,6 @@ class AuditTranslationCli(AuditCliBase):
                     target_path,
                     guide_path,
                     json_path,
-                    difficulties=difficulties,
                     row_filter=row_filter,
                     first_index=first_index,
                     last_index=last_index,
@@ -352,7 +402,6 @@ class AuditTranslationCli(AuditCliBase):
                     source_path,
                     guide_path,
                     json_path,
-                    difficulties=difficulties,
                     row_filter=row_filter,
                     first_index=first_index,
                     last_index=last_index,
@@ -361,6 +410,8 @@ class AuditTranslationCli(AuditCliBase):
                 )
         except ScinoephileError as exc:
             parser.error(str(exc))
+
+        # Write output
         cls.write_report(parser, report, outfile_path, overwrite)
 
     @staticmethod
@@ -372,7 +423,16 @@ class AuditTranslationCli(AuditCliBase):
         target_path: Path | None,
         guide_path: Path | None,
     ):
-        """Validate mode-specific translation input paths."""
+        """Validate mode-specific translation input paths.
+
+        Arguments:
+            parser: parser used to report user-facing errors
+            mode: translation workflow to audit
+            source_path: optional source subtitle SRT path
+            target_path: optional gapped target subtitle SRT path
+            guide_path: optional guide subtitle SRT path
+        """
+        # Validate required inputs
         required = {
             _TranslationAuditMode.standard: ((source_path, "--source"),),
             _TranslationAuditMode.gapped: (
@@ -388,6 +448,7 @@ class AuditTranslationCli(AuditCliBase):
             if path is None:
                 parser.error(f"{option} is required in {mode.value} mode")
 
+        # Validate unsupported inputs
         unsupported = {
             _TranslationAuditMode.standard: (
                 (target_path, "--target"),

--- a/scinoephile/cli/audit/audit_translation_cli.py
+++ b/scinoephile/cli/audit/audit_translation_cli.py
@@ -8,10 +8,8 @@ from argparse import ArgumentParser
 from pathlib import Path
 
 from scinoephile.analysis.audit.gap_translation import audit_gap_translation
-from scinoephile.analysis.audit.translation import (
-    audit_guided_translation,
-    audit_translation,
-)
+from scinoephile.analysis.audit.guided_translation import audit_guided_translation
+from scinoephile.analysis.audit.translation import audit_translation
 from scinoephile.analysis.audit.utils import VerificationAuditFilter
 from scinoephile.cli.helpers.io import read_series
 from scinoephile.common.argument_parsing import (

--- a/scinoephile/cli/audit/audit_translation_cli.py
+++ b/scinoephile/cli/audit/audit_translation_cli.py
@@ -10,12 +10,9 @@ from pathlib import Path
 from scinoephile.analysis.audit.gap_translation import audit_gap_translation
 from scinoephile.analysis.audit.guided_translation import audit_guided_translation
 from scinoephile.analysis.audit.translation import audit_translation
-from scinoephile.analysis.audit.utils import VerificationAuditFilter
+from scinoephile.analysis.audit.utils import AuditFilter
 from scinoephile.cli.helpers.io import read_series
 from scinoephile.common.argument_parsing import (
-    enum_arg,
-    enum_metavar,
-    enum_options_list_str,
     get_arg_groups_by_name,
     input_file_arg,
 )
@@ -45,8 +42,12 @@ AUDIT_TRANSLATION_LOCALIZATIONS: dict[str, dict[str, str]] = {
         "translation test-case JSON file for the selected workflow": (
             "所选工作流的翻译测试用例 JSON 文件"
         ),
-        "rows to include: all or unverified (default: %(default)s)": (
-            "要包含的行：all 表示全部，unverified 表示未验证（默认：%(default)s）"
+        (
+            "rows to include: all or unverified; all includes every translation; "
+            "unverified includes cases not marked verified (default: %(default)s)"
+        ): (
+            "要包含的行：all 表示每个翻译，unverified 表示未标记为已验证的案例"
+            "（默认：%(default)s）"
         ),
     },
     "zh-hant": {
@@ -65,8 +66,12 @@ AUDIT_TRANSLATION_LOCALIZATIONS: dict[str, dict[str, str]] = {
         "translation test-case JSON file for the selected workflow": (
             "所選工作流程的翻譯測試案例 JSON 檔"
         ),
-        "rows to include: all or unverified (default: %(default)s)": (
-            "要包含的列：all 表示全部，unverified 表示未驗證（預設：%(default)s）"
+        (
+            "rows to include: all or unverified; all includes every translation; "
+            "unverified includes cases not marked verified (default: %(default)s)"
+        ): (
+            "要包含的列：all 表示每個翻譯，unverified 表示未標記為已驗證的案例"
+            "（預設：%(default)s）"
         ),
     },
 }
@@ -125,15 +130,13 @@ class AuditTranslationCli(AuditCliBase):
         )
 
         # Operation arguments
-        arg_groups["operation arguments"].add_argument(
-            "--filter",
-            default=VerificationAuditFilter.all,
-            dest="row_filter",
-            metavar=enum_metavar(VerificationAuditFilter),
-            type=enum_arg(VerificationAuditFilter),
-            help=(
-                f"rows to include: {enum_options_list_str(VerificationAuditFilter)} "
-                "(default: %(default)s)"
+        cls.add_row_filter_argument(
+            parser,
+            AuditFilter,
+            AuditFilter.all,
+            description=(
+                "all includes every translation; unverified includes cases not "
+                "marked verified"
             ),
         )
 
@@ -154,7 +157,7 @@ class AuditTranslationCli(AuditCliBase):
         guide_path: Path,
         json_path: Path,
         *,
-        row_filter: VerificationAuditFilter,
+        row_filter: AuditFilter,
         first_index: int | None,
         last_index: int | None,
         first_block: int | None,
@@ -205,7 +208,7 @@ class AuditTranslationCli(AuditCliBase):
         guide_path: Path,
         json_path: Path,
         *,
-        row_filter: VerificationAuditFilter,
+        row_filter: AuditFilter,
         first_index: int | None,
         last_index: int | None,
         first_block: int | None,
@@ -255,7 +258,7 @@ class AuditTranslationCli(AuditCliBase):
         source_path: Path,
         json_path: Path,
         *,
-        row_filter: VerificationAuditFilter,
+        row_filter: AuditFilter,
         first_index: int | None,
         last_index: int | None,
         first_block: int | None,
@@ -304,7 +307,7 @@ class AuditTranslationCli(AuditCliBase):
         target_path: Path | None,
         guide_path: Path | None,
         json_path: Path,
-        row_filter: VerificationAuditFilter,
+        row_filter: AuditFilter,
         first_index: int | None,
         last_index: int | None,
         first_block: int | None,

--- a/scinoephile/cli/audit/audit_translation_cli.py
+++ b/scinoephile/cli/audit/audit_translation_cli.py
@@ -7,18 +7,17 @@ from __future__ import annotations
 from argparse import ArgumentParser
 from pathlib import Path
 
-from scinoephile.analysis.audit.gap_translation import (
-    GapTranslationAuditFilter,
-    audit_gap_translation,
-)
+from scinoephile.analysis.audit.gap_translation import audit_gap_translation
 from scinoephile.analysis.audit.translation import (
-    TranslationAuditFilter,
     audit_guided_translation,
     audit_translation,
 )
+from scinoephile.analysis.audit.utils import VerificationAuditFilter
 from scinoephile.cli.helpers.io import read_series
 from scinoephile.common.argument_parsing import (
     enum_arg,
+    enum_metavar,
+    enum_options_list_str,
     get_arg_groups_by_name,
     input_file_arg,
 )
@@ -48,8 +47,8 @@ AUDIT_TRANSLATION_LOCALIZATIONS: dict[str, dict[str, str]] = {
         "translation test-case JSON file for the selected workflow": (
             "所选工作流的翻译测试用例 JSON 文件"
         ),
-        "rows to include: all or unverified (default: all)": (
-            "要包含的行：all 表示全部，unverified 表示未验证（默认：all）"
+        "rows to include: all or unverified (default: %(default)s)": (
+            "要包含的行：all 表示全部，unverified 表示未验证（默认：%(default)s）"
         ),
     },
     "zh-hant": {
@@ -68,8 +67,8 @@ AUDIT_TRANSLATION_LOCALIZATIONS: dict[str, dict[str, str]] = {
         "translation test-case JSON file for the selected workflow": (
             "所選工作流程的翻譯測試案例 JSON 檔"
         ),
-        "rows to include: all or unverified (default: all)": (
-            "要包含的列：all 表示全部，unverified 表示未驗證（預設：all）"
+        "rows to include: all or unverified (default: %(default)s)": (
+            "要包含的列：all 表示全部，unverified 表示未驗證（預設：%(default)s）"
         ),
     },
 }
@@ -130,12 +129,14 @@ class AuditTranslationCli(AuditCliBase):
         # Operation arguments
         arg_groups["operation arguments"].add_argument(
             "--filter",
-            choices=tuple(TranslationAuditFilter),
-            default=TranslationAuditFilter.all,
+            default=VerificationAuditFilter.all,
             dest="row_filter",
-            metavar="{all,unverified}",
-            type=enum_arg(TranslationAuditFilter),
-            help="rows to include: all or unverified (default: all)",
+            metavar=enum_metavar(VerificationAuditFilter),
+            type=enum_arg(VerificationAuditFilter),
+            help=(
+                f"rows to include: {enum_options_list_str(VerificationAuditFilter)} "
+                "(default: %(default)s)"
+            ),
         )
 
     @classmethod
@@ -155,7 +156,7 @@ class AuditTranslationCli(AuditCliBase):
         guide_path: Path,
         json_path: Path,
         *,
-        row_filter: TranslationAuditFilter,
+        row_filter: VerificationAuditFilter,
         first_index: int | None,
         last_index: int | None,
         first_block: int | None,
@@ -191,7 +192,7 @@ class AuditTranslationCli(AuditCliBase):
             target,
             guide,
             test_cases,
-            row_filter=GapTranslationAuditFilter(row_filter.value),
+            row_filter=row_filter,
             first_index=first_index,
             last_index=last_index,
             first_block=first_block,
@@ -206,7 +207,7 @@ class AuditTranslationCli(AuditCliBase):
         guide_path: Path,
         json_path: Path,
         *,
-        row_filter: TranslationAuditFilter,
+        row_filter: VerificationAuditFilter,
         first_index: int | None,
         last_index: int | None,
         first_block: int | None,
@@ -256,7 +257,7 @@ class AuditTranslationCli(AuditCliBase):
         source_path: Path,
         json_path: Path,
         *,
-        row_filter: TranslationAuditFilter,
+        row_filter: VerificationAuditFilter,
         first_index: int | None,
         last_index: int | None,
         first_block: int | None,
@@ -305,7 +306,7 @@ class AuditTranslationCli(AuditCliBase):
         target_path: Path | None,
         guide_path: Path | None,
         json_path: Path,
-        row_filter: TranslationAuditFilter,
+        row_filter: VerificationAuditFilter,
         first_index: int | None,
         last_index: int | None,
         first_block: int | None,
@@ -331,10 +332,6 @@ class AuditTranslationCli(AuditCliBase):
         """
         # Validate arguments
         parser = _parser or cls.argparser()
-        if source_path is None and target_path is None:
-            parser.error("one of --source or --target is required")
-        if source_path is not None and target_path is not None:
-            parser.error("--source and --target are mutually exclusive")
         if target_path is not None and guide_path is None:
             parser.error("--guide is required with --target")
 

--- a/scinoephile/cli/audit/audit_translation_cli.py
+++ b/scinoephile/cli/audit/audit_translation_cli.py
@@ -1,0 +1,405 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Command-line interface for standard, gapped, and guided translation audits."""
+
+from __future__ import annotations
+
+from argparse import ArgumentParser
+from collections.abc import Sequence
+from enum import StrEnum
+from pathlib import Path
+
+from scinoephile.analysis.audit.gap_translation import (
+    GapTranslationAuditFilter,
+    audit_gap_translation,
+)
+from scinoephile.analysis.audit.translation import (
+    TranslationAuditFilter,
+    audit_guided_translation,
+    audit_translation,
+)
+from scinoephile.cli.helpers.io import read_series
+from scinoephile.common.argument_parsing import (
+    enum_arg,
+    get_arg_groups_by_name,
+    input_file_arg,
+    int_arg,
+)
+from scinoephile.core.exceptions import ScinoephileError
+from scinoephile.llms.gap_translation import GapTranslationManager
+from scinoephile.llms.guided_translation import GuidedTranslationManager
+from scinoephile.llms.translation import TranslationManager
+
+from .audit_cli_base import AuditCliBase
+
+__all__ = ["AuditTranslationCli"]
+
+AUDIT_TRANSLATION_LOCALIZATIONS: dict[str, dict[str, str]] = {
+    "zh-hans": {
+        "audit standard, gapped, or guided subtitle translations": (
+            "审核标准、缺口或引导式字幕翻译"
+        ),
+        (
+            "translation workflow to audit: standard, gapped, or guided "
+            "(default: standard)"
+        ): ("要审核的翻译工作流：standard、gapped 或 guided（默认：standard）"),
+        "source subtitle SRT file used for standard or guided translation": (
+            "用于标准或引导式翻译的源字幕 SRT 文件"
+        ),
+        "gapped target subtitle SRT file used for gapped translation": (
+            "用于缺口翻译的含缺失项目标字幕 SRT 文件"
+        ),
+        "guide subtitle SRT file used for gapped or guided translation": (
+            "用于缺口或引导式翻译的参考字幕 SRT 文件"
+        ),
+        "translation test-case JSON file for the selected workflow": (
+            "所选工作流的翻译测试用例 JSON 文件"
+        ),
+        "rows to include: all or unverified (default: all)": (
+            "要包含的行：all 表示全部，unverified 表示未验证（默认：all）"
+        ),
+        "exact case difficulty levels to include (default: all)": (
+            "要包含的指定测试用例难度级别（默认：all）"
+        ),
+    },
+    "zh-hant": {
+        "audit standard, gapped, or guided subtitle translations": (
+            "稽核標準、缺口或引導式字幕翻譯"
+        ),
+        (
+            "translation workflow to audit: standard, gapped, or guided "
+            "(default: standard)"
+        ): ("要稽核的翻譯工作流程：standard、gapped 或 guided（預設：standard）"),
+        "source subtitle SRT file used for standard or guided translation": (
+            "用於標準或引導式翻譯的來源字幕 SRT 檔"
+        ),
+        "gapped target subtitle SRT file used for gapped translation": (
+            "用於缺口翻譯的含缺失項目標字幕 SRT 檔"
+        ),
+        "guide subtitle SRT file used for gapped or guided translation": (
+            "用於缺口或引導式翻譯的參考字幕 SRT 檔"
+        ),
+        "translation test-case JSON file for the selected workflow": (
+            "所選工作流程的翻譯測試案例 JSON 檔"
+        ),
+        "rows to include: all or unverified (default: all)": (
+            "要包含的列：all 表示全部，unverified 表示未驗證（預設：all）"
+        ),
+        "exact case difficulty levels to include (default: all)": (
+            "要包含的指定測試案例難度級別（預設：all）"
+        ),
+    },
+}
+"""Localized help text keyed by locale and English source text."""
+
+
+class _TranslationAuditMode(StrEnum):
+    """Translation workflows supported by the unified audit command."""
+
+    gapped = "gapped"
+    """Audit translations generated for gaps in an existing target track."""
+    guided = "guided"
+    """Audit translations generated with target-language guide subtitles."""
+    standard = "standard"
+    """Audit standard source-to-target translations."""
+
+
+class AuditTranslationCli(AuditCliBase):
+    """Audit standard, gapped, or guided subtitle translations."""
+
+    localizations = AUDIT_TRANSLATION_LOCALIZATIONS
+    """Localized help text keyed by locale and English source text."""
+
+    @classmethod
+    def add_arguments_to_argparser(cls, parser: ArgumentParser):
+        """Add arguments to a nascent argument parser.
+
+        Arguments:
+            parser: nascent argument parser
+        """
+        super().add_arguments_to_argparser(parser)
+        arg_groups = get_arg_groups_by_name(
+            parser,
+            "input arguments",
+            "operation arguments",
+            optional_arguments_name="additional arguments",
+        )
+        arg_groups["input arguments"].add_argument(
+            "--source",
+            dest="source_path",
+            type=input_file_arg(),
+            help="source subtitle SRT file used for standard or guided translation",
+        )
+        arg_groups["input arguments"].add_argument(
+            "--target",
+            dest="target_path",
+            type=input_file_arg(),
+            help="gapped target subtitle SRT file used for gapped translation",
+        )
+        arg_groups["input arguments"].add_argument(
+            "--guide",
+            dest="guide_path",
+            type=input_file_arg(),
+            help="guide subtitle SRT file used for gapped or guided translation",
+        )
+        arg_groups["input arguments"].add_argument(
+            "--json",
+            dest="json_path",
+            required=True,
+            type=input_file_arg(),
+            help="translation test-case JSON file for the selected workflow",
+        )
+        arg_groups["operation arguments"].add_argument(
+            "--mode",
+            choices=tuple(_TranslationAuditMode),
+            default=_TranslationAuditMode.standard,
+            type=enum_arg(_TranslationAuditMode),
+            help=(
+                "translation workflow to audit: standard, gapped, or guided "
+                "(default: standard)"
+            ),
+        )
+        arg_groups["operation arguments"].add_argument(
+            "--filter",
+            choices=tuple(TranslationAuditFilter),
+            default=TranslationAuditFilter.all,
+            dest="row_filter",
+            metavar="{all,unverified}",
+            type=enum_arg(TranslationAuditFilter),
+            help="rows to include: all or unverified (default: all)",
+        )
+        arg_groups["operation arguments"].add_argument(
+            "--difficulty",
+            default=(),
+            dest="difficulties",
+            metavar="LEVEL",
+            nargs="+",
+            type=int_arg(min_value=0),
+            help="exact case difficulty levels to include (default: all)",
+        )
+
+    @classmethod
+    def name(cls) -> str:
+        """Name of this tool used to define it when it is a subparser."""
+        return "translation"
+
+    @classmethod
+    def _audit_gapped(
+        cls,
+        parser: ArgumentParser,
+        target_path: Path,
+        guide_path: Path,
+        json_path: Path,
+        *,
+        difficulties: Sequence[int],
+        row_filter: TranslationAuditFilter,
+        first_index: int | None,
+        last_index: int | None,
+        first_block: int | None,
+        last_block: int | None,
+    ) -> str:
+        """Load and audit one gapped-translation workflow."""
+        target = read_series(parser, target_path)
+        guide = read_series(parser, guide_path)
+        test_cases = cls.load_test_cases(
+            parser,
+            json_path,
+            GapTranslationManager,
+            workflow_name="gapped translation",
+        )
+        return audit_gap_translation(
+            target,
+            guide,
+            test_cases,
+            difficulties=difficulties,
+            row_filter=GapTranslationAuditFilter(row_filter.value),
+            first_index=first_index,
+            last_index=last_index,
+            first_block=first_block,
+            last_block=last_block,
+        )
+
+    @classmethod
+    def _audit_guided(
+        cls,
+        parser: ArgumentParser,
+        source_path: Path,
+        guide_path: Path,
+        json_path: Path,
+        *,
+        difficulties: Sequence[int],
+        row_filter: TranslationAuditFilter,
+        first_index: int | None,
+        last_index: int | None,
+        first_block: int | None,
+        last_block: int | None,
+    ) -> str:
+        """Load and audit one guided-translation workflow."""
+        source = read_series(parser, source_path)
+        guide = read_series(parser, guide_path)
+        test_cases = cls.load_test_cases(
+            parser,
+            json_path,
+            GuidedTranslationManager,
+            workflow_name="guided translation",
+        )
+        return audit_guided_translation(
+            source,
+            guide,
+            test_cases,
+            difficulties=difficulties,
+            row_filter=row_filter,
+            first_index=first_index,
+            last_index=last_index,
+            first_block=first_block,
+            last_block=last_block,
+        )
+
+    @classmethod
+    def _audit_standard(
+        cls,
+        parser: ArgumentParser,
+        source_path: Path,
+        json_path: Path,
+        *,
+        difficulties: Sequence[int],
+        row_filter: TranslationAuditFilter,
+        first_index: int | None,
+        last_index: int | None,
+        first_block: int | None,
+        last_block: int | None,
+    ) -> str:
+        """Load and audit one standard-translation workflow."""
+        source = read_series(parser, source_path)
+        test_cases = cls.load_test_cases(
+            parser,
+            json_path,
+            TranslationManager,
+            workflow_name="standard translation",
+        )
+        return audit_translation(
+            source,
+            test_cases,
+            difficulties=difficulties,
+            row_filter=row_filter,
+            first_index=first_index,
+            last_index=last_index,
+            first_block=first_block,
+            last_block=last_block,
+        )
+
+    @classmethod
+    def _main(
+        cls,
+        *,
+        _parser: ArgumentParser | None = None,
+        source_path: Path | None,
+        target_path: Path | None,
+        guide_path: Path | None,
+        json_path: Path,
+        mode: _TranslationAuditMode,
+        difficulties: Sequence[int],
+        row_filter: TranslationAuditFilter,
+        first_index: int | None,
+        last_index: int | None,
+        first_block: int | None,
+        last_block: int | None,
+        outfile_path: Path | None,
+        overwrite: bool,
+    ):
+        """Execute with provided keyword arguments."""
+        parser = _parser or cls.argparser()
+        cls._validate_mode_inputs(
+            parser,
+            mode,
+            source_path=source_path,
+            target_path=target_path,
+            guide_path=guide_path,
+        )
+
+        try:
+            if mode is _TranslationAuditMode.standard:
+                assert source_path is not None
+                report = cls._audit_standard(
+                    parser,
+                    source_path,
+                    json_path,
+                    difficulties=difficulties,
+                    row_filter=row_filter,
+                    first_index=first_index,
+                    last_index=last_index,
+                    first_block=first_block,
+                    last_block=last_block,
+                )
+            elif mode is _TranslationAuditMode.gapped:
+                assert target_path is not None and guide_path is not None
+                report = cls._audit_gapped(
+                    parser,
+                    target_path,
+                    guide_path,
+                    json_path,
+                    difficulties=difficulties,
+                    row_filter=row_filter,
+                    first_index=first_index,
+                    last_index=last_index,
+                    first_block=first_block,
+                    last_block=last_block,
+                )
+            else:
+                assert source_path is not None and guide_path is not None
+                report = cls._audit_guided(
+                    parser,
+                    source_path,
+                    guide_path,
+                    json_path,
+                    difficulties=difficulties,
+                    row_filter=row_filter,
+                    first_index=first_index,
+                    last_index=last_index,
+                    first_block=first_block,
+                    last_block=last_block,
+                )
+        except ScinoephileError as exc:
+            parser.error(str(exc))
+        cls.write_report(parser, report, outfile_path, overwrite)
+
+    @staticmethod
+    def _validate_mode_inputs(
+        parser: ArgumentParser,
+        mode: _TranslationAuditMode,
+        *,
+        source_path: Path | None,
+        target_path: Path | None,
+        guide_path: Path | None,
+    ):
+        """Validate mode-specific translation input paths."""
+        required = {
+            _TranslationAuditMode.standard: ((source_path, "--source"),),
+            _TranslationAuditMode.gapped: (
+                (target_path, "--target"),
+                (guide_path, "--guide"),
+            ),
+            _TranslationAuditMode.guided: (
+                (source_path, "--source"),
+                (guide_path, "--guide"),
+            ),
+        }
+        for path, option in required[mode]:
+            if path is None:
+                parser.error(f"{option} is required in {mode.value} mode")
+
+        unsupported = {
+            _TranslationAuditMode.standard: (
+                (target_path, "--target"),
+                (guide_path, "--guide"),
+            ),
+            _TranslationAuditMode.gapped: ((source_path, "--source"),),
+            _TranslationAuditMode.guided: ((target_path, "--target"),),
+        }
+        for path, option in unsupported[mode]:
+            if path is not None:
+                parser.error(f"{option} is not supported in {mode.value} mode")
+
+
+if __name__ == "__main__":
+    AuditTranslationCli.main()

--- a/scinoephile/cli/audit/audit_translation_cli.py
+++ b/scinoephile/cli/audit/audit_translation_cli.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
-from enum import StrEnum
 from pathlib import Path
 
 from scinoephile.analysis.audit.gap_translation import (
@@ -37,10 +36,6 @@ AUDIT_TRANSLATION_LOCALIZATIONS: dict[str, dict[str, str]] = {
         "audit standard, gapped, or guided subtitle translations": (
             "审核标准、缺口或引导式字幕翻译"
         ),
-        (
-            "translation workflow to audit: standard, gapped, or guided "
-            "(default: standard)"
-        ): ("要审核的翻译工作流：standard、gapped 或 guided（默认：standard）"),
         "source subtitle SRT file used for standard or guided translation": (
             "用于标准或引导式翻译的源字幕 SRT 文件"
         ),
@@ -61,10 +56,6 @@ AUDIT_TRANSLATION_LOCALIZATIONS: dict[str, dict[str, str]] = {
         "audit standard, gapped, or guided subtitle translations": (
             "稽核標準、缺口或引導式字幕翻譯"
         ),
-        (
-            "translation workflow to audit: standard, gapped, or guided "
-            "(default: standard)"
-        ): ("要稽核的翻譯工作流程：standard、gapped 或 guided（預設：standard）"),
         "source subtitle SRT file used for standard or guided translation": (
             "用於標準或引導式翻譯的來源字幕 SRT 檔"
         ),
@@ -83,17 +74,6 @@ AUDIT_TRANSLATION_LOCALIZATIONS: dict[str, dict[str, str]] = {
     },
 }
 """Localized help text keyed by locale and English source text."""
-
-
-class _TranslationAuditMode(StrEnum):
-    """Translation workflows supported by the unified audit command."""
-
-    gapped = "gapped"
-    """Audit translations generated for gaps in an existing target track."""
-    guided = "guided"
-    """Audit translations generated with target-language guide subtitles."""
-    standard = "standard"
-    """Audit standard source-to-target translations."""
 
 
 class AuditTranslationCli(AuditCliBase):
@@ -118,13 +98,16 @@ class AuditTranslationCli(AuditCliBase):
         )
 
         # Input arguments
-        arg_groups["input arguments"].add_argument(
+        workflow_inputs = arg_groups["input arguments"].add_mutually_exclusive_group(
+            required=True
+        )
+        workflow_inputs.add_argument(
             "--source",
             dest="source_path",
             type=input_file_arg(),
             help="source subtitle SRT file used for standard or guided translation",
         )
-        arg_groups["input arguments"].add_argument(
+        workflow_inputs.add_argument(
             "--target",
             dest="target_path",
             type=input_file_arg(),
@@ -145,16 +128,6 @@ class AuditTranslationCli(AuditCliBase):
         )
 
         # Operation arguments
-        arg_groups["operation arguments"].add_argument(
-            "--mode",
-            choices=tuple(_TranslationAuditMode),
-            default=_TranslationAuditMode.standard,
-            type=enum_arg(_TranslationAuditMode),
-            help=(
-                "translation workflow to audit: standard, gapped, or guided "
-                "(default: standard)"
-            ),
-        )
         arg_groups["operation arguments"].add_argument(
             "--filter",
             choices=tuple(TranslationAuditFilter),
@@ -332,7 +305,6 @@ class AuditTranslationCli(AuditCliBase):
         target_path: Path | None,
         guide_path: Path | None,
         json_path: Path,
-        mode: _TranslationAuditMode,
         row_filter: TranslationAuditFilter,
         first_index: int | None,
         last_index: int | None,
@@ -349,7 +321,6 @@ class AuditTranslationCli(AuditCliBase):
             target_path: optional gapped target subtitle SRT path
             guide_path: optional guide subtitle SRT path
             json_path: translation test-case JSON path
-            mode: translation workflow to audit
             row_filter: rows to include in the report
             first_index: first workflow subtitle number to include
             last_index: last workflow subtitle number to include
@@ -360,30 +331,17 @@ class AuditTranslationCli(AuditCliBase):
         """
         # Validate arguments
         parser = _parser or cls.argparser()
-        cls._validate_mode_inputs(
-            parser,
-            mode,
-            source_path=source_path,
-            target_path=target_path,
-            guide_path=guide_path,
-        )
+        if source_path is None and target_path is None:
+            parser.error("one of --source or --target is required")
+        if source_path is not None and target_path is not None:
+            parser.error("--source and --target are mutually exclusive")
+        if target_path is not None and guide_path is None:
+            parser.error("--guide is required with --target")
 
         # Perform operation
         try:
-            if mode is _TranslationAuditMode.standard:
-                assert source_path is not None
-                report = cls._audit_standard(
-                    parser,
-                    source_path,
-                    json_path,
-                    row_filter=row_filter,
-                    first_index=first_index,
-                    last_index=last_index,
-                    first_block=first_block,
-                    last_block=last_block,
-                )
-            elif mode is _TranslationAuditMode.gapped:
-                assert target_path is not None and guide_path is not None
+            if target_path is not None:
+                assert guide_path is not None
                 report = cls._audit_gapped(
                     parser,
                     target_path,
@@ -395,12 +353,24 @@ class AuditTranslationCli(AuditCliBase):
                     first_block=first_block,
                     last_block=last_block,
                 )
-            else:
-                assert source_path is not None and guide_path is not None
+            elif guide_path is not None:
+                assert source_path is not None
                 report = cls._audit_guided(
                     parser,
                     source_path,
                     guide_path,
+                    json_path,
+                    row_filter=row_filter,
+                    first_index=first_index,
+                    last_index=last_index,
+                    first_block=first_block,
+                    last_block=last_block,
+                )
+            else:
+                assert source_path is not None
+                report = cls._audit_standard(
+                    parser,
+                    source_path,
                     json_path,
                     row_filter=row_filter,
                     first_index=first_index,
@@ -413,53 +383,6 @@ class AuditTranslationCli(AuditCliBase):
 
         # Write output
         cls.write_report(parser, report, outfile_path, overwrite)
-
-    @staticmethod
-    def _validate_mode_inputs(
-        parser: ArgumentParser,
-        mode: _TranslationAuditMode,
-        *,
-        source_path: Path | None,
-        target_path: Path | None,
-        guide_path: Path | None,
-    ):
-        """Validate mode-specific translation input paths.
-
-        Arguments:
-            parser: parser used to report user-facing errors
-            mode: translation workflow to audit
-            source_path: optional source subtitle SRT path
-            target_path: optional gapped target subtitle SRT path
-            guide_path: optional guide subtitle SRT path
-        """
-        # Validate required inputs
-        required = {
-            _TranslationAuditMode.standard: ((source_path, "--source"),),
-            _TranslationAuditMode.gapped: (
-                (target_path, "--target"),
-                (guide_path, "--guide"),
-            ),
-            _TranslationAuditMode.guided: (
-                (source_path, "--source"),
-                (guide_path, "--guide"),
-            ),
-        }
-        for path, option in required[mode]:
-            if path is None:
-                parser.error(f"{option} is required in {mode.value} mode")
-
-        # Validate unsupported inputs
-        unsupported = {
-            _TranslationAuditMode.standard: (
-                (target_path, "--target"),
-                (guide_path, "--guide"),
-            ),
-            _TranslationAuditMode.gapped: ((source_path, "--source"),),
-            _TranslationAuditMode.guided: ((target_path, "--target"),),
-        }
-        for path, option in unsupported[mode]:
-            if path is not None:
-                parser.error(f"{option} is not supported in {mode.value} mode")
 
 
 if __name__ == "__main__":

--- a/skills/audit-ocr-fusion/SKILL.md
+++ b/skills/audit-ocr-fusion/SKILL.md
@@ -12,17 +12,18 @@ cleaning or review stages.
 
 Save the complete Markdown report under `local/`.
 
-- Keep these columns: `Index`, `Case`, `Difficulty`, `Source one`, `Source two`,
-  `Fused`, and `Validated`. When JSON is supplied, also include `Notes` and
+- Keep these columns: `Subtitle`, `Case`, `Difficulty`, `Source one`, `Source
+  two`, `Fused`, `Validated`, and `Notes`. When JSON is supplied, also include
   `Verified`.
 - `Case` and `Difficulty` are `—` for deterministic rows and rows audited
   without JSON. When JSON is supplied, `Verified` is `—` for deterministic
   rows, `✓` for verified JSON cases, and empty for unverified JSON cases.
 - Treat `Validated` as ground truth when supplied. It is `—` when omitted.
-- When JSON is supplied, generated `Notes` contains the recorded LLM note or
-  the automatic fusion explanation. Read it as context, then replace the entire
-  cell with your own independent judgment; do not append to or merely endorse
-  the generated content.
+- Generated `Notes` contains the recorded LLM note when JSON is supplied, an
+  automatic fusion explanation for deterministic rows, or an empty cell when
+  no context is available. Read it as context, then replace the entire cell
+  with your own independent judgment; do not append to or merely endorse the
+  generated content.
 - Validate the saved table after generating it and provide a clickable link.
   Do not paste the full table inline unless the user requests it.
 

--- a/skills/audit-ocr-fusion/SKILL.md
+++ b/skills/audit-ocr-fusion/SKILL.md
@@ -16,11 +16,13 @@ Save the complete Markdown report under `local/`.
   `Fused`, and `Validated`. When JSON is supplied, also include `Notes` and
   `Verified`.
 - `Case` and `Difficulty` are `—` for deterministic rows and rows audited
-  without JSON. An empty `Verified` cell on a deterministic row does not
-  indicate an unverified JSON case.
+  without JSON. When JSON is supplied, `Verified` is `—` for deterministic
+  rows, `✓` for verified JSON cases, and empty for unverified JSON cases.
 - Treat `Validated` as ground truth when supplied. It is `—` when omitted.
-- When JSON is supplied, `Notes` contains the recorded LLM note or the automatic
-  fusion explanation.
+- When JSON is supplied, generated `Notes` contains the recorded LLM note or
+  the automatic fusion explanation. Read it as context, then replace the entire
+  cell with your own independent judgment; do not append to or merely endorse
+  the generated content.
 - Validate the saved table after generating it and provide a clickable link.
   Do not paste the full table inline unless the user requests it.
 

--- a/skills/audit-ocr-fusion/SKILL.md
+++ b/skills/audit-ocr-fusion/SKILL.md
@@ -65,21 +65,21 @@ UV_CACHE_DIR=/tmp/uv-cache uv run scinoephile audit ocr-fusion \
   --validated <validated.srt> \
   --first-index <first> \
   --last-index <last> \
-  --filter changes \
+  --filter all \
   --outfile local/<dataset>_ocr_fusion_audit_<first>-<last>.md \
   --overwrite
 ```
 
 Omit `--json` when no decision log is available. Omit `--validated` when no
-aligned truth track exists. The inclusive range uses fused-track indexes. Filters
-are:
+aligned truth track exists. The inclusive range uses fused-track indexes. Use
+`all` for a complete audit. Filters are:
 
-- `changes`: source disagreements, including deterministic one-source rows
 - `all`: every fused subtitle, including identical and empty sources
-- `unverified`: only unverified LLM cases; without JSON, all rows requiring an
-  LLM decision are unverified
+- `changes`: source disagreements, including deterministic one-source rows
 - `discrepancies`: only fused rows that differ from `--validated`; this filter
   requires the validated track and includes deterministic rows
+- `unverified`: only unverified LLM cases; without JSON, all rows requiring an
+  LLM decision are unverified
 
 Use `--first-block` and `--last-block` for an inclusive, one-based range of
 fused-track blocks. Block and subtitle bounds are mutually exclusive. Omit
@@ -105,8 +105,8 @@ unless the validated track itself is demonstrably wrong.
   identical source text remains correct against validated truth.
 - Do not assess later cleaning, translation, or subtitle-review decisions.
 
-When reporting a finding, use exactly `OK` for a correct fusion. Otherwise begin
-the finding with one of:
+For every displayed row, replace the generated `Notes` cell with exactly `OK`
+for a correct fusion. Otherwise begin the finding with one of:
 
 - `Incorrect fusion;` for a clear wrong selection or synthesized error
 - `Validated discrepancy;` when fused text differs from reliable validated

--- a/skills/audit-ocr-fusion/agents/openai.yaml
+++ b/skills/audit-ocr-fusion/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Audit OCR Fusion"
-  short_description: "Audit fused OCR against sources and validated truth"
-  default_prompt: "Use $audit-ocr-fusion to audit OCR-fusion decisions and compare them with the validated subtitle track."
+  short_description: "Audit fused OCR against sources and optional truth"
+  default_prompt: "Use $audit-ocr-fusion to audit OCR-fusion decisions and compare them with the validated subtitle track when available."

--- a/skills/audit-subtitle-reviews/SKILL.md
+++ b/skills/audit-subtitle-reviews/SKILL.md
@@ -14,7 +14,9 @@ Save the complete Markdown report under `local/`, audit every displayed row,
 and write each independent finding in its `Notes` cell.
 
 - Preserve the exact columns emitted by the selected command.
-- Treat JSON notes as context, not proof. Replace them with your own judgment.
+- The generated `Notes` cell contains any applicable JSON revision note. Read it
+  as context, then replace the entire cell with your own independent judgment;
+  do not append to or merely endorse the recorded note.
 - When emitted, preserve `Verified`: `✓` means the complete JSON case was
   verified.
 - Validate the edited table and provide a clickable link. Do not paste the full
@@ -164,7 +166,9 @@ simplification review for conversion-specific cleanup.
 
 Guided reports contain `Index`, `Block`, `Guide`, `Target / revision`, `Notes`,
 and `Verified`. The target appears above the proposed revision; `(unanswered)`
-means the JSON case has no answer.
+means the JSON case has no answer. For a proposed revision, the generated
+`Notes` cell contains that revision's JSON note; replace it during the audit as
+described above.
 
 - Audit proposed revisions and no-revision decisions. An unchanged target is a
   decision, not an automatic pass.

--- a/skills/audit-subtitle-reviews/SKILL.md
+++ b/skills/audit-subtitle-reviews/SKILL.md
@@ -11,7 +11,7 @@ review before selecting a workflow; language alone does not determine it.
 ## Required report file
 
 Save the complete Markdown report under `local/`, audit every displayed row,
-and write each independent finding in its `Notes` cell.
+and write each independent judgment in its `Notes` cell.
 
 - Preserve the exact columns emitted by the selected command.
 - The generated `Notes` cell contains any applicable JSON revision note. Read it
@@ -78,7 +78,7 @@ UV_CACHE_DIR=/tmp/uv-cache uv run scinoephile audit review \
   --original <original.srt> \
   --reviewed <reviewed.srt> \
   --json <review.json> \
-  --filter changes \
+  --filter all \
   --outfile local/<dataset>_review_audit.md \
   --overwrite
 ```
@@ -106,7 +106,7 @@ UV_CACHE_DIR=/tmp/uv-cache uv run scinoephile audit review-trad \
   --traditional-simplified-reviewed <simplified-traditional-reviewed.srt> \
   --traditional-json <review.json> \
   --traditional-simplified-json <simplify-review.json> \
-  --filter changes \
+  --filter all \
   --outfile local/<dataset>_review_trad_audit.md \
   --overwrite
 ```
@@ -124,17 +124,19 @@ UV_CACHE_DIR=/tmp/uv-cache uv run scinoephile audit review-dual \
   --simplified-json <simplified-review.json> \
   --traditional-json <traditional-review.json> \
   --traditional-simplified-json <simplify-review.json> \
-  --filter changes \
+  --filter all \
   --outfile local/<dataset>_review_dual_audit.md \
   --overwrite
 ```
 
 Regular, guided, and traditional review support `all`, `changes`, and
 `unverified`; dual review additionally supports `discrepancies`. All default to
-`changes`. The `unverified` filter requires the corresponding JSON for every
-review path. Use inclusive `--first-index` and `--last-index`. `--characters`
-is available for regular, traditional, and dual review, with script variants
-added automatically; use it only for a requested or suspected conversion issue.
+`changes`, but a complete audit must explicitly use `all` so unchanged subtitles
+can be checked for missed corrections. Use `changes` only for an applied-edit
+audit. The `unverified` filter requires the corresponding JSON for every review
+path. Use inclusive `--first-index` and `--last-index`. `--characters` is
+available for regular, traditional, and dual review, with script variants added
+automatically; use it only for a requested or suspected conversion issue.
 
 Use `--first-block` and `--last-block` for an inclusive, one-based workflow
 block range. In guided review these are paired target/guide blocks; in regular,
@@ -152,9 +154,10 @@ Read the relevant language policy before judging rows:
   rules.
 
 Check incorrect edits, missed corrections, script leakage, lexical and OCR
-errors, grammar, punctuation, and whitespace. Begin accepted edits with `OK;`,
-rejected edits with `Incorrect;`, and unresolved cases with `Check;`. Keep notes
-terse and use arrow notation for simple substitutions.
+errors, grammar, punctuation, and whitespace. Write exactly `OK` for every
+acceptable edited or unchanged row. Begin rejected rows with `Incorrect;` and
+unresolved rows with `Check;`. Keep notes terse and use arrow notation for simple
+substitutions.
 
 Review stages must preserve source punctuation and whitespace exactly. When a
 text correction also changes either, keep the text correction but restore the
@@ -175,9 +178,9 @@ described above.
 - Use the guide as semantic evidence, not text to copy. Accept legitimate
   differences in vocabulary, syntax, particles, omissions, and segmentation.
 - Reject punctuation-only or whitespace-only revisions at this stage.
-- Write exactly `OK` for an appropriate proposed revision. Leave a correct
-  no-revision row blank. Otherwise use `Incorrect revision;`,
-  `Missed revision;`, or `Uncertain;`.
+- Write exactly `OK` for an appropriate proposed revision or no-revision
+  decision. Otherwise use `Incorrect revision;`, `Missed revision;`, or
+  `Uncertain;`. Never mark an unanswered row `OK`.
 - For substitutions, add the smallest relevant tone-marked Yale reading for
   `yue-*` or Hanyu Pinyin reading for `zho-*`; do not guess uncertain readings.
 

--- a/skills/audit-transcription-delineation/SKILL.md
+++ b/skills/audit-transcription-delineation/SKILL.md
@@ -19,7 +19,10 @@ cell. Do not leave notes only in commentary, tool output, or the final response.
 
 - Keep the table at exactly these columns: `Indexes`, `Reference`, `Input`,
   `Output`, `Notes`, and `Verified`.
-- Leave `Notes` blank when a row needs no note.
+- Delineation JSON has no note field, so generated `Notes` cells begin blank.
+  If a future schema populates one, read it as context and replace the entire
+  cell with your own independent judgment; never append to or merely endorse
+  generated note content. Leave the cell blank when a row needs no finding.
 - Preserve the generated `Verified` cell: `✓` means the JSON test case is
   verified, and an empty cell means it is not verified.
 - Do not add a separate findings section; keep each observation beside the row

--- a/skills/audit-transcription-delineation/SKILL.md
+++ b/skills/audit-transcription-delineation/SKILL.md
@@ -14,15 +14,16 @@ wording, or character choice; those are reviewed later in a separate workflow.
 ## Required report file
 
 Always save the complete six-column Markdown report under `local/`. After
-auditing every row, add each concise audit note directly to that file's `Notes`
-cell. Do not leave notes only in commentary, tool output, or the final response.
+auditing every row, add each concise audit judgment directly to that file's
+`Notes` cell. Do not leave notes only in commentary, tool output, or the final
+response.
 
 - Keep the table at exactly these columns: `Indexes`, `Reference`, `Input`,
   `Output`, `Notes`, and `Verified`.
 - Delineation JSON has no note field, so generated `Notes` cells begin blank.
   If a future schema populates one, read it as context and replace the entire
   cell with your own independent judgment; never append to or merely endorse
-  generated note content. Leave the cell blank when a row needs no finding.
+  generated note content.
 - Preserve the generated `Verified` cell: `✓` means the JSON test case is
   verified, and an empty cell means it is not verified.
 - Do not add a separate findings section; keep each observation beside the row
@@ -107,7 +108,7 @@ subtitles.
 Judge only alignment. Ignore misspellings, mistranscriptions, Mandarinisms,
 punctuation, omissions, repetitions, and other defects in the target text except
 as fixed evidence for deciding which side of the boundary owns each phrase. Do
-not mention these defects in Notes. Leave Notes blank when the shift or no-shift
+not mention these defects in Notes. Write exactly `OK` when the shift or no-shift
 answer is appropriate.
 
 Use semantic and discourse alignment rather than literal word matching:
@@ -130,13 +131,13 @@ Classify alignment notes precisely:
 - **Uncertain:** the appropriateness of the boundary cannot be determined from
   the provided target text, guide pair, and available context.
 
-After reviewing every row, fill the saved report's `Notes` cells wherever you
-have an alignment observation. Begin each note with `Delineation error;` or
+After reviewing every row, replace every saved report `Notes` cell with `OK` or
+an alignment finding. Begin each finding with `Delineation error;` or
 `Uncertain;`, followed by a concise explanation focused only on boundary
-ownership. Leave the cell blank when the row needs no note. Validate that the
-edited file retains every generated row and the exact six-column shape. Do not
-claim the audit is complete until every row has been reviewed, all notes have
-been written to the saved report, and its link is ready for the final response.
+ownership. Never mark an unanswered row `OK`. Validate that the edited file
+retains every generated row and the exact six-column shape. Do not claim the
+audit is complete until every row has been reviewed, all notes have been written
+to the saved report, and its link is ready for the final response.
 
 ## Correct and verify cases
 

--- a/skills/audit-transcription-punctuation/SKILL.md
+++ b/skills/audit-transcription-punctuation/SKILL.md
@@ -6,8 +6,8 @@ description: Audit Scinoephile transcription punctuation logs by matching JSON g
 # Audit Transcription Punctuation
 
 Audit the punctuation and whitespace added to fixed transcription text. Produce a
-Markdown report, inspect every requested row, and record concise findings in its
-Notes column.
+Markdown report, inspect every requested row, and record a concise judgment in
+each `Notes` cell.
 
 ## Scope
 
@@ -87,16 +87,16 @@ Consider:
 - whether punctuation splits a grammatical phrase or implies the wrong
   relationship between clauses
 
-Enter a note only when there is an actionable issue or genuine ambiguity. Use
-one of these exact prefixes:
+Write exactly `OK` for an acceptable answer. Otherwise use one of these exact
+prefixes:
 
 - `Punctuation error;` for a clear punctuation or whitespace error
 - `Uncertain;` when the audio or broader context is needed to judge the choice
 
 Punctuation JSON has no note field, so generated Notes cells begin blank. If a
 future schema populates one, read it as context and replace the entire cell with
-your own concise finding rather than appending to or treating it as proof.
-Leave Notes blank for acceptable answers.
+your own concise judgment rather than appending to or treating it as proof.
+Never mark an unanswered row `OK`.
 
 ## Correct and verify cases
 

--- a/skills/audit-transcription-punctuation/SKILL.md
+++ b/skills/audit-transcription-punctuation/SKILL.md
@@ -93,8 +93,10 @@ one of these exact prefixes:
 - `Punctuation error;` for a clear punctuation or whitespace error
 - `Uncertain;` when the audio or broader context is needed to judge the choice
 
-Leave Notes blank for acceptable answers. Replace generated/source notes with
-your own interpretation rather than copying them mechanically.
+Punctuation JSON has no note field, so generated Notes cells begin blank. If a
+future schema populates one, read it as context and replace the entire cell with
+your own concise finding rather than appending to or treating it as proof.
+Leave Notes blank for acceptable answers.
 
 ## Correct and verify cases
 

--- a/skills/audit-translations/SKILL.md
+++ b/skills/audit-translations/SKILL.md
@@ -35,6 +35,10 @@ reports have exactly: `Indexes`, `Case / block`, `Difficulty`, `Guide`,
   JSON index. Always use `Q` when editing an answer.
 - `C` is the one-based JSON case position and `B` the reconstructed block.
 - `✓` means the entire JSON case is verified, not merely one displayed row.
+- Translation JSON has no note field, so generated `Notes` cells begin blank.
+  If a future schema populates one, read it as context and replace the entire
+  cell with your own independent judgment; never append to or merely endorse
+  generated note content.
 - Keep findings beside rows, validate the edited report, and provide its link.
   Do not paste the table inline unless the user requests it.
 
@@ -111,8 +115,9 @@ gapped workflows. Subtitle-index and block ranges are mutually exclusive. Omit
 either bound for an open-ended range.
 Use `--filter unverified` to resume verification; the default is `all`.
 
-`(unanswered)` means the case has no answer. In the gapped workflow, `(empty)`
-is an answered output that intentionally emits no target subtitle.
+`(unanswered)` means the case has no answer. `(empty)` means an answered output
+emitted empty text; in the gapped workflow this may intentionally mean that no
+target subtitle is needed.
 
 ## Audit every translation
 

--- a/skills/audit-translations/SKILL.md
+++ b/skills/audit-translations/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: audit-translations
+description: Audit Scinoephile standard, gapped, or guided translation JSON against the exact source, target-context, and guide SRT files used to generate it. Use when inspecting translation, gap_translation, or guided_translation JSON; judging translated, empty, unnecessary, or unanswered outputs; filtering by difficulty or verification state; or correcting and verifying translation cases.
+---
+
+# Audit Translations
+
+Run commands from the repository root. Select the workflow from the JSON and
+the inputs that produced it; do not infer it from language alone.
+
+## Select the mode
+
+| Workflow | Required SRT inputs | Mode |
+|---|---|---|
+| Standard translation | source track | `standard` |
+| Translation of missing target positions | gapped target and complete guide | `gapped` |
+| Translation using target-language guide context | source and guide | `guided` |
+
+Use one `scinoephile audit translation` command for all three modes.
+
+## Required report file
+
+Save the complete Markdown report under `local/`, audit every row, and write
+each finding into its `Notes` cell.
+
+Standard and guided reports have exactly: `Indexes`, `Case / block`,
+`Difficulty`, `Source`, `Guide`, `Translation`, `Notes`, `Verified`. Gapped
+reports have exactly: `Indexes`, `Case / block`, `Difficulty`, `Guide`,
+`Target context`, `Translation`, `Notes`, `Verified`.
+
+- In standard and guided reports, `S` is the global source index and `Q` is
+  its query-local JSON index; guided `G` labels are query-local guide indexes.
+  In gapped reports, `G` is the global guide index and `Q` is its query-local
+  JSON index. Always use `Q` when editing an answer.
+- `C` is the one-based JSON case position and `B` the reconstructed block.
+- `✓` means the entire JSON case is verified, not merely one displayed row.
+- Keep findings beside rows, validate the edited report, and provide its link.
+  Do not paste the table inline unless the user requests it.
+
+## Protect source data
+
+- Never edit files under `test/data/<dataset>/input/`.
+- For an audit-only request, do not modify input SRTs, JSON, generated
+  translations, or downstream review artifacts.
+- When corrections are requested, edit JSON answers and verification metadata,
+  then regenerate outputs. Never hand-edit a generated translated SRT.
+- Preserve every JSON query exactly.
+
+## Locate exact inputs
+
+Standard translation uses the source SRT passed to the regular translator and
+its `translation.json`. Guided translation uses the source and guide SRTs
+passed to guided translation and its `guided_translation/<device>.json`.
+
+Gapped translation uses:
+
+- target: the gapped target before translation, commonly
+  `transcribe_clean_review.srt` or `transcribe_review.srt`
+- guide: the complete source-language SRT used to identify gaps
+- JSON: `<target-output>/lang/<target-source>/gap_translation/<device>.json`
+
+Never pass the already gap-translated output as `--target`; doing so removes
+the gaps the audit must reconstruct.
+
+## Generate the report
+
+Always set `UV_CACHE_DIR=/tmp/uv-cache`.
+
+Standard:
+
+```shell
+UV_CACHE_DIR=/tmp/uv-cache uv run scinoephile audit translation \
+  --mode standard \
+  --source <source.srt> \
+  --json <translation.json> \
+  --filter all \
+  --outfile local/<dataset>_translation_audit.md \
+  --overwrite
+```
+
+Gapped:
+
+```shell
+UV_CACHE_DIR=/tmp/uv-cache uv run scinoephile audit translation \
+  --mode gapped \
+  --target <gapped-target.srt> \
+  --guide <complete-guide.srt> \
+  --json <gap_translation/device.json> \
+  --filter all \
+  --outfile local/<dataset>_gap_translation_audit.md \
+  --overwrite
+```
+
+Guided:
+
+```shell
+UV_CACHE_DIR=/tmp/uv-cache uv run scinoephile audit translation \
+  --mode guided \
+  --source <source.srt> \
+  --guide <target-language-guide.srt> \
+  --json <guided_translation/device.json> \
+  --filter all \
+  --outfile local/<dataset>_guided_translation_audit.md \
+  --overwrite
+```
+
+Use inclusive `--first-index` and `--last-index`. They refer to global source
+indexes in standard and guided mode, and global guide indexes in gapped mode.
+Use `--first-block` and `--last-block` for inclusive, one-based workflow block
+ranges: source blocks in standard mode and paired blocks in guided or gapped
+mode. Block and subtitle bounds may be combined; their intersection determines
+the displayed rows. Omit either bound for an open-ended range.
+Use `--filter unverified` to resume verification; the default is `all`. Omit
+`--difficulty` for all levels or pass exact values such as
+`--difficulty 1 2`. Difficulty and verification filters compose.
+
+`(unanswered)` means the case has no answer. In gapped mode, `(empty)` is an
+answered output that intentionally emits no target subtitle.
+
+## Audit every translation
+
+Judge whether each output accurately and idiomatically expresses its source in
+the intended target language and script.
+
+- Check omissions, additions, mistranslations, polarity, modality, pronouns,
+  names, numbers, register, terminology, continuity, and meaning-changing
+  punctuation.
+- Preserve natural target-language grammar rather than copying source syntax.
+- In guided mode, use the guide as target-language context and semantic
+  evidence, not as text that must be copied.
+- In gapped mode, treat existing target subtitles as context, not as text to
+  rewrite. Accept an empty output only when the guide position genuinely needs
+  no target subtitle.
+- Treat every unanswered case as incomplete.
+
+Write exactly `OK` for a clearly appropriate translation. Otherwise begin with:
+
+- `Incorrect translation;` for wrong, unsupported, unidiomatic, or wrong-script
+  output
+- `Missing translation;` for an empty or unanswered gap that needs text
+- `Unnecessary translation;` for a generated gap that should remain empty
+- `Uncertain;` when the source, guide, target context, and optional audio do not
+  establish the correct output
+
+Audit every displayed row. Do not mark an unanswered row `OK`.
+
+## Correct and verify cases
+
+When corrections are requested:
+
+- For standard and guided cases, keep one output for every source `Q` index in
+  ascending order.
+- For gapped cases, keep one output for every guide `Q` index absent from query
+  targets; use an empty string only for an intentional no-subtitle result.
+- Mark `verified: true` only after auditing and correcting every output in the
+  case. Do not verify a case when the selected range contains only some rows.
+- Never verify unanswered or unaudited cases.
+
+Regenerate translated and downstream artifacts through the dataset workflow.
+Rerun the corrected range, confirm canonical JSON, and confirm corrected cases
+leave `--filter unverified` before linking the interpreted report.

--- a/skills/audit-translations/SKILL.md
+++ b/skills/audit-translations/SKILL.md
@@ -22,7 +22,7 @@ inputs.
 ## Required report file
 
 Save the complete Markdown report under `local/`, audit every row, and write
-each finding into its `Notes` cell.
+each judgment into its `Notes` cell.
 
 Standard and guided reports have exactly: `Indexes`, `Case / block`,
 `Difficulty`, `Source`, `Guide`, `Translation`, `Notes`, `Verified`. Gapped

--- a/skills/audit-translations/SKILL.md
+++ b/skills/audit-translations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: audit-translations
-description: Audit Scinoephile standard, gapped, or guided translation JSON against the exact source, target-context, and guide SRT files used to generate it. Use when inspecting translation, gap_translation, or guided_translation JSON; judging translated, empty, unnecessary, or unanswered outputs; filtering by difficulty or verification state; or correcting and verifying translation cases.
+description: Audit Scinoephile standard, gapped, or guided translation JSON against the exact source, target-context, and guide SRT files used to generate it. Use when inspecting translation, gap_translation, or guided_translation JSON; judging translated, empty, unnecessary, or unanswered outputs; filtering by verification state; or correcting and verifying translation cases.
 ---
 
 # Audit Translations
@@ -110,9 +110,7 @@ Use `--first-block` and `--last-block` for inclusive, one-based workflow block
 ranges: source blocks in standard mode and paired blocks in guided or gapped
 mode. Block and subtitle bounds may be combined; their intersection determines
 the displayed rows. Omit either bound for an open-ended range.
-Use `--filter unverified` to resume verification; the default is `all`. Omit
-`--difficulty` for all levels or pass exact values such as
-`--difficulty 1 2`. Difficulty and verification filters compose.
+Use `--filter unverified` to resume verification; the default is `all`.
 
 `(unanswered)` means the case has no answer. In gapped mode, `(empty)` is an
 answered output that intentionally emits no target subtitle.

--- a/skills/audit-translations/SKILL.md
+++ b/skills/audit-translations/SKILL.md
@@ -8,15 +8,16 @@ description: Audit Scinoephile standard, gapped, or guided translation JSON agai
 Run commands from the repository root. Select the workflow from the JSON and
 the inputs that produced it; do not infer it from language alone.
 
-## Select the mode
+## Select the inputs
 
-| Workflow | Required SRT inputs | Mode |
-|---|---|---|
-| Standard translation | source track | `standard` |
-| Translation of missing target positions | gapped target and complete guide | `gapped` |
-| Translation using target-language guide context | source and guide | `guided` |
+| Workflow | Required SRT inputs |
+|---|---|
+| Standard translation | source track |
+| Translation of missing target positions | gapped target and complete guide |
+| Translation using target-language guide context | source and guide |
 
-Use one `scinoephile audit translation` command for all three modes.
+The `scinoephile audit translation` command infers the workflow from the SRT
+inputs.
 
 ## Required report file
 
@@ -70,7 +71,6 @@ Standard:
 
 ```shell
 UV_CACHE_DIR=/tmp/uv-cache uv run scinoephile audit translation \
-  --mode standard \
   --source <source.srt> \
   --json <translation.json> \
   --filter all \
@@ -82,7 +82,6 @@ Gapped:
 
 ```shell
 UV_CACHE_DIR=/tmp/uv-cache uv run scinoephile audit translation \
-  --mode gapped \
   --target <gapped-target.srt> \
   --guide <complete-guide.srt> \
   --json <gap_translation/device.json> \
@@ -95,7 +94,6 @@ Guided:
 
 ```shell
 UV_CACHE_DIR=/tmp/uv-cache uv run scinoephile audit translation \
-  --mode guided \
   --source <source.srt> \
   --guide <target-language-guide.srt> \
   --json <guided_translation/device.json> \
@@ -105,15 +103,16 @@ UV_CACHE_DIR=/tmp/uv-cache uv run scinoephile audit translation \
 ```
 
 Use inclusive `--first-index` and `--last-index`. They refer to global source
-indexes in standard and guided mode, and global guide indexes in gapped mode.
+indexes in standard and guided workflows, and global guide indexes in the gapped
+workflow.
 Use `--first-block` and `--last-block` for inclusive, one-based workflow block
-ranges: source blocks in standard mode and paired blocks in guided or gapped
-mode. Block and subtitle bounds may be combined; their intersection determines
-the displayed rows. Omit either bound for an open-ended range.
+ranges: source blocks in the standard workflow and paired blocks in guided or
+gapped workflows. Block and subtitle bounds may be combined; their intersection
+determines the displayed rows. Omit either bound for an open-ended range.
 Use `--filter unverified` to resume verification; the default is `all`.
 
-`(unanswered)` means the case has no answer. In gapped mode, `(empty)` is an
-answered output that intentionally emits no target subtitle.
+`(unanswered)` means the case has no answer. In the gapped workflow, `(empty)`
+is an answered output that intentionally emits no target subtitle.
 
 ## Audit every translation
 
@@ -124,11 +123,11 @@ the intended target language and script.
   names, numbers, register, terminology, continuity, and meaning-changing
   punctuation.
 - Preserve natural target-language grammar rather than copying source syntax.
-- In guided mode, use the guide as target-language context and semantic
+- In the guided workflow, use the guide as target-language context and semantic
   evidence, not as text that must be copied.
-- In gapped mode, treat existing target subtitles as context, not as text to
-  rewrite. Accept an empty output only when the guide position genuinely needs
-  no target subtitle.
+- In the gapped workflow, treat existing target subtitles as context, not as
+  text to rewrite. Accept an empty output only when the guide position genuinely
+  needs no target subtitle.
 - Treat every unanswered case as incomplete.
 
 Write exactly `OK` for a clearly appropriate translation. Otherwise begin with:

--- a/skills/audit-translations/SKILL.md
+++ b/skills/audit-translations/SKILL.md
@@ -107,8 +107,8 @@ indexes in standard and guided workflows, and global guide indexes in the gapped
 workflow.
 Use `--first-block` and `--last-block` for inclusive, one-based workflow block
 ranges: source blocks in the standard workflow and paired blocks in guided or
-gapped workflows. Block and subtitle bounds may be combined; their intersection
-determines the displayed rows. Omit either bound for an open-ended range.
+gapped workflows. Subtitle-index and block ranges are mutually exclusive. Omit
+either bound for an open-ended range.
 Use `--filter unverified` to resume verification; the default is `all`.
 
 `(unanswered)` means the case has no answer. In the gapped workflow, `(empty)`

--- a/skills/audit-translations/agents/openai.yaml
+++ b/skills/audit-translations/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Audit Translations"
+  short_description: "Audit standard, gapped, and guided translations"
+  default_prompt: "Use $audit-translations to audit the appropriate translation workflow for this dataset."

--- a/test/analysis/test_audit_utils.py
+++ b/test/analysis/test_audit_utils.py
@@ -9,6 +9,7 @@ from pytest import raises
 from scinoephile.analysis.audit.utils import (
     AuditFilter,
     format_audit_report,
+    format_verification_marker,
     resolve_contextual_index,
 )
 from scinoephile.core.exceptions import ScinoephileError
@@ -21,6 +22,19 @@ def test_audit_filter_has_common_options():
         AuditFilter.changes,
         AuditFilter.unverified,
     )
+
+
+def test_format_audit_report_formats_block_range():
+    """Test shared report framing includes an optional block range."""
+    report = format_audit_report(
+        title="Example Audit",
+        summary_items=(),
+        columns=(("Index", "right"),),
+        rows=(),
+        first_block=4,
+    )
+
+    assert "- block range: from 4" in report
 
 
 def test_format_audit_report_formats_ranges_and_table():
@@ -52,19 +66,6 @@ def test_format_audit_report_formats_ranges_and_table():
     )
 
 
-def test_format_audit_report_formats_block_range():
-    """Test shared report framing includes an optional block range."""
-    report = format_audit_report(
-        title="Example Audit",
-        summary_items=(),
-        columns=(("Index", "right"),),
-        rows=(),
-        first_block=4,
-    )
-
-    assert "- block range: from 4" in report
-
-
 def test_format_audit_report_rejects_invalid_semantic_data():
     """Test report ranges, column alignments, and row widths are validated."""
     with raises(ScinoephileError, match="ranges are mutually exclusive"):
@@ -94,14 +95,11 @@ def test_format_audit_report_rejects_invalid_semantic_data():
         )
 
 
-def test_resolve_contextual_index_returns_direct_index():
-    """Test a directly resolved index is returned without modification."""
-    resolved_indexes = [2, None]
-
-    index = resolve_contextual_index((1, 2), resolved_indexes, 0)
-
-    assert index == 2
-    assert resolved_indexes == [2, None]
+def test_format_verification_marker_formats_semantic_state():
+    """Test verification states use the shared report markers."""
+    assert format_verification_marker(True) == "✓"
+    assert format_verification_marker(False) == ""
+    assert format_verification_marker(None) == "—"
 
 
 def test_resolve_contextual_index_memoizes_contextual_match():
@@ -122,3 +120,13 @@ def test_resolve_contextual_index_retains_ambiguity_without_anchors():
 
     assert index is None
     assert resolved_indexes == [None, None, None]
+
+
+def test_resolve_contextual_index_returns_direct_index():
+    """Test a directly resolved index is returned without modification."""
+    resolved_indexes = [2, None]
+
+    index = resolve_contextual_index((1, 2), resolved_indexes, 0)
+
+    assert index == 2
+    assert resolved_indexes == [2, None]

--- a/test/analysis/test_audit_utils.py
+++ b/test/analysis/test_audit_utils.py
@@ -8,6 +8,7 @@ from pytest import raises
 
 from scinoephile.analysis.audit.utils import (
     AuditFilter,
+    ComparisonAuditFilter,
     format_audit_report,
     format_verification_marker,
     resolve_contextual_index,
@@ -21,6 +22,16 @@ def test_audit_filter_has_common_options():
         AuditFilter.all,
         AuditFilter.changes,
         AuditFilter.unverified,
+    )
+
+
+def test_comparison_audit_filter_has_comparison_options():
+    """Test comparison audits share one filter contract."""
+    assert tuple(ComparisonAuditFilter) == (
+        ComparisonAuditFilter.all,
+        ComparisonAuditFilter.changes,
+        ComparisonAuditFilter.discrepancies,
+        ComparisonAuditFilter.unverified,
     )
 
 

--- a/test/analysis/test_audit_utils.py
+++ b/test/analysis/test_audit_utils.py
@@ -8,7 +8,8 @@ from pytest import raises
 
 from scinoephile.analysis.audit.utils import (
     AuditFilter,
-    ComparisonAuditFilter,
+    ChangeAuditFilter,
+    ExtendedAuditFilter,
     format_audit_report,
     format_verification_marker,
     resolve_contextual_index,
@@ -16,22 +17,30 @@ from scinoephile.analysis.audit.utils import (
 from scinoephile.core.exceptions import ScinoephileError
 
 
-def test_audit_filter_has_common_options():
-    """Test the shared audit filter exposes the common row options."""
+def test_audit_filter_has_verification_options():
+    """Test the base audit filter exposes verification row options."""
     assert tuple(AuditFilter) == (
         AuditFilter.all,
-        AuditFilter.changes,
         AuditFilter.unverified,
     )
 
 
-def test_comparison_audit_filter_has_comparison_options():
-    """Test comparison audits share one filter contract."""
-    assert tuple(ComparisonAuditFilter) == (
-        ComparisonAuditFilter.all,
-        ComparisonAuditFilter.changes,
-        ComparisonAuditFilter.discrepancies,
-        ComparisonAuditFilter.unverified,
+def test_change_audit_filter_has_change_options():
+    """Test change audits share one filter contract."""
+    assert tuple(ChangeAuditFilter) == (
+        ChangeAuditFilter.all,
+        ChangeAuditFilter.changes,
+        ChangeAuditFilter.unverified,
+    )
+
+
+def test_extended_audit_filter_has_extended_options():
+    """Test extended audits share one filter contract."""
+    assert tuple(ExtendedAuditFilter) == (
+        ExtendedAuditFilter.all,
+        ExtendedAuditFilter.changes,
+        ExtendedAuditFilter.discrepancies,
+        ExtendedAuditFilter.unverified,
     )
 
 

--- a/test/analysis/test_audit_utils.py
+++ b/test/analysis/test_audit_utils.py
@@ -11,6 +11,7 @@ from scinoephile.analysis.audit.utils import (
     format_audit_report,
     resolve_contextual_index,
 )
+from scinoephile.core.exceptions import ScinoephileError
 
 
 def test_audit_filter_has_common_options():
@@ -26,14 +27,12 @@ def test_format_audit_report_formats_ranges_and_table():
     """Test shared report framing includes optional ranges and table rows."""
     report = format_audit_report(
         title="Example Audit",
-        summary_lines=("- cases: 1",),
-        column_labels=("Index", "Text"),
-        column_separators=("---:", "---"),
-        rows=("| 2 | example |",),
+        summary_items=("cases: 1",),
+        columns=(("Index", "right"), ("Text | value", "left")),
+        rows=(("2", "example|line\nnext"),),
         first_index=2,
         last_index=3,
         index_track_name="target",
-        first_block=4,
     )
 
     assert report == (
@@ -43,26 +42,55 @@ def test_format_audit_report_formats_ranges_and_table():
         "\n"
         "- cases: 1\n"
         "- target subtitle range: 2 through 3\n"
-        "- block range: from 4\n"
         "- table rows: 1\n"
         "\n"
         "## Audit Table\n"
         "\n"
-        "| Index | Text |\n"
+        "| Index | Text \\| value |\n"
         "|---:|---|\n"
-        "| 2 | example |\n"
+        "| 2 | example\\|line<br>next |\n"
     )
 
 
-def test_format_audit_report_rejects_mismatched_table_columns():
-    """Test table labels and separators must describe the same columns."""
-    with raises(ValueError, match="same length"):
+def test_format_audit_report_formats_block_range():
+    """Test shared report framing includes an optional block range."""
+    report = format_audit_report(
+        title="Example Audit",
+        summary_items=(),
+        columns=(("Index", "right"),),
+        rows=(),
+        first_block=4,
+    )
+
+    assert "- block range: from 4" in report
+
+
+def test_format_audit_report_rejects_invalid_semantic_data():
+    """Test report ranges, column alignments, and row widths are validated."""
+    with raises(ScinoephileError, match="ranges are mutually exclusive"):
         format_audit_report(
             title="Example Audit",
-            summary_lines=(),
-            column_labels=("Index", "Text"),
-            column_separators=("---:",),
+            summary_items=(),
+            columns=(("Index", "right"),),
             rows=(),
+            first_index=1,
+            first_block=1,
+        )
+
+    with raises(ValueError, match="Unsupported table column alignment"):
+        format_audit_report(
+            title="Example Audit",
+            summary_items=(),
+            columns=(("Index", "diagonal"),),  # ty: ignore[invalid-argument-type]
+            rows=(),
+        )
+
+    with raises(ValueError, match="Table row 1 has 1 cells; expected 2"):
+        format_audit_report(
+            title="Example Audit",
+            summary_items=(),
+            columns=(("Index", "right"), ("Text", "left")),
+            rows=(("1",),),
         )
 
 

--- a/test/analysis/test_delineation_audit.py
+++ b/test/analysis/test_delineation_audit.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from pytest import raises
 
 from scinoephile.analysis.audit.delineation import audit_delineation
-from scinoephile.analysis.audit.utils import AuditFilter
+from scinoephile.analysis.audit.utils import ChangeAuditFilter
 from scinoephile.core import ScinoephileError
 from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.llms.delineation import (
@@ -128,12 +128,12 @@ def test_audit_delineation_filters_rows_and_subtitle_range():
     changed_report = audit_delineation(
         reference,
         test_cases,
-        row_filter=AuditFilter.changes,
+        row_filter=ChangeAuditFilter.changes,
     )
     unverified_report = audit_delineation(
         reference,
         test_cases,
-        row_filter=AuditFilter.unverified,
+        row_filter=ChangeAuditFilter.unverified,
     )
     ranged_report = audit_delineation(
         reference,

--- a/test/analysis/test_dual_review_audit.py
+++ b/test/analysis/test_dual_review_audit.py
@@ -1,0 +1,258 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests of parallel dual-script subtitle review auditing."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TypedDict
+
+from scinoephile.analysis.audit.dual_review import audit_dual_review
+from scinoephile.analysis.audit.utils import ExtendedAuditFilter
+from scinoephile.core.llms import TestCase
+from scinoephile.core.llms.utils import load_test_cases_from_json
+from scinoephile.core.subtitles import Series, Subtitle
+from scinoephile.llms.review import ReviewManager
+
+
+class _AuditInputs(TypedDict):
+    """Inputs comprising one complete audit input set."""
+
+    traditional: Series
+    """Traditional review input."""
+
+    traditional_reviewed: Series
+    """Traditional reviewed subtitles."""
+
+    traditional_simplified: Series
+    """Traditional simplification review input."""
+
+    traditional_simplified_reviewed: Series
+    """Traditional simplification reviewed subtitles."""
+
+    simplified: Series
+    """Simplified review input."""
+
+    simplified_reviewed: Series
+    """Simplified reviewed subtitles."""
+
+    traditional_review_cases: list[TestCase]
+    """Traditional review test cases."""
+
+    traditional_simplified_review_cases: list[TestCase]
+    """Traditional simplification review test cases."""
+
+    simplified_review_cases: list[TestCase]
+    """Simplified review test cases."""
+
+
+def test_audit_dual_review_filters_and_includes_json_notes(tmp_path: Path):
+    """Test row filters, character filters, and JSON-backed notes.
+
+    Arguments:
+        tmp_path: temporary path
+    """
+    inputs = _get_audit_inputs(tmp_path)
+
+    report = audit_dual_review(
+        **inputs,
+        row_filter=ExtendedAuditFilter.changes,
+    )
+
+    assert "- simplified review edits: 1" in report
+    assert "- traditional review edits: 1" in report
+    assert "- traditional simplification review edits: 1" in report
+    assert "- final text discrepancies: 2" in report
+    assert "- table rows: 3" in report
+    assert "| Notes | Verified |" in report
+    assert "| 1 |" not in report
+    assert (
+        "| 2 | 简错<br>简正 | 傳錯<br>傳正 | 传正 | 简正<br>传正 | "
+        "Simplified review: 修正简体字。<br>Traditional review: 修正繁體字。 |  |"
+        in report
+    )
+    assert "| 3 | 着正 | 著 | 着错<br>着正 | 着正 |" in report
+    assert "Simplified review: 修正简体字。" in report
+    assert "Traditional review: 修正繁體字。" in report
+    assert "Traditional simplification review: 修正簡化結果。" in report
+
+    report = audit_dual_review(
+        **inputs,
+        row_filter=ExtendedAuditFilter.discrepancies,
+    )
+    assert "- table rows: 2" in report
+    assert "| 2 |" in report
+    assert "| 3 |" not in report
+    assert "| 4 |" in report
+
+    report = audit_dual_review(
+        **inputs,
+        row_filter=ExtendedAuditFilter.all,
+        characters=("著", "丙"),
+    )
+    assert "- character filter: 著, 丙" in report
+    assert "- table rows: 1" in report
+    assert "| 1 |" not in report
+    assert "| 3 |" in report
+
+    report = audit_dual_review(
+        **inputs,
+        row_filter=ExtendedAuditFilter.all,
+        first_index=2,
+        last_index=3,
+    )
+    assert "- final text discrepancies: 1" in report
+    assert "- subtitle range: 2 through 3" in report
+    assert "- table rows: 2" in report
+    assert "| 1 |" not in report
+    assert "| 2 |" in report
+    assert "| 3 |" in report
+    assert "| 4 |" not in report
+
+
+def test_audit_dual_review_ignores_timing_differences(tmp_path: Path):
+    """Test timing differences do not prevent count-aligned audits.
+
+    Arguments:
+        tmp_path: temporary path
+    """
+    inputs = _get_audit_inputs(tmp_path)
+    inputs["traditional_reviewed"].events[1].start = 62_000
+    inputs["traditional_reviewed"].events[1].end = 62_500
+
+    report = audit_dual_review(**inputs, row_filter=ExtendedAuditFilter.all)
+
+    assert "- table rows: 4" in report
+
+
+def test_audit_dual_review_reuses_deduplicated_json_note(tmp_path: Path):
+    """Test one cached JSON block can annotate repeated matching subtitle rows.
+
+    Arguments:
+        tmp_path: temporary path
+    """
+    original_texts = ("錯", "錯")
+    reviewed_texts = ("正", "正")
+    original = _get_series(original_texts)
+    reviewed = _get_series(reviewed_texts)
+    json_path = tmp_path / "review.json"
+    _write_review_json(json_path, ("錯",), {1: ("正", "修正。")})
+
+    report = audit_dual_review(
+        traditional=original,
+        traditional_reviewed=reviewed,
+        traditional_simplified=reviewed,
+        traditional_simplified_reviewed=reviewed,
+        simplified=reviewed,
+        simplified_reviewed=reviewed,
+        traditional_review_cases=_load_review_cases(json_path),
+    )
+
+    assert report.count("Traditional review: 修正。") == 2
+
+
+def _get_audit_inputs(tmp_path: Path) -> _AuditInputs:
+    """Get a complete audit input set.
+
+    Arguments:
+        tmp_path: temporary path
+    Returns:
+        audit inputs
+    """
+    texts_by_name = {
+        "traditional": ("甲", "傳錯", "著", "異"),
+        "traditional_reviewed": ("甲", "傳正", "著", "異"),
+        "traditional_simplified": ("甲", "传正", "着错", "异乙"),
+        "traditional_simplified_reviewed": ("甲", "传正", "着正", "异乙"),
+        "simplified": ("甲", "简错", "着正", "异甲"),
+        "simplified_reviewed": ("甲", "简正", "着正", "异甲"),
+    }
+    series = {name: _get_series(texts) for name, texts in texts_by_name.items()}
+
+    traditional_json_path = tmp_path / "traditional.json"
+    _write_review_json(
+        traditional_json_path,
+        texts_by_name["traditional"],
+        {2: ("傳正", "修正繁體字。")},
+    )
+    traditional_simplified_json_path = tmp_path / "traditional_simplified.json"
+    _write_review_json(
+        traditional_simplified_json_path,
+        texts_by_name["traditional_simplified"],
+        {3: ("着正", "修正簡化結果。")},
+    )
+    simplified_json_path = tmp_path / "simplified.json"
+    _write_review_json(
+        simplified_json_path,
+        texts_by_name["simplified"],
+        {2: ("简正", "修正简体字。")},
+    )
+    return _AuditInputs(
+        traditional=series["traditional"],
+        traditional_reviewed=series["traditional_reviewed"],
+        traditional_simplified=series["traditional_simplified"],
+        traditional_simplified_reviewed=series["traditional_simplified_reviewed"],
+        simplified=series["simplified"],
+        simplified_reviewed=series["simplified_reviewed"],
+        traditional_review_cases=_load_review_cases(traditional_json_path),
+        traditional_simplified_review_cases=_load_review_cases(
+            traditional_simplified_json_path
+        ),
+        simplified_review_cases=_load_review_cases(simplified_json_path),
+    )
+
+
+def _get_series(texts: tuple[str, ...]) -> Series:
+    """Get a subtitle series fixture.
+
+    Arguments:
+        texts: subtitle texts
+    Returns:
+        subtitle series
+    """
+    return Series(events=[Subtitle(text=text) for text in texts])
+
+
+def _load_review_cases(json_path: Path) -> list[TestCase]:
+    """Load review test cases from a JSON fixture.
+
+    Arguments:
+        json_path: review JSON path
+    Returns:
+        deserialized review test cases
+    """
+    return load_test_cases_from_json(
+        json_path,
+        ReviewManager,
+        ReviewManager.base_prompt,
+    )
+
+
+def _write_review_json(
+    json_path: Path,
+    texts: tuple[str, ...],
+    revisions: dict[int, tuple[str, str]],
+):
+    """Write one block-based review JSON fixture.
+
+    Arguments:
+        json_path: output JSON path
+        texts: query texts
+        revisions: revised text and note keyed by one-based local index
+    """
+    query = {
+        "subtitles": [
+            {"index": index, "text": text} for index, text in enumerate(texts, 1)
+        ]
+    }
+    answer = {
+        "revisions": [
+            {"index": index, "text": revised, "note": note}
+            for index, (revised, note) in revisions.items()
+        ]
+    }
+    json_path.write_text(
+        json.dumps([{"query": query, "answer": answer}], ensure_ascii=False),
+        encoding="utf-8",
+    )

--- a/test/analysis/test_gap_translation_audit.py
+++ b/test/analysis/test_gap_translation_audit.py
@@ -1,0 +1,313 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests for gap-translation audit reports."""
+
+from __future__ import annotations
+
+from pytest import raises
+
+from scinoephile.analysis.audit.gap_translation import (
+    GapTranslationAuditFilter,
+    audit_gap_translation,
+)
+from scinoephile.core.exceptions import ScinoephileError
+from scinoephile.core.subtitles import Series, Subtitle
+from scinoephile.llms.gap_translation import (
+    GapTranslationAnswer,
+    GapTranslationQuery,
+    GapTranslationSubtitle,
+    GapTranslationTestCase,
+)
+
+
+def test_audit_gap_translation_formats_answer_and_context():
+    """Test one translated gap is rendered with global and local context."""
+    target = _get_series(
+        (0, 1000, "現有|一"),
+        (2000, 3000, "現有三"),
+    )
+    guide = _get_series(
+        (0, 1000, "參考一"),
+        (1000, 2000, "參|考二"),
+        (2000, 3000, "參考三"),
+    )
+    test_case = _get_test_case(
+        targets=((1, "現有|一"), (3, "現有三")),
+        guides=((1, "參考一"), (2, "參|考二"), (3, "參考三")),
+        outputs=((2, "翻譯\n二"),),
+        verified=True,
+    )
+
+    report = audit_gap_translation(target, guide, (test_case,))
+
+    assert "- logged cases: 1" in report
+    assert "- gaps: 1" in report
+    assert "- translated gaps: 1" in report
+    assert "- verified gaps: 1" in report
+    assert "- difficulty filter: all" in report
+    assert (
+        "| G 2<br>Q 2 | C 1<br>B 1 | 1 | 參\\|考二 | "
+        "G 1: 現有\\|一<br>G 3: 現有三 | 翻譯<br>二 |  | ✓ |"
+    ) in report
+
+
+def test_audit_gap_translation_formats_empty_and_unanswered_gaps():
+    """Test empty answers and missing answers remain distinguishable."""
+    target = _get_series(
+        (0, 1000, "現有一"),
+        (6000, 7000, "現有三"),
+    )
+    guide = _get_series(
+        (0, 1000, "參考一"),
+        (1000, 2000, "參考二"),
+        (6000, 7000, "參考三"),
+        (7000, 8000, "參考四"),
+    )
+    test_cases = (
+        _get_test_case(
+            targets=((1, "現有一"),),
+            guides=((1, "參考一"), (2, "參考二")),
+            outputs=((2, ""),),
+            verified=True,
+        ),
+        _get_test_case(
+            targets=((1, "現有三"),),
+            guides=((1, "參考三"), (2, "參考四")),
+        ),
+    )
+
+    report = audit_gap_translation(target, guide, test_cases)
+    unverified_report = audit_gap_translation(
+        target,
+        guide,
+        test_cases,
+        row_filter=GapTranslationAuditFilter.unverified,
+    )
+    ranged_report = audit_gap_translation(
+        target,
+        guide,
+        test_cases,
+        first_index=4,
+        last_index=4,
+    )
+    block_report = audit_gap_translation(
+        target,
+        guide,
+        test_cases,
+        first_block=2,
+        last_block=2,
+    )
+
+    assert "- empty translations: 1" in report
+    assert "- unanswered gaps: 1" in report
+    assert "| G 2<br>Q 2 | C 1<br>B 1 | 0 | 參考二 | G 1: 現有一 | (empty) |" in report
+    assert (
+        "| G 4<br>Q 2 | C 2<br>B 2 | 0 | 參考四 | G 3: 現有三 | "
+        "(unanswered) |" in report
+    )
+    assert "- row filter: unverified" in unverified_report
+    assert "- table rows: 1" in unverified_report
+    assert "| G 2<br>Q 2 |" not in unverified_report
+    assert "| G 4<br>Q 2 |" in unverified_report
+    assert "- guide subtitle range: 4 through 4" in ranged_report
+    assert "- logged cases: 1" in ranged_report
+    assert "| G 4<br>Q 2 |" in ranged_report
+    assert "- block range: 2 through 2" in block_report
+    assert "| G 2<br>Q 2 |" not in block_report
+    assert "| G 4<br>Q 2 |" in block_report
+
+
+def test_audit_gap_translation_filters_case_difficulty():
+    """Test exact difficulty levels compose into one case selection."""
+    target = _get_series(
+        (0, 1000, "現有一"),
+        (6000, 7000, "現有三"),
+    )
+    guide = _get_series(
+        (0, 1000, "參考一"),
+        (1000, 2000, "參考二"),
+        (6000, 7000, "參考三"),
+        (7000, 8000, "參考四"),
+    )
+    test_cases = (
+        _get_test_case(
+            targets=((1, "現有一"),),
+            guides=((1, "參考一"), (2, "參考二")),
+            outputs=((2, "翻譯二"),),
+        ),
+        _get_test_case(
+            targets=((1, "現有三"),),
+            guides=((1, "參考三"), (2, "參考四")),
+            outputs=((2, "翻譯四"),),
+            difficulty=2,
+        ),
+    )
+
+    report = audit_gap_translation(
+        target,
+        guide,
+        test_cases,
+        difficulties=(2,),
+    )
+
+    assert "- difficulty filter: 2" in report
+    assert "- logged cases: 1" in report
+    assert "- gaps: 1" in report
+    assert "| G 2<br>Q 2 |" not in report
+    assert "| G 4<br>Q 2 | C 2<br>B 2 | 2 |" in report
+
+
+def test_audit_gap_translation_ignores_superseded_target_revision():
+    """Test a current query supersedes retained history for the same guide block."""
+    target = _get_series((0, 1000, "目前"))
+    guide = _get_series(
+        (0, 1000, "參考一"),
+        (1000, 2000, "參考二"),
+    )
+    historical_case = _get_test_case(
+        targets=((1, "舊文"),),
+        guides=((1, "參考一"), (2, "參考二")),
+        outputs=((2, "舊翻譯"),),
+    )
+    current_case = _get_test_case(
+        targets=((1, "目前"),),
+        guides=((1, "參考一"), (2, "參考二")),
+        outputs=((2, "目前翻譯"),),
+    )
+
+    report = audit_gap_translation(
+        target,
+        guide,
+        (historical_case, current_case),
+    )
+
+    assert "- logged cases: 1" in report
+    assert "C 1" not in report
+    assert "| G 2<br>Q 2 | C 2<br>B 1 |" in report
+    assert "目前翻譯" in report
+    assert "舊翻譯" not in report
+
+
+def test_audit_gap_translation_rejects_ambiguous_block():
+    """Test repeated current blocks cannot be assigned an arbitrary index."""
+    target = _get_series(
+        (0, 1000, "現有"),
+        (6000, 7000, "現有"),
+    )
+    guide = _get_series(
+        (0, 1000, "重複一"),
+        (1000, 2000, "重複二"),
+        (6000, 7000, "重複一"),
+        (7000, 8000, "重複二"),
+    )
+    test_case = _get_test_case(
+        targets=((1, "現有"),),
+        guides=((1, "重複一"), (2, "重複二")),
+        outputs=((2, "翻譯"),),
+    )
+
+    with raises(ScinoephileError, match="test case 1 is ambiguous.*1, 2"):
+        audit_gap_translation(target, guide, (test_case,))
+
+    report = audit_gap_translation(
+        target,
+        guide,
+        (test_case,),
+        difficulties=(2,),
+    )
+    block_report = audit_gap_translation(
+        target,
+        guide,
+        (test_case,),
+        first_block=2,
+        last_block=2,
+    )
+    assert "- logged cases: 0" in report
+    assert "- table rows: 0" in report
+    assert "| G 4<br>Q 2 | C 1<br>B 2 |" in block_report
+
+
+def test_audit_gap_translation_rejects_invalid_range():
+    """Test direct callers receive a domain error for an invalid range."""
+    with raises(ScinoephileError, match="First index must be at least 1"):
+        audit_gap_translation(Series(), Series(), (), first_index=0)
+
+    with raises(ScinoephileError, match="First block must be at least 1"):
+        audit_gap_translation(Series(), Series(), (), first_block=0)
+
+    with raises(ScinoephileError, match="Difficulty must be at least 0"):
+        audit_gap_translation(Series(), Series(), (), difficulties=(-1,))
+
+
+def test_audit_gap_translation_rejects_unmatched_case():
+    """Test a logged case absent from current blocks is rejected."""
+    test_case = _get_test_case(
+        targets=((1, "現有"),),
+        guides=((1, "不同一"), (2, "不同二")),
+        outputs=((2, "翻譯"),),
+    )
+
+    with raises(ScinoephileError, match="test case 1 was not found"):
+        audit_gap_translation(
+            _get_series((0, 1000, "現有")),
+            _get_series((0, 1000, "參考一"), (1000, 2000, "參考二")),
+            (test_case,),
+        )
+
+
+def _get_series(*events: tuple[int, int, str]) -> Series:
+    """Construct a subtitle series with explicit timing.
+
+    Arguments:
+        *events: start time, end time, and text by subtitle
+    Returns:
+        constructed subtitle series
+    """
+    return Series(
+        events=[
+            Subtitle(start=start, end=end, text=text) for start, end, text in events
+        ]
+    )
+
+
+def _get_test_case(
+    *,
+    targets: tuple[tuple[int, str], ...],
+    guides: tuple[tuple[int, str], ...],
+    outputs: tuple[tuple[int, str], ...] | None = None,
+    difficulty: int = 0,
+    verified: bool = False,
+) -> GapTranslationTestCase:
+    """Construct one gap-translation test case.
+
+    Arguments:
+        targets: query-local indexes and existing target texts
+        guides: query-local indexes and guide texts
+        outputs: optional query-local indexes and translated texts
+        difficulty: requested test-case difficulty
+        verified: whether the complete case is verified
+    Returns:
+        constructed gap-translation test case
+    """
+    answer = None
+    if outputs is not None:
+        answer = GapTranslationAnswer(
+            outputs=[
+                GapTranslationSubtitle(index=index, text=text)
+                for index, text in outputs
+            ]
+        )
+    return GapTranslationTestCase(
+        query=GapTranslationQuery(
+            targets=[
+                GapTranslationSubtitle(index=index, text=text)
+                for index, text in targets
+            ],
+            guides=[
+                GapTranslationSubtitle(index=index, text=text) for index, text in guides
+            ],
+        ),
+        answer=answer,
+        difficulty=difficulty,
+        verified=verified,
+    )

--- a/test/analysis/test_gap_translation_audit.py
+++ b/test/analysis/test_gap_translation_audit.py
@@ -44,7 +44,6 @@ def test_audit_gap_translation_formats_answer_and_context():
     assert "- gaps: 1" in report
     assert "- translated gaps: 1" in report
     assert "- verified gaps: 1" in report
-    assert "- difficulty filter: all" in report
     assert (
         "| G 2<br>Q 2 | C 1<br>B 1 | 1 | 參\\|考二 | "
         "G 1: 現有\\|一<br>G 3: 現有三 | 翻譯<br>二 |  | ✓ |"
@@ -117,46 +116,6 @@ def test_audit_gap_translation_formats_empty_and_unanswered_gaps():
     assert "| G 4<br>Q 2 |" in block_report
 
 
-def test_audit_gap_translation_filters_case_difficulty():
-    """Test exact difficulty levels compose into one case selection."""
-    target = _get_series(
-        (0, 1000, "現有一"),
-        (6000, 7000, "現有三"),
-    )
-    guide = _get_series(
-        (0, 1000, "參考一"),
-        (1000, 2000, "參考二"),
-        (6000, 7000, "參考三"),
-        (7000, 8000, "參考四"),
-    )
-    test_cases = (
-        _get_test_case(
-            targets=((1, "現有一"),),
-            guides=((1, "參考一"), (2, "參考二")),
-            outputs=((2, "翻譯二"),),
-        ),
-        _get_test_case(
-            targets=((1, "現有三"),),
-            guides=((1, "參考三"), (2, "參考四")),
-            outputs=((2, "翻譯四"),),
-            difficulty=2,
-        ),
-    )
-
-    report = audit_gap_translation(
-        target,
-        guide,
-        test_cases,
-        difficulties=(2,),
-    )
-
-    assert "- difficulty filter: 2" in report
-    assert "- logged cases: 1" in report
-    assert "- gaps: 1" in report
-    assert "| G 2<br>Q 2 |" not in report
-    assert "| G 4<br>Q 2 | C 2<br>B 2 | 2 |" in report
-
-
 def test_audit_gap_translation_ignores_superseded_target_revision():
     """Test a current query supersedes retained history for the same guide block."""
     target = _get_series((0, 1000, "目前"))
@@ -209,12 +168,6 @@ def test_audit_gap_translation_rejects_ambiguous_block():
     with raises(ScinoephileError, match="test case 1 is ambiguous.*1, 2"):
         audit_gap_translation(target, guide, (test_case,))
 
-    report = audit_gap_translation(
-        target,
-        guide,
-        (test_case,),
-        difficulties=(2,),
-    )
     block_report = audit_gap_translation(
         target,
         guide,
@@ -222,8 +175,6 @@ def test_audit_gap_translation_rejects_ambiguous_block():
         first_block=2,
         last_block=2,
     )
-    assert "- logged cases: 0" in report
-    assert "- table rows: 0" in report
     assert "| G 4<br>Q 2 | C 1<br>B 2 |" in block_report
 
 
@@ -234,9 +185,6 @@ def test_audit_gap_translation_rejects_invalid_range():
 
     with raises(ScinoephileError, match="First block must be at least 1"):
         audit_gap_translation(Series(), Series(), (), first_block=0)
-
-    with raises(ScinoephileError, match="Difficulty must be at least 0"):
-        audit_gap_translation(Series(), Series(), (), difficulties=(-1,))
 
 
 def test_audit_gap_translation_rejects_unmatched_case():
@@ -275,7 +223,6 @@ def _get_test_case(
     targets: tuple[tuple[int, str], ...],
     guides: tuple[tuple[int, str], ...],
     outputs: tuple[tuple[int, str], ...] | None = None,
-    difficulty: int = 0,
     verified: bool = False,
 ) -> GapTranslationTestCase:
     """Construct one gap-translation test case.
@@ -284,7 +231,6 @@ def _get_test_case(
         targets: query-local indexes and existing target texts
         guides: query-local indexes and guide texts
         outputs: optional query-local indexes and translated texts
-        difficulty: requested test-case difficulty
         verified: whether the complete case is verified
     Returns:
         constructed gap-translation test case
@@ -308,6 +254,5 @@ def _get_test_case(
             ],
         ),
         answer=answer,
-        difficulty=difficulty,
         verified=verified,
     )

--- a/test/analysis/test_gap_translation_audit.py
+++ b/test/analysis/test_gap_translation_audit.py
@@ -114,6 +114,36 @@ def test_audit_gap_translation_formats_empty_and_unanswered_gaps():
     assert "| G 4<br>Q 2 |" in block_report
 
 
+def test_audit_gap_translation_ignores_superseded_guide_revision():
+    """Test a current query supersedes retained history with old guide text."""
+    target = _get_series((0, 1000, "現有"))
+    guide = _get_series(
+        (0, 1000, "新參考一"),
+        (1000, 2000, "新參考二"),
+    )
+    historical_case = _get_test_case(
+        targets=((1, "現有"),),
+        guides=((1, "舊參考一"), (2, "舊參考二")),
+        outputs=((2, "舊翻譯"),),
+    )
+    current_case = _get_test_case(
+        targets=((1, "現有"),),
+        guides=((1, "新參考一"), (2, "新參考二")),
+        outputs=((2, "新翻譯"),),
+    )
+
+    report = audit_gap_translation(
+        target,
+        guide,
+        (historical_case, current_case),
+    )
+
+    assert "C 1" not in report
+    assert "| G 2<br>Q 2 | C 2<br>B 1 |" in report
+    assert "新翻譯" in report
+    assert "舊翻譯" not in report
+
+
 def test_audit_gap_translation_ignores_superseded_target_revision():
     """Test a current query supersedes retained history for the same guide block."""
     target = _get_series((0, 1000, "目前"))

--- a/test/analysis/test_gap_translation_audit.py
+++ b/test/analysis/test_gap_translation_audit.py
@@ -6,10 +6,8 @@ from __future__ import annotations
 
 from pytest import raises
 
-from scinoephile.analysis.audit.gap_translation import (
-    GapTranslationAuditFilter,
-    audit_gap_translation,
-)
+from scinoephile.analysis.audit.gap_translation import audit_gap_translation
+from scinoephile.analysis.audit.utils import VerificationAuditFilter
 from scinoephile.core.exceptions import ScinoephileError
 from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.llms.gap_translation import (
@@ -80,7 +78,7 @@ def test_audit_gap_translation_formats_empty_and_unanswered_gaps():
         target,
         guide,
         test_cases,
-        row_filter=GapTranslationAuditFilter.unverified,
+        row_filter=VerificationAuditFilter.unverified,
     )
     ranged_report = audit_gap_translation(
         target,
@@ -178,6 +176,37 @@ def test_audit_gap_translation_rejects_ambiguous_block():
     assert "| G 4<br>Q 2 | C 1<br>B 2 |" in block_report
 
 
+def test_audit_gap_translation_rejects_missing_current_case():
+    """Test every selected current gap block requires a logged case."""
+    target = _get_series(
+        (0, 1000, "現有一"),
+        (6000, 7000, "現有二"),
+    )
+    guide = _get_series(
+        (0, 1000, "參考一"),
+        (1000, 2000, "缺口一"),
+        (6000, 7000, "參考二"),
+        (7000, 8000, "缺口二"),
+    )
+    first_case = _get_test_case(
+        targets=((1, "現有一"),),
+        guides=((1, "參考一"), (2, "缺口一")),
+        outputs=((2, "翻譯一"),),
+    )
+
+    with raises(ScinoephileError, match="no matching logged test case: 2"):
+        audit_gap_translation(target, guide, (first_case,))
+
+    first_block_report = audit_gap_translation(
+        target,
+        guide,
+        (first_case,),
+        first_block=1,
+        last_block=1,
+    )
+    assert "| G 2<br>Q 2 | C 1<br>B 1 |" in first_block_report
+
+
 def test_audit_gap_translation_rejects_invalid_range():
     """Test direct callers receive a domain error for an invalid range."""
     with raises(ScinoephileError, match="First index must be at least 1"):
@@ -185,6 +214,18 @@ def test_audit_gap_translation_rejects_invalid_range():
 
     with raises(ScinoephileError, match="First block must be at least 1"):
         audit_gap_translation(Series(), Series(), (), first_block=0)
+
+    with raises(
+        ScinoephileError,
+        match="Subtitle-index and block ranges are mutually exclusive",
+    ):
+        audit_gap_translation(
+            Series(),
+            Series(),
+            (),
+            first_index=1,
+            first_block=1,
+        )
 
 
 def test_audit_gap_translation_rejects_unmatched_case():

--- a/test/analysis/test_gap_translation_audit.py
+++ b/test/analysis/test_gap_translation_audit.py
@@ -145,35 +145,25 @@ def test_audit_gap_translation_ignores_superseded_target_revision():
     assert "舊翻譯" not in report
 
 
-def test_audit_gap_translation_rejects_ambiguous_block():
-    """Test repeated current blocks cannot be assigned an arbitrary index."""
-    target = _get_series(
-        (0, 1000, "現有"),
-        (6000, 7000, "現有"),
-    )
-    guide = _get_series(
-        (0, 1000, "重複一"),
-        (1000, 2000, "重複二"),
-        (6000, 7000, "重複一"),
-        (7000, 8000, "重複二"),
-    )
-    test_case = _get_test_case(
-        targets=((1, "現有"),),
-        guides=((1, "重複一"), (2, "重複二")),
-        outputs=((2, "翻譯"),),
-    )
+def test_audit_gap_translation_rejects_invalid_range():
+    """Test direct callers receive a domain error for an invalid range."""
+    with raises(ScinoephileError, match="First index must be at least 1"):
+        audit_gap_translation(Series(), Series(), (), first_index=0)
 
-    with raises(ScinoephileError, match="test case 1 is ambiguous.*1, 2"):
-        audit_gap_translation(target, guide, (test_case,))
+    with raises(ScinoephileError, match="First block must be at least 1"):
+        audit_gap_translation(Series(), Series(), (), first_block=0)
 
-    block_report = audit_gap_translation(
-        target,
-        guide,
-        (test_case,),
-        first_block=2,
-        last_block=2,
-    )
-    assert "| G 4<br>Q 2 | C 1<br>B 2 |" in block_report
+    with raises(
+        ScinoephileError,
+        match="Subtitle-index and block ranges are mutually exclusive",
+    ):
+        audit_gap_translation(
+            Series(),
+            Series(),
+            (),
+            first_index=1,
+            first_block=1,
+        )
 
 
 def test_audit_gap_translation_rejects_missing_current_case():
@@ -207,27 +197,6 @@ def test_audit_gap_translation_rejects_missing_current_case():
     assert "| G 2<br>Q 2 | C 1<br>B 1 |" in first_block_report
 
 
-def test_audit_gap_translation_rejects_invalid_range():
-    """Test direct callers receive a domain error for an invalid range."""
-    with raises(ScinoephileError, match="First index must be at least 1"):
-        audit_gap_translation(Series(), Series(), (), first_index=0)
-
-    with raises(ScinoephileError, match="First block must be at least 1"):
-        audit_gap_translation(Series(), Series(), (), first_block=0)
-
-    with raises(
-        ScinoephileError,
-        match="Subtitle-index and block ranges are mutually exclusive",
-    ):
-        audit_gap_translation(
-            Series(),
-            Series(),
-            (),
-            first_index=1,
-            first_block=1,
-        )
-
-
 def test_audit_gap_translation_rejects_unmatched_case():
     """Test a logged case absent from current blocks is rejected."""
     test_case = _get_test_case(
@@ -242,6 +211,40 @@ def test_audit_gap_translation_rejects_unmatched_case():
             _get_series((0, 1000, "參考一"), (1000, 2000, "參考二")),
             (test_case,),
         )
+
+
+def test_audit_gap_translation_reuses_case_for_repeated_blocks():
+    """Test one deduplicated case applies to every identical current block."""
+    target = _get_series(
+        (0, 1000, "現有"),
+        (6000, 7000, "現有"),
+    )
+    guide = _get_series(
+        (0, 1000, "重複一"),
+        (1000, 2000, "重複二"),
+        (6000, 7000, "重複一"),
+        (7000, 8000, "重複二"),
+    )
+    test_case = _get_test_case(
+        targets=((1, "現有"),),
+        guides=((1, "重複一"), (2, "重複二")),
+        outputs=((2, "翻譯"),),
+    )
+
+    report = audit_gap_translation(target, guide, (test_case,))
+
+    block_report = audit_gap_translation(
+        target,
+        guide,
+        (test_case,),
+        first_block=2,
+        last_block=2,
+    )
+    assert "- logged cases: 1" in report
+    assert "- gaps: 2" in report
+    assert "| G 2<br>Q 2 | C 1<br>B 1 |" in report
+    assert "| G 4<br>Q 2 | C 1<br>B 2 |" in report
+    assert "| G 4<br>Q 2 | C 1<br>B 2 |" in block_report
 
 
 def _get_series(*events: tuple[int, int, str]) -> Series:

--- a/test/analysis/test_gap_translation_audit.py
+++ b/test/analysis/test_gap_translation_audit.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from pytest import raises
 
 from scinoephile.analysis.audit.gap_translation import audit_gap_translation
-from scinoephile.analysis.audit.utils import VerificationAuditFilter
+from scinoephile.analysis.audit.utils import AuditFilter
 from scinoephile.core.exceptions import ScinoephileError
 from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.llms.gap_translation import (
@@ -78,7 +78,7 @@ def test_audit_gap_translation_formats_empty_and_unanswered_gaps():
         target,
         guide,
         test_cases,
-        row_filter=VerificationAuditFilter.unverified,
+        row_filter=AuditFilter.unverified,
     )
     ranged_report = audit_gap_translation(
         target,

--- a/test/analysis/test_guided_review_audit.py
+++ b/test/analysis/test_guided_review_audit.py
@@ -51,7 +51,7 @@ def test_audit_guided_review_formats_and_sorts_subtitles():
     assert "- unverified subtitles: 2" in report
     assert "| Index | Block | Guide | Target / revision | Notes | Verified |" in report
     first_row = "| 1 | 1 | 參考一 | 甲\\|乙 |  |  |"
-    second_row = "| 2 | 1 | 參考一 | 丙<br>修訂丙 |  |  |"
+    second_row = "| 2 | 1 | 參考一 | 丙<br>修訂丙 | correction |  |"
     third_row = "| 3 | 2 | 參考二 | 丁 |  | ✓ |"
     assert report.index(first_row) < report.index(second_row) < report.index(third_row)
 
@@ -102,6 +102,43 @@ def test_audit_guided_review_supports_target_only_block_in_range():
     assert "- subtitles: 1" in report
     assert "- target subtitle range: 1 through 1" in report
     assert "| 1 | 1 | — | 原文 |  |  |" in report
+
+
+def test_audit_guided_review_rejects_missing_current_case():
+    """Test every selected current target block requires a logged case."""
+    target = Series(
+        events=[
+            Subtitle(start=0, end=1000, text="甲"),
+            Subtitle(start=6000, end=7000, text="乙"),
+        ]
+    )
+    guide = Series(
+        events=[
+            Subtitle(start=0, end=1000, text="參考甲"),
+            Subtitle(start=6000, end=7000, text="參考乙"),
+        ]
+    )
+    first_case = GuidedReviewTestCase.model_validate(
+        {
+            "query": {
+                "targets": [{"index": 1, "text": "甲"}],
+                "guides": [{"index": 1, "text": "參考甲"}],
+            },
+            "answer": {"revisions": []},
+        }
+    )
+
+    with raises(ScinoephileError, match="no matching logged test case: 2"):
+        audit_guided_review(target, guide, (first_case,))
+
+    first_block_report = audit_guided_review(
+        target,
+        guide,
+        (first_case,),
+        first_block=1,
+        last_block=1,
+    )
+    assert "| 1 | 1 | 參考甲 | 甲 |  |  |" in first_block_report
 
 
 def test_audit_guided_review_rejects_invalid_range():
@@ -205,18 +242,18 @@ def test_audit_guided_review_filters_rows_and_target_range():
 
     assert "- row filter: changes" in changed_report
     assert "- table rows: 1" in changed_report
-    assert "| 2 | 1 | 參考一 | 丙<br>修訂丙 |  |  |" in changed_report
+    assert "| 2 | 1 | 參考一 | 丙<br>修訂丙 | correction |  |" in changed_report
     assert "- row filter: unverified" in unverified_report
     assert "- table rows: 2" in unverified_report
     assert "| 1 | 1 | 參考一 | 甲\\|乙 |  |  |" in unverified_report
-    assert "| 2 | 1 | 參考一 | 丙<br>修訂丙 |  |  |" in unverified_report
+    assert "| 2 | 1 | 參考一 | 丙<br>修訂丙 | correction |  |" in unverified_report
     assert "- subtitles: 1" in ranged_report
     assert "- target subtitle range: 3 through 3" in ranged_report
     assert "- table rows: 1" in ranged_report
     assert "| 3 | 2 | 參考二 | 丁 |  | ✓ |" in ranged_report
     assert "- subtitles: 1" in second_report
     assert "- target subtitle range: 2 through 2" in second_report
-    assert "| 2 | 1 | 參考一 | 丙<br>修訂丙 |  |  |" in second_report
+    assert "| 2 | 1 | 參考一 | 丙<br>修訂丙 | correction |  |" in second_report
     assert "- block range: 2 through 2" in block_report
     assert "| 1 | 1 |" not in block_report
     assert "| 2 | 1 |" not in block_report
@@ -297,7 +334,7 @@ def test_audit_guided_review_ignores_superseded_segmentation_case():
     report = audit_guided_review(target, guide, (stale_case, current_case))
 
     assert "| 1 | 1 | 參考 | 甲 |  |  |" in report
-    assert "| 2 | 1 | 參考 | 乙丙<br>修訂乙丙 |  |  |" in report
+    assert "| 2 | 1 | 參考 | 乙丙<br>修訂乙丙 | correction |  |" in report
 
 
 def test_audit_guided_review_ignores_superseded_guide_revision():
@@ -328,7 +365,7 @@ def test_audit_guided_review_ignores_superseded_guide_revision():
     report = audit_guided_review(target, guide, (stale_case, current_case))
 
     assert "舊修訂" not in report
-    assert "| 1 | 1 | 已更正參考 | 目標<br>新修訂 |  |  |" in report
+    assert "| 1 | 1 | 已更正參考 | 目標<br>新修訂 | current |  |" in report
 
 
 def test_audit_guided_review_matches_after_punctuation_changes():
@@ -435,7 +472,16 @@ def test_audit_guided_review_ignores_unmatched_case_outside_range():
             Subtitle(start=6500, end=7000, text="新增參考"),
         ]
     )
-    test_case = GuidedReviewTestCase.model_validate(
+    current_case = GuidedReviewTestCase.model_validate(
+        {
+            "query": {
+                "targets": [{"index": 1, "text": "甲"}],
+                "guides": [{"index": 1, "text": "參考一"}],
+            },
+            "answer": {"revisions": []},
+        }
+    )
+    stale_case = GuidedReviewTestCase.model_validate(
         {
             "query": {
                 "targets": [{"index": 1, "text": "乙"}],
@@ -448,13 +494,14 @@ def test_audit_guided_review_ignores_unmatched_case_outside_range():
     report = audit_guided_review(
         target,
         guide,
-        (test_case,),
+        (current_case, stale_case),
         first_index=1,
         last_index=1,
     )
 
-    assert "- subtitles: 0" in report
-    assert "- table rows: 0" in report
+    assert "- subtitles: 1" in report
+    assert "- table rows: 1" in report
+    assert "| 1 | 1 | 參考一 | 甲 |  |  |" in report
 
 
 def test_audit_guided_review_allows_range_beyond_target():

--- a/test/analysis/test_guided_review_audit.py
+++ b/test/analysis/test_guided_review_audit.py
@@ -13,79 +13,50 @@ from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.llms.guided_review import GuidedReviewTestCase
 
 
-def test_audit_guided_review_formats_and_sorts_subtitles():
-    """Test sparse revisions and notes are rendered in subtitle order."""
-    target, guide = _get_series_pair()
-    first_case = GuidedReviewTestCase.model_validate(
+def test_audit_guided_review_allows_range_beyond_target():
+    """Test an empty oversized range does not index beyond the target series."""
+    target = Series(events=[Subtitle(start=0, end=1000, text="目前")])
+    guide = Series(events=[Subtitle(start=0, end=1000, text="目前參考")])
+    stale_case = GuidedReviewTestCase.model_validate(
         {
             "query": {
-                "targets": [
-                    {"index": 1, "text": "甲|乙"},
-                    {"index": 2, "text": "丙"},
-                ],
-                "guides": [{"index": 1, "text": "參考一"}],
-            },
-            "answer": {
-                "revisions": [{"index": 2, "text": "修訂丙", "note": "correction"}]
-            },
-        }
-    )
-    second_case = GuidedReviewTestCase.model_validate(
-        {
-            "query": {
-                "targets": [{"index": 1, "text": "丁"}],
-                "guides": [{"index": 1, "text": "參考二"}],
-            },
-            "answer": {"revisions": []},
-            "verified": True,
-        }
-    )
-
-    report = audit_guided_review(target, guide, (second_case, first_case))
-
-    assert "- subtitles: 3" in report
-    assert "- revised subtitles: 1" in report
-    assert "- unchanged subtitles: 2" in report
-    assert "- unanswered subtitles: 0" in report
-    assert "- verified subtitles: 1" in report
-    assert "- unverified subtitles: 2" in report
-    assert "| Index | Block | Guide | Target / revision | Notes | Verified |" in report
-    first_row = "| 1 | 1 | 參考一 | 甲\\|乙 |  |  |"
-    second_row = "| 2 | 1 | 參考一 | 丙<br>修訂丙 | correction |  |"
-    third_row = "| 3 | 2 | 參考二 | 丁 |  | ✓ |"
-    assert report.index(first_row) < report.index(second_row) < report.index(third_row)
-
-
-def test_audit_guided_review_formats_unanswered_case():
-    """Test an absent answer is distinct from an explicit no-revision answer."""
-    target = Series(events=[Subtitle(start=0, end=1000, text="原文")])
-    guide = Series(events=[Subtitle(start=0, end=1000, text="參考")])
-    test_case = GuidedReviewTestCase.model_validate(
-        {
-            "query": {
-                "targets": [{"index": 1, "text": "原文"}],
-                "guides": [{"index": 1, "text": "參考"}],
+                "targets": [{"index": 1, "text": "舊文"}],
+                "guides": [{"index": 1, "text": "舊參考"}],
             }
         }
     )
 
-    report = audit_guided_review(target, guide, (test_case,))
+    report = audit_guided_review(
+        target,
+        guide,
+        (stale_case,),
+        first_index=2,
+        last_index=2,
+    )
 
-    assert "- revised subtitles: 0" in report
-    assert "- unchanged subtitles: 0" in report
-    assert "- unanswered subtitles: 1" in report
-    assert "| 1 | 1 | 參考 | 原文<br>(unanswered) |  |  |" in report
+    assert "- subtitles: 0" in report
+    assert "- target subtitle range: 2 through 2" in report
+    assert "- table rows: 0" in report
 
 
-def test_audit_guided_review_supports_target_only_block_in_range():
-    """Test a target-only block remains auditable with an index range."""
-    target = Series(events=[Subtitle(start=0, end=1000, text="原文")])
-    guide = Series()
+def test_audit_guided_review_allows_unaffected_range_before_changed_segmentation():
+    """Test a range before later segmentation drift remains auditable."""
+    target = Series(
+        events=[
+            Subtitle(start=0, end=1000, text="甲"),
+            Subtitle(start=1100, end=2000, text="乙丙"),
+        ]
+    )
+    guide = Series(events=[Subtitle(start=0, end=2000, text="參考")])
     test_case = GuidedReviewTestCase.model_validate(
         {
             "query": {
-                "targets": [{"index": 1, "text": "原文"}],
-                "guides": [],
+                "targets": [
+                    {"index": 1, "text": "甲"},
+                    {"index": 2, "text": "乙"},
+                    {"index": 3, "text": "丙"},
+                ],
+                "guides": [{"index": 1, "text": "參考"}],
             },
             "answer": {"revisions": []},
         }
@@ -99,81 +70,8 @@ def test_audit_guided_review_supports_target_only_block_in_range():
         last_index=1,
     )
 
-    assert "- subtitles: 1" in report
-    assert "- target subtitle range: 1 through 1" in report
-    assert "| 1 | 1 | — | 原文 |  |  |" in report
-
-
-def test_audit_guided_review_rejects_missing_current_case():
-    """Test every selected current target block requires a logged case."""
-    target = Series(
-        events=[
-            Subtitle(start=0, end=1000, text="甲"),
-            Subtitle(start=6000, end=7000, text="乙"),
-        ]
-    )
-    guide = Series(
-        events=[
-            Subtitle(start=0, end=1000, text="參考甲"),
-            Subtitle(start=6000, end=7000, text="參考乙"),
-        ]
-    )
-    first_case = GuidedReviewTestCase.model_validate(
-        {
-            "query": {
-                "targets": [{"index": 1, "text": "甲"}],
-                "guides": [{"index": 1, "text": "參考甲"}],
-            },
-            "answer": {"revisions": []},
-        }
-    )
-
-    with raises(ScinoephileError, match="no matching logged test case: 2"):
-        audit_guided_review(target, guide, (first_case,))
-
-    first_block_report = audit_guided_review(
-        target,
-        guide,
-        (first_case,),
-        first_block=1,
-        last_block=1,
-    )
-    assert "| 1 | 1 | 參考甲 | 甲 |  |  |" in first_block_report
-
-
-def test_audit_guided_review_rejects_invalid_range():
-    """Test direct callers receive domain errors for invalid options."""
-    target, guide = _get_series_pair()
-
-    with raises(ScinoephileError, match="First index must be at least 1"):
-        audit_guided_review(target, guide, (), first_index=0)
-
-    with raises(ScinoephileError, match="mutually exclusive"):
-        audit_guided_review(target, guide, (), first_index=1, first_block=1)
-
-
-def test_audit_guided_review_rejects_stale_target_only_case():
-    """Test a stale target-only case reports a domain error within a range."""
-    target = Series(events=[Subtitle(start=0, end=1000, text="目前")])
-    guide = Series(events=[Subtitle(start=0, end=1000, text="目前參考")])
-    stale_case = GuidedReviewTestCase.model_validate(
-        {
-            "query": {
-                "targets": [{"index": 1, "text": "舊文"}],
-                "guides": [],
-            },
-            "answer": {"revisions": []},
-        }
-    )
-
-    with raises(ScinoephileError, match="test case 1 was not found"):
-        audit_guided_review(
-            target,
-            guide,
-            (stale_case,),
-            first_index=1,
-            last_index=1,
-        )
+    assert "- table rows: 1" in report
+    assert "| 1 | 1 | 參考 | 甲 |  |  |" in report
 
 
 def test_audit_guided_review_filters_rows_and_target_range():
@@ -260,38 +158,99 @@ def test_audit_guided_review_filters_rows_and_target_range():
     assert "| 3 | 2 | 參考二 | 丁 |  | ✓ |" in block_report
 
 
-def test_audit_guided_review_uses_latest_case_per_subtitle():
-    """Test repeated logged cases emit only their latest decision."""
-    target = Series(events=[Subtitle(start=0, end=1000, text="原文")])
-    guide = Series(events=[Subtitle(start=0, end=1000, text="參考")])
-    revised_case = GuidedReviewTestCase.model_validate(
+def test_audit_guided_review_formats_and_sorts_subtitles():
+    """Test sparse revisions and notes are rendered in subtitle order."""
+    target, guide = _get_series_pair()
+    first_case = GuidedReviewTestCase.model_validate(
         {
             "query": {
-                "targets": [{"index": 1, "text": "原文"}],
-                "guides": [{"index": 1, "text": "參考"}],
+                "targets": [
+                    {"index": 1, "text": "甲|乙"},
+                    {"index": 2, "text": "丙"},
+                ],
+                "guides": [{"index": 1, "text": "參考一"}],
             },
             "answer": {
-                "revisions": [{"index": 1, "text": "舊修訂", "note": "old correction"}]
+                "revisions": [{"index": 2, "text": "修訂丙", "note": "correction"}]
             },
         }
     )
-    unchanged_case = GuidedReviewTestCase.model_validate(
+    second_case = GuidedReviewTestCase.model_validate(
         {
-            "query": revised_case.query.model_dump(),
+            "query": {
+                "targets": [{"index": 1, "text": "丁"}],
+                "guides": [{"index": 1, "text": "參考二"}],
+            },
             "answer": {"revisions": []},
             "verified": True,
         }
     )
 
-    report = audit_guided_review(target, guide, (revised_case, unchanged_case))
+    report = audit_guided_review(target, guide, (second_case, first_case))
 
-    assert "- subtitles: 1" in report
-    assert "- revised subtitles: 0" in report
-    assert "- unchanged subtitles: 1" in report
+    assert "- subtitles: 3" in report
+    assert "- revised subtitles: 1" in report
+    assert "- unchanged subtitles: 2" in report
+    assert "- unanswered subtitles: 0" in report
     assert "- verified subtitles: 1" in report
-    assert "- table rows: 1" in report
+    assert "- unverified subtitles: 2" in report
+    assert "| Index | Block | Guide | Target / revision | Notes | Verified |" in report
+    first_row = "| 1 | 1 | 參考一 | 甲\\|乙 |  |  |"
+    second_row = "| 2 | 1 | 參考一 | 丙<br>修訂丙 | correction |  |"
+    third_row = "| 3 | 2 | 參考二 | 丁 |  | ✓ |"
+    assert report.index(first_row) < report.index(second_row) < report.index(third_row)
+
+
+def test_audit_guided_review_formats_unanswered_case():
+    """Test an absent answer is distinct from an explicit no-revision answer."""
+    target = Series(events=[Subtitle(start=0, end=1000, text="原文")])
+    guide = Series(events=[Subtitle(start=0, end=1000, text="參考")])
+    test_case = GuidedReviewTestCase.model_validate(
+        {
+            "query": {
+                "targets": [{"index": 1, "text": "原文"}],
+                "guides": [{"index": 1, "text": "參考"}],
+            }
+        }
+    )
+
+    report = audit_guided_review(target, guide, (test_case,))
+
+    assert "- revised subtitles: 0" in report
+    assert "- unchanged subtitles: 0" in report
+    assert "- unanswered subtitles: 1" in report
+    assert "| 1 | 1 | 參考 | 原文<br>(unanswered) |  |  |" in report
+
+
+def test_audit_guided_review_ignores_superseded_guide_revision():
+    """Test a current guide correction supersedes the historical case."""
+    target = Series(events=[Subtitle(start=0, end=1000, text="目標")])
+    guide = Series(events=[Subtitle(start=0, end=1000, text="已更正參考")])
+    stale_case = GuidedReviewTestCase.model_validate(
+        {
+            "query": {
+                "targets": [{"index": 1, "text": "目標"}],
+                "guides": [{"index": 1, "text": "舊參考"}],
+            },
+            "answer": {"revisions": [{"index": 1, "text": "舊修訂", "note": "old"}]},
+        }
+    )
+    current_case = GuidedReviewTestCase.model_validate(
+        {
+            "query": {
+                "targets": [{"index": 1, "text": "目標"}],
+                "guides": [{"index": 1, "text": "已更正參考"}],
+            },
+            "answer": {
+                "revisions": [{"index": 1, "text": "新修訂", "note": "current"}]
+            },
+        }
+    )
+
+    report = audit_guided_review(target, guide, (stale_case, current_case))
+
     assert "舊修訂" not in report
-    assert "| 1 | 1 | 參考 | 原文 |  | ✓ |" in report
+    assert "| 1 | 1 | 已更正參考 | 目標<br>新修訂 | current |  |" in report
 
 
 def test_audit_guided_review_ignores_superseded_segmentation_case():
@@ -335,126 +294,6 @@ def test_audit_guided_review_ignores_superseded_segmentation_case():
 
     assert "| 1 | 1 | 參考 | 甲 |  |  |" in report
     assert "| 2 | 1 | 參考 | 乙丙<br>修訂乙丙 | correction |  |" in report
-
-
-def test_audit_guided_review_ignores_superseded_guide_revision():
-    """Test a current guide correction supersedes the historical case."""
-    target = Series(events=[Subtitle(start=0, end=1000, text="目標")])
-    guide = Series(events=[Subtitle(start=0, end=1000, text="已更正參考")])
-    stale_case = GuidedReviewTestCase.model_validate(
-        {
-            "query": {
-                "targets": [{"index": 1, "text": "目標"}],
-                "guides": [{"index": 1, "text": "舊參考"}],
-            },
-            "answer": {"revisions": [{"index": 1, "text": "舊修訂", "note": "old"}]},
-        }
-    )
-    current_case = GuidedReviewTestCase.model_validate(
-        {
-            "query": {
-                "targets": [{"index": 1, "text": "目標"}],
-                "guides": [{"index": 1, "text": "已更正參考"}],
-            },
-            "answer": {
-                "revisions": [{"index": 1, "text": "新修訂", "note": "current"}]
-            },
-        }
-    )
-
-    report = audit_guided_review(target, guide, (stale_case, current_case))
-
-    assert "舊修訂" not in report
-    assert "| 1 | 1 | 已更正參考 | 目標<br>新修訂 | current |  |" in report
-
-
-def test_audit_guided_review_matches_after_punctuation_changes():
-    """Test source punctuation changes do not obscure the reviewed input."""
-    target = Series(events=[Subtitle(start=0, end=1000, text="原文！")])
-    guide = Series(events=[Subtitle(start=0, end=1000, text="參考")])
-    test_case = GuidedReviewTestCase.model_validate(
-        {
-            "query": {
-                "targets": [{"index": 1, "text": "原文。"}],
-                "guides": [{"index": 1, "text": "參考"}],
-            },
-            "answer": {"revisions": []},
-        }
-    )
-
-    report = audit_guided_review(target, guide, (test_case,))
-
-    assert "| 1 | 1 | 參考 | 原文。 |  |  |" in report
-
-
-def test_audit_guided_review_allows_unaffected_range_before_changed_segmentation():
-    """Test a range before later segmentation drift remains auditable."""
-    target = Series(
-        events=[
-            Subtitle(start=0, end=1000, text="甲"),
-            Subtitle(start=1100, end=2000, text="乙丙"),
-        ]
-    )
-    guide = Series(events=[Subtitle(start=0, end=2000, text="參考")])
-    test_case = GuidedReviewTestCase.model_validate(
-        {
-            "query": {
-                "targets": [
-                    {"index": 1, "text": "甲"},
-                    {"index": 2, "text": "乙"},
-                    {"index": 3, "text": "丙"},
-                ],
-                "guides": [{"index": 1, "text": "參考"}],
-            },
-            "answer": {"revisions": []},
-        }
-    )
-
-    report = audit_guided_review(
-        target,
-        guide,
-        (test_case,),
-        first_index=1,
-        last_index=1,
-    )
-
-    assert "- table rows: 1" in report
-    assert "| 1 | 1 | 參考 | 甲 |  |  |" in report
-
-
-def test_audit_guided_review_rejects_selected_changed_segmentation():
-    """Test selected rows cannot use stale target segmentation."""
-    target = Series(
-        events=[
-            Subtitle(start=0, end=1000, text="甲"),
-            Subtitle(start=1100, end=2000, text="乙丙"),
-        ]
-    )
-    guide = Series(events=[Subtitle(start=0, end=2000, text="參考")])
-    test_case = GuidedReviewTestCase.model_validate(
-        {
-            "query": {
-                "targets": [
-                    {"index": 1, "text": "甲"},
-                    {"index": 2, "text": "乙"},
-                    {"index": 3, "text": "丙"},
-                ],
-                "guides": [{"index": 1, "text": "參考"}],
-            },
-            "answer": {"revisions": []},
-        }
-    )
-
-    with raises(
-        ScinoephileError, match="segmentation no longer matches subtitle index 2"
-    ):
-        audit_guided_review(
-            target,
-            guide,
-            (test_case,),
-            first_index=2,
-            last_index=2,
-        )
 
 
 def test_audit_guided_review_ignores_unmatched_case_outside_range():
@@ -504,30 +343,23 @@ def test_audit_guided_review_ignores_unmatched_case_outside_range():
     assert "| 1 | 1 | 參考一 | 甲 |  |  |" in report
 
 
-def test_audit_guided_review_allows_range_beyond_target():
-    """Test an empty oversized range does not index beyond the target series."""
-    target = Series(events=[Subtitle(start=0, end=1000, text="目前")])
-    guide = Series(events=[Subtitle(start=0, end=1000, text="目前參考")])
-    stale_case = GuidedReviewTestCase.model_validate(
+def test_audit_guided_review_matches_after_punctuation_changes():
+    """Test source punctuation changes do not obscure the reviewed input."""
+    target = Series(events=[Subtitle(start=0, end=1000, text="原文！")])
+    guide = Series(events=[Subtitle(start=0, end=1000, text="參考")])
+    test_case = GuidedReviewTestCase.model_validate(
         {
             "query": {
-                "targets": [{"index": 1, "text": "舊文"}],
-                "guides": [{"index": 1, "text": "舊參考"}],
-            }
+                "targets": [{"index": 1, "text": "原文。"}],
+                "guides": [{"index": 1, "text": "參考"}],
+            },
+            "answer": {"revisions": []},
         }
     )
 
-    report = audit_guided_review(
-        target,
-        guide,
-        (stale_case,),
-        first_index=2,
-        last_index=2,
-    )
+    report = audit_guided_review(target, guide, (test_case,))
 
-    assert "- subtitles: 0" in report
-    assert "- target subtitle range: 2 through 2" in report
-    assert "- table rows: 0" in report
+    assert "| 1 | 1 | 參考 | 原文。 |  |  |" in report
 
 
 def test_audit_guided_review_rejects_changed_selected_target():
@@ -549,8 +381,115 @@ def test_audit_guided_review_rejects_changed_selected_target():
         audit_guided_review(target, guide, (test_case,))
 
 
-def test_audit_guided_review_rejects_ambiguous_case():
-    """Test repeated target and guide blocks cannot receive misleading indexes."""
+def test_audit_guided_review_rejects_invalid_range():
+    """Test direct callers receive domain errors for invalid options."""
+    target, guide = _get_series_pair()
+
+    with raises(ScinoephileError, match="First index must be at least 1"):
+        audit_guided_review(target, guide, (), first_index=0)
+
+    with raises(ScinoephileError, match="mutually exclusive"):
+        audit_guided_review(target, guide, (), first_index=1, first_block=1)
+
+
+def test_audit_guided_review_rejects_missing_current_case():
+    """Test every selected current target block requires a logged case."""
+    target = Series(
+        events=[
+            Subtitle(start=0, end=1000, text="甲"),
+            Subtitle(start=6000, end=7000, text="乙"),
+        ]
+    )
+    guide = Series(
+        events=[
+            Subtitle(start=0, end=1000, text="參考甲"),
+            Subtitle(start=6000, end=7000, text="參考乙"),
+        ]
+    )
+    first_case = GuidedReviewTestCase.model_validate(
+        {
+            "query": {
+                "targets": [{"index": 1, "text": "甲"}],
+                "guides": [{"index": 1, "text": "參考甲"}],
+            },
+            "answer": {"revisions": []},
+        }
+    )
+
+    with raises(ScinoephileError, match="no matching logged test case: 2"):
+        audit_guided_review(target, guide, (first_case,))
+
+    first_block_report = audit_guided_review(
+        target,
+        guide,
+        (first_case,),
+        first_block=1,
+        last_block=1,
+    )
+    assert "| 1 | 1 | 參考甲 | 甲 |  |  |" in first_block_report
+
+
+def test_audit_guided_review_rejects_selected_changed_segmentation():
+    """Test selected rows cannot use stale target segmentation."""
+    target = Series(
+        events=[
+            Subtitle(start=0, end=1000, text="甲"),
+            Subtitle(start=1100, end=2000, text="乙丙"),
+        ]
+    )
+    guide = Series(events=[Subtitle(start=0, end=2000, text="參考")])
+    test_case = GuidedReviewTestCase.model_validate(
+        {
+            "query": {
+                "targets": [
+                    {"index": 1, "text": "甲"},
+                    {"index": 2, "text": "乙"},
+                    {"index": 3, "text": "丙"},
+                ],
+                "guides": [{"index": 1, "text": "參考"}],
+            },
+            "answer": {"revisions": []},
+        }
+    )
+
+    with raises(
+        ScinoephileError, match="segmentation no longer matches subtitle index 2"
+    ):
+        audit_guided_review(
+            target,
+            guide,
+            (test_case,),
+            first_index=2,
+            last_index=2,
+        )
+
+
+def test_audit_guided_review_rejects_stale_target_only_case():
+    """Test a stale target-only case reports a domain error within a range."""
+    target = Series(events=[Subtitle(start=0, end=1000, text="目前")])
+    guide = Series(events=[Subtitle(start=0, end=1000, text="目前參考")])
+    stale_case = GuidedReviewTestCase.model_validate(
+        {
+            "query": {
+                "targets": [{"index": 1, "text": "舊文"}],
+                "guides": [],
+            },
+            "answer": {"revisions": []},
+        }
+    )
+
+    with raises(ScinoephileError, match="test case 1 was not found"):
+        audit_guided_review(
+            target,
+            guide,
+            (stale_case,),
+            first_index=1,
+            last_index=1,
+        )
+
+
+def test_audit_guided_review_reuses_case_for_repeated_blocks():
+    """Test one deduplicated case applies to every identical current block."""
     target = Series(
         events=[
             Subtitle(start=0, end=1000, text="原文"),
@@ -572,8 +511,7 @@ def test_audit_guided_review_rejects_ambiguous_case():
         }
     )
 
-    with raises(ScinoephileError, match="test case 1 is ambiguous.*1, 2"):
-        audit_guided_review(target, guide, (test_case,))
+    all_report = audit_guided_review(target, guide, (test_case,))
 
     report = audit_guided_review(
         target,
@@ -582,7 +520,71 @@ def test_audit_guided_review_rejects_ambiguous_case():
         first_block=2,
         last_block=2,
     )
+    assert "- subtitles: 2" in all_report
+    assert "| 1 | 1 | 參考 | 原文<br>(unanswered) |" in all_report
+    assert "| 2 | 2 | 參考 | 原文<br>(unanswered) |" in all_report
     assert "| 2 | 2 | 參考 | 原文<br>(unanswered) |" in report
+
+
+def test_audit_guided_review_supports_target_only_block_in_range():
+    """Test a target-only block remains auditable with an index range."""
+    target = Series(events=[Subtitle(start=0, end=1000, text="原文")])
+    guide = Series()
+    test_case = GuidedReviewTestCase.model_validate(
+        {
+            "query": {
+                "targets": [{"index": 1, "text": "原文"}],
+                "guides": [],
+            },
+            "answer": {"revisions": []},
+        }
+    )
+
+    report = audit_guided_review(
+        target,
+        guide,
+        (test_case,),
+        first_index=1,
+        last_index=1,
+    )
+
+    assert "- subtitles: 1" in report
+    assert "- target subtitle range: 1 through 1" in report
+    assert "| 1 | 1 | — | 原文 |  |  |" in report
+
+
+def test_audit_guided_review_uses_latest_case_per_subtitle():
+    """Test repeated logged cases emit only their latest decision."""
+    target = Series(events=[Subtitle(start=0, end=1000, text="原文")])
+    guide = Series(events=[Subtitle(start=0, end=1000, text="參考")])
+    revised_case = GuidedReviewTestCase.model_validate(
+        {
+            "query": {
+                "targets": [{"index": 1, "text": "原文"}],
+                "guides": [{"index": 1, "text": "參考"}],
+            },
+            "answer": {
+                "revisions": [{"index": 1, "text": "舊修訂", "note": "old correction"}]
+            },
+        }
+    )
+    unchanged_case = GuidedReviewTestCase.model_validate(
+        {
+            "query": revised_case.query.model_dump(),
+            "answer": {"revisions": []},
+            "verified": True,
+        }
+    )
+
+    report = audit_guided_review(target, guide, (revised_case, unchanged_case))
+
+    assert "- subtitles: 1" in report
+    assert "- revised subtitles: 0" in report
+    assert "- unchanged subtitles: 1" in report
+    assert "- verified subtitles: 1" in report
+    assert "- table rows: 1" in report
+    assert "舊修訂" not in report
+    assert "| 1 | 1 | 參考 | 原文 |  | ✓ |" in report
 
 
 def _get_series_pair() -> tuple[Series, Series]:

--- a/test/analysis/test_guided_review_audit.py
+++ b/test/analysis/test_guided_review_audit.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from pytest import raises
 
 from scinoephile.analysis.audit.guided_review import audit_guided_review
-from scinoephile.analysis.audit.utils import AuditFilter
+from scinoephile.analysis.audit.utils import ChangeAuditFilter
 from scinoephile.core import ScinoephileError
 from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.llms.guided_review import GuidedReviewTestCase
@@ -30,7 +30,7 @@ def test_audit_guided_review_allows_range_beyond_target():
         target,
         guide,
         (stale_case,),
-        row_filter=AuditFilter.all,
+        row_filter=ChangeAuditFilter.all,
         first_index=2,
         last_index=2,
     )
@@ -67,7 +67,7 @@ def test_audit_guided_review_allows_unaffected_range_before_changed_segmentation
         target,
         guide,
         (test_case,),
-        row_filter=AuditFilter.all,
+        row_filter=ChangeAuditFilter.all,
         first_index=1,
         last_index=1,
     )
@@ -115,13 +115,13 @@ def test_audit_guided_review_filters_rows_and_target_range():
         target,
         guide,
         test_cases,
-        row_filter=AuditFilter.unverified,
+        row_filter=ChangeAuditFilter.unverified,
     )
     ranged_report = audit_guided_review(
         target,
         guide,
         test_cases,
-        row_filter=AuditFilter.all,
+        row_filter=ChangeAuditFilter.all,
         first_index=3,
         last_index=3,
     )
@@ -129,7 +129,7 @@ def test_audit_guided_review_filters_rows_and_target_range():
         target,
         guide,
         test_cases,
-        row_filter=AuditFilter.all,
+        row_filter=ChangeAuditFilter.all,
         first_index=2,
         last_index=2,
     )
@@ -137,7 +137,7 @@ def test_audit_guided_review_filters_rows_and_target_range():
         target,
         guide,
         test_cases,
-        row_filter=AuditFilter.all,
+        row_filter=ChangeAuditFilter.all,
         first_block=2,
         last_block=2,
     )
@@ -194,7 +194,7 @@ def test_audit_guided_review_formats_and_sorts_subtitles():
         target,
         guide,
         (second_case, first_case),
-        row_filter=AuditFilter.all,
+        row_filter=ChangeAuditFilter.all,
     )
 
     assert "- subtitles: 3" in report
@@ -227,7 +227,7 @@ def test_audit_guided_review_formats_unanswered_case():
         target,
         guide,
         (test_case,),
-        row_filter=AuditFilter.all,
+        row_filter=ChangeAuditFilter.all,
     )
 
     assert "- revised subtitles: 0" in report
@@ -265,7 +265,7 @@ def test_audit_guided_review_ignores_superseded_guide_revision():
         target,
         guide,
         (stale_case, current_case),
-        row_filter=AuditFilter.all,
+        row_filter=ChangeAuditFilter.all,
     )
 
     assert "舊修訂" not in report
@@ -313,7 +313,7 @@ def test_audit_guided_review_ignores_superseded_segmentation_case():
         target,
         guide,
         (stale_case, current_case),
-        row_filter=AuditFilter.all,
+        row_filter=ChangeAuditFilter.all,
     )
 
     assert "| 1 | 1 | 參考 | 甲 |  |  |" in report
@@ -358,7 +358,7 @@ def test_audit_guided_review_ignores_unmatched_case_outside_range():
         target,
         guide,
         (current_case, stale_case),
-        row_filter=AuditFilter.all,
+        row_filter=ChangeAuditFilter.all,
         first_index=1,
         last_index=1,
     )
@@ -386,7 +386,7 @@ def test_audit_guided_review_matches_after_punctuation_changes():
         target,
         guide,
         (test_case,),
-        row_filter=AuditFilter.all,
+        row_filter=ChangeAuditFilter.all,
     )
 
     assert "| 1 | 1 | 參考 | 原文。 |  |  |" in report
@@ -453,7 +453,7 @@ def test_audit_guided_review_rejects_missing_current_case():
         target,
         guide,
         (first_case,),
-        row_filter=AuditFilter.all,
+        row_filter=ChangeAuditFilter.all,
         first_block=1,
         last_block=1,
     )
@@ -546,14 +546,14 @@ def test_audit_guided_review_reuses_case_for_repeated_blocks():
         target,
         guide,
         (test_case,),
-        row_filter=AuditFilter.all,
+        row_filter=ChangeAuditFilter.all,
     )
 
     report = audit_guided_review(
         target,
         guide,
         (test_case,),
-        row_filter=AuditFilter.all,
+        row_filter=ChangeAuditFilter.all,
         first_block=2,
         last_block=2,
     )
@@ -581,7 +581,7 @@ def test_audit_guided_review_supports_target_only_block_in_range():
         target,
         guide,
         (test_case,),
-        row_filter=AuditFilter.all,
+        row_filter=ChangeAuditFilter.all,
         first_index=1,
         last_index=1,
     )
@@ -618,7 +618,7 @@ def test_audit_guided_review_uses_latest_case_per_subtitle():
         target,
         guide,
         (revised_case, unchanged_case),
-        row_filter=AuditFilter.all,
+        row_filter=ChangeAuditFilter.all,
     )
 
     assert "- subtitles: 1" in report

--- a/test/analysis/test_guided_review_audit.py
+++ b/test/analysis/test_guided_review_audit.py
@@ -30,6 +30,7 @@ def test_audit_guided_review_allows_range_beyond_target():
         target,
         guide,
         (stale_case,),
+        row_filter=AuditFilter.all,
         first_index=2,
         last_index=2,
     )
@@ -66,6 +67,7 @@ def test_audit_guided_review_allows_unaffected_range_before_changed_segmentation
         target,
         guide,
         (test_case,),
+        row_filter=AuditFilter.all,
         first_index=1,
         last_index=1,
     )
@@ -108,7 +110,6 @@ def test_audit_guided_review_filters_rows_and_target_range():
         target,
         guide,
         test_cases,
-        row_filter=AuditFilter.changes,
     )
     unverified_report = audit_guided_review(
         target,
@@ -120,6 +121,7 @@ def test_audit_guided_review_filters_rows_and_target_range():
         target,
         guide,
         test_cases,
+        row_filter=AuditFilter.all,
         first_index=3,
         last_index=3,
     )
@@ -127,6 +129,7 @@ def test_audit_guided_review_filters_rows_and_target_range():
         target,
         guide,
         test_cases,
+        row_filter=AuditFilter.all,
         first_index=2,
         last_index=2,
     )
@@ -134,6 +137,7 @@ def test_audit_guided_review_filters_rows_and_target_range():
         target,
         guide,
         test_cases,
+        row_filter=AuditFilter.all,
         first_block=2,
         last_block=2,
     )
@@ -186,7 +190,12 @@ def test_audit_guided_review_formats_and_sorts_subtitles():
         }
     )
 
-    report = audit_guided_review(target, guide, (second_case, first_case))
+    report = audit_guided_review(
+        target,
+        guide,
+        (second_case, first_case),
+        row_filter=AuditFilter.all,
+    )
 
     assert "- subtitles: 3" in report
     assert "- revised subtitles: 1" in report
@@ -214,7 +223,12 @@ def test_audit_guided_review_formats_unanswered_case():
         }
     )
 
-    report = audit_guided_review(target, guide, (test_case,))
+    report = audit_guided_review(
+        target,
+        guide,
+        (test_case,),
+        row_filter=AuditFilter.all,
+    )
 
     assert "- revised subtitles: 0" in report
     assert "- unchanged subtitles: 0" in report
@@ -247,7 +261,12 @@ def test_audit_guided_review_ignores_superseded_guide_revision():
         }
     )
 
-    report = audit_guided_review(target, guide, (stale_case, current_case))
+    report = audit_guided_review(
+        target,
+        guide,
+        (stale_case, current_case),
+        row_filter=AuditFilter.all,
+    )
 
     assert "舊修訂" not in report
     assert "| 1 | 1 | 已更正參考 | 目標<br>新修訂 | current |  |" in report
@@ -290,7 +309,12 @@ def test_audit_guided_review_ignores_superseded_segmentation_case():
         }
     )
 
-    report = audit_guided_review(target, guide, (stale_case, current_case))
+    report = audit_guided_review(
+        target,
+        guide,
+        (stale_case, current_case),
+        row_filter=AuditFilter.all,
+    )
 
     assert "| 1 | 1 | 參考 | 甲 |  |  |" in report
     assert "| 2 | 1 | 參考 | 乙丙<br>修訂乙丙 | correction |  |" in report
@@ -334,6 +358,7 @@ def test_audit_guided_review_ignores_unmatched_case_outside_range():
         target,
         guide,
         (current_case, stale_case),
+        row_filter=AuditFilter.all,
         first_index=1,
         last_index=1,
     )
@@ -357,7 +382,12 @@ def test_audit_guided_review_matches_after_punctuation_changes():
         }
     )
 
-    report = audit_guided_review(target, guide, (test_case,))
+    report = audit_guided_review(
+        target,
+        guide,
+        (test_case,),
+        row_filter=AuditFilter.all,
+    )
 
     assert "| 1 | 1 | 參考 | 原文。 |  |  |" in report
 
@@ -423,6 +453,7 @@ def test_audit_guided_review_rejects_missing_current_case():
         target,
         guide,
         (first_case,),
+        row_filter=AuditFilter.all,
         first_block=1,
         last_block=1,
     )
@@ -511,12 +542,18 @@ def test_audit_guided_review_reuses_case_for_repeated_blocks():
         }
     )
 
-    all_report = audit_guided_review(target, guide, (test_case,))
+    all_report = audit_guided_review(
+        target,
+        guide,
+        (test_case,),
+        row_filter=AuditFilter.all,
+    )
 
     report = audit_guided_review(
         target,
         guide,
         (test_case,),
+        row_filter=AuditFilter.all,
         first_block=2,
         last_block=2,
     )
@@ -544,6 +581,7 @@ def test_audit_guided_review_supports_target_only_block_in_range():
         target,
         guide,
         (test_case,),
+        row_filter=AuditFilter.all,
         first_index=1,
         last_index=1,
     )
@@ -576,7 +614,12 @@ def test_audit_guided_review_uses_latest_case_per_subtitle():
         }
     )
 
-    report = audit_guided_review(target, guide, (revised_case, unchanged_case))
+    report = audit_guided_review(
+        target,
+        guide,
+        (revised_case, unchanged_case),
+        row_filter=AuditFilter.all,
+    )
 
     assert "- subtitles: 1" in report
     assert "- revised subtitles: 0" in report

--- a/test/analysis/test_ocr_fusion_audit.py
+++ b/test/analysis/test_ocr_fusion_audit.py
@@ -84,9 +84,9 @@ def test_audit_ocr_fusion_filters_unverified_and_automatic_rows():
         row_filter=OcrFusionAuditFilter.unverified,
     )
 
-    assert "| 1 | — | — | 相同 | 相同 | 相同 | — | Sources identical |" in report
-    assert "| 2 | — | — | 只有一 | — | 只有一 | — | Source two empty |" in report
-    assert "| 3 | 1 | 1 | 甲 | 乙 | 甲 | — | (unanswered) |" in report
+    assert "| 1 | — | — | 相同 | 相同 | 相同 | — | Sources identical | — |" in report
+    assert "| 2 | — | — | 只有一 | — | 只有一 | — | Source two empty | — |" in report
+    assert "| 3 | 1 | 1 | 甲 | 乙 | 甲 | — | (unanswered) |  |" in report
     assert "- table rows: 1" in unverified_report
     assert "| 3 | 1 |" in unverified_report
 

--- a/test/analysis/test_ocr_fusion_audit.py
+++ b/test/analysis/test_ocr_fusion_audit.py
@@ -6,10 +6,8 @@ from __future__ import annotations
 
 from pytest import raises
 
-from scinoephile.analysis.audit.ocr_fusion import (
-    OcrFusionAuditFilter,
-    audit_ocr_fusion,
-)
+from scinoephile.analysis.audit.ocr_fusion import audit_ocr_fusion
+from scinoephile.analysis.audit.utils import ComparisonAuditFilter
 from scinoephile.core.exceptions import ScinoephileError
 from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.llms.ocr_fusion import OcrFusionTestCase
@@ -41,7 +39,7 @@ def test_audit_ocr_fusion_filters_fused_blocks():
         source_two,
         fused,
         (),
-        row_filter=OcrFusionAuditFilter.all,
+        row_filter=ComparisonAuditFilter.all,
         first_block=2,
         last_block=2,
     )
@@ -65,14 +63,14 @@ def test_audit_ocr_fusion_filters_unverified_and_automatic_rows():
         source_two,
         fused,
         (test_case,),
-        row_filter=OcrFusionAuditFilter.all,
+        row_filter=ComparisonAuditFilter.all,
     )
     unverified_report = audit_ocr_fusion(
         source_one,
         source_two,
         fused,
         (test_case,),
-        row_filter=OcrFusionAuditFilter.unverified,
+        row_filter=ComparisonAuditFilter.unverified,
     )
 
     assert "| 1 | — | — | 相同 | 相同 | 相同 | — | Sources identical | — |" in report
@@ -110,7 +108,7 @@ def test_audit_ocr_fusion_formats_llm_decision_and_validated_discrepancy():
         fused,
         (test_case,),
         validated=validated,
-        row_filter=OcrFusionAuditFilter.discrepancies,
+        row_filter=ComparisonAuditFilter.discrepancies,
     )
 
     assert report.startswith("# OCR Fusion Audit\n")
@@ -137,7 +135,7 @@ def test_audit_ocr_fusion_keeps_notes_without_test_cases():
         source_one,
         source_two,
         fused,
-        row_filter=OcrFusionAuditFilter.all,
+        row_filter=ComparisonAuditFilter.all,
     )
 
     assert "- decision log: omitted" in report
@@ -180,7 +178,7 @@ def test_audit_ocr_fusion_rejects_invalid_inputs():
             two,
             one,
             (test_case,),
-            row_filter=OcrFusionAuditFilter.discrepancies,
+            row_filter=ComparisonAuditFilter.discrepancies,
         )
 
     misaligned = Series(events=[Subtitle(start=1000, end=1500, text="甲")])

--- a/test/analysis/test_ocr_fusion_audit.py
+++ b/test/analysis/test_ocr_fusion_audit.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from pytest import raises
 
 from scinoephile.analysis.audit.ocr_fusion import audit_ocr_fusion
-from scinoephile.analysis.audit.utils import ComparisonAuditFilter
+from scinoephile.analysis.audit.utils import ExtendedAuditFilter
 from scinoephile.core.exceptions import ScinoephileError
 from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.llms.ocr_fusion import OcrFusionTestCase
@@ -39,7 +39,7 @@ def test_audit_ocr_fusion_filters_fused_blocks():
         source_two,
         fused,
         (),
-        row_filter=ComparisonAuditFilter.all,
+        row_filter=ExtendedAuditFilter.all,
         first_block=2,
         last_block=2,
     )
@@ -63,14 +63,14 @@ def test_audit_ocr_fusion_filters_unverified_and_automatic_rows():
         source_two,
         fused,
         (test_case,),
-        row_filter=ComparisonAuditFilter.all,
+        row_filter=ExtendedAuditFilter.all,
     )
     unverified_report = audit_ocr_fusion(
         source_one,
         source_two,
         fused,
         (test_case,),
-        row_filter=ComparisonAuditFilter.unverified,
+        row_filter=ExtendedAuditFilter.unverified,
     )
 
     assert "| 1 | — | — | 相同 | 相同 | 相同 | — | Sources identical | — |" in report
@@ -108,7 +108,7 @@ def test_audit_ocr_fusion_formats_llm_decision_and_validated_discrepancy():
         fused,
         (test_case,),
         validated=validated,
-        row_filter=ComparisonAuditFilter.discrepancies,
+        row_filter=ExtendedAuditFilter.discrepancies,
     )
 
     assert report.startswith("# OCR Fusion Audit\n")
@@ -135,7 +135,7 @@ def test_audit_ocr_fusion_keeps_notes_without_test_cases():
         source_one,
         source_two,
         fused,
-        row_filter=ComparisonAuditFilter.all,
+        row_filter=ExtendedAuditFilter.all,
     )
 
     assert "- decision log: omitted" in report
@@ -178,7 +178,7 @@ def test_audit_ocr_fusion_rejects_invalid_inputs():
             two,
             one,
             (test_case,),
-            row_filter=ComparisonAuditFilter.discrepancies,
+            row_filter=ExtendedAuditFilter.discrepancies,
         )
 
     misaligned = Series(events=[Subtitle(start=1000, end=1500, text="甲")])

--- a/test/analysis/test_ocr_fusion_audit.py
+++ b/test/analysis/test_ocr_fusion_audit.py
@@ -15,6 +15,73 @@ from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.llms.ocr_fusion import OcrFusionTestCase
 
 
+def test_audit_ocr_fusion_filters_fused_blocks():
+    """Test block bounds select fused rows separated by long pauses."""
+    source_one = Series(
+        events=[
+            Subtitle(start=0, end=500, text="相同一"),
+            Subtitle(start=6000, end=6500, text="相同二"),
+        ]
+    )
+    source_two = Series(
+        events=[
+            Subtitle(start=0, end=500, text="相同一"),
+            Subtitle(start=6000, end=6500, text="相同二"),
+        ]
+    )
+    fused = Series(
+        events=[
+            Subtitle(start=0, end=500, text="相同一"),
+            Subtitle(start=6000, end=6500, text="相同二"),
+        ]
+    )
+
+    report = audit_ocr_fusion(
+        source_one,
+        source_two,
+        fused,
+        (),
+        row_filter=OcrFusionAuditFilter.all,
+        first_block=2,
+        last_block=2,
+    )
+
+    assert "- block range: 2 through 2" in report
+    assert "| 1 | — |" not in report
+    assert "| 2 | — |" in report
+
+
+def test_audit_ocr_fusion_filters_unverified_and_automatic_rows():
+    """Test automatic rows and unanswered LLM cases remain distinguishable."""
+    source_one = _get_series("相同", "只有一", "甲")
+    source_two = _get_series("相同", "", "乙")
+    fused = _get_series("相同", "只有一", "甲")
+    test_case = OcrFusionTestCase.model_validate(
+        {"query": {"source_one": "甲", "source_two": "乙"}}
+    )
+
+    report = audit_ocr_fusion(
+        source_one,
+        source_two,
+        fused,
+        (test_case,),
+        row_filter=OcrFusionAuditFilter.all,
+    )
+    unverified_report = audit_ocr_fusion(
+        source_one,
+        source_two,
+        fused,
+        (test_case,),
+        row_filter=OcrFusionAuditFilter.unverified,
+    )
+
+    assert "| 1 | — | — | 相同 | 相同 | 相同 | — | Sources identical | — |" in report
+    assert "| 2 | — | — | 只有一 | — | 只有一 | — | Source two empty | — |" in report
+    assert "| 3 | 1 | 1 | 甲 | 乙 | 甲 | — | (unanswered) |  |" in report
+    assert "- table rows: 1" in unverified_report
+    assert "| 3 | 1 |" in unverified_report
+
+
 def test_audit_ocr_fusion_formats_llm_decision_and_validated_discrepancy():
     """Test LLM metadata and optional validated truth are shown together."""
     source_one = _get_series("相同", "甲錯")
@@ -60,39 +127,8 @@ def test_audit_ocr_fusion_formats_llm_decision_and_validated_discrepancy():
     assert "- table rows: 1" in discrepancy_report
 
 
-def test_audit_ocr_fusion_filters_unverified_and_automatic_rows():
-    """Test automatic rows and unanswered LLM cases remain distinguishable."""
-    source_one = _get_series("相同", "只有一", "甲")
-    source_two = _get_series("相同", "", "乙")
-    fused = _get_series("相同", "只有一", "甲")
-    test_case = OcrFusionTestCase.model_validate(
-        {"query": {"source_one": "甲", "source_two": "乙"}}
-    )
-
-    report = audit_ocr_fusion(
-        source_one,
-        source_two,
-        fused,
-        (test_case,),
-        row_filter=OcrFusionAuditFilter.all,
-    )
-    unverified_report = audit_ocr_fusion(
-        source_one,
-        source_two,
-        fused,
-        (test_case,),
-        row_filter=OcrFusionAuditFilter.unverified,
-    )
-
-    assert "| 1 | — | — | 相同 | 相同 | 相同 | — | Sources identical | — |" in report
-    assert "| 2 | — | — | 只有一 | — | 只有一 | — | Source two empty | — |" in report
-    assert "| 3 | 1 | 1 | 甲 | 乙 | 甲 | — | (unanswered) |  |" in report
-    assert "- table rows: 1" in unverified_report
-    assert "| 3 | 1 |" in unverified_report
-
-
-def test_audit_ocr_fusion_omits_log_columns_without_test_cases():
-    """Test source and fused output can be audited without a decision log."""
+def test_audit_ocr_fusion_keeps_notes_without_test_cases():
+    """Test a report without a decision log retains its Notes column."""
     source_one = _get_series("甲錯")
     source_two = _get_series("甲正")
     fused = _get_series("甲正")
@@ -107,48 +143,11 @@ def test_audit_ocr_fusion_omits_log_columns_without_test_cases():
     assert "- decision log: omitted" in report
     assert "- LLM-required rows: 1" in report
     assert (
-        "| Subtitle | Case | Difficulty | Source one | Source two | Fused | Validated |"
-        in report
+        "| Subtitle | Case | Difficulty | Source one | Source two | "
+        "Fused | Validated | Notes |" in report
     )
-    assert "| 1 | — | — | 甲錯 | 甲正 | 甲正 | — |" in report
-    assert "Notes" not in report
+    assert "| 1 | — | — | 甲錯 | 甲正 | 甲正 | — |  |" in report
     assert "Verified" not in report
-
-
-def test_audit_ocr_fusion_filters_fused_blocks():
-    """Test block bounds select fused rows separated by long pauses."""
-    source_one = Series(
-        events=[
-            Subtitle(start=0, end=500, text="相同一"),
-            Subtitle(start=6000, end=6500, text="相同二"),
-        ]
-    )
-    source_two = Series(
-        events=[
-            Subtitle(start=0, end=500, text="相同一"),
-            Subtitle(start=6000, end=6500, text="相同二"),
-        ]
-    )
-    fused = Series(
-        events=[
-            Subtitle(start=0, end=500, text="相同一"),
-            Subtitle(start=6000, end=6500, text="相同二"),
-        ]
-    )
-
-    report = audit_ocr_fusion(
-        source_one,
-        source_two,
-        fused,
-        (),
-        row_filter=OcrFusionAuditFilter.all,
-        first_block=2,
-        last_block=2,
-    )
-
-    assert "- block range: 2 through 2" in report
-    assert "| 1 | — |" not in report
-    assert "| 2 | — |" in report
 
 
 def test_audit_ocr_fusion_rejects_invalid_inputs():

--- a/test/analysis/test_punctuation_audit.py
+++ b/test/analysis/test_punctuation_audit.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from pytest import raises
 
 from scinoephile.analysis.audit.punctuation import audit_punctuation
-from scinoephile.analysis.audit.utils import AuditFilter
+from scinoephile.analysis.audit.utils import ChangeAuditFilter
 from scinoephile.core.exceptions import ScinoephileError
 from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.llms.punctuation import (
@@ -83,13 +83,13 @@ def test_audit_punctuation_filters_rows_and_subtitle_range():
         reference,
         target,
         test_cases,
-        row_filter=AuditFilter.changes,
+        row_filter=ChangeAuditFilter.changes,
     )
     unverified_report = audit_punctuation(
         reference,
         target,
         test_cases,
-        row_filter=AuditFilter.unverified,
+        row_filter=ChangeAuditFilter.unverified,
     )
     ranged_report = audit_punctuation(
         reference,

--- a/test/analysis/test_review_audit.py
+++ b/test/analysis/test_review_audit.py
@@ -1,162 +1,16 @@
 #  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
-"""Tests of dual-script subtitle review auditing."""
+"""Tests of subtitle review auditing."""
 
 from __future__ import annotations
 
-import json
-from pathlib import Path
-from typing import TypedDict
-
 from pytest import raises
 
-from scinoephile.analysis.audit.review import (
-    ReviewAuditPair,
-    audit_dual_review,
-    audit_review,
-)
+from scinoephile.analysis.audit.review import ReviewAuditPair, audit_review
 from scinoephile.analysis.audit.utils import ChangeAuditFilter, ExtendedAuditFilter
 from scinoephile.core import ScinoephileError
-from scinoephile.core.llms import TestCase
-from scinoephile.core.llms.utils import load_test_cases_from_json
 from scinoephile.core.subtitles import Series, Subtitle
-from scinoephile.llms.review import ReviewManager, ReviewTestCase
-
-
-class _AuditInputs(TypedDict):
-    """Inputs comprising one complete audit input set."""
-
-    traditional: Series
-    """Traditional review input."""
-
-    traditional_reviewed: Series
-    """Traditional reviewed subtitles."""
-
-    traditional_simplified: Series
-    """Traditional simplification review input."""
-
-    traditional_simplified_reviewed: Series
-    """Traditional simplification reviewed subtitles."""
-
-    simplified: Series
-    """Simplified review input."""
-
-    simplified_reviewed: Series
-    """Simplified reviewed subtitles."""
-
-    traditional_review_cases: list[TestCase]
-    """Traditional review test cases."""
-
-    traditional_simplified_review_cases: list[TestCase]
-    """Traditional simplification review test cases."""
-
-    simplified_review_cases: list[TestCase]
-    """Simplified review test cases."""
-
-
-def test_audit_dual_review_filters_and_includes_json_notes(tmp_path: Path):
-    """Test row filters, character filters, and JSON-backed notes.
-
-    Arguments:
-        tmp_path: temporary path
-    """
-    inputs = _get_audit_inputs(tmp_path)
-
-    report = audit_dual_review(
-        **inputs,
-        row_filter=ExtendedAuditFilter.changes,
-    )
-
-    assert "- simplified review edits: 1" in report
-    assert "- traditional review edits: 1" in report
-    assert "- traditional simplification review edits: 1" in report
-    assert "- final text discrepancies: 2" in report
-    assert "- table rows: 3" in report
-    assert "| Notes | Verified |" in report
-    assert "| 1 |" not in report
-    assert (
-        "| 2 | 简错<br>简正 | 傳錯<br>傳正 | 传正 | 简正<br>传正 | "
-        "Simplified review: 修正简体字。<br>Traditional review: 修正繁體字。 |  |"
-        in report
-    )
-    assert "| 3 | 着正 | 著 | 着错<br>着正 | 着正 |" in report
-    assert "Simplified review: 修正简体字。" in report
-    assert "Traditional review: 修正繁體字。" in report
-    assert "Traditional simplification review: 修正簡化結果。" in report
-
-    report = audit_dual_review(
-        **inputs,
-        row_filter=ExtendedAuditFilter.discrepancies,
-    )
-    assert "- table rows: 2" in report
-    assert "| 2 |" in report
-    assert "| 3 |" not in report
-    assert "| 4 |" in report
-
-    report = audit_dual_review(
-        **inputs,
-        row_filter=ExtendedAuditFilter.all,
-        characters=("著", "丙"),
-    )
-    assert "- character filter: 著, 丙" in report
-    assert "- table rows: 1" in report
-    assert "| 1 |" not in report
-    assert "| 3 |" in report
-
-    report = audit_dual_review(
-        **inputs,
-        row_filter=ExtendedAuditFilter.all,
-        first_index=2,
-        last_index=3,
-    )
-    assert "- final text discrepancies: 1" in report
-    assert "- subtitle range: 2 through 3" in report
-    assert "- table rows: 2" in report
-    assert "| 1 |" not in report
-    assert "| 2 |" in report
-    assert "| 3 |" in report
-    assert "| 4 |" not in report
-
-
-def test_audit_dual_review_ignores_timing_differences(tmp_path: Path):
-    """Test timing differences do not prevent count-aligned audits.
-
-    Arguments:
-        tmp_path: temporary path
-    """
-    inputs = _get_audit_inputs(tmp_path)
-    inputs["traditional_reviewed"].events[1].start = 62_000
-    inputs["traditional_reviewed"].events[1].end = 62_500
-
-    report = audit_dual_review(**inputs, row_filter=ExtendedAuditFilter.all)
-
-    assert "- table rows: 4" in report
-
-
-def test_audit_dual_review_reuses_deduplicated_json_note(tmp_path: Path):
-    """Test one cached JSON block can annotate repeated matching subtitle rows.
-
-    Arguments:
-        tmp_path: temporary path
-    """
-    original_texts = ("錯", "錯")
-    reviewed_texts = ("正", "正")
-    original = _get_series(original_texts)
-    reviewed = _get_series(reviewed_texts)
-    json_path = tmp_path / "review.json"
-    _write_review_json(json_path, ("錯",), {1: ("正", "修正。")})
-
-    report = audit_dual_review(
-        traditional=original,
-        traditional_reviewed=reviewed,
-        traditional_simplified=reviewed,
-        traditional_simplified_reviewed=reviewed,
-        simplified=reviewed,
-        simplified_reviewed=reviewed,
-        traditional_review_cases=_load_review_cases(json_path),
-    )
-
-    assert report.count("Traditional review: 修正。") == 2
+from scinoephile.llms.review import ReviewTestCase
 
 
 def test_audit_review_filters_unverified_cases():
@@ -357,57 +211,6 @@ def test_audit_review_uses_latest_duplicate_case():
     assert "- table rows: 0" in unverified_report
 
 
-def _get_audit_inputs(tmp_path: Path) -> _AuditInputs:
-    """Get a complete audit input set.
-
-    Arguments:
-        tmp_path: temporary path
-    Returns:
-        audit inputs
-    """
-    texts_by_name = {
-        "traditional": ("甲", "傳錯", "著", "異"),
-        "traditional_reviewed": ("甲", "傳正", "著", "異"),
-        "traditional_simplified": ("甲", "传正", "着错", "异乙"),
-        "traditional_simplified_reviewed": ("甲", "传正", "着正", "异乙"),
-        "simplified": ("甲", "简错", "着正", "异甲"),
-        "simplified_reviewed": ("甲", "简正", "着正", "异甲"),
-    }
-    series = {name: _get_series(texts) for name, texts in texts_by_name.items()}
-
-    traditional_json_path = tmp_path / "traditional.json"
-    _write_review_json(
-        traditional_json_path,
-        texts_by_name["traditional"],
-        {2: ("傳正", "修正繁體字。")},
-    )
-    traditional_simplified_json_path = tmp_path / "traditional_simplified.json"
-    _write_review_json(
-        traditional_simplified_json_path,
-        texts_by_name["traditional_simplified"],
-        {3: ("着正", "修正簡化結果。")},
-    )
-    simplified_json_path = tmp_path / "simplified.json"
-    _write_review_json(
-        simplified_json_path,
-        texts_by_name["simplified"],
-        {2: ("简正", "修正简体字。")},
-    )
-    return _AuditInputs(
-        traditional=series["traditional"],
-        traditional_reviewed=series["traditional_reviewed"],
-        traditional_simplified=series["traditional_simplified"],
-        traditional_simplified_reviewed=series["traditional_simplified_reviewed"],
-        simplified=series["simplified"],
-        simplified_reviewed=series["simplified_reviewed"],
-        traditional_review_cases=_load_review_cases(traditional_json_path),
-        traditional_simplified_review_cases=_load_review_cases(
-            traditional_simplified_json_path
-        ),
-        simplified_review_cases=_load_review_cases(simplified_json_path),
-    )
-
-
 def _get_series(texts: tuple[str, ...]) -> Series:
     """Get a subtitle series fixture.
 
@@ -417,47 +220,3 @@ def _get_series(texts: tuple[str, ...]) -> Series:
         subtitle series
     """
     return Series(events=[Subtitle(text=text) for text in texts])
-
-
-def _load_review_cases(json_path: Path) -> list[TestCase]:
-    """Load review test cases from a JSON fixture.
-
-    Arguments:
-        json_path: review JSON path
-    Returns:
-        deserialized review test cases
-    """
-    return load_test_cases_from_json(
-        json_path,
-        ReviewManager,
-        ReviewManager.base_prompt,
-    )
-
-
-def _write_review_json(
-    json_path: Path,
-    texts: tuple[str, ...],
-    revisions: dict[int, tuple[str, str]],
-):
-    """Write one block-based review JSON fixture.
-
-    Arguments:
-        json_path: output JSON path
-        texts: query texts
-        revisions: revised text and note keyed by one-based local index
-    """
-    query = {
-        "subtitles": [
-            {"index": index, "text": text} for index, text in enumerate(texts, 1)
-        ]
-    }
-    answer = {
-        "revisions": [
-            {"index": index, "text": revised, "note": note}
-            for index, (revised, note) in revisions.items()
-        ]
-    }
-    json_path.write_text(
-        json.dumps([{"query": query, "answer": answer}], ensure_ascii=False),
-        encoding="utf-8",
-    )

--- a/test/analysis/test_review_audit.py
+++ b/test/analysis/test_review_audit.py
@@ -15,7 +15,7 @@ from scinoephile.analysis.audit.review import (
     audit_review_workflow,
     audit_reviews,
 )
-from scinoephile.analysis.audit.utils import AuditFilter, ComparisonAuditFilter
+from scinoephile.analysis.audit.utils import ChangeAuditFilter, ExtendedAuditFilter
 from scinoephile.core import ScinoephileError
 from scinoephile.core.llms import TestCase
 from scinoephile.core.llms.utils import load_test_cases_from_json
@@ -83,7 +83,7 @@ def test_audit_review_workflow_filters_unverified_cases():
                 review_cases=(unverified_case, verified_case),
             ),
         ),
-        row_filter=AuditFilter.unverified,
+        row_filter=ChangeAuditFilter.unverified,
     )
 
     assert "- row filter: unverified" in report
@@ -101,7 +101,7 @@ def test_audit_review_workflow_filters_unverified_cases():
                 review_cases=(unverified_case, verified_case),
             ),
         ),
-        row_filter=AuditFilter.all,
+        row_filter=ChangeAuditFilter.all,
     )
     assert "| 1 | First<br>First revised | Test review: Revised. |  |" in all_report
     assert "| 2 | Second |  | ✓ |" in all_report
@@ -147,7 +147,7 @@ def test_audit_review_workflow_ignores_retained_historical_cases():
                 review_cases=(historical_case, current_case),
             ),
         ),
-        row_filter=AuditFilter.all,
+        row_filter=ChangeAuditFilter.all,
     )
 
     assert "Historical note." not in report
@@ -184,7 +184,7 @@ def test_audit_review_workflow_selects_blocks():
 
     report = audit_review_workflow(
         reviews=reviews,
-        row_filter=AuditFilter.all,
+        row_filter=ChangeAuditFilter.all,
         first_block=2,
         last_block=2,
     )
@@ -204,7 +204,7 @@ def test_audit_review_workflow_selects_blocks():
     with raises(ScinoephileError, match="requires at least one comparison"):
         audit_review_workflow(
             reviews=reviews,
-            row_filter=ComparisonAuditFilter.discrepancies,
+            row_filter=ExtendedAuditFilter.discrepancies,
         )
 
 
@@ -240,10 +240,10 @@ def test_audit_review_workflow_uses_latest_duplicate_case():
         ),
     )
 
-    report = audit_review_workflow(reviews=reviews, row_filter=AuditFilter.all)
+    report = audit_review_workflow(reviews=reviews, row_filter=ChangeAuditFilter.all)
     unverified_report = audit_review_workflow(
         reviews=reviews,
-        row_filter=AuditFilter.unverified,
+        row_filter=ChangeAuditFilter.unverified,
     )
 
     assert "Historical note." not in report
@@ -262,7 +262,7 @@ def test_audit_reviews_filters_and_includes_json_notes(tmp_path: Path):
 
     report = audit_reviews(
         **inputs,
-        row_filter=ComparisonAuditFilter.changes,
+        row_filter=ExtendedAuditFilter.changes,
     )
 
     assert "- simplified review edits: 1" in report
@@ -284,7 +284,7 @@ def test_audit_reviews_filters_and_includes_json_notes(tmp_path: Path):
 
     report = audit_reviews(
         **inputs,
-        row_filter=ComparisonAuditFilter.discrepancies,
+        row_filter=ExtendedAuditFilter.discrepancies,
     )
     assert "- table rows: 2" in report
     assert "| 2 |" in report
@@ -293,7 +293,7 @@ def test_audit_reviews_filters_and_includes_json_notes(tmp_path: Path):
 
     report = audit_reviews(
         **inputs,
-        row_filter=ComparisonAuditFilter.all,
+        row_filter=ExtendedAuditFilter.all,
         characters=("著", "丙"),
     )
     assert "- character filter: 著, 丙" in report
@@ -303,7 +303,7 @@ def test_audit_reviews_filters_and_includes_json_notes(tmp_path: Path):
 
     report = audit_reviews(
         **inputs,
-        row_filter=ComparisonAuditFilter.all,
+        row_filter=ExtendedAuditFilter.all,
         first_index=2,
         last_index=3,
     )
@@ -326,7 +326,7 @@ def test_audit_reviews_ignores_timing_differences(tmp_path: Path):
     inputs["traditional_reviewed"].events[1].start = 62_000
     inputs["traditional_reviewed"].events[1].end = 62_500
 
-    report = audit_reviews(**inputs, row_filter=ComparisonAuditFilter.all)
+    report = audit_reviews(**inputs, row_filter=ExtendedAuditFilter.all)
 
     assert "- table rows: 4" in report
 

--- a/test/analysis/test_review_audit.py
+++ b/test/analysis/test_review_audit.py
@@ -55,6 +55,110 @@ class _AuditInputs(TypedDict):
     """Simplified review test cases."""
 
 
+def test_audit_review_workflow_filters_unverified_cases():
+    """Test regular review audits select subtitles in unverified logged cases."""
+    original = _get_series(("First", "Second", "Third"))
+    reviewed = _get_series(("First revised", "Second", "Third"))
+    unverified_case = ReviewTestCase.model_validate(
+        {
+            "query": {"subtitles": [{"index": 1, "text": "First"}]},
+            "answer": {
+                "revisions": [{"index": 1, "text": "First revised", "note": "Revised."}]
+            },
+        }
+    )
+    verified_case = ReviewTestCase.model_validate(
+        {
+            "query": {"subtitles": [{"index": 1, "text": "Second"}]},
+            "answer": {"revisions": []},
+            "verified": True,
+        }
+    )
+
+    report = audit_review_workflow(
+        reviews=(
+            ReviewAuditPair(
+                label="Test",
+                original=original,
+                reviewed=reviewed,
+                review_cases=(unverified_case, verified_case),
+            ),
+        ),
+        row_filter=AuditFilter.unverified,
+    )
+
+    assert "- row filter: unverified" in report
+    assert "- table rows: 1" in report
+    assert "| 1 | First<br>First revised | Test review: Revised. |  |" in report
+    assert "| 2 |" not in report
+    assert "| 3 |" not in report
+
+    all_report = audit_review_workflow(
+        reviews=(
+            ReviewAuditPair(
+                label="Test",
+                original=original,
+                reviewed=reviewed,
+                review_cases=(unverified_case, verified_case),
+            ),
+        ),
+        row_filter=AuditFilter.all,
+    )
+    assert "| 1 | First<br>First revised | Test review: Revised. |  |" in all_report
+    assert "| 2 | Second |  | ✓ |" in all_report
+    assert "| 3 | Third |  | — |" in all_report
+
+
+def test_audit_review_workflow_selects_blocks():
+    """Test review audits select one workflow block at a time."""
+    original = Series(
+        events=[
+            Subtitle(start=0, end=500, text="First"),
+            Subtitle(start=1_000, end=1_500, text="Second"),
+            Subtitle(start=5_000, end=5_500, text="Third"),
+        ]
+    )
+    reviewed = Series(
+        events=[
+            Subtitle(start=0, end=500, text="First"),
+            Subtitle(start=1_000, end=1_500, text="Second"),
+            Subtitle(start=5_000, end=5_500, text="Third revised"),
+        ]
+    )
+    reviews = (
+        ReviewAuditPair(
+            label="Test",
+            original=original,
+            reviewed=reviewed,
+        ),
+    )
+
+    report = audit_review_workflow(
+        reviews=reviews,
+        row_filter=AuditFilter.all,
+        first_block=2,
+        last_block=2,
+    )
+
+    assert "- block range: 2 through 2" in report
+    assert "| 1 |" not in report
+    assert "| 2 |" not in report
+    assert "| 3 | Third<br>Third revised |" in report
+
+    with raises(ScinoephileError, match="mutually exclusive"):
+        audit_review_workflow(
+            reviews=reviews,
+            first_index=1,
+            first_block=2,
+        )
+
+    with raises(ScinoephileError, match="requires at least one comparison"):
+        audit_review_workflow(
+            reviews=reviews,
+            row_filter=ComparativeReviewAuditFilter.discrepancies,
+        )
+
+
 def test_audit_reviews_filters_and_includes_json_notes(tmp_path: Path):
     """Test row filters, character filters, and JSON-backed notes.
 
@@ -119,58 +223,19 @@ def test_audit_reviews_filters_and_includes_json_notes(tmp_path: Path):
     assert "| 4 |" not in report
 
 
-def test_audit_review_workflow_filters_unverified_cases():
-    """Test regular review audits select subtitles in unverified logged cases."""
-    original = _get_series(("First", "Second", "Third"))
-    reviewed = _get_series(("First revised", "Second", "Third"))
-    unverified_case = ReviewTestCase.model_validate(
-        {
-            "query": {"subtitles": [{"index": 1, "text": "First"}]},
-            "answer": {
-                "revisions": [{"index": 1, "text": "First revised", "note": "Revised."}]
-            },
-        }
-    )
-    verified_case = ReviewTestCase.model_validate(
-        {
-            "query": {"subtitles": [{"index": 1, "text": "Second"}]},
-            "answer": {"revisions": []},
-            "verified": True,
-        }
-    )
+def test_audit_reviews_ignores_timing_differences(tmp_path: Path):
+    """Test timing differences do not prevent count-aligned audits.
 
-    report = audit_review_workflow(
-        reviews=(
-            ReviewAuditPair(
-                label="Test",
-                original=original,
-                reviewed=reviewed,
-                review_cases=(unverified_case, verified_case),
-            ),
-        ),
-        row_filter=AuditFilter.unverified,
-    )
+    Arguments:
+        tmp_path: temporary path
+    """
+    inputs = _get_audit_inputs(tmp_path)
+    inputs["traditional_reviewed"].events[1].start = 62_000
+    inputs["traditional_reviewed"].events[1].end = 62_500
 
-    assert "- row filter: unverified" in report
-    assert "- table rows: 1" in report
-    assert "| 1 | First<br>First revised | Test review: Revised. |  |" in report
-    assert "| 2 |" not in report
-    assert "| 3 |" not in report
+    report = audit_reviews(**inputs, row_filter=ComparativeReviewAuditFilter.all)
 
-    all_report = audit_review_workflow(
-        reviews=(
-            ReviewAuditPair(
-                label="Test",
-                original=original,
-                reviewed=reviewed,
-                review_cases=(unverified_case, verified_case),
-            ),
-        ),
-        row_filter=AuditFilter.all,
-    )
-    assert "| 1 | First<br>First revised | Test review: Revised. |  |" in all_report
-    assert "| 2 | Second |  | ✓ |" in all_report
-    assert "| 3 | Third |  | — |" in all_report
+    assert "- table rows: 4" in report
 
 
 def test_audit_reviews_reuses_deduplicated_json_note(tmp_path: Path):
@@ -197,71 +262,6 @@ def test_audit_reviews_reuses_deduplicated_json_note(tmp_path: Path):
     )
 
     assert report.count("Traditional review: 修正。") == 2
-
-
-def test_audit_reviews_ignores_timing_differences(tmp_path: Path):
-    """Test timing differences do not prevent count-aligned audits.
-
-    Arguments:
-        tmp_path: temporary path
-    """
-    inputs = _get_audit_inputs(tmp_path)
-    inputs["traditional_reviewed"].events[1].start = 62_000
-    inputs["traditional_reviewed"].events[1].end = 62_500
-
-    report = audit_reviews(**inputs, row_filter=ComparativeReviewAuditFilter.all)
-
-    assert "- table rows: 4" in report
-
-
-def test_audit_review_workflow_selects_blocks():
-    """Test review audits select one workflow block at a time."""
-    original = Series(
-        events=[
-            Subtitle(start=0, end=500, text="First"),
-            Subtitle(start=1_000, end=1_500, text="Second"),
-            Subtitle(start=5_000, end=5_500, text="Third"),
-        ]
-    )
-    reviewed = Series(
-        events=[
-            Subtitle(start=0, end=500, text="First"),
-            Subtitle(start=1_000, end=1_500, text="Second"),
-            Subtitle(start=5_000, end=5_500, text="Third revised"),
-        ]
-    )
-    reviews = (
-        ReviewAuditPair(
-            label="Test",
-            original=original,
-            reviewed=reviewed,
-        ),
-    )
-
-    report = audit_review_workflow(
-        reviews=reviews,
-        row_filter=AuditFilter.all,
-        first_block=2,
-        last_block=2,
-    )
-
-    assert "- block range: 2 through 2" in report
-    assert "| 1 |" not in report
-    assert "| 2 |" not in report
-    assert "| 3 | Third<br>Third revised |" in report
-
-    with raises(ScinoephileError, match="mutually exclusive"):
-        audit_review_workflow(
-            reviews=reviews,
-            first_index=1,
-            first_block=2,
-        )
-
-    with raises(ScinoephileError, match="requires at least one comparison"):
-        audit_review_workflow(
-            reviews=reviews,
-            row_filter=ComparativeReviewAuditFilter.discrepancies,
-        )
 
 
 def _get_audit_inputs(tmp_path: Path) -> _AuditInputs:

--- a/test/analysis/test_review_audit.py
+++ b/test/analysis/test_review_audit.py
@@ -12,8 +12,8 @@ from pytest import raises
 
 from scinoephile.analysis.audit.review import (
     ReviewAuditPair,
+    audit_dual_review,
     audit_review,
-    audit_reviews,
 )
 from scinoephile.analysis.audit.utils import ChangeAuditFilter, ExtendedAuditFilter
 from scinoephile.core import ScinoephileError
@@ -52,6 +52,111 @@ class _AuditInputs(TypedDict):
 
     simplified_review_cases: list[TestCase]
     """Simplified review test cases."""
+
+
+def test_audit_dual_review_filters_and_includes_json_notes(tmp_path: Path):
+    """Test row filters, character filters, and JSON-backed notes.
+
+    Arguments:
+        tmp_path: temporary path
+    """
+    inputs = _get_audit_inputs(tmp_path)
+
+    report = audit_dual_review(
+        **inputs,
+        row_filter=ExtendedAuditFilter.changes,
+    )
+
+    assert "- simplified review edits: 1" in report
+    assert "- traditional review edits: 1" in report
+    assert "- traditional simplification review edits: 1" in report
+    assert "- final text discrepancies: 2" in report
+    assert "- table rows: 3" in report
+    assert "| Notes | Verified |" in report
+    assert "| 1 |" not in report
+    assert (
+        "| 2 | 简错<br>简正 | 傳錯<br>傳正 | 传正 | 简正<br>传正 | "
+        "Simplified review: 修正简体字。<br>Traditional review: 修正繁體字。 |  |"
+        in report
+    )
+    assert "| 3 | 着正 | 著 | 着错<br>着正 | 着正 |" in report
+    assert "Simplified review: 修正简体字。" in report
+    assert "Traditional review: 修正繁體字。" in report
+    assert "Traditional simplification review: 修正簡化結果。" in report
+
+    report = audit_dual_review(
+        **inputs,
+        row_filter=ExtendedAuditFilter.discrepancies,
+    )
+    assert "- table rows: 2" in report
+    assert "| 2 |" in report
+    assert "| 3 |" not in report
+    assert "| 4 |" in report
+
+    report = audit_dual_review(
+        **inputs,
+        row_filter=ExtendedAuditFilter.all,
+        characters=("著", "丙"),
+    )
+    assert "- character filter: 著, 丙" in report
+    assert "- table rows: 1" in report
+    assert "| 1 |" not in report
+    assert "| 3 |" in report
+
+    report = audit_dual_review(
+        **inputs,
+        row_filter=ExtendedAuditFilter.all,
+        first_index=2,
+        last_index=3,
+    )
+    assert "- final text discrepancies: 1" in report
+    assert "- subtitle range: 2 through 3" in report
+    assert "- table rows: 2" in report
+    assert "| 1 |" not in report
+    assert "| 2 |" in report
+    assert "| 3 |" in report
+    assert "| 4 |" not in report
+
+
+def test_audit_dual_review_ignores_timing_differences(tmp_path: Path):
+    """Test timing differences do not prevent count-aligned audits.
+
+    Arguments:
+        tmp_path: temporary path
+    """
+    inputs = _get_audit_inputs(tmp_path)
+    inputs["traditional_reviewed"].events[1].start = 62_000
+    inputs["traditional_reviewed"].events[1].end = 62_500
+
+    report = audit_dual_review(**inputs, row_filter=ExtendedAuditFilter.all)
+
+    assert "- table rows: 4" in report
+
+
+def test_audit_dual_review_reuses_deduplicated_json_note(tmp_path: Path):
+    """Test one cached JSON block can annotate repeated matching subtitle rows.
+
+    Arguments:
+        tmp_path: temporary path
+    """
+    original_texts = ("錯", "錯")
+    reviewed_texts = ("正", "正")
+    original = _get_series(original_texts)
+    reviewed = _get_series(reviewed_texts)
+    json_path = tmp_path / "review.json"
+    _write_review_json(json_path, ("錯",), {1: ("正", "修正。")})
+
+    report = audit_dual_review(
+        traditional=original,
+        traditional_reviewed=reviewed,
+        traditional_simplified=reviewed,
+        traditional_simplified_reviewed=reviewed,
+        simplified=reviewed,
+        simplified_reviewed=reviewed,
+        traditional_review_cases=_load_review_cases(json_path),
+    )
+
+    assert report.count("Traditional review: 修正。") == 2
 
 
 def test_audit_review_filters_unverified_cases():
@@ -250,111 +355,6 @@ def test_audit_review_uses_latest_duplicate_case():
     assert "Test review: Current note." in report
     assert "| 1 | Input<br>Output | Test review: Current note. | ✓ |" in report
     assert "- table rows: 0" in unverified_report
-
-
-def test_audit_reviews_filters_and_includes_json_notes(tmp_path: Path):
-    """Test row filters, character filters, and JSON-backed notes.
-
-    Arguments:
-        tmp_path: temporary path
-    """
-    inputs = _get_audit_inputs(tmp_path)
-
-    report = audit_reviews(
-        **inputs,
-        row_filter=ExtendedAuditFilter.changes,
-    )
-
-    assert "- simplified review edits: 1" in report
-    assert "- traditional review edits: 1" in report
-    assert "- traditional simplification review edits: 1" in report
-    assert "- final text discrepancies: 2" in report
-    assert "- table rows: 3" in report
-    assert "| Notes | Verified |" in report
-    assert "| 1 |" not in report
-    assert (
-        "| 2 | 简错<br>简正 | 傳錯<br>傳正 | 传正 | 简正<br>传正 | "
-        "Simplified review: 修正简体字。<br>Traditional review: 修正繁體字。 |  |"
-        in report
-    )
-    assert "| 3 | 着正 | 著 | 着错<br>着正 | 着正 |" in report
-    assert "Simplified review: 修正简体字。" in report
-    assert "Traditional review: 修正繁體字。" in report
-    assert "Traditional simplification review: 修正簡化結果。" in report
-
-    report = audit_reviews(
-        **inputs,
-        row_filter=ExtendedAuditFilter.discrepancies,
-    )
-    assert "- table rows: 2" in report
-    assert "| 2 |" in report
-    assert "| 3 |" not in report
-    assert "| 4 |" in report
-
-    report = audit_reviews(
-        **inputs,
-        row_filter=ExtendedAuditFilter.all,
-        characters=("著", "丙"),
-    )
-    assert "- character filter: 著, 丙" in report
-    assert "- table rows: 1" in report
-    assert "| 1 |" not in report
-    assert "| 3 |" in report
-
-    report = audit_reviews(
-        **inputs,
-        row_filter=ExtendedAuditFilter.all,
-        first_index=2,
-        last_index=3,
-    )
-    assert "- final text discrepancies: 1" in report
-    assert "- subtitle range: 2 through 3" in report
-    assert "- table rows: 2" in report
-    assert "| 1 |" not in report
-    assert "| 2 |" in report
-    assert "| 3 |" in report
-    assert "| 4 |" not in report
-
-
-def test_audit_reviews_ignores_timing_differences(tmp_path: Path):
-    """Test timing differences do not prevent count-aligned audits.
-
-    Arguments:
-        tmp_path: temporary path
-    """
-    inputs = _get_audit_inputs(tmp_path)
-    inputs["traditional_reviewed"].events[1].start = 62_000
-    inputs["traditional_reviewed"].events[1].end = 62_500
-
-    report = audit_reviews(**inputs, row_filter=ExtendedAuditFilter.all)
-
-    assert "- table rows: 4" in report
-
-
-def test_audit_reviews_reuses_deduplicated_json_note(tmp_path: Path):
-    """Test one cached JSON block can annotate repeated matching subtitle rows.
-
-    Arguments:
-        tmp_path: temporary path
-    """
-    original_texts = ("錯", "錯")
-    reviewed_texts = ("正", "正")
-    original = _get_series(original_texts)
-    reviewed = _get_series(reviewed_texts)
-    json_path = tmp_path / "review.json"
-    _write_review_json(json_path, ("錯",), {1: ("正", "修正。")})
-
-    report = audit_reviews(
-        traditional=original,
-        traditional_reviewed=reviewed,
-        traditional_simplified=reviewed,
-        traditional_simplified_reviewed=reviewed,
-        simplified=reviewed,
-        simplified_reviewed=reviewed,
-        traditional_review_cases=_load_review_cases(json_path),
-    )
-
-    assert report.count("Traditional review: 修正。") == 2
 
 
 def _get_audit_inputs(tmp_path: Path) -> _AuditInputs:

--- a/test/analysis/test_review_audit.py
+++ b/test/analysis/test_review_audit.py
@@ -12,7 +12,7 @@ from pytest import raises
 
 from scinoephile.analysis.audit.review import (
     ReviewAuditPair,
-    audit_review_workflow,
+    audit_review,
     audit_reviews,
 )
 from scinoephile.analysis.audit.utils import ChangeAuditFilter, ExtendedAuditFilter
@@ -54,7 +54,7 @@ class _AuditInputs(TypedDict):
     """Simplified review test cases."""
 
 
-def test_audit_review_workflow_filters_unverified_cases():
+def test_audit_review_filters_unverified_cases():
     """Test regular review audits select subtitles in unverified logged cases."""
     original = _get_series(("First", "Second", "Third"))
     reviewed = _get_series(("First revised", "Second", "Third"))
@@ -74,7 +74,7 @@ def test_audit_review_workflow_filters_unverified_cases():
         }
     )
 
-    report = audit_review_workflow(
+    report = audit_review(
         reviews=(
             ReviewAuditPair(
                 label="Test",
@@ -92,7 +92,7 @@ def test_audit_review_workflow_filters_unverified_cases():
     assert "| 2 |" not in report
     assert "| 3 |" not in report
 
-    all_report = audit_review_workflow(
+    all_report = audit_review(
         reviews=(
             ReviewAuditPair(
                 label="Test",
@@ -108,7 +108,7 @@ def test_audit_review_workflow_filters_unverified_cases():
     assert "| 3 | Third |  | — |" in all_report
 
 
-def test_audit_review_workflow_ignores_retained_historical_cases():
+def test_audit_review_ignores_retained_historical_cases():
     """Test source revisions do not make retained review history fatal."""
     original = _get_series(("Current input",))
     reviewed = _get_series(("Current output",))
@@ -138,7 +138,7 @@ def test_audit_review_workflow_ignores_retained_historical_cases():
         }
     )
 
-    report = audit_review_workflow(
+    report = audit_review(
         reviews=(
             ReviewAuditPair(
                 label="Test",
@@ -158,7 +158,7 @@ def test_audit_review_workflow_ignores_retained_historical_cases():
     )
 
 
-def test_audit_review_workflow_selects_blocks():
+def test_audit_review_selects_blocks():
     """Test review audits select one workflow block at a time."""
     original = Series(
         events=[
@@ -182,7 +182,7 @@ def test_audit_review_workflow_selects_blocks():
         ),
     )
 
-    report = audit_review_workflow(
+    report = audit_review(
         reviews=reviews,
         row_filter=ChangeAuditFilter.all,
         first_block=2,
@@ -195,20 +195,20 @@ def test_audit_review_workflow_selects_blocks():
     assert "| 3 | Third<br>Third revised |" in report
 
     with raises(ScinoephileError, match="mutually exclusive"):
-        audit_review_workflow(
+        audit_review(
             reviews=reviews,
             first_index=1,
             first_block=2,
         )
 
     with raises(ScinoephileError, match="requires at least one comparison"):
-        audit_review_workflow(
+        audit_review(
             reviews=reviews,
             row_filter=ExtendedAuditFilter.discrepancies,
         )
 
 
-def test_audit_review_workflow_uses_latest_duplicate_case():
+def test_audit_review_uses_latest_duplicate_case():
     """Test the latest duplicate review case controls notes and verification."""
     original = _get_series(("Input",))
     reviewed = _get_series(("Output",))
@@ -240,8 +240,8 @@ def test_audit_review_workflow_uses_latest_duplicate_case():
         ),
     )
 
-    report = audit_review_workflow(reviews=reviews, row_filter=ChangeAuditFilter.all)
-    unverified_report = audit_review_workflow(
+    report = audit_review(reviews=reviews, row_filter=ChangeAuditFilter.all)
+    unverified_report = audit_review(
         reviews=reviews,
         row_filter=ChangeAuditFilter.unverified,
     )

--- a/test/analysis/test_review_audit.py
+++ b/test/analysis/test_review_audit.py
@@ -73,8 +73,13 @@ def test_audit_reviews_filters_and_includes_json_notes(tmp_path: Path):
     assert "- traditional simplification review edits: 1" in report
     assert "- final text discrepancies: 2" in report
     assert "- table rows: 3" in report
+    assert "| Notes | Verified |" in report
     assert "| 1 |" not in report
-    assert "| 2 | 简错<br>简正 | 傳錯<br>傳正 | 传正 | 简正<br>传正 |" in report
+    assert (
+        "| 2 | 简错<br>简正 | 傳錯<br>傳正 | 传正 | 简正<br>传正 | "
+        "Simplified review: 修正简体字。<br>Traditional review: 修正繁體字。 |  |"
+        in report
+    )
     assert "| 3 | 着正 | 著 | 着错<br>着正 | 着正 |" in report
     assert "Simplified review: 修正简体字。" in report
     assert "Traditional review: 修正繁體字。" in report
@@ -148,9 +153,24 @@ def test_audit_review_workflow_filters_unverified_cases():
 
     assert "- row filter: unverified" in report
     assert "- table rows: 1" in report
-    assert "| 1 | First<br>First revised | Test review: Revised. |" in report
+    assert "| 1 | First<br>First revised | Test review: Revised. |  |" in report
     assert "| 2 |" not in report
     assert "| 3 |" not in report
+
+    all_report = audit_review_workflow(
+        reviews=(
+            ReviewAuditPair(
+                label="Test",
+                original=original,
+                reviewed=reviewed,
+                review_cases=(unverified_case, verified_case),
+            ),
+        ),
+        row_filter=AuditFilter.all,
+    )
+    assert "| 1 | First<br>First revised | Test review: Revised. |  |" in all_report
+    assert "| 2 | Second |  | ✓ |" in all_report
+    assert "| 3 | Third |  | — |" in all_report
 
 
 def test_audit_reviews_reuses_deduplicated_json_note(tmp_path: Path):

--- a/test/analysis/test_review_audit.py
+++ b/test/analysis/test_review_audit.py
@@ -11,12 +11,11 @@ from typing import TypedDict
 from pytest import raises
 
 from scinoephile.analysis.audit.review import (
-    ComparativeReviewAuditFilter,
     ReviewAuditPair,
     audit_review_workflow,
     audit_reviews,
 )
-from scinoephile.analysis.audit.utils import AuditFilter
+from scinoephile.analysis.audit.utils import AuditFilter, ComparisonAuditFilter
 from scinoephile.core import ScinoephileError
 from scinoephile.core.llms import TestCase
 from scinoephile.core.llms.utils import load_test_cases_from_json
@@ -109,6 +108,56 @@ def test_audit_review_workflow_filters_unverified_cases():
     assert "| 3 | Third |  | — |" in all_report
 
 
+def test_audit_review_workflow_ignores_retained_historical_cases():
+    """Test source revisions do not make retained review history fatal."""
+    original = _get_series(("Current input",))
+    reviewed = _get_series(("Current output",))
+    historical_case = ReviewTestCase.model_validate(
+        {
+            "query": {"subtitles": [{"index": 1, "text": "Historical input"}]},
+            "answer": {
+                "revisions": [
+                    {
+                        "index": 1,
+                        "text": "Historical output",
+                        "note": "Historical note.",
+                    }
+                ]
+            },
+        }
+    )
+    current_case = ReviewTestCase.model_validate(
+        {
+            "query": {"subtitles": [{"index": 1, "text": "Current input"}]},
+            "answer": {
+                "revisions": [
+                    {"index": 1, "text": "Current output", "note": "Current note."}
+                ]
+            },
+            "verified": True,
+        }
+    )
+
+    report = audit_review_workflow(
+        reviews=(
+            ReviewAuditPair(
+                label="Test",
+                original=original,
+                reviewed=reviewed,
+                review_cases=(historical_case, current_case),
+            ),
+        ),
+        row_filter=AuditFilter.all,
+    )
+
+    assert "Historical note." not in report
+    assert "Test review: Current note." in report
+    assert (
+        "| 1 | Current input<br>Current output | Test review: Current note. | ✓ |"
+        in report
+    )
+
+
 def test_audit_review_workflow_selects_blocks():
     """Test review audits select one workflow block at a time."""
     original = Series(
@@ -155,8 +204,52 @@ def test_audit_review_workflow_selects_blocks():
     with raises(ScinoephileError, match="requires at least one comparison"):
         audit_review_workflow(
             reviews=reviews,
-            row_filter=ComparativeReviewAuditFilter.discrepancies,
+            row_filter=ComparisonAuditFilter.discrepancies,
         )
+
+
+def test_audit_review_workflow_uses_latest_duplicate_case():
+    """Test the latest duplicate review case controls notes and verification."""
+    original = _get_series(("Input",))
+    reviewed = _get_series(("Output",))
+    historical_case = ReviewTestCase.model_validate(
+        {
+            "query": {"subtitles": [{"index": 1, "text": "Input"}]},
+            "answer": {
+                "revisions": [
+                    {"index": 1, "text": "Output", "note": "Historical note."}
+                ]
+            },
+        }
+    )
+    current_case = ReviewTestCase.model_validate(
+        {
+            "query": historical_case.query.model_dump(),
+            "answer": {
+                "revisions": [{"index": 1, "text": "Output", "note": "Current note."}]
+            },
+            "verified": True,
+        }
+    )
+    reviews = (
+        ReviewAuditPair(
+            label="Test",
+            original=original,
+            reviewed=reviewed,
+            review_cases=(historical_case, current_case),
+        ),
+    )
+
+    report = audit_review_workflow(reviews=reviews, row_filter=AuditFilter.all)
+    unverified_report = audit_review_workflow(
+        reviews=reviews,
+        row_filter=AuditFilter.unverified,
+    )
+
+    assert "Historical note." not in report
+    assert "Test review: Current note." in report
+    assert "| 1 | Input<br>Output | Test review: Current note. | ✓ |" in report
+    assert "- table rows: 0" in unverified_report
 
 
 def test_audit_reviews_filters_and_includes_json_notes(tmp_path: Path):
@@ -169,7 +262,7 @@ def test_audit_reviews_filters_and_includes_json_notes(tmp_path: Path):
 
     report = audit_reviews(
         **inputs,
-        row_filter=ComparativeReviewAuditFilter.changes,
+        row_filter=ComparisonAuditFilter.changes,
     )
 
     assert "- simplified review edits: 1" in report
@@ -191,7 +284,7 @@ def test_audit_reviews_filters_and_includes_json_notes(tmp_path: Path):
 
     report = audit_reviews(
         **inputs,
-        row_filter=ComparativeReviewAuditFilter.discrepancies,
+        row_filter=ComparisonAuditFilter.discrepancies,
     )
     assert "- table rows: 2" in report
     assert "| 2 |" in report
@@ -200,7 +293,7 @@ def test_audit_reviews_filters_and_includes_json_notes(tmp_path: Path):
 
     report = audit_reviews(
         **inputs,
-        row_filter=ComparativeReviewAuditFilter.all,
+        row_filter=ComparisonAuditFilter.all,
         characters=("著", "丙"),
     )
     assert "- character filter: 著, 丙" in report
@@ -210,7 +303,7 @@ def test_audit_reviews_filters_and_includes_json_notes(tmp_path: Path):
 
     report = audit_reviews(
         **inputs,
-        row_filter=ComparativeReviewAuditFilter.all,
+        row_filter=ComparisonAuditFilter.all,
         first_index=2,
         last_index=3,
     )
@@ -233,7 +326,7 @@ def test_audit_reviews_ignores_timing_differences(tmp_path: Path):
     inputs["traditional_reviewed"].events[1].start = 62_000
     inputs["traditional_reviewed"].events[1].end = 62_500
 
-    report = audit_reviews(**inputs, row_filter=ComparativeReviewAuditFilter.all)
+    report = audit_reviews(**inputs, row_filter=ComparisonAuditFilter.all)
 
     assert "- table rows: 4" in report
 

--- a/test/analysis/test_translation_audit.py
+++ b/test/analysis/test_translation_audit.py
@@ -1,0 +1,160 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests for standard and guided translation audit reports."""
+
+from __future__ import annotations
+
+from pytest import raises
+
+from scinoephile.analysis.audit.translation import (
+    TranslationAuditFilter,
+    audit_guided_translation,
+    audit_translation,
+)
+from scinoephile.core.exceptions import ScinoephileError
+from scinoephile.core.subtitles import Series, Subtitle
+from scinoephile.llms.guided_translation import GuidedTranslationTestCase
+from scinoephile.llms.translation import TranslationTestCase
+
+
+def test_audit_translation_formats_standard_blocks_and_unanswered_case():
+    """Test standard translation rows retain global, local, case, and block indexes."""
+    source = _get_series((0, "甲"), (1000, "乙"), (6000, "丙"))
+    test_cases = (
+        TranslationTestCase.model_validate(
+            {
+                "query": {
+                    "subtitles": [
+                        {"index": 1, "text": "甲"},
+                        {"index": 2, "text": "乙"},
+                    ]
+                },
+                "answer": {
+                    "outputs": [
+                        {"index": 1, "text": "A"},
+                        {"index": 2, "text": "B"},
+                    ]
+                },
+                "verified": True,
+            }
+        ),
+        TranslationTestCase.model_validate(
+            {"query": {"subtitles": [{"index": 1, "text": "丙"}]}}
+        ),
+    )
+
+    report = audit_translation(source, test_cases)
+    unverified_report = audit_translation(
+        source,
+        test_cases,
+        row_filter=TranslationAuditFilter.unverified,
+    )
+    block_report = audit_translation(
+        source,
+        test_cases,
+        first_block=2,
+        last_block=2,
+    )
+
+    assert report.startswith("# Standard Translation Audit\n")
+    assert "- logged cases: 2" in report
+    assert "- translated subtitles: 2" in report
+    assert "- unanswered subtitles: 1" in report
+    assert "| S 1<br>Q 1 | C 1<br>B 1 | 0 | 甲 | — | A |  | ✓ |" in report
+    assert "| S 3<br>Q 1 | C 2<br>B 2 | 0 | 丙 | — | (unanswered) |" in report
+    assert "- table rows: 1" in unverified_report
+    assert "| S 3<br>Q 1 |" in unverified_report
+    assert "- block range: 2 through 2" in block_report
+    assert "| S 1<br>Q 1 |" not in block_report
+    assert "| S 3<br>Q 1 |" in block_report
+
+
+def test_audit_guided_translation_formats_guide_and_filters_range_difficulty():
+    """Test guided translation displays guide context and composes filters."""
+    source = _get_series((0, "甲"), (1000, "乙"))
+    guide = _get_series((0, "Guide one"), (1000, "Guide two"))
+    test_case = GuidedTranslationTestCase.model_validate(
+        {
+            "query": {
+                "subtitles": [
+                    {"index": 1, "text": "甲"},
+                    {"index": 2, "text": "乙"},
+                ],
+                "guides": [
+                    {"index": 1, "text": "Guide one"},
+                    {"index": 2, "text": "Guide two"},
+                ],
+            },
+            "answer": {
+                "outputs": [
+                    {"index": 1, "text": "A"},
+                    {"index": 2, "text": "B"},
+                ]
+            },
+            "difficulty": 2,
+        }
+    )
+
+    report = audit_guided_translation(
+        source,
+        guide,
+        (test_case,),
+        difficulties=(2,),
+        first_index=2,
+        last_index=2,
+    )
+
+    assert report.startswith("# Guided Translation Audit\n")
+    assert "- difficulty filter: 2" in report
+    assert "- source subtitle range: 2 through 2" in report
+    assert "- table rows: 1" in report
+    assert (
+        "| S 2<br>Q 2 | C 1<br>B 1 | 2 | 乙 | "
+        "G 1: Guide one<br>G 2: Guide two | B |  |  |"
+    ) in report
+
+
+def test_audit_translation_uses_latest_case_and_rejects_invalid_selection():
+    """Test latest-case selection and direct API validation."""
+    source = _get_series((0, "甲"))
+    old_case = TranslationTestCase.model_validate(
+        {
+            "query": {"subtitles": [{"index": 1, "text": "甲"}]},
+            "answer": {"outputs": [{"index": 1, "text": "Old"}]},
+        }
+    )
+    new_case = TranslationTestCase.model_validate(
+        {
+            "query": old_case.query.model_dump(),
+            "answer": {"outputs": [{"index": 1, "text": "New"}]},
+            "verified": True,
+        }
+    )
+
+    report = audit_translation(source, (old_case, new_case))
+
+    assert "C 1" not in report
+    assert "| S 1<br>Q 1 | C 2<br>B 1 |" in report
+    assert "New" in report
+    assert "Old" not in report
+    with raises(ScinoephileError, match="First index must be at least 1"):
+        audit_translation(source, (new_case,), first_index=0)
+    with raises(ScinoephileError, match="Difficulty must be at least 0"):
+        audit_translation(source, (new_case,), difficulties=(-1,))
+    with raises(ScinoephileError, match="no matching logged test case"):
+        audit_translation(source, ())
+
+
+def _get_series(*events: tuple[int, str]) -> Series:
+    """Build a subtitle series from start times and text.
+
+    Arguments:
+        *events: subtitle start and text pairs
+    Returns:
+        subtitle series
+    """
+    return Series(
+        events=[
+            Subtitle(start=start, end=start + 500, text=text) for start, text in events
+        ]
+    )

--- a/test/analysis/test_translation_audit.py
+++ b/test/analysis/test_translation_audit.py
@@ -7,10 +7,10 @@ from __future__ import annotations
 from pytest import raises
 
 from scinoephile.analysis.audit.translation import (
-    TranslationAuditFilter,
     audit_guided_translation,
     audit_translation,
 )
+from scinoephile.analysis.audit.utils import VerificationAuditFilter
 from scinoephile.core.exceptions import ScinoephileError
 from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.llms.guided_translation import GuidedTranslationTestCase
@@ -47,7 +47,7 @@ def test_audit_translation_formats_standard_blocks_and_unanswered_case():
     unverified_report = audit_translation(
         source,
         test_cases,
-        row_filter=TranslationAuditFilter.unverified,
+        row_filter=VerificationAuditFilter.unverified,
     )
     block_report = audit_translation(
         source,
@@ -112,6 +112,46 @@ def test_audit_guided_translation_formats_guide_and_filters_range():
     ) in report
 
 
+def test_audit_translation_formats_empty_output():
+    """Test an empty answered output remains visible and separately counted."""
+    source = _get_series((0, "甲"))
+    test_case = TranslationTestCase.model_validate(
+        {
+            "query": {"subtitles": [{"index": 1, "text": "甲"}]},
+            "answer": {"outputs": [{"index": 1, "text": ""}]},
+        }
+    )
+
+    report = audit_translation(source, (test_case,))
+
+    assert "- translated subtitles: 0" in report
+    assert "- empty translations: 1" in report
+    assert "- unanswered subtitles: 0" in report
+    assert "| S 1<br>Q 1 | C 1<br>B 1 | 0 | 甲 | — | (empty) |" in report
+
+
+def test_audit_translation_rejects_ambiguous_repeated_block():
+    """Test repeated current blocks require a range that selects only one."""
+    source = _get_series((0, "重複"), (6000, "重複"))
+    test_case = TranslationTestCase.model_validate(
+        {
+            "query": {"subtitles": [{"index": 1, "text": "重複"}]},
+            "answer": {"outputs": [{"index": 1, "text": "Repeated"}]},
+        }
+    )
+
+    with raises(ScinoephileError, match="blocks 1, 2 have identical"):
+        audit_translation(source, (test_case,))
+
+    second_block_report = audit_translation(
+        source,
+        (test_case,),
+        first_block=2,
+        last_block=2,
+    )
+    assert "| S 2<br>Q 1 | C 1<br>B 2 |" in second_block_report
+
+
 def test_audit_translation_uses_latest_case_and_rejects_invalid_selection():
     """Test latest-case selection and direct API validation."""
     source = _get_series((0, "甲"))
@@ -139,6 +179,16 @@ def test_audit_translation_uses_latest_case_and_rejects_invalid_selection():
         audit_translation(source, (new_case,), first_index=0)
     with raises(ScinoephileError, match="no matching logged test case"):
         audit_translation(source, ())
+    with raises(
+        ScinoephileError,
+        match="Subtitle-index and block ranges are mutually exclusive",
+    ):
+        audit_translation(
+            source,
+            (new_case,),
+            first_index=1,
+            first_block=1,
+        )
 
 
 def _get_series(*events: tuple[int, str]) -> Series:

--- a/test/analysis/test_translation_audit.py
+++ b/test/analysis/test_translation_audit.py
@@ -8,7 +8,7 @@ from pytest import raises
 
 from scinoephile.analysis.audit.guided_translation import audit_guided_translation
 from scinoephile.analysis.audit.translation import audit_translation
-from scinoephile.analysis.audit.utils import VerificationAuditFilter
+from scinoephile.analysis.audit.utils import AuditFilter
 from scinoephile.core.exceptions import ScinoephileError
 from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.llms.guided_translation import GuidedTranslationTestCase
@@ -106,7 +106,7 @@ def test_audit_translation_formats_standard_blocks_and_unanswered_case():
     unverified_report = audit_translation(
         source,
         test_cases,
-        row_filter=VerificationAuditFilter.unverified,
+        row_filter=AuditFilter.unverified,
     )
     block_report = audit_translation(
         source,

--- a/test/analysis/test_translation_audit.py
+++ b/test/analysis/test_translation_audit.py
@@ -6,10 +6,8 @@ from __future__ import annotations
 
 from pytest import raises
 
-from scinoephile.analysis.audit.translation import (
-    audit_guided_translation,
-    audit_translation,
-)
+from scinoephile.analysis.audit.guided_translation import audit_guided_translation
+from scinoephile.analysis.audit.translation import audit_translation
 from scinoephile.analysis.audit.utils import VerificationAuditFilter
 from scinoephile.core.exceptions import ScinoephileError
 from scinoephile.core.subtitles import Series, Subtitle

--- a/test/analysis/test_translation_audit.py
+++ b/test/analysis/test_translation_audit.py
@@ -69,8 +69,8 @@ def test_audit_translation_formats_standard_blocks_and_unanswered_case():
     assert "| S 3<br>Q 1 |" in block_report
 
 
-def test_audit_guided_translation_formats_guide_and_filters_range_difficulty():
-    """Test guided translation displays guide context and composes filters."""
+def test_audit_guided_translation_formats_guide_and_filters_range():
+    """Test guided translation displays guide context and filters its range."""
     source = _get_series((0, "甲"), (1000, "乙"))
     guide = _get_series((0, "Guide one"), (1000, "Guide two"))
     test_case = GuidedTranslationTestCase.model_validate(
@@ -99,13 +99,11 @@ def test_audit_guided_translation_formats_guide_and_filters_range_difficulty():
         source,
         guide,
         (test_case,),
-        difficulties=(2,),
         first_index=2,
         last_index=2,
     )
 
     assert report.startswith("# Guided Translation Audit\n")
-    assert "- difficulty filter: 2" in report
     assert "- source subtitle range: 2 through 2" in report
     assert "- table rows: 1" in report
     assert (
@@ -139,8 +137,6 @@ def test_audit_translation_uses_latest_case_and_rejects_invalid_selection():
     assert "Old" not in report
     with raises(ScinoephileError, match="First index must be at least 1"):
         audit_translation(source, (new_case,), first_index=0)
-    with raises(ScinoephileError, match="Difficulty must be at least 0"):
-        audit_translation(source, (new_case,), difficulties=(-1,))
     with raises(ScinoephileError, match="no matching logged test case"):
         audit_translation(source, ())
 

--- a/test/analysis/test_translation_audit.py
+++ b/test/analysis/test_translation_audit.py
@@ -15,58 +15,6 @@ from scinoephile.llms.guided_translation import GuidedTranslationTestCase
 from scinoephile.llms.translation import TranslationTestCase
 
 
-def test_audit_translation_formats_standard_blocks_and_unanswered_case():
-    """Test standard translation rows retain global, local, case, and block indexes."""
-    source = _get_series((0, "甲"), (1000, "乙"), (6000, "丙"))
-    test_cases = (
-        TranslationTestCase.model_validate(
-            {
-                "query": {
-                    "subtitles": [
-                        {"index": 1, "text": "甲"},
-                        {"index": 2, "text": "乙"},
-                    ]
-                },
-                "answer": {
-                    "outputs": [
-                        {"index": 1, "text": "A"},
-                        {"index": 2, "text": "B"},
-                    ]
-                },
-                "verified": True,
-            }
-        ),
-        TranslationTestCase.model_validate(
-            {"query": {"subtitles": [{"index": 1, "text": "丙"}]}}
-        ),
-    )
-
-    report = audit_translation(source, test_cases)
-    unverified_report = audit_translation(
-        source,
-        test_cases,
-        row_filter=VerificationAuditFilter.unverified,
-    )
-    block_report = audit_translation(
-        source,
-        test_cases,
-        first_block=2,
-        last_block=2,
-    )
-
-    assert report.startswith("# Standard Translation Audit\n")
-    assert "- logged cases: 2" in report
-    assert "- translated subtitles: 2" in report
-    assert "- unanswered subtitles: 1" in report
-    assert "| S 1<br>Q 1 | C 1<br>B 1 | 0 | 甲 | — | A |  | ✓ |" in report
-    assert "| S 3<br>Q 1 | C 2<br>B 2 | 0 | 丙 | — | (unanswered) |" in report
-    assert "- table rows: 1" in unverified_report
-    assert "| S 3<br>Q 1 |" in unverified_report
-    assert "- block range: 2 through 2" in block_report
-    assert "| S 1<br>Q 1 |" not in block_report
-    assert "| S 3<br>Q 1 |" in block_report
-
-
 def test_audit_guided_translation_formats_guide_and_filters_range():
     """Test guided translation displays guide context and filters its range."""
     source = _get_series((0, "甲"), (1000, "乙"))
@@ -128,8 +76,60 @@ def test_audit_translation_formats_empty_output():
     assert "| S 1<br>Q 1 | C 1<br>B 1 | 0 | 甲 | — | (empty) |" in report
 
 
-def test_audit_translation_rejects_ambiguous_repeated_block():
-    """Test repeated current blocks require a range that selects only one."""
+def test_audit_translation_formats_standard_blocks_and_unanswered_case():
+    """Test standard translation rows retain global, local, case, and block indexes."""
+    source = _get_series((0, "甲"), (1000, "乙"), (6000, "丙"))
+    test_cases = (
+        TranslationTestCase.model_validate(
+            {
+                "query": {
+                    "subtitles": [
+                        {"index": 1, "text": "甲"},
+                        {"index": 2, "text": "乙"},
+                    ]
+                },
+                "answer": {
+                    "outputs": [
+                        {"index": 1, "text": "A"},
+                        {"index": 2, "text": "B"},
+                    ]
+                },
+                "verified": True,
+            }
+        ),
+        TranslationTestCase.model_validate(
+            {"query": {"subtitles": [{"index": 1, "text": "丙"}]}}
+        ),
+    )
+
+    report = audit_translation(source, test_cases)
+    unverified_report = audit_translation(
+        source,
+        test_cases,
+        row_filter=VerificationAuditFilter.unverified,
+    )
+    block_report = audit_translation(
+        source,
+        test_cases,
+        first_block=2,
+        last_block=2,
+    )
+
+    assert report.startswith("# Standard Translation Audit\n")
+    assert "- logged cases: 2" in report
+    assert "- translated subtitles: 2" in report
+    assert "- unanswered subtitles: 1" in report
+    assert "| S 1<br>Q 1 | C 1<br>B 1 | 0 | 甲 | — | A |  | ✓ |" in report
+    assert "| S 3<br>Q 1 | C 2<br>B 2 | 0 | 丙 | — | (unanswered) |" in report
+    assert "- table rows: 1" in unverified_report
+    assert "| S 3<br>Q 1 |" in unverified_report
+    assert "- block range: 2 through 2" in block_report
+    assert "| S 1<br>Q 1 |" not in block_report
+    assert "| S 3<br>Q 1 |" in block_report
+
+
+def test_audit_translation_reuses_case_for_repeated_blocks():
+    """Test one deduplicated case applies to every identical current block."""
     source = _get_series((0, "重複"), (6000, "重複"))
     test_case = TranslationTestCase.model_validate(
         {
@@ -138,8 +138,7 @@ def test_audit_translation_rejects_ambiguous_repeated_block():
         }
     )
 
-    with raises(ScinoephileError, match="blocks 1, 2 have identical"):
-        audit_translation(source, (test_case,))
+    report = audit_translation(source, (test_case,))
 
     second_block_report = audit_translation(
         source,
@@ -147,6 +146,10 @@ def test_audit_translation_rejects_ambiguous_repeated_block():
         first_block=2,
         last_block=2,
     )
+    assert "- logged cases: 1" in report
+    assert "- subtitles: 2" in report
+    assert "| S 1<br>Q 1 | C 1<br>B 1 |" in report
+    assert "| S 2<br>Q 1 | C 1<br>B 2 |" in report
     assert "| S 2<br>Q 1 | C 1<br>B 2 |" in second_block_report
 
 

--- a/test/cli/test_audit_cli.py
+++ b/test/cli/test_audit_cli.py
@@ -371,7 +371,7 @@ def test_audit_review_cli_guided_mode_stdout_and_outfile(
     assert "- row filter: changes" in stdout
     assert "- target subtitle range: 1 through 1" in stdout
     assert "- subtitles: 1" in stdout
-    assert "| 1 | 1 | 參考 | 原文<br>修訂 |  |  |" in stdout
+    assert "| 1 | 1 | 參考 | 原文<br>修訂 | correction |  |" in stdout
 
     outfile_path = tmp_path / "audit.md"
     run_cli_with_args(

--- a/test/cli/test_audit_cli.py
+++ b/test/cli/test_audit_cli.py
@@ -26,6 +26,276 @@ from scinoephile.common.argument_parsing import enum_metavar, enum_options_list_
 from scinoephile.common.testing import run_cli_with_args
 
 
+def test_audit_cli_subcommands():
+    """Test the audit CLI and its workflow subcommands are registered."""
+    assert issubclass(AuditDelineationCli, AuditCliBase)
+    assert issubclass(AuditPunctuationCli, AuditCliBase)
+    assert issubclass(AuditReviewCli, AuditCliBase)
+    assert issubclass(AuditReviewDualCli, AuditCliBase)
+    assert issubclass(AuditReviewTradCli, AuditCliBase)
+    assert issubclass(AuditTranslationCli, AuditCliBase)
+    assert ScinoephileCli.subcommands()["audit"] is AuditCli
+    assert AuditCli.subcommands() == {
+        "delineation": AuditDelineationCli,
+        "ocr-fusion": AuditOcrFusionCli,
+        "punctuation": AuditPunctuationCli,
+        "review": AuditReviewCli,
+        "review-dual": AuditReviewDualCli,
+        "review-trad": AuditReviewTradCli,
+        "translation": AuditTranslationCli,
+    }
+
+
+@mark.parametrize(
+    ("texts", "label"),
+    (
+        (
+            ("他们正在这里", "我们没有这个东西", "她说这是真的吗"),
+            "Simplified Chinese",
+        ),
+        (
+            ("他們正在這裡", "我們沒有這個東西", "她說這是真的嗎"),
+            "Traditional Chinese",
+        ),
+        (
+            ("我唔知点解你冇这个", "佢哋系咪想睇这个", "咁样冇嘢喺这边"),
+            "Simplified Cantonese",
+        ),
+        (
+            ("我唔知點解你冇這個", "佢哋係咪想睇這個", "咁樣冇嘢喺這邊"),
+            "Traditional Cantonese",
+        ),
+    ),
+)
+def test_audit_review_cli_detects_chinese_language_and_script(
+    tmp_path: Path,
+    capsys: CaptureFixture,
+    texts: tuple[str, ...],
+    label: str,
+):
+    """Test single reviews detect Chinese language and script combinations.
+
+    Arguments:
+        tmp_path: temporary path
+        capsys: pytest stdout/stderr capture fixture
+        texts: original subtitle text
+        label: expected report label
+    """
+    original_path = tmp_path / "original.srt"
+    reviewed_path = tmp_path / "reviewed.srt"
+    _write_srt(original_path, texts)
+    _write_srt(reviewed_path, (f"{texts[0]}！", *texts[1:]))
+
+    run_cli_with_args(
+        AuditReviewCli,
+        f"--original {original_path} --reviewed {reviewed_path}",
+    )
+
+    stdout = capsys.readouterr().out
+    assert f"- {label.lower()} review edits: 1" in stdout
+    assert f"| Subtitle | {label} | Notes |" in stdout
+
+
+def test_audit_review_cli_detects_language(tmp_path: Path, capsys: CaptureFixture):
+    """Test a single review audit detects its language.
+
+    Arguments:
+        tmp_path: temporary path
+        capsys: pytest stdout/stderr capture fixture
+    """
+    original_path = tmp_path / "original.srt"
+    reviewed_path = tmp_path / "reviewed.srt"
+    original_path.write_text(
+        "1\n00:00:01,000 --> 00:00:01,500\nThis line needs work.\n\n"
+        "2\n00:00:02,000 --> 00:00:02,500\nThis line is fine.\n\n"
+        "3\n00:00:03,000 --> 00:00:03,500\nAnother English subtitle.\n",
+        encoding="utf-8",
+    )
+    reviewed_path.write_text(
+        "1\n00:00:01,000 --> 00:00:01,500\nThis line is improved.\n\n"
+        "2\n00:00:02,000 --> 00:00:02,500\nThis line is fine.\n\n"
+        "3\n00:00:03,000 --> 00:00:03,500\nAnother English subtitle.\n",
+        encoding="utf-8",
+    )
+
+    run_cli_with_args(
+        AuditReviewCli,
+        f"--original {original_path} --reviewed {reviewed_path}",
+    )
+
+    stdout = capsys.readouterr().out
+    assert "- english review edits: 1" in stdout
+    assert "| Subtitle | English | Notes |" in stdout
+    assert "| 1 | This line needs work.<br>This line is improved. |" in stdout
+
+    with raises(SystemExit):
+        run_cli_with_args(
+            AuditReviewCli,
+            (
+                f"--original {original_path} --reviewed {reviewed_path} "
+                "--filter unverified"
+            ),
+        )
+    assert "--filter unverified requires --json" in capsys.readouterr().err
+
+    json_path = tmp_path / "review.json"
+    json_path.write_text(
+        json.dumps(
+            [
+                {
+                    "query": {
+                        "subtitles": [
+                            {"index": 1, "text": "This line needs work."},
+                            {"index": 2, "text": "This line is fine."},
+                            {"index": 3, "text": "Another English subtitle."},
+                        ]
+                    },
+                    "answer": {
+                        "revisions": [
+                            {
+                                "index": 1,
+                                "text": "This line is improved.",
+                                "note": "Improved.",
+                            }
+                        ]
+                    },
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    run_cli_with_args(
+        AuditReviewCli,
+        (
+            f"--original {original_path} --reviewed {reviewed_path} "
+            f"--json {json_path} --filter unverified"
+        ),
+    )
+    stdout = capsys.readouterr().out
+    assert "- row filter: unverified" in stdout
+    assert "- table rows: 3" in stdout
+
+
+def test_audit_review_cli_guided_mode_stdout_and_outfile(
+    tmp_path: Path,
+    capsys: CaptureFixture,
+):
+    """Test guided-review audit output to stdout and a file.
+
+    Arguments:
+        tmp_path: temporary path
+        capsys: pytest stdout/stderr capture fixture
+    """
+    target_path = tmp_path / "target.srt"
+    guide_path = tmp_path / "guide.srt"
+    _write_srt(target_path, ("原文",))
+    _write_srt(guide_path, ("參考",))
+    json_path = tmp_path / "guided_review.json"
+    json_path.write_text(
+        json.dumps(
+            [
+                {
+                    "query": {
+                        "targets": [{"index": 1, "text": "原文"}],
+                        "guides": [{"index": 1, "text": "參考"}],
+                    },
+                    "answer": {
+                        "revisions": [
+                            {
+                                "index": 1,
+                                "text": "修訂",
+                                "note": "correction",
+                            }
+                        ]
+                    },
+                }
+            ],
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    arguments = f"--original {target_path} --guide {guide_path} --json {json_path}"
+
+    run_cli_with_args(
+        AuditReviewCli,
+        f"{arguments} --first-index 1 --last-index 1 --filter changes",
+    )
+    stdout = capsys.readouterr().out
+    assert stdout.startswith("# Guided Subtitle Review Audit\n")
+    assert "- row filter: changes" in stdout
+    assert "- target subtitle range: 1 through 1" in stdout
+    assert "- subtitles: 1" in stdout
+    assert "| 1 | 1 | 參考 | 原文<br>修訂 | correction |  |" in stdout
+
+    outfile_path = tmp_path / "audit.md"
+    run_cli_with_args(
+        AuditReviewCli,
+        f"{arguments} --outfile {outfile_path}",
+    )
+    assert capsys.readouterr().out == ""
+    assert outfile_path.read_text(encoding="utf-8").startswith(
+        "# Guided Subtitle Review Audit\n"
+    )
+
+    with raises(SystemExit):
+        run_cli_with_args(
+            AuditReviewCli,
+            f"{arguments} --first-index 2 --last-index 1",
+        )
+    assert "First index must be less than or equal to last index" in (
+        capsys.readouterr().err
+    )
+
+    with raises(SystemExit):
+        run_cli_with_args(
+            AuditReviewCli,
+            f"{arguments} --first-index 1 --first-block 1",
+        )
+    assert "mutually exclusive" in capsys.readouterr().err
+
+    with raises(SystemExit):
+        run_cli_with_args(
+            AuditReviewCli,
+            f"{arguments} --reviewed {target_path}",
+        )
+    assert "not allowed with argument --guide" in capsys.readouterr().err
+
+    with raises(SystemExit):
+        run_cli_with_args(
+            AuditReviewCli,
+            (f"--original {target_path} --guide {guide_path} --filter unverified"),
+        )
+    assert "--filter unverified requires --json" in capsys.readouterr().err
+
+
+def test_audit_review_cli_help_is_consistent():
+    """Test review audit help documents JSON inputs and option defaults."""
+    for cli_class in (AuditReviewCli, AuditReviewDualCli, AuditReviewTradCli):
+        actions = {
+            action.dest: action
+            for action in cli_class.argparser()._actions  # noqa: SLF001
+        }
+        if cli_class is AuditReviewCli:
+            assert "mode" not in actions
+            assert actions["original_path"].option_strings == ["--original"]
+        filter_type = AuditFilter
+        if cli_class is AuditReviewDualCli:
+            filter_type = ComparativeReviewAuditFilter
+        filter_action = actions["row_filter"]
+        assert filter_action.choices is None
+        assert filter_action.metavar == enum_metavar(filter_type)
+        assert isinstance(filter_action.help, str)
+        assert enum_options_list_str(filter_type) in filter_action.help
+        character_help = actions["characters"].help
+        assert isinstance(character_help, str)
+        assert "(default: no character filter)" in character_help
+        for destination, action in actions.items():
+            if destination.endswith("json_path"):
+                assert isinstance(action.help, str)
+                assert "test-case JSON file" in action.help
+                assert "--filter unverified" in action.help
+
+
 def test_audit_review_dual_cli_stdout_outfile_and_validation(
     tmp_path: Path,
     capsys: CaptureFixture,
@@ -175,325 +445,6 @@ def test_audit_review_dual_cli_stdout_outfile_and_validation(
     )
 
 
-def test_audit_cli_subcommands():
-    """Test the audit CLI and its workflow subcommands are registered."""
-    assert issubclass(AuditDelineationCli, AuditCliBase)
-    assert issubclass(AuditPunctuationCli, AuditCliBase)
-    assert issubclass(AuditReviewCli, AuditCliBase)
-    assert issubclass(AuditReviewDualCli, AuditCliBase)
-    assert issubclass(AuditReviewTradCli, AuditCliBase)
-    assert issubclass(AuditTranslationCli, AuditCliBase)
-    assert ScinoephileCli.subcommands()["audit"] is AuditCli
-    assert AuditCli.subcommands() == {
-        "delineation": AuditDelineationCli,
-        "ocr-fusion": AuditOcrFusionCli,
-        "punctuation": AuditPunctuationCli,
-        "review": AuditReviewCli,
-        "review-dual": AuditReviewDualCli,
-        "review-trad": AuditReviewTradCli,
-        "translation": AuditTranslationCli,
-    }
-
-
-def test_audit_translation_cli_infers_workflow_from_inputs(
-    tmp_path: Path,
-    capsys: CaptureFixture,
-):
-    """Test translation audit workflow inference and input validation.
-
-    Arguments:
-        tmp_path: temporary path
-        capsys: pytest stdout/stderr capture fixture
-    """
-    # Set up input paths
-    source_path = tmp_path / "source.srt"
-    target_path = tmp_path / "target.srt"
-    guide_path = tmp_path / "guide.srt"
-    json_path = tmp_path / "translation.json"
-    for input_path in (source_path, target_path, guide_path, json_path):
-        input_path.touch()
-
-    # Infer standard translation from a source alone
-    with patch.object(
-        AuditTranslationCli,
-        "_audit_standard",
-        return_value="standard\n",
-    ) as audit_standard:
-        run_cli_with_args(
-            AuditTranslationCli,
-            f"--source {source_path} --json {json_path}",
-        )
-    audit_standard.assert_called_once()
-    assert capsys.readouterr().out == "standard\n"
-
-    # Infer guided translation from a source and guide
-    with patch.object(
-        AuditTranslationCli,
-        "_audit_guided",
-        return_value="guided\n",
-    ) as audit_guided:
-        run_cli_with_args(
-            AuditTranslationCli,
-            f"--source {source_path} --guide {guide_path} --json {json_path}",
-        )
-    audit_guided.assert_called_once()
-    assert capsys.readouterr().out == "guided\n"
-
-    # Infer gapped translation from a target and guide
-    with patch.object(
-        AuditTranslationCli,
-        "_audit_gapped",
-        return_value="gapped\n",
-    ) as audit_gapped:
-        run_cli_with_args(
-            AuditTranslationCli,
-            f"--target {target_path} --guide {guide_path} --json {json_path}",
-        )
-    audit_gapped.assert_called_once()
-    assert capsys.readouterr().out == "gapped\n"
-
-    # Reject an incomplete gapped-translation input set
-    with raises(SystemExit):
-        run_cli_with_args(
-            AuditTranslationCli,
-            f"--target {target_path} --json {json_path}",
-        )
-    assert "--guide is required with --target" in capsys.readouterr().err
-
-    # Keep the redundant mode option out of the parser
-    actions = {
-        action.dest: action
-        for action in AuditTranslationCli.argparser()._actions  # noqa: SLF001
-    }
-    assert "mode" not in actions
-    filter_action = actions["row_filter"]
-    assert filter_action.choices is None
-    assert filter_action.default is VerificationAuditFilter.all
-    assert filter_action.metavar == enum_metavar(VerificationAuditFilter)
-    assert isinstance(filter_action.help, str)
-    assert enum_options_list_str(VerificationAuditFilter) in filter_action.help
-
-
-def test_transcription_audit_cli_help_describes_subtitle_indexes():
-    """Test transcription audit range help describes subtitle indexes."""
-    for cli_class in (AuditDelineationCli, AuditPunctuationCli):
-        actions = {
-            action.dest: action
-            for action in cli_class.argparser()._actions  # noqa: SLF001
-        }
-        assert actions["first_index"].help == (
-            "first 1-indexed subtitle number to include, inclusive"
-        )
-        assert actions["last_index"].help == (
-            "last 1-indexed subtitle number to include, inclusive"
-        )
-        filter_action = actions["row_filter"]
-        assert filter_action.choices is None
-        assert filter_action.metavar == enum_metavar(AuditFilter)
-        assert isinstance(filter_action.help, str)
-        assert enum_options_list_str(AuditFilter) in filter_action.help
-
-
-def test_audit_review_cli_help_is_consistent():
-    """Test review audit help documents JSON inputs and option defaults."""
-    for cli_class in (AuditReviewCli, AuditReviewDualCli, AuditReviewTradCli):
-        actions = {
-            action.dest: action
-            for action in cli_class.argparser()._actions  # noqa: SLF001
-        }
-        if cli_class is AuditReviewCli:
-            assert "mode" not in actions
-            assert actions["original_path"].option_strings == ["--original"]
-        filter_type = AuditFilter
-        if cli_class is AuditReviewDualCli:
-            filter_type = ComparativeReviewAuditFilter
-        filter_action = actions["row_filter"]
-        assert filter_action.choices is None
-        assert filter_action.metavar == enum_metavar(filter_type)
-        assert isinstance(filter_action.help, str)
-        assert enum_options_list_str(filter_type) in filter_action.help
-        character_help = actions["characters"].help
-        assert isinstance(character_help, str)
-        assert "(default: no character filter)" in character_help
-        for destination, action in actions.items():
-            if destination.endswith("json_path"):
-                assert isinstance(action.help, str)
-                assert "test-case JSON file" in action.help
-                assert "--filter unverified" in action.help
-
-
-def test_audit_review_cli_guided_mode_stdout_and_outfile(
-    tmp_path: Path,
-    capsys: CaptureFixture,
-):
-    """Test guided-review audit output to stdout and a file.
-
-    Arguments:
-        tmp_path: temporary path
-        capsys: pytest stdout/stderr capture fixture
-    """
-    target_path = tmp_path / "target.srt"
-    guide_path = tmp_path / "guide.srt"
-    _write_srt(target_path, ("原文",))
-    _write_srt(guide_path, ("參考",))
-    json_path = tmp_path / "guided_review.json"
-    json_path.write_text(
-        json.dumps(
-            [
-                {
-                    "query": {
-                        "targets": [{"index": 1, "text": "原文"}],
-                        "guides": [{"index": 1, "text": "參考"}],
-                    },
-                    "answer": {
-                        "revisions": [
-                            {
-                                "index": 1,
-                                "text": "修訂",
-                                "note": "correction",
-                            }
-                        ]
-                    },
-                }
-            ],
-            ensure_ascii=False,
-        ),
-        encoding="utf-8",
-    )
-    arguments = f"--original {target_path} --guide {guide_path} --json {json_path}"
-
-    run_cli_with_args(
-        AuditReviewCli,
-        f"{arguments} --first-index 1 --last-index 1 --filter changes",
-    )
-    stdout = capsys.readouterr().out
-    assert stdout.startswith("# Guided Subtitle Review Audit\n")
-    assert "- row filter: changes" in stdout
-    assert "- target subtitle range: 1 through 1" in stdout
-    assert "- subtitles: 1" in stdout
-    assert "| 1 | 1 | 參考 | 原文<br>修訂 | correction |  |" in stdout
-
-    outfile_path = tmp_path / "audit.md"
-    run_cli_with_args(
-        AuditReviewCli,
-        f"{arguments} --outfile {outfile_path}",
-    )
-    assert capsys.readouterr().out == ""
-    assert outfile_path.read_text(encoding="utf-8").startswith(
-        "# Guided Subtitle Review Audit\n"
-    )
-
-    with raises(SystemExit):
-        run_cli_with_args(
-            AuditReviewCli,
-            f"{arguments} --first-index 2 --last-index 1",
-        )
-    assert "First index must be less than or equal to last index" in (
-        capsys.readouterr().err
-    )
-
-    with raises(SystemExit):
-        run_cli_with_args(
-            AuditReviewCli,
-            f"{arguments} --first-index 1 --first-block 1",
-        )
-    assert "mutually exclusive" in capsys.readouterr().err
-
-    with raises(SystemExit):
-        run_cli_with_args(
-            AuditReviewCli,
-            f"{arguments} --reviewed {target_path}",
-        )
-    assert "not allowed with argument --guide" in capsys.readouterr().err
-
-    with raises(SystemExit):
-        run_cli_with_args(
-            AuditReviewCli,
-            (f"--original {target_path} --guide {guide_path} --filter unverified"),
-        )
-    assert "--filter unverified requires --json" in capsys.readouterr().err
-
-
-def test_audit_review_cli_detects_language(tmp_path: Path, capsys: CaptureFixture):
-    """Test a single review audit detects its language.
-
-    Arguments:
-        tmp_path: temporary path
-        capsys: pytest stdout/stderr capture fixture
-    """
-    original_path = tmp_path / "original.srt"
-    reviewed_path = tmp_path / "reviewed.srt"
-    original_path.write_text(
-        "1\n00:00:01,000 --> 00:00:01,500\nThis line needs work.\n\n"
-        "2\n00:00:02,000 --> 00:00:02,500\nThis line is fine.\n\n"
-        "3\n00:00:03,000 --> 00:00:03,500\nAnother English subtitle.\n",
-        encoding="utf-8",
-    )
-    reviewed_path.write_text(
-        "1\n00:00:01,000 --> 00:00:01,500\nThis line is improved.\n\n"
-        "2\n00:00:02,000 --> 00:00:02,500\nThis line is fine.\n\n"
-        "3\n00:00:03,000 --> 00:00:03,500\nAnother English subtitle.\n",
-        encoding="utf-8",
-    )
-
-    run_cli_with_args(
-        AuditReviewCli,
-        f"--original {original_path} --reviewed {reviewed_path}",
-    )
-
-    stdout = capsys.readouterr().out
-    assert "- english review edits: 1" in stdout
-    assert "| Subtitle | English | Notes |" in stdout
-    assert "| 1 | This line needs work.<br>This line is improved. |" in stdout
-
-    with raises(SystemExit):
-        run_cli_with_args(
-            AuditReviewCli,
-            (
-                f"--original {original_path} --reviewed {reviewed_path} "
-                "--filter unverified"
-            ),
-        )
-    assert "--filter unverified requires --json" in capsys.readouterr().err
-
-    json_path = tmp_path / "review.json"
-    json_path.write_text(
-        json.dumps(
-            [
-                {
-                    "query": {
-                        "subtitles": [
-                            {"index": 1, "text": "This line needs work."},
-                            {"index": 2, "text": "This line is fine."},
-                            {"index": 3, "text": "Another English subtitle."},
-                        ]
-                    },
-                    "answer": {
-                        "revisions": [
-                            {
-                                "index": 1,
-                                "text": "This line is improved.",
-                                "note": "Improved.",
-                            }
-                        ]
-                    },
-                }
-            ]
-        ),
-        encoding="utf-8",
-    )
-    run_cli_with_args(
-        AuditReviewCli,
-        (
-            f"--original {original_path} --reviewed {reviewed_path} "
-            f"--json {json_path} --filter unverified"
-        ),
-    )
-    stdout = capsys.readouterr().out
-    assert "- row filter: unverified" in stdout
-    assert "- table rows: 3" in stdout
-
-
 def test_audit_review_trad_cli(tmp_path: Path, capsys: CaptureFixture):
     """Test a traditional-to-simplified two-review audit.
 
@@ -595,54 +546,103 @@ def test_audit_review_trad_cli(tmp_path: Path, capsys: CaptureFixture):
     ) in capsys.readouterr().err
 
 
-@mark.parametrize(
-    ("texts", "label"),
-    (
-        (
-            ("他们正在这里", "我们没有这个东西", "她说这是真的吗"),
-            "Simplified Chinese",
-        ),
-        (
-            ("他們正在這裡", "我們沒有這個東西", "她說這是真的嗎"),
-            "Traditional Chinese",
-        ),
-        (
-            ("我唔知点解你冇这个", "佢哋系咪想睇这个", "咁样冇嘢喺这边"),
-            "Simplified Cantonese",
-        ),
-        (
-            ("我唔知點解你冇這個", "佢哋係咪想睇這個", "咁樣冇嘢喺這邊"),
-            "Traditional Cantonese",
-        ),
-    ),
-)
-def test_audit_review_cli_detects_chinese_language_and_script(
+def test_audit_translation_cli_infers_workflow_from_inputs(
     tmp_path: Path,
     capsys: CaptureFixture,
-    texts: tuple[str, ...],
-    label: str,
 ):
-    """Test single reviews detect Chinese language and script combinations.
+    """Test translation audit workflow inference and input validation.
 
     Arguments:
         tmp_path: temporary path
         capsys: pytest stdout/stderr capture fixture
-        texts: original subtitle text
-        label: expected report label
     """
-    original_path = tmp_path / "original.srt"
-    reviewed_path = tmp_path / "reviewed.srt"
-    _write_srt(original_path, texts)
-    _write_srt(reviewed_path, (f"{texts[0]}！", *texts[1:]))
+    # Set up input paths
+    source_path = tmp_path / "source.srt"
+    target_path = tmp_path / "target.srt"
+    guide_path = tmp_path / "guide.srt"
+    json_path = tmp_path / "translation.json"
+    for input_path in (source_path, target_path, guide_path, json_path):
+        input_path.touch()
 
-    run_cli_with_args(
-        AuditReviewCli,
-        f"--original {original_path} --reviewed {reviewed_path}",
-    )
+    # Infer standard translation from a source alone
+    with patch.object(
+        AuditTranslationCli,
+        "_audit_standard",
+        return_value="standard\n",
+    ) as audit_standard:
+        run_cli_with_args(
+            AuditTranslationCli,
+            f"--source {source_path} --json {json_path}",
+        )
+    audit_standard.assert_called_once()
+    assert capsys.readouterr().out == "standard\n"
 
-    stdout = capsys.readouterr().out
-    assert f"- {label.lower()} review edits: 1" in stdout
-    assert f"| Subtitle | {label} | Notes |" in stdout
+    # Infer guided translation from a source and guide
+    with patch.object(
+        AuditTranslationCli,
+        "_audit_guided",
+        return_value="guided\n",
+    ) as audit_guided:
+        run_cli_with_args(
+            AuditTranslationCli,
+            f"--source {source_path} --guide {guide_path} --json {json_path}",
+        )
+    audit_guided.assert_called_once()
+    assert capsys.readouterr().out == "guided\n"
+
+    # Infer gapped translation from a target and guide
+    with patch.object(
+        AuditTranslationCli,
+        "_audit_gapped",
+        return_value="gapped\n",
+    ) as audit_gapped:
+        run_cli_with_args(
+            AuditTranslationCli,
+            f"--target {target_path} --guide {guide_path} --json {json_path}",
+        )
+    audit_gapped.assert_called_once()
+    assert capsys.readouterr().out == "gapped\n"
+
+    # Reject an incomplete gapped-translation input set
+    with raises(SystemExit):
+        run_cli_with_args(
+            AuditTranslationCli,
+            f"--target {target_path} --json {json_path}",
+        )
+    assert "--guide is required with --target" in capsys.readouterr().err
+
+    # Keep the redundant mode option out of the parser
+    actions = {
+        action.dest: action
+        for action in AuditTranslationCli.argparser()._actions  # noqa: SLF001
+    }
+    assert "mode" not in actions
+    filter_action = actions["row_filter"]
+    assert filter_action.choices is None
+    assert filter_action.default is VerificationAuditFilter.all
+    assert filter_action.metavar == enum_metavar(VerificationAuditFilter)
+    assert isinstance(filter_action.help, str)
+    assert enum_options_list_str(VerificationAuditFilter) in filter_action.help
+
+
+def test_transcription_audit_cli_help_describes_subtitle_indexes():
+    """Test transcription audit range help describes subtitle indexes."""
+    for cli_class in (AuditDelineationCli, AuditPunctuationCli):
+        actions = {
+            action.dest: action
+            for action in cli_class.argparser()._actions  # noqa: SLF001
+        }
+        assert actions["first_index"].help == (
+            "first 1-indexed subtitle number to include, inclusive"
+        )
+        assert actions["last_index"].help == (
+            "last 1-indexed subtitle number to include, inclusive"
+        )
+        filter_action = actions["row_filter"]
+        assert filter_action.choices is None
+        assert filter_action.metavar == enum_metavar(AuditFilter)
+        assert isinstance(filter_action.help, str)
+        assert enum_options_list_str(AuditFilter) in filter_action.help
 
 
 def _write_srt(file_path: Path, texts: tuple[str, ...]):

--- a/test/cli/test_audit_cli.py
+++ b/test/cli/test_audit_cli.py
@@ -19,6 +19,7 @@ from scinoephile.cli.audit.audit_punctuation_cli import AuditPunctuationCli
 from scinoephile.cli.audit.audit_review_cli import AuditReviewCli
 from scinoephile.cli.audit.audit_review_dual_cli import AuditReviewDualCli
 from scinoephile.cli.audit.audit_review_trad_cli import AuditReviewTradCli
+from scinoephile.cli.audit.audit_translation_cli import AuditTranslationCli
 from scinoephile.cli.scinoephile_cli import ScinoephileCli
 from scinoephile.common.argument_parsing import enum_metavar, enum_options_list_str
 from scinoephile.common.testing import run_cli_with_args
@@ -180,6 +181,7 @@ def test_audit_cli_subcommands():
     assert issubclass(AuditReviewCli, AuditCliBase)
     assert issubclass(AuditReviewDualCli, AuditCliBase)
     assert issubclass(AuditReviewTradCli, AuditCliBase)
+    assert issubclass(AuditTranslationCli, AuditCliBase)
     assert ScinoephileCli.subcommands()["audit"] is AuditCli
     assert AuditCli.subcommands() == {
         "delineation": AuditDelineationCli,
@@ -188,6 +190,7 @@ def test_audit_cli_subcommands():
         "review": AuditReviewCli,
         "review-dual": AuditReviewDualCli,
         "review-trad": AuditReviewTradCli,
+        "translation": AuditTranslationCli,
     }
 
 

--- a/test/cli/test_audit_cli.py
+++ b/test/cli/test_audit_cli.py
@@ -12,8 +12,8 @@ from pytest import CaptureFixture, mark, raises
 
 from scinoephile.analysis.audit.utils import (
     AuditFilter,
-    ComparisonAuditFilter,
-    VerificationAuditFilter,
+    ChangeAuditFilter,
+    ExtendedAuditFilter,
 )
 from scinoephile.cli.audit import AuditCli
 from scinoephile.cli.audit.audit_cli_base import AuditCliBase
@@ -281,14 +281,17 @@ def test_audit_review_cli_help_is_consistent():
         if cli_class is AuditReviewCli:
             assert "mode" not in actions
             assert actions["original_path"].option_strings == ["--original"]
-        filter_type = AuditFilter
+        filter_type = ChangeAuditFilter
         if cli_class is AuditReviewDualCli:
-            filter_type = ComparisonAuditFilter
+            filter_type = ExtendedAuditFilter
         filter_action = actions["row_filter"]
         assert filter_action.choices is None
         assert filter_action.metavar == enum_metavar(filter_type)
         assert isinstance(filter_action.help, str)
         assert enum_options_list_str(filter_type) in filter_action.help
+        assert "all includes every subtitle" in filter_action.help
+        assert "changes includes" in filter_action.help
+        assert "unverified includes" in filter_action.help
         character_help = actions["characters"].help
         assert isinstance(character_help, str)
         assert "(default: no character filter)" in character_help
@@ -622,10 +625,12 @@ def test_audit_translation_cli_infers_workflow_from_inputs(
     assert "mode" not in actions
     filter_action = actions["row_filter"]
     assert filter_action.choices is None
-    assert filter_action.default is VerificationAuditFilter.all
-    assert filter_action.metavar == enum_metavar(VerificationAuditFilter)
+    assert filter_action.default is AuditFilter.all
+    assert filter_action.metavar == enum_metavar(AuditFilter)
     assert isinstance(filter_action.help, str)
-    assert enum_options_list_str(VerificationAuditFilter) in filter_action.help
+    assert enum_options_list_str(AuditFilter) in filter_action.help
+    assert "all includes every translation" in filter_action.help
+    assert "unverified includes" in filter_action.help
 
 
 def test_transcription_audit_cli_help_describes_subtitle_indexes():
@@ -643,9 +648,12 @@ def test_transcription_audit_cli_help_describes_subtitle_indexes():
         )
         filter_action = actions["row_filter"]
         assert filter_action.choices is None
-        assert filter_action.metavar == enum_metavar(AuditFilter)
+        assert filter_action.metavar == enum_metavar(ChangeAuditFilter)
         assert isinstance(filter_action.help, str)
-        assert enum_options_list_str(AuditFilter) in filter_action.help
+        assert enum_options_list_str(ChangeAuditFilter) in filter_action.help
+        assert "all includes every decision" in filter_action.help
+        assert "changes includes" in filter_action.help
+        assert "unverified includes" in filter_action.help
 
 
 def _write_srt(file_path: Path, texts: tuple[str, ...]):

--- a/test/cli/test_audit_cli.py
+++ b/test/cli/test_audit_cli.py
@@ -11,8 +11,7 @@ from unittest.mock import patch
 from pytest import CaptureFixture, mark, raises
 
 from scinoephile.analysis.audit.review import ComparativeReviewAuditFilter
-from scinoephile.analysis.audit.translation import TranslationAuditFilter
-from scinoephile.analysis.audit.utils import AuditFilter
+from scinoephile.analysis.audit.utils import AuditFilter, VerificationAuditFilter
 from scinoephile.cli.audit import AuditCli
 from scinoephile.cli.audit.audit_cli_base import AuditCliBase
 from scinoephile.cli.audit.audit_delineation_cli import AuditDelineationCli
@@ -267,7 +266,12 @@ def test_audit_translation_cli_infers_workflow_from_inputs(
         for action in AuditTranslationCli.argparser()._actions  # noqa: SLF001
     }
     assert "mode" not in actions
-    assert actions["row_filter"].default is TranslationAuditFilter.all
+    filter_action = actions["row_filter"]
+    assert filter_action.choices is None
+    assert filter_action.default is VerificationAuditFilter.all
+    assert filter_action.metavar == enum_metavar(VerificationAuditFilter)
+    assert isinstance(filter_action.help, str)
+    assert enum_options_list_str(VerificationAuditFilter) in filter_action.help
 
 
 def test_transcription_audit_cli_help_describes_subtitle_indexes():
@@ -283,6 +287,11 @@ def test_transcription_audit_cli_help_describes_subtitle_indexes():
         assert actions["last_index"].help == (
             "last 1-indexed subtitle number to include, inclusive"
         )
+        filter_action = actions["row_filter"]
+        assert filter_action.choices is None
+        assert filter_action.metavar == enum_metavar(AuditFilter)
+        assert isinstance(filter_action.help, str)
+        assert enum_options_list_str(AuditFilter) in filter_action.help
 
 
 def test_audit_review_cli_help_is_consistent():

--- a/test/cli/test_audit_cli.py
+++ b/test/cli/test_audit_cli.py
@@ -10,8 +10,11 @@ from unittest.mock import patch
 
 from pytest import CaptureFixture, mark, raises
 
-from scinoephile.analysis.audit.review import ComparativeReviewAuditFilter
-from scinoephile.analysis.audit.utils import AuditFilter, VerificationAuditFilter
+from scinoephile.analysis.audit.utils import (
+    AuditFilter,
+    ComparisonAuditFilter,
+    VerificationAuditFilter,
+)
 from scinoephile.cli.audit import AuditCli
 from scinoephile.cli.audit.audit_cli_base import AuditCliBase
 from scinoephile.cli.audit.audit_delineation_cli import AuditDelineationCli
@@ -280,7 +283,7 @@ def test_audit_review_cli_help_is_consistent():
             assert actions["original_path"].option_strings == ["--original"]
         filter_type = AuditFilter
         if cli_class is AuditReviewDualCli:
-            filter_type = ComparativeReviewAuditFilter
+            filter_type = ComparisonAuditFilter
         filter_action = actions["row_filter"]
         assert filter_action.choices is None
         assert filter_action.metavar == enum_metavar(filter_type)

--- a/test/cli/test_audit_cli.py
+++ b/test/cli/test_audit_cli.py
@@ -6,10 +6,12 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 from pytest import CaptureFixture, mark, raises
 
 from scinoephile.analysis.audit.review import ComparativeReviewAuditFilter
+from scinoephile.analysis.audit.translation import TranslationAuditFilter
 from scinoephile.analysis.audit.utils import AuditFilter
 from scinoephile.cli.audit import AuditCli
 from scinoephile.cli.audit.audit_cli_base import AuditCliBase
@@ -192,6 +194,80 @@ def test_audit_cli_subcommands():
         "review-trad": AuditReviewTradCli,
         "translation": AuditTranslationCli,
     }
+
+
+def test_audit_translation_cli_infers_workflow_from_inputs(
+    tmp_path: Path,
+    capsys: CaptureFixture,
+):
+    """Test translation audit workflow inference and input validation.
+
+    Arguments:
+        tmp_path: temporary path
+        capsys: pytest stdout/stderr capture fixture
+    """
+    # Set up input paths
+    source_path = tmp_path / "source.srt"
+    target_path = tmp_path / "target.srt"
+    guide_path = tmp_path / "guide.srt"
+    json_path = tmp_path / "translation.json"
+    for input_path in (source_path, target_path, guide_path, json_path):
+        input_path.touch()
+
+    # Infer standard translation from a source alone
+    with patch.object(
+        AuditTranslationCli,
+        "_audit_standard",
+        return_value="standard\n",
+    ) as audit_standard:
+        run_cli_with_args(
+            AuditTranslationCli,
+            f"--source {source_path} --json {json_path}",
+        )
+    audit_standard.assert_called_once()
+    assert capsys.readouterr().out == "standard\n"
+
+    # Infer guided translation from a source and guide
+    with patch.object(
+        AuditTranslationCli,
+        "_audit_guided",
+        return_value="guided\n",
+    ) as audit_guided:
+        run_cli_with_args(
+            AuditTranslationCli,
+            f"--source {source_path} --guide {guide_path} --json {json_path}",
+        )
+    audit_guided.assert_called_once()
+    assert capsys.readouterr().out == "guided\n"
+
+    # Infer gapped translation from a target and guide
+    with patch.object(
+        AuditTranslationCli,
+        "_audit_gapped",
+        return_value="gapped\n",
+    ) as audit_gapped:
+        run_cli_with_args(
+            AuditTranslationCli,
+            f"--target {target_path} --guide {guide_path} --json {json_path}",
+        )
+    audit_gapped.assert_called_once()
+    assert capsys.readouterr().out == "gapped\n"
+
+    # Reject an incomplete gapped-translation input set
+    with raises(SystemExit):
+        run_cli_with_args(
+            AuditTranslationCli,
+            f"--target {target_path} --json {json_path}",
+        )
+    assert "--guide is required with --target" in capsys.readouterr().err
+
+    # Keep the redundant mode option out of the parser
+    actions = {
+        action.dest: action
+        for action in AuditTranslationCli.argparser()._actions  # noqa: SLF001
+    }
+    assert "mode" not in actions
+    assert actions["row_filter"].default is TranslationAuditFilter.all
 
 
 def test_transcription_audit_cli_help_describes_subtitle_indexes():

--- a/test/cli/test_audit_ocr_fusion_cli.py
+++ b/test/cli/test_audit_ocr_fusion_cli.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from pytest import CaptureFixture, raises
 
-from scinoephile.analysis.audit.ocr_fusion import OcrFusionAuditFilter
+from scinoephile.analysis.audit.utils import ComparisonAuditFilter
 from scinoephile.cli.audit.audit_ocr_fusion_cli import AuditOcrFusionCli
 from scinoephile.common.argument_parsing import enum_metavar, enum_options_list_str
 from scinoephile.common.testing import run_cli_with_args
@@ -24,9 +24,9 @@ def test_audit_ocr_fusion_cli_filter_help_is_consistent():
     action = actions["row_filter"]
 
     assert action.choices is None
-    assert action.metavar == enum_metavar(OcrFusionAuditFilter)
+    assert action.metavar == enum_metavar(ComparisonAuditFilter)
     assert isinstance(action.help, str)
-    assert enum_options_list_str(OcrFusionAuditFilter) in action.help
+    assert enum_options_list_str(ComparisonAuditFilter) in action.help
     json_help = actions["json_path"].help
     assert isinstance(json_help, str)
     assert "notes and verification state" in json_help

--- a/test/cli/test_audit_ocr_fusion_cli.py
+++ b/test/cli/test_audit_ocr_fusion_cli.py
@@ -29,7 +29,7 @@ def test_audit_ocr_fusion_cli_filter_help_is_consistent():
     assert enum_options_list_str(OcrFusionAuditFilter) in action.help
     json_help = actions["json_path"].help
     assert isinstance(json_help, str)
-    assert "--filter unverified" in json_help
+    assert "notes and verification state" in json_help
 
 
 def test_audit_ocr_fusion_cli_writes_validated_discrepancy_report(
@@ -108,12 +108,14 @@ def test_audit_ocr_fusion_cli_writes_validated_discrepancy_report(
         f"--source-one {source_one_path} --source-two {source_two_path} "
         f"--fused {fused_path}"
     )
-    with raises(SystemExit):
-        run_cli_with_args(
-            AuditOcrFusionCli,
-            f"{no_json_arguments} --filter unverified",
-        )
-    assert "--filter unverified requires --json" in capsys.readouterr().err
+    run_cli_with_args(
+        AuditOcrFusionCli,
+        f"{no_json_arguments} --filter unverified",
+    )
+    report = capsys.readouterr().out
+    assert "- row filter: unverified" in report
+    assert "- table rows: 1" in report
+    assert "| 1 | — | — | 甲錯 | 甲正 | 甲正 | — |  |" in report
 
     with raises(SystemExit):
         run_cli_with_args(
@@ -129,8 +131,8 @@ def test_audit_ocr_fusion_cli_writes_validated_discrepancy_report(
     report = capsys.readouterr().out
     assert "- decision log: omitted" in report
     assert (
-        "| Subtitle | Case | Difficulty | Source one | Source two | Fused | Validated |"
-        in report
+        "| Subtitle | Case | Difficulty | Source one | Source two | "
+        "Fused | Validated | Notes |" in report
     )
 
 

--- a/test/cli/test_audit_ocr_fusion_cli.py
+++ b/test/cli/test_audit_ocr_fusion_cli.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from pytest import CaptureFixture, raises
 
-from scinoephile.analysis.audit.utils import ComparisonAuditFilter
+from scinoephile.analysis.audit.utils import ExtendedAuditFilter
 from scinoephile.cli.audit.audit_ocr_fusion_cli import AuditOcrFusionCli
 from scinoephile.common.argument_parsing import enum_metavar, enum_options_list_str
 from scinoephile.common.testing import run_cli_with_args
@@ -24,9 +24,11 @@ def test_audit_ocr_fusion_cli_filter_help_is_consistent():
     action = actions["row_filter"]
 
     assert action.choices is None
-    assert action.metavar == enum_metavar(ComparisonAuditFilter)
+    assert action.metavar == enum_metavar(ExtendedAuditFilter)
     assert isinstance(action.help, str)
-    assert enum_options_list_str(ComparisonAuditFilter) in action.help
+    assert enum_options_list_str(ExtendedAuditFilter) in action.help
+    assert "changes includes source disagreements" in action.help
+    assert "discrepancies includes differences from the validated track" in action.help
     json_help = actions["json_path"].help
     assert isinstance(json_help, str)
     assert "notes and verification state" in json_help


### PR DESCRIPTION
## Summary

- split the translation audit CLI out of `feature/kob-yue-hant-transcription`
- add Markdown audits for standard, gapped, and guided translation workflows
- register `scinoephile audit translation` with localized help and infer the workflow from `--source`, `--target`, and `--guide`
- share one verification filter and semantic audit-report renderer across translation, review, OCR-fusion, punctuation, and delineation audits
- reject missing or ambiguous current-block matches and distinguish empty translations from unanswered cases
- populate the single `Notes` column from JSON where the schema records notes, and expose consistent `Verified` state
- update audit skills to require replacing generated notes with an independent audit judgment

## Impact

Translation test-case logs can be audited independently of the KOB Yue/Hant transcription work. Subtitle-index and workflow-block ranges are mutually exclusive across audit tools. Markdown escaping, alignment, summary formatting, and row-width validation are centralized, while individual audits provide semantic column and row data.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format <changed Python files>`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix <changed Python files>`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check <changed Python files>`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` (`1944 passed, 9 skipped`)