### PR TITLE
Centralize OCR and web optional dependency imports

### DIFF
--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -28,6 +28,12 @@
   `from scinoephile.core.exceptions import ScinoephileError` within
   `scinoephile.core.llms`, not `from scinoephile.core import ScinoephileError`).
 * Use `if TYPE_CHECKING:` blocks only when necessary to avoid circular imports.
+* Name dedicated lazy-import helpers
+  `import_<module>[_<symbol_or_purpose>]` when public and
+  `_import_<module>[_<symbol_or_purpose>]` when private, spelling nested module
+  paths and imported symbols with underscores (for example,
+  `import_huggingface_hub_snapshot_download`). Reserve `get_...` and `_get_...`
+  for helpers that retrieve or cache values rather than merely importing them.
 * Allow `ruff` to manage import sorting.
 
 ## Exports

--- a/scinoephile/core/__init__.py
+++ b/scinoephile/core/__init__.py
@@ -3,8 +3,8 @@
 """Core code.
 
 Package hierarchy (modules may import from any above):
-* dictionaries / exceptions / ml / paths
-* cache / subtitles / text
+* dependencies / dictionaries / exceptions / paths
+* cache / ml / subtitles / text
 * language / pairs / romanization / timing
 * cli / llms / media / synchronization
 * stacking

--- a/scinoephile/core/dependencies/__init__.py
+++ b/scinoephile/core/dependencies/__init__.py
@@ -1,0 +1,7 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Lazy access to optional dependencies.
+
+Package hierarchy (modules may import from any above):
+* ocr / web
+"""

--- a/scinoephile/core/dependencies/ocr.py
+++ b/scinoephile/core/dependencies/ocr.py
@@ -1,0 +1,62 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+# ruff: noqa: PLC0415
+"""Lazy access to optional OCR dependencies."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+__all__ = [
+    "import_chrome_lens_py_lens_api",
+    "import_chrome_lens_py_lens_api_error",
+    "import_paddleocr_paddle_ocr",
+]
+
+if TYPE_CHECKING:
+    from chrome_lens_py import LensAPI, LensAPIError
+    from paddleocr import PaddleOCR
+
+_OCR_EXTRA_MESSAGE = (
+    "OCR support requires optional OCR dependencies. Install scinoephile with the "
+    "'ocr' extra, or the 'ocr-cuda' extra for CUDA support."
+)
+
+
+def import_chrome_lens_py_lens_api() -> type[LensAPI]:
+    """Import the Google Lens API class on demand.
+
+    Returns:
+        Google Lens API class
+    """
+    try:
+        from chrome_lens_py import LensAPI
+    except ImportError as exc:
+        raise ImportError(_OCR_EXTRA_MESSAGE) from exc
+    return LensAPI
+
+
+def import_chrome_lens_py_lens_api_error() -> type[LensAPIError]:
+    """Import the Google Lens API error class on demand.
+
+    Returns:
+        Google Lens API error class
+    """
+    try:
+        from chrome_lens_py import LensAPIError
+    except ImportError as exc:
+        raise ImportError(_OCR_EXTRA_MESSAGE) from exc
+    return LensAPIError
+
+
+def import_paddleocr_paddle_ocr() -> type[PaddleOCR]:
+    """Import the PaddleOCR class on demand.
+
+    Returns:
+        PaddleOCR class
+    """
+    try:
+        from paddleocr import PaddleOCR
+    except ImportError as exc:
+        raise ImportError(_OCR_EXTRA_MESSAGE) from exc
+    return PaddleOCR

--- a/scinoephile/core/dependencies/web.py
+++ b/scinoephile/core/dependencies/web.py
@@ -1,0 +1,122 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+# ruff: noqa: PLC0415
+"""Lazy access to optional web dependencies."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, NoReturn
+
+__all__ = [
+    "import_flask_abort",
+    "import_flask_current_app",
+    "import_flask_flask",
+    "import_flask_render_template",
+    "import_flask_request",
+    "import_flask_response",
+    "import_werkzeug_serving_make_server",
+]
+
+if TYPE_CHECKING:
+    from flask import Flask, Request, Response
+    from werkzeug.serving import BaseWSGIServer
+
+    type FlaskApp = Flask
+    type FlaskResponse = Response
+
+_WEB_EXTRA_MESSAGE = (
+    "Web support requires optional web dependencies. "
+    "Install scinoephile with the 'web' extra."
+)
+
+
+def import_flask_abort() -> Callable[..., NoReturn]:
+    """Import the Flask request-abort function on demand.
+
+    Returns:
+        Flask request-abort function
+    """
+    try:
+        from flask import abort
+    except ImportError as exc:
+        raise ImportError(_WEB_EXTRA_MESSAGE) from exc
+    return abort
+
+
+def import_flask_current_app() -> Flask:
+    """Import the Flask current-app proxy on demand.
+
+    Returns:
+        Flask current-app proxy
+    """
+    try:
+        from flask import current_app
+    except ImportError as exc:
+        raise ImportError(_WEB_EXTRA_MESSAGE) from exc
+    return current_app
+
+
+def import_flask_flask() -> type[Flask]:
+    """Import the Flask app class on demand.
+
+    Returns:
+        Flask app class
+    """
+    try:
+        from flask import Flask
+    except ImportError as exc:
+        raise ImportError(_WEB_EXTRA_MESSAGE) from exc
+    return Flask
+
+
+def import_flask_render_template() -> Callable[..., str]:
+    """Import the Flask template-rendering function on demand.
+
+    Returns:
+        Flask template-rendering function
+    """
+    try:
+        from flask import render_template
+    except ImportError as exc:
+        raise ImportError(_WEB_EXTRA_MESSAGE) from exc
+    return render_template
+
+
+def import_flask_request() -> Request:
+    """Import the Flask request proxy on demand.
+
+    Returns:
+        Flask request proxy
+    """
+    try:
+        from flask import request
+    except ImportError as exc:
+        raise ImportError(_WEB_EXTRA_MESSAGE) from exc
+    return request
+
+
+def import_flask_response() -> type[Response]:
+    """Import the Flask response class on demand.
+
+    Returns:
+        Flask response class
+    """
+    try:
+        from flask import Response
+    except ImportError as exc:
+        raise ImportError(_WEB_EXTRA_MESSAGE) from exc
+    return Response
+
+
+def import_werkzeug_serving_make_server() -> Callable[..., BaseWSGIServer]:
+    """Import the Werkzeug server factory on demand.
+
+    Returns:
+        Werkzeug server factory
+    """
+    try:
+        from werkzeug.serving import make_server
+    except ImportError as exc:
+        raise ImportError(_WEB_EXTRA_MESSAGE) from exc
+    return make_server

--- a/scinoephile/image/ocr/lens/lens_recognizer.py
+++ b/scinoephile/image/ocr/lens/lens_recognizer.py
@@ -10,12 +10,16 @@ import json
 from collections.abc import Mapping
 from logging import getLogger
 from pathlib import Path
-from typing import Any, TypedDict, cast, override
+from typing import TypedDict, cast, override
 
 from PIL import Image
 
 from scinoephile.common.validation import val_int, val_output_dir_path
 from scinoephile.core import Language
+from scinoephile.core.dependencies.ocr import (
+    import_chrome_lens_py_lens_api,
+    import_chrome_lens_py_lens_api_error,
+)
 
 __all__ = [
     "LensRecognizer",
@@ -24,10 +28,6 @@ __all__ = [
 
 logger = getLogger(__name__)
 
-_OCR_EXTRA_MESSAGE = (
-    "Google Lens OCR support requires optional OCR dependencies. "
-    "Install scinoephile with the 'ocr' extra."
-)
 _LENS_RETRY_DELAY_SECONDS = 1.5
 _LENS_LANGUAGE_CODES = {
     Language.eng: "en",
@@ -87,8 +87,9 @@ class LensRecognizer:
             raise ValueError(f"{language} is not supported by Google Lens OCR") from exc
         self.overwrite_cache = overwrite_cache
         self.retries = val_int(retries, min_value=1)
-        self._lens_api_error_class = self._get_lens_api_error_class()
-        self._api = self._get_lens_api_class()()
+        lens_api_cls = import_chrome_lens_py_lens_api()
+        self._lens_api_error_cls = import_chrome_lens_py_lens_api_error()
+        self._api = lens_api_cls()
 
     @override
     def __repr__(self) -> str:
@@ -154,7 +155,7 @@ class LensRecognizer:
         Returns:
             transient exception classes
         """
-        return self._lens_api_error_class, _GoogleLensRequestError
+        return self._lens_api_error_cls, _GoogleLensRequestError
 
     @staticmethod
     def _clean_text(text: str) -> str:
@@ -215,50 +216,6 @@ class LensRecognizer:
             subtitle text
         """
         return LensRecognizer._clean_text("\n".join(lines))
-
-    @staticmethod
-    def _get_lens_api_class() -> Any:
-        """Import chrome-lens-py on demand.
-
-        Returns:
-            chrome-lens-py LensAPI class
-        Raises:
-            ImportError: if chrome-lens-py is not installed
-        """
-        try:
-            from chrome_lens_py import (  # noqa: PLC0415
-                LensAPI,
-            )
-        except ImportError as exc:
-            raise ImportError(_OCR_EXTRA_MESSAGE) from exc
-        return LensAPI
-
-    @staticmethod
-    def _get_lens_api_error_class() -> type[Exception]:
-        """Import chrome-lens-py LensAPIError on demand.
-
-        Returns:
-            chrome-lens-py LensAPIError class
-        Raises:
-            ImportError: if chrome-lens-py is not installed
-        """
-        try:
-            from chrome_lens_py.exceptions import (  # noqa: PLC0415
-                LensAPIError,
-            )
-        except ImportError as module_exc:
-            try:
-                from chrome_lens_py import (  # noqa: PLC0415
-                    LensAPIError,
-                )
-            except ImportError as package_exc:
-                raise ImportError(_OCR_EXTRA_MESSAGE) from package_exc
-            if module_exc.name != "chrome_lens_py.exceptions":
-                logger.debug(
-                    f"Imported LensAPIError from chrome_lens_py package after "
-                    f"submodule import failed: {module_exc}"
-                )
-        return cast(type[Exception], LensAPIError)
 
     @staticmethod
     def _load_lens_lines(cache_path: Path) -> list[str]:

--- a/scinoephile/image/ocr/paddle/paddle_recognizer.py
+++ b/scinoephile/image/ocr/paddle/paddle_recognizer.py
@@ -18,6 +18,7 @@ from PIL import Image
 
 from scinoephile.common.validation import val_output_dir_path
 from scinoephile.core import Language
+from scinoephile.core.dependencies.ocr import import_paddleocr_paddle_ocr
 
 from .bounding_box import PaddleOcrBoundingBox
 from .text_result import PaddleOcrTextResult
@@ -32,10 +33,6 @@ logger = getLogger(__name__)
 _TEXT_DETECTION_MODEL_NAME = "PP-OCRv5_server_det"
 _TEXT_RECOGNITION_MODEL_NAME = "PP-OCRv5_server_rec"
 _TEXTLINE_ORIENTATION_MODEL_NAME = "PP-LCNet_x1_0_textline_ori"
-_OCR_EXTRA_MESSAGE = (
-    "PaddleOCR support requires optional OCR dependencies. "
-    "Install scinoephile with the 'ocr' extra."
-)
 _PADDLE_LANGUAGE_CODES = {
     Language.eng: "en",
     Language.yue_hans: "ch",
@@ -95,7 +92,7 @@ class PaddleRecognizer:
         if cache_dir_path is not None:
             self.cache_dir_path = val_output_dir_path(cache_dir_path)
 
-        paddle_ocr_cls = self._get_paddle_ocr_class()
+        paddle_ocr_cls = import_paddleocr_paddle_ocr()
         root_logger = getLogger()
         root_logger_level = root_logger.level
         try:
@@ -177,17 +174,6 @@ class PaddleRecognizer:
         )
         cache_sha256 = hashlib.sha256(cache_key.encode("utf-8")).hexdigest()
         return self.cache_dir_path / f"{cache_sha256}.json"
-
-    @staticmethod
-    def _get_paddle_ocr_class() -> Any:
-        """Import PaddleOCR on demand."""
-        try:
-            from paddleocr import (  # noqa: PLC0415
-                PaddleOCR,
-            )
-        except ImportError as exc:
-            raise ImportError(_OCR_EXTRA_MESSAGE) from exc
-        return PaddleOCR
 
     @staticmethod
     def _format_paddle_ocr_text(

--- a/scinoephile/web/ocr_validation/app.py
+++ b/scinoephile/web/ocr_validation/app.py
@@ -10,26 +10,25 @@ from typing import TYPE_CHECKING
 
 from scinoephile.common import package_root
 from scinoephile.core import ScinoephileError
+from scinoephile.core.dependencies.web import (
+    import_flask_flask,
+    import_werkzeug_serving_make_server,
+)
 
 from .session import OcrValidationSession
 
 if TYPE_CHECKING:
-    from flask import Flask
+    from scinoephile.core.dependencies.web import FlaskApp
 
 __all__ = [
     "create_app",
     "run_app",
 ]
 
-_WEB_EXTRA_MESSAGE = (
-    "OCR validation web UI support requires optional web dependencies. "
-    "Install scinoephile with the 'web' extra."
-)
-
 logger = getLogger(__name__)
 
 
-def create_app(session: OcrValidationSession) -> Flask:
+def create_app(session: OcrValidationSession) -> FlaskApp:
     """Create the OCR validation Flask app.
 
     Arguments:
@@ -40,14 +39,13 @@ def create_app(session: OcrValidationSession) -> Flask:
         ScinoephileError: if optional web dependencies are not installed
     """
     try:
-        from flask import Flask  # noqa: PLC0415
-
+        flask_cls = import_flask_flask()
         from .routes import register_routes  # noqa: PLC0415
     except ImportError as exc:
-        raise ScinoephileError(_WEB_EXTRA_MESSAGE) from exc
+        raise ScinoephileError(str(exc)) from exc
 
     static_dir_path = package_root / "web/static"
-    app = Flask(__name__, static_folder=str(static_dir_path))
+    app = flask_cls(__name__, static_folder=str(static_dir_path))
     app.config["OCR_VALIDATION_SESSION"] = session
     app.config["OCR_VALIDATION_SERVER"] = None
     register_routes(app)
@@ -65,12 +63,12 @@ def run_app(session: OcrValidationSession, host: str, port: int):
         ScinoephileError: if optional dependencies are missing or server startup fails
     """
     try:
-        try:
-            from werkzeug.serving import make_server  # noqa: PLC0415
-        except ImportError as exc:
-            raise ScinoephileError(_WEB_EXTRA_MESSAGE) from exc
+        make_server = import_werkzeug_serving_make_server()
+    except ImportError as exc:
+        raise ScinoephileError(str(exc)) from exc
 
-        app = create_app(session)
+    app = create_app(session)
+    try:
         server_port = port
         if _port_is_in_use(_connection_host(host), port):
             logger.warning(

--- a/scinoephile/web/ocr_validation/routes.py
+++ b/scinoephile/web/ocr_validation/routes.py
@@ -6,24 +6,34 @@ from __future__ import annotations
 
 from io import BytesIO
 from threading import Thread
+from typing import TYPE_CHECKING
 
-from flask import (
-    Flask,
-    Response,
-    abort,
-    current_app,
-    render_template,
-    request,
-)
 from PIL import Image
+
+from scinoephile.core.dependencies.web import (
+    import_flask_abort,
+    import_flask_current_app,
+    import_flask_render_template,
+    import_flask_request,
+    import_flask_response,
+)
 
 from .concerns import SubtitleRowView
 from .session import OcrValidationSession
 
 __all__ = ["register_routes"]
 
+if TYPE_CHECKING:
+    from scinoephile.core.dependencies.web import FlaskApp, FlaskResponse
 
-def register_routes(app: Flask):
+abort = import_flask_abort()
+current_app = import_flask_current_app()
+render_template = import_flask_render_template()
+request = import_flask_request()
+response_cls = import_flask_response()
+
+
+def register_routes(app: FlaskApp):
     """Register OCR validation routes with a Flask app.
 
     Arguments:
@@ -54,7 +64,7 @@ def register_routes(app: Flask):
         return _render_subtitle_row(session, row)
 
     @app.get("/subtitles/<int:sub_idx>/concern.png")
-    def concern_image(sub_idx: int) -> Response:
+    def concern_image(sub_idx: int) -> FlaskResponse:
         """Render one current concern image.
 
         Arguments:
@@ -67,7 +77,7 @@ def register_routes(app: Flask):
         return _png_response(image)
 
     @app.get("/subtitles/<int:sub_idx>/validation.png")
-    def validation_image(sub_idx: int) -> Response:
+    def validation_image(sub_idx: int) -> FlaskResponse:
         """Render one subtitle image with validation bboxes.
 
         Arguments:
@@ -160,7 +170,7 @@ def _handle_value_error(exc: ValueError) -> tuple[str, int]:
     return str(exc), 400
 
 
-def _png_response(image: Image.Image) -> Response:
+def _png_response(image: Image.Image) -> FlaskResponse:
     """Encode an image as a PNG Flask response.
 
     Arguments:
@@ -170,10 +180,10 @@ def _png_response(image: Image.Image) -> Response:
     """
     output = BytesIO()
     image.save(output, format="PNG")
-    return Response(output.getvalue(), mimetype="image/png")
+    return response_cls(output.getvalue(), mimetype="image/png")
 
 
-def _register_error_handlers(app: Flask):
+def _register_error_handlers(app: FlaskApp):
     """Register request-facing validation error handlers.
 
     Arguments:
@@ -183,7 +193,7 @@ def _register_error_handlers(app: Flask):
     app.register_error_handler(ValueError, _handle_value_error)
 
 
-def _register_exit_route(app: Flask):
+def _register_exit_route(app: FlaskApp):
     """Register the route that finishes validation and stops the web server.
 
     Arguments:
@@ -208,7 +218,7 @@ def _register_exit_route(app: Flask):
         return "Validation exited. You can close this tab."
 
 
-def _register_filter_routes(app: Flask):
+def _register_filter_routes(app: FlaskApp):
     """Register filter update routes.
 
     Arguments:

--- a/test/core/dependencies/test_dependencies.py
+++ b/test/core/dependencies/test_dependencies.py
@@ -4,10 +4,26 @@
 
 from __future__ import annotations
 
-from scinoephile.core.dependencies import ocr, web
+from importlib import import_module
+from pkgutil import iter_modules
+
+from scinoephile.core import dependencies
 
 
 def test_dependency_exports_use_lazy_import_naming():
     """Test dependency helpers use the public lazy-import naming convention."""
-    for module in (ocr, web):
-        assert all(name.startswith("import_") for name in module.__all__)
+    module_names = sorted(
+        module_info.name
+        for module_info in iter_modules(
+            dependencies.__path__,
+            f"{dependencies.__name__}.",
+        )
+        if not module_info.name.rsplit(".", 1)[-1].startswith("_")
+    )
+
+    assert module_names
+    for module_name in module_names:
+        module = import_module(module_name)
+        exports = getattr(module, "__all__", None)
+        assert isinstance(exports, list)
+        assert all(name.startswith("import_") for name in exports)

--- a/test/core/dependencies/test_dependencies.py
+++ b/test/core/dependencies/test_dependencies.py
@@ -1,0 +1,13 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests of centralized optional dependency access."""
+
+from __future__ import annotations
+
+from scinoephile.core.dependencies import ocr, web
+
+
+def test_dependency_exports_use_lazy_import_naming():
+    """Test dependency helpers use the public lazy-import naming convention."""
+    for module in (ocr, web):
+        assert all(name.startswith("import_") for name in module.__all__)

--- a/test/image/ocr/lens/test_lens_recognizer.py
+++ b/test/image/ocr/lens/test_lens_recognizer.py
@@ -16,6 +16,7 @@ from pytest import MonkeyPatch, raises
 
 from scinoephile.common.subprocess import run_command
 from scinoephile.core import Language
+from scinoephile.core.dependencies.ocr import import_chrome_lens_py_lens_api
 from scinoephile.image.ocr.lens.lens_recognizer import LensRecognizer
 from test.helpers import parametrize
 
@@ -54,7 +55,7 @@ class CountingLensRecognizer(LensRecognizer):
             results = [["cached", "text"]]
         self.results = results
         self._api = self
-        self._lens_api_error_class = FakeLensApiError
+        self._lens_api_error_cls = FakeLensApiError
 
     async def process_image(self, **kwargs: object) -> dict[str, object]:
         """Process an image.
@@ -187,13 +188,13 @@ def test_lens_recognizer_maps_supported_languages_to_engine_codes(
         """Fake chrome-lens-py LensAPI class."""
 
     monkeypatch.setattr(
-        "scinoephile.image.ocr.lens.lens_recognizer.LensRecognizer._get_lens_api_class",
-        staticmethod(lambda: FakeLensApi),
+        "scinoephile.image.ocr.lens.lens_recognizer.import_chrome_lens_py_lens_api",
+        lambda: FakeLensApi,
     )
     monkeypatch.setattr(
-        "scinoephile.image.ocr.lens.lens_recognizer.LensRecognizer."
-        "_get_lens_api_error_class",
-        staticmethod(lambda: FakeLensApiError),
+        "scinoephile.image.ocr.lens.lens_recognizer."
+        "import_chrome_lens_py_lens_api_error",
+        lambda: FakeLensApiError,
     )
 
     recognizer = LensRecognizer(language=language)
@@ -476,7 +477,7 @@ def test_lens_recognizer_import_error_is_actionable(monkeypatch: MonkeyPatch):
     monkeypatch.setattr("builtins.__import__", fake_import)
 
     with raises(ImportError, match="'ocr' extra"):
-        LensRecognizer._get_lens_api_class()
+        import_chrome_lens_py_lens_api()
 
 
 def test_lens_recognizer_imports_chrome_lens_py_only_when_needed():

--- a/test/image/ocr/paddle/test_paddle_recognizer.py
+++ b/test/image/ocr/paddle/test_paddle_recognizer.py
@@ -17,6 +17,7 @@ from pytest import MonkeyPatch, raises
 
 from scinoephile.common.subprocess import run_command
 from scinoephile.core import Language
+from scinoephile.core.dependencies.ocr import import_paddleocr_paddle_ocr
 from scinoephile.image.ocr.paddle import PaddleRecognizer
 from scinoephile.image.ocr.paddle.bounding_box import PaddleOcrBoundingBox
 from scinoephile.image.ocr.paddle.text_result import PaddleOcrTextResult
@@ -181,9 +182,8 @@ def test_paddle_recognizer_preserves_root_logger_level(monkeypatch: MonkeyPatch)
     root_logger = logging.getLogger()
     previous_level = root_logger.level
     monkeypatch.setattr(
-        "scinoephile.image.ocr.paddle.paddle_recognizer.PaddleRecognizer."
-        "_get_paddle_ocr_class",
-        staticmethod(lambda: FakePaddleOCR),
+        "scinoephile.image.ocr.paddle.paddle_recognizer.import_paddleocr_paddle_ocr",
+        lambda: FakePaddleOCR,
     )
 
     try:
@@ -244,7 +244,7 @@ def test_paddle_ocr_class_requires_ocr_extra(monkeypatch: MonkeyPatch):
     monkeypatch.setattr("builtins.__import__", fake_import)
 
     with raises(ImportError, match="'ocr' extra"):
-        PaddleRecognizer._get_paddle_ocr_class()
+        import_paddleocr_paddle_ocr()
 
 
 def test_paddle_recognizer_rejects_unsupported_languages():
@@ -289,9 +289,8 @@ def test_paddle_recognizer_maps_supported_languages_to_engine_codes(
             observed_kwargs.update(kwargs)
 
     monkeypatch.setattr(
-        "scinoephile.image.ocr.paddle.paddle_recognizer.PaddleRecognizer."
-        "_get_paddle_ocr_class",
-        staticmethod(lambda: FakePaddleOCR),
+        "scinoephile.image.ocr.paddle.paddle_recognizer.import_paddleocr_paddle_ocr",
+        lambda: FakePaddleOCR,
     )
 
     recognizer = PaddleRecognizer(language=language)

--- a/test/media/offset/video/test_detection.py
+++ b/test/media/offset/video/test_detection.py
@@ -28,11 +28,22 @@ class _VideoOffsetKwargs(TypedDict, total=False):
     """Keyword arguments for video offset detection."""
 
     max_offset: float
+    """Maximum offset to consider."""
+
     sample_rate: float
+    """Video frame sampling rate."""
+
     coarse_step: float
+    """Step size for the coarse offset search."""
+
     sample_windows: int
+    """Number of sample windows to compare."""
+
     width: int
+    """Width to which sampled frames are resized."""
+
     height: int
+    """Height to which sampled frames are resized."""
 
 
 def test_get_video_offset_prefers_known_shift():

--- a/test/test_style.py
+++ b/test/test_style.py
@@ -88,6 +88,47 @@ def test_python_sources_do_not_use_percent_string_interpolation():
     )
 
 
+def test_typed_dict_field_documentation_violations_are_detected():
+    """Test undocumented TypedDict fields are detected."""
+    tree = ast.parse(
+        '''
+class Example(TypedDict):
+    """Example payload."""
+
+    documented: str
+    """Documented field."""
+
+    undocumented: int
+'''
+    )
+
+    violations = get_typed_dict_field_documentation_violations(
+        file_path=Path("sample.py"),
+        tree=tree,
+    )
+
+    assert violations == [
+        "sample.py:8: TypedDict field Example.undocumented lacks documentation"
+    ]
+
+
+def test_typed_dict_fields_are_documented():
+    """Test TypedDict fields have attribute docstrings."""
+    violations: list[str] = []
+    for file_path in get_python_files(package_root.parent):
+        tree = ast.parse(
+            file_path.read_text(encoding="utf-8"), filename=file_path.as_posix()
+        )
+        violations.extend(
+            get_typed_dict_field_documentation_violations(
+                file_path=file_path.relative_to(package_root.parent),
+                tree=tree,
+            )
+        )
+
+    assert not violations, "Document TypedDict fields:\n" + "\n".join(violations)
+
+
 def get_python_files(target_dir_path: Path) -> list[Path]:
     """Get Python files under a target directory.
 
@@ -133,6 +174,51 @@ def get_string_interpolation_violations(
                     message="uses `%` interpolation arguments; prefer f-strings",
                 )
             )
+    return violations
+
+
+def get_typed_dict_field_documentation_violations(
+    file_path: Path,
+    tree: ast.Module,
+) -> list[str]:
+    """Get undocumented TypedDict fields from a parsed Python file.
+
+    Arguments:
+        file_path: source file path
+        tree: parsed Python module
+    Returns:
+        formatted documentation violations
+    """
+    violations = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        if not any(
+            (isinstance(base, ast.Name) and base.id == "TypedDict")
+            or (isinstance(base, ast.Attribute) and base.attr == "TypedDict")
+            for base in node.bases
+        ):
+            continue
+
+        for statement_idx, statement in enumerate(node.body):
+            if not isinstance(statement, ast.AnnAssign) or not isinstance(
+                statement.target, ast.Name
+            ):
+                continue
+            next_statement_idx = statement_idx + 1
+            next_statement = None
+            if next_statement_idx < len(node.body):
+                next_statement = node.body[next_statement_idx]
+            has_docstring = (
+                isinstance(next_statement, ast.Expr)
+                and isinstance(next_statement.value, ast.Constant)
+                and isinstance(next_statement.value.value, str)
+            )
+            if not has_docstring:
+                violations.append(
+                    f"{file_path}:{statement.lineno}: TypedDict field "
+                    f"{node.name}.{statement.target.id} lacks documentation"
+                )
     return violations
 
 


### PR DESCRIPTION
## Summary

- Centralize lazy imports for the OCR and web optional dependency groups under `scinoephile/core/dependencies`.
- Keep actionable optional-extra error messages at the dependency boundary and simplify callers.
- Document the lazy-import naming convention and enforce documented `TypedDict` fields.

## Stack

1. This PR
2. Demucs cache and transcription dependency refactor
3. Shared transcription preprocessing fallbacks
4. #1194 — MLX-Audio inference backend
5. #1193 — MLX-Audio transcriber
6. #1195 — MLX-Audio CLI integration

## Validation

- Ruff formatting and linting on changed Python files
- `ty check` on changed Python files
- Full test suite: 2,034 passed, 9 skipped