### PR TITLE
Compact short formatted expressions

### DIFF
--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -9,8 +9,6 @@
 
 ## Formatting
 * Allow `ruff format` to manage code formatting details.
-* Keep expressions on one line when they fit within the configured line length;
-  trailing commas should not force an expanded multiline layout.
 
 ## Imports
 * Include `from __future__ import annotations` in Python modules that contain
@@ -41,8 +39,6 @@
 ## Exports
 * Include `__all__` in Python modules that export public names.
 * Do not include empty `__all__` assignments.
-* Allow `ruff format` to keep short `__all__` assignments on one line and expand
-  longer assignments across multiple lines.
 * `__all__` should list the intended public API for the module.
 * Do not include internal helpers, which are names prefixed with an underscore.
 * In `__init__.py` files, only import classes from the module, not functions or

--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -9,6 +9,8 @@
 
 ## Formatting
 * Allow `ruff format` to manage code formatting details.
+* Keep expressions on one line when they fit within the configured line length;
+  trailing commas should not force an expanded multiline layout.
 
 ## Imports
 * Include `from __future__ import annotations` in Python modules that contain
@@ -39,10 +41,8 @@
 ## Exports
 * Include `__all__` in Python modules that export public names.
 * Do not include empty `__all__` assignments.
-* If `__all__` contains one entry, keep it on one line, such as
-  `__all__ = ["foo"]`.
-* If `__all__` contains multiple entries, include a trailing comma after the
-  last entry so `ruff` formats it as one item per line.
+* Allow `ruff format` to keep short `__all__` assignments on one line and expand
+  longer assignments across multiple lines.
 * `__all__` should list the intended public API for the module.
 * Do not include internal helpers, which are names prefixed with an underscore.
 * In `__init__.py` files, only import classes from the module, not functions or

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,9 @@ filterwarnings = [
 [tool.ruff]
 line-length = 88
 
+[tool.ruff.format]
+skip-magic-trailing-comma = true
+
 [tool.ruff.lint]
 select = [
     "D", # pydocstyle
@@ -112,6 +115,9 @@ ignore = [
     "PLR0917", # Too many positional arguments
     "PLR2004" # Magic value used in comparison
 ]
+
+[tool.ruff.lint.isort]
+split-on-trailing-comma = false
 
 [tool.ruff.lint.pydocstyle]
 convention = 'google'

--- a/scinoephile/analysis/audit/aligned_diff.py
+++ b/scinoephile/analysis/audit/aligned_diff.py
@@ -12,15 +12,9 @@ from scinoephile.core.exceptions import ScinoephileError
 from scinoephile.core.subtitles import Series
 from scinoephile.core.text import join_text_lines
 
-from .utils import (
-    format_audit_report,
-    get_selected_event_indexes,
-)
+from .utils import format_audit_report, get_selected_event_indexes
 
-__all__ = [
-    "AlignedDiffAuditFilter",
-    "audit_aligned_diff",
-]
+__all__ = ["AlignedDiffAuditFilter", "audit_aligned_diff"]
 
 
 class AlignedDiffAuditFilter(StrEnum):
@@ -142,11 +136,7 @@ def audit_aligned_diff(
             f"equal rows: {equal_rows}",
             f"row filter: {row_filter.value}",
         ),
-        columns=(
-            ("Indexes", "right"),
-            ("Alignment", "left"),
-            ("Notes", "left"),
-        ),
+        columns=(("Indexes", "right"), ("Alignment", "left"), ("Notes", "left")),
         rows=[
             _format_row(
                 message,
@@ -256,9 +246,7 @@ def _format_event_indices(prefix: str, event_idxs: tuple[int, ...]) -> str:
 
 
 def _format_original_text(
-    original: Series,
-    timing_track: Series,
-    event_idxs: tuple[int, ...],
+    original: Series, timing_track: Series, event_idxs: tuple[int, ...]
 ) -> str:
     """Join original text that overlaps the indexed events' time range.
 
@@ -321,9 +309,7 @@ def _format_row(
             original_timing_track = reference
             original_event_idxs = reference_idxs
         original_text = _format_original_text(
-            original,
-            original_timing_track,
-            original_event_idxs,
+            original, original_timing_track, original_event_idxs
         )
         aligned_lines.append(f"O │ {_escape_preformatted(original_text)}")
     aligned_lines.extend(

--- a/scinoephile/analysis/audit/delineation.py
+++ b/scinoephile/analysis/audit/delineation.py
@@ -21,10 +21,7 @@ from .utils import (
     resolve_contextual_index,
 )
 
-__all__ = [
-    "DelineationAuditFilter",
-    "audit_delineation",
-]
+__all__ = ["DelineationAuditFilter", "audit_delineation"]
 
 
 class DelineationAuditFilter(StrEnum):
@@ -78,8 +75,7 @@ def audit_delineation(
         last_block=last_block,
     )
     candidate_indexes_by_case, direct_indexes = _get_case_indexes(
-        pair_indexes,
-        test_cases,
+        pair_indexes, test_cases
     )
 
     rows: list[tuple[int, tuple[str, ...]]] = []
@@ -192,9 +188,7 @@ def _get_case_index(
         ScinoephileError: if a case remains ambiguous
     """
     index = resolve_contextual_index(
-        candidate_indexes,
-        direct_indexes,
-        test_case_index - 1,
+        candidate_indexes, direct_indexes, test_case_index - 1
     )
     if index is not None:
         return index
@@ -221,19 +215,15 @@ def _get_case_indexes(
     Raises:
         ScinoephileError: if a logged reference pair is absent
     """
-    target_pairs_by_reference_pair: dict[
-        tuple[str, str],
-        set[tuple[str, str]],
-    ] = defaultdict(set)
+    target_pairs_by_reference_pair: dict[tuple[str, str], set[tuple[str, str]]] = (
+        defaultdict(set)
+    )
     for test_case in test_cases:
         query = test_case.query
         reference_pair = (query.reference_one, query.reference_two)
         target_pair = (query.target_one, query.target_two)
         target_pairs_by_reference_pair[reference_pair].add(target_pair)
-    superseded_pairs = get_superseded_keys(
-        pair_indexes,
-        target_pairs_by_reference_pair,
-    )
+    superseded_pairs = get_superseded_keys(pair_indexes, target_pairs_by_reference_pair)
     candidate_indexes_by_case: list[list[int]] = []
     direct_indexes: list[int | None] = []
     for test_case_index, test_case in enumerate(test_cases, 1):
@@ -287,9 +277,7 @@ def _get_selected_case_index(
         return None
 
     index = _get_case_index(
-        candidate_indexes,
-        direct_indexes,
-        test_case_index=test_case_index,
+        candidate_indexes, direct_indexes, test_case_index=test_case_index
     )
     if index not in selected_candidate_indexes:
         return None

--- a/scinoephile/analysis/audit/dual_review.py
+++ b/scinoephile/analysis/audit/dual_review.py
@@ -10,16 +10,9 @@ from enum import StrEnum
 from scinoephile.core.llms import TestCase
 from scinoephile.core.subtitles import Series
 
-from .review import (
-    ReviewAuditComparison,
-    ReviewAuditPair,
-    audit_review,
-)
+from .review import ReviewAuditComparison, ReviewAuditPair, audit_review
 
-__all__ = [
-    "DualReviewAuditFilter",
-    "audit_dual_review",
-]
+__all__ = ["DualReviewAuditFilter", "audit_dual_review"]
 
 
 class DualReviewAuditFilter(StrEnum):

--- a/scinoephile/analysis/audit/gap_translation.py
+++ b/scinoephile/analysis/audit/gap_translation.py
@@ -15,11 +15,7 @@ from scinoephile.core.synchronization import get_sync_overlap_matrix
 from scinoephile.llms.gap_translation import GapTranslationTestCase
 
 from .translation import TranslationAuditFilter, resolve_translation_audit_output
-from .utils import (
-    format_audit_report,
-    format_verification_marker,
-    validate_audit_range,
-)
+from .utils import format_audit_report, format_verification_marker, validate_audit_range
 
 __all__ = ["audit_gap_translation"]
 
@@ -89,11 +85,7 @@ def audit_gap_translation(
     # Build paired workflow blocks and validate the selection
     block_pairs = get_block_pairs_by_pause(target, guide)
     validate_audit_range(
-        first_index,
-        last_index,
-        first_block,
-        last_block,
-        block_count=len(block_pairs),
+        first_index, last_index, first_block, last_block, block_count=len(block_pairs)
     )
 
     # Reconstruct current gap blocks and their global guide indexes
@@ -127,10 +119,7 @@ def audit_gap_translation(
         verified_marker = format_verification_marker(test_case.verified)
         for local_index, (global_index, guide_text, target_text) in enumerate(
             zip(
-                block.guide_indexes,
-                block.guide_texts,
-                block.target_texts,
-                strict=True,
+                block.guide_indexes, block.guide_texts, block.target_texts, strict=True
             ),
             1,
         ):
@@ -142,8 +131,7 @@ def audit_gap_translation(
                 continue
 
             output_text, answered, empty = resolve_translation_audit_output(
-                outputs_by_index,
-                local_index,
+                outputs_by_index, local_index
             )
             cells = (
                 f"G {global_index}\nQ {local_index}",
@@ -236,9 +224,7 @@ def _block_intersects_range(
             and (first_index is None or guide_index >= first_index)
             and (last_index is None or guide_index <= last_index)
             for guide_index, target_text in zip(
-                block.guide_indexes,
-                block.target_texts,
-                strict=True,
+                block.guide_indexes, block.target_texts, strict=True
             )
         )
     )
@@ -318,8 +304,7 @@ def _get_active_test_case_blocks(
 
     # Match exact current cases, retaining the latest case for each block
     active_by_block_number: dict[
-        int,
-        tuple[int, GapTranslationTestCase, _GapTranslationBlock],
+        int, tuple[int, GapTranslationTestCase, _GapTranslationBlock]
     ] = {}
     unmatched_cases: list[tuple[int, GapTranslationTestCase]] = []
     for test_case_index, test_case in enumerate(test_cases, 1):
@@ -332,11 +317,7 @@ def _get_active_test_case_blocks(
             block
             for block in matches
             if _block_intersects_range(
-                block,
-                first_index,
-                last_index,
-                first_block,
-                last_block,
+                block, first_index, last_index, first_block, last_block
             )
         ]
         if not selected_matches:
@@ -379,11 +360,7 @@ def _get_active_test_case_blocks(
             block
             for block in matches
             if _block_intersects_range(
-                block,
-                first_index,
-                last_index,
-                first_block,
-                last_block,
+                block, first_index, last_index, first_block, last_block
             )
         ]
         if not selected_matches:
@@ -418,11 +395,7 @@ def _get_active_test_case_blocks(
         block.block_number
         for block in blocks
         if _block_intersects_range(
-            block,
-            first_index,
-            last_index,
-            first_block,
-            last_block,
+            block, first_index, last_index, first_block, last_block
         )
     }
     missing_block_numbers = sorted(selected_block_numbers - set(active_by_block_number))
@@ -435,8 +408,7 @@ def _get_active_test_case_blocks(
 
     # Return active cases in current workflow order
     return sorted(
-        active_by_block_number.values(),
-        key=lambda item: item[2].block_number,
+        active_by_block_number.values(), key=lambda item: item[2].block_number
     )
 
 

--- a/scinoephile/analysis/audit/guided_review.py
+++ b/scinoephile/analysis/audit/guided_review.py
@@ -88,11 +88,7 @@ def audit_guided_review(
     """
     block_pairs = get_block_pairs_by_pause(target, guide)
     validate_audit_range(
-        first_index,
-        last_index,
-        first_block,
-        last_block,
-        block_count=len(block_pairs),
+        first_index, last_index, first_block, last_block, block_count=len(block_pairs)
     )
     blocks_by_key = _get_blocks_by_key(block_pairs)
     rows_by_subtitle_index: dict[int, _GuidedReviewRow] = {}
@@ -296,11 +292,7 @@ def _get_active_test_case_blocks(  # noqa: PLR0912
             block
             for block in matches
             if _block_intersects_range(
-                block,
-                first_index,
-                last_index,
-                first_block,
-                last_block,
+                block, first_index, last_index, first_block, last_block
             )
         ]
         if selected_matches:
@@ -354,11 +346,7 @@ def _get_active_test_case_blocks(  # noqa: PLR0912
             block
             for block in matches
             if _block_intersects_range(
-                block,
-                first_index,
-                last_index,
-                first_block,
-                last_block,
+                block, first_index, last_index, first_block, last_block
             )
         ]
         if not selected_matches or all(
@@ -389,11 +377,7 @@ def _get_active_test_case_blocks(  # noqa: PLR0912
         for blocks in blocks_by_key.values()
         for block in blocks
         if _block_intersects_range(
-            block,
-            first_index,
-            last_index,
-            first_block,
-            last_block,
+            block, first_index, last_index, first_block, last_block
         )
     }
     active_block_numbers = {block.block_number for _, _, block in active_cases}
@@ -419,8 +403,7 @@ def _get_blocks_by_key(
         guided-review blocks keyed by target and guide text
     """
     blocks_by_key: dict[
-        tuple[tuple[str, ...], tuple[str, ...]],
-        list[_GuidedReviewBlock],
+        tuple[tuple[str, ...], tuple[str, ...]], list[_GuidedReviewBlock]
     ] = defaultdict(list)
     target_offset = 0
     for block_number, (target_block, guide_block) in enumerate(block_pairs, 1):

--- a/scinoephile/analysis/audit/guided_translation.py
+++ b/scinoephile/analysis/audit/guided_translation.py
@@ -51,11 +51,7 @@ def audit_guided_translation(
     # Build paired workflow blocks and validate the selection
     block_pairs = get_block_pairs_by_pause(source, guide)
     validate_audit_range(
-        first_index,
-        last_index,
-        first_block,
-        last_block,
-        block_count=len(block_pairs),
+        first_index, last_index, first_block, last_block, block_count=len(block_pairs)
     )
     blocks = _get_blocks(block_pairs)
 

--- a/scinoephile/analysis/audit/ocr_fusion.py
+++ b/scinoephile/analysis/audit/ocr_fusion.py
@@ -20,10 +20,7 @@ from .utils import (
     get_selected_event_indexes,
 )
 
-__all__ = [
-    "OcrFusionAuditFilter",
-    "audit_ocr_fusion",
-]
+__all__ = ["OcrFusionAuditFilter", "audit_ocr_fusion"]
 
 
 class OcrFusionAuditFilter(StrEnum):
@@ -168,10 +165,7 @@ def audit_ocr_fusion(
         )
     else:
         summary_items.extend(
-            (
-                f"LLM-required rows: {len(llm_rows)}",
-                "decision log: omitted",
-            )
+            (f"LLM-required rows: {len(llm_rows)}", "decision log: omitted")
         )
     columns: list[AuditColumn] = [
         ("Subtitle", "right"),
@@ -199,8 +193,7 @@ def audit_ocr_fusion(
 
 
 def _filter_rows(
-    rows: Sequence[_OcrFusionRow],
-    row_filter: OcrFusionAuditFilter,
+    rows: Sequence[_OcrFusionRow], row_filter: OcrFusionAuditFilter
 ) -> list[_OcrFusionRow]:
     """Filter OCR-fusion rows by their status.
 

--- a/scinoephile/analysis/audit/punctuation.py
+++ b/scinoephile/analysis/audit/punctuation.py
@@ -22,10 +22,7 @@ from .utils import (
     resolve_contextual_index,
 )
 
-__all__ = [
-    "PunctuationAuditFilter",
-    "audit_punctuation",
-]
+__all__ = ["PunctuationAuditFilter", "audit_punctuation"]
 
 
 class PunctuationAuditFilter(StrEnum):
@@ -75,13 +72,10 @@ def audit_punctuation(
         reference_indexes_by_text[subtitle.text].append(index)
 
     target_text_by_reference_index = _get_target_text_by_reference_index(
-        reference,
-        target,
+        reference, target
     )
     candidate_indexes_by_case, direct_indexes = _get_case_indexes(
-        reference_indexes_by_text,
-        target_text_by_reference_index,
-        test_cases,
+        reference_indexes_by_text, target_text_by_reference_index, test_cases
     )
     selected_reference_indexes = get_selected_event_indexes(
         reference,
@@ -103,9 +97,7 @@ def audit_punctuation(
         if selected_reference_indexes.isdisjoint(candidates):
             continue
         index = _get_case_index(
-            candidates,
-            direct_indexes,
-            test_case_index=test_case_index,
+            candidates, direct_indexes, test_case_index=test_case_index
         )
         if index not in selected_reference_indexes:
             continue
@@ -154,8 +146,7 @@ def audit_punctuation(
 
 
 def _format_case_row(
-    test_case: PunctuationTestCase,
-    index: int,
+    test_case: PunctuationTestCase, index: int
 ) -> tuple[tuple[str, ...], AuditResult]:
     """Format one punctuation case as semantic table data.
 
@@ -190,10 +181,7 @@ def _format_case_row(
 
 
 def _get_case_index(
-    candidates: Sequence[int],
-    direct_indexes: list[int | None],
-    *,
-    test_case_index: int,
+    candidates: Sequence[int], direct_indexes: list[int | None], *, test_case_index: int
 ) -> int:
     """Resolve the reference index for one punctuation test case.
 
@@ -206,11 +194,7 @@ def _get_case_index(
     Raises:
         ScinoephileError: if the case remains ambiguous
     """
-    index = resolve_contextual_index(
-        candidates,
-        direct_indexes,
-        test_case_index - 1,
-    )
+    index = resolve_contextual_index(candidates, direct_indexes, test_case_index - 1)
     if index is not None:
         return index
 
@@ -241,10 +225,7 @@ def _get_case_indexes(
     inputs_by_guide: dict[str, set[tuple[str, ...]]] = defaultdict(set)
     for test_case in test_cases:
         inputs_by_guide[test_case.query.guide].add(tuple(test_case.query.subtitles))
-    superseded_guides = get_superseded_keys(
-        reference_indexes_by_text,
-        inputs_by_guide,
-    )
+    superseded_guides = get_superseded_keys(reference_indexes_by_text, inputs_by_guide)
     candidate_indexes_by_case: list[list[int]] = []
     direct_indexes: list[int | None] = []
     for test_case_index, test_case in enumerate(test_cases, 1):
@@ -299,8 +280,7 @@ def _get_case_indexes(
 
 
 def _get_target_text_by_reference_index(
-    reference: Series,
-    target: Series,
+    reference: Series, target: Series
 ) -> dict[int, str]:
     """Align target text to reference indexes by exact timing.
 

--- a/scinoephile/analysis/audit/review.py
+++ b/scinoephile/analysis/audit/review.py
@@ -159,11 +159,7 @@ def audit_review(
     try:
         review_metadata = tuple(
             _get_review_metadata(review.review_cases, original, reviewed)
-            for review, (original, reviewed) in zip(
-                reviews,
-                review_series,
-                strict=True,
-            )
+            for review, (original, reviewed) in zip(reviews, review_series, strict=True)
         )
         notes = tuple(metadata.notes_by_index for metadata in review_metadata)
         covered_indexes = frozenset(
@@ -279,17 +275,13 @@ def _format_report(
         cells.extend(
             _format_review_cell(index, changed_indexes, original, reviewed)
             for changed_indexes, (original, reviewed) in zip(
-                review_changes,
-                review_series,
-                strict=True,
+                review_changes, review_series, strict=True
             )
         )
         cells.extend(
             _format_review_cell(index, changed_indexes, left, right)
             for changed_indexes, (left, right) in zip(
-                comparison_changes,
-                comparison_series,
-                strict=True,
+                comparison_changes, comparison_series, strict=True
             )
         )
         cells.append("\n".join(note_lines))
@@ -308,9 +300,7 @@ def _format_report(
     summary_items.extend(
         f"{comparison.summary_label.lower()} discrepancies: {len(changed_indexes)}"
         for comparison, changed_indexes in zip(
-            comparisons,
-            comparison_changes,
-            strict=True,
+            comparisons, comparison_changes, strict=True
         )
     )
     summary_items.append(f"row filter: {row_filter}")
@@ -357,9 +347,7 @@ def _format_review_cell(
 
 
 def _get_changed_indexes(
-    original: Sequence[str],
-    reviewed: Sequence[str],
-    indexes: Iterable[int],
+    original: Sequence[str], reviewed: Sequence[str], indexes: Iterable[int]
 ) -> set[int]:
     """Get subtitle indexes changed during review.
 
@@ -428,11 +416,7 @@ def _get_filtered_indexes(
 
 def _get_review_case_data(
     review_case: TestCase,
-) -> tuple[
-    tuple[str, ...],
-    tuple[str, ...],
-    dict[int, dict[str, int | str]],
-]:
+) -> tuple[tuple[str, ...], tuple[str, ...], dict[int, dict[str, int | str]]]:
     """Get query, reviewed, and revision data from a review test case.
 
     Arguments:
@@ -442,14 +426,12 @@ def _get_review_case_data(
     """
     answer = review_case.answer
     query_subtitles = cast(
-        list[dict[str, int | str]],
-        review_case.query.model_dump()["subtitles"],
+        list[dict[str, int | str]], review_case.query.model_dump()["subtitles"]
     )
     answer_revisions: list[dict[str, int | str]] = []
     if answer is not None:
         answer_revisions = cast(
-            list[dict[str, int | str]],
-            answer.model_dump()["revisions"],
+            list[dict[str, int | str]], answer.model_dump()["revisions"]
         )
     query_texts = tuple(cast(str, subtitle["text"]) for subtitle in query_subtitles)
     revision_by_index = {

--- a/scinoephile/analysis/audit/translation.py
+++ b/scinoephile/analysis/audit/translation.py
@@ -12,11 +12,7 @@ from scinoephile.core.exceptions import ScinoephileError
 from scinoephile.core.subtitles import Series
 from scinoephile.llms.translation import TranslationTestCase
 
-from .utils import (
-    format_audit_report,
-    format_verification_marker,
-    validate_audit_range,
-)
+from .utils import format_audit_report, format_verification_marker, validate_audit_range
 
 __all__ = [
     "TranslationAuditBlock",
@@ -118,11 +114,7 @@ def audit_translation(
     # Build current workflow blocks and validate the selection
     blocks = _get_standard_blocks(source)
     validate_audit_range(
-        first_index,
-        last_index,
-        first_block,
-        last_block,
-        block_count=len(blocks),
+        first_index, last_index, first_block, last_block, block_count=len(blocks)
     )
 
     # Adapt concrete test cases to shared semantic data
@@ -198,8 +190,7 @@ def audit_translation_blocks(
         for position in selected_positions:
             local_index = position + 1
             output_text, answered, empty = resolve_translation_audit_output(
-                case.outputs_by_index,
-                local_index,
+                case.outputs_by_index, local_index
             )
             if not answered:
                 unanswered_subtitles += 1
@@ -217,12 +208,7 @@ def audit_translation_blocks(
                 "",
                 verified_marker,
             )
-            all_rows.append(
-                _TranslationAuditRow(
-                    cells=cells,
-                    verified=case.verified,
-                )
-            )
+            all_rows.append(_TranslationAuditRow(cells=cells, verified=case.verified))
 
     # Apply the row filter after calculating complete selection statistics
     rows = [
@@ -263,8 +249,7 @@ def audit_translation_blocks(
 
 
 def resolve_translation_audit_output(
-    outputs_by_index: Mapping[int, str] | None,
-    local_index: int,
+    outputs_by_index: Mapping[int, str] | None, local_index: int
 ) -> tuple[str, bool, bool]:
     """Resolve one logged translation output for audit display.
 

--- a/scinoephile/analysis/audit/utils.py
+++ b/scinoephile/analysis/audit/utils.py
@@ -75,11 +75,7 @@ def format_audit_report(
     validate_audit_range(first_index, last_index, first_block, last_block)
 
     # Format and validate the table schema
-    separators_by_alignment = {
-        "left": "---",
-        "right": "---:",
-        "center": ":---:",
-    }
+    separators_by_alignment = {"left": "---", "right": "---:", "center": ":---:"}
     column_labels = []
     column_separators = []
     for label, alignment in columns:
@@ -107,9 +103,7 @@ def format_audit_report(
         *(f"- {item}" for item in summary_items),
     ]
     index_range = _format_index_range(
-        first_index,
-        last_index,
-        track_name=index_track_name,
+        first_index, last_index, track_name=index_track_name
     )
     if index_range is not None:
         lines.append(f"- {index_range}")
@@ -245,11 +239,7 @@ def get_selected_event_indexes(
     if block_indexes is not None:
         block_count = len(block_indexes)
     validate_audit_range(
-        first_index,
-        last_index,
-        first_block,
-        last_block,
-        block_count=block_count,
+        first_index, last_index, first_block, last_block, block_count=block_count
     )
 
     if not has_block_range:
@@ -264,10 +254,7 @@ def get_selected_event_indexes(
     assert block_indexes is not None
     selected_block_indexes = {
         event_index
-        for block_number, (block_start, block_stop) in enumerate(
-            block_indexes,
-            1,
-        )
+        for block_number, (block_start, block_stop) in enumerate(block_indexes, 1)
         if is_block_in_range(block_number, first_block, last_block)
         for event_index in range(block_start, block_stop)
     }
@@ -275,8 +262,7 @@ def get_selected_event_indexes(
 
 
 def get_superseded_keys[KeyT: Hashable, ValueT: Hashable](
-    current_keys: Collection[KeyT],
-    values_by_key: Mapping[KeyT, Collection[ValueT]],
+    current_keys: Collection[KeyT], values_by_key: Mapping[KeyT, Collection[ValueT]]
 ) -> set[KeyT]:
     """Get historical keys directly replaced by current logged cases.
 
@@ -301,9 +287,7 @@ def get_superseded_keys[KeyT: Hashable, ValueT: Hashable](
 
 
 def is_block_in_range(
-    block_number: int,
-    first_block: int | None,
-    last_block: int | None,
+    block_number: int, first_block: int | None, last_block: int | None
 ) -> bool:
     """Check whether a one-based block number is selected.
 
@@ -337,11 +321,7 @@ def resolve_contextual_index(
     if index is not None:
         return index
 
-    index = get_contextual_index(
-        candidate_indexes,
-        resolved_indexes,
-        test_case_index,
-    )
+    index = get_contextual_index(candidate_indexes, resolved_indexes, test_case_index)
     if index is not None:
         resolved_indexes[test_case_index] = index
     return index
@@ -385,10 +365,7 @@ def _escape_table_cell(value: str) -> str:
     return value.replace("\\N", "\n").replace("\n", "<br>").replace("|", "\\|")
 
 
-def _format_block_range(
-    first_block: int | None,
-    last_block: int | None,
-) -> str | None:
+def _format_block_range(first_block: int | None, last_block: int | None) -> str | None:
     """Format an optional block range for a report summary.
 
     Arguments:
@@ -407,10 +384,7 @@ def _format_block_range(
 
 
 def _format_index_range(
-    first_index: int | None,
-    last_index: int | None,
-    *,
-    track_name: str | None = None,
+    first_index: int | None, last_index: int | None, *, track_name: str | None = None
 ) -> str | None:
     """Format an optional subtitle range for a report summary.
 
@@ -434,9 +408,7 @@ def _format_index_range(
 
 
 def _validate_block_range(
-    first_block: int | None,
-    last_block: int | None,
-    block_count: int | None = None,
+    first_block: int | None, last_block: int | None, block_count: int | None = None
 ):
     """Validate optional one-based block boundaries.
 

--- a/scinoephile/analysis/character_error_rate/__init__.py
+++ b/scinoephile/analysis/character_error_rate/__init__.py
@@ -12,7 +12,4 @@ from __future__ import annotations
 from .line_cer import LineCER
 from .series_cer import SeriesCER
 
-__all__ = [
-    "LineCER",
-    "SeriesCER",
-]
+__all__ = ["LineCER", "SeriesCER"]

--- a/scinoephile/analysis/character_error_rate/series_cer.py
+++ b/scinoephile/analysis/character_error_rate/series_cer.py
@@ -92,8 +92,7 @@ class SeriesCER:
                 chunk_result = LineCER("", "".join(message.two_texts or []))
             else:
                 chunk_result = LineCER(
-                    "".join(message.one_texts or []),
-                    "".join(message.two_texts or []),
+                    "".join(message.one_texts or []), "".join(message.two_texts or [])
                 )
             self.substitutions += chunk_result.substitutions
             self.insertions += chunk_result.insertions

--- a/scinoephile/analysis/diff/__init__.py
+++ b/scinoephile/analysis/diff/__init__.py
@@ -14,8 +14,4 @@ from .line_diff import LineDiff
 from .line_diff_kind import LineDiffKind
 from .series_diff import SeriesDiff
 
-__all__ = [
-    "LineDiff",
-    "LineDiffKind",
-    "SeriesDiff",
-]
+__all__ = ["LineDiff", "LineDiffKind", "SeriesDiff"]

--- a/scinoephile/analysis/diff/series_diff.py
+++ b/scinoephile/analysis/diff/series_diff.py
@@ -18,10 +18,7 @@ from scinoephile.core.synchronization import are_series_one_to_one
 from .line_diff import LineDiff
 from .line_diff_kind import LineDiffKind
 
-__all__ = [
-    "SeriesDiff",
-    "SeriesDiffKwargs",
-]
+__all__ = ["SeriesDiff", "SeriesDiffKwargs"]
 
 
 class SeriesDiffKwargs(TypedDict, total=False):
@@ -134,8 +131,7 @@ class SeriesDiff:
         return f"[\n{formatted_messages}\n]"
 
     def get_event_indices(
-        self,
-        message: LineDiff,
+        self, message: LineDiff
     ) -> tuple[tuple[int, ...], tuple[int, ...]]:
         """Get subtitle event indices represented by a line diff message.
 
@@ -145,12 +141,10 @@ class SeriesDiff:
             first- and second-side zero-based subtitle event indices
         """
         one_event_idxs = self._get_message_event_indices(
-            message.one_idxs,
-            self._one_line_event_idxs,
+            message.one_idxs, self._one_line_event_idxs
         )
         two_event_idxs = self._get_message_event_indices(
-            message.two_idxs,
-            self._two_line_event_idxs,
+            message.two_idxs, self._two_line_event_idxs
         )
         return one_event_idxs, two_event_idxs
 
@@ -198,8 +192,7 @@ class SeriesDiff:
 
         return "\n".join(
             message.get_stacked_str(
-                color=color,
-                three_texts=self._get_third_texts(message, three),
+                color=color, three_texts=self._get_third_texts(message, three)
             )
             for message in messages
         )
@@ -242,18 +235,9 @@ class SeriesDiff:
                 return
 
         kind = self._get_changed_span_kind(
-            one_side,
-            two_side,
-            one_local_idxs,
-            two_local_idxs,
+            one_side, two_side, one_local_idxs, two_local_idxs
         )
-        self._add_message(
-            kind,
-            one_side,
-            two_side,
-            one_local_idxs,
-            two_local_idxs,
-        )
+        self._add_message(kind, one_side, two_side, one_local_idxs, two_local_idxs)
 
     def _add_equal_message(
         self,
@@ -319,9 +303,7 @@ class SeriesDiff:
             matched_two_local_idxs = two_local_idxs[two_start:two_end]
             if tag == "equal":
                 for one_local_idx, two_local_idx in zip(
-                    matched_one_local_idxs,
-                    matched_two_local_idxs,
-                    strict=True,
+                    matched_one_local_idxs, matched_two_local_idxs, strict=True
                 ):
                     self._add_equal_message(
                         one_side=one_side,
@@ -331,17 +313,12 @@ class SeriesDiff:
                     )
                 continue
             self._add_changed_span(
-                one_side,
-                two_side,
-                matched_one_local_idxs,
-                matched_two_local_idxs,
+                one_side, two_side, matched_one_local_idxs, matched_two_local_idxs
             )
         return one_line_stop, two_line_stop
 
     def _add_delete_messages(
-        self,
-        one_side: _SeriesDiffBlockSide,
-        one_local_idxs: tuple[int, ...],
+        self, one_side: _SeriesDiffBlockSide, one_local_idxs: tuple[int, ...]
     ):
         """Add delete messages for first-side-only changed lines.
 
@@ -361,9 +338,7 @@ class SeriesDiff:
             self._stacked_messages.append(message)
 
     def _add_insert_messages(
-        self,
-        two_side: _SeriesDiffBlockSide,
-        two_local_idxs: tuple[int, ...],
+        self, two_side: _SeriesDiffBlockSide, two_local_idxs: tuple[int, ...]
     ):
         """Add insert messages for second-side-only changed lines.
 
@@ -442,9 +417,7 @@ class SeriesDiff:
         return self.messages
 
     def _diff_block(
-        self,
-        one_side: _SeriesDiffBlockSide,
-        two_side: _SeriesDiffBlockSide,
+        self, one_side: _SeriesDiffBlockSide, two_side: _SeriesDiffBlockSide
     ):
         """Compare a subtitle block using character alignment.
 
@@ -474,9 +447,7 @@ class SeriesDiff:
             if not one_changed and not two_changed:
                 return
             separator_span = self._get_separator_only_changed_span(
-                one_side,
-                two_side,
-                changed_columns,
+                one_side, two_side, changed_columns
             )
             if separator_span is None:
                 one_local_idxs = tuple(sorted(one_changed))
@@ -495,19 +466,11 @@ class SeriesDiff:
                 changed_columns.append((column.operation, one_pos, two_pos))
                 if column.one is not None:
                     one_changed.update(
-                        self._get_changed_line_idxs(
-                            one_side,
-                            one_pos,
-                            column.operation,
-                        )
+                        self._get_changed_line_idxs(one_side, one_pos, column.operation)
                     )
                 if column.two is not None:
                     two_changed.update(
-                        self._get_changed_line_idxs(
-                            two_side,
-                            two_pos,
-                            column.operation,
-                        )
+                        self._get_changed_line_idxs(two_side, two_pos, column.operation)
                     )
                 if column.operation == LineAlignmentOperation.DELETE:
                     two_changed.update(
@@ -535,16 +498,10 @@ class SeriesDiff:
 
         flush_changed()
         spans = self._merge_changed_spans(spans)
-        spans = self._merge_adjacent_one_sided_spans(
-            spans,
-            one_side,
-            two_side,
-        )
+        spans = self._merge_adjacent_one_sided_spans(spans, one_side, two_side)
         spans = self._split_uncovered_multiline_spans(spans, one_side, two_side)
         spans = self._pair_one_sided_spans_with_implicit_lines(
-            spans,
-            one_side,
-            two_side,
+            spans, one_side, two_side
         )
         self._add_block_messages(one_side, two_side, spans)
 
@@ -588,12 +545,7 @@ class SeriesDiff:
                 one_line_stop=one_line_stop,
                 two_line_stop=two_line_stop,
             )
-            self._add_changed_span(
-                one_side,
-                two_side,
-                one_local_idxs,
-                two_local_idxs,
-            )
+            self._add_changed_span(one_side, two_side, one_local_idxs, two_local_idxs)
             if one_local_idxs:
                 one_line_pos = one_local_idxs[-1] + 1
             if two_local_idxs:
@@ -607,18 +559,14 @@ class SeriesDiff:
             two_line_stop=len(two_side.lines),
         )
         self._add_delete_messages(
-            one_side,
-            tuple(range(one_line_pos, len(one_side.lines))),
+            one_side, tuple(range(one_line_pos, len(one_side.lines)))
         )
         self._add_insert_messages(
-            two_side,
-            tuple(range(two_line_pos, len(two_side.lines))),
+            two_side, tuple(range(two_line_pos, len(two_side.lines)))
         )
 
     def _diff_block_by_lines(
-        self,
-        one_side: _SeriesDiffBlockSide,
-        two_side: _SeriesDiffBlockSide,
+        self, one_side: _SeriesDiffBlockSide, two_side: _SeriesDiffBlockSide
     ):
         """Compare a large subtitle block using line-level fallback alignment.
 
@@ -628,19 +576,13 @@ class SeriesDiff:
         """
         spans: list[tuple[tuple[int, ...], tuple[int, ...]]] = []
         matcher = difflib.SequenceMatcher(
-            None,
-            one_side.normlines,
-            two_side.normlines,
-            autojunk=False,
+            None, one_side.normlines, two_side.normlines, autojunk=False
         )
         for tag, one_start, one_end, two_start, two_end in matcher.get_opcodes():
             if tag == "equal":
                 continue
             spans.append(
-                (
-                    tuple(range(one_start, one_end)),
-                    tuple(range(two_start, two_end)),
-                )
+                (tuple(range(one_start, one_end)), tuple(range(two_start, two_end)))
             )
 
         self._add_block_messages(one_side, two_side, spans)
@@ -679,10 +621,7 @@ class SeriesDiff:
                 kind = LineDiffKind.MERGE_EDIT
         else:
             ratio = difflib.SequenceMatcher(
-                None,
-                one_joined,
-                two_joined,
-                autojunk=False,
+                None, one_joined, two_joined, autojunk=False
             ).ratio()
             if ratio >= self.similarity_cutoff:
                 kind = LineDiffKind.SHIFT
@@ -727,10 +666,7 @@ class SeriesDiff:
                 continue
             candidate_text = target_side.normlines[candidate_idx]
             ratio = difflib.SequenceMatcher(
-                None,
-                source_text,
-                candidate_text,
-                autojunk=False,
+                None, source_text, candidate_text, autojunk=False
             ).ratio()
             if ratio >= self.similarity_cutoff:
                 context_idxs.append(candidate_idx)
@@ -739,9 +675,7 @@ class SeriesDiff:
 
     @staticmethod
     def _get_changed_line_idxs(
-        side: _SeriesDiffBlockSide,
-        char_pos: int,
-        operation: LineAlignmentOperation,
+        side: _SeriesDiffBlockSide, char_pos: int, operation: LineAlignmentOperation
     ) -> tuple[int, ...]:
         """Get local line indices touched by a changed character.
 
@@ -784,10 +718,7 @@ class SeriesDiff:
             return None
         one_local_idxs, two_local_idxs = span
         if not self._is_separator_span_valid(
-            one_side,
-            two_side,
-            one_local_idxs,
-            two_local_idxs,
+            one_side, two_side, one_local_idxs, two_local_idxs
         ):
             return None
 
@@ -813,26 +744,19 @@ class SeriesDiff:
         if not one_local_idxs or not two_local_idxs:
             return False
         if not self._are_lines_similar(
-            one_side,
-            two_side,
-            one_local_idxs,
-            two_local_idxs,
+            one_side, two_side, one_local_idxs, two_local_idxs
         ):
             return False
         if len(one_local_idxs) > len(two_local_idxs):
             target_text = SeriesDiff._join_normlines(two_side, two_local_idxs)
             if not self._are_separator_lines_covered(
-                one_side,
-                one_local_idxs,
-                target_text,
+                one_side, one_local_idxs, target_text
             ):
                 return False
         elif len(two_local_idxs) > len(one_local_idxs):
             target_text = SeriesDiff._join_normlines(one_side, one_local_idxs)
             if not self._are_separator_lines_covered(
-                two_side,
-                two_local_idxs,
-                target_text,
+                two_side, two_local_idxs, target_text
             ):
                 return False
 
@@ -856,17 +780,11 @@ class SeriesDiff:
         operation, one_pos, two_pos = changed_column
         if operation == LineAlignmentOperation.DELETE:
             return SeriesDiff._get_separator_delete_span(
-                one_side,
-                two_side,
-                one_pos,
-                two_pos,
+                one_side, two_side, one_pos, two_pos
             )
         if operation == LineAlignmentOperation.INSERT:
             return SeriesDiff._get_separator_insert_span(
-                one_side,
-                two_side,
-                one_pos,
-                two_pos,
+                one_side, two_side, one_pos, two_pos
             )
         return None
 
@@ -892,10 +810,7 @@ class SeriesDiff:
         one_local_idxs = one_side.char_line_idxs[one_pos]
         if len(one_local_idxs) != 2:
             return None
-        two_local_idxs = SeriesDiff._get_separator_target_line_idxs(
-            two_side,
-            two_pos,
-        )
+        two_local_idxs = SeriesDiff._get_separator_target_line_idxs(two_side, two_pos)
         return (one_local_idxs, two_local_idxs)
 
     @staticmethod
@@ -917,10 +832,7 @@ class SeriesDiff:
         """
         if two_side.text[two_pos] != "\n":
             return None
-        one_local_idxs = SeriesDiff._get_separator_target_line_idxs(
-            one_side,
-            one_pos,
-        )
+        one_local_idxs = SeriesDiff._get_separator_target_line_idxs(one_side, one_pos)
         two_local_idxs = two_side.char_line_idxs[two_pos]
         if len(two_local_idxs) != 2:
             return None
@@ -928,8 +840,7 @@ class SeriesDiff:
 
     @staticmethod
     def _get_separator_target_line_idxs(
-        side: _SeriesDiffBlockSide,
-        target_pos: int,
+        side: _SeriesDiffBlockSide, target_pos: int
     ) -> tuple[int, ...]:
         """Get the target line bridged by a removed or inserted separator.
 
@@ -952,10 +863,7 @@ class SeriesDiff:
         return bridged_line_idxs
 
     def _are_separator_lines_covered(
-        self,
-        side: _SeriesDiffBlockSide,
-        local_idxs: tuple[int, ...],
-        target_text: str,
+        self, side: _SeriesDiffBlockSide, local_idxs: tuple[int, ...], target_text: str
     ) -> bool:
         """Check whether each separator-side line is covered by target text.
 
@@ -973,8 +881,7 @@ class SeriesDiff:
             if not line_compact:
                 continue
             best_ratio = self._get_best_substring_similarity(
-                line_compact,
-                target_compact,
+                line_compact, target_compact
             )
             if best_ratio < coverage_cutoff:
                 return False
@@ -996,20 +903,14 @@ class SeriesDiff:
 
         if len(haystack) <= len(needle):
             return difflib.SequenceMatcher(
-                None,
-                needle,
-                haystack,
-                autojunk=False,
+                None, needle, haystack, autojunk=False
             ).ratio()
 
         best_ratio = 0.0
         for start_idx in range(len(haystack) - len(needle) + 1):
             candidate = haystack[start_idx : start_idx + len(needle)]
             ratio = difflib.SequenceMatcher(
-                None,
-                needle,
-                candidate,
-                autojunk=False,
+                None, needle, candidate, autojunk=False
             ).ratio()
             best_ratio = max(best_ratio, ratio)
 
@@ -1026,10 +927,7 @@ class SeriesDiff:
             best full-line or substring similarity
         """
         full_ratio = difflib.SequenceMatcher(
-            None,
-            one_text,
-            two_text,
-            autojunk=False,
+            None, one_text, two_text, autojunk=False
         ).ratio()
         one_compact = re.sub(r"\s+", "", one_text)
         two_compact = re.sub(r"\s+", "", two_text)
@@ -1059,19 +957,13 @@ class SeriesDiff:
             if len(one_idxs) == 1 and len(two_idxs) > 1:
                 split_spans.extend(
                     self._split_uncovered_one_to_many_span(
-                        one_side,
-                        two_side,
-                        one_idxs[0],
-                        two_idxs,
+                        one_side, two_side, one_idxs[0], two_idxs
                     )
                 )
             elif len(two_idxs) == 1 and len(one_idxs) > 1:
                 split_spans.extend(
                     self._split_uncovered_many_to_one_span(
-                        one_side,
-                        two_side,
-                        one_idxs,
-                        two_idxs[0],
+                        one_side, two_side, one_idxs, two_idxs[0]
                     )
                 )
             else:
@@ -1100,12 +992,7 @@ class SeriesDiff:
         first_one_idx = one_idxs[0]
         remaining_one_idxs = one_idxs[1:]
         if self._should_split_uncovered_multiline_span(
-            one_side,
-            two_side,
-            first_one_idx,
-            two_idx,
-            remaining_one_idxs,
-            target_text,
+            one_side, two_side, first_one_idx, two_idx, remaining_one_idxs, target_text
         ):
             return self._get_split_many_to_one_spans(
                 one_side,
@@ -1119,12 +1006,7 @@ class SeriesDiff:
         last_one_idx = one_idxs[-1]
         remaining_one_idxs = one_idxs[:-1]
         if self._should_split_uncovered_multiline_span(
-            one_side,
-            two_side,
-            last_one_idx,
-            two_idx,
-            remaining_one_idxs,
-            target_text,
+            one_side, two_side, last_one_idx, two_idx, remaining_one_idxs, target_text
         ):
             return self._get_split_many_to_one_spans(
                 one_side,
@@ -1158,12 +1040,7 @@ class SeriesDiff:
         first_two_idx = two_idxs[0]
         remaining_two_idxs = two_idxs[1:]
         if self._should_split_uncovered_multiline_span(
-            two_side,
-            one_side,
-            first_two_idx,
-            one_idx,
-            remaining_two_idxs,
-            target_text,
+            two_side, one_side, first_two_idx, one_idx, remaining_two_idxs, target_text
         ):
             return self._get_split_one_to_many_spans(
                 one_side,
@@ -1177,12 +1054,7 @@ class SeriesDiff:
         last_two_idx = two_idxs[-1]
         remaining_two_idxs = two_idxs[:-1]
         if self._should_split_uncovered_multiline_span(
-            two_side,
-            one_side,
-            last_two_idx,
-            one_idx,
-            remaining_two_idxs,
-            target_text,
+            two_side, one_side, last_two_idx, one_idx, remaining_two_idxs, target_text
         ):
             return self._get_split_one_to_many_spans(
                 one_side,
@@ -1219,30 +1091,18 @@ class SeriesDiff:
         if not remaining_multi_idxs:
             return False
         if not self._are_lines_similar(
-            single_side,
-            multi_side,
-            (single_idx,),
-            (paired_multi_idx,),
+            single_side, multi_side, (single_idx,), (paired_multi_idx,)
         ):
-            paired_text = re.sub(
-                r"\s+",
-                "",
-                multi_side.normlines[paired_multi_idx],
-            )
+            paired_text = re.sub(r"\s+", "", multi_side.normlines[paired_multi_idx])
             target_compact = re.sub(r"\s+", "", target_text)
             coverage_cutoff = max(self.similarity_cutoff, 0.75)
             if (
-                self._get_best_substring_similarity(
-                    paired_text,
-                    target_compact,
-                )
+                self._get_best_substring_similarity(paired_text, target_compact)
                 < coverage_cutoff
             ):
                 return False
         return not self._are_separator_lines_covered(
-            multi_side,
-            remaining_multi_idxs,
-            target_text,
+            multi_side, remaining_multi_idxs, target_text
         )
 
     @staticmethod
@@ -1335,12 +1195,7 @@ class SeriesDiff:
             one_idxs, two_idxs = spans[idx]
             next_one_idxs, next_two_idxs = spans[idx + 1]
             if self._should_merge_adjacent_one_sided_spans(
-                one_side,
-                two_side,
-                one_idxs,
-                two_idxs,
-                next_one_idxs,
-                next_two_idxs,
+                one_side, two_side, one_idxs, two_idxs, next_one_idxs, next_two_idxs
             ):
                 merged.append(
                     (
@@ -1390,19 +1245,14 @@ class SeriesDiff:
                 merged_two_idxs = tuple(sorted({*two_idxs, *next_two_idxs}))
                 if abs(merged_one_idxs[0] - merged_two_idxs[0]) <= 1:
                     should_merge = self._are_lines_similar(
-                        one_side,
-                        two_side,
-                        merged_one_idxs,
-                        merged_two_idxs,
+                        one_side, two_side, merged_one_idxs, merged_two_idxs
                     )
 
         return should_merge
 
     @staticmethod
     def _get_block_event_index_pairs_by_pause(
-        one: Series,
-        two: Series,
-        pause_length: int = 3000,
+        one: Series, two: Series, pause_length: int = 3000
     ) -> list[tuple[tuple[int, ...], tuple[int, ...]]]:
         """Split a pair of series into event-index blocks using pauses.
 
@@ -1539,8 +1389,7 @@ class SeriesDiff:
             third-side subtitle texts in first-side event order
         """
         event_idxs = self._get_message_event_indices(
-            message.one_idxs,
-            self._one_line_event_idxs,
+            message.one_idxs, self._one_line_event_idxs
         )
 
         texts = []
@@ -1559,8 +1408,7 @@ class SeriesDiff:
 
     @staticmethod
     def _get_message_event_indices(
-        line_idxs: tuple[int, ...] | None,
-        line_event_idxs: tuple[int, ...],
+        line_idxs: tuple[int, ...] | None, line_event_idxs: tuple[int, ...]
     ) -> tuple[int, ...]:
         """Map line indices to unique subtitle event indices in order.
 
@@ -1579,10 +1427,7 @@ class SeriesDiff:
         return tuple(event_idxs)
 
     @staticmethod
-    def _join_normlines(
-        side: _SeriesDiffBlockSide,
-        local_idxs: tuple[int, ...],
-    ) -> str:
+    def _join_normlines(side: _SeriesDiffBlockSide, local_idxs: tuple[int, ...]) -> str:
         """Join normalized lines for classification.
 
         Arguments:
@@ -1612,10 +1457,7 @@ class SeriesDiff:
 
             prev_one, prev_two = merged[-1]
             if SeriesDiff._should_merge_changed_spans(
-                prev_one,
-                prev_two,
-                next_one,
-                next_two,
+                prev_one, prev_two, next_one, next_two
             ):
                 one_idxs = tuple(sorted({*prev_one, *next_one}))
                 two_idxs = tuple(sorted({*prev_two, *next_two}))
@@ -1759,12 +1601,7 @@ class SeriesDiff:
                 continue
             if two_idxs:
                 candidate_one_idxs = self._get_implicit_candidate_indices(
-                    spans,
-                    idx,
-                    0,
-                    claimed_one_idxs,
-                    len(one_side.lines),
-                    two_idxs[0],
+                    spans, idx, 0, claimed_one_idxs, len(one_side.lines), two_idxs[0]
                 )
                 paired.extend(
                     self._pair_implicit_lines(
@@ -1778,12 +1615,7 @@ class SeriesDiff:
                 )
                 continue
             candidate_two_idxs = self._get_implicit_candidate_indices(
-                spans,
-                idx,
-                1,
-                claimed_two_idxs,
-                len(two_side.lines),
-                one_idxs[0],
+                spans, idx, 1, claimed_two_idxs, len(two_side.lines), one_idxs[0]
             )
             paired.extend(
                 self._pair_implicit_lines(
@@ -1817,10 +1649,7 @@ class SeriesDiff:
         one_text = self._join_normlines(one_side, one_local_idxs)
         two_text = self._join_normlines(two_side, two_local_idxs)
         ratio = difflib.SequenceMatcher(
-            None,
-            one_text,
-            two_text,
-            autojunk=False,
+            None, one_text, two_text, autojunk=False
         ).ratio()
         return ratio >= self.similarity_cutoff
 

--- a/scinoephile/analysis/line_alignment/__init__.py
+++ b/scinoephile/analysis/line_alignment/__init__.py
@@ -14,8 +14,4 @@ from .line_alignment import LineAlignment
 from .line_alignment_operation import LineAlignmentOperation
 from .line_alignment_pair import LineAlignmentPair
 
-__all__ = [
-    "LineAlignment",
-    "LineAlignmentOperation",
-    "LineAlignmentPair",
-]
+__all__ = ["LineAlignment", "LineAlignmentOperation", "LineAlignmentPair"]

--- a/scinoephile/analysis/line_alignment/line_alignment.py
+++ b/scinoephile/analysis/line_alignment/line_alignment.py
@@ -67,10 +67,7 @@ class LineAlignment:
         two = _get_codepoints(self.two)
         return _get_alignment_operation_table(one, two)
 
-    def _populate_alignment_pairs(
-        self,
-        operation_table: np.ndarray,
-    ):
+    def _populate_alignment_pairs(self, operation_table: np.ndarray):
         """Populate alignment pairs by backtracing DP operations.
 
         Arguments:
@@ -94,27 +91,17 @@ class LineAlignment:
                 LineAlignmentOperation.SUBSTITUTE,
             ):
                 pair = LineAlignmentPair(
-                    self.one[one_idx - 1],
-                    self.two[two_idx - 1],
-                    operation,
+                    self.one[one_idx - 1], self.two[two_idx - 1], operation
                 )
                 one_idx -= 1
                 two_idx -= 1
             # Resolve insertions horizontally
             elif operation == LineAlignmentOperation.INSERT:
-                pair = LineAlignmentPair(
-                    None,
-                    self.two[two_idx - 1],
-                    operation,
-                )
+                pair = LineAlignmentPair(None, self.two[two_idx - 1], operation)
                 two_idx -= 1
             # Resolve deletions vertically
             else:
-                pair = LineAlignmentPair(
-                    self.one[one_idx - 1],
-                    None,
-                    operation,
-                )
+                pair = LineAlignmentPair(self.one[one_idx - 1], None, operation)
                 one_idx -= 1
             self.alignment_pairs.append(pair)
 
@@ -124,8 +111,7 @@ class LineAlignment:
 
 @nb.jit(nopython=True, nogil=True, cache=True)
 def _get_alignment_operation_table(  # noqa: PLR0915
-    one: np.ndarray,
-    two: np.ndarray,
+    one: np.ndarray, two: np.ndarray
 ) -> np.ndarray:
     """Get the compact dynamic-programming operation table.
 
@@ -139,9 +125,7 @@ def _get_alignment_operation_table(  # noqa: PLR0915
     one_length = len(one)
     two_length = len(two)
     operation_table = np.full(
-        (one_length + 1, two_length + 1),
-        _OPERATION_NONE,
-        dtype=np.uint8,
+        (one_length + 1, two_length + 1), _OPERATION_NONE, dtype=np.uint8
     )
     if two_length > 0:
         operation_table[0, 1:] = _OPERATION_INSERT
@@ -260,13 +244,7 @@ def _get_alignment_operation_table(  # noqa: PLR0915
 
             # Store the chosen candidate and operation
             _set_metric(
-                current_metrics,
-                two_idx,
-                best_0,
-                best_1,
-                best_2,
-                best_3,
-                best_4,
+                current_metrics, two_idx, best_0, best_1, best_2, best_3, best_4
             )
             current_gaps[two_idx] = best_gap
             operation_table[one_idx, two_idx] = best_operation

--- a/scinoephile/audio/subtitles/series.py
+++ b/scinoephile/audio/subtitles/series.py
@@ -28,10 +28,7 @@ from scinoephile.media.audio import extract_audio
 
 from .subtitle import AudioSubtitle
 
-__all__ = [
-    "AudioSeries",
-    "AudioSeriesLoadKwargs",
-]
+__all__ = ["AudioSeries", "AudioSeriesLoadKwargs"]
 
 logger = getLogger(__name__)
 
@@ -247,9 +244,7 @@ class AudioSeries(Series):
             with get_temp_directory_path() as temp_dir_path:
                 full_audio_path = temp_dir_path / "full_audio.wav"
                 extract_audio(
-                    validated_media_path,
-                    full_audio_path,
-                    stream_index=stream_index,
+                    validated_media_path, full_audio_path, stream_index=stream_index
                 )
                 logger.info(f"Loading full audio from {full_audio_path}")
                 full_audio = AudioSegment.from_wav(full_audio_path)
@@ -262,10 +257,7 @@ class AudioSeries(Series):
 
     @classmethod
     def build_series(
-        cls,
-        text_series: Series,
-        full_audio: AudioSegment,
-        buffer: int,
+        cls, text_series: Series, full_audio: AudioSegment, buffer: int
     ) -> Self:
         """Construct a series from text and full audio.
 
@@ -308,10 +300,7 @@ class AudioSeries(Series):
             clip = full_audio[start_time:end_time]
             events.append(
                 cls.event_class(
-                    start=original_start,
-                    end=original_end,
-                    audio=clip,
-                    text=event.text,
+                    start=original_start, end=original_end, audio=clip, text=event.text
                 )
             )
         series.events = events

--- a/scinoephile/audio/subtitles/subtitle.py
+++ b/scinoephile/audio/subtitles/subtitle.py
@@ -34,8 +34,7 @@ class AudioSubtitle(Subtitle):
         """
         super_field_names = {f.name for f in fields(Subtitle)}
         super_kwargs = cast(
-            SubtitleKwargs,
-            {k: v for k, v in kwargs.items() if k in super_field_names},
+            SubtitleKwargs, {k: v for k, v in kwargs.items() if k in super_field_names}
         )
         super().__init__(**super_kwargs)
 

--- a/scinoephile/audio/transcription/cache.py
+++ b/scinoephile/audio/transcription/cache.py
@@ -65,9 +65,7 @@ class TranscriptionCache:
         """Cache paths refreshed by this cache instance."""
 
     def get_path(
-        self,
-        audio: AudioSegment,
-        backend_metadata: Mapping[str, object],
+        self, audio: AudioSegment, backend_metadata: Mapping[str, object]
     ) -> Path:
         """Get the cache path for audio and backend configuration.
 
@@ -89,9 +87,7 @@ class TranscriptionCache:
         return self.cache_dir_path / f"{cache_hash.hexdigest()}.json"
 
     def load(
-        self,
-        audio: AudioSegment,
-        backend_metadata: Mapping[str, object],
+        self, audio: AudioSegment, backend_metadata: Mapping[str, object]
     ) -> tuple[Path, list[TranscribedSegment]] | None:
         """Load a cached transcription.
 
@@ -159,9 +155,7 @@ class TranscriptionCache:
         return cache_path, segments
 
     def remove(
-        self,
-        audio: AudioSegment,
-        backend_metadata: Mapping[str, object],
+        self, audio: AudioSegment, backend_metadata: Mapping[str, object]
     ) -> Path | None:
         """Remove a cached transcription.
 
@@ -220,9 +214,7 @@ class TranscriptionCache:
         )
 
     def _get_metadata(
-        self,
-        audio: AudioSegment,
-        backend_metadata: Mapping[str, object],
+        self, audio: AudioSegment, backend_metadata: Mapping[str, object]
     ) -> dict[str, object]:
         """Get complete cache identity metadata.
 

--- a/scinoephile/audio/transcription/ctc_aligner.py
+++ b/scinoephile/audio/transcription/ctc_aligner.py
@@ -52,10 +52,7 @@ class CtcAligner:
     """Loaded processors shared by model name."""
 
     def __init__(
-        self,
-        language: Language,
-        model_name: str | None = None,
-        device: str = "cpu",
+        self, language: Language, model_name: str | None = None, device: str = "cpu"
     ):
         """Initialize.
 
@@ -93,11 +90,7 @@ class CtcAligner:
         self._processor: CtcProcessor | None = None
         """Processor associated with the CTC model."""
 
-    def __call__(
-        self,
-        audio: AudioSegment,
-        text: str,
-    ) -> list[TranscribedSegment]:
+    def __call__(self, audio: AudioSegment, text: str) -> list[TranscribedSegment]:
         """Align transcript text to source audio.
 
         Arguments:
@@ -151,11 +144,7 @@ class CtcAligner:
             self._processors[self.model_name] = processor
         return self._processor
 
-    def align(
-        self,
-        audio: AudioSegment,
-        text: str,
-    ) -> list[TranscribedSegment]:
+    def align(self, audio: AudioSegment, text: str) -> list[TranscribedSegment]:
         """Align transcript text to source audio.
 
         Arguments:
@@ -182,25 +171,16 @@ class CtcAligner:
 
             # Find frame timings for supported characters
             if token_ids:
-                path = self._get_best_path(
-                    log_probs,
-                    token_ids,
-                    blank_token_id,
-                )
+                path = self._get_best_path(log_probs, token_ids, blank_token_id)
                 timed_chars = self._get_character_timings(
-                    path,
-                    char_indices,
-                    log_probs.shape[0],
-                    duration_seconds,
+                    path, char_indices, log_probs.shape[0], duration_seconds
                 )
             else:
                 timed_chars = {}
 
             # Fill gaps for unsupported characters and build the aligned segment
             words = self._get_transcribed_words(
-                transcript_text,
-                timed_chars,
-                duration_seconds,
+                transcript_text, timed_chars, duration_seconds
             )
             if not words:
                 raise TranscriptionAlignmentError(
@@ -224,9 +204,7 @@ class CtcAligner:
             ) from exc
 
     def _get_alignment_inputs(
-        self,
-        audio: AudioSegment,
-        text: str,
+        self, audio: AudioSegment, text: str
     ) -> tuple[np.ndarray, list[int], list[int], int]:
         """Get CTC log probabilities and transcript token mapping.
 
@@ -250,9 +228,7 @@ class CtcAligner:
         samples = self._get_audio_samples(audio, sampling_rate)
         processor_callable = cast(Callable[..., Mapping[str, Any]], processor)
         inputs = processor_callable(
-            samples,
-            sampling_rate=sampling_rate,
-            return_tensors="pt",
+            samples, sampling_rate=sampling_rate, return_tensors="pt"
         )
         if self.device != "cpu":
             inputs = {key: value.to(self.device) for key, value in inputs.items()}
@@ -336,9 +312,7 @@ class CtcAligner:
 
     @staticmethod
     def _attach_boundary_text(
-        run_text: str,
-        words: list[TranscribedWord],
-        has_next_timing: bool,
+        run_text: str, words: list[TranscribedWord], has_next_timing: bool
     ) -> str | None:
         """Attach unaligned boundary punctuation or whitespace to a timed character.
 
@@ -361,10 +335,7 @@ class CtcAligner:
         return None
 
     @staticmethod
-    def _get_audio_samples(
-        audio: AudioSegment,
-        sampling_rate: int,
-    ) -> np.ndarray:
+    def _get_audio_samples(audio: AudioSegment, sampling_rate: int) -> np.ndarray:
         """Get audio samples for CTC alignment.
 
         Arguments:
@@ -389,9 +360,7 @@ class CtcAligner:
 
     @staticmethod
     def _get_best_path(
-        log_probs: np.ndarray,
-        token_ids: Sequence[int],
-        blank_token_id: int,
+        log_probs: np.ndarray, token_ids: Sequence[int], blank_token_id: int
     ) -> list[tuple[int, int, float]]:
         """Get the best CTC path through a transcript-token trellis.
 
@@ -405,9 +374,7 @@ class CtcAligner:
             TranscriptionAlignmentError: if no complete path can be found
         """
         frame_count = CtcAligner._validate_best_path_inputs(
-            log_probs,
-            token_ids,
-            blank_token_id,
+            log_probs, token_ids, blank_token_id
         )
 
         # Insert required blanks between adjacent repeated labels
@@ -532,9 +499,7 @@ class CtcAligner:
 
     @staticmethod
     def _get_token_id(
-        char: str,
-        converted_char: str | None,
-        tokenizer: object,
+        char: str, converted_char: str | None, tokenizer: object
     ) -> int | None:
         """Get an aligner token ID for one transcript character.
 
@@ -550,9 +515,7 @@ class CtcAligner:
         convert_tokens_to_ids = getattr(tokenizer, "convert_tokens_to_ids", None)
         if char.isspace():
             word_delimiter_token_id = getattr(
-                tokenizer,
-                "word_delimiter_token_id",
-                None,
+                tokenizer, "word_delimiter_token_id", None
             )
             if (
                 isinstance(word_delimiter_token_id, int)
@@ -637,9 +600,7 @@ class CtcAligner:
 
             # Attach boundary text to the nearest aligned character
             boundary_pending_text = CtcAligner._attach_boundary_text(
-                run_text,
-                words,
-                char_idx < len(text),
+                run_text, words, char_idx < len(text)
             )
             if boundary_pending_text is not None:
                 pending_text = boundary_pending_text
@@ -750,9 +711,7 @@ class CtcAligner:
 
     @staticmethod
     def _validate_best_path_inputs(
-        log_probs: np.ndarray,
-        token_ids: Sequence[int],
-        blank_token_id: int,
+        log_probs: np.ndarray, token_ids: Sequence[int], blank_token_id: int
     ) -> int:
         """Validate CTC path inputs.
 

--- a/scinoephile/audio/transcription/demucs/cache.py
+++ b/scinoephile/audio/transcription/demucs/cache.py
@@ -29,10 +29,7 @@ class DemucsCache:
     """Caches separated vocals by audio and Demucs model configuration."""
 
     def __init__(
-        self,
-        cache_root_path: Path | None,
-        model_name: str,
-        overwrite: bool = False,
+        self, cache_root_path: Path | None, model_name: str, overwrite: bool = False
     ):
         """Initialize.
 
@@ -125,11 +122,7 @@ class DemucsCache:
         logger.info(f"Removed Demucs vocals cache: {cache_path}")
         return cache_path
 
-    def save(
-        self,
-        audio: AudioSegment,
-        vocals: AudioSegment,
-    ) -> Path:
+    def save(self, audio: AudioSegment, vocals: AudioSegment) -> Path:
         """Save Demucs-separated vocals to the cache.
 
         Arguments:
@@ -144,8 +137,7 @@ class DemucsCache:
         # Export beside the target so replacement is atomic on the same filesystem
         try:
             with TemporaryDirectory(
-                dir=cache_path.parent,
-                prefix=f".{cache_path.stem}-",
+                dir=cache_path.parent, prefix=f".{cache_path.stem}-"
             ) as temp_dir:
                 staging_path = Path(temp_dir) / cache_path.name
                 vocals.export(staging_path, format="wav")

--- a/scinoephile/audio/transcription/demucs/separator.py
+++ b/scinoephile/audio/transcription/demucs/separator.py
@@ -164,23 +164,17 @@ class DemucsSeparator:
         if target_frame_rate != normalized_audio.frame_rate:
             torchaudio = import_torchaudio()
             vocals = torchaudio.functional.resample(
-                vocals,
-                target_frame_rate,
-                normalized_audio.frame_rate,
+                vocals, target_frame_rate, normalized_audio.frame_rate
             )
 
         # Restore the original channel layout and convert back to pydub
         return self._get_audio_segment(
-            vocals,
-            normalized_audio.frame_rate,
-            input_channels,
+            vocals, normalized_audio.frame_rate, input_channels
         )
 
     @staticmethod
     def _get_audio_segment(
-        vocals: TorchTensor,
-        frame_rate: int,
-        channels: int,
+        vocals: TorchTensor, frame_rate: int, channels: int
     ) -> AudioSegment:
         """Convert separated vocals waveform into a pydub AudioSegment.
 

--- a/scinoephile/audio/transcription/mlx_audio/backend.py
+++ b/scinoephile/audio/transcription/mlx_audio/backend.py
@@ -103,9 +103,7 @@ class MlxAudioBackend:
     """Loaded models shared by resolved model reference."""
 
     def __init__(
-        self,
-        model_name: str = MIMO_MODEL_NAME,
-        language: Language = Language.yue_hant,
+        self, model_name: str = MIMO_MODEL_NAME, language: Language = Language.yue_hant
     ):
         """Initialize.
 
@@ -148,9 +146,7 @@ class MlxAudioBackend:
         """Loaded MLX-Audio model."""
 
     def transcribe(
-        self,
-        audio_path: Path,
-        max_tokens: int | None = None,
+        self, audio_path: Path, max_tokens: int | None = None
     ) -> MlxAudioInferenceResult:
         """Transcribe one audio file using MLX-Audio.
 
@@ -163,15 +159,10 @@ class MlxAudioBackend:
             ImportError: if MLX-Audio is unavailable
             ValueError: if the model returns malformed output
         """
-        generate_kwargs: dict[str, object] = {
-            "language": self.mlx_audio_language,
-        }
+        generate_kwargs: dict[str, object] = {"language": self.mlx_audio_language}
         if max_tokens is not None:
             generate_kwargs["max_tokens"] = max_tokens
-        result: object = self._loaded_model.generate(
-            str(audio_path),
-            **generate_kwargs,
-        )
+        result: object = self._loaded_model.generate(str(audio_path), **generate_kwargs)
 
         # Normalize mapping- and attribute-based results
         if isinstance(result, Mapping):
@@ -192,10 +183,7 @@ class MlxAudioBackend:
                 "MLX-Audio inference result has an invalid generation token count."
             )
 
-        return MlxAudioInferenceResult(
-            text=text,
-            generation_tokens=generation_tokens,
-        )
+        return MlxAudioInferenceResult(text=text, generation_tokens=generation_tokens)
 
     @property
     def _loaded_model(self) -> MlxAudioModel:
@@ -215,10 +203,7 @@ class MlxAudioBackend:
             load = import_mlx_audio_stt_load()
             cached_model = cast(
                 "MlxAudioModel",
-                load(
-                    self._model_reference,
-                    model_type=self._model_type,
-                ),
+                load(self._model_reference, model_type=self._model_type),
             )
             self._models_by_reference[model_reference] = cached_model
         self._model = cached_model
@@ -239,10 +224,7 @@ def _get_mlx_audio_model_identity(model_name: str) -> str:
         return model_name.lower()
 
     if model_path.is_dir():
-        metadata_paths = (
-            model_path / "config.json",
-            model_path / "mlx_manifest.json",
-        )
+        metadata_paths = (model_path / "config.json", model_path / "mlx_manifest.json")
     elif model_path.suffix.lower() == ".json":
         metadata_paths = (model_path,)
     else:

--- a/scinoephile/audio/transcription/preprocessing_settings.py
+++ b/scinoephile/audio/transcription/preprocessing_settings.py
@@ -7,11 +7,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import StrEnum
 
-__all__ = [
-    "DemucsMode",
-    "TranscriptionPreprocessingSettings",
-    "VADMode",
-]
+__all__ = ["DemucsMode", "TranscriptionPreprocessingSettings", "VADMode"]
 
 
 class DemucsMode(StrEnum):

--- a/scinoephile/audio/transcription/transcriber.py
+++ b/scinoephile/audio/transcription/transcriber.py
@@ -63,10 +63,7 @@ class Transcriber(ABC):
         """Voice activity detection mode."""
 
         self._cache = TranscriptionCache(
-            cache_root_path,
-            self.backend_name,
-            self.backend_label,
-            overwrite_cache,
+            cache_root_path, self.backend_name, self.backend_label, overwrite_cache
         )
         """Timestamped transcription cache."""
 
@@ -94,10 +91,7 @@ class Transcriber(ABC):
         Returns:
             transcription split into timestamped segments
         """
-        return self.transcribe(
-            audio,
-            is_usable=is_usable,
-        )
+        return self.transcribe(audio, is_usable=is_usable)
 
     def get_cached_transcription(
         self,
@@ -114,9 +108,7 @@ class Transcriber(ABC):
             first usable cached transcription, if present
         """
         segments, _ = self._find_cached_transcription(
-            audio,
-            self._get_preprocessing_settings(),
-            is_usable,
+            audio, self._get_preprocessing_settings(), is_usable
         )
         return segments
 
@@ -127,10 +119,7 @@ class Transcriber(ABC):
             audio: audio used for cache-key generation
         """
         for settings in self._get_preprocessing_settings():
-            self._cache.remove(
-                audio,
-                self._get_cache_metadata(settings),
-            )
+            self._cache.remove(audio, self._get_cache_metadata(settings))
 
     def transcribe(
         self,
@@ -150,9 +139,7 @@ class Transcriber(ABC):
 
         # Inspect every cache before running expensive preprocessing
         segments, rejected_settings = self._find_cached_transcription(
-            audio,
-            preprocessing_settings,
-            is_usable,
+            audio, preprocessing_settings, is_usable
         )
         if segments is not None:
             return segments
@@ -170,17 +157,11 @@ class Transcriber(ABC):
         # Run Demucs once if any remaining configuration requires separated audio
         separated_audio = None
         if any(settings.use_demucs for settings in settings_to_run):
-            separated_audio = self._get_separated_audio(
-                audio,
-            )
+            separated_audio = self._get_separated_audio(audio)
 
         # Run remaining transcription configurations
         return self._run_configurations(
-            audio,
-            settings_to_run,
-            rejected_settings,
-            separated_audio,
-            is_usable,
+            audio, settings_to_run, rejected_settings, separated_audio, is_usable
         )
 
     def _find_cached_transcription(
@@ -207,11 +188,7 @@ class Transcriber(ABC):
             if cached_transcription is None:
                 continue
             cache_path, segments = cached_transcription
-            segments = self._prepare_cached_segments(
-                segments,
-                cache_path,
-                settings,
-            )
+            segments = self._prepare_cached_segments(segments, cache_path, settings)
             if is_usable is None or is_usable(segments):
                 return segments, rejected_settings
             rejected_settings.add(settings)
@@ -247,8 +224,7 @@ class Transcriber(ABC):
 
     @abstractmethod
     def _get_backend_cache_metadata(
-        self,
-        settings: TranscriptionPreprocessingSettings,
+        self, settings: TranscriptionPreprocessingSettings
     ) -> Mapping[str, object]:
         """Get backend-specific cache metadata for one configuration.
 
@@ -260,8 +236,7 @@ class Transcriber(ABC):
         raise NotImplementedError()
 
     def _get_cache_metadata(
-        self,
-        settings: TranscriptionPreprocessingSettings,
+        self, settings: TranscriptionPreprocessingSettings
     ) -> dict[str, object]:
         """Get complete backend and preprocessing cache metadata.
 
@@ -281,10 +256,7 @@ class Transcriber(ABC):
             "use_vad": settings.use_vad,
         }
 
-    def _get_separated_audio(
-        self,
-        audio: AudioSegment,
-    ) -> AudioSegment | None:
+    def _get_separated_audio(self, audio: AudioSegment) -> AudioSegment | None:
         """Get Demucs-separated audio for configured preprocessing settings.
 
         Arguments:
@@ -353,21 +325,14 @@ class Transcriber(ABC):
             if self.vad_mode is VADMode.AUTO and not settings.use_vad:
                 logger.info(f"Retrying {self.backend_label} without VAD")
             try:
-                segments = self._transcribe_attempt(
-                    transcription_audio,
-                    settings,
-                )
+                segments = self._transcribe_attempt(transcription_audio, settings)
             except TranscriptionError as exc:
                 logger.warning(f"{self.backend_label} attempt failed: {exc}")
                 last_error = exc
                 continue
             successful_result = True
 
-            self._cache.save(
-                audio,
-                self._get_cache_metadata(settings),
-                segments,
-            )
+            self._cache.save(audio, self._get_cache_metadata(settings), segments)
             if is_usable is None or is_usable(segments):
                 return segments
 
@@ -377,9 +342,7 @@ class Transcriber(ABC):
 
     @abstractmethod
     def _transcribe_attempt(
-        self,
-        audio: AudioSegment,
-        settings: TranscriptionPreprocessingSettings,
+        self, audio: AudioSegment, settings: TranscriptionPreprocessingSettings
     ) -> list[TranscribedSegment]:
         """Run one uncached transcription attempt.
 

--- a/scinoephile/audio/transcription/whisper_transcriber.py
+++ b/scinoephile/audio/transcription/whisper_transcriber.py
@@ -92,11 +92,7 @@ class WhisperTranscriber(Transcriber):
         self.temperature: float | Sequence[float] = temperature
         self.condition_on_previous_text = condition_on_previous_text
         super().__init__(
-            cache_root_path,
-            demucs_mode,
-            vad_mode,
-            overwrite_cache,
-            demucs_separator,
+            cache_root_path, demucs_mode, vad_mode, overwrite_cache, demucs_separator
         )
 
     @property
@@ -116,8 +112,7 @@ class WhisperTranscriber(Transcriber):
             whisper_timestamped = import_whisper_timestamped()
             try:
                 self._model = whisper_timestamped.load_model(
-                    self.model_name,
-                    device=device,
+                    self.model_name, device=device
                 )
             except FileNotFoundError:
                 if not self._model_name_is_huggingface_repo_id():
@@ -129,8 +124,7 @@ class WhisperTranscriber(Transcriber):
                 huggingface_hub = import_huggingface_hub()
                 huggingface_hub.snapshot_download(repo_id=self.model_name)
                 self._model = whisper_timestamped.load_model(
-                    self.model_name,
-                    device=device,
+                    self.model_name, device=device
                 )
             self._models[model_key] = self._model
         return self._model
@@ -204,8 +198,7 @@ class WhisperTranscriber(Transcriber):
             if segment_idx + 1 < len(segments):
                 next_segment = segments[segment_idx + 1]
                 if segment_text_from_words := self._get_duplicate_segment_pair_text(
-                    segment,
-                    next_segment,
+                    segment, next_segment
                 ):
                     logger.warning(
                         f"Coalescing malformed Whisper segment pair for "
@@ -217,9 +210,7 @@ class WhisperTranscriber(Transcriber):
                     )
                     normalized_segments.append(
                         self._get_coalesced_segment(
-                            segment,
-                            next_segment,
-                            segment_text_from_words,
+                            segment, next_segment, segment_text_from_words
                         )
                     )
                     segment_idx += 2
@@ -266,8 +257,7 @@ class WhisperTranscriber(Transcriber):
 
     @staticmethod
     def _get_duplicate_segment_pair_text(
-        segment: TranscribedSegment,
-        next_segment: TranscribedSegment,
+        segment: TranscribedSegment, next_segment: TranscribedSegment
     ) -> str | None:
         """Get repaired text for a known malformed duplicate-segment pair.
 
@@ -293,8 +283,7 @@ class WhisperTranscriber(Transcriber):
         return segment_text_from_words
 
     def _get_backend_cache_metadata(
-        self,
-        settings: TranscriptionPreprocessingSettings,
+        self, settings: TranscriptionPreprocessingSettings
     ) -> dict[str, object]:
         """Get cache metadata identifying configured Whisper output.
 
@@ -333,16 +322,11 @@ class WhisperTranscriber(Transcriber):
             normalized cached segments
         """
         return self._normalize_transcription_segments(
-            segments,
-            source="cache",
-            cache_path=cache_path,
-            use_vad=settings.use_vad,
+            segments, source="cache", cache_path=cache_path, use_vad=settings.use_vad
         )
 
     def _transcribe_attempt(
-        self,
-        audio: AudioSegment,
-        settings: TranscriptionPreprocessingSettings,
+        self, audio: AudioSegment, settings: TranscriptionPreprocessingSettings
     ) -> list[TranscribedSegment]:
         """Run one uncached Whisper transcription attempt.
 
@@ -381,8 +365,5 @@ class WhisperTranscriber(Transcriber):
             TranscribedSegment.model_validate(segment) for segment in result["segments"]
         ]
         return self._normalize_transcription_segments(
-            segments,
-            source="whisper",
-            cache_path=None,
-            use_vad=settings.use_vad,
+            segments, source="whisper", cache_path=None, use_vad=settings.use_vad
         )

--- a/scinoephile/cli/audit/audit_cli.py
+++ b/scinoephile/cli/audit/audit_cli.py
@@ -22,12 +22,8 @@ from .audit_translation_cli import AuditTranslationCli
 __all__ = ["AuditCli"]
 
 AUDIT_LOCALIZATIONS: dict[str, dict[str, str]] = {
-    "zh-hans": {
-        "audit subtitle workflows": "审核字幕工作流",
-    },
-    "zh-hant": {
-        "audit subtitle workflows": "稽核字幕工作流程",
-    },
+    "zh-hans": {"audit subtitle workflows": "审核字幕工作流"},
+    "zh-hant": {"audit subtitle workflows": "稽核字幕工作流程"},
 }
 """Localized help text keyed by locale and English source text."""
 
@@ -47,9 +43,7 @@ class AuditCli(ScinoephileCliBase):
         """
         super().add_arguments_to_argparser(parser)
         subparsers = parser.add_subparsers(
-            dest="audit_subcommand_name",
-            help="subcommand",
-            required=True,
+            dest="audit_subcommand_name", help="subcommand", required=True
         )
         subcommands = cls.subcommands()
         for name in sorted(subcommands):
@@ -74,12 +68,7 @@ class AuditCli(ScinoephileCliBase):
         }
 
     @classmethod
-    def _main(
-        cls,
-        *,
-        audit_subcommand_name: str,
-        **kwargs: Any,
-    ):
+    def _main(cls, *, audit_subcommand_name: str, **kwargs: Any):
         """Execute with provided keyword arguments.
 
         Arguments:

--- a/scinoephile/cli/audit/audit_cli_base.py
+++ b/scinoephile/cli/audit/audit_cli_base.py
@@ -58,9 +58,7 @@ class AuditCliBase(ScinoephileCliBase):
     """Shared command-line support for subtitle audits."""
 
     localizations = merge_localizations(
-        BLOCK_LOCALIZATIONS,
-        LLM_LOCALIZATIONS,
-        AUDIT_CLI_LOCALIZATIONS,
+        BLOCK_LOCALIZATIONS, LLM_LOCALIZATIONS, AUDIT_CLI_LOCALIZATIONS
     )
     """Localized help text keyed by locale and English source text."""
 
@@ -98,9 +96,7 @@ class AuditCliBase(ScinoephileCliBase):
             help="Markdown outfile path (default: stdout)",
         )
         arg_groups["output arguments"].add_argument(
-            "--overwrite",
-            action="store_true",
-            help="overwrite outfile if it exists",
+            "--overwrite", action="store_true", help="overwrite outfile if it exists"
         )
         parser.set_defaults(_parser=parser)
 
@@ -162,19 +158,14 @@ class AuditCliBase(ScinoephileCliBase):
         """
         try:
             return load_test_cases_from_json(
-                json_path,
-                manager_cls,
-                manager_cls.base_prompt,
+                json_path, manager_cls, manager_cls.base_prompt
             )
         except (KeyError, OSError, TypeError, UnicodeError, ValueError) as exc:
             parser.error(f"Unable to load {workflow_name} JSON: {exc}")
 
     @staticmethod
     def write_report(
-        parser: ArgumentParser,
-        report: str,
-        outfile_path: Path | None,
-        overwrite: bool,
+        parser: ArgumentParser, report: str, outfile_path: Path | None, overwrite: bool
     ):
         """Write a report to stdout or a file.
 

--- a/scinoephile/cli/audit/audit_delineation_cli.py
+++ b/scinoephile/cli/audit/audit_delineation_cli.py
@@ -12,10 +12,7 @@ from scinoephile.analysis.audit.delineation import (
     audit_delineation,
 )
 from scinoephile.cli.helpers.io import read_series
-from scinoephile.common.argument_parsing import (
-    get_arg_groups_by_name,
-    input_file_arg,
-)
+from scinoephile.common.argument_parsing import get_arg_groups_by_name, input_file_arg
 from scinoephile.core import ScinoephileError
 from scinoephile.llms.delineation import DelineationManager
 
@@ -148,10 +145,7 @@ class AuditDelineationCli(AuditCliBase):
         # Read inputs
         reference = read_series(parser, reference_path)
         test_cases = cls.load_test_cases(
-            parser,
-            json_path,
-            DelineationManager,
-            workflow_name="delineation",
+            parser, json_path, DelineationManager, workflow_name="delineation"
         )
 
         # Perform operation

--- a/scinoephile/cli/audit/audit_ocr_fusion_cli.py
+++ b/scinoephile/cli/audit/audit_ocr_fusion_cli.py
@@ -7,15 +7,9 @@ from __future__ import annotations
 from argparse import ArgumentParser
 from pathlib import Path
 
-from scinoephile.analysis.audit.ocr_fusion import (
-    OcrFusionAuditFilter,
-    audit_ocr_fusion,
-)
+from scinoephile.analysis.audit.ocr_fusion import OcrFusionAuditFilter, audit_ocr_fusion
 from scinoephile.cli.helpers.io import read_series
-from scinoephile.common.argument_parsing import (
-    get_arg_groups_by_name,
-    input_file_arg,
-)
+from scinoephile.common.argument_parsing import get_arg_groups_by_name, input_file_arg
 from scinoephile.core.exceptions import ScinoephileError
 from scinoephile.llms.ocr_fusion import OcrFusionManager
 
@@ -207,10 +201,7 @@ class AuditOcrFusionCli(AuditCliBase):
         test_cases = None
         if json_path is not None:
             test_cases = cls.load_test_cases(
-                parser,
-                json_path,
-                OcrFusionManager,
-                workflow_name="OCR-fusion",
+                parser, json_path, OcrFusionManager, workflow_name="OCR-fusion"
             )
 
         # Perform operation

--- a/scinoephile/cli/audit/audit_punctuation_cli.py
+++ b/scinoephile/cli/audit/audit_punctuation_cli.py
@@ -12,10 +12,7 @@ from scinoephile.analysis.audit.punctuation import (
     audit_punctuation,
 )
 from scinoephile.cli.helpers.io import read_series
-from scinoephile.common.argument_parsing import (
-    get_arg_groups_by_name,
-    input_file_arg,
-)
+from scinoephile.common.argument_parsing import get_arg_groups_by_name, input_file_arg
 from scinoephile.core import ScinoephileError
 from scinoephile.llms.punctuation import PunctuationManager
 
@@ -160,10 +157,7 @@ class AuditPunctuationCli(AuditCliBase):
         reference = read_series(parser, reference_path)
         target = read_series(parser, target_path)
         test_cases = cls.load_test_cases(
-            parser,
-            json_path,
-            PunctuationManager,
-            workflow_name="punctuation",
+            parser, json_path, PunctuationManager, workflow_name="punctuation"
         )
 
         # Perform operation

--- a/scinoephile/cli/audit/audit_review_cli.py
+++ b/scinoephile/cli/audit/audit_review_cli.py
@@ -15,10 +15,7 @@ from scinoephile.analysis.audit.review import (
     audit_review,
 )
 from scinoephile.cli.helpers.io import read_series
-from scinoephile.common.argument_parsing import (
-    get_arg_groups_by_name,
-    input_file_arg,
-)
+from scinoephile.common.argument_parsing import get_arg_groups_by_name, input_file_arg
 from scinoephile.core import Language
 from scinoephile.core.exceptions import ScinoephileError
 from scinoephile.lang.id import get_series_language
@@ -207,10 +204,7 @@ class AuditReviewCli(AuditCliBase):
         target = read_series(parser, target_path)
         guide = read_series(parser, guide_path)
         test_cases = cls.load_test_cases(
-            parser,
-            json_path,
-            GuidedReviewManager,
-            workflow_name="guided review",
+            parser, json_path, GuidedReviewManager, workflow_name="guided review"
         )
 
         # Perform operation

--- a/scinoephile/cli/audit/audit_review_dual_cli.py
+++ b/scinoephile/cli/audit/audit_review_dual_cli.py
@@ -13,10 +13,7 @@ from scinoephile.analysis.audit.dual_review import (
     audit_dual_review,
 )
 from scinoephile.cli.helpers.io import read_series
-from scinoephile.common.argument_parsing import (
-    get_arg_groups_by_name,
-    input_file_arg,
-)
+from scinoephile.common.argument_parsing import get_arg_groups_by_name, input_file_arg
 from scinoephile.core import ScinoephileError
 from scinoephile.lang.zho.script.conversion import get_zho_character_variants
 
@@ -366,8 +363,7 @@ class AuditReviewDualCli(AuditCliBase):
         traditional_reviewed = read_series(parser, traditional_reviewed_path)
         traditional_simplified = read_series(parser, traditional_simplified_path)
         traditional_simplified_reviewed = read_series(
-            parser,
-            traditional_simplified_reviewed_path,
+            parser, traditional_simplified_reviewed_path
         )
         input_series = (
             simplified,

--- a/scinoephile/cli/audit/audit_review_trad_cli.py
+++ b/scinoephile/cli/audit/audit_review_trad_cli.py
@@ -14,10 +14,7 @@ from scinoephile.analysis.audit.review import (
     audit_review,
 )
 from scinoephile.cli.helpers.io import read_series
-from scinoephile.common.argument_parsing import (
-    get_arg_groups_by_name,
-    input_file_arg,
-)
+from scinoephile.common.argument_parsing import get_arg_groups_by_name, input_file_arg
 from scinoephile.core import ScinoephileError
 from scinoephile.lang.zho.script.conversion import get_zho_character_variants
 
@@ -276,8 +273,7 @@ class AuditReviewTradCli(AuditCliBase):
         traditional_reviewed = read_series(parser, traditional_reviewed_path)
         traditional_simplified = read_series(parser, traditional_simplified_path)
         traditional_simplified_reviewed = read_series(
-            parser,
-            traditional_simplified_reviewed_path,
+            parser, traditional_simplified_reviewed_path
         )
         traditional_review_cases = load_review_test_cases(parser, traditional_json_path)
         traditional_simplified_review_cases = load_review_test_cases(

--- a/scinoephile/cli/audit/audit_translation_cli.py
+++ b/scinoephile/cli/audit/audit_translation_cli.py
@@ -14,10 +14,7 @@ from scinoephile.analysis.audit.translation import (
     audit_translation,
 )
 from scinoephile.cli.helpers.io import read_series
-from scinoephile.common.argument_parsing import (
-    get_arg_groups_by_name,
-    input_file_arg,
-)
+from scinoephile.common.argument_parsing import get_arg_groups_by_name, input_file_arg
 from scinoephile.core.exceptions import ScinoephileError
 from scinoephile.llms.gap_translation import GapTranslationManager
 from scinoephile.llms.guided_translation import GuidedTranslationManager
@@ -178,10 +175,7 @@ class AuditTranslationCli(AuditCliBase):
         target = read_series(parser, target_path)
         guide = read_series(parser, guide_path)
         test_cases = cls.load_test_cases(
-            parser,
-            json_path,
-            GapTranslationManager,
-            workflow_name="gapped translation",
+            parser, json_path, GapTranslationManager, workflow_name="gapped translation"
         )
 
         # Perform operation
@@ -277,10 +271,7 @@ class AuditTranslationCli(AuditCliBase):
         # Read inputs
         source = read_series(parser, source_path)
         test_cases = cls.load_test_cases(
-            parser,
-            json_path,
-            TranslationManager,
-            workflow_name="standard translation",
+            parser, json_path, TranslationManager, workflow_name="standard translation"
         )
 
         # Perform operation

--- a/scinoephile/cli/audit/utils.py
+++ b/scinoephile/cli/audit/utils.py
@@ -17,8 +17,7 @@ __all__ = ["load_review_test_cases"]
 
 
 def load_review_test_cases(
-    parser: ArgumentParser,
-    json_path: Path | None,
+    parser: ArgumentParser, json_path: Path | None
 ) -> Sequence[TestCase]:
     """Load optional review test cases from JSON.
 
@@ -31,8 +30,5 @@ def load_review_test_cases(
     if json_path is None:
         return ()
     return AuditCliBase.load_test_cases(
-        parser,
-        json_path,
-        ReviewManager,
-        workflow_name="review",
+        parser, json_path, ReviewManager, workflow_name="review"
     )

--- a/scinoephile/cli/dictionary/__init__.py
+++ b/scinoephile/cli/dictionary/__init__.py
@@ -12,7 +12,4 @@ from __future__ import annotations
 from .dictionary_cli import DictionaryCli
 from .dictionary_search_cli import DictionarySearchCli
 
-__all__ = [
-    "DictionaryCli",
-    "DictionarySearchCli",
-]
+__all__ = ["DictionaryCli", "DictionarySearchCli"]

--- a/scinoephile/cli/dictionary/build/dictionary_build_cli.py
+++ b/scinoephile/cli/dictionary/build/dictionary_build_cli.py
@@ -78,12 +78,7 @@ class DictionaryBuildCli(ScinoephileCliBase):
         }
 
     @classmethod
-    def _main(
-        cls,
-        *,
-        dictionary_build_subcommand_name: str,
-        **kwargs: Any,
-    ):
+    def _main(cls, *, dictionary_build_subcommand_name: str, **kwargs: Any):
         """Execute with provided keyword arguments."""
         cls.subcommands()[dictionary_build_subcommand_name]._main(**kwargs)
 

--- a/scinoephile/cli/dictionary/build/dictionary_build_cuhk_cli.py
+++ b/scinoephile/cli/dictionary/build/dictionary_build_cuhk_cli.py
@@ -68,8 +68,7 @@ class DictionaryBuildCuhkCli(DictionaryBuildCliBase):
     """Dictionary source built by this CLI."""
 
     localizations = merge_localizations(
-        CACHE_LOCALIZATIONS,
-        DICTIONARY_BUILD_CUHK_LOCALIZATIONS,
+        CACHE_LOCALIZATIONS, DICTIONARY_BUILD_CUHK_LOCALIZATIONS
     )
     """Localized help text keyed by locale and English source text."""
 
@@ -194,10 +193,7 @@ class DictionaryBuildCuhkCli(DictionaryBuildCliBase):
             source_json_path=None,
         )
         try:
-            database_path = service.build(
-                overwrite=overwrite,
-                max_words=max_words,
-            )
+            database_path = service.build(overwrite=overwrite, max_words=max_words)
         except FileNotFoundError as exc:
             logger.error(str(exc))
             raise SystemExit(1) from exc

--- a/scinoephile/cli/dictionary/build/dictionary_build_gzzj_cli.py
+++ b/scinoephile/cli/dictionary/build/dictionary_build_gzzj_cli.py
@@ -88,8 +88,7 @@ class DictionaryBuildGzzjCli(DictionaryBuildCliBase):
     ):
         """Execute with provided keyword arguments."""
         service = GzzjDictionaryService(
-            database_path=database_path,
-            source_json_path=source_json_path,
+            database_path=database_path, source_json_path=source_json_path
         )
         cls.log_config(
             database_path=service.database_path,

--- a/scinoephile/cli/dictionary/dictionary_cli.py
+++ b/scinoephile/cli/dictionary/dictionary_cli.py
@@ -44,9 +44,7 @@ class DictionaryCli(ScinoephileCliBase):
         super().add_arguments_to_argparser(parser)
 
         subparsers = parser.add_subparsers(
-            dest="dictionary_subcommand_name",
-            help="subcommand",
-            required=True,
+            dest="dictionary_subcommand_name", help="subcommand", required=True
         )
         subcommands = cls.subcommands()
         for name in sorted(subcommands):
@@ -65,12 +63,7 @@ class DictionaryCli(ScinoephileCliBase):
         }
 
     @classmethod
-    def _main(
-        cls,
-        *,
-        dictionary_subcommand_name: str,
-        **kwargs: Any,
-    ):
+    def _main(cls, *, dictionary_subcommand_name: str, **kwargs: Any):
         """Execute with provided keyword arguments."""
         cls.subcommands()[dictionary_subcommand_name]._main(**kwargs)
 

--- a/scinoephile/cli/dictionary/dictionary_search_cli.py
+++ b/scinoephile/cli/dictionary/dictionary_search_cli.py
@@ -122,10 +122,7 @@ class DictionarySearchCli(ScinoephileCliBase):
 
     @classmethod
     def _format_search_results(
-        cls,
-        query: str,
-        entries: list[DictionaryEntry],
-        dictionary_name: str,
+        cls, query: str, entries: list[DictionaryEntry], dictionary_name: str
     ) -> list[str]:
         """Format search results.
 
@@ -152,10 +149,7 @@ class DictionarySearchCli(ScinoephileCliBase):
 
     @classmethod
     def _write_search_results(
-        cls,
-        query: str,
-        entries: list[DictionaryEntry],
-        dictionary_name: str,
+        cls, query: str, entries: list[DictionaryEntry], dictionary_name: str
     ):
         """Write formatted search results to stdout and logs.
 
@@ -202,12 +196,7 @@ class DictionarySearchCli(ScinoephileCliBase):
 
     @classmethod
     def _search_dictionaries(
-        cls,
-        *,
-        query: str,
-        limit: int,
-        dictionary_name: str,
-        database_path: Path | None,
+        cls, *, query: str, limit: int, dictionary_name: str, database_path: Path | None
     ) -> list[DictionaryEntry]:
         """Search one or more configured dictionaries.
 

--- a/scinoephile/cli/helpers/blocks.py
+++ b/scinoephile/cli/helpers/blocks.py
@@ -8,11 +8,7 @@ from argparse import ArgumentParser, _ArgumentGroup  # noqa: PLC2701
 
 from scinoephile.common.argument_parsing import int_arg
 
-__all__ = [
-    "BLOCK_LOCALIZATIONS",
-    "add_block_range_args",
-    "get_block_range_indexes",
-]
+__all__ = ["BLOCK_LOCALIZATIONS", "add_block_range_args", "get_block_range_indexes"]
 
 BLOCK_LOCALIZATIONS: dict[str, dict[str, str]] = {
     "zh-hans": {
@@ -49,14 +45,10 @@ def add_block_range_args(
         last_help: help text for the last-block argument
     """
     operation_arg_group.add_argument(
-        "--first-block",
-        type=int_arg(min_value=1),
-        help=first_help,
+        "--first-block", type=int_arg(min_value=1), help=first_help
     )
     operation_arg_group.add_argument(
-        "--last-block",
-        type=int_arg(min_value=1),
-        help=last_help,
+        "--last-block", type=int_arg(min_value=1), help=last_help
     )
 
 

--- a/scinoephile/cli/helpers/conversion.py
+++ b/scinoephile/cli/helpers/conversion.py
@@ -100,8 +100,7 @@ OPENCC_CONFIG_LOCALIZATIONS: dict[str, dict[str, str]] = {
 
 
 def add_opencc_convert_argument(
-    operation_arg_group: _ArgumentGroup,
-    additional_help_arg_group: _ArgumentGroup,
+    operation_arg_group: _ArgumentGroup, additional_help_arg_group: _ArgumentGroup
 ):
     """Add standard OpenCC conversion and help arguments to argument groups.
 
@@ -126,8 +125,7 @@ def add_opencc_convert_argument(
 
 
 def add_opencc_convert_auto_argument(
-    operation_arg_group: _ArgumentGroup,
-    additional_help_arg_group: _ArgumentGroup,
+    operation_arg_group: _ArgumentGroup, additional_help_arg_group: _ArgumentGroup
 ):
     """Add OpenCC conversion arguments allowing automatic config selection.
 
@@ -196,8 +194,7 @@ class _ListOpenCCConfigsAction(Action):
         """
         locale_name = ScinoephileCliBase.locale_name
         heading = CONVERSION_LOCALIZATIONS.get(locale_name, {}).get(
-            "Available OpenCC configurations:",
-            "Available OpenCC configurations:",
+            "Available OpenCC configurations:", "Available OpenCC configurations:"
         )
         config_localizations = OPENCC_CONFIG_LOCALIZATIONS.get(locale_name, {})
         lines = [heading]

--- a/scinoephile/cli/helpers/io.py
+++ b/scinoephile/cli/helpers/io.py
@@ -18,11 +18,7 @@ from scinoephile.core import ScinoephileError
 from scinoephile.core.subtitles import Series
 from scinoephile.image.subtitles import ImageSeries
 
-__all__ = [
-    "read_image_series",
-    "read_series",
-    "write_series",
-]
+__all__ = ["read_image_series", "read_series", "write_series"]
 
 
 def read_image_series(parser: ArgumentParser, infile: str | Path) -> ImageSeries:
@@ -37,20 +33,12 @@ def read_image_series(parser: ArgumentParser, infile: str | Path) -> ImageSeries
     try:
         infile_path = val_input_file_or_dir_path(infile)
         return ImageSeries.load(infile_path)
-    except (
-        FileNotFoundError,
-        NotADirectoryError,
-        ScinoephileError,
-        ValueError,
-    ) as exc:
+    except (FileNotFoundError, NotADirectoryError, ScinoephileError, ValueError) as exc:
         parser.error(str(exc))
 
 
 def read_series(
-    parser: ArgumentParser,
-    infile: str | Path,
-    *,
-    allow_stdin: bool = False,
+    parser: ArgumentParser, infile: str | Path, *, allow_stdin: bool = False
 ) -> Series:
     """Load a subtitle series from stdin or a file.
 

--- a/scinoephile/cli/helpers/llms.py
+++ b/scinoephile/cli/helpers/llms.py
@@ -88,8 +88,7 @@ class LlmArguments:
 
 
 def add_llm_provider_args(
-    llm_arg_group: _ArgumentGroup,
-    additional_help_arg_group: _ArgumentGroup,
+    llm_arg_group: _ArgumentGroup, additional_help_arg_group: _ArgumentGroup
 ):
     """Add standard LLM provider arguments to argument groups.
 
@@ -151,10 +150,7 @@ def add_llm_test_case_json_arg(
         help_text: argument help text
     """
     llm_arg_group.add_argument(
-        option_name,
-        dest=dest,
-        type=output_file_arg(exist_ok=True),
-        help=help_text,
+        option_name, dest=dest, type=output_file_arg(exist_ok=True), help=help_text
     )
 
 
@@ -178,8 +174,7 @@ def llm_provider_name_arg(value: str) -> str:
 
 
 def read_llm_additional_context(
-    parser: ArgumentParser,
-    llm_additional_context_file_path: Path | None,
+    parser: ArgumentParser, llm_additional_context_file_path: Path | None
 ) -> str | None:
     """Read additional context for LLM prompts.
 
@@ -228,8 +223,7 @@ class _ListLLMProvidersAction(Action):
         """
         locale_name = ScinoephileCliBase.locale_name
         heading = LLM_LOCALIZATIONS.get(locale_name, {}).get(
-            "Available LLM providers:",
-            "Available LLM providers:",
+            "Available LLM providers:", "Available LLM providers:"
         )
         lines = [heading]
         for provider_name in get_provider_names():

--- a/scinoephile/cli/helpers/web.py
+++ b/scinoephile/cli/helpers/web.py
@@ -11,11 +11,7 @@ from scinoephile.common.argument_parsing import int_arg
 
 from .argument_bundle_field_action import ArgumentBundleFieldAction
 
-__all__ = [
-    "WEB_LOCALIZATIONS",
-    "WebServerArguments",
-    "add_web_server_args",
-]
+__all__ = ["WEB_LOCALIZATIONS", "WebServerArguments", "add_web_server_args"]
 
 WEB_LOCALIZATIONS: dict[str, dict[str, str]] = {
     "zh-hans": {

--- a/scinoephile/cli/media/media_cli.py
+++ b/scinoephile/cli/media/media_cli.py
@@ -62,9 +62,7 @@ class MediaCli(ScinoephileCliBase):
         super().add_arguments_to_argparser(parser)
 
         subparsers = parser.add_subparsers(
-            dest="media_subcommand_name",
-            help="subcommand",
-            required=True,
+            dest="media_subcommand_name", help="subcommand", required=True
         )
         subcommands = cls.subcommands()
         for name in sorted(subcommands):
@@ -85,12 +83,7 @@ class MediaCli(ScinoephileCliBase):
         }
 
     @classmethod
-    def _main(
-        cls,
-        *,
-        media_subcommand_name: str,
-        **kwargs: Any,
-    ):
+    def _main(cls, *, media_subcommand_name: str, **kwargs: Any):
         """Execute with provided keyword arguments."""
         cls.subcommands()[media_subcommand_name]._main(**kwargs)
 

--- a/scinoephile/cli/media/media_extract_subs_cli.py
+++ b/scinoephile/cli/media/media_extract_subs_cli.py
@@ -79,8 +79,7 @@ class MediaExtractSubsCli(ScinoephileCliBase):
     """Extract matching subtitle streams from a video file."""
 
     localizations = merge_localizations(
-        CACHE_LOCALIZATIONS,
-        MEDIA_EXTRACT_SUBS_LOCALIZATIONS,
+        CACHE_LOCALIZATIONS, MEDIA_EXTRACT_SUBS_LOCALIZATIONS
     )
     """Localized help text keyed by locale and English source text."""
 

--- a/scinoephile/cli/media/media_probe_cli.py
+++ b/scinoephile/cli/media/media_probe_cli.py
@@ -12,10 +12,7 @@ from scinoephile.cli.helpers.cache import (
     CacheArguments,
     add_cache_args,
 )
-from scinoephile.common.argument_parsing import (
-    get_arg_groups_by_name,
-    input_file_arg,
-)
+from scinoephile.common.argument_parsing import get_arg_groups_by_name, input_file_arg
 from scinoephile.core import ScinoephileError
 from scinoephile.core.cli import ScinoephileCliBase
 from scinoephile.core.cli.localization import merge_localizations
@@ -85,9 +82,7 @@ class MediaProbeCli(ScinoephileCliBase):
 
         # Operation arguments
         arg_groups["operation arguments"].add_argument(
-            "--details",
-            action="store_true",
-            help="include additional stream details",
+            "--details", action="store_true", help="include additional stream details"
         )
         arg_groups["operation arguments"].add_argument(
             "--force-check-script",
@@ -128,8 +123,7 @@ class MediaProbeCli(ScinoephileCliBase):
         try:
             if force_check_script:
                 subtitle_cache = SubtitleCache(
-                    cache_args.root_path,
-                    cache_args.overwrite,
+                    cache_args.root_path, cache_args.overwrite
                 )
                 stream = SubtitleStream(
                     index=0,
@@ -138,9 +132,7 @@ class MediaProbeCli(ScinoephileCliBase):
                     language="zho",
                 )
                 analysis = analyze_zho_subtitle_stream_script(
-                    infile_path,
-                    stream,
-                    subtitle_cache=subtitle_cache,
+                    infile_path, stream, subtitle_cache=subtitle_cache
                 )
                 language = analysis.script
                 if language is None:
@@ -151,22 +143,18 @@ class MediaProbeCli(ScinoephileCliBase):
                 streams = get_streams(infile_path)
                 if details:
                     subtitle_cache = SubtitleCache(
-                        cache_args.root_path,
-                        cache_args.overwrite,
+                        cache_args.root_path, cache_args.overwrite
                     )
                     detailed_subtitle_streams_by_index = {
                         stream.index: stream
                         for stream in get_zho_subtitle_streams(
-                            infile_path,
-                            streams=streams,
-                            subtitle_cache=subtitle_cache,
+                            infile_path, streams=streams, subtitle_cache=subtitle_cache
                         )
                     }
                     for index, stream in enumerate(streams):
                         if isinstance(stream, SubtitleStream):
                             streams[index] = detailed_subtitle_streams_by_index.get(
-                                stream.index,
-                                stream,
+                                stream.index, stream
                             )
         except ScinoephileError as exc:
             parser.error(str(exc))

--- a/scinoephile/cli/multi/multi_cer_cli.py
+++ b/scinoephile/cli/multi/multi_cer_cli.py
@@ -73,9 +73,7 @@ class MultiCerCli(ScinoephileCliBase):
         """
         super().add_arguments_to_argparser(parser)
         arg_groups = get_arg_groups_by_name(
-            parser,
-            "input arguments",
-            optional_arguments_name="additional arguments",
+            parser, "input arguments", optional_arguments_name="additional arguments"
         )
 
         # Input arguments

--- a/scinoephile/cli/multi/multi_cli.py
+++ b/scinoephile/cli/multi/multi_cli.py
@@ -54,9 +54,7 @@ class MultiCli(ScinoephileCliBase):
         super().add_arguments_to_argparser(parser)
 
         subparsers = parser.add_subparsers(
-            dest="multi_subcommand_name",
-            help="subcommand",
-            required=True,
+            dest="multi_subcommand_name", help="subcommand", required=True
         )
         subcommands = cls.subcommands()
         for name in sorted(subcommands):
@@ -78,12 +76,7 @@ class MultiCli(ScinoephileCliBase):
         }
 
     @classmethod
-    def _main(
-        cls,
-        *,
-        multi_subcommand_name: str,
-        **kwargs: Any,
-    ):
+    def _main(cls, *, multi_subcommand_name: str, **kwargs: Any):
         """Execute with provided keyword arguments."""
         cls.subcommands()[multi_subcommand_name]._main(**kwargs)
 

--- a/scinoephile/cli/multi/multi_stack_cli.py
+++ b/scinoephile/cli/multi/multi_stack_cli.py
@@ -24,14 +24,9 @@ from scinoephile.common.argument_parsing import (
 from scinoephile.core import ScinoephileError
 from scinoephile.core.cli import ScinoephileCliBase
 from scinoephile.core.stacking import StackTimingMode, get_stacked_series
-from scinoephile.core.synchronization import (
-    get_sync_offset_stats,
-)
+from scinoephile.core.synchronization import get_sync_offset_stats
 
-__all__ = [
-    "MultiStackCli",
-    "StackSyncMode",
-]
+__all__ = ["MultiStackCli", "StackSyncMode"]
 
 logger = getLogger(__name__)
 
@@ -186,9 +181,7 @@ class MultiStackCli(ScinoephileCliBase):
             help="stacked subtitle outfile path (default: stdout)",
         )
         arg_groups["output arguments"].add_argument(
-            "--overwrite",
-            action="store_true",
-            help="overwrite outfile if it exists",
+            "--overwrite", action="store_true", help="overwrite outfile if it exists"
         )
         parser.set_defaults(_parser=parser)
 
@@ -231,10 +224,7 @@ class MultiStackCli(ScinoephileCliBase):
             timing_mode = StackTimingMode.OUTER
             if sync_mode == StackSyncMode.ANCHOR_TOP:
                 stats = get_sync_offset_stats(
-                    top,
-                    bottom,
-                    sync_cutoff=sync_cutoff,
-                    pause_length=pause_length,
+                    top, bottom, sync_cutoff=sync_cutoff, pause_length=pause_length
                 )
                 bottom = deepcopy(bottom)
                 bottom.shift(ms=int(round(-stats.mean_ms)))
@@ -242,10 +232,7 @@ class MultiStackCli(ScinoephileCliBase):
                 logger.info(f"Mean offset: {stats.mean_ms / 1000:+.3f} s")
             elif sync_mode == StackSyncMode.ANCHOR_BOTTOM:
                 stats = get_sync_offset_stats(
-                    bottom,
-                    top,
-                    sync_cutoff=sync_cutoff,
-                    pause_length=pause_length,
+                    bottom, top, sync_cutoff=sync_cutoff, pause_length=pause_length
                 )
                 top = deepcopy(top)
                 top.shift(ms=int(round(-stats.mean_ms)))

--- a/scinoephile/cli/multi/multi_sync_cli.py
+++ b/scinoephile/cli/multi/multi_sync_cli.py
@@ -148,9 +148,7 @@ class MultiSyncCli(ScinoephileCliBase):
             help="synced mobile subtitle outfile path (default: stdout)",
         )
         arg_groups["output arguments"].add_argument(
-            "--overwrite",
-            action="store_true",
-            help="overwrite outfile if it exists",
+            "--overwrite", action="store_true", help="overwrite outfile if it exists"
         )
         parser.set_defaults(_parser=parser)
 
@@ -190,10 +188,7 @@ class MultiSyncCli(ScinoephileCliBase):
         # Perform operations
         try:
             stats = get_sync_offset_stats(
-                anchor,
-                mobile,
-                sync_cutoff=sync_cutoff,
-                pause_length=pause_length,
+                anchor, mobile, sync_cutoff=sync_cutoff, pause_length=pause_length
             )
         except ScinoephileError as exc:
             parser.error(str(exc))
@@ -204,10 +199,7 @@ class MultiSyncCli(ScinoephileCliBase):
 
         # Write outputs
         write_series(
-            parser,
-            synced,
-            outfile_path if outfile_path is not None else "-",
-            overwrite,
+            parser, synced, outfile_path if outfile_path is not None else "-", overwrite
         )
 
 

--- a/scinoephile/cli/multi/multi_timewarp_cli.py
+++ b/scinoephile/cli/multi/multi_timewarp_cli.py
@@ -146,9 +146,7 @@ class MultiTimewarpCli(ScinoephileCliBase):
             help="timewarped subtitle outfile path (default: stdout)",
         )
         arg_groups["output arguments"].add_argument(
-            "--overwrite",
-            action="store_true",
-            help="overwrite outfile if it exists",
+            "--overwrite", action="store_true", help="overwrite outfile if it exists"
         )
         parser.set_defaults(_parser=parser)
 

--- a/scinoephile/cli/ocr/ocr_cli.py
+++ b/scinoephile/cli/ocr/ocr_cli.py
@@ -51,9 +51,7 @@ class OcrCli(ScinoephileCliBase):
         super().add_arguments_to_argparser(parser)
 
         subparsers = parser.add_subparsers(
-            dest="ocr_subcommand_name",
-            help="subcommand",
-            required=True,
+            dest="ocr_subcommand_name", help="subcommand", required=True
         )
         subcommands = cls.subcommands()
         for name in sorted(subcommands):
@@ -83,12 +81,7 @@ class OcrCli(ScinoephileCliBase):
         }
 
     @classmethod
-    def _main(
-        cls,
-        *,
-        ocr_subcommand_name: str,
-        **kwargs: Any,
-    ):
+    def _main(cls, *, ocr_subcommand_name: str, **kwargs: Any):
         """Execute with provided keyword arguments."""
         cls.subcommands()[ocr_subcommand_name]._main(**kwargs)
 

--- a/scinoephile/cli/ocr/ocr_fuse_cli.py
+++ b/scinoephile/cli/ocr/ocr_fuse_cli.py
@@ -171,9 +171,7 @@ class OcrFuseCli(ScinoephileCliBase):
             help="fused subtitle outfile path (default: stdout)",
         )
         arg_groups["output arguments"].add_argument(
-            "--overwrite",
-            action="store_true",
-            help="overwrite outfile if it exists",
+            "--overwrite", action="store_true", help="overwrite outfile if it exists"
         )
         parser.set_defaults(_parser=parser)
 
@@ -264,12 +262,10 @@ class OcrFuseCli(ScinoephileCliBase):
                 secondary,
                 language=fusion_language,
                 provider=get_provider(
-                    llm_args.provider_name,
-                    model=llm_args.model_name,
+                    llm_args.provider_name, model=llm_args.model_name
                 ),
                 additional_context=read_llm_additional_context(
-                    parser,
-                    llm_args.additional_context_file_path,
+                    parser, llm_args.additional_context_file_path
                 ),
                 cache_root_path=cache_args.root_path,
                 overwrite_cache=cache_args.overwrite,

--- a/scinoephile/cli/ocr/ocr_lens_cli.py
+++ b/scinoephile/cli/ocr/ocr_lens_cli.py
@@ -129,9 +129,7 @@ class OcrLensCli(ScinoephileCliBase):
             help="recognized subtitle outfile path",
         )
         arg_groups["output arguments"].add_argument(
-            "--overwrite",
-            action="store_true",
-            help="overwrite outfile if it exists",
+            "--overwrite", action="store_true", help="overwrite outfile if it exists"
         )
         parser.set_defaults(_parser=parser)
 

--- a/scinoephile/cli/ocr/ocr_paddle_cli.py
+++ b/scinoephile/cli/ocr/ocr_paddle_cli.py
@@ -119,9 +119,7 @@ class OcrPaddleCli(ScinoephileCliBase):
             help="recognized subtitle outfile path",
         )
         arg_groups["output arguments"].add_argument(
-            "--overwrite",
-            action="store_true",
-            help="overwrite outfile if it exists",
+            "--overwrite", action="store_true", help="overwrite outfile if it exists"
         )
         parser.set_defaults(_parser=parser)
 

--- a/scinoephile/cli/ocr/ocr_tesseract_cli.py
+++ b/scinoephile/cli/ocr/ocr_tesseract_cli.py
@@ -77,8 +77,7 @@ class OcrTesseractCli(ScinoephileCliBase):
     """
 
     localizations = merge_localizations(
-        CACHE_LOCALIZATIONS,
-        OCR_TESSERACT_LOCALIZATIONS,
+        CACHE_LOCALIZATIONS, OCR_TESSERACT_LOCALIZATIONS
     )
     """Localized help text keyed by locale and English source text."""
 
@@ -137,9 +136,7 @@ class OcrTesseractCli(ScinoephileCliBase):
             help="recognized subtitle outfile path",
         )
         arg_groups["output arguments"].add_argument(
-            "--overwrite",
-            action="store_true",
-            help="overwrite outfile if it exists",
+            "--overwrite", action="store_true", help="overwrite outfile if it exists"
         )
         parser.set_defaults(_parser=parser)
 

--- a/scinoephile/cli/ocr/ocr_validate_cli.py
+++ b/scinoephile/cli/ocr/ocr_validate_cli.py
@@ -71,10 +71,7 @@ OCR_VALIDATE_LOCALIZATIONS: dict[str, dict[str, str]] = {
 class OcrValidateCli(ScinoephileCliBase):
     """Validate OCR text against subtitle images."""
 
-    localizations = merge_localizations(
-        WEB_LOCALIZATIONS,
-        OCR_VALIDATE_LOCALIZATIONS,
-    )
+    localizations = merge_localizations(WEB_LOCALIZATIONS, OCR_VALIDATE_LOCALIZATIONS)
     """Localized help text keyed by locale and English source text."""
 
     @classmethod
@@ -140,9 +137,7 @@ class OcrValidateCli(ScinoephileCliBase):
             help="validated subtitle outfile path",
         )
         arg_groups["output arguments"].add_argument(
-            "--overwrite",
-            action="store_true",
-            help="overwrite outfile if it exists",
+            "--overwrite", action="store_true", help="overwrite outfile if it exists"
         )
         parser.set_defaults(_parser=parser)
 

--- a/scinoephile/cli/process_cli.py
+++ b/scinoephile/cli/process_cli.py
@@ -21,10 +21,7 @@ from scinoephile.common.argument_parsing import (
 from scinoephile.core import Language, ScinoephileError
 from scinoephile.core.cli import ScinoephileCliBase
 from scinoephile.core.cli.localization import merge_localizations
-from scinoephile.lang.zho.script.conversion import (
-    OpenCCConfig,
-    get_zho_converted,
-)
+from scinoephile.lang.zho.script.conversion import OpenCCConfig, get_zho_converted
 from scinoephile.workflows.clean import clean_series
 from scinoephile.workflows.flatten import flatten_series
 from scinoephile.workflows.helpers import resolve_language
@@ -93,10 +90,7 @@ PROCESS_LOCALIZATIONS: dict[str, dict[str, str]] = {
 class ProcessCli(ScinoephileCliBase):
     """Process subtitles."""
 
-    localizations = merge_localizations(
-        CONVERSION_LOCALIZATIONS,
-        PROCESS_LOCALIZATIONS,
-    )
+    localizations = merge_localizations(CONVERSION_LOCALIZATIONS, PROCESS_LOCALIZATIONS)
     """Localized help text keyed by locale and English source text."""
 
     @classmethod
@@ -139,8 +133,7 @@ class ProcessCli(ScinoephileCliBase):
             help="clean subtitles of closed-caption annotations and other anomalies",
         )
         add_opencc_convert_auto_argument(
-            arg_groups["operation arguments"],
-            arg_groups["additional help"],
+            arg_groups["operation arguments"], arg_groups["additional help"]
         )
         arg_groups["operation arguments"].add_argument(
             "--flatten",
@@ -168,9 +161,7 @@ class ProcessCli(ScinoephileCliBase):
             help="subtitle outfile path (default: stdout)",
         )
         arg_groups["output arguments"].add_argument(
-            "--overwrite",
-            action="store_true",
-            help="overwrite outfile if it exists",
+            "--overwrite", action="store_true", help="overwrite outfile if it exists"
         )
         parser.set_defaults(_parser=parser)
 
@@ -224,11 +215,7 @@ class ProcessCli(ScinoephileCliBase):
         if flatten:
             series = flatten_series(series, language=resolved_language)
         if romanize:
-            series = romanize_series(
-                series,
-                language=resolved_language,
-                append=True,
-            )
+            series = romanize_series(series, language=resolved_language, append=True)
         if offset:
             series.shift(ms=offset)
 

--- a/scinoephile/cli/review_cli.py
+++ b/scinoephile/cli/review_cli.py
@@ -22,10 +22,7 @@ from scinoephile.core.cli import ScinoephileCliBase
 from scinoephile.core.cli.localization import merge_localizations
 from scinoephile.core.pairs import get_block_pair_indexes_by_pause
 from scinoephile.llms.providers.registry import get_provider
-from scinoephile.workflows.review import (
-    review_series,
-    review_series_guided,
-)
+from scinoephile.workflows.review import review_series, review_series_guided
 
 from .helpers.blocks import (
     BLOCK_LOCALIZATIONS,
@@ -154,9 +151,7 @@ class ReviewCli(ScinoephileCliBase):
             help="subtitle outfile path (default: stdout)",
         )
         arg_groups["output arguments"].add_argument(
-            "--overwrite",
-            action="store_true",
-            help="overwrite outfile if it exists",
+            "--overwrite", action="store_true", help="overwrite outfile if it exists"
         )
         parser.set_defaults(_parser=parser)
 
@@ -194,10 +189,7 @@ class ReviewCli(ScinoephileCliBase):
         else:
             block_count = len(series.blocks)
         start_at_idx, stop_at_idx = get_block_range_indexes(
-            parser,
-            first_block,
-            last_block,
-            block_count,
+            parser, first_block, last_block, block_count
         )
         provider = get_provider(llm_args.provider_name, model=llm_args.model_name)
         additional_context = read_llm_additional_context(

--- a/scinoephile/cli/scinoephile_cli.py
+++ b/scinoephile/cli/scinoephile_cli.py
@@ -123,17 +123,13 @@ class ScinoephileCli(ScinoephileCliBase):
         )
 
         subparsers = parser.add_subparsers(
-            dest="subcommand_name",
-            help="subcommand",
-            required=True,
+            dest="subcommand_name", help="subcommand", required=True
         )
         subcommands = cls.subcommands()
         for name in sorted(subcommands):
             subcommands[name].argparser(subparsers=subparsers)
         get_arg_groups_by_name(
-            parser,
-            "additional help",
-            optional_arguments_name="additional arguments",
+            parser, "additional help", optional_arguments_name="additional arguments"
         )
 
     @classmethod
@@ -157,12 +153,7 @@ class ScinoephileCli(ScinoephileCliBase):
         }
 
     @classmethod
-    def _main(
-        cls,
-        *,
-        subcommand_name: str,
-        **kwargs: Any,
-    ):
+    def _main(cls, *, subcommand_name: str, **kwargs: Any):
         """Execute with provided keyword arguments."""
         cls.subcommands()[subcommand_name]._main(**kwargs)
 

--- a/scinoephile/cli/transcribe_cli.py
+++ b/scinoephile/cli/transcribe_cli.py
@@ -242,9 +242,7 @@ class TranscribeCli(ScinoephileCliBase):
             help="subtitle outfile path (default: stdout)",
         )
         arg_groups["output arguments"].add_argument(
-            "--overwrite",
-            action="store_true",
-            help="overwrite outfile if it exists",
+            "--overwrite", action="store_true", help="overwrite outfile if it exists"
         )
         parser.set_defaults(_parser=parser)
 
@@ -281,10 +279,7 @@ class TranscribeCli(ScinoephileCliBase):
         # Read inputs
         guide = read_series(parser, guide_infile_path, allow_stdin=True)
         start_at_idx, stop_at_idx = get_block_range_indexes(
-            parser,
-            first_block,
-            last_block,
-            len(guide.blocks),
+            parser, first_block, last_block, len(guide.blocks)
         )
         try:
             if guide_infile_path == "-":
@@ -323,12 +318,10 @@ class TranscribeCli(ScinoephileCliBase):
                 cache_root_path=cache_args.root_path,
                 overwrite_cache=cache_args.overwrite,
                 provider=get_provider(
-                    llm_args.provider_name,
-                    model=llm_args.model_name,
+                    llm_args.provider_name, model=llm_args.model_name
                 ),
                 additional_context=read_llm_additional_context(
-                    parser,
-                    llm_args.additional_context_file_path,
+                    parser, llm_args.additional_context_file_path
                 ),
                 delineation_json_path=delineation_json_path,
                 punctuation_json_path=punctuation_json_path,

--- a/scinoephile/cli/translate_cli.py
+++ b/scinoephile/cli/translate_cli.py
@@ -187,9 +187,7 @@ class TranslateCli(ScinoephileCliBase):
             help="subtitle outfile path (default: stdout)",
         )
         arg_groups["output arguments"].add_argument(
-            "--overwrite",
-            action="store_true",
-            help="overwrite outfile if it exists",
+            "--overwrite", action="store_true", help="overwrite outfile if it exists"
         )
         parser.set_defaults(_parser=parser)
 
@@ -230,10 +228,7 @@ class TranslateCli(ScinoephileCliBase):
         else:
             block_count = len(source.blocks)
         start_at_idx, stop_at_idx = get_block_range_indexes(
-            parser,
-            first_block,
-            last_block,
-            block_count,
+            parser, first_block, last_block, block_count
         )
         kwargs: dict[str, Any] = {
             "source_language": source_language,

--- a/scinoephile/cli/utility/cache/cache_clear_cli.py
+++ b/scinoephile/cli/utility/cache/cache_clear_cli.py
@@ -82,8 +82,7 @@ class CacheClearCli(ScinoephileCliBase):
 
         # Operation arguments
         arg_groups["operation arguments"].add_argument(
-            "--namespace",
-            help="cache namespace to clear",
+            "--namespace", help="cache namespace to clear"
         )
         arg_groups["operation arguments"].add_argument(
             "--all",
@@ -103,9 +102,7 @@ class CacheClearCli(ScinoephileCliBase):
             help="maximum entries to print; use 0 to show all (default: %(default)s)",
         )
         arg_groups["operation arguments"].add_argument(
-            "--yes",
-            action="store_true",
-            help="confirm destructive deletion",
+            "--yes", action="store_true", help="confirm destructive deletion"
         )
         parser.set_defaults(_parser=parser)
 
@@ -151,9 +148,7 @@ class CacheClearCli(ScinoephileCliBase):
                     entries = get_cache_entries(cache_root_path, namespace=namespace)
             else:
                 entries = clear_cache(
-                    cache_root_path,
-                    namespace=namespace,
-                    all_namespaces=all_namespaces,
+                    cache_root_path, namespace=namespace, all_namespaces=all_namespaces
                 )
         except (NotADirectoryError, ScinoephileError) as exc:
             parser.error(str(exc))

--- a/scinoephile/cli/utility/cache/cache_cli.py
+++ b/scinoephile/cli/utility/cache/cache_cli.py
@@ -40,9 +40,7 @@ class CacheCli(ScinoephileCliBase):
         super().add_arguments_to_argparser(parser)
 
         subparsers = parser.add_subparsers(
-            dest="cache_subcommand_name",
-            help="subcommand",
-            required=True,
+            dest="cache_subcommand_name", help="subcommand", required=True
         )
         subcommands = cls.subcommands()
         for name in sorted(subcommands):
@@ -63,12 +61,7 @@ class CacheCli(ScinoephileCliBase):
         }
 
     @classmethod
-    def _main(
-        cls,
-        *,
-        cache_subcommand_name: str,
-        **kwargs: Any,
-    ):
+    def _main(cls, *, cache_subcommand_name: str, **kwargs: Any):
         """Execute with provided keyword arguments."""
         cls.subcommands()[cache_subcommand_name]._main(**kwargs)
 

--- a/scinoephile/cli/utility/cache/cache_list_cli.py
+++ b/scinoephile/cli/utility/cache/cache_list_cli.py
@@ -75,8 +75,7 @@ class CacheListCli(ScinoephileCliBase):
 
         # Operation arguments
         arg_groups["operation arguments"].add_argument(
-            "--namespace",
-            help="cache namespace to inspect",
+            "--namespace", help="cache namespace to inspect"
         )
         arg_groups["operation arguments"].add_argument(
             "--format",
@@ -97,9 +96,7 @@ class CacheListCli(ScinoephileCliBase):
             help="sort field",
         )
         arg_groups["operation arguments"].add_argument(
-            "--reverse",
-            action="store_true",
-            help="reverse sort order",
+            "--reverse", action="store_true", help="reverse sort order"
         )
         parser.set_defaults(_parser=parser)
 

--- a/scinoephile/cli/utility/cache/cache_prune_cli.py
+++ b/scinoephile/cli/utility/cache/cache_prune_cli.py
@@ -97,8 +97,7 @@ class CachePruneCli(ScinoephileCliBase):
             help="delete entries older than a duration such as 7d, 30d, or 12h",
         )
         arg_groups["operation arguments"].add_argument(
-            "--namespace",
-            help="cache namespace to inspect",
+            "--namespace", help="cache namespace to inspect"
         )
         arg_groups["operation arguments"].add_argument(
             "--dry-run",
@@ -112,9 +111,7 @@ class CachePruneCli(ScinoephileCliBase):
             help="maximum entries to print; use 0 to show all (default: %(default)s)",
         )
         arg_groups["operation arguments"].add_argument(
-            "--yes",
-            action="store_true",
-            help="confirm destructive deletion",
+            "--yes", action="store_true", help="confirm destructive deletion"
         )
         parser.set_defaults(_parser=parser)
 

--- a/scinoephile/cli/utility/cache/cache_stats_cli.py
+++ b/scinoephile/cli/utility/cache/cache_stats_cli.py
@@ -69,8 +69,7 @@ class CacheStatsCli(ScinoephileCliBase):
 
         # Operation arguments
         arg_groups["operation arguments"].add_argument(
-            "--namespace",
-            help="cache namespace to inspect",
+            "--namespace", help="cache namespace to inspect"
         )
         arg_groups["operation arguments"].add_argument(
             "--format",

--- a/scinoephile/cli/utility/cache/output.py
+++ b/scinoephile/cli/utility/cache/output.py
@@ -58,10 +58,7 @@ def format_cache_stats(stats: CacheStats) -> dict[str, Any]:
 
 
 def print_entries(
-    entries: list[CacheEntry],
-    output_format: str,
-    *,
-    limit: int | None = None,
+    entries: list[CacheEntry], output_format: str, *, limit: int | None = None
 ):
     """Print cache entries.
 

--- a/scinoephile/cli/utility/optimization/optimization_cli.py
+++ b/scinoephile/cli/utility/optimization/optimization_cli.py
@@ -48,9 +48,7 @@ class OptimizationCli(ScinoephileCliBase):
         super().add_arguments_to_argparser(parser)
 
         subparsers = parser.add_subparsers(
-            dest="optimization_subcommand_name",
-            help="subcommand",
-            required=True,
+            dest="optimization_subcommand_name", help="subcommand", required=True
         )
         subcommands = cls.subcommands()
         for name in sorted(subcommands):
@@ -69,12 +67,7 @@ class OptimizationCli(ScinoephileCliBase):
         }
 
     @classmethod
-    def _main(
-        cls,
-        *,
-        optimization_subcommand_name: str,
-        **kwargs: Any,
-    ):
+    def _main(cls, *, optimization_subcommand_name: str, **kwargs: Any):
         """Execute with provided keyword arguments."""
         cls.subcommands()[optimization_subcommand_name]._main(**kwargs)
 

--- a/scinoephile/cli/utility/optimization/optimization_prompts_cli.py
+++ b/scinoephile/cli/utility/optimization/optimization_prompts_cli.py
@@ -7,10 +7,7 @@ from __future__ import annotations
 from argparse import ArgumentParser
 from pathlib import Path
 
-from scinoephile.common.argument_parsing import (
-    get_arg_groups_by_name,
-    output_file_arg,
-)
+from scinoephile.common.argument_parsing import get_arg_groups_by_name, output_file_arg
 from scinoephile.core import ScinoephileError
 from scinoephile.core.cli import ScinoephileCliBase
 from scinoephile.optimization.persistence.prompts.sync import sync_prompts
@@ -133,11 +130,7 @@ class OptimizationSyncPromptsCli(ScinoephileCliBase):
         if not selected_prompt_specs:
             parser.error("One or more prompts must be selected.")
         try:
-            report = sync_prompts(
-                selected_prompt_specs,
-                outfile_path,
-                dry_run=dry_run,
-            )
+            report = sync_prompts(selected_prompt_specs, outfile_path, dry_run=dry_run)
         except ScinoephileError as exc:
             parser.error(str(exc))
 

--- a/scinoephile/cli/utility/optimization/optimization_test_cases_cli.py
+++ b/scinoephile/cli/utility/optimization/optimization_test_cases_cli.py
@@ -15,9 +15,7 @@ from scinoephile.common.argument_parsing import (
 from scinoephile.core import ScinoephileError
 from scinoephile.core.cli import ScinoephileCliBase
 from scinoephile.core.llms import Manager
-from scinoephile.optimization.persistence.test_cases.sync import (
-    sync_test_cases,
-)
+from scinoephile.optimization.persistence.test_cases.sync import sync_test_cases
 
 from .argument_types import operation_arg
 
@@ -138,10 +136,7 @@ class OptimizationSyncTestCasesCli(ScinoephileCliBase):
         # Perform operations
         try:
             report = sync_test_cases(
-                infile_paths,
-                outfile_path,
-                manager_cls,
-                dry_run=dry_run,
+                infile_paths, outfile_path, manager_cls, dry_run=dry_run
             )
         except ScinoephileError as exc:
             parser.error(str(exc))

--- a/scinoephile/cli/utility/utility_cli.py
+++ b/scinoephile/cli/utility/utility_cli.py
@@ -44,9 +44,7 @@ class UtilityCli(ScinoephileCliBase):
         super().add_arguments_to_argparser(parser)
 
         subparsers = parser.add_subparsers(
-            dest="utility_subcommand_name",
-            help="subcommand",
-            required=True,
+            dest="utility_subcommand_name", help="subcommand", required=True
         )
         subcommands = cls.subcommands()
         for name in sorted(subcommands):
@@ -59,18 +57,10 @@ class UtilityCli(ScinoephileCliBase):
         Returns:
             mapping of subcommand names to CLI classes
         """
-        return {
-            CacheCli.name(): CacheCli,
-            OptimizationCli.name(): OptimizationCli,
-        }
+        return {CacheCli.name(): CacheCli, OptimizationCli.name(): OptimizationCli}
 
     @classmethod
-    def _main(
-        cls,
-        *,
-        utility_subcommand_name: str,
-        **kwargs: Any,
-    ):
+    def _main(cls, *, utility_subcommand_name: str, **kwargs: Any):
         """Execute with provided keyword arguments."""
         cls.subcommands()[utility_subcommand_name]._main(**kwargs)
 

--- a/scinoephile/common/cli/__init__.py
+++ b/scinoephile/common/cli/__init__.py
@@ -12,7 +12,4 @@ from __future__ import annotations
 from .command_line_interface import CommandLineInterface
 from .list_all_commands_action import ListAllCommandsAction
 
-__all__ = [
-    "CommandLineInterface",
-    "ListAllCommandsAction",
-]
+__all__ = ["CommandLineInterface", "ListAllCommandsAction"]

--- a/scinoephile/common/cli/list_all_commands_action.py
+++ b/scinoephile/common/cli/list_all_commands_action.py
@@ -61,8 +61,7 @@ class ListAllCommandsAction(Action):
             option_string: option string used
         """
         parser._print_message(  # noqa: SLF001
-            f"{self.format_all_commands(self.root_cli_class)}\n",
-            sys.stdout,
+            f"{self.format_all_commands(self.root_cli_class)}\n", sys.stdout
         )
         parser.exit(0)
 
@@ -141,8 +140,7 @@ class ListAllCommandsAction(Action):
 
     @staticmethod
     def iter_command_rows(
-        cli: type[CommandLineInterface],
-        level: int = 0,
+        cli: type[CommandLineInterface], level: int = 0
     ) -> list[tuple[str, str]]:
         """Get all command names and descriptions below a CLI.
 

--- a/scinoephile/common/csv.py
+++ b/scinoephile/common/csv.py
@@ -4,10 +4,7 @@
 
 from __future__ import annotations
 
-__all__ = [
-    "parse_csv_int_list",
-    "parse_csv_str_list",
-]
+__all__ = ["parse_csv_int_list", "parse_csv_str_list"]
 
 
 def parse_csv_int_list(values: str, *, name: str) -> list[int]:

--- a/scinoephile/common/file.py
+++ b/scinoephile/common/file.py
@@ -68,9 +68,7 @@ def get_temp_file_path(suffix: str | None = None) -> Generator[Path]:
 
 @contextmanager
 def open_atomic_text_file(
-    output_path: Path,
-    *,
-    encoding: str = "utf-8",
+    output_path: Path, *, encoding: str = "utf-8"
 ) -> Generator[TextIO]:
     """Open a temporary text file that atomically replaces an output on success.
 

--- a/scinoephile/common/logs.py
+++ b/scinoephile/common/logs.py
@@ -11,11 +11,7 @@ from typing import TextIO
 DEFAULT_LOG_FORMAT = "%(levelname)s: %(name)s: %(message)s"
 """Default format for log messages."""
 
-__all__ = [
-    "DEFAULT_LOG_FORMAT",
-    "configure_logging",
-    "set_logging_verbosity",
-]
+__all__ = ["DEFAULT_LOG_FORMAT", "configure_logging", "set_logging_verbosity"]
 
 
 def configure_logging(verbosity: int = 1, log_format: str | None = None):

--- a/scinoephile/common/subprocess.py
+++ b/scinoephile/common/subprocess.py
@@ -116,12 +116,7 @@ def run_command_live(
     stderr_chunks = []
 
     with Popen(
-        command,
-        stdout=PIPE,
-        stderr=PIPE,
-        cwd=cwd_path,
-        env=env,
-        bufsize=0,
+        command, stdout=PIPE, stderr=PIPE, cwd=cwd_path, env=env, bufsize=0
     ) as child:
         assert child.stdout is not None
         assert child.stderr is not None
@@ -287,7 +282,4 @@ def _wait_for_live_process(
     return exitcode
 
 
-__all__ = [
-    "run_command",
-    "run_command_live",
-]
+__all__ = ["run_command", "run_command_live"]

--- a/scinoephile/common/testing.py
+++ b/scinoephile/common/testing.py
@@ -14,10 +14,7 @@ from unittest.mock import patch
 
 from .command_line_interface import CommandLineInterface
 
-__all__ = [
-    "echo_command",
-    "run_cli_with_args",
-]
+__all__ = ["echo_command", "run_cli_with_args"]
 
 
 def echo_command(*arguments: str) -> list[str]:

--- a/scinoephile/common/validation.py
+++ b/scinoephile/common/validation.py
@@ -39,10 +39,7 @@ __all__ = [
 logger = getLogger(__name__)
 
 
-def val_child_path(
-    parent_dir_path: str | PathLike[str],
-    child_name: str,
-) -> Path:
+def val_child_path(parent_dir_path: str | PathLike[str], child_name: str) -> Path:
     """Validate that a child name resolves within a parent directory.
 
     Arguments:
@@ -197,9 +194,7 @@ def val_float(
 
 
 def val_index_range(
-    item_count: int,
-    start_at_idx: int = 0,
-    stop_at_idx: int | None = None,
+    item_count: int, start_at_idx: int = 0, stop_at_idx: int | None = None
 ) -> range:
     """Validate and construct a zero-based processing range.
 
@@ -295,9 +290,7 @@ def val_input_file_or_dir_path(value: str | PathLike[str]) -> Path: ...
 
 
 @overload
-def val_input_file_or_dir_path(
-    value: Iterable[str | PathLike[str]],
-) -> list[Path]: ...
+def val_input_file_or_dir_path(value: Iterable[str | PathLike[str]]) -> list[Path]: ...
 
 
 def val_input_file_or_dir_path(
@@ -315,9 +308,7 @@ def val_input_file_or_dir_path(
         ValueError: If any path is neither a file nor a directory
     """
 
-    def _val_input_file_or_dir_path(
-        value_to_validate: str | PathLike[str],
-    ) -> Path:
+    def _val_input_file_or_dir_path(value_to_validate: str | PathLike[str]) -> Path:
         """Validate a path.
 
         Arguments:
@@ -514,8 +505,7 @@ def val_output_dir_path(
 
 
 def val_output_dir_path(
-    value: str | PathLike[str] | Iterable[str | PathLike[str]],
-    create: bool = True,
+    value: str | PathLike[str] | Iterable[str | PathLike[str]], create: bool = True
 ) -> Path | list[Path]:
     """Validate output directory path(s), make them absolute, and create them if needed.
 
@@ -595,17 +585,13 @@ def val_output_dir_path(
 
 @overload
 def val_output_path(
-    value: str | PathLike[str],
-    exist_ok: bool = False,
-    create: bool = True,
+    value: str | PathLike[str], exist_ok: bool = False, create: bool = True
 ) -> Path: ...
 
 
 @overload
 def val_output_path(
-    value: Iterable[str | PathLike[str]],
-    exist_ok: bool = False,
-    create: bool = True,
+    value: Iterable[str | PathLike[str]], exist_ok: bool = False, create: bool = True
 ) -> list[Path]: ...
 
 

--- a/scinoephile/core/__init__.py
+++ b/scinoephile/core/__init__.py
@@ -15,8 +15,4 @@ from __future__ import annotations
 from .exceptions import ScinoephileError, UnsupportedCharacterError
 from .language import Language
 
-__all__ = [
-    "Language",
-    "ScinoephileError",
-    "UnsupportedCharacterError",
-]
+__all__ = ["Language", "ScinoephileError", "UnsupportedCharacterError"]

--- a/scinoephile/core/cache/__init__.py
+++ b/scinoephile/core/cache/__init__.py
@@ -12,7 +12,4 @@ from __future__ import annotations
 from .cache_entry import CacheEntry
 from .cache_stats import CacheStats
 
-__all__ = [
-    "CacheEntry",
-    "CacheStats",
-]
+__all__ = ["CacheEntry", "CacheStats"]

--- a/scinoephile/core/cache/operations.py
+++ b/scinoephile/core/cache/operations.py
@@ -53,13 +53,10 @@ def clear_cache(
 
     discovered_namespace_names = discover_cache_namespaces(cache_root_path)
     namespace_names = _get_namespace_names(
-        discovered_namespace_names,
-        namespace=namespace,
+        discovered_namespace_names, namespace=namespace
     )
     entries = _get_cache_entries(
-        cache_root_path,
-        namespace_names,
-        discovered_namespace_names,
+        cache_root_path, namespace_names, discovered_namespace_names
     )
     for entry in entries:
         _delete_entry(entry.path)
@@ -81,10 +78,7 @@ def clear_cache(
             for protected_namespace_path in protected_namespace_paths
         ):
             continue
-        namespace_dir_path = _get_namespace_dir_path(
-            cache_root_path,
-            namespace_name,
-        )
+        namespace_dir_path = _get_namespace_dir_path(cache_root_path, namespace_name)
         if namespace_dir_path.exists():
             _delete_entry(namespace_dir_path)
 
@@ -135,15 +129,13 @@ def discover_cache_namespaces(cache_root_path: Path) -> list[str]:
 
     # Add recognized namespaces nested beneath another namespace
     for nested_namespace_name in sorted(
-        _NESTED_CACHE_NAMESPACE_NAMES,
-        key=lambda name: len(PurePosixPath(name).parts),
+        _NESTED_CACHE_NAMESPACE_NAMES, key=lambda name: len(PurePosixPath(name).parts)
     ):
         nested_namespace_path = PurePosixPath(nested_namespace_name)
         if nested_namespace_path.parent.as_posix() not in namespace_names:
             continue
         nested_namespace_dir_path = _get_namespace_dir_path(
-            cache_root_path,
-            nested_namespace_name,
+            cache_root_path, nested_namespace_name
         )
         if (
             nested_namespace_dir_path.is_dir()
@@ -168,13 +160,10 @@ def get_cache_entries(
     """
     discovered_namespace_names = discover_cache_namespaces(cache_root_path)
     namespace_names = _get_namespace_names(
-        discovered_namespace_names,
-        namespace=namespace,
+        discovered_namespace_names, namespace=namespace
     )
     return _get_cache_entries(
-        cache_root_path,
-        namespace_names,
-        discovered_namespace_names,
+        cache_root_path, namespace_names, discovered_namespace_names
     )
 
 
@@ -191,13 +180,10 @@ def get_cache_stats(
     """
     discovered_namespace_names = discover_cache_namespaces(cache_root_path)
     namespace_names = _get_namespace_names(
-        discovered_namespace_names,
-        namespace=namespace,
+        discovered_namespace_names, namespace=namespace
     )
     entries = _get_cache_entries(
-        cache_root_path,
-        namespace_names,
-        discovered_namespace_names,
+        cache_root_path, namespace_names, discovered_namespace_names
     )
     stats = [
         _aggregate_cache_stats(
@@ -225,15 +211,12 @@ def prune_cache(
     cutoff = datetime.now().astimezone() - older_than
     discovered_namespace_names = discover_cache_namespaces(cache_root_path)
     namespace_names = _get_namespace_names(
-        discovered_namespace_names,
-        namespace=namespace,
+        discovered_namespace_names, namespace=namespace
     )
     entries = [
         entry
         for entry in _get_cache_entries(
-            cache_root_path,
-            namespace_names,
-            discovered_namespace_names,
+            cache_root_path, namespace_names, discovered_namespace_names
         )
         if entry.modified_at < cutoff
     ]
@@ -328,10 +311,7 @@ def _get_cache_entries(
     entries = []
     for namespace_name in namespace_names:
         namespace_path = PurePosixPath(namespace_name)
-        namespace_dir_path = _get_namespace_dir_path(
-            cache_root_path,
-            namespace_name,
-        )
+        namespace_dir_path = _get_namespace_dir_path(cache_root_path, namespace_name)
         nested_namespace_dir_names = {
             discovered_namespace_path.name
             for discovered_namespace_path in discovered_namespace_paths
@@ -346,10 +326,7 @@ def _get_cache_entries(
     return entries
 
 
-def _get_namespace_dir_path(
-    cache_root_path: Path,
-    namespace_name: str,
-) -> Path:
+def _get_namespace_dir_path(cache_root_path: Path, namespace_name: str) -> Path:
     """Get a namespace directory path from its portable name.
 
     Arguments:
@@ -362,9 +339,7 @@ def _get_namespace_dir_path(
 
 
 def _get_namespace_names(
-    discovered_namespace_names: list[str],
-    *,
-    namespace: str | None,
+    discovered_namespace_names: list[str], *, namespace: str | None
 ) -> list[str]:
     """Filter discovered namespace names.
 

--- a/scinoephile/core/cli/constants.py
+++ b/scinoephile/core/cli/constants.py
@@ -4,11 +4,7 @@
 
 from __future__ import annotations
 
-__all__ = [
-    "DEFAULT_CLI_LOCALE",
-    "LOCALE_ALIASES",
-    "SUPPORTED_CLI_LOCALES",
-]
+__all__ = ["DEFAULT_CLI_LOCALE", "LOCALE_ALIASES", "SUPPORTED_CLI_LOCALES"]
 
 DEFAULT_CLI_LOCALE = "en"
 SUPPORTED_CLI_LOCALES = ("en", "zh-hans", "zh-hant")

--- a/scinoephile/core/cli/localization.py
+++ b/scinoephile/core/cli/localization.py
@@ -4,10 +4,7 @@
 
 from __future__ import annotations
 
-__all__ = [
-    "BASE_CLI_LOCALIZATIONS",
-    "merge_localizations",
-]
+__all__ = ["BASE_CLI_LOCALIZATIONS", "merge_localizations"]
 
 BASE_CLI_LOCALIZATIONS: dict[str, dict[str, str]] = {
     "zh-hans": {

--- a/scinoephile/core/dependencies/ocr.py
+++ b/scinoephile/core/dependencies/ocr.py
@@ -7,10 +7,7 @@ from __future__ import annotations
 
 from types import ModuleType
 
-__all__ = [
-    "import_chrome_lens_py",
-    "import_paddleocr",
-]
+__all__ = ["import_chrome_lens_py", "import_paddleocr"]
 
 _OCR_EXTRA_MESSAGE = (
     "OCR support requires optional OCR dependencies. Install scinoephile with the "

--- a/scinoephile/core/dependencies/web.py
+++ b/scinoephile/core/dependencies/web.py
@@ -8,10 +8,7 @@ from __future__ import annotations
 from types import ModuleType
 from typing import TYPE_CHECKING
 
-__all__ = [
-    "import_flask",
-    "import_werkzeug_serving",
-]
+__all__ = ["import_flask", "import_werkzeug_serving"]
 
 if TYPE_CHECKING:
     from flask import Flask, Response

--- a/scinoephile/core/dictionaries/serialization.py
+++ b/scinoephile/core/dictionaries/serialization.py
@@ -7,10 +7,7 @@ from __future__ import annotations
 from .dictionary_definition import DictionaryDefinition
 from .dictionary_entry import DictionaryEntry
 
-__all__ = [
-    "dictionary_definition_to_dict",
-    "dictionary_entry_to_dict",
-]
+__all__ = ["dictionary_definition_to_dict", "dictionary_entry_to_dict"]
 
 
 def dictionary_definition_to_dict(definition: DictionaryDefinition) -> dict[str, str]:
@@ -21,10 +18,7 @@ def dictionary_definition_to_dict(definition: DictionaryDefinition) -> dict[str,
     Returns:
         serialized dictionary definition
     """
-    return {
-        "label": definition.label,
-        "text": definition.text,
-    }
+    return {"label": definition.label, "text": definition.text}
 
 
 def dictionary_entry_to_dict(

--- a/scinoephile/core/dictionaries/sqlite_store.py
+++ b/scinoephile/core/dictionaries/sqlite_store.py
@@ -91,14 +91,10 @@ class DictionarySqliteStore:
         Column("definition", Text),
         Column("label", Text),
         Column(
-            "fk_entry_id",
-            Integer,
-            ForeignKey("entries.entry_id", onupdate="CASCADE"),
+            "fk_entry_id", Integer, ForeignKey("entries.entry_id", onupdate="CASCADE")
         ),
         Column(
-            "fk_source_id",
-            Integer,
-            ForeignKey("sources.source_id", ondelete="CASCADE"),
+            "fk_source_id", Integer, ForeignKey("sources.source_id", ondelete="CASCADE")
         ),
         UniqueConstraint(
             "definition",
@@ -147,9 +143,7 @@ class DictionarySqliteStore:
         Column("sentence", Text),
         Column("language", Text),
         UniqueConstraint(
-            "non_chinese_sentence_id",
-            "sentence",
-            sqlite_on_conflict="IGNORE",
+            "non_chinese_sentence_id", "sentence", sqlite_on_conflict="IGNORE"
         ),
     )
     """Non-Chinese sentence compatibility table."""
@@ -168,9 +162,7 @@ class DictionarySqliteStore:
             ForeignKey("nonchinese_sentences.non_chinese_sentence_id"),
         ),
         Column(
-            "fk_source_id",
-            Integer,
-            ForeignKey("sources.source_id", ondelete="CASCADE"),
+            "fk_source_id", Integer, ForeignKey("sources.source_id", ondelete="CASCADE")
         ),
         Column("direct", Boolean),
         UniqueConstraint(
@@ -195,9 +187,7 @@ class DictionarySqliteStore:
             ForeignKey("chinese_sentences.chinese_sentence_id"),
         ),
         UniqueConstraint(
-            "fk_definition_id",
-            "fk_chinese_sentence_id",
-            sqlite_on_conflict="IGNORE",
+            "fk_definition_id", "fk_chinese_sentence_id", sqlite_on_conflict="IGNORE"
         ),
     )
     """Definition-to-sentence compatibility table."""
@@ -308,8 +298,7 @@ class DictionarySqliteStore:
         return self._fetch_entries(entry_ids)
 
     def persist(
-        self,
-        source_data: tuple[DictionarySource, list[DictionaryEntry]],
+        self, source_data: tuple[DictionarySource, list[DictionaryEntry]]
     ) -> Path:
         """Persist dictionary data to SQLite.
 
@@ -321,8 +310,7 @@ class DictionarySqliteStore:
         source, entries = source_data
         self.database_path.parent.mkdir(parents=True, exist_ok=True)
         with TemporaryDirectory(
-            dir=self.database_path.parent,
-            prefix=f".{self.database_path.name}.",
+            dir=self.database_path.parent, prefix=f".{self.database_path.name}."
         ) as temporary_dir_name:
             temporary_database_path = Path(temporary_dir_name) / self.database_path.name
             temporary_engine = self._create_engine(temporary_database_path)
@@ -336,10 +324,7 @@ class DictionarySqliteStore:
                         entry_id = self._insert_entry(connection, entry)
                         for definition in entry.definitions:
                             self._insert_definition(
-                                connection,
-                                definition,
-                                entry_id,
-                                source_id,
+                                connection, definition, entry_id, source_id
                             )
 
                     self._generate_indices(connection)
@@ -382,8 +367,7 @@ class DictionarySqliteStore:
             if definition is not None:
                 definitions_map[entry_id].append(
                     DictionaryDefinition(
-                        text=str(definition),
-                        label="" if label is None else str(label),
+                        text=str(definition), label="" if label is None else str(label)
                     )
                 )
 
@@ -463,10 +447,7 @@ class DictionarySqliteStore:
             poolclass=NullPool,
         )
 
-    def _fetch_entries(
-        self,
-        entry_ids: list[int],
-    ) -> list[DictionaryEntry]:
+    def _fetch_entries(self, entry_ids: list[int]) -> list[DictionaryEntry]:
         """Fetch entry rows and definitions for selected entry IDs.
 
         Arguments:
@@ -649,7 +630,7 @@ class DictionarySqliteStore:
                 link=source.link,
                 update_url=source.update_url,
                 other=source.other,
-            ),
+            )
         )
         inserted_primary_key = result.inserted_primary_key
         if not inserted_primary_key:

--- a/scinoephile/core/exceptions.py
+++ b/scinoephile/core/exceptions.py
@@ -4,10 +4,7 @@
 
 from __future__ import annotations
 
-__all__ = [
-    "ScinoephileError",
-    "UnsupportedCharacterError",
-]
+__all__ = ["ScinoephileError", "UnsupportedCharacterError"]
 
 
 class ScinoephileError(Exception):

--- a/scinoephile/core/language.py
+++ b/scinoephile/core/language.py
@@ -8,11 +8,7 @@ from scinoephile.common.described_enum import DescribedEnum
 
 from .text import ChineseScript
 
-__all__ = [
-    "Language",
-    "is_chinese_language_tag",
-    "normalize_language_tag",
-]
+__all__ = ["Language", "is_chinese_language_tag", "normalize_language_tag"]
 
 _CHINESE_LANGUAGE_CODES = {"chi", "zho", "yue"}
 """Language codes treated as Chinese."""

--- a/scinoephile/core/llms/answer.py
+++ b/scinoephile/core/llms/answer.py
@@ -22,8 +22,4 @@ class Answer(LLMModel, ABC):
 
     def __str__(self) -> str:
         """String representation."""
-        return json.dumps(
-            self.model_dump(by_alias=True),
-            indent=2,
-            ensure_ascii=False,
-        )
+        return json.dumps(self.model_dump(by_alias=True), indent=2, ensure_ascii=False)

--- a/scinoephile/core/llms/cache.py
+++ b/scinoephile/core/llms/cache.py
@@ -25,10 +25,7 @@ class LlmCache:
     """Cache of LLM response payloads."""
 
     def __init__(
-        self,
-        cache_root_path: Path | None,
-        operation: str,
-        overwrite: bool = False,
+        self, cache_root_path: Path | None, operation: str, overwrite: bool = False
     ):
         """Initialize.
 
@@ -56,11 +53,7 @@ class LlmCache:
         """Cache paths refreshed by this cache instance."""
 
     def get_path(
-        self,
-        identity: object,
-        system_prompt: str,
-        tools_json: str,
-        query_json: str,
+        self, identity: object, system_prompt: str, tools_json: str, query_json: str
     ) -> Path:
         """Get a cache path based on query identity and prompts.
 
@@ -73,10 +66,7 @@ class LlmCache:
             path to cache file
         """
         identity_json = json.dumps(
-            {
-                "cache_version": _CACHE_VERSION,
-                "identity": identity,
-            },
+            {"cache_version": _CACHE_VERSION, "identity": identity},
             ensure_ascii=True,
             separators=(",", ":"),
             sort_keys=True,

--- a/scinoephile/core/llms/llm_provider.py
+++ b/scinoephile/core/llms/llm_provider.py
@@ -12,10 +12,7 @@ from pydantic import JsonValue
 from .answer import Answer
 from .tool_box import ToolBox
 
-__all__ = [
-    "ChatCompletionKwargs",
-    "LLMProvider",
-]
+__all__ = ["ChatCompletionKwargs", "LLMProvider"]
 
 
 class ChatCompletionKwargs(TypedDict, total=False):

--- a/scinoephile/core/llms/manager.py
+++ b/scinoephile/core/llms/manager.py
@@ -19,10 +19,7 @@ from .prompt import Prompt
 from .query import Query
 from .test_case import TestCase
 
-__all__ = [
-    "Manager",
-    "PromptModelField",
-]
+__all__ = ["Manager", "PromptModelField"]
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)

--- a/scinoephile/core/llms/models.py
+++ b/scinoephile/core/llms/models.py
@@ -11,11 +11,7 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, ValidationInfo, model_validator
 from pydantic_core import PydanticCustomError
 
-__all__ = [
-    "LLMModel",
-    "get_model_name",
-    "make_hashable",
-]
+__all__ = ["LLMModel", "get_model_name", "make_hashable"]
 
 
 class LLMModel(BaseModel):
@@ -58,9 +54,7 @@ class LLMModel(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def require_aliases_at_json_boundaries(
-        cls,
-        value: object,
-        info: ValidationInfo,
+        cls, value: object, info: ValidationInfo
     ) -> object:
         """Reject semantic field names at alias-only JSON boundaries.
 

--- a/scinoephile/core/llms/openai_provider_base.py
+++ b/scinoephile/core/llms/openai_provider_base.py
@@ -81,10 +81,7 @@ class OpenAIProviderBase(LLMProvider):
         if base_url is None:
             base_url = self.base_url
         if base_url is None:
-            base_url = os.environ.get(
-                "OPENAI_BASE_URL",
-                "https://api.openai.com/v1",
-            )
+            base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
         if base_url is not None:
             base_url = base_url.rstrip("/")
         identity.update(
@@ -213,9 +210,7 @@ class OpenAIProviderBase(LLMProvider):
         ]
 
     def _query(
-        self,
-        messages: list[dict[str, Any]],
-        request_kwargs: dict[str, Any],
+        self, messages: list[dict[str, Any]], request_kwargs: dict[str, Any]
     ) -> Any:
         """Query provider for completion.
 

--- a/scinoephile/core/llms/processor.py
+++ b/scinoephile/core/llms/processor.py
@@ -16,10 +16,7 @@ from .test_case import TestCase
 from .tool_box import ToolBox
 from .utils import load_test_cases, save_test_cases_to_json
 
-__all__ = [
-    "Processor",
-    "ProcessorKwargs",
-]
+__all__ = ["Processor", "ProcessorKwargs"]
 
 
 class ProcessorKwargs(TypedDict, total=False):

--- a/scinoephile/core/llms/prompt.py
+++ b/scinoephile/core/llms/prompt.py
@@ -12,10 +12,7 @@ from typing import Self, TypedDict
 
 from scinoephile.core.language import Language
 
-__all__ = [
-    "Prompt",
-    "SharedPromptLocalizationFields",
-]
+__all__ = ["Prompt", "SharedPromptLocalizationFields"]
 
 
 class SharedPromptLocalizationFields(TypedDict):

--- a/scinoephile/core/llms/query.py
+++ b/scinoephile/core/llms/query.py
@@ -22,11 +22,7 @@ class Query(LLMModel, ABC):
 
     def __str__(self) -> str:
         """String representation."""
-        return json.dumps(
-            self.model_dump(by_alias=True),
-            indent=2,
-            ensure_ascii=False,
-        )
+        return json.dumps(self.model_dump(by_alias=True), indent=2, ensure_ascii=False)
 
     @property
     def key(self) -> tuple:

--- a/scinoephile/core/llms/queryer.py
+++ b/scinoephile/core/llms/queryer.py
@@ -72,9 +72,7 @@ class Queryer[TTestCase: TestCase]:
         """Test cases actually encountered."""
 
         self._cache = LlmCache(
-            cache_root_path,
-            self.test_case_cls.operation,
-            overwrite_cache,
+            cache_root_path, self.test_case_cls.operation, overwrite_cache
         )
         """LLM response cache."""
 
@@ -109,11 +107,7 @@ class Queryer[TTestCase: TestCase]:
         # Load from cache if available
         query_json = test_case.query.model_dump_json(by_alias=True, indent=4)
         tools_json = self.tool_box.to_json()
-        cache_path = self._get_cache_path(
-            self.system_prompt,
-            tools_json,
-            query_json,
-        )
+        cache_path = self._get_cache_path(self.system_prompt, tools_json, query_json)
         if cached_test_case := self._get_cached_test_case(test_case, cache_path):
             return cached_test_case
 
@@ -211,10 +205,7 @@ class Queryer[TTestCase: TestCase]:
         self.log_encountered_test_case(test_case)
 
         # Update cache
-        contents = test_case.answer.model_dump_json(
-            exclude_defaults=True,
-            indent=2,
-        )
+        contents = test_case.answer.model_dump_json(exclude_defaults=True, indent=2)
         self._cache.save(cache_path, contents)
 
         return test_case
@@ -227,15 +218,9 @@ class Queryer[TTestCase: TestCase]:
         for test_case in self.few_shot_test_cases.values():
             assert test_case.answer is not None
             few_shot += f"\n\n{self.prompt.few_shot_query_intro}\n"
-            few_shot += test_case.query.model_dump_json(
-                by_alias=True,
-                indent=4,
-            )
+            few_shot += test_case.query.model_dump_json(by_alias=True, indent=4)
             few_shot += f"\n{self.prompt.few_shot_answer_intro}\n"
-            few_shot += test_case.answer.model_dump_json(
-                by_alias=True,
-                indent=4,
-            )
+            few_shot += test_case.answer.model_dump_json(by_alias=True, indent=4)
         return few_shot
 
     def log_encountered_test_case(self, test_case: TestCase):
@@ -279,9 +264,7 @@ class Queryer[TTestCase: TestCase]:
         )
 
     def _get_cached_test_case(
-        self,
-        test_case: TTestCase,
-        cache_path: Path,
+        self, test_case: TTestCase, cache_path: Path
     ) -> TTestCase | None:
         """Get cached test case for the given query if available.
 
@@ -332,8 +315,7 @@ class Queryer[TTestCase: TestCase]:
         return None
 
     def _get_verified_test_cases(
-        self,
-        test_cases: list[TestCase],
+        self, test_cases: list[TestCase]
     ) -> dict[tuple, TTestCase]:
         """Snapshot, validate, and merge verified test cases.
 

--- a/scinoephile/core/llms/test_case.py
+++ b/scinoephile/core/llms/test_case.py
@@ -37,18 +37,15 @@ class TestCase(LLMModel, ABC):
     answer: Answer | None = None
     """Answer data for the test case."""
     difficulty: int = Field(
-        0,
-        description="Difficulty level of the test case, used for filtering.",
+        0, description="Difficulty level of the test case, used for filtering."
     )
     """Difficulty level for filtering and prioritization."""
     few_shot: bool = Field(
-        False,
-        description="Whether to include test case in few-shot examples.",
+        False, description="Whether to include test case in few-shot examples."
     )
     """Whether the test case is included as a few-shot example."""
     verified: bool = Field(
-        False,
-        description="Whether to include test case in the verified answers cache.",
+        False, description="Whether to include test case in the verified answers cache."
     )
     """Whether the test case answer has been verified."""
 

--- a/scinoephile/core/llms/test_case_subtitle.py
+++ b/scinoephile/core/llms/test_case_subtitle.py
@@ -8,10 +8,7 @@ from pydantic import Field
 
 from .models import LLMModel
 
-__all__ = [
-    "AnnotatedTestCaseSubtitle",
-    "TestCaseSubtitle",
-]
+__all__ = ["AnnotatedTestCaseSubtitle", "TestCaseSubtitle"]
 
 
 class TestCaseSubtitle(LLMModel):

--- a/scinoephile/core/llms/tool_box.py
+++ b/scinoephile/core/llms/tool_box.py
@@ -47,9 +47,7 @@ class ToolBox:
             for tool in sorted(
                 self._tools_by_name.values(),
                 key=lambda tool: json.dumps(
-                    tool.spec,
-                    ensure_ascii=False,
-                    sort_keys=True,
+                    tool.spec, ensure_ascii=False, sort_keys=True
                 ),
             )
         ]
@@ -93,8 +91,7 @@ class ToolBox:
             return {"error": f"Unsupported tool '{tool_name}'."}
 
         parsed_arguments = self._parse_arguments(
-            tool_name=tool_name,
-            raw_arguments=raw_arguments,
+            tool_name=tool_name, raw_arguments=raw_arguments
         )
         if isinstance(parsed_arguments, dict) and "error" in parsed_arguments:
             return parsed_arguments
@@ -106,10 +103,7 @@ class ToolBox:
         if not self:
             return ""
         return json.dumps(
-            {
-                "handler_names": self.handler_names,
-                "tools": self.specs,
-            },
+            {"handler_names": self.handler_names, "tools": self.specs},
             ensure_ascii=False,
             sort_keys=True,
         )

--- a/scinoephile/core/llms/utils.py
+++ b/scinoephile/core/llms/utils.py
@@ -18,11 +18,7 @@ from .manager import Manager
 from .prompt import Prompt
 from .test_case import TestCase
 
-__all__ = [
-    "load_test_cases",
-    "load_test_cases_from_json",
-    "save_test_cases_to_json",
-]
+__all__ = ["load_test_cases", "load_test_cases_from_json", "save_test_cases_to_json"]
 
 
 def load_test_cases[TTestCase: TestCase](
@@ -52,19 +48,13 @@ def load_test_cases[TTestCase: TestCase](
         test_case.query.key: test_case for test_case in test_cases
     }
     if test_case_path is not None and test_case_path.exists():
-        for test_case in load_test_cases_from_json(
-            test_case_path,
-            manager_cls,
-            prompt,
-        ):
+        for test_case in load_test_cases_from_json(test_case_path, manager_cls, prompt):
             test_cases_by_query_key[test_case.query.key] = test_case
     return list(test_cases_by_query_key.values()), test_case_path
 
 
 def load_test_cases_from_json[TTestCase: TestCase](
-    input_path: Path,
-    manager_cls: type[Manager[TTestCase]],
-    prompt: Prompt,
+    input_path: Path, manager_cls: type[Manager[TTestCase]], prompt: Prompt
 ) -> list[TTestCase]:
     """Load test cases from JSON file.
 
@@ -124,9 +114,7 @@ def save_test_cases_to_json[TTestCase: TestCase](
     test_cases_to_save = list(test_cases)
     if output_path.exists() and not prune:
         existing_test_cases = load_test_cases_from_json(
-            output_path,
-            manager_cls,
-            manager_cls.base_prompt,
+            output_path, manager_cls, manager_cls.base_prompt
         )
         encountered_query_keys = {
             test_case.query.key for test_case in test_cases_to_save
@@ -144,11 +132,7 @@ def save_test_cases_to_json[TTestCase: TestCase](
             test_case.model_dump(mode="json")
         )
         data.append(
-            base_test_case.model_dump(
-                mode="json",
-                by_alias=True,
-                exclude_defaults=True,
-            )
+            base_test_case.model_dump(mode="json", by_alias=True, exclude_defaults=True)
         )
     output_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/scinoephile/core/media/__init__.py
+++ b/scinoephile/core/media/__init__.py
@@ -14,9 +14,4 @@ from .stream import Stream
 from .subtitle_stream import SubtitleStream
 from .video_stream import VideoStream
 
-__all__ = [
-    "AudioStream",
-    "Stream",
-    "SubtitleStream",
-    "VideoStream",
-]
+__all__ = ["AudioStream", "Stream", "SubtitleStream", "VideoStream"]

--- a/scinoephile/core/pairs.py
+++ b/scinoephile/core/pairs.py
@@ -18,9 +18,7 @@ __all__ = [
 
 
 def get_block_pair_indexes_by_pause(
-    one: Series,
-    two: Series,
-    pause_length: int = 3000,
+    one: Series, two: Series, pause_length: int = 3000
 ) -> list[tuple[tuple[int, int], tuple[int, int]]]:
     """Get indexes of paired blocks split by pauses without text in either series.
 
@@ -76,9 +74,7 @@ def get_block_pair_indexes_by_pause(
 
 
 def get_block_pairs_by_pause(
-    one: Series,
-    two: Series,
-    pause_length: int = 3000,
+    one: Series, two: Series, pause_length: int = 3000
 ) -> list[tuple[Series, Series]]:
     """Split a pair of series into blocks using pauses without text in either.
 
@@ -91,9 +87,7 @@ def get_block_pairs_by_pause(
     """
     blocks = []
     for one_indexes, two_indexes in get_block_pair_indexes_by_pause(
-        one,
-        two,
-        pause_length,
+        one, two, pause_length
     ):
         block_one = one.__class__()
         block_two = two.__class__()

--- a/scinoephile/core/paths.py
+++ b/scinoephile/core/paths.py
@@ -11,10 +11,7 @@ from tempfile import gettempdir
 
 from scinoephile.common.validation import val_output_dir_path
 
-__all__ = [
-    "get_runtime_cache_root_path",
-    "get_runtime_data_root_path",
-]
+__all__ = ["get_runtime_cache_root_path", "get_runtime_data_root_path"]
 
 
 def get_runtime_cache_root_path(*, create: bool = True) -> Path:

--- a/scinoephile/core/romanization.py
+++ b/scinoephile/core/romanization.py
@@ -91,9 +91,7 @@ def normalize_romanized_punctuation(text: str) -> str:
 
 
 def _get_symmetric_quote_roles(
-    tokens: list[str],
-    open_quotes: set[str],
-    token_kinds: list[RomanizedTokenKind],
+    tokens: list[str], open_quotes: set[str], token_kinds: list[RomanizedTokenKind]
 ) -> list[Literal["closing", "infix", "opening"] | None]:
     """Get spacing roles for straight quote tokens.
 
@@ -142,10 +140,7 @@ def _is_romanized_punctuation_char(char: str) -> bool:
     )
 
 
-def _is_infix_quote_context(
-    index: int,
-    token_kinds: list[RomanizedTokenKind],
-) -> bool:
+def _is_infix_quote_context(index: int, token_kinds: list[RomanizedTokenKind]) -> bool:
     """Check whether a single quote joins raw text tokens.
 
     Arguments:

--- a/scinoephile/core/stacking.py
+++ b/scinoephile/core/stacking.py
@@ -15,11 +15,7 @@ from .pairs import get_block_pairs_by_pause, get_pair_strings
 from .subtitles import Series, Subtitle, get_concatenated_series
 from .synchronization import SyncGroup, get_sync_groups
 
-__all__ = [
-    "StackTimingMode",
-    "get_stacked_series",
-    "get_stacked_series_from_groups",
-]
+__all__ = ["StackTimingMode", "get_stacked_series", "get_stacked_series_from_groups"]
 
 logger = getLogger(__name__)
 
@@ -226,9 +222,7 @@ def _get_series_without_overlaps(series: Series) -> Series:
 
 
 def _get_stack_group_interval(
-    one_subs: list[Subtitle],
-    two_subs: list[Subtitle],
-    timing_mode: StackTimingMode,
+    one_subs: list[Subtitle], two_subs: list[Subtitle], timing_mode: StackTimingMode
 ) -> tuple[int, int]:
     """Get the selected timing interval for a stack group.
 

--- a/scinoephile/core/subtitles/series.py
+++ b/scinoephile/core/subtitles/series.py
@@ -218,12 +218,7 @@ class Series(SSAFile):
         return string.rstrip()
 
     @override
-    def to_string(
-        self,
-        format_: str,
-        fps: float | None = None,
-        **kwargs: Any,
-    ) -> str:
+    def to_string(self, format_: str, fps: float | None = None, **kwargs: Any) -> str:
         """Serialize series to a string.
 
         Arguments:
@@ -261,8 +256,7 @@ class Series(SSAFile):
         """
         try:
             series = cast(
-                Self,
-                super().from_string(string, format_=format_, fps=fps, **kwargs),
+                Self, super().from_string(string, format_=format_, fps=fps, **kwargs)
             )
             series.events = [
                 cls.event_class(**ssaevent.as_dict()) for ssaevent in series
@@ -304,8 +298,7 @@ class Series(SSAFile):
                 str(validated_path), encoding=encoding, errors=errors
             ) as input_file:
                 series = cast(
-                    Self,
-                    cls.from_file(input_file, format_=format_, fps=fps, **kwargs),
+                    Self, cls.from_file(input_file, format_=format_, fps=fps, **kwargs)
                 )
                 series.events = [
                     cls.event_class(**ssaevent.as_dict()) for ssaevent in series

--- a/scinoephile/core/subtitles/subtitle.py
+++ b/scinoephile/core/subtitles/subtitle.py
@@ -10,10 +10,7 @@ from typing import Any, TypedDict, Unpack, override
 from pysubs2 import SSAEvent
 from pysubs2.time import ms_to_str
 
-__all__ = [
-    "Subtitle",
-    "SubtitleKwargs",
-]
+__all__ = ["Subtitle", "SubtitleKwargs"]
 
 
 class SubtitleKwargs(TypedDict, total=False):

--- a/scinoephile/core/synchronization/groups.py
+++ b/scinoephile/core/synchronization/groups.py
@@ -14,11 +14,7 @@ from scinoephile.core.subtitles import Series
 
 from .overlap import get_overlap_string, get_sync_overlap_matrix
 
-__all__ = [
-    "SyncGroup",
-    "get_sync_groups",
-    "get_sync_groups_string",
-]
+__all__ = ["SyncGroup", "get_sync_groups", "get_sync_groups_string"]
 
 logger = getLogger(__name__)
 

--- a/scinoephile/core/synchronization/offsets.py
+++ b/scinoephile/core/synchronization/offsets.py
@@ -13,11 +13,7 @@ from scinoephile.core.subtitles import Series, Subtitle
 
 from .groups import get_sync_groups
 
-__all__ = [
-    "SyncOffsetDatum",
-    "SyncOffsetStats",
-    "get_sync_offset_stats",
-]
+__all__ = ["SyncOffsetDatum", "SyncOffsetStats", "get_sync_offset_stats"]
 
 
 @dataclass(frozen=True)
@@ -70,10 +66,7 @@ class SyncOffsetStats:
 
 
 def get_sync_offset_stats(
-    anchor: Series,
-    mobile: Series,
-    sync_cutoff: float = 0.16,
-    pause_length: int = 3000,
+    anchor: Series, mobile: Series, sync_cutoff: float = 0.16, pause_length: int = 3000
 ) -> SyncOffsetStats:
     """Estimate subtitle offset statistics between already-close series.
 

--- a/scinoephile/core/synchronization/overlap.py
+++ b/scinoephile/core/synchronization/overlap.py
@@ -9,10 +9,7 @@ import numpy as np
 from scinoephile.core.exceptions import ScinoephileError
 from scinoephile.core.subtitles import Series
 
-__all__ = [
-    "get_overlap_string",
-    "get_sync_overlap_matrix",
-]
+__all__ = ["get_overlap_string", "get_sync_overlap_matrix"]
 
 
 def get_overlap_string(overlap: np.ndarray) -> str:

--- a/scinoephile/core/text.py
+++ b/scinoephile/core/text.py
@@ -158,10 +158,7 @@ FULL_PUNC = {
 }
 """Selected full-width punctuation characters."""
 
-WHITESPACE = {
-    "IDEOGRAPHIC SPACE": "　",
-    "SPACE": " ",
-}
+WHITESPACE = {"IDEOGRAPHIC SPACE": "　", "SPACE": " "}
 """Selected whitespace characters."""
 
 HALF_PUNC_CHARS = set(HALF_PUNC.values())
@@ -202,14 +199,7 @@ _FULLWIDTH_ALPHANUMERICS_TO_ASCII = str.maketrans(
 )
 """Mapping from fullwidth ASCII letters and digits to regular ASCII."""
 
-_OCR_CONFUSABLES_TO_ASCII = str.maketrans(
-    {
-        "Κ": "K",
-        "Ο": "O",
-        "κ": "k",
-        "ο": "o",
-    }
-)
+_OCR_CONFUSABLES_TO_ASCII = str.maketrans({"Κ": "K", "Ο": "O", "κ": "k", "ο": "o"})
 """Mapping from OCR-confusable characters to regular ASCII."""
 
 RE_HANZI = re.compile(

--- a/scinoephile/dictionaries/cuhk/cache.py
+++ b/scinoephile/dictionaries/cuhk/cache.py
@@ -23,10 +23,7 @@ class CuhkResponseCache:
     """Caches CUHK HTTP response bodies."""
 
     def __init__(
-        self,
-        cache_root_path: Path | None,
-        cache_dir_name: str,
-        overwrite: bool = False,
+        self, cache_root_path: Path | None, cache_dir_name: str, overwrite: bool = False
     ):
         """Initialize.
 

--- a/scinoephile/dictionaries/cuhk/scraper.py
+++ b/scinoephile/dictionaries/cuhk/scraper.py
@@ -42,10 +42,7 @@ from .constants import (
     TERMS_URL,
 )
 
-__all__ = [
-    "CuhkDictionaryScraper",
-    "CuhkDictionaryScraperKwargs",
-]
+__all__ = ["CuhkDictionaryScraper", "CuhkDictionaryScraperKwargs"]
 
 logger = getLogger(__name__)
 
@@ -103,15 +100,11 @@ class CuhkDictionaryScraper:
             session: requests session for dependency injection
         """
         self.discovery_cache = CuhkResponseCache(
-            cache_root_path,
-            "cuhk-discovery",
-            overwrite_cache,
+            cache_root_path, "cuhk-discovery", overwrite_cache
         )
         """Cache of CUHK discovery pages."""
         self.scraped_cache = CuhkResponseCache(
-            self.discovery_cache.cache_root_path,
-            "cuhk-pages",
-            overwrite_cache,
+            self.discovery_cache.cache_root_path, "cuhk-pages", overwrite_cache
         )
         """Cache of CUHK word pages."""
 
@@ -138,10 +131,7 @@ class CuhkDictionaryScraper:
             return []
 
         html = self._get_or_fetch_text(
-            TERMS_URL,
-            self.discovery_cache,
-            "terms",
-            cache_label="CUHK terms index",
+            TERMS_URL, self.discovery_cache, "terms", cache_label="CUHK terms index"
         )
         soup = BeautifulSoup(html, "html.parser")
         main_panel = soup.find("div", id="MainContent_panelTermsIndex")
@@ -202,8 +192,7 @@ class CuhkDictionaryScraper:
         return word_links
 
     def parse_scraped_pages(
-        self,
-        stems: list[str] | None = None,
+        self, stems: list[str] | None = None
     ) -> list[DictionaryEntry]:
         """Parse scraped CUHK pages into normalized entries.
 
@@ -256,11 +245,7 @@ class CuhkDictionaryScraper:
 
         return entries
 
-    def parse_word_html(
-        self,
-        html: str,
-        html_path: Path,
-    ) -> DictionaryEntry | None:
+    def parse_word_html(self, html: str, html_path: Path) -> DictionaryEntry | None:
         """Parse the contents of one CUHK word page.
 
         Arguments:
@@ -375,8 +360,7 @@ class CuhkDictionaryScraper:
         )
 
     def scrape(
-        self,
-        max_words: int | None = None,
+        self, max_words: int | None = None
     ) -> tuple[DictionarySource, list[DictionaryEntry]]:
         """Scrape CUHK data into source metadata and dictionary entries.
 
@@ -403,10 +387,7 @@ class CuhkDictionaryScraper:
         logger.info(f"Parsed {len(entries)} CUHK entry(ies)")
         return CUHK_SOURCE, entries
 
-    def scrape_word_pages(
-        self,
-        word_links: list[tuple[str, str]],
-    ):
+    def scrape_word_pages(self, word_links: list[tuple[str, str]]):
         """Scrape CUHK word pages into cached HTML files.
 
         Arguments:
@@ -458,11 +439,7 @@ class CuhkDictionaryScraper:
         cache.save(cache_stem, contents)
         return contents
 
-    def _fetch_text(
-        self,
-        url: str,
-        cache_label: str | None = None,
-    ) -> str:
+    def _fetch_text(self, url: str, cache_label: str | None = None) -> str:
         """Fetch text with retry and timeout.
 
         Arguments:

--- a/scinoephile/dictionaries/dictionary_tools.py
+++ b/scinoephile/dictionaries/dictionary_tools.py
@@ -13,10 +13,7 @@ from scinoephile.core.llms.tool_box import ToolBox
 
 from .lookup import lookup_dictionary_entries
 
-__all__ = [
-    "get_dictionary_tools",
-    "lookup_dictionary",
-]
+__all__ = ["get_dictionary_tools", "lookup_dictionary"]
 logger = getLogger(__name__)
 """Module logger."""
 
@@ -70,7 +67,7 @@ def get_dictionary_tools(prompt: DictionaryToolPrompt) -> ToolBox:
                                 "description": (
                                     prompt.dictionary_tool_query_description
                                 ),
-                            },
+                            }
                         },
                     },
                 },
@@ -81,9 +78,7 @@ def get_dictionary_tools(prompt: DictionaryToolPrompt) -> ToolBox:
 
 
 def lookup_dictionary(
-    query: str,
-    *,
-    auto_build_missing: bool = False,
+    query: str, *, auto_build_missing: bool = False
 ) -> DictionaryLookupResponse:
     """Lookup entries in local dictionary data.
 
@@ -104,9 +99,7 @@ def lookup_dictionary(
 
     try:
         entries = lookup_dictionary_entries(
-            query=normalized_query,
-            limit=10,
-            auto_build_missing=auto_build_missing,
+            query=normalized_query, limit=10, auto_build_missing=auto_build_missing
         )
     except (FileNotFoundError, ValueError) as exc:
         logger.warning(f"Dictionary lookup failed: {exc}")

--- a/scinoephile/dictionaries/gzzj/constants.py
+++ b/scinoephile/dictionaries/gzzj/constants.py
@@ -29,8 +29,4 @@ GZZJ_SOURCE = DictionarySource(
     other="words",
 )
 
-__all__ = [
-    "GZZJ_DOWNLOAD_URL",
-    "GZZJ_SOURCE",
-    "MAX_LOOKUP_LIMIT",
-]
+__all__ = ["GZZJ_DOWNLOAD_URL", "GZZJ_SOURCE", "MAX_LOOKUP_LIMIT"]

--- a/scinoephile/dictionaries/gzzj/parser.py
+++ b/scinoephile/dictionaries/gzzj/parser.py
@@ -37,8 +37,7 @@ class GzzjDictionaryParser:
         self.opencc_converter = opencc.OpenCC("hk2s")
 
     def parse(
-        self,
-        source_json_path: Path,
+        self, source_json_path: Path
     ) -> tuple[DictionarySource, list[DictionaryEntry]]:
         """Parse a manually downloaded GZZJ source file.
 
@@ -124,10 +123,7 @@ class GzzjDictionaryParser:
         return (
             " ".join(
                 lazy_pinyin(
-                    text,
-                    style=Style.TONE3,
-                    neutral_tone_with_five=True,
-                    v_to_u=True,
+                    text, style=Style.TONE3, neutral_tone_with_five=True, v_to_u=True
                 )
             )
             .lower()

--- a/scinoephile/dictionaries/kaifangcidian/downloader.py
+++ b/scinoephile/dictionaries/kaifangcidian/downloader.py
@@ -14,10 +14,7 @@ import opencc
 import requests
 from pypinyin import Style, lazy_pinyin
 
-from .constants import (
-    KAIFANGCIDIAN_HZSG_URL,
-    KAIFANGCIDIAN_JPSG_URL,
-)
+from .constants import KAIFANGCIDIAN_HZSG_URL, KAIFANGCIDIAN_JPSG_URL
 
 __all__ = ["KaifangcidianDownloader"]
 
@@ -119,10 +116,7 @@ class KaifangcidianDownloader:
         Returns:
             javascript payload text by source key
         """
-        urls = {
-            "hzsg": KAIFANGCIDIAN_HZSG_URL,
-            "jpsg": KAIFANGCIDIAN_JPSG_URL,
-        }
+        urls = {"hzsg": KAIFANGCIDIAN_HZSG_URL, "jpsg": KAIFANGCIDIAN_JPSG_URL}
         payloads: dict[str, str] = {}
         for payload_name, url in urls.items():
             logger.info(f"Downloading Kaifangcidian payload: {url}")
@@ -198,11 +192,7 @@ class KaifangcidianDownloader:
         return rows
 
     def _parse_paired_row(
-        self,
-        *,
-        kind: str,
-        han_row: str,
-        jyutping_row: str,
+        self, *, kind: str, han_row: str, jyutping_row: str
     ) -> list[_CanonicalRow]:
         """Parse one paired Han/Jyutping row.
 
@@ -266,10 +256,7 @@ class KaifangcidianDownloader:
         return (
             " ".join(
                 lazy_pinyin(
-                    text,
-                    style=Style.TONE3,
-                    neutral_tone_with_five=True,
-                    v_to_u=True,
+                    text, style=Style.TONE3, neutral_tone_with_five=True, v_to_u=True
                 )
             )
             .lower()

--- a/scinoephile/dictionaries/kaifangcidian/parser.py
+++ b/scinoephile/dictionaries/kaifangcidian/parser.py
@@ -107,8 +107,7 @@ class KaifangcidianDictionaryParser:
             dictionary entries
         """
         definitions_by_key: dict[
-            tuple[str, str, str, str],
-            list[DictionaryDefinition],
+            tuple[str, str, str, str], list[DictionaryDefinition]
         ] = {}
         for row in rows:
             traditional = row.get("traditional", "").strip()
@@ -117,12 +116,7 @@ class KaifangcidianDictionaryParser:
             jyutping = row.get("jyutping", "").strip().lower()
             if not traditional:
                 continue
-            key = (
-                traditional,
-                simplified or traditional,
-                pinyin,
-                jyutping,
-            )
+            key = (traditional, simplified or traditional, pinyin, jyutping)
             definitions_by_key.setdefault(key, [])
             definitions_by_key[key].extend(
                 KaifangcidianDictionaryParser._row_definitions(row)

--- a/scinoephile/dictionaries/kaifangcidian/service.py
+++ b/scinoephile/dictionaries/kaifangcidian/service.py
@@ -87,8 +87,7 @@ class KaifangcidianDictionaryService:
             return self.database_path
 
         source_csv_path = self._require_source_csv_path(
-            force_download=force_download,
-            update_local_data=update_local_data,
+            force_download=force_download, update_local_data=update_local_data
         )
         parsed_data = self.parser.parse(source_csv_path=source_csv_path)
         return self.database.persist(parsed_data)
@@ -156,10 +155,7 @@ class KaifangcidianDictionaryService:
         self.build(overwrite=False)
 
     def _require_source_csv_path(
-        self,
-        *,
-        force_download: bool,
-        update_local_data: bool,
+        self, *, force_download: bool, update_local_data: bool
     ) -> Path:
         """Get canonical source CSV, downloading and normalizing if needed.
 
@@ -177,8 +173,7 @@ class KaifangcidianDictionaryService:
         if not force_download and runtime_csv_path.exists():
             if update_local_data:
                 return self._copy_runtime_csv_to_local(
-                    runtime_csv_path=runtime_csv_path,
-                    local_csv_path=local_csv_path,
+                    runtime_csv_path=runtime_csv_path, local_csv_path=local_csv_path
                 )
             return val_input_path(runtime_csv_path)
 
@@ -187,15 +182,11 @@ class KaifangcidianDictionaryService:
             return runtime_csv_path
 
         return self._copy_runtime_csv_to_local(
-            runtime_csv_path=runtime_csv_path,
-            local_csv_path=local_csv_path,
+            runtime_csv_path=runtime_csv_path, local_csv_path=local_csv_path
         )
 
     def _copy_runtime_csv_to_local(
-        self,
-        *,
-        runtime_csv_path: Path,
-        local_csv_path: Path,
+        self, *, runtime_csv_path: Path, local_csv_path: Path
     ) -> Path:
         """Copy runtime canonical CSV into the repository-local snapshot.
 

--- a/scinoephile/dictionaries/lookup.py
+++ b/scinoephile/dictionaries/lookup.py
@@ -15,11 +15,7 @@ from .kaifangcidian import KaifangcidianDictionaryService
 from .unihan import UnihanDictionaryService
 from .wiktionary import WiktionaryDictionaryService
 
-__all__ = [
-    "AVAILABLE_DICTIONARY_NAMES",
-    "DictionaryName",
-    "lookup_dictionary_entries",
-]
+__all__ = ["AVAILABLE_DICTIONARY_NAMES", "DictionaryName", "lookup_dictionary_entries"]
 
 type DictionaryName = Literal["cuhk", "gzzj", "kaifangcidian", "unihan", "wiktionary"]
 
@@ -73,12 +69,7 @@ def _merge_entries(entries: list[DictionaryEntry]) -> list[DictionaryEntry]:
     """
     merged_entries: dict[tuple[str, str, str, str], DictionaryEntry] = {}
     for entry in entries:
-        key = (
-            entry.traditional,
-            entry.simplified,
-            entry.pinyin,
-            entry.jyutping,
-        )
+        key = (entry.traditional, entry.simplified, entry.pinyin, entry.jyutping)
         if key not in merged_entries:
             merged_entries[key] = entry
             continue
@@ -162,8 +153,7 @@ def lookup_dictionary_entries(
     available_dictionary_count = 0
     for dictionary_name in dictionary_names:
         service = _DICTIONARY_SERVICES[dictionary_name](
-            database_path=database_path,
-            auto_build_missing=auto_build_missing,
+            database_path=database_path, auto_build_missing=auto_build_missing
         )
         try:
             entries.extend(service.lookup(query=query, limit=limit))

--- a/scinoephile/dictionaries/unihan/parser.py
+++ b/scinoephile/dictionaries/unihan/parser.py
@@ -85,13 +85,7 @@ class UnihanDictionaryParser:
         return UNIHAN_SOURCE, entries
 
     @classmethod
-    def _append_cangjie(
-        cls,
-        *,
-        entry_data: _EntryData,
-        label: str,
-        content: str,
-    ):
+    def _append_cangjie(cls, *, entry_data: _EntryData, label: str, content: str):
         """Append Cangjie metadata with merge logic for trad/simp duplicates.
 
         Arguments:
@@ -119,8 +113,7 @@ class UnihanDictionaryParser:
 
     @classmethod
     def _entries_data_to_entries(
-        cls,
-        entries_data: dict[tuple[str, str], _EntryData],
+        cls, entries_data: dict[tuple[str, str], _EntryData]
     ) -> list[DictionaryEntry]:
         """Convert mutable accumulators into normalized dictionary entries.
 

--- a/scinoephile/dictionaries/unihan/service.py
+++ b/scinoephile/dictionaries/unihan/service.py
@@ -252,8 +252,7 @@ class UnihanDictionaryService:
         return downloaded_paths
 
     def _resolve_explicit_source_paths(
-        self,
-        explicit_paths: dict[str, Path | None],
+        self, explicit_paths: dict[str, Path | None]
     ) -> dict[str, Path]:
         """Resolve optional explicit source path overrides.
 

--- a/scinoephile/dictionaries/wiktionary/parser.py
+++ b/scinoephile/dictionaries/wiktionary/parser.py
@@ -70,8 +70,7 @@ class WiktionaryDictionaryParser:
                     continue
                 record = json.loads(line)
                 self._append_record_entries(
-                    record=record,
-                    definitions_by_key=definitions_by_key,
+                    record=record, definitions_by_key=definitions_by_key
                 )
 
         entries: list[DictionaryEntry] = []
@@ -288,10 +287,7 @@ class WiktionaryDictionaryParser:
         return (
             " ".join(
                 lazy_pinyin(
-                    text,
-                    style=Style.TONE3,
-                    neutral_tone_with_five=True,
-                    v_to_u=True,
+                    text, style=Style.TONE3, neutral_tone_with_five=True, v_to_u=True
                 )
             )
             .lower()

--- a/scinoephile/image/bboxes.py
+++ b/scinoephile/image/bboxes.py
@@ -14,10 +14,7 @@ from .colors import (
     get_grayscale_and_alpha_arrs,
 )
 
-__all__ = [
-    "get_bboxes",
-    "get_merged_bbox",
-]
+__all__ = ["get_bboxes", "get_merged_bbox"]
 
 
 def get_bboxes(img: Image.Image) -> list[Bbox]:  # noqa: PLR0912, PLR0915
@@ -146,14 +143,7 @@ def get_bboxes(img: Image.Image) -> list[Bbox]:  # noqa: PLR0912, PLR0915
             section_y2 = (
                 int(len(white_pixels) - np.argmax(white_pixels[::-1] > 0) - 1) + 1
             )
-            bboxes.append(
-                Bbox(
-                    x1=x1,
-                    x2=x2,
-                    y1=y1 + section_y1,
-                    y2=y1 + section_y2,
-                )
-            )
+            bboxes.append(Bbox(x1=x1, x2=x2, y1=y1 + section_y1, y2=y1 + section_y2))
 
     return bboxes
 

--- a/scinoephile/image/colors.py
+++ b/scinoephile/image/colors.py
@@ -44,9 +44,7 @@ def get_grayscale_and_alpha_arrs(img: Image.Image) -> tuple[np.ndarray, np.ndarr
 
 
 def get_fill_color_mask_arr(
-    grayscale: np.ndarray,
-    alpha: np.ndarray,
-    fill_color: int,
+    grayscale: np.ndarray, alpha: np.ndarray, fill_color: int
 ) -> np.ndarray:
     """Get a boolean mask array that is true for pixels close to a provided fill color.
 
@@ -64,8 +62,7 @@ def get_fill_color_mask_arr(
 
 
 def get_fill_and_outline_colors(
-    grayscale: np.ndarray,
-    alpha: np.ndarray,
+    grayscale: np.ndarray, alpha: np.ndarray
 ) -> tuple[int, int]:
     """Get fill and outline grayscale values from grayscale/alpha arrays.
 

--- a/scinoephile/image/drawing.py
+++ b/scinoephile/image/drawing.py
@@ -18,11 +18,7 @@ from .colors import (
     get_grayscale_and_alpha_arrs,
 )
 
-__all__ = [
-    "convert_rgba_img_to_la",
-    "get_img_with_bboxes",
-    "get_img_with_white_bg",
-]
+__all__ = ["convert_rgba_img_to_la", "get_img_with_bboxes", "get_img_with_white_bg"]
 
 
 def convert_rgba_img_to_la(img: Image.Image) -> Image.Image:
@@ -64,8 +60,7 @@ def get_img_with_bboxes(
         base_img = img.convert("RGBA")
 
     img_with_bboxes = base_img.resize(
-        (img.width * 2, img.height * 2),
-        resample=Image.Resampling.NEAREST,
+        (img.width * 2, img.height * 2), resample=Image.Resampling.NEAREST
     )
     draw = ImageDraw.Draw(img_with_bboxes)
 

--- a/scinoephile/image/ocr/cache.py
+++ b/scinoephile/image/ocr/cache.py
@@ -61,9 +61,7 @@ class OcrCacheBase[TResult](ABC):
         """Cache paths refreshed by this cache instance."""
 
     def get_path(
-        self,
-        image: Image.Image,
-        backend_metadata: Mapping[str, object],
+        self, image: Image.Image, backend_metadata: Mapping[str, object]
     ) -> Path:
         """Get the cache path for an image and recognizer configuration.
 
@@ -89,9 +87,7 @@ class OcrCacheBase[TResult](ABC):
         return self.cache_dir_path / f"{cache_hash.hexdigest()}.json"
 
     def load(
-        self,
-        image: Image.Image,
-        backend_metadata: Mapping[str, object],
+        self, image: Image.Image, backend_metadata: Mapping[str, object]
     ) -> TResult | None:
         """Load a cached OCR result.
 
@@ -141,9 +137,7 @@ class OcrCacheBase[TResult](ABC):
         return result
 
     def remove(
-        self,
-        image: Image.Image,
-        backend_metadata: Mapping[str, object],
+        self, image: Image.Image, backend_metadata: Mapping[str, object]
     ) -> Path | None:
         """Remove a cached OCR result.
 
@@ -178,10 +172,7 @@ class OcrCacheBase[TResult](ABC):
         cache_path = self.get_path(image, backend_metadata)
         with open_atomic_text_file(cache_path) as file:
             json.dump(
-                {
-                    "cache_version": self._version,
-                    "result": self._serialize(result),
-                },
+                {"cache_version": self._version, "result": self._serialize(result)},
                 file,
                 ensure_ascii=False,
             )

--- a/scinoephile/image/ocr/lens/__init__.py
+++ b/scinoephile/image/ocr/lens/__init__.py
@@ -30,8 +30,7 @@ logger = getLogger(__name__)
 
 
 def ocr_image_series_with_lens(
-    image_series: ImageSeries,
-    **kwargs: Unpack[LensRecognizerKwargs],
+    image_series: ImageSeries, **kwargs: Unpack[LensRecognizerKwargs]
 ) -> Series:
     """OCR an image subtitle series with Google Lens.
 
@@ -53,21 +52,12 @@ def ocr_image_series_with_lens(
             image_subtitle = cast(ImageSubtitle, subtitle)
             text = lens_recognizer.recognize_image(image_subtitle.img)
             events.append(
-                Subtitle(
-                    start=image_subtitle.start,
-                    end=image_subtitle.end,
-                    text=text,
-                )
+                Subtitle(start=image_subtitle.start, end=image_subtitle.end, text=text)
             )
         return Series(events=events)
     except ScinoephileError:
         raise
-    except (
-        ImportError,
-        OSError,
-        RuntimeError,
-        ValueError,
-    ) as exc:
+    except (ImportError, OSError, RuntimeError, ValueError) as exc:
         raise ScinoephileError(
             f"Unable to OCR image series with Google Lens: {exc}"
         ) from exc

--- a/scinoephile/image/ocr/lens/cache.py
+++ b/scinoephile/image/ocr/lens/cache.py
@@ -18,11 +18,7 @@ _CACHE_VERSION = 1
 class LensCache(OcrCacheBase[list[str]]):
     """Caches normalized Google Lens OCR lines."""
 
-    def __init__(
-        self,
-        cache_root_path: Path | None = None,
-        overwrite: bool = False,
-    ):
+    def __init__(self, cache_root_path: Path | None = None, overwrite: bool = False):
         """Initialize.
 
         Arguments:
@@ -30,11 +26,7 @@ class LensCache(OcrCacheBase[list[str]]):
             overwrite: whether to replace matching cache files
         """
         super().__init__(
-            cache_root_path,
-            "google-lens",
-            "Google Lens OCR",
-            _CACHE_VERSION,
-            overwrite,
+            cache_root_path, "google-lens", "Google Lens OCR", _CACHE_VERSION, overwrite
         )
 
     def _deserialize(self, payload: object) -> list[str]:

--- a/scinoephile/image/ocr/lens/lens_recognizer.py
+++ b/scinoephile/image/ocr/lens/lens_recognizer.py
@@ -18,10 +18,7 @@ from scinoephile.core.dependencies.ocr import import_chrome_lens_py
 
 from .cache import LensCache
 
-__all__ = [
-    "LensRecognizer",
-    "LensRecognizerKwargs",
-]
+__all__ = ["LensRecognizer", "LensRecognizerKwargs"]
 
 logger = getLogger(__name__)
 

--- a/scinoephile/image/ocr/paddle/__init__.py
+++ b/scinoephile/image/ocr/paddle/__init__.py
@@ -32,8 +32,7 @@ logger = getLogger(__name__)
 
 
 def ocr_image_series_with_paddle(
-    image_series: ImageSeries,
-    **kwargs: Unpack[PaddleRecognizerKwargs],
+    image_series: ImageSeries, **kwargs: Unpack[PaddleRecognizerKwargs]
 ) -> Series:
     """OCR an image subtitle series with PaddleOCR.
 
@@ -58,11 +57,7 @@ def ocr_image_series_with_paddle(
             preprocessed_image = preprocess_paddle_ocr_image(image_subtitle.img)
             text = paddle_recognizer.recognize_image(preprocessed_image)
             events.append(
-                Subtitle(
-                    start=image_subtitle.start,
-                    end=image_subtitle.end,
-                    text=text,
-                )
+                Subtitle(start=image_subtitle.start, end=image_subtitle.end, text=text)
             )
         return Series(events=events)
     except ScinoephileError:

--- a/scinoephile/image/ocr/paddle/cache.py
+++ b/scinoephile/image/ocr/paddle/cache.py
@@ -23,11 +23,7 @@ _CACHE_VERSION = 1
 class PaddleCache(OcrCacheBase[list[PaddleOcrTextResult]]):
     """Caches normalized PaddleOCR text results."""
 
-    def __init__(
-        self,
-        cache_root_path: Path | None = None,
-        overwrite: bool = False,
-    ):
+    def __init__(self, cache_root_path: Path | None = None, overwrite: bool = False):
         """Initialize.
 
         Arguments:
@@ -35,11 +31,7 @@ class PaddleCache(OcrCacheBase[list[PaddleOcrTextResult]]):
             overwrite: whether to replace matching cache files
         """
         super().__init__(
-            cache_root_path,
-            "paddleocr",
-            "PaddleOCR",
-            _CACHE_VERSION,
-            overwrite,
+            cache_root_path, "paddleocr", "PaddleOCR", _CACHE_VERSION, overwrite
         )
 
     def _deserialize(self, payload: object) -> list[PaddleOcrTextResult]:

--- a/scinoephile/image/ocr/paddle/paddle_recognizer.py
+++ b/scinoephile/image/ocr/paddle/paddle_recognizer.py
@@ -20,10 +20,7 @@ from .bounding_box import PaddleOcrBoundingBox
 from .cache import PaddleCache
 from .text_result import PaddleOcrTextResult
 
-__all__ = [
-    "PaddleRecognizer",
-    "PaddleRecognizerKwargs",
-]
+__all__ = ["PaddleRecognizer", "PaddleRecognizerKwargs"]
 
 _TEXT_DETECTION_MODEL_NAME = "PP-OCRv5_server_det"
 _TEXT_RECOGNITION_MODEL_NAME = "PP-OCRv5_server_rec"
@@ -139,9 +136,7 @@ class PaddleRecognizer:
 
     @staticmethod
     def _format_paddle_ocr_text(
-        results: list[PaddleOcrTextResult],
-        *,
-        min_confidence: float = 0.0,
+        results: list[PaddleOcrTextResult], *, min_confidence: float = 0.0
     ) -> str:
         """Format PaddleOCR results as subtitle text.
 
@@ -161,8 +156,7 @@ class PaddleRecognizer:
             result.bounding_box.height for result in filtered_results
         ) / len(filtered_results)
         sorted_results = sorted(
-            filtered_results,
-            key=lambda result: result.bounding_box.center[1],
+            filtered_results, key=lambda result: result.bounding_box.center[1]
         )
         lines: list[list[PaddleOcrTextResult]] = []
         line: list[PaddleOcrTextResult] = []
@@ -186,17 +180,14 @@ class PaddleRecognizer:
         if line:
             lines.append(
                 sorted(
-                    line,
-                    key=lambda line_result: line_result.bounding_box.top_left[0],
+                    line, key=lambda line_result: line_result.bounding_box.top_left[0]
                 )
             )
 
         return "\\N".join(" ".join(result.text for result in line) for line in lines)
 
     @staticmethod
-    def _normalize_paddle_ocr_results(
-        raw_results: Any,
-    ) -> list[PaddleOcrTextResult]:
+    def _normalize_paddle_ocr_results(raw_results: Any) -> list[PaddleOcrTextResult]:
         """Normalize raw PaddleOCR results.
 
         Arguments:

--- a/scinoephile/image/ocr/paddle/preprocessing.py
+++ b/scinoephile/image/ocr/paddle/preprocessing.py
@@ -26,10 +26,7 @@ def preprocess_paddle_ocr_image(image: Image.Image, border: int = 10) -> Image.I
     total_border = border * 2
     preprocessed = Image.new(
         "RGBA",
-        (
-            rgba_image.width + 2 * total_border,
-            rgba_image.height + 2 * total_border,
-        ),
+        (rgba_image.width + 2 * total_border, rgba_image.height + 2 * total_border),
         (0, 0, 0, 0),
     )
     inner_border = Image.new(

--- a/scinoephile/image/ocr/tesseract/__init__.py
+++ b/scinoephile/image/ocr/tesseract/__init__.py
@@ -32,8 +32,7 @@ logger = getLogger(__name__)
 
 
 def ocr_image_series_with_tesseract(
-    image_series: ImageSeries,
-    **kwargs: Unpack[TesseractRecognizerKwargs],
+    image_series: ImageSeries, **kwargs: Unpack[TesseractRecognizerKwargs]
 ) -> Series:
     """OCR an image subtitle series with Tesseract.
 
@@ -55,11 +54,7 @@ def ocr_image_series_with_tesseract(
             image_subtitle = cast(ImageSubtitle, subtitle)
             text = tesseract_recognizer.recognize_image(image_subtitle.img)
             events.append(
-                Subtitle(
-                    start=image_subtitle.start,
-                    end=image_subtitle.end,
-                    text=text,
-                )
+                Subtitle(start=image_subtitle.start, end=image_subtitle.end, text=text)
             )
         return Series(events=events)
     except ScinoephileError:

--- a/scinoephile/image/ocr/tesseract/cache.py
+++ b/scinoephile/image/ocr/tesseract/cache.py
@@ -17,11 +17,7 @@ _CACHE_VERSION = 1
 class TesseractCache(OcrCacheBase[str]):
     """Caches normalized Tesseract OCR text."""
 
-    def __init__(
-        self,
-        cache_root_path: Path | None = None,
-        overwrite: bool = False,
-    ):
+    def __init__(self, cache_root_path: Path | None = None, overwrite: bool = False):
         """Initialize.
 
         Arguments:
@@ -29,11 +25,7 @@ class TesseractCache(OcrCacheBase[str]):
             overwrite: whether to replace matching cache files
         """
         super().__init__(
-            cache_root_path,
-            "tesseract",
-            "Tesseract OCR",
-            _CACHE_VERSION,
-            overwrite,
+            cache_root_path, "tesseract", "Tesseract OCR", _CACHE_VERSION, overwrite
         )
 
     def _deserialize(self, payload: object) -> str:

--- a/scinoephile/image/ocr/tesseract/hocr.py
+++ b/scinoephile/image/ocr/tesseract/hocr.py
@@ -233,9 +233,7 @@ def _apply_italic_mask(text: str, italic_mask: list[bool]) -> str:
 
 
 def _format_tesseract_hocr_words(
-    lines: list[list[TesseractHocrWord]],
-    *,
-    word_separator: str = " ",
+    lines: list[list[TesseractHocrWord]], *, word_separator: str = " "
 ) -> str:
     """Format parsed hOCR words as subtitle text.
 
@@ -258,9 +256,7 @@ def _format_tesseract_hocr_words(
 
 
 def _get_text_and_word_spans(
-    lines: list[list[TesseractHocrWord]],
-    *,
-    word_separator: str = " ",
+    lines: list[list[TesseractHocrWord]], *, word_separator: str = " "
 ) -> tuple[str, list[_TesseractHocrWordSpan]]:
     """Get formatted plain text and word spans.
 

--- a/scinoephile/image/ocr/tesseract/legacy_data_cache.py
+++ b/scinoephile/image/ocr/tesseract/legacy_data_cache.py
@@ -23,11 +23,7 @@ _CACHE_VERSION = 1
 class TesseractLegacyDataCache:
     """Caches legacy-capable Tesseract traineddata files."""
 
-    def __init__(
-        self,
-        cache_root_path: Path | None = None,
-        overwrite: bool = False,
-    ):
+    def __init__(self, cache_root_path: Path | None = None, overwrite: bool = False):
         """Initialize.
 
         Arguments:
@@ -106,8 +102,7 @@ class TesseractLegacyDataCache:
         try:
             traineddata_path.parent.mkdir(parents=True, exist_ok=True)
             with TemporaryDirectory(
-                dir=traineddata_path.parent,
-                prefix=f".{traineddata_path.name}-",
+                dir=traineddata_path.parent, prefix=f".{traineddata_path.name}-"
             ) as temp_dir:
                 staging_path = Path(temp_dir) / traineddata_path.name
                 staging_path.write_bytes(contents)

--- a/scinoephile/image/ocr/tesseract/preprocessing.py
+++ b/scinoephile/image/ocr/tesseract/preprocessing.py
@@ -38,6 +38,5 @@ def preprocess_tesseract_ocr_image(
         return rgb_image
 
     return rgb_image.resize(
-        (rgb_image.width * scale, rgb_image.height * scale),
-        Image.Resampling.NEAREST,
+        (rgb_image.width * scale, rgb_image.height * scale), Image.Resampling.NEAREST
     )

--- a/scinoephile/image/ocr/tesseract/tesseract_recognizer.py
+++ b/scinoephile/image/ocr/tesseract/tesseract_recognizer.py
@@ -13,10 +13,7 @@ import requests
 from PIL import Image
 
 from scinoephile.common.subprocess import run_command
-from scinoephile.common.validation import (
-    val_executable,
-    val_input_dir_path,
-)
+from scinoephile.common.validation import val_executable, val_input_dir_path
 from scinoephile.core import Language, ScinoephileError
 
 from .cache import TesseractCache
@@ -24,10 +21,7 @@ from .hocr import parse_tesseract_hocr, transfer_tesseract_hocr_italics
 from .legacy_data_cache import TesseractLegacyDataCache
 from .preprocessing import preprocess_tesseract_ocr_image
 
-__all__ = [
-    "TesseractRecognizer",
-    "TesseractRecognizerKwargs",
-]
+__all__ = ["TesseractRecognizer", "TesseractRecognizerKwargs"]
 
 logger = getLogger(__name__)
 
@@ -128,8 +122,7 @@ class TesseractRecognizer:
         self.scale = scale
         self._cache = TesseractCache(cache_root_path, overwrite_cache)
         self._legacy_data_cache = TesseractLegacyDataCache(
-            cache_root_path,
-            overwrite_cache,
+            cache_root_path, overwrite_cache
         )
 
         if skip_executable_validation:
@@ -254,9 +247,7 @@ class TesseractRecognizer:
         return command
 
     def _build_legacy_fallback_command(
-        self,
-        image_path: Path,
-        output_base_path: Path,
+        self, image_path: Path, output_base_path: Path
     ) -> list[str]:
         """Build Tesseract legacy-engine hOCR command for blank fallback.
 
@@ -269,9 +260,7 @@ class TesseractRecognizer:
         return self._build_legacy_command(image_path, output_base_path, psm=7)
 
     def _build_legacy_italics_command(
-        self,
-        image_path: Path,
-        output_base_path: Path,
+        self, image_path: Path, output_base_path: Path
     ) -> list[str]:
         """Build Tesseract legacy-engine hOCR command for italic detection.
 
@@ -282,10 +271,7 @@ class TesseractRecognizer:
             command arguments
         """
         return self._build_legacy_command(
-            image_path,
-            output_base_path,
-            psm=self.psm,
-            include_font_info=True,
+            image_path, output_base_path, psm=self.psm, include_font_info=True
         )
 
     def _download_legacy_traineddata(self) -> bytes:
@@ -320,8 +306,7 @@ class TesseractRecognizer:
         traineddata_path = self._legacy_data_cache.load(self.tesseract_language_code)
         if traineddata_path is None:
             traineddata_path = self._legacy_data_cache.save(
-                self.tesseract_language_code,
-                self._download_legacy_traineddata(),
+                self.tesseract_language_code, self._download_legacy_traineddata()
             )
         return traineddata_path.parent
 
@@ -348,8 +333,7 @@ class TesseractRecognizer:
             fallback_image = preprocess_tesseract_ocr_image(image, scale=1)
             fallback_image.save(fallback_image_path)
             fallback_text = self._run_legacy_blank_fallback(
-                fallback_image_path,
-                fallback_output_base_path,
+                fallback_image_path, fallback_output_base_path
             )
             if self._is_usable_legacy_blank_fallback_text(fallback_text):
                 logger.info(
@@ -370,9 +354,7 @@ class TesseractRecognizer:
         return run_command(command)
 
     def _run_legacy_blank_fallback(
-        self,
-        image_path: Path,
-        output_base_path: Path,
+        self, image_path: Path, output_base_path: Path
     ) -> str:
         """Run Tesseract legacy-engine fallback and parse hOCR output.
 
@@ -413,10 +395,7 @@ class TesseractRecognizer:
         )
         try:
             self._run_command(
-                self._build_legacy_italics_command(
-                    image_path,
-                    legacy_output_base_path,
-                )
+                self._build_legacy_italics_command(image_path, legacy_output_base_path)
             )
             legacy_hocr = self._read_hocr_output(legacy_output_base_path)
         except (OSError, ValueError) as exc:

--- a/scinoephile/image/ocr/validation/__init__.py
+++ b/scinoephile/image/ocr/validation/__init__.py
@@ -13,7 +13,4 @@ from __future__ import annotations
 
 from .validation_manager import MAX_CHAR_DIM_BBOXES, ValidationManager
 
-__all__ = [
-    "MAX_CHAR_DIM_BBOXES",
-    "ValidationManager",
-]
+__all__ = ["MAX_CHAR_DIM_BBOXES", "ValidationManager"]

--- a/scinoephile/image/ocr/validation/char_dims.py
+++ b/scinoephile/image/ocr/validation/char_dims.py
@@ -12,11 +12,7 @@ from scinoephile.image.bbox import Bbox
 
 from .csv import save_csv_rows
 
-__all__ = [
-    "get_dims_tuple",
-    "load_char_dims",
-    "save_char_dims",
-]
+__all__ = ["get_dims_tuple", "load_char_dims", "save_char_dims"]
 
 
 logger = getLogger(__name__)

--- a/scinoephile/image/ocr/validation/char_grp_dims.py
+++ b/scinoephile/image/ocr/validation/char_grp_dims.py
@@ -10,18 +10,13 @@ from pathlib import Path
 
 from .csv import save_csv_rows
 
-__all__ = [
-    "load_char_grp_dims",
-    "save_char_grp_dims",
-]
+__all__ = ["load_char_grp_dims", "save_char_grp_dims"]
 
 
 logger = getLogger(__name__)
 
 
-def load_char_grp_dims(
-    file_path: Path,
-) -> dict[int, dict[str, set[tuple[int, ...]]]]:
+def load_char_grp_dims(file_path: Path) -> dict[int, dict[str, set[tuple[int, ...]]]]:
     """Load character group dimensions from file.
 
     Arguments:

--- a/scinoephile/image/ocr/validation/char_pair_gaps.py
+++ b/scinoephile/image/ocr/validation/char_pair_gaps.py
@@ -133,12 +133,7 @@ def load_char_pair_gaps(
                 continue
             char_1, char_2, cutoff_1, cutoff_2, cutoff_3, cutoff_4 = row
             char_pair = (char_1, char_2)
-            cutoffs = (
-                int(cutoff_1),
-                int(cutoff_2),
-                int(cutoff_3),
-                int(cutoff_4),
-            )
+            cutoffs = (int(cutoff_1), int(cutoff_2), int(cutoff_3), int(cutoff_4))
             _validate_char_pair_gap_cutoffs(
                 char_pair, cutoffs, file_path=file_path, line_no=line_no
             )

--- a/scinoephile/image/ocr/validation/validation_manager.py
+++ b/scinoephile/image/ocr/validation/validation_manager.py
@@ -25,10 +25,7 @@ from .char_pair_gaps import (
 )
 from .gap_cursor import GapCursor
 
-__all__ = [
-    "MAX_CHAR_DIM_BBOXES",
-    "ValidationManager",
-]
+__all__ = ["MAX_CHAR_DIM_BBOXES", "ValidationManager"]
 
 
 logger = getLogger(__name__)
@@ -68,10 +65,7 @@ class ValidationManager:
     """
 
     def __init__(
-        self,
-        *,
-        validation_data_dir_path: Path | str | None = None,
-        dev: bool = False,
+        self, *, validation_data_dir_path: Path | str | None = None, dev: bool = False
     ):
         """Initialize.
 
@@ -86,10 +80,7 @@ class ValidationManager:
                 f"Unable to initialize OCR validation data: {exc}"
             ) from exc
 
-    def validate(
-        self,
-        series: ImageSeries,
-    ) -> ImageSeries:
+    def validate(self, series: ImageSeries) -> ImageSeries:
         """Validate all subtitles in an image series.
 
         Arguments:
@@ -111,9 +102,7 @@ class ValidationManager:
         return output_series
 
     def _init_data(  # noqa: PLR0912
-        self,
-        validation_data_dir_path: Path | str | None,
-        dev: bool,
+        self, validation_data_dir_path: Path | str | None, dev: bool
     ):
         """Initialize OCR validation data.
 
@@ -156,8 +145,7 @@ class ValidationManager:
                 )
             else:
                 self.validation_data_dir_path = val_output_dir_path(
-                    validation_data_dir_path,
-                    create=False,
+                    validation_data_dir_path, create=False
                 )
 
             # Initialize char_dims_by_n
@@ -173,10 +161,7 @@ class ValidationManager:
             file_path = self.validation_data_dir_path / "char_grp_dims.csv"
             if file_path.exists():
                 self.user_char_grp_dims_by_n = load_char_grp_dims(file_path)
-                for (
-                    group_size,
-                    char_grp_dims,
-                ) in self.user_char_grp_dims_by_n.items():
+                for group_size, char_grp_dims in self.user_char_grp_dims_by_n.items():
                     target_char_grp_dims = self.char_grp_dims_by_n.setdefault(
                         group_size, {}
                     )
@@ -213,11 +198,7 @@ class ValidationManager:
 
         return char_messages + gap_messages
 
-    def _validate_chars(
-        self,
-        sub: ImageSubtitle,
-        sub_idx: int,
-    ) -> list[str]:
+    def _validate_chars(self, sub: ImageSubtitle, sub_idx: int) -> list[str]:
         """Merge bboxes per character and collect validation messages.
 
         Arguments:
@@ -338,9 +319,7 @@ class ValidationManager:
         return False
 
     def _validate_gaps(  # noqa: PLR0912, PLR0915
-        self,
-        sub: ImageSubtitle,
-        sub_idx: int,
+        self, sub: ImageSubtitle, sub_idx: int
     ) -> list[str]:
         """Validate gaps between bboxes and collect validation messages.
 

--- a/scinoephile/image/subtitles/__init__.py
+++ b/scinoephile/image/subtitles/__init__.py
@@ -12,7 +12,4 @@ from __future__ import annotations
 from .series import ImageSeries
 from .subtitle import ImageSubtitle
 
-__all__ = [
-    "ImageSeries",
-    "ImageSubtitle",
-]
+__all__ = ["ImageSeries", "ImageSubtitle"]

--- a/scinoephile/image/subtitles/series.py
+++ b/scinoephile/image/subtitles/series.py
@@ -211,9 +211,7 @@ class ImageSeries(Series):
             if format_ == "html" or (not format_ and path.suffix == ""):
                 validated_output_dir_path = val_output_dir_path(path)
                 self._save_html(
-                    validated_output_dir_path,
-                    encoding=encoding,
-                    errors=errors,
+                    validated_output_dir_path, encoding=encoding, errors=errors
                 )
                 logger.info(f"Saved series to {validated_output_dir_path}")
                 return
@@ -261,11 +259,7 @@ class ImageSeries(Series):
         try:
             validated_path = val_input_file_or_dir_path(path)
             if validated_path.is_dir():
-                return cls._load_html(
-                    validated_path,
-                    encoding=encoding,
-                    errors=errors,
-                )
+                return cls._load_html(validated_path, encoding=encoding, errors=errors)
             if format_ == "sup" or validated_path.suffix == ".sup":
                 return cls._load_sup(validated_path)
         except (OSError, UnicodeError, ValueError) as exc:
@@ -346,10 +340,7 @@ class ImageSeries(Series):
         self._text_font_size = max(size_counts)
 
     def _save_html(
-        self,
-        dir_path: Path,
-        encoding: str = "utf-8",
-        errors: str | None = None,
+        self, dir_path: Path, encoding: str = "utf-8", errors: str | None = None
     ):
         """Save series to directory with HTML index and png files.
 
@@ -360,8 +351,7 @@ class ImageSeries(Series):
         """
         # Stage the complete managed output before changing the destination
         with TemporaryDirectory(
-            dir=dir_path.parent,
-            prefix=f".{dir_path.name}.",
+            dir=dir_path.parent, prefix=f".{dir_path.name}."
         ) as staging_dir_name:
             staging_dir_path = Path(staging_dir_name)
             image_paths = []
@@ -369,11 +359,7 @@ class ImageSeries(Series):
                 image_path = staging_dir_path / f"{i:04d}.png"
                 event.img.save(image_path)
                 image_paths.append(image_path)
-            self.save_html_index(
-                staging_dir_path,
-                encoding=encoding,
-                errors=errors,
-            )
+            self.save_html_index(staging_dir_path, encoding=encoding, errors=errors)
 
             # Reject conflicting directories before replacing any managed files
             staged_paths = [*image_paths, staging_dir_path / "index.html"]
@@ -390,10 +376,7 @@ class ImageSeries(Series):
 
     @classmethod
     def _load_html(
-        cls,
-        dir_path: Path,
-        encoding: str = "utf-8",
-        errors: str | None = None,
+        cls, dir_path: Path, encoding: str = "utf-8", errors: str | None = None
     ) -> Self:
         """Load series from a directory of png files and HTML index.
 
@@ -451,9 +434,7 @@ class ImageSeries(Series):
             img = convert_rgba_img_to_la(img)
             events.append(
                 cls.event_class(
-                    start=int(round(start * 1000)),
-                    end=int(round(end * 1000)),
-                    img=img,
+                    start=int(round(start * 1000)), end=int(round(end * 1000)), img=img
                 )
             )
         series = cls(events=events)
@@ -461,11 +442,7 @@ class ImageSeries(Series):
         return series
 
     @classmethod
-    def parse_html_events(
-        cls,
-        html_text: str,
-        dir_path: Path,
-    ) -> list[dict[str, Any]]:
+    def parse_html_events(cls, html_text: str, dir_path: Path) -> list[dict[str, Any]]:
         """Parse HTML events for image subtitles.
 
         Arguments:
@@ -522,12 +499,7 @@ class ImageSeries(Series):
 
     @staticmethod
     def format_html_entry(
-        *,
-        index: int,
-        start: int,
-        end: int,
-        image_name: str,
-        text: str,
+        *, index: int, start: int, end: int, image_name: str, text: str
     ) -> str:
         """Format one HTML subtitle entry.
 

--- a/scinoephile/image/subtitles/subtitle.py
+++ b/scinoephile/image/subtitles/subtitle.py
@@ -35,8 +35,7 @@ class ImageSubtitle(Subtitle):
         """
         super_field_names = {f.name for f in fields(Subtitle)}
         super_kwargs = cast(
-            SubtitleKwargs,
-            {k: v for k, v in kwargs.items() if k in super_field_names},
+            SubtitleKwargs, {k: v for k, v in kwargs.items() if k in super_field_names}
         )
         super().__init__(**super_kwargs)
 

--- a/scinoephile/image/subtitles/sup.py
+++ b/scinoephile/image/subtitles/sup.py
@@ -7,19 +7,12 @@ from __future__ import annotations
 import numba as nb
 import numpy as np
 
-__all__ = [
-    "read_sup_image_array",
-    "read_sup_palette",
-    "read_sup_series",
-]
+__all__ = ["read_sup_image_array", "read_sup_palette", "read_sup_series"]
 
 
 @nb.jit(nopython=True, nogil=True, cache=True, fastmath=True)
 def _render_sup_image(
-    compressed_image: np.ndarray,
-    height: int,
-    width: int,
-    palette: np.ndarray,
+    compressed_image: np.ndarray, height: int, width: int, palette: np.ndarray
 ) -> np.ndarray:
     """Render an RGBA subtitle image from palette and compressed image data.
 
@@ -40,9 +33,7 @@ def _render_sup_image(
 
 @nb.jit(nopython=True, nogil=True, cache=True, fastmath=True)
 def read_sup_image_array(  # noqa: PLR0912, PLR0915
-    bytes_: np.ndarray,
-    height: int,
-    width: int,
+    bytes_: np.ndarray, height: int, width: int
 ) -> np.ndarray:
     """Read a palette-compressed image from a block of bytes.
 
@@ -256,9 +247,7 @@ def read_sup_series(  # noqa: PLR0912, PLR0915
                 if len(pending_image_data) != pending_image_data_length:
                     raise ValueError("SUP image segment data is truncated.")
                 current_image = read_sup_image_array(
-                    pending_image_data,
-                    pending_image_height,
-                    pending_image_width,
+                    pending_image_data, pending_image_height, pending_image_width
                 )
                 has_current_image = True
                 pending_image_data = np.zeros(0, np.uint8)

--- a/scinoephile/lang/cmn/romanization.py
+++ b/scinoephile/lang/cmn/romanization.py
@@ -190,10 +190,7 @@ def get_cmn_text_romanized(text: str) -> str:
     return "\n".join(lines).strip()
 
 
-def _get_cmn_section_romanized(
-    section: str,
-    open_symmetric_quotes: set[str],
-) -> str:
+def _get_cmn_section_romanized(section: str, open_symmetric_quotes: set[str]) -> str:
     """Get Mandarin pinyin romanization for a whitespace-delimited section.
 
     Arguments:
@@ -267,10 +264,7 @@ def _get_cmn_word_romanization_tokens(
     return tokens
 
 
-def _romanize_cmn_token(
-    chars: list[str],
-    token_kind: str,
-) -> str:
+def _romanize_cmn_token(chars: list[str], token_kind: str) -> str:
     """Romanize a Mandarin token.
 
     Arguments:

--- a/scinoephile/lang/eng/review.py
+++ b/scinoephile/lang/eng/review.py
@@ -11,10 +11,7 @@ from scinoephile.llms.review import ReviewPrompt
 
 from .prompts import ENG_PROMPT_FIELDS
 
-__all__ = [
-    "GuidedReviewPromptEng",
-    "ReviewPromptEng",
-]
+__all__ = ["GuidedReviewPromptEng", "ReviewPromptEng"]
 
 
 GuidedReviewPromptEng = GuidedReviewPrompt(

--- a/scinoephile/lang/id/__init__.py
+++ b/scinoephile/lang/id/__init__.py
@@ -15,10 +15,7 @@ from scinoephile.core.subtitles import Series
 
 from .language_id import LanguageId
 
-__all__ = [
-    "LanguageId",
-    "get_series_language",
-]
+__all__ = ["LanguageId", "get_series_language"]
 
 SERIES_LANGUAGE_AGREEMENT_THRESHOLD = 3
 """Number of conclusive subtitles that must agree on a series language."""

--- a/scinoephile/lang/id/language_id.py
+++ b/scinoephile/lang/id/language_id.py
@@ -153,10 +153,7 @@ class LanguageId:
 
     @staticmethod
     def _get_chinese_language(
-        text: str,
-        *,
-        is_simplified: bool,
-        is_traditional: bool,
+        text: str, *, is_simplified: bool, is_traditional: bool
     ) -> Language | None:
         """Get the Chinese language represented by text.
 
@@ -230,7 +227,5 @@ class LanguageId:
             return None
 
         return LanguageId._get_chinese_language(
-            text,
-            is_simplified=is_simplified,
-            is_traditional=is_traditional,
+            text, is_simplified=is_simplified, is_traditional=is_traditional
         )

--- a/scinoephile/lang/ocr_fusion.py
+++ b/scinoephile/lang/ocr_fusion.py
@@ -23,10 +23,7 @@ from .eng.ocr_fusion import OcrFusionPromptEng
 from .yue.ocr_fusion import OcrFusionPromptYueHans, OcrFusionPromptYueHant
 from .zho.ocr_fusion import OcrFusionPromptZhoHans, OcrFusionPromptZhoHant
 
-__all__ = [
-    "DEFAULT_PROMPTS",
-    "get_ocr_fuser",
-]
+__all__ = ["DEFAULT_PROMPTS", "get_ocr_fuser"]
 
 _ENG_OCR_FUSION_JSON_PATHS = (
     Path("kob/output/eng_ocr/lang/eng/ocr_fusion.json"),

--- a/scinoephile/lang/review/guided.py
+++ b/scinoephile/lang/review/guided.py
@@ -37,10 +37,7 @@ from scinoephile.llms.guided_review import (
 )
 from scinoephile.llms.providers.registry import get_provider
 
-__all__ = [
-    "DEFAULT_PROMPTS",
-    "get_guided_reviewer",
-]
+__all__ = ["DEFAULT_PROMPTS", "get_guided_reviewer"]
 
 _YUE_ZHO_JSON_PATHS = (
     Path("mlamd/output/yue-Hans_transcribe/lang/yue_zho/guided_review/cuda.json"),

--- a/scinoephile/lang/review/standard.py
+++ b/scinoephile/lang/review/standard.py
@@ -18,10 +18,7 @@ from scinoephile.llms import load_default_test_cases
 from scinoephile.llms.providers.registry import get_provider
 from scinoephile.llms.review import ReviewManager, ReviewProcessor, ReviewPrompt
 
-__all__ = [
-    "DEFAULT_PROMPTS",
-    "get_reviewer",
-]
+__all__ = ["DEFAULT_PROMPTS", "get_reviewer"]
 
 _ENG_REVIEW_JSON_PATHS = (
     Path("kob/output/eng_ocr/lang/eng/review.json"),

--- a/scinoephile/lang/transcription/aligner.py
+++ b/scinoephile/lang/transcription/aligner.py
@@ -61,9 +61,7 @@ class TranscriptionAligner:
         """Punctuate transcription text using corresponding reference subtitles."""
 
     def align(
-        self,
-        reference_subs: Series,
-        transcription_subs: AudioSeries,
+        self, reference_subs: Series, transcription_subs: AudioSeries
     ) -> TranscriptionAlignment:
         """Align transcribed subtitles with reference subtitles.
 
@@ -111,8 +109,7 @@ class TranscriptionAligner:
         delineation_prompt = cast(DelineationPrompt, delineation_queryer.prompt)
         for sync_group_one_idx in range(len(alignment.sync_groups) - 1):
             test_case = alignment.get_delineation_test_case(
-                sync_group_one_idx,
-                delineation_prompt,
+                sync_group_one_idx, delineation_prompt
             )
             if test_case is None:
                 logger.info(
@@ -120,10 +117,7 @@ class TranscriptionAligner:
                     f"{sync_group_one_idx + 1} with no transcription"
                 )
                 continue
-            test_case = cast(
-                DelineationTestCase,
-                delineation_queryer(test_case),
-            )
+            test_case = cast(DelineationTestCase, delineation_queryer(test_case))
 
             query = test_case.query
             answer = test_case.answer
@@ -133,12 +127,7 @@ class TranscriptionAligner:
                 raise ScinoephileError(message)
             if not answer.output_one and not answer.output_two:
                 continue
-            if self._delineate_one(
-                alignment,
-                sync_group_one_idx,
-                query,
-                answer,
-            ):
+            if self._delineate_one(alignment, sync_group_one_idx, query, answer):
                 return True
         return False
 
@@ -189,9 +178,7 @@ class TranscriptionAligner:
                 subtitle = alignment.transcription[transcription_two_idx]
                 if len(subtitle.text) > remaining_chars:
                     alignment.transcription = get_series_with_sub_split_at_idx(
-                        alignment.transcription,
-                        transcription_two_idx,
-                        remaining_chars,
+                        alignment.transcription, transcription_two_idx, remaining_chars
                     )
                     alignment._sync_groups_override = None
                     return True
@@ -272,8 +259,7 @@ class TranscriptionAligner:
                 continue
 
             test_case = alignment.get_punctuation_test_case(
-                sync_group_idx,
-                punctuation_prompt,
+                sync_group_idx, punctuation_prompt
             )
             if test_case is None:
                 logger.info(
@@ -283,10 +269,7 @@ class TranscriptionAligner:
                 nascent_sync_groups.append(([reference_idx], []))
                 continue
             try:
-                test_case = cast(
-                    PunctuationTestCase,
-                    punctuation_queryer(test_case),
-                )
+                test_case = cast(PunctuationTestCase, punctuation_queryer(test_case))
             except ValidationError as exc:
                 logger.error(
                     f"Error punctuating sync group {sync_group_idx}; "
@@ -295,10 +278,7 @@ class TranscriptionAligner:
             punctuated_text = None
             if test_case.answer is not None:
                 punctuated_text = test_case.answer.output
-            subtitle = get_sub_merged(
-                transcription_subtitles,
-                text=punctuated_text,
-            )
+            subtitle = get_sub_merged(transcription_subtitles, text=punctuated_text)
             subtitle.start = reference.start
             subtitle.end = reference.end
 

--- a/scinoephile/lang/transcription/alignment.py
+++ b/scinoephile/lang/transcription/alignment.py
@@ -149,9 +149,7 @@ class TranscriptionAlignment:
         return sorted(set(range(len(self.transcription))) - transcription_idxs)
 
     def get_delineation_test_case(
-        self,
-        sync_group_one_idx: int,
-        prompt: DelineationPrompt,
+        self, sync_group_one_idx: int, prompt: DelineationPrompt
     ) -> DelineationTestCase | None:
         """Get a delineation test case for adjacent sync groups.
 
@@ -220,9 +218,7 @@ class TranscriptionAlignment:
         return cast(DelineationTestCase, test_case_cls(query=query))
 
     def get_punctuation_test_case(
-        self,
-        sync_group_idx: int,
-        prompt: PunctuationPrompt,
+        self, sync_group_idx: int, prompt: PunctuationPrompt
     ) -> PunctuationTestCase | None:
         """Get a punctuation test case for a sync group.
 
@@ -254,9 +250,6 @@ class TranscriptionAlignment:
 
         test_case_cls = PunctuationManager.get_test_case_cls(prompt=prompt)
         query = test_case_cls.query_cls.model_validate(
-            {
-                "subtitles": transcriptions,
-                "guide": reference,
-            }
+            {"subtitles": transcriptions, "guide": reference}
         )
         return cast(PunctuationTestCase, test_case_cls(query=query))

--- a/scinoephile/lang/transcription/guided.py
+++ b/scinoephile/lang/transcription/guided.py
@@ -138,28 +138,15 @@ _YUE_HANT_SPEC = GuidedTranscriptionSpec(
 """Guided transcription specification for traditional written Cantonese."""
 
 
-DEFAULT_SPECS: Mapping[
-    tuple[Language, Language],
-    GuidedTranscriptionSpec,
-] = MappingProxyType(
-    {
-        (
-            Language.yue_hans,
-            Language.zho_hans,
-        ): _YUE_HANS_SPEC,
-        (
-            Language.yue_hans,
-            Language.zho_hant,
-        ): _YUE_HANS_SPEC,
-        (
-            Language.yue_hant,
-            Language.zho_hans,
-        ): _YUE_HANT_SPEC,
-        (
-            Language.yue_hant,
-            Language.zho_hant,
-        ): _YUE_HANT_SPEC,
-    }
+DEFAULT_SPECS: Mapping[tuple[Language, Language], GuidedTranscriptionSpec] = (
+    MappingProxyType(
+        {
+            (Language.yue_hans, Language.zho_hans): _YUE_HANS_SPEC,
+            (Language.yue_hans, Language.zho_hant): _YUE_HANS_SPEC,
+            (Language.yue_hant, Language.zho_hans): _YUE_HANT_SPEC,
+            (Language.yue_hant, Language.zho_hant): _YUE_HANT_SPEC,
+        }
+    )
 )
 """Guided transcription specifications keyed by transcription and guide language."""
 
@@ -240,9 +227,7 @@ def get_guided_transcriber(
     if delineation_test_cases is None:
         delineation_test_cases = list(
             load_default_test_cases(
-                DelineationManager,
-                delineation_prompt,
-                spec.delineation_json_paths,
+                DelineationManager, delineation_prompt, spec.delineation_json_paths
             )
         )
     if provider is None:
@@ -260,9 +245,7 @@ def get_guided_transcriber(
     if punctuation_test_cases is None:
         punctuation_test_cases = list(
             load_default_test_cases(
-                PunctuationManager,
-                punctuation_prompt,
-                spec.punctuation_json_paths,
+                PunctuationManager, punctuation_prompt, spec.punctuation_json_paths
             )
         )
     punctuation_processor = PunctuationProcessor(

--- a/scinoephile/lang/transcription/transcriber.py
+++ b/scinoephile/lang/transcription/transcriber.py
@@ -25,16 +25,10 @@ from scinoephile.core.subtitles import Series
 
 from .aligner import TranscriptionAligner
 
-__all__ = [
-    "GuidedTranscriber",
-    "TranscribedSegmentSplitter",
-]
+__all__ = ["GuidedTranscriber", "TranscribedSegmentSplitter"]
 
 
-TranscribedSegmentSplitter = Callable[
-    [TranscribedSegment],
-    list[TranscribedSegment],
-]
+TranscribedSegmentSplitter = Callable[[TranscribedSegment], list[TranscribedSegment]]
 """Callable that splits one transcribed segment into zero or more segments."""
 
 logger = getLogger(__name__)
@@ -202,9 +196,7 @@ class GuidedTranscriber:
         return output
 
     def process_block(
-        self,
-        audio_block: AudioSeries,
-        reference_block: Series,
+        self, audio_block: AudioSeries, reference_block: Series
     ) -> AudioSeries:
         """Transcribe and align a single audio block.
 
@@ -217,13 +209,9 @@ class GuidedTranscriber:
         offset = audio_block.buffered_start
         if offset is None:
             offset = audio_block[0].start
-        expected_last_start = max(
-            0.0,
-            (reference_block[-1].start - offset) / 1000,
-        )
+        expected_last_start = max(0.0, (reference_block[-1].start - offset) / 1000)
         segments = self._transcribe_block_audio(
-            audio_block.audio,
-            expected_last_start=expected_last_start,
+            audio_block.audio, expected_last_start=expected_last_start
         )
         if self.segment_splitter is None:
             split_segments = segments
@@ -233,18 +221,13 @@ class GuidedTranscriber:
                 split_segments.extend(self.segment_splitter(segment))
 
         transcription_block = get_series_from_segments(
-            split_segments,
-            audio=audio_block.audio,
-            offset=offset,
+            split_segments, audio=audio_block.audio, offset=offset
         )
         alignment = self.aligner.align(reference_block, transcription_block)
         return alignment.transcription
 
     def _transcribe_block_audio(
-        self,
-        audio: AudioSegment,
-        *,
-        expected_last_start: float | None = None,
+        self, audio: AudioSegment, *, expected_last_start: float | None = None
     ) -> list[TranscribedSegment]:
         """Transcribe one block of audio with the configured VAD behavior.
 
@@ -258,39 +241,26 @@ class GuidedTranscriber:
 
         def is_usable(candidate: list[TranscribedSegment]) -> bool:
             """Determine whether a transcription candidate is usable."""
-            return self._segments_are_usable(
-                candidate,
-                audio_duration=audio_duration,
-            )
+            return self._segments_are_usable(candidate, audio_duration=audio_duration)
 
         # Inspect standard and recovery caches before invoking Demucs
-        segments = self.transcriber.get_cached_transcription(
-            audio,
-            is_usable=is_usable,
-        )
+        segments = self.transcriber.get_cached_transcription(audio, is_usable=is_usable)
         if segments is None:
             segments = self.recovery_transcriber.get_cached_transcription(
-                audio,
-                is_usable=is_usable,
+                audio, is_usable=is_usable
             )
 
         # Run standard fallbacks, followed by defensive decoding
         if segments is None:
             try:
-                segments = self.transcriber(
-                    audio,
-                    is_usable=is_usable,
-                )
+                segments = self.transcriber(audio, is_usable=is_usable)
             except TranscriptionError as exc:
                 logger.warning(f"Whisper transcription attempts failed: {exc}")
                 segments = []
         if not segments:
             logger.info("Retrying block transcription with defensive Whisper decoding")
             try:
-                segments = self.recovery_transcriber(
-                    audio,
-                    is_usable=is_usable,
-                )
+                segments = self.recovery_transcriber(audio, is_usable=is_usable)
             except TranscriptionError as exc:
                 logger.warning(f"Defensive Whisper decoding failed: {exc}")
                 segments = []
@@ -302,9 +272,7 @@ class GuidedTranscriber:
             )
             return []
         return self._transcribe_with_focused_tail_recovery(
-            segments,
-            audio,
-            expected_last_start=expected_last_start,
+            segments, audio, expected_last_start=expected_last_start
         )
 
     def _transcribe_with_focused_tail_recovery(
@@ -333,8 +301,7 @@ class GuidedTranscriber:
             return segments
 
         tail_start = max(
-            last_word_end,
-            expected_last_start - _TAIL_RECOVERY_CONTEXT_SECONDS,
+            last_word_end, expected_last_start - _TAIL_RECOVERY_CONTEXT_SECONDS
         )
         tail_start_ms = round(tail_start * 1000)
         tail_audio = audio[tail_start_ms:]
@@ -351,16 +318,14 @@ class GuidedTranscriber:
             f"subtitle begins at {expected_last_start:.2f}s"
         )
         normalized_tail_audio = normalize(
-            tail_audio,
-            headroom=_TAIL_RECOVERY_HEADROOM_DB,
+            tail_audio, headroom=_TAIL_RECOVERY_HEADROOM_DB
         )
         tail_audio_duration = len(normalized_tail_audio) / 1000
         try:
             tail_segments = self.tail_recovery_transcriber(
                 normalized_tail_audio,
                 is_usable=lambda candidate: self._segments_are_usable(
-                    candidate,
-                    audio_duration=tail_audio_duration,
+                    candidate, audio_duration=tail_audio_duration
                 ),
             )
         except TranscriptionError as exc:
@@ -377,9 +342,7 @@ class GuidedTranscriber:
             return segments
 
         recovered_segments = self._get_credible_tail_segments(
-            tail_segments,
-            tail_start,
-            max(segment.id for segment in segments) + 1,
+            tail_segments, tail_start, max(segment.id for segment in segments) + 1
         )
 
         if not recovered_segments:
@@ -455,9 +418,7 @@ class GuidedTranscriber:
 
     @staticmethod
     def _segments_are_usable(
-        segments: list[TranscribedSegment],
-        *,
-        audio_duration: float | None = None,
+        segments: list[TranscribedSegment], *, audio_duration: float | None = None
     ) -> bool:
         """Determine whether transcribed segments are usable for alignment.
 

--- a/scinoephile/lang/translation/gap.py
+++ b/scinoephile/lang/translation/gap.py
@@ -10,11 +10,7 @@ from types import MappingProxyType
 from typing import Unpack
 
 from scinoephile.core import Language, ScinoephileError
-from scinoephile.core.llms import (
-    LLMProvider,
-    ProcessorKwargs,
-    TestCase,
-)
+from scinoephile.core.llms import LLMProvider, ProcessorKwargs, TestCase
 from scinoephile.lang.eng_yue.translation import EngYueGapTranslationPrompt
 from scinoephile.lang.eng_zho.translation import EngZhoGapTranslationPrompt
 from scinoephile.lang.yue_eng.translation import (
@@ -41,10 +37,7 @@ from scinoephile.llms.gap_translation import (
 )
 from scinoephile.llms.providers.registry import get_provider
 
-__all__ = [
-    "DEFAULT_PROMPTS",
-    "get_gap_translator",
-]
+__all__ = ["DEFAULT_PROMPTS", "get_gap_translator"]
 
 _ENG_YUE_GAP_TRANSLATION_JSON_PATHS: tuple[Path, ...] = ()
 """Default written Cantonese-to-English gap translation JSON paths."""

--- a/scinoephile/lang/translation/guided.py
+++ b/scinoephile/lang/translation/guided.py
@@ -10,11 +10,7 @@ from types import MappingProxyType
 from typing import Unpack
 
 from scinoephile.core import Language, ScinoephileError
-from scinoephile.core.llms import (
-    LLMProvider,
-    ProcessorKwargs,
-    TestCase,
-)
+from scinoephile.core.llms import LLMProvider, ProcessorKwargs, TestCase
 from scinoephile.lang.eng_yue.translation import EngYueGuidedTranslationPrompt
 from scinoephile.lang.eng_zho.translation import EngZhoGuidedTranslationPrompt
 from scinoephile.lang.yue_eng.translation import (
@@ -41,10 +37,7 @@ from scinoephile.llms.guided_translation import (
 )
 from scinoephile.llms.providers.registry import get_provider
 
-__all__ = [
-    "DEFAULT_PROMPTS",
-    "get_guided_translator",
-]
+__all__ = ["DEFAULT_PROMPTS", "get_guided_translator"]
 
 _ENG_YUE_GUIDED_TRANSLATION_JSON_PATHS: tuple[Path, ...] = ()
 """Default written Cantonese-to-English guided translation JSON paths."""

--- a/scinoephile/lang/translation/standard.py
+++ b/scinoephile/lang/translation/standard.py
@@ -37,10 +37,7 @@ from scinoephile.llms.translation import (
     TranslationPrompt,
 )
 
-__all__ = [
-    "DEFAULT_PROMPTS",
-    "get_translator",
-]
+__all__ = ["DEFAULT_PROMPTS", "get_translator"]
 
 _ENG_YUE_TRANSLATION_JSON_PATHS: tuple[Path, ...] = ()
 """Default written Cantonese-to-English regular translation JSON paths."""

--- a/scinoephile/lang/yue/ocr_fusion.py
+++ b/scinoephile/lang/yue/ocr_fusion.py
@@ -13,10 +13,7 @@ from scinoephile.llms.ocr_fusion import OcrFusionPrompt
 
 from .prompts import YUE_HANT_PROMPT_FIELDS
 
-__all__ = [
-    "OcrFusionPromptYueHans",
-    "OcrFusionPromptYueHant",
-]
+__all__ = ["OcrFusionPromptYueHans", "OcrFusionPromptYueHant"]
 
 
 OcrFusionPromptYueHant = OcrFusionPrompt(
@@ -45,7 +42,6 @@ OcrFusionPromptYueHant = OcrFusionPrompt(
 """LLM correspondence text for traditional written Cantonese OCR fusion."""
 
 OcrFusionPromptYueHans = OcrFusionPromptYueHant.transformed(
-    Language.yue_hans,
-    partial(get_zho_text_converted, config=OpenCCConfig.hk2s),
+    Language.yue_hans, partial(get_zho_text_converted, config=OpenCCConfig.hk2s)
 )
 """LLM correspondence text for simplified written Cantonese OCR fusion."""

--- a/scinoephile/lang/yue/review.py
+++ b/scinoephile/lang/yue/review.py
@@ -59,8 +59,7 @@ GuidedReviewPromptYueHant = GuidedReviewPrompt(
 """LLM correspondence text for guided review of traditional Cantonese."""
 
 GuidedReviewPromptYueHans = GuidedReviewPromptYueHant.transformed(
-    Language.yue_hans,
-    partial(get_zho_text_converted, config=OpenCCConfig.hk2s),
+    Language.yue_hans, partial(get_zho_text_converted, config=OpenCCConfig.hk2s)
 )
 """LLM correspondence text for guided review of simplified Cantonese."""
 
@@ -96,7 +95,6 @@ ReviewPromptYueHant = ReviewPrompt(
 """LLM correspondence text for traditional written Cantonese review."""
 
 ReviewPromptYueHans = ReviewPromptYueHant.transformed(
-    Language.yue_hans,
-    partial(get_zho_text_converted, config=OpenCCConfig.hk2s),
+    Language.yue_hans, partial(get_zho_text_converted, config=OpenCCConfig.hk2s)
 )
 """LLM correspondence text for simplified written Cantonese review."""

--- a/scinoephile/lang/yue/romanization.py
+++ b/scinoephile/lang/yue/romanization.py
@@ -154,10 +154,7 @@ def get_yue_text_romanized(text: str) -> str:
     return "\n".join(lines).strip()
 
 
-def _get_yue_section_romanized(
-    section: str,
-    open_symmetric_quotes: set[str],
-) -> str:
+def _get_yue_section_romanized(section: str, open_symmetric_quotes: set[str]) -> str:
     """Get the Yale Cantonese romanization of a whitespace-delimited section.
 
     Arguments:

--- a/scinoephile/lang/yue_eng/review.py
+++ b/scinoephile/lang/yue_eng/review.py
@@ -9,10 +9,7 @@ from scinoephile.lang.yue.review import (
     GuidedReviewPromptYueHant,
 )
 
-__all__ = [
-    "YueEngGuidedReviewPromptYueHans",
-    "YueEngGuidedReviewPromptYueHant",
-]
+__all__ = ["YueEngGuidedReviewPromptYueHans", "YueEngGuidedReviewPromptYueHant"]
 
 
 YueEngGuidedReviewPromptYueHant = GuidedReviewPromptYueHant

--- a/scinoephile/lang/yue_eng/translation.py
+++ b/scinoephile/lang/yue_eng/translation.py
@@ -57,8 +57,7 @@ YueEngTranslationPromptYueHant = TranslationPrompt(
 """Text for traditional written Cantonese translation from English."""
 
 YueEngTranslationPromptYueHans = YueEngTranslationPromptYueHant.transformed(
-    Language.yue_hans,
-    partial(get_zho_text_converted, config=OpenCCConfig.hk2s),
+    Language.yue_hans, partial(get_zho_text_converted, config=OpenCCConfig.hk2s)
 )
 """Text for simplified written Cantonese translation from English."""
 
@@ -100,8 +99,7 @@ YueEngGapTranslationPromptYueHant = GapTranslationPrompt(
 """Text for traditional written Cantonese gap translation using English."""
 
 YueEngGapTranslationPromptYueHans = YueEngGapTranslationPromptYueHant.transformed(
-    Language.yue_hans,
-    partial(get_zho_text_converted, config=OpenCCConfig.hk2s),
+    Language.yue_hans, partial(get_zho_text_converted, config=OpenCCConfig.hk2s)
 )
 """Text for simplified written Cantonese gap translation using English."""
 
@@ -144,7 +142,6 @@ YueEngGuidedTranslationPromptYueHant = GuidedTranslationPrompt(
 """Text for traditional guided written Cantonese translation from English."""
 
 YueEngGuidedTranslationPromptYueHans = YueEngGuidedTranslationPromptYueHant.transformed(
-    Language.yue_hans,
-    partial(get_zho_text_converted, config=OpenCCConfig.hk2s),
+    Language.yue_hans, partial(get_zho_text_converted, config=OpenCCConfig.hk2s)
 )
 """Text for simplified guided written Cantonese translation from English."""

--- a/scinoephile/lang/yue_zho/review.py
+++ b/scinoephile/lang/yue_zho/review.py
@@ -12,10 +12,7 @@ from scinoephile.lang.yue.prompts import YUE_HANT_PROMPT_FIELDS
 from scinoephile.lang.zho.script.conversion import OpenCCConfig, get_zho_text_converted
 from scinoephile.llms.guided_review import GuidedReviewPrompt
 
-__all__ = [
-    "YueZhoGuidedReviewPromptYueHans",
-    "YueZhoGuidedReviewPromptYueHant",
-]
+__all__ = ["YueZhoGuidedReviewPromptYueHans", "YueZhoGuidedReviewPromptYueHant"]
 
 
 YueZhoGuidedReviewPromptYueHant = GuidedReviewPrompt(
@@ -58,7 +55,6 @@ YueZhoGuidedReviewPromptYueHant = GuidedReviewPrompt(
 """Prompt for guided review of traditional written Cantonese using Chinese."""
 
 YueZhoGuidedReviewPromptYueHans = YueZhoGuidedReviewPromptYueHant.transformed(
-    Language.yue_hans,
-    partial(get_zho_text_converted, config=OpenCCConfig.hk2s),
+    Language.yue_hans, partial(get_zho_text_converted, config=OpenCCConfig.hk2s)
 )
 """Prompt for guided review of simplified written Cantonese using Chinese."""

--- a/scinoephile/lang/yue_zho/transcription.py
+++ b/scinoephile/lang/yue_zho/transcription.py
@@ -60,8 +60,7 @@ YueZhoDelineationPromptYueHant = DelineationPrompt(
 """Text for LLM correspondence for traditional written Cantonese delineation."""
 
 YueZhoDelineationPromptYueHans = YueZhoDelineationPromptYueHant.transformed(
-    Language.yue_hans,
-    partial(get_zho_text_converted, config=OpenCCConfig.hk2s),
+    Language.yue_hans, partial(get_zho_text_converted, config=OpenCCConfig.hk2s)
 )
 """Text for LLM correspondence for simplified written Cantonese delineation."""
 
@@ -97,7 +96,6 @@ YueZhoPunctuationPromptYueHant = PunctuationPrompt(
 """Text for traditional written Cantonese/standard Chinese punctuation."""
 
 YueZhoPunctuationPromptYueHans = YueZhoPunctuationPromptYueHant.transformed(
-    Language.yue_hans,
-    partial(get_zho_text_converted, config=OpenCCConfig.hk2s),
+    Language.yue_hans, partial(get_zho_text_converted, config=OpenCCConfig.hk2s)
 )
 """Text for simplified written Cantonese/standard Chinese punctuation."""

--- a/scinoephile/lang/yue_zho/translation.py
+++ b/scinoephile/lang/yue_zho/translation.py
@@ -57,8 +57,7 @@ YueZhoTranslationPromptYueHant = TranslationPrompt(
 """Text for traditional written Cantonese translation from Chinese."""
 
 YueZhoTranslationPromptYueHans = YueZhoTranslationPromptYueHant.transformed(
-    Language.yue_hans,
-    partial(get_zho_text_converted, config=OpenCCConfig.hk2s),
+    Language.yue_hans, partial(get_zho_text_converted, config=OpenCCConfig.hk2s)
 )
 """Text for simplified written Cantonese translation from Chinese."""
 
@@ -102,8 +101,7 @@ YueZhoGapTranslationPromptYueHant = GapTranslationPrompt(
 """Text for traditional written Cantonese gap translation using Chinese."""
 
 YueZhoGapTranslationPromptYueHans = YueZhoGapTranslationPromptYueHant.transformed(
-    Language.yue_hans,
-    partial(get_zho_text_converted, config=OpenCCConfig.hk2s),
+    Language.yue_hans, partial(get_zho_text_converted, config=OpenCCConfig.hk2s)
 )
 """Text for simplified written Cantonese gap translation using Chinese."""
 
@@ -146,7 +144,6 @@ YueZhoGuidedTranslationPromptYueHant = GuidedTranslationPrompt(
 """Text for traditional guided written Cantonese translation from Chinese."""
 
 YueZhoGuidedTranslationPromptYueHans = YueZhoGuidedTranslationPromptYueHant.transformed(
-    Language.yue_hans,
-    partial(get_zho_text_converted, config=OpenCCConfig.hk2s),
+    Language.yue_hans, partial(get_zho_text_converted, config=OpenCCConfig.hk2s)
 )
 """Text for simplified guided written Cantonese translation from Chinese."""

--- a/scinoephile/lang/zho/flattening.py
+++ b/scinoephile/lang/zho/flattening.py
@@ -31,8 +31,7 @@ def get_zho_text_flattened(text: str) -> str:
 
     # Merge conversations
     conversation = re.match(
-        r"^[-－﹣]?\s*(?P<first>.+)\s+[-－﹣]\s*(?P<second>.+)$",
-        flattened,
+        r"^[-－﹣]?\s*(?P<first>.+)\s+[-－﹣]\s*(?P<second>.+)$", flattened
     )
     if conversation is not None:
         flattened = (

--- a/scinoephile/lang/zho/ocr_fusion.py
+++ b/scinoephile/lang/zho/ocr_fusion.py
@@ -13,10 +13,7 @@ from scinoephile.llms.ocr_fusion import OcrFusionPrompt
 from .prompts import ZHO_HANT_PROMPT_FIELDS
 from .script.conversion import OpenCCConfig, get_zho_text_converted
 
-__all__ = [
-    "OcrFusionPromptZhoHans",
-    "OcrFusionPromptZhoHant",
-]
+__all__ = ["OcrFusionPromptZhoHans", "OcrFusionPromptZhoHant"]
 
 
 OcrFusionPromptZhoHant = OcrFusionPrompt(
@@ -45,7 +42,6 @@ OcrFusionPromptZhoHant = OcrFusionPrompt(
 """Text for LLM correspondence for traditional standard Chinese OCR fusion."""
 
 OcrFusionPromptZhoHans = OcrFusionPromptZhoHant.transformed(
-    Language.zho_hans,
-    partial(get_zho_text_converted, config=OpenCCConfig.t2s),
+    Language.zho_hans, partial(get_zho_text_converted, config=OpenCCConfig.t2s)
 )
 """Text for LLM correspondence for simplified standard Chinese OCR fusion."""

--- a/scinoephile/lang/zho/review.py
+++ b/scinoephile/lang/zho/review.py
@@ -59,8 +59,7 @@ GuidedReviewPromptZhoHant = GuidedReviewPrompt(
 """LLM correspondence text for guided review of traditional Chinese."""
 
 GuidedReviewPromptZhoHans = GuidedReviewPromptZhoHant.transformed(
-    Language.zho_hans,
-    partial(get_zho_text_converted, config=OpenCCConfig.t2s),
+    Language.zho_hans, partial(get_zho_text_converted, config=OpenCCConfig.t2s)
 )
 """LLM correspondence text for guided review of simplified Chinese."""
 
@@ -96,7 +95,6 @@ ReviewPromptZhoHant = ReviewPrompt(
 """LLM correspondence text for traditional standard Chinese review."""
 
 ReviewPromptZhoHans = ReviewPromptZhoHant.transformed(
-    Language.zho_hans,
-    partial(get_zho_text_converted, config=OpenCCConfig.t2s),
+    Language.zho_hans, partial(get_zho_text_converted, config=OpenCCConfig.t2s)
 )
 """LLM correspondence text for simplified standard Chinese review."""

--- a/scinoephile/lang/zho/script/analysis.py
+++ b/scinoephile/lang/zho/script/analysis.py
@@ -52,14 +52,10 @@ def get_zho_script_analysis(text: str) -> ZhoScriptAnalysis:
     for match in RE_HANZI.finditer(text):
         char = match.group(0)
         simplified_char = get_zho_text_converted(
-            char,
-            OpenCCConfig.t2s,
-            apply_exclusions=False,
+            char, OpenCCConfig.t2s, apply_exclusions=False
         )
         traditional_char = get_zho_text_converted(
-            char,
-            OpenCCConfig.s2t,
-            apply_exclusions=False,
+            char, OpenCCConfig.s2t, apply_exclusions=False
         )
         if char != simplified_char:
             traditional_count += 1
@@ -92,11 +88,7 @@ def is_simplified(text: str) -> bool:
     """
     if RE_HANZI.search(text) is None:
         return False
-    simplified = get_zho_text_converted(
-        text,
-        OpenCCConfig.t2s,
-        apply_exclusions=False,
-    )
+    simplified = get_zho_text_converted(text, OpenCCConfig.t2s, apply_exclusions=False)
     return text == simplified
 
 
@@ -110,11 +102,7 @@ def is_traditional(text: str) -> bool:
     """
     if RE_HANZI.search(text) is None:
         return False
-    traditional = get_zho_text_converted(
-        text,
-        OpenCCConfig.s2t,
-        apply_exclusions=False,
-    )
+    traditional = get_zho_text_converted(text, OpenCCConfig.s2t, apply_exclusions=False)
     return text == traditional
 
 

--- a/scinoephile/lang/zho/subtitles/analysis/cache.py
+++ b/scinoephile/lang/zho/subtitles/analysis/cache.py
@@ -30,11 +30,7 @@ _CACHE_VERSION = 1
 class ZhoScriptAnalysisCache:
     """Caches Chinese subtitle script analysis results."""
 
-    def __init__(
-        self,
-        cache_root_path: Path | None = None,
-        overwrite: bool = False,
-    ):
+    def __init__(self, cache_root_path: Path | None = None, overwrite: bool = False):
         """Initialize.
 
         Arguments:
@@ -107,12 +103,7 @@ class ZhoScriptAnalysisCache:
         Returns:
             cached script analysis, if present and valid
         """
-        cache_path = self.get_path(
-            infile_path,
-            stream,
-            sample_size,
-            ocr_languages,
-        )
+        cache_path = self.get_path(infile_path, stream, sample_size, ocr_languages)
         if self.overwrite and cache_path not in self._refreshed_paths:
             self._refreshed_paths.add(cache_path)
             if cache_path.exists():
@@ -154,12 +145,7 @@ class ZhoScriptAnalysisCache:
         Returns:
             removed cache path, if present
         """
-        cache_path = self.get_path(
-            infile_path,
-            stream,
-            sample_size,
-            ocr_languages,
-        )
+        cache_path = self.get_path(infile_path, stream, sample_size, ocr_languages)
         if not cache_path.exists():
             return None
         cache_path.unlink()
@@ -185,18 +171,10 @@ class ZhoScriptAnalysisCache:
         Returns:
             saved cache path
         """
-        cache_path = self.get_path(
-            infile_path,
-            stream,
-            sample_size,
-            ocr_languages,
-        )
+        cache_path = self.get_path(infile_path, stream, sample_size, ocr_languages)
         with open_atomic_text_file(cache_path) as file:
             json.dump(
-                {
-                    "cache_version": _CACHE_VERSION,
-                    "analysis": asdict(analysis),
-                },
+                {"cache_version": _CACHE_VERSION, "analysis": asdict(analysis)},
                 file,
                 ensure_ascii=False,
                 sort_keys=True,

--- a/scinoephile/lang/zho/subtitles/analysis/script.py
+++ b/scinoephile/lang/zho/subtitles/analysis/script.py
@@ -47,9 +47,7 @@ def analyze_zho_subtitle_stream_script(
         subtitle script analysis
     """
     if not is_chinese_language_tag(stream.language):
-        return ZhoScriptAnalysisResult(
-            failure_reason="not a Chinese subtitle stream",
-        )
+        return ZhoScriptAnalysisResult(failure_reason="not a Chinese subtitle stream")
 
     # Resolve one subtitle cache and use its policy for related cached artifacts
     if subtitle_cache is None:
@@ -61,15 +59,9 @@ def analyze_zho_subtitle_stream_script(
     ocr_language_codes = tuple(
         language.code for language in _ZHO_SUBTITLE_OCR_LANGUAGES
     )
-    analysis_cache = ZhoScriptAnalysisCache(
-        cache_root_path,
-        overwrite_cache,
-    )
+    analysis_cache = ZhoScriptAnalysisCache(cache_root_path, overwrite_cache)
     cached_analysis = analysis_cache.load(
-        infile_path,
-        stream,
-        sample_size,
-        ocr_language_codes,
+        infile_path, stream, sample_size, ocr_language_codes
     )
     if cached_analysis is not None:
         return cached_analysis
@@ -79,10 +71,7 @@ def analyze_zho_subtitle_stream_script(
 
     # Analyze either rendered SUP images or text subtitle events
     if stream.extension == "sup":
-        image_dir_path = subtitle_cache.get_image_series_dir_path(
-            infile_path,
-            stream,
-        )
+        image_dir_path = subtitle_cache.get_image_series_dir_path(infile_path, stream)
         analysis = _get_zho_image_subtitle_script_analysis(
             image_dir_path,
             cache_root_path=cache_root_path,
@@ -95,13 +84,7 @@ def analyze_zho_subtitle_stream_script(
         analysis = _get_zho_subtitle_script_analysis(text)
 
     # Persist the analysis for reuse by later probes
-    analysis_cache.save(
-        infile_path,
-        stream,
-        sample_size,
-        ocr_language_codes,
-        analysis,
-    )
+    analysis_cache.save(infile_path, stream, sample_size, ocr_language_codes, analysis)
     return analysis
 
 
@@ -201,9 +184,7 @@ def _get_zho_image_subtitle_script_analysis(
     event_count = len(series)
     sample_indexes = _get_evenly_spaced_indexes(event_count, sample_size)
     if not sample_indexes:
-        return ZhoScriptAnalysisResult(
-            failure_reason="no subtitle images to sample",
-        )
+        return ZhoScriptAnalysisResult(failure_reason="no subtitle images to sample")
 
     return _get_image_subtitle_sample_analysis(
         series,
@@ -214,9 +195,7 @@ def _get_zho_image_subtitle_script_analysis(
 
 
 def _get_zho_subtitle_script_analysis(
-    text: str,
-    *,
-    failure_reason: str | None = None,
+    text: str, *, failure_reason: str | None = None
 ) -> ZhoScriptAnalysisResult:
     """Analyze Chinese script in subtitle text.
 

--- a/scinoephile/lang/zho/subtitles/streams.py
+++ b/scinoephile/lang/zho/subtitles/streams.py
@@ -37,9 +37,7 @@ def get_zho_subtitle_streams(
 
     zho_streams = []
     for stream in get_detailed_subtitle_streams(
-        infile_path,
-        streams=streams,
-        subtitle_cache=subtitle_cache,
+        infile_path, streams=streams, subtitle_cache=subtitle_cache
     ):
         language = stream.language
         if language is None or not is_chinese_language_tag(language):
@@ -47,9 +45,7 @@ def get_zho_subtitle_streams(
             continue
 
         analysis = analyze_zho_subtitle_stream_script(
-            infile_path,
-            stream,
-            subtitle_cache=subtitle_cache,
+            infile_path, stream, subtitle_cache=subtitle_cache
         )
         language = language.split("-", 1)[0]
         if language == "chi":

--- a/scinoephile/lang/zho_eng/review.py
+++ b/scinoephile/lang/zho_eng/review.py
@@ -9,10 +9,7 @@ from scinoephile.lang.zho.review import (
     GuidedReviewPromptZhoHant,
 )
 
-__all__ = [
-    "ZhoEngGuidedReviewPromptZhoHans",
-    "ZhoEngGuidedReviewPromptZhoHant",
-]
+__all__ = ["ZhoEngGuidedReviewPromptZhoHans", "ZhoEngGuidedReviewPromptZhoHant"]
 
 
 ZhoEngGuidedReviewPromptZhoHant = GuidedReviewPromptZhoHant

--- a/scinoephile/lang/zho_eng/translation.py
+++ b/scinoephile/lang/zho_eng/translation.py
@@ -54,8 +54,7 @@ ZhoEngTranslationPromptZhoHant = TranslationPrompt(
 """Text for traditional standard Chinese translation from English."""
 
 ZhoEngTranslationPromptZhoHans = ZhoEngTranslationPromptZhoHant.transformed(
-    Language.zho_hans,
-    partial(get_zho_text_converted, config=OpenCCConfig.t2s),
+    Language.zho_hans, partial(get_zho_text_converted, config=OpenCCConfig.t2s)
 )
 """Text for simplified standard Chinese translation from English."""
 
@@ -94,8 +93,7 @@ ZhoEngGapTranslationPromptZhoHant = GapTranslationPrompt(
 """Text for traditional standard Chinese gap translation using English."""
 
 ZhoEngGapTranslationPromptZhoHans = ZhoEngGapTranslationPromptZhoHant.transformed(
-    Language.zho_hans,
-    partial(get_zho_text_converted, config=OpenCCConfig.t2s),
+    Language.zho_hans, partial(get_zho_text_converted, config=OpenCCConfig.t2s)
 )
 """Text for simplified standard Chinese gap translation using English."""
 
@@ -135,7 +133,6 @@ ZhoEngGuidedTranslationPromptZhoHant = GuidedTranslationPrompt(
 """Text for traditional guided standard Chinese translation from English."""
 
 ZhoEngGuidedTranslationPromptZhoHans = ZhoEngGuidedTranslationPromptZhoHant.transformed(
-    Language.zho_hans,
-    partial(get_zho_text_converted, config=OpenCCConfig.t2s),
+    Language.zho_hans, partial(get_zho_text_converted, config=OpenCCConfig.t2s)
 )
 """Text for simplified guided standard Chinese translation from English."""

--- a/scinoephile/lang/zho_yue/review.py
+++ b/scinoephile/lang/zho_yue/review.py
@@ -9,10 +9,7 @@ from scinoephile.lang.zho.review import (
     GuidedReviewPromptZhoHant,
 )
 
-__all__ = [
-    "ZhoYueGuidedReviewPromptZhoHans",
-    "ZhoYueGuidedReviewPromptZhoHant",
-]
+__all__ = ["ZhoYueGuidedReviewPromptZhoHans", "ZhoYueGuidedReviewPromptZhoHant"]
 
 
 ZhoYueGuidedReviewPromptZhoHant = GuidedReviewPromptZhoHant

--- a/scinoephile/lang/zho_yue/translation.py
+++ b/scinoephile/lang/zho_yue/translation.py
@@ -54,8 +54,7 @@ ZhoYueTranslationPromptZhoHant = TranslationPrompt(
 """Text for traditional standard Chinese translation from written Cantonese."""
 
 ZhoYueTranslationPromptZhoHans = ZhoYueTranslationPromptZhoHant.transformed(
-    Language.zho_hans,
-    partial(get_zho_text_converted, config=OpenCCConfig.t2s),
+    Language.zho_hans, partial(get_zho_text_converted, config=OpenCCConfig.t2s)
 )
 """Text for simplified standard Chinese translation from written Cantonese."""
 
@@ -94,8 +93,7 @@ ZhoYueGapTranslationPromptZhoHant = GapTranslationPrompt(
 """Text for traditional standard Chinese gap translation using Cantonese."""
 
 ZhoYueGapTranslationPromptZhoHans = ZhoYueGapTranslationPromptZhoHant.transformed(
-    Language.zho_hans,
-    partial(get_zho_text_converted, config=OpenCCConfig.t2s),
+    Language.zho_hans, partial(get_zho_text_converted, config=OpenCCConfig.t2s)
 )
 """Text for simplified standard Chinese gap translation using Cantonese."""
 
@@ -135,7 +133,6 @@ ZhoYueGuidedTranslationPromptZhoHant = GuidedTranslationPrompt(
 """Text for traditional guided standard Chinese translation from Cantonese."""
 
 ZhoYueGuidedTranslationPromptZhoHans = ZhoYueGuidedTranslationPromptZhoHant.transformed(
-    Language.zho_hans,
-    partial(get_zho_text_converted, config=OpenCCConfig.t2s),
+    Language.zho_hans, partial(get_zho_text_converted, config=OpenCCConfig.t2s)
 )
 """Text for simplified guided standard Chinese translation from Cantonese."""

--- a/scinoephile/llms/__init__.py
+++ b/scinoephile/llms/__init__.py
@@ -37,9 +37,7 @@ logger = logging.getLogger(__name__)
 
 @functools.cache
 def load_default_test_cases(
-    manager_cls: type[Manager],
-    prompt: Prompt,
-    relative_paths: tuple[Path, ...],
+    manager_cls: type[Manager], prompt: Prompt, relative_paths: tuple[Path, ...]
 ) -> tuple[TestCase, ...]:
     """Load default test cases from repository JSON files and cache the result.
 

--- a/scinoephile/llms/delineation/manager.py
+++ b/scinoephile/llms/delineation/manager.py
@@ -7,13 +7,7 @@ from __future__ import annotations
 from functools import cache
 from typing import ClassVar
 
-from scinoephile.core.llms import (
-    Answer,
-    Manager,
-    PromptModelField,
-    Query,
-    TestCase,
-)
+from scinoephile.core.llms import Answer, Manager, PromptModelField, Query, TestCase
 
 from .models import DelineationAnswer, DelineationQuery, DelineationTestCase
 from .prompt import DelineationPrompt
@@ -33,10 +27,7 @@ class DelineationManager(Manager[DelineationTestCase]):
 
     @classmethod
     @cache
-    def get_answer_cls(
-        cls,
-        prompt: DelineationPrompt,
-    ) -> type[Answer]:
+    def get_answer_cls(cls, prompt: DelineationPrompt) -> type[Answer]:
         """Get concrete answer class with prompt-specific JSON field aliases.
 
         Arguments:
@@ -61,10 +52,7 @@ class DelineationManager(Manager[DelineationTestCase]):
 
     @classmethod
     @cache
-    def get_query_cls(
-        cls,
-        prompt: DelineationPrompt,
-    ) -> type[Query]:
+    def get_query_cls(cls, prompt: DelineationPrompt) -> type[Query]:
         """Get concrete query class with prompt-specific JSON field aliases.
 
         Arguments:
@@ -77,20 +65,16 @@ class DelineationManager(Manager[DelineationTestCase]):
             prompt,
             {
                 "reference_one": PromptModelField(
-                    alias=prompt.ref_sub_1,
-                    description=prompt.ref_sub_1_desc,
+                    alias=prompt.ref_sub_1, description=prompt.ref_sub_1_desc
                 ),
                 "reference_two": PromptModelField(
-                    alias=prompt.ref_sub_2,
-                    description=prompt.ref_sub_2_desc,
+                    alias=prompt.ref_sub_2, description=prompt.ref_sub_2_desc
                 ),
                 "target_one": PromptModelField(
-                    alias=prompt.target_sub_1,
-                    description=prompt.target_sub_1_desc,
+                    alias=prompt.target_sub_1, description=prompt.target_sub_1_desc
                 ),
                 "target_two": PromptModelField(
-                    alias=prompt.target_sub_2,
-                    description=prompt.target_sub_2_desc,
+                    alias=prompt.target_sub_2, description=prompt.target_sub_2_desc
                 ),
             },
         )

--- a/scinoephile/llms/delineation/models.py
+++ b/scinoephile/llms/delineation/models.py
@@ -12,11 +12,7 @@ from scinoephile.core.llms import Answer, Query, TestCase
 
 from .prompt import DelineationPrompt
 
-__all__ = [
-    "DelineationAnswer",
-    "DelineationQuery",
-    "DelineationTestCase",
-]
+__all__ = ["DelineationAnswer", "DelineationQuery", "DelineationTestCase"]
 
 
 _BASE_PROMPT = DelineationPrompt()

--- a/scinoephile/llms/gap_translation/manager.py
+++ b/scinoephile/llms/gap_translation/manager.py
@@ -7,13 +7,7 @@ from __future__ import annotations
 from functools import cache
 from typing import ClassVar
 
-from scinoephile.core.llms import (
-    Answer,
-    Manager,
-    PromptModelField,
-    Query,
-    TestCase,
-)
+from scinoephile.core.llms import Answer, Manager, PromptModelField, Query, TestCase
 
 from .models import (
     GapTranslationAnswer,
@@ -55,15 +49,14 @@ class GapTranslationManager(Manager[GapTranslationTestCase]):
                     alias=prompt.outputs,
                     annotation=list[output_cls],  # ty: ignore[invalid-type-form]
                     description=prompt.outputs_desc,
-                ),
+                )
             },
         )
 
     @classmethod
     @cache
     def get_guide_cls(
-        cls,
-        prompt: GapTranslationPrompt,
+        cls, prompt: GapTranslationPrompt
     ) -> type[GapTranslationSubtitle]:
         """Get guide class with prompt-specific JSON field aliases.
 
@@ -77,12 +70,10 @@ class GapTranslationManager(Manager[GapTranslationTestCase]):
             prompt,
             {
                 "index": PromptModelField(
-                    alias=prompt.index,
-                    description=prompt.index_desc,
+                    alias=prompt.index, description=prompt.index_desc
                 ),
                 "text": PromptModelField(
-                    alias=prompt.text,
-                    description=prompt.guide_text_desc,
+                    alias=prompt.text, description=prompt.guide_text_desc
                 ),
             },
             name="GapTranslationGuide",
@@ -91,8 +82,7 @@ class GapTranslationManager(Manager[GapTranslationTestCase]):
     @classmethod
     @cache
     def get_output_cls(
-        cls,
-        prompt: GapTranslationPrompt,
+        cls, prompt: GapTranslationPrompt
     ) -> type[GapTranslationSubtitle]:
         """Get output class with prompt-specific JSON field aliases.
 
@@ -106,12 +96,10 @@ class GapTranslationManager(Manager[GapTranslationTestCase]):
             prompt,
             {
                 "index": PromptModelField(
-                    alias=prompt.index,
-                    description=prompt.index_desc,
+                    alias=prompt.index, description=prompt.index_desc
                 ),
                 "text": PromptModelField(
-                    alias=prompt.text,
-                    description=prompt.output_text_desc,
+                    alias=prompt.text, description=prompt.output_text_desc
                 ),
             },
             name="GapTranslationOutput",
@@ -149,8 +137,7 @@ class GapTranslationManager(Manager[GapTranslationTestCase]):
     @classmethod
     @cache
     def get_target_cls(
-        cls,
-        prompt: GapTranslationPrompt,
+        cls, prompt: GapTranslationPrompt
     ) -> type[GapTranslationSubtitle]:
         """Get target class with prompt-specific JSON field aliases.
 
@@ -164,12 +151,10 @@ class GapTranslationManager(Manager[GapTranslationTestCase]):
             prompt,
             {
                 "index": PromptModelField(
-                    alias=prompt.index,
-                    description=prompt.index_desc,
+                    alias=prompt.index, description=prompt.index_desc
                 ),
                 "text": PromptModelField(
-                    alias=prompt.text,
-                    description=prompt.target_text_desc,
+                    alias=prompt.text, description=prompt.target_text_desc
                 ),
             },
             name="GapTranslationTarget",

--- a/scinoephile/llms/guided_review/manager.py
+++ b/scinoephile/llms/guided_review/manager.py
@@ -52,7 +52,7 @@ class GuidedReviewManager(Manager[GuidedReviewTestCase]):
                     alias=prompt.revisions,
                     annotation=list[revision_cls],  # ty: ignore[invalid-type-form]
                     description=prompt.revisions_desc,
-                ),
+                )
             },
         )
 
@@ -71,12 +71,10 @@ class GuidedReviewManager(Manager[GuidedReviewTestCase]):
             prompt,
             {
                 "index": PromptModelField(
-                    alias=prompt.index,
-                    description=prompt.index_desc,
+                    alias=prompt.index, description=prompt.index_desc
                 ),
                 "text": PromptModelField(
-                    alias=prompt.text,
-                    description=prompt.guide_text_desc,
+                    alias=prompt.text, description=prompt.guide_text_desc
                 ),
             },
             module=GuidedReviewQuery.__module__,
@@ -115,8 +113,7 @@ class GuidedReviewManager(Manager[GuidedReviewTestCase]):
     @classmethod
     @cache
     def get_revision_cls(
-        cls,
-        prompt: GuidedReviewPrompt,
+        cls, prompt: GuidedReviewPrompt
     ) -> type[AnnotatedTestCaseSubtitle]:
         """Get revision class with prompt-specific JSON field aliases.
 
@@ -130,16 +127,13 @@ class GuidedReviewManager(Manager[GuidedReviewTestCase]):
             prompt,
             {
                 "index": PromptModelField(
-                    alias=prompt.index,
-                    description=prompt.index_desc,
+                    alias=prompt.index, description=prompt.index_desc
                 ),
                 "text": PromptModelField(
-                    alias=prompt.text,
-                    description=prompt.revision_text_desc,
+                    alias=prompt.text, description=prompt.revision_text_desc
                 ),
                 "note": PromptModelField(
-                    alias=prompt.note,
-                    description=prompt.note_desc,
+                    alias=prompt.note, description=prompt.note_desc
                 ),
             },
             module=GuidedReviewAnswer.__module__,
@@ -161,12 +155,10 @@ class GuidedReviewManager(Manager[GuidedReviewTestCase]):
             prompt,
             {
                 "index": PromptModelField(
-                    alias=prompt.index,
-                    description=prompt.index_desc,
+                    alias=prompt.index, description=prompt.index_desc
                 ),
                 "text": PromptModelField(
-                    alias=prompt.text,
-                    description=prompt.target_text_desc,
+                    alias=prompt.text, description=prompt.target_text_desc
                 ),
             },
             module=GuidedReviewQuery.__module__,

--- a/scinoephile/llms/guided_review/models.py
+++ b/scinoephile/llms/guided_review/models.py
@@ -18,11 +18,7 @@ from scinoephile.core.llms import (
 
 from .prompt import GuidedReviewPrompt
 
-__all__ = [
-    "GuidedReviewAnswer",
-    "GuidedReviewQuery",
-    "GuidedReviewTestCase",
-]
+__all__ = ["GuidedReviewAnswer", "GuidedReviewQuery", "GuidedReviewTestCase"]
 
 
 _BASE_PROMPT = GuidedReviewPrompt()

--- a/scinoephile/llms/guided_review/processor.py
+++ b/scinoephile/llms/guided_review/processor.py
@@ -67,17 +67,11 @@ class GuidedReviewProcessor(Processor):
             query = query_cls.model_validate(
                 {
                     "targets": [
-                        {
-                            "index": idx,
-                            "text": subtitle.text_with_newline.strip(),
-                        }
+                        {"index": idx, "text": subtitle.text_with_newline.strip()}
                         for idx, subtitle in enumerate(target_block, 1)
                     ],
                     "guides": [
-                        {
-                            "index": idx,
-                            "text": subtitle.text_with_newline.strip(),
-                        }
+                        {"index": idx, "text": subtitle.text_with_newline.strip()}
                         for idx, subtitle in enumerate(guide_block, 1)
                     ],
                 }

--- a/scinoephile/llms/guided_translation/manager.py
+++ b/scinoephile/llms/guided_translation/manager.py
@@ -7,13 +7,7 @@ from __future__ import annotations
 from functools import cache
 from typing import ClassVar
 
-from scinoephile.core.llms import (
-    Answer,
-    Manager,
-    PromptModelField,
-    Query,
-    TestCase,
-)
+from scinoephile.core.llms import Answer, Manager, PromptModelField, Query, TestCase
 
 from .models import (
     GuidedTranslationAnswer,
@@ -55,15 +49,14 @@ class GuidedTranslationManager(Manager[GuidedTranslationTestCase]):
                     alias=prompt.outputs,
                     annotation=list[output_cls],  # ty: ignore[invalid-type-form]
                     description=prompt.outputs_desc,
-                ),
+                )
             },
         )
 
     @classmethod
     @cache
     def get_guide_cls(
-        cls,
-        prompt: GuidedTranslationPrompt,
+        cls, prompt: GuidedTranslationPrompt
     ) -> type[GuidedTranslationSubtitle]:
         """Get guide-item class with prompt-specific JSON field aliases.
 
@@ -77,12 +70,10 @@ class GuidedTranslationManager(Manager[GuidedTranslationTestCase]):
             prompt,
             {
                 "index": PromptModelField(
-                    alias=prompt.index,
-                    description=prompt.index_desc,
+                    alias=prompt.index, description=prompt.index_desc
                 ),
                 "text": PromptModelField(
-                    alias=prompt.text,
-                    description=prompt.guide_text_desc,
+                    alias=prompt.text, description=prompt.guide_text_desc
                 ),
             },
             name="GuidedTranslationGuide",
@@ -91,8 +82,7 @@ class GuidedTranslationManager(Manager[GuidedTranslationTestCase]):
     @classmethod
     @cache
     def get_output_cls(
-        cls,
-        prompt: GuidedTranslationPrompt,
+        cls, prompt: GuidedTranslationPrompt
     ) -> type[GuidedTranslationSubtitle]:
         """Get output-item class with prompt-specific JSON field aliases.
 
@@ -106,12 +96,10 @@ class GuidedTranslationManager(Manager[GuidedTranslationTestCase]):
             prompt,
             {
                 "index": PromptModelField(
-                    alias=prompt.index,
-                    description=prompt.index_desc,
+                    alias=prompt.index, description=prompt.index_desc
                 ),
                 "text": PromptModelField(
-                    alias=prompt.text,
-                    description=prompt.output_text_desc,
+                    alias=prompt.text, description=prompt.output_text_desc
                 ),
             },
             name="GuidedTranslationOutput",
@@ -149,8 +137,7 @@ class GuidedTranslationManager(Manager[GuidedTranslationTestCase]):
     @classmethod
     @cache
     def get_subtitle_cls(
-        cls,
-        prompt: GuidedTranslationPrompt,
+        cls, prompt: GuidedTranslationPrompt
     ) -> type[GuidedTranslationSubtitle]:
         """Get subtitle-item class with prompt-specific JSON field aliases.
 
@@ -164,12 +151,10 @@ class GuidedTranslationManager(Manager[GuidedTranslationTestCase]):
             prompt,
             {
                 "index": PromptModelField(
-                    alias=prompt.index,
-                    description=prompt.index_desc,
+                    alias=prompt.index, description=prompt.index_desc
                 ),
                 "text": PromptModelField(
-                    alias=prompt.text,
-                    description=prompt.subtitle_text_desc,
+                    alias=prompt.text, description=prompt.subtitle_text_desc
                 ),
             },
         )

--- a/scinoephile/llms/guided_translation/processor.py
+++ b/scinoephile/llms/guided_translation/processor.py
@@ -63,17 +63,11 @@ class GuidedTranslationProcessor(Processor):
             query = query_cls.model_validate(
                 {
                     "subtitles": [
-                        {
-                            "index": idx,
-                            "text": subtitle.text_with_newline.strip(),
-                        }
+                        {"index": idx, "text": subtitle.text_with_newline.strip()}
                         for idx, subtitle in enumerate(one_blk.events, 1)
                     ],
                     "guides": [
-                        {
-                            "index": idx,
-                            "text": guide.text_with_newline.strip(),
-                        }
+                        {"index": idx, "text": guide.text_with_newline.strip()}
                         for idx, guide in enumerate(two_blk.events, 1)
                     ],
                 }

--- a/scinoephile/llms/ocr_fusion/manager.py
+++ b/scinoephile/llms/ocr_fusion/manager.py
@@ -7,13 +7,7 @@ from __future__ import annotations
 from functools import cache
 from typing import ClassVar
 
-from scinoephile.core.llms import (
-    Answer,
-    Manager,
-    PromptModelField,
-    Query,
-    TestCase,
-)
+from scinoephile.core.llms import Answer, Manager, PromptModelField, Query, TestCase
 
 from .models import OcrFusionAnswer, OcrFusionQuery, OcrFusionTestCase
 from .prompt import OcrFusionPrompt
@@ -46,12 +40,10 @@ class OcrFusionManager(Manager[OcrFusionTestCase]):
             prompt,
             {
                 "output": PromptModelField(
-                    alias=prompt.output,
-                    description=prompt.output_desc,
+                    alias=prompt.output, description=prompt.output_desc
                 ),
                 "note": PromptModelField(
-                    alias=prompt.note,
-                    description=prompt.note_desc,
+                    alias=prompt.note, description=prompt.note_desc
                 ),
             },
             module=Answer.__module__,
@@ -73,12 +65,10 @@ class OcrFusionManager(Manager[OcrFusionTestCase]):
             prompt,
             {
                 "source_one": PromptModelField(
-                    alias=prompt.src_1,
-                    description=prompt.src_1_desc,
+                    alias=prompt.src_1, description=prompt.src_1_desc
                 ),
                 "source_two": PromptModelField(
-                    alias=prompt.src_2,
-                    description=prompt.src_2_desc,
+                    alias=prompt.src_2, description=prompt.src_2_desc
                 ),
             },
             module=Query.__module__,

--- a/scinoephile/llms/ocr_fusion/models.py
+++ b/scinoephile/llms/ocr_fusion/models.py
@@ -13,11 +13,7 @@ from scinoephile.core.llms import Answer, Query, TestCase
 
 from .prompt import OcrFusionPrompt
 
-__all__ = [
-    "OcrFusionAnswer",
-    "OcrFusionQuery",
-    "OcrFusionTestCase",
-]
+__all__ = ["OcrFusionAnswer", "OcrFusionQuery", "OcrFusionTestCase"]
 
 
 _BASE_PROMPT = OcrFusionPrompt()

--- a/scinoephile/llms/providers/__init__.py
+++ b/scinoephile/llms/providers/__init__.py
@@ -12,7 +12,4 @@ from __future__ import annotations
 from .deepseek_provider import DeepSeekProvider
 from .openai_provider import OpenAIProvider
 
-__all__ = [
-    "DeepSeekProvider",
-    "OpenAIProvider",
-]
+__all__ = ["DeepSeekProvider", "OpenAIProvider"]

--- a/scinoephile/llms/punctuation/manager.py
+++ b/scinoephile/llms/punctuation/manager.py
@@ -7,13 +7,7 @@ from __future__ import annotations
 from functools import cache
 from typing import ClassVar
 
-from scinoephile.core.llms import (
-    Answer,
-    Manager,
-    PromptModelField,
-    Query,
-    TestCase,
-)
+from scinoephile.core.llms import Answer, Manager, PromptModelField, Query, TestCase
 
 from .models import PunctuationAnswer, PunctuationQuery, PunctuationTestCase
 from .prompt import PunctuationPrompt
@@ -33,10 +27,7 @@ class PunctuationManager(Manager[PunctuationTestCase]):
 
     @classmethod
     @cache
-    def get_answer_cls(
-        cls,
-        prompt: PunctuationPrompt,
-    ) -> type[Answer]:
+    def get_answer_cls(cls, prompt: PunctuationPrompt) -> type[Answer]:
         """Get concrete answer class with prompt-specific JSON field aliases.
 
         Arguments:
@@ -51,16 +42,13 @@ class PunctuationManager(Manager[PunctuationTestCase]):
                 "output": PromptModelField(
                     alias=prompt.target_sub_punctuated,
                     description=prompt.target_sub_punctuated_desc,
-                ),
+                )
             },
         )
 
     @classmethod
     @cache
-    def get_query_cls(
-        cls,
-        prompt: PunctuationPrompt,
-    ) -> type[Query]:
+    def get_query_cls(cls, prompt: PunctuationPrompt) -> type[Query]:
         """Get concrete query class with prompt-specific JSON field aliases.
 
         Arguments:
@@ -73,12 +61,10 @@ class PunctuationManager(Manager[PunctuationTestCase]):
             prompt,
             {
                 "guide": PromptModelField(
-                    alias=prompt.ref_sub,
-                    description=prompt.ref_sub_desc,
+                    alias=prompt.ref_sub, description=prompt.ref_sub_desc
                 ),
                 "subtitles": PromptModelField(
-                    alias=prompt.target_subs,
-                    description=prompt.target_subs_desc,
+                    alias=prompt.target_subs, description=prompt.target_subs_desc
                 ),
             },
         )

--- a/scinoephile/llms/punctuation/models.py
+++ b/scinoephile/llms/punctuation/models.py
@@ -16,11 +16,7 @@ from scinoephile.core.text import (
 
 from .prompt import PunctuationPrompt
 
-__all__ = [
-    "PunctuationAnswer",
-    "PunctuationQuery",
-    "PunctuationTestCase",
-]
+__all__ = ["PunctuationAnswer", "PunctuationQuery", "PunctuationTestCase"]
 
 
 _BASE_PROMPT = PunctuationPrompt()

--- a/scinoephile/llms/punctuation/prompt.py
+++ b/scinoephile/llms/punctuation/prompt.py
@@ -67,6 +67,5 @@ class PunctuationPrompt(Prompt):
             error message
         """
         return self.target_chars_changed_err_tpl.format(
-            expected=expected,
-            received=received,
+            expected=expected, received=received
         )

--- a/scinoephile/llms/review/__init__.py
+++ b/scinoephile/llms/review/__init__.py
@@ -12,11 +12,7 @@ Package hierarchy (modules may import from any above):
 from __future__ import annotations
 
 from .manager import ReviewManager
-from .models import (
-    ReviewAnswer,
-    ReviewQuery,
-    ReviewTestCase,
-)
+from .models import ReviewAnswer, ReviewQuery, ReviewTestCase
 from .processor import ReviewProcessor
 from .prompt import ReviewPrompt
 

--- a/scinoephile/llms/review/manager.py
+++ b/scinoephile/llms/review/manager.py
@@ -52,7 +52,7 @@ class ReviewManager(Manager[ReviewTestCase]):
                     alias=prompt.revisions,
                     annotation=list[revision_cls],  # ty: ignore[invalid-type-form]
                     description=prompt.revisions_desc,
-                ),
+                )
             },
         )
 
@@ -75,16 +75,13 @@ class ReviewManager(Manager[ReviewTestCase]):
                     alias=prompt.subtitles,
                     annotation=list[subtitle_cls],  # ty: ignore[invalid-type-form]
                     description=prompt.subtitles_desc,
-                ),
+                )
             },
         )
 
     @classmethod
     @cache
-    def get_revision_cls(
-        cls,
-        prompt: ReviewPrompt,
-    ) -> type[AnnotatedTestCaseSubtitle]:
+    def get_revision_cls(cls, prompt: ReviewPrompt) -> type[AnnotatedTestCaseSubtitle]:
         """Get revision class with prompt-specific JSON field aliases.
 
         Arguments:
@@ -97,16 +94,13 @@ class ReviewManager(Manager[ReviewTestCase]):
             prompt,
             {
                 "index": PromptModelField(
-                    alias=prompt.index,
-                    description=prompt.index_desc,
+                    alias=prompt.index, description=prompt.index_desc
                 ),
                 "text": PromptModelField(
-                    alias=prompt.text,
-                    description=prompt.revision_text_desc,
+                    alias=prompt.text, description=prompt.revision_text_desc
                 ),
                 "note": PromptModelField(
-                    alias=prompt.note,
-                    description=prompt.note_desc,
+                    alias=prompt.note, description=prompt.note_desc
                 ),
             },
             module=ReviewAnswer.__module__,
@@ -128,12 +122,10 @@ class ReviewManager(Manager[ReviewTestCase]):
             prompt,
             {
                 "index": PromptModelField(
-                    alias=prompt.index,
-                    description=prompt.index_desc,
+                    alias=prompt.index, description=prompt.index_desc
                 ),
                 "text": PromptModelField(
-                    alias=prompt.text,
-                    description=prompt.subtitle_text_desc,
+                    alias=prompt.text, description=prompt.subtitle_text_desc
                 ),
             },
             module=ReviewQuery.__module__,

--- a/scinoephile/llms/review/models.py
+++ b/scinoephile/llms/review/models.py
@@ -18,11 +18,7 @@ from scinoephile.core.llms import (
 
 from .prompt import ReviewPrompt
 
-__all__ = [
-    "ReviewAnswer",
-    "ReviewQuery",
-    "ReviewTestCase",
-]
+__all__ = ["ReviewAnswer", "ReviewQuery", "ReviewTestCase"]
 
 
 _BASE_PROMPT = ReviewPrompt()

--- a/scinoephile/llms/review/processor.py
+++ b/scinoephile/llms/review/processor.py
@@ -32,11 +32,7 @@ class ReviewProcessor(Processor):
     """Manager class used to construct test case models."""
 
     def process(
-        self,
-        series: Series,
-        stop_at_idx: int | None = None,
-        *,
-        start_at_idx: int = 0,
+        self, series: Series, stop_at_idx: int | None = None, *, start_at_idx: int = 0
     ) -> Series:
         """Process review LLM queries.
 
@@ -62,10 +58,7 @@ class ReviewProcessor(Processor):
             query = query_cls.model_validate(
                 {
                     "subtitles": [
-                        {
-                            "index": idx,
-                            "text": subtitle.text_with_newline.strip(),
-                        }
+                        {"index": idx, "text": subtitle.text_with_newline.strip()}
                         for idx, subtitle in enumerate(block.events, 1)
                     ]
                 }

--- a/scinoephile/llms/translation/manager.py
+++ b/scinoephile/llms/translation/manager.py
@@ -56,7 +56,7 @@ class TranslationManager(Manager[TranslationTestCase]):
                     alias=prompt.outputs,
                     annotation=list[output_cls],  # ty: ignore[invalid-type-form]
                     description=prompt.outputs_desc,
-                ),
+                )
             },
         )
 
@@ -75,12 +75,10 @@ class TranslationManager(Manager[TranslationTestCase]):
             prompt,
             {
                 "index": PromptModelField(
-                    alias=prompt.index,
-                    description=prompt.index_desc,
+                    alias=prompt.index, description=prompt.index_desc
                 ),
                 "text": PromptModelField(
-                    alias=prompt.text,
-                    description=prompt.output_text_desc,
+                    alias=prompt.text, description=prompt.output_text_desc
                 ),
             },
         )
@@ -104,7 +102,7 @@ class TranslationManager(Manager[TranslationTestCase]):
                     alias=prompt.subtitles,
                     annotation=list[subtitle_cls],  # ty: ignore[invalid-type-form]
                     description=prompt.subtitles_desc,
-                ),
+                )
             },
         )
 
@@ -123,12 +121,10 @@ class TranslationManager(Manager[TranslationTestCase]):
             prompt,
             {
                 "index": PromptModelField(
-                    alias=prompt.index,
-                    description=prompt.index_desc,
+                    alias=prompt.index, description=prompt.index_desc
                 ),
                 "text": PromptModelField(
-                    alias=prompt.text,
-                    description=prompt.subtitle_text_desc,
+                    alias=prompt.text, description=prompt.subtitle_text_desc
                 ),
             },
             module=TranslationQuery.__module__,

--- a/scinoephile/llms/translation/processor.py
+++ b/scinoephile/llms/translation/processor.py
@@ -32,11 +32,7 @@ class TranslationProcessor(Processor):
     """Manager class used to construct test case models."""
 
     def process(
-        self,
-        series: Series,
-        stop_at_idx: int | None = None,
-        *,
-        start_at_idx: int = 0,
+        self, series: Series, stop_at_idx: int | None = None, *, start_at_idx: int = 0
     ) -> Series:
         """Process translation LLM queries.
 
@@ -63,10 +59,7 @@ class TranslationProcessor(Processor):
             query = query_cls.model_validate(
                 {
                     "subtitles": [
-                        {
-                            "index": idx,
-                            "text": subtitle.text_with_newline.strip(),
-                        }
+                        {"index": idx, "text": subtitle.text_with_newline.strip()}
                         for idx, subtitle in enumerate(block.events, 1)
                     ]
                 }

--- a/scinoephile/media/audio.py
+++ b/scinoephile/media/audio.py
@@ -86,19 +86,13 @@ def extract_audio(
             "channel count"
         )
     _extract_audio_track(
-        validated_infile_path,
-        validated_outfile_path,
-        stream.index,
-        stream.channels,
+        validated_infile_path, validated_outfile_path, stream.index, stream.channels
     )
     return stream
 
 
 def _extract_audio_track(
-    infile_path: Path,
-    outfile_path: Path,
-    stream_index: int,
-    channels: int,
+    infile_path: Path, outfile_path: Path, stream_index: int, channels: int
 ):
     """Extract a known media audio stream as a mono 16 kHz WAV file.
 
@@ -131,11 +125,7 @@ def _extract_audio_track(
                 f"{outfile_path}"
             )
             ffmpeg.input(str(infile_path)).output(
-                str(outfile_path),
-                format="wav",
-                ar=16000,
-                map=f"0:{stream_index}",
-                ac=1,
+                str(outfile_path), format="wav", ar=16000, map=f"0:{stream_index}", ac=1
             ).run(quiet=False, overwrite_output=True)
     except (ffmpeg.Error, OSError) as exc:
         raise ScinoephileError(

--- a/scinoephile/media/constants.py
+++ b/scinoephile/media/constants.py
@@ -4,9 +4,7 @@
 
 from __future__ import annotations
 
-__all__ = [
-    "DEFAULT_SUBTITLE_LANGUAGES",
-]
+__all__ = ["DEFAULT_SUBTITLE_LANGUAGES"]
 
 DEFAULT_SUBTITLE_LANGUAGES = ("chi", "eng", "yue", "zho")
 """Default ISO 639 language codes for subtitle extraction."""

--- a/scinoephile/media/offset/video/detection.py
+++ b/scinoephile/media/offset/video/detection.py
@@ -79,24 +79,16 @@ def get_video_offset(
 
     # Probe metadata needed for frame-grid search and automatic windows
     reference_metadata = _probe_video_metadata(
-        reference_infile_path,
-        label="reference",
-        require_frame_rate=True,
+        reference_infile_path, label="reference", require_frame_rate=True
     )
     target_metadata = _probe_video_metadata(
-        target_infile_path,
-        label="target",
-        require_frame_rate=False,
+        target_infile_path, label="target", require_frame_rate=False
     )
     frame_rate = reference_metadata.frame_rate
     if frame_rate is None:
         raise ScinoephileError("Could not probe reference video frame rate")
     frame_duration = float(Fraction(1, 1) / frame_rate)
-    duration = min(
-        duration,
-        reference_metadata.duration,
-        target_metadata.duration,
-    )
+    duration = min(duration, reference_metadata.duration, target_metadata.duration)
     start_times = _get_sample_window_starts(
         duration=duration,
         sample_windows=sample_windows,
@@ -131,10 +123,7 @@ def get_video_offset(
             offset_frames=window.offset_frames,
         )
 
-    aggregate = _aggregate_window_results(
-        window_results,
-        frame_duration=frame_duration,
-    )
+    aggregate = _aggregate_window_results(window_results, frame_duration=frame_duration)
     best_window = min(
         window_results,
         key=lambda window: (
@@ -154,9 +143,7 @@ def get_video_offset(
 
 
 def _aggregate_window_results(
-    windows: tuple[VideoOffsetWindowResult, ...],
-    *,
-    frame_duration: float,
+    windows: tuple[VideoOffsetWindowResult, ...], *, frame_duration: float
 ) -> VideoOffsetAggregate:
     """Aggregate window results in reference frame units.
 
@@ -187,8 +174,7 @@ def _aggregate_window_results(
 
 
 def _get_aggregate_confidence(
-    windows: tuple[VideoOffsetWindowResult, ...],
-    aggregate: VideoOffsetAggregate,
+    windows: tuple[VideoOffsetWindowResult, ...], aggregate: VideoOffsetAggregate
 ) -> str:
     """Return aggregate confidence from window agreement.
 
@@ -208,9 +194,7 @@ def _get_aggregate_confidence(
 
 
 def _get_candidate_confidence(
-    *,
-    best: VideoOffsetCandidate,
-    second_best: VideoOffsetCandidate | None,
+    *, best: VideoOffsetCandidate, second_best: VideoOffsetCandidate | None
 ) -> str:
     """Classify confidence from match support and score separation.
 
@@ -413,10 +397,7 @@ def _get_offsets(start: float, end: float, step: float) -> list[float]:
 
 
 def _probe_video_metadata(
-    infile_path: Path,
-    *,
-    label: str,
-    require_frame_rate: bool,
+    infile_path: Path, *, label: str, require_frame_rate: bool
 ) -> VideoMetadata:
     """Probe video metadata needed for offset detection.
 

--- a/scinoephile/media/probe.py
+++ b/scinoephile/media/probe.py
@@ -12,10 +12,7 @@ import ffmpeg
 from scinoephile.core.exceptions import ScinoephileError
 from scinoephile.core.media import AudioStream, Stream, SubtitleStream, VideoStream
 
-__all__ = [
-    "get_streams",
-    "get_subtitle_streams",
-]
+__all__ = ["get_streams", "get_subtitle_streams"]
 
 
 def get_streams(infile_path: Path) -> list[Stream]:

--- a/scinoephile/media/subtitles/cache.py
+++ b/scinoephile/media/subtitles/cache.py
@@ -26,11 +26,7 @@ _CACHE_VERSION = 1
 class SubtitleCache:
     """Cache of subtitle streams extracted from media."""
 
-    def __init__(
-        self,
-        cache_root_path: Path | None = None,
-        overwrite: bool = False,
-    ):
+    def __init__(self, cache_root_path: Path | None = None, overwrite: bool = False):
         """Initialize.
 
         Arguments:
@@ -54,9 +50,7 @@ class SubtitleCache:
         """Cache paths refreshed by this cache instance."""
 
     def get_image_series_dir_path(
-        self,
-        infile_path: Path,
-        stream: SubtitleStream,
+        self, infile_path: Path, stream: SubtitleStream
     ) -> Path:
         """Get the cache directory for a rendered image subtitle series.
 
@@ -91,11 +85,7 @@ class SubtitleCache:
         cache_key = hashlib.sha256(encoded_payload).hexdigest()
         return self.cache_dir_path / cache_key / f"{stream.index}.{stream.extension}"
 
-    def load(
-        self,
-        infile_path: Path,
-        stream: SubtitleStream,
-    ) -> Path | None:
+    def load(self, infile_path: Path, stream: SubtitleStream) -> Path | None:
         """Load a cached subtitle stream path.
 
         Arguments:
@@ -116,9 +106,7 @@ class SubtitleCache:
         return None
 
     def load_image_series(
-        self,
-        infile_path: Path,
-        stream: SubtitleStream,
+        self, infile_path: Path, stream: SubtitleStream
     ) -> Path | None:
         """Load a cached image subtitle series directory.
 
@@ -159,9 +147,7 @@ class SubtitleCache:
         return stream_path
 
     def remove_image_series(
-        self,
-        infile_path: Path,
-        stream: SubtitleStream,
+        self, infile_path: Path, stream: SubtitleStream
     ) -> Path | None:
         """Remove a cached image subtitle series.
 
@@ -179,10 +165,7 @@ class SubtitleCache:
         return image_dir_path
 
     def save(
-        self,
-        infile_path: Path,
-        stream: SubtitleStream,
-        staging_path: Path,
+        self, infile_path: Path, stream: SubtitleStream, staging_path: Path
     ) -> Path:
         """Save an extracted subtitle stream to the cache.
 
@@ -201,10 +184,7 @@ class SubtitleCache:
         return stream_path
 
     def save_image_series(
-        self,
-        infile_path: Path,
-        stream: SubtitleStream,
-        image_series: ImageSeries,
+        self, infile_path: Path, stream: SubtitleStream, image_series: ImageSeries
     ) -> Path:
         """Save a rendered image subtitle series to the cache.
 

--- a/scinoephile/media/subtitles/details.py
+++ b/scinoephile/media/subtitles/details.py
@@ -46,18 +46,13 @@ def get_detailed_subtitle_streams(
             stream for stream in streams if isinstance(stream, SubtitleStream)
         ]
     if subtitle_streams:
-        SubtitleExtractor(subtitle_cache).extract(
-            infile_path,
-            subtitle_streams,
-        )
+        SubtitleExtractor(subtitle_cache).extract(infile_path, subtitle_streams)
 
     detailed_streams = []
     for stream in subtitle_streams:
         try:
             stats = get_subtitle_stream_stats(
-                infile_path,
-                stream,
-                subtitle_cache=subtitle_cache,
+                infile_path, stream, subtitle_cache=subtitle_cache
             )
         except (ScinoephileError, ValueError, IndexError) as exc:
             logger.warning(

--- a/scinoephile/media/subtitles/extraction.py
+++ b/scinoephile/media/subtitles/extraction.py
@@ -37,9 +37,7 @@ def extract_subtitle_stream(
     """
     cache = SubtitleCache(cache_root_path)
     stream_path = SubtitleExtractor(cache).extract(
-        infile_path,
-        [stream],
-        render_images=False,
+        infile_path, [stream], render_images=False
     )[0]
     if stream_path != outfile_path:
         if not outfile_path.parent.exists():

--- a/scinoephile/media/subtitles/extractor.py
+++ b/scinoephile/media/subtitles/extractor.py
@@ -58,8 +58,7 @@ class SubtitleExtractor:
         if missing:
             input_stream = ffmpeg.input(str(infile_path))
             with TemporaryDirectory(
-                dir=self._cache.cache_dir_path,
-                prefix=".subtitle-extraction-",
+                dir=self._cache.cache_dir_path, prefix=".subtitle-extraction-"
             ) as temp_dir:
                 staged_paths: list[tuple[SubtitleStream, Path]] = []
                 output_streams = []
@@ -69,16 +68,12 @@ class SubtitleExtractor:
                     output_streams.append(
                         input_stream.output(
                             str(staging_path),
-                            **{
-                                "map": f"0:{stream.index}",
-                                "c:s": stream.output_codec,
-                            },
+                            **{"map": f"0:{stream.index}", "c:s": stream.output_codec},
                         )
                     )
                 try:
                     ffmpeg.merge_outputs(*output_streams).run(
-                        quiet=False,
-                        overwrite_output=True,
+                        quiet=False, overwrite_output=True
                     )
                 except ffmpeg.Error as exc:
                     raise ScinoephileError(

--- a/scinoephile/media/subtitles/selection.py
+++ b/scinoephile/media/subtitles/selection.py
@@ -14,8 +14,7 @@ __all__ = ["get_media_subtitle_stream"]
 
 
 def get_media_subtitle_stream(
-    infile_path: Path,
-    stream_index: int | None,
+    infile_path: Path, stream_index: int | None
 ) -> SubtitleStream:
     """Get selected image-based subtitle stream from a media input.
 

--- a/scinoephile/media/subtitles/stats.py
+++ b/scinoephile/media/subtitles/stats.py
@@ -14,10 +14,7 @@ from scinoephile.image.subtitles import ImageSeries
 from .cache import SubtitleCache
 from .extractor import SubtitleExtractor
 
-__all__ = [
-    "SubtitleStreamStats",
-    "get_subtitle_stream_stats",
-]
+__all__ = ["SubtitleStreamStats", "get_subtitle_stream_stats"]
 
 
 @dataclass(frozen=True)
@@ -51,10 +48,7 @@ def get_subtitle_stream_stats(
         subtitle_cache = SubtitleCache()
     stream_path = SubtitleExtractor(subtitle_cache).extract(infile_path, [stream])[0]
     if stream.extension == "sup":
-        image_dir_path = subtitle_cache.get_image_series_dir_path(
-            infile_path,
-            stream,
-        )
+        image_dir_path = subtitle_cache.get_image_series_dir_path(infile_path, stream)
         series = ImageSeries.load(image_dir_path)
     else:
         series = Series.load(stream_path)
@@ -66,7 +60,5 @@ def get_subtitle_stream_stats(
         first_start_ms = None
         last_end_ms = None
     return SubtitleStreamStats(
-        event_count=len(series),
-        first_start_ms=first_start_ms,
-        last_end_ms=last_end_ms,
+        event_count=len(series), first_start_ms=first_start_ms, last_end_ms=last_end_ms
     )

--- a/scinoephile/optimization/persistence/models/__init__.py
+++ b/scinoephile/optimization/persistence/models/__init__.py
@@ -13,7 +13,4 @@ from __future__ import annotations
 from .persisted_model import PersistedModel
 from .sqlite_store import ModelSqliteStore
 
-__all__ = [
-    "ModelSqliteStore",
-    "PersistedModel",
-]
+__all__ = ["ModelSqliteStore", "PersistedModel"]

--- a/scinoephile/optimization/persistence/models/persisted_model.py
+++ b/scinoephile/optimization/persistence/models/persisted_model.py
@@ -89,10 +89,7 @@ class PersistedModel:
 
         return cls(
             model_id=get_model_id(
-                provider_name,
-                model_name,
-                base_url,
-                normalized_settings,
+                provider_name, model_name, base_url, normalized_settings
             ),
             provider_name=provider_name,
             model_name=model_name,
@@ -115,14 +112,7 @@ def _is_credential_name(name: str) -> bool:
     if compact_name == "authorization":
         return True
     return compact_name.endswith(
-        (
-            "apikey",
-            "credential",
-            "credentials",
-            "password",
-            "secret",
-            "token",
-        )
+        ("apikey", "credential", "credentials", "password", "secret", "token")
     )
 
 

--- a/scinoephile/optimization/persistence/models/sqlite_store.py
+++ b/scinoephile/optimization/persistence/models/sqlite_store.py
@@ -48,13 +48,9 @@ class ModelSqliteStore(OptimizationSqliteStore):
         Column("model", Text, nullable=False),
         Column("base_url", Text),
         Column("settings_json", Text, nullable=False),
+        CheckConstraint("json_valid(settings_json)", name="models_settings_json_valid"),
         CheckConstraint(
-            "json_valid(settings_json)",
-            name="models_settings_json_valid",
-        ),
-        CheckConstraint(
-            "json_type(settings_json) = 'object'",
-            name="models_settings_json_object",
+            "json_type(settings_json) = 'object'", name="models_settings_json_object"
         ),
         Index("models_provider_model", "provider", "model"),
     )
@@ -158,15 +154,11 @@ class ModelSqliteStore(OptimizationSqliteStore):
             str(row["model"]),
             base_url=base_url,
             settings=deserialize_json(
-                row["settings_json"],
-                f"Persisted model {model_id} settings",
+                row["settings_json"], f"Persisted model {model_id} settings"
             ),
         )
         expected_id = get_model_id(
-            model.provider_name,
-            model.model_name,
-            model.base_url,
-            model.settings,
+            model.provider_name, model.model_name, model.base_url, model.settings
         )
         if model_id != expected_id:
             raise ScinoephileError(

--- a/scinoephile/optimization/persistence/prompts/__init__.py
+++ b/scinoephile/optimization/persistence/prompts/__init__.py
@@ -15,8 +15,4 @@ from .persisted_prompt import PersistedPrompt
 from .sqlite_store import PromptSqliteStore
 from .sync import PromptSyncReport
 
-__all__ = [
-    "PersistedPrompt",
-    "PromptSqliteStore",
-    "PromptSyncReport",
-]
+__all__ = ["PersistedPrompt", "PromptSqliteStore", "PromptSyncReport"]

--- a/scinoephile/optimization/persistence/prompts/persisted_prompt.py
+++ b/scinoephile/optimization/persistence/prompts/persisted_prompt.py
@@ -29,11 +29,7 @@ class PersistedPrompt:
     """Ordered effective string attributes."""
 
     @classmethod
-    def from_prompt(
-        cls,
-        prompt: Prompt,
-        manager_cls: type[Manager],
-    ) -> PersistedPrompt:
+    def from_prompt(cls, prompt: Prompt, manager_cls: type[Manager]) -> PersistedPrompt:
         """Convert a prompt to its persisted representation.
 
         Arguments:
@@ -58,11 +54,7 @@ class PersistedPrompt:
             )
         )
         return cls(
-            prompt_id=get_prompt_id(
-                attributes,
-                manager_cls.operation,
-                prompt.language,
-            ),
+            prompt_id=get_prompt_id(attributes, manager_cls.operation, prompt.language),
             operation=manager_cls.operation,
             language=prompt.language,
             attributes=attributes,

--- a/scinoephile/optimization/persistence/prompts/sqlite_store.py
+++ b/scinoephile/optimization/persistence/prompts/sqlite_store.py
@@ -43,8 +43,7 @@ class PromptSqliteStore(OptimizationSqliteStore):
         Column("language", Text, nullable=False),
         Column("attributes_json", Text, nullable=False),
         CheckConstraint(
-            "json_valid(attributes_json)",
-            name="prompts_attributes_json_valid",
+            "json_valid(attributes_json)", name="prompts_attributes_json_valid"
         ),
         CheckConstraint(
             "json_type(attributes_json) = 'object'",
@@ -78,10 +77,7 @@ class PromptSqliteStore(OptimizationSqliteStore):
             return self._row_to_prompt(row)
 
     def sync_aliases(
-        self,
-        alias_prompts: Mapping[str, PersistedPrompt],
-        *,
-        dry_run: bool,
+        self, alias_prompts: Mapping[str, PersistedPrompt], *, dry_run: bool
     ) -> tuple[set[str], set[str]]:
         """Synchronize current prompt content by stable alias.
 
@@ -95,9 +91,7 @@ class PromptSqliteStore(OptimizationSqliteStore):
         """
         for prompt in alias_prompts.values():
             expected_id = get_prompt_id(
-                prompt.attributes,
-                prompt.operation,
-                prompt.language,
+                prompt.attributes, prompt.operation, prompt.language
             )
             if prompt.prompt_id != expected_id:
                 raise ScinoephileError(
@@ -140,9 +134,7 @@ class PromptSqliteStore(OptimizationSqliteStore):
         return changes
 
     def _get_changes(
-        self,
-        connection: Connection,
-        alias_prompts: Mapping[str, PersistedPrompt],
+        self, connection: Connection, alias_prompts: Mapping[str, PersistedPrompt]
     ) -> tuple[set[str], set[str]]:
         """Get changes required to synchronize prompt aliases.
 
@@ -181,8 +173,7 @@ class PromptSqliteStore(OptimizationSqliteStore):
         """
         prompt_id = str(row["prompt_id"])
         loaded_attributes = deserialize_json(
-            row["attributes_json"],
-            "Persisted prompt attributes",
+            row["attributes_json"], "Persisted prompt attributes"
         )
         if not all(isinstance(value, str) for value in loaded_attributes.values()):
             raise ScinoephileError(
@@ -203,9 +194,7 @@ class PromptSqliteStore(OptimizationSqliteStore):
             attributes=attributes,
         )
         if prompt.prompt_id != get_prompt_id(
-            prompt.attributes,
-            prompt.operation,
-            prompt.language,
+            prompt.attributes, prompt.operation, prompt.language
         ):
             raise ScinoephileError(
                 f"Persisted prompt {prompt_id} does not match its content-addressed ID."

--- a/scinoephile/optimization/persistence/prompts/sync.py
+++ b/scinoephile/optimization/persistence/prompts/sync.py
@@ -13,10 +13,7 @@ from scinoephile.optimization.prompt_spec import PromptSpec
 from .persisted_prompt import PersistedPrompt
 from .sqlite_store import PromptSqliteStore
 
-__all__ = [
-    "PromptSyncReport",
-    "sync_prompts",
-]
+__all__ = ["PromptSyncReport", "sync_prompts"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -32,10 +29,7 @@ class PromptSyncReport:
 
 
 def sync_prompts(
-    prompt_specs: Mapping[str, PromptSpec],
-    output_path: Path,
-    *,
-    dry_run: bool,
+    prompt_specs: Mapping[str, PromptSpec], output_path: Path, *, dry_run: bool
 ) -> PromptSyncReport:
     """Synchronize registered prompts into SQLite.
 
@@ -49,18 +43,12 @@ def sync_prompts(
         ScinoephileError: if a prompt is incompatible with its manager
     """
     alias_prompts = {
-        alias: PersistedPrompt.from_prompt(
-            prompt_spec.prompt,
-            prompt_spec.manager_cls,
-        )
+        alias: PersistedPrompt.from_prompt(prompt_spec.prompt, prompt_spec.manager_cls)
         for alias, prompt_spec in prompt_specs.items()
     }
 
     store = PromptSqliteStore(output_path)
-    insert_aliases, update_aliases = store.sync_aliases(
-        alias_prompts,
-        dry_run=dry_run,
-    )
+    insert_aliases, update_aliases = store.sync_aliases(alias_prompts, dry_run=dry_run)
     return PromptSyncReport(
         prompt_count=len(alias_prompts),
         insert_aliases=tuple(sorted(insert_aliases)),

--- a/scinoephile/optimization/persistence/sqlite.py
+++ b/scinoephile/optimization/persistence/sqlite.py
@@ -18,11 +18,7 @@ from sqlalchemy.pool import ConnectionPoolEntry, NullPool
 from scinoephile.common.validation import val_output_path
 from scinoephile.core.exceptions import ScinoephileError
 
-__all__ = [
-    "OptimizationSqliteStore",
-    "deserialize_json",
-    "serialize_json",
-]
+__all__ = ["OptimizationSqliteStore", "deserialize_json", "serialize_json"]
 
 
 def deserialize_json(value: object, subject: str) -> dict[str, JsonValue]:
@@ -55,12 +51,7 @@ def serialize_json(value: dict[str, JsonValue]) -> str:
     Returns:
         canonical JSON text
     """
-    return json.dumps(
-        value,
-        ensure_ascii=False,
-        sort_keys=True,
-        separators=(",", ":"),
-    )
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
 
 
 class OptimizationSqliteStore:
@@ -75,11 +66,7 @@ class OptimizationSqliteStore:
         Arguments:
             database_path: SQLite database path
         """
-        self.database_path = val_output_path(
-            database_path,
-            exist_ok=True,
-            create=False,
-        )
+        self.database_path = val_output_path(database_path, exist_ok=True, create=False)
         self.engine = create_engine(
             URL.create("sqlite", database=str(self.database_path)),
             future=True,
@@ -95,8 +82,7 @@ class OptimizationSqliteStore:
 
     @staticmethod
     def _enable_sqlite_foreign_keys(
-        dbapi_connection: DBAPIConnection,
-        _connection_record: ConnectionPoolEntry,
+        dbapi_connection: DBAPIConnection, _connection_record: ConnectionPoolEntry
     ):
         """Enable SQLite foreign-key enforcement on a new DB-API connection.
 

--- a/scinoephile/optimization/persistence/test_cases/__init__.py
+++ b/scinoephile/optimization/persistence/test_cases/__init__.py
@@ -15,8 +15,4 @@ from .persisted_test_case import PersistedTestCase
 from .sqlite_store import TestCaseSqliteStore
 from .sync import SyncReport
 
-__all__ = [
-    "PersistedTestCase",
-    "SyncReport",
-    "TestCaseSqliteStore",
-]
+__all__ = ["PersistedTestCase", "SyncReport", "TestCaseSqliteStore"]

--- a/scinoephile/optimization/persistence/test_cases/persisted_test_case.py
+++ b/scinoephile/optimization/persistence/test_cases/persisted_test_case.py
@@ -39,9 +39,7 @@ class PersistedTestCase:
 
     @classmethod
     def from_test_case(
-        cls,
-        test_case: TestCase,
-        manager_cls: type[Manager],
+        cls, test_case: TestCase, manager_cls: type[Manager]
     ) -> PersistedTestCase:
         """Convert a loaded test case to its persisted representation.
 
@@ -53,9 +51,7 @@ class PersistedTestCase:
         """
         if test_case.answer is None:
             raise ScinoephileError("Optimization test cases must include an answer.")
-        base_test_case_cls = manager_cls.get_test_case_cls(
-            manager_cls.base_prompt,
-        )
+        base_test_case_cls = manager_cls.get_test_case_cls(manager_cls.base_prompt)
         base_test_case = base_test_case_cls.model_validate(
             test_case.model_dump(mode="json")
         )

--- a/scinoephile/optimization/persistence/test_cases/sqlite_store.py
+++ b/scinoephile/optimization/persistence/test_cases/sqlite_store.py
@@ -106,10 +106,7 @@ class TestCaseSqliteStore(OptimizationSqliteStore):
             return self._row_to_test_case(connection, row)
 
     def get_test_cases_by_source_path(
-        self,
-        source_path: str,
-        *,
-        manager_cls: type[Manager] | None = None,
+        self, source_path: str, *, manager_cls: type[Manager] | None = None
     ) -> list[PersistedTestCase]:
         """Fetch test cases associated with a source path.
 
@@ -172,9 +169,7 @@ class TestCaseSqliteStore(OptimizationSqliteStore):
                         f"synchronized operation {manager_cls.operation}."
                     )
                 expected_id = get_test_case_id(
-                    test_case.query,
-                    test_case.answer,
-                    manager_cls,
+                    test_case.query, test_case.answer, manager_cls
                 )
                 if test_case.test_case_id != expected_id:
                     raise ScinoephileError(
@@ -228,9 +223,7 @@ class TestCaseSqliteStore(OptimizationSqliteStore):
         return changes
 
     def _get_source_paths(
-        self,
-        connection: Connection,
-        test_case_id: str,
+        self, connection: Connection, test_case_id: str
     ) -> tuple[str, ...]:
         """Get source paths for a test case.
 
@@ -250,9 +243,7 @@ class TestCaseSqliteStore(OptimizationSqliteStore):
         )
 
     def _row_to_test_case(
-        self,
-        connection: Connection,
-        row: RowMapping,
+        self, connection: Connection, row: RowMapping
     ) -> PersistedTestCase:
         """Convert a test-case row to a model.
 

--- a/scinoephile/optimization/persistence/test_cases/sync.py
+++ b/scinoephile/optimization/persistence/test_cases/sync.py
@@ -15,10 +15,7 @@ from scinoephile.core.llms.utils import load_test_cases_from_json
 from .persisted_test_case import PersistedTestCase
 from .sqlite_store import TestCaseSqliteStore
 
-__all__ = [
-    "SyncReport",
-    "sync_test_cases",
-]
+__all__ = ["SyncReport", "sync_test_cases"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -56,18 +53,13 @@ def sync_test_cases(
     """
     input_paths_tuple = tuple(input_path.resolve() for input_path in input_paths)
     source_test_cases = {
-        str(input_path): _load_test_cases(
-            input_path,
-            manager_cls,
-        )
+        str(input_path): _load_test_cases(input_path, manager_cls)
         for input_path in input_paths_tuple
     }
 
     store = TestCaseSqliteStore(output_path)
     insert_ids, delete_ids = store.sync_source_paths(
-        source_test_cases,
-        manager_cls=manager_cls,
-        dry_run=dry_run,
+        source_test_cases, manager_cls=manager_cls, dry_run=dry_run
     )
     return SyncReport(
         operation=manager_cls.operation,
@@ -78,8 +70,7 @@ def sync_test_cases(
 
 
 def _load_test_cases(
-    input_path: Path,
-    manager_cls: type[Manager],
+    input_path: Path, manager_cls: type[Manager]
 ) -> list[PersistedTestCase]:
     """Load, validate, and normalize persisted test cases from JSON.
 
@@ -93,9 +84,7 @@ def _load_test_cases(
     """
     try:
         test_cases = load_test_cases_from_json(
-            input_path,
-            manager_cls,
-            manager_cls.base_prompt,
+            input_path, manager_cls, manager_cls.base_prompt
         )
         return [
             PersistedTestCase.from_test_case(test_case, manager_cls)

--- a/scinoephile/web/ocr_validation/app.py
+++ b/scinoephile/web/ocr_validation/app.py
@@ -17,10 +17,7 @@ from .session import OcrValidationSession
 if TYPE_CHECKING:
     from scinoephile.core.dependencies.web import FlaskApp
 
-__all__ = [
-    "create_app",
-    "run_app",
-]
+__all__ = ["create_app", "run_app"]
 
 logger = getLogger(__name__)
 

--- a/scinoephile/web/ocr_validation/routes.py
+++ b/scinoephile/web/ocr_validation/routes.py
@@ -119,11 +119,7 @@ def register_routes(app: FlaskApp):
             abort(400, "Missing n_bboxes.")
         except ValueError:
             abort(400, "Invalid integer for n_bboxes.")
-        row = session.resolve_char_concern(
-            sub_idx,
-            action=action,
-            n_bboxes=n_bboxes,
-        )
+        row = session.resolve_char_concern(sub_idx, action=action, n_bboxes=n_bboxes)
         return _render_subtitle_row(session, row)
 
     @app.post("/subtitles/<int:sub_idx>/concern/gap")
@@ -268,8 +264,7 @@ def _render_index(session: OcrValidationSession) -> str:
 
 
 def _render_index_body(
-    session: OcrValidationSession,
-    rows: list[SubtitleRowView] | None = None,
+    session: OcrValidationSession, rows: list[SubtitleRowView] | None = None
 ) -> str:
     """Render the body content of the subtitle list.
 

--- a/scinoephile/web/ocr_validation/session.py
+++ b/scinoephile/web/ocr_validation/session.py
@@ -257,11 +257,7 @@ class OcrValidationSession:
         return get_img_with_bboxes(sub.img, sub.bboxes)
 
     def resolve_char_concern(
-        self,
-        sub_idx: int,
-        *,
-        action: str,
-        n_bboxes: int,
+        self, sub_idx: int, *, action: str, n_bboxes: int
     ) -> SubtitleRowView:
         """Resolve the current character bbox concern for one subtitle.
 
@@ -447,8 +443,7 @@ class OcrValidationSession:
             sub = self.series.events[sub_idx]
             sub.bboxes = get_bboxes(sub.img)
             state = _SubtitleValidationState(
-                sub_idx=sub_idx,
-                char_cursor=CharCursor(sub=sub, sub_idx=sub_idx),
+                sub_idx=sub_idx, char_cursor=CharCursor(sub=sub, sub_idx=sub_idx)
             )
             self._states[sub_idx] = state
             self._scan_state(state)
@@ -587,9 +582,7 @@ class OcrValidationSession:
         self._save_outfile()
 
     def _scan_gap_with_cutoffs(  # noqa: PLR0911
-        self,
-        cursor: GapCursor,
-        cutoffs: tuple[int, int, int, int],
+        self, cursor: GapCursor, cutoffs: tuple[int, int, int, int]
     ) -> OcrConcern | None:
         """Scan one prepared gap using its cutoff tuple.
 
@@ -607,8 +600,7 @@ class OcrValidationSession:
         if cutoffs[0] < cursor.gap < cutoffs[1]:
             if cursor.gap == cutoffs[0] + 1 and cursor.gap_chars == "":
                 self.manager.update_pair_gaps(
-                    cursor.char_pair,
-                    (cursor.gap, cutoffs[1], cutoffs[2], cutoffs[3]),
+                    cursor.char_pair, (cursor.gap, cutoffs[1], cutoffs[2], cutoffs[3])
                 )
                 return None
             if (
@@ -616,8 +608,7 @@ class OcrValidationSession:
                 and cursor.gap_chars == cursor.expected_space
             ):
                 self.manager.update_pair_gaps(
-                    cursor.char_pair,
-                    (cutoffs[0], cursor.gap, cutoffs[2], cutoffs[3]),
+                    cursor.char_pair, (cutoffs[0], cursor.gap, cutoffs[2], cutoffs[3])
                 )
                 return None
             return self._gap_concern(cursor, cutoffs, kind=ConcernKind.SPACE_GAP)
@@ -633,14 +624,12 @@ class OcrValidationSession:
                 and cursor.gap_chars == cursor.expected_space
             ):
                 self.manager.update_pair_gaps(
-                    cursor.char_pair,
-                    (cutoffs[0], cutoffs[1], cursor.gap, cutoffs[3]),
+                    cursor.char_pair, (cutoffs[0], cutoffs[1], cursor.gap, cutoffs[3])
                 )
                 return None
             if cursor.gap == cutoffs[3] - 1 and cursor.gap_chars == cursor.expected_tab:
                 self.manager.update_pair_gaps(
-                    cursor.char_pair,
-                    (cutoffs[0], cutoffs[1], cutoffs[2], cursor.gap),
+                    cursor.char_pair, (cutoffs[0], cutoffs[1], cutoffs[2], cursor.gap)
                 )
                 return None
             return self._gap_concern(cursor, cutoffs, kind=ConcernKind.TAB_GAP)
@@ -650,11 +639,7 @@ class OcrValidationSession:
         return None
 
     def _replace_gap_text(
-        self,
-        cursor: GapCursor,
-        replacement: str,
-        *,
-        reset_state: bool = False,
+        self, cursor: GapCursor, replacement: str, *, reset_state: bool = False
     ):
         """Replace the current gap text.
 
@@ -673,9 +658,7 @@ class OcrValidationSession:
         self._set_text(cursor.sub_idx, cursor.sub.text, reset_state=reset_state)
 
     def _resolve_adjacent_gap_action(
-        self,
-        cursor: GapCursor,
-        cutoffs: tuple[int, int, int, int],
+        self, cursor: GapCursor, cutoffs: tuple[int, int, int, int]
     ):
         """Update cutoffs after choosing adjacent spacing.
 
@@ -692,10 +675,7 @@ class OcrValidationSession:
         self.manager.update_pair_gaps(cursor.char_pair, updated_cutoffs)
 
     def _resolve_space_gap_action(
-        self,
-        cursor: GapCursor,
-        cutoffs: tuple[int, int, int, int],
-        action: str,
+        self, cursor: GapCursor, cutoffs: tuple[int, int, int, int], action: str
     ) -> str:
         """Resolve one adjacent-or-space gap action.
 
@@ -709,8 +689,7 @@ class OcrValidationSession:
         if action == "space":
             if cutoffs[0] < cursor.gap < cutoffs[1]:
                 self.manager.update_pair_gaps(
-                    cursor.char_pair,
-                    (cutoffs[0], cursor.gap, cutoffs[2], cutoffs[3]),
+                    cursor.char_pair, (cutoffs[0], cursor.gap, cutoffs[2], cutoffs[3])
                 )
             return cursor.expected_space
         if action == "adjacent":
@@ -719,10 +698,7 @@ class OcrValidationSession:
         raise ValueError(f"Unrecognized space gap action: {action}")
 
     def _resolve_tab_gap_action(
-        self,
-        cursor: GapCursor,
-        cutoffs: tuple[int, int, int, int],
-        action: str,
+        self, cursor: GapCursor, cutoffs: tuple[int, int, int, int], action: str
     ) -> str:
         """Resolve one space-or-tab gap action.
 
@@ -736,23 +712,19 @@ class OcrValidationSession:
         if action == "tab":
             if cutoffs[2] < cursor.gap < cutoffs[3]:
                 self.manager.update_pair_gaps(
-                    cursor.char_pair,
-                    (cutoffs[0], cutoffs[1], cutoffs[2], cursor.gap),
+                    cursor.char_pair, (cutoffs[0], cutoffs[1], cutoffs[2], cursor.gap)
                 )
             return cursor.expected_tab
         if action == "space":
             if cutoffs[2] < cursor.gap < cutoffs[3]:
                 self.manager.update_pair_gaps(
-                    cursor.char_pair,
-                    (cutoffs[0], cutoffs[1], cursor.gap, cutoffs[3]),
+                    cursor.char_pair, (cutoffs[0], cutoffs[1], cursor.gap, cutoffs[3])
                 )
             return cursor.expected_space
         raise ValueError(f"Unrecognized tab gap action: {action}")
 
     def _validated_n_bboxes(
-        self,
-        state: _SubtitleValidationState,
-        n_bboxes: int,
+        self, state: _SubtitleValidationState, n_bboxes: int
     ) -> int:
         """Validate and clamp a bbox selection count.
 

--- a/scinoephile/workflows/clean.py
+++ b/scinoephile/workflows/clean.py
@@ -17,10 +17,7 @@ __all__ = ["clean_series"]
 
 
 def clean_series(
-    series: Series,
-    *,
-    language: Language | None = None,
-    remove_empty: bool = True,
+    series: Series, *, language: Language | None = None, remove_empty: bool = True
 ) -> Series:
     """Clean a subtitle series.
 

--- a/scinoephile/workflows/ocr_fusion.py
+++ b/scinoephile/workflows/ocr_fusion.py
@@ -10,10 +10,7 @@ from scinoephile.core import Language
 from scinoephile.core.llms import LLMProvider, ProcessorKwargs, TestCase
 from scinoephile.core.subtitles import Series
 from scinoephile.lang.ocr_fusion import get_ocr_fuser
-from scinoephile.llms.ocr_fusion import (
-    OcrFusionProcessor,
-    OcrFusionPrompt,
-)
+from scinoephile.llms.ocr_fusion import OcrFusionProcessor, OcrFusionPrompt
 
 __all__ = ["fuse_ocr_series"]
 

--- a/scinoephile/workflows/ocr_processing.py
+++ b/scinoephile/workflows/ocr_processing.py
@@ -13,13 +13,9 @@ from scinoephile.core import Language, ScinoephileError
 from scinoephile.core.llms import LLMProvider
 from scinoephile.core.paths import get_runtime_data_root_path
 from scinoephile.core.subtitles import Series
-from scinoephile.image.ocr.lens import (
-    ocr_image_series_with_lens,
-)
+from scinoephile.image.ocr.lens import ocr_image_series_with_lens
 from scinoephile.image.ocr.paddle import ocr_image_series_with_paddle
-from scinoephile.image.ocr.tesseract import (
-    ocr_image_series_with_tesseract,
-)
+from scinoephile.image.ocr.tesseract import ocr_image_series_with_tesseract
 from scinoephile.image.subtitles import ImageSeries
 from scinoephile.media.subtitles.cache import SubtitleCache
 from scinoephile.media.subtitles.extractor import SubtitleExtractor
@@ -29,10 +25,7 @@ from .clean import clean_series
 from .ocr_fusion import fuse_ocr_series
 from .ocr_validation import validate_ocr
 
-__all__ = [
-    "OcrProcessingResult",
-    "OcrProcessingWorkflow",
-]
+__all__ = ["OcrProcessingResult", "OcrProcessingWorkflow"]
 
 logger = getLogger(__name__)
 
@@ -217,8 +210,7 @@ class OcrProcessingWorkflow:
 
             stream = get_media_subtitle_stream(self.infile_path, self.stream_index)
             stream_path = SubtitleExtractor(self._subtitle_cache).extract(
-                self.infile_path,
-                [stream],
+                self.infile_path, [stream]
             )[0]
             return ImageSeries.load(stream_path)
         except (OSError, RuntimeError, ValueError) as exc:

--- a/scinoephile/workflows/ocr_validation.py
+++ b/scinoephile/workflows/ocr_validation.py
@@ -69,8 +69,7 @@ def validate_ocr(
         else:
             image_series = ImageSeries.load(source)
         validation_manager = ValidationManager(
-            validation_data_dir_path=validation_data_dir_path,
-            dev=dev,
+            validation_data_dir_path=validation_data_dir_path, dev=dev
         )
         validated = validation_manager.validate(image_series)
         validated.save(outfile_path, format_="srt", exist_ok=True)

--- a/scinoephile/workflows/prompt_catalog.py
+++ b/scinoephile/workflows/prompt_catalog.py
@@ -39,24 +39,16 @@ def _build_prompt_specs() -> Mapping[str, PromptSpec]:
         _build_monolingual_prompt_specs(ReviewManager, review.DEFAULT_PROMPTS),
         _build_monolingual_prompt_specs(OcrFusionManager, ocr_fusion.DEFAULT_PROMPTS),
         _build_pair_prompt_specs(
-            GuidedReviewManager,
-            guided_review.DEFAULT_PROMPTS,
-            separator="vs",
+            GuidedReviewManager, guided_review.DEFAULT_PROMPTS, separator="vs"
         ),
         _build_pair_prompt_specs(
-            TranslationManager,
-            translation.DEFAULT_PROMPTS,
-            separator="to",
+            TranslationManager, translation.DEFAULT_PROMPTS, separator="to"
         ),
         _build_pair_prompt_specs(
-            GapTranslationManager,
-            gap_translation.DEFAULT_PROMPTS,
-            separator="to",
+            GapTranslationManager, gap_translation.DEFAULT_PROMPTS, separator="to"
         ),
         _build_pair_prompt_specs(
-            GuidedTranslationManager,
-            guided_translation.DEFAULT_PROMPTS,
-            separator="to",
+            GuidedTranslationManager, guided_translation.DEFAULT_PROMPTS, separator="to"
         ),
         _build_transcription_prompt_specs(guided_transcription.DEFAULT_SPECS),
     )
@@ -72,8 +64,7 @@ def _build_prompt_specs() -> Mapping[str, PromptSpec]:
 
 
 def _build_monolingual_prompt_specs(
-    manager_cls: type[Manager],
-    prompts: Mapping[Language, Prompt],
+    manager_cls: type[Manager], prompts: Mapping[Language, Prompt]
 ) -> dict[str, PromptSpec]:
     """Build prompt specifications for a monolingual operation.
 
@@ -85,8 +76,7 @@ def _build_monolingual_prompt_specs(
     """
     return {
         f"{manager_cls.operation}-{language.code.lower()}": PromptSpec(
-            manager_cls=manager_cls,
-            prompt=prompt,
+            manager_cls=manager_cls, prompt=prompt
         )
         for language, prompt in prompts.items()
     }
@@ -111,18 +101,14 @@ def _build_pair_prompt_specs(
         (
             f"{manager_cls.operation}-{first_language.code.lower()}-"
             f"{separator}-{second_language.code.lower()}"
-        ): PromptSpec(
-            manager_cls=manager_cls,
-            prompt=prompt,
-        )
+        ): PromptSpec(manager_cls=manager_cls, prompt=prompt)
         for (first_language, second_language), prompt in prompts.items()
     }
 
 
 def _build_transcription_prompt_specs(
     specs: Mapping[
-        tuple[Language, Language],
-        guided_transcription.GuidedTranscriptionSpec,
+        tuple[Language, Language], guided_transcription.GuidedTranscriptionSpec
     ],
 ) -> dict[str, PromptSpec]:
     """Build prompt specifications for guided transcription.

--- a/scinoephile/workflows/review.py
+++ b/scinoephile/workflows/review.py
@@ -16,10 +16,7 @@ from scinoephile.llms.review import ReviewProcessor, ReviewPrompt
 
 from .helpers import resolve_language
 
-__all__ = [
-    "review_series",
-    "review_series_guided",
-]
+__all__ = ["review_series", "review_series_guided"]
 
 
 def review_series(
@@ -55,17 +52,9 @@ def review_series(
 
     if reviewer is None:
         reviewer = get_reviewer(
-            resolved_language,
-            prompt,
-            test_cases,
-            provider,
-            **kwargs,
+            resolved_language, prompt, test_cases, provider, **kwargs
         )
-    return reviewer.process(
-        series,
-        stop_at_idx=stop_at_idx,
-        start_at_idx=start_at_idx,
-    )
+    return reviewer.process(series, stop_at_idx=stop_at_idx, start_at_idx=start_at_idx)
 
 
 def review_series_guided(
@@ -113,8 +102,5 @@ def review_series_guided(
             **kwargs,
         )
     return reviewer.process(
-        target,
-        guide,
-        stop_at_idx=stop_at_idx,
-        start_at_idx=start_at_idx,
+        target, guide, stop_at_idx=stop_at_idx, start_at_idx=start_at_idx
     )

--- a/scinoephile/workflows/romanize.py
+++ b/scinoephile/workflows/romanize.py
@@ -18,10 +18,7 @@ __all__ = ["romanize_series"]
 
 
 def romanize_series(
-    series: Series,
-    *,
-    language: Language | None = None,
-    append: bool = True,
+    series: Series, *, language: Language | None = None, append: bool = True
 ) -> Series:
     """Romanize a subtitle series using the appropriate language-specific system.
 

--- a/scinoephile/workflows/subtitle_extraction.py
+++ b/scinoephile/workflows/subtitle_extraction.py
@@ -124,9 +124,7 @@ def extract_subtitles(
     streams = [
         stream
         for stream in _get_workflow_subtitle_streams(
-            infile_path,
-            details=details,
-            subtitle_cache=subtitle_cache,
+            infile_path, details=details, subtitle_cache=subtitle_cache
         )
         if _language_matches(stream.language, requested_language_tags)
     ]
@@ -136,8 +134,7 @@ def extract_subtitles(
     streams_to_extract = []
     for stream in streams:
         outfile_path = _get_subtitle_output_path(
-            output_dir_path,
-            stream.outfile_filename,
+            output_dir_path, stream.outfile_filename
         )
         status = _get_stream_file_status(outfile_path, overwrite=overwrite)
         outputs.append(
@@ -155,16 +152,12 @@ def extract_subtitles(
     stream_paths_by_index: dict[int, Path] = {}
     if streams_to_extract:
         stream_paths = SubtitleExtractor(subtitle_cache).extract(
-            infile_path,
-            streams_to_extract,
-            render_images=False,
+            infile_path, streams_to_extract, render_images=False
         )
         stream_paths_by_index = {
             stream.index: stream_path
             for stream, stream_path in zip(
-                streams_to_extract,
-                stream_paths,
-                strict=True,
+                streams_to_extract, stream_paths, strict=True
             )
         }
 
@@ -173,8 +166,7 @@ def extract_subtitles(
     for output in outputs:
         if output.status != SubtitleExtractionOutputStatus.EXISTED:
             _copy_cached_stream_file(
-                stream_paths_by_index[output.stream.index],
-                output.path,
+                stream_paths_by_index[output.stream.index], output.path
             )
         handled_outputs.append(output)
         if output.stream.extension == "sup" and export_images:
@@ -189,10 +181,7 @@ def extract_subtitles(
     return SubtitleExtractionResult(infile_path=infile_path, outputs=handled_outputs)
 
 
-def _copy_cached_stream_file(
-    stream_path: Path,
-    outfile_path: Path,
-) -> Path:
+def _copy_cached_stream_file(stream_path: Path, outfile_path: Path) -> Path:
     """Copy a cached subtitle stream file into place.
 
     Arguments:
@@ -212,10 +201,7 @@ def _copy_cached_stream_file(
 
 
 def _get_workflow_subtitle_streams(
-    infile_path: Path,
-    *,
-    details: bool,
-    subtitle_cache: SubtitleCache,
+    infile_path: Path, *, details: bool, subtitle_cache: SubtitleCache
 ) -> list[SubtitleStream]:
     """Get subtitle streams with optional workflow-level detail enrichment.
 
@@ -228,10 +214,7 @@ def _get_workflow_subtitle_streams(
     """
     # Use downstream Chinese script analysis only when details are requested
     if details:
-        return get_zho_subtitle_streams(
-            infile_path,
-            subtitle_cache=subtitle_cache,
-        )
+        return get_zho_subtitle_streams(infile_path, subtitle_cache=subtitle_cache)
     return get_subtitle_streams(infile_path)
 
 
@@ -252,9 +235,7 @@ def _language_matches(language: str | None, requested_language_tags: set[str]) -
 
 
 def _get_stream_file_status(
-    outfile_path: Path,
-    *,
-    overwrite: bool,
+    outfile_path: Path, *, overwrite: bool
 ) -> SubtitleExtractionOutputStatus:
     """Get the status to report for a subtitle stream file.
 
@@ -299,9 +280,7 @@ def _extract_sup_file(
     """
     # Probe the standalone SUP file and optionally enrich stream details
     streams = _get_workflow_subtitle_streams(
-        infile_path,
-        details=details,
-        subtitle_cache=subtitle_cache,
+        infile_path, details=details, subtitle_cache=subtitle_cache
     )
     if not streams:
         raise ScinoephileError(f"No subtitle streams found in {infile_path}")
@@ -310,8 +289,7 @@ def _extract_sup_file(
     requested_language_tags = set(languages)
     stream = streams[0]
     if stream.language is not None and not _language_matches(
-        stream.language,
-        requested_language_tags,
+        stream.language, requested_language_tags
     ):
         return []
     outfile_name = infile_path.name
@@ -320,11 +298,7 @@ def _extract_sup_file(
     outfile_path = _get_subtitle_output_path(output_dir_path, outfile_name)
 
     # Copy the SUP file and report its output status
-    status = _copy_sup_file(
-        infile_path,
-        outfile_path,
-        overwrite=overwrite,
-    )
+    status = _copy_sup_file(infile_path, outfile_path, overwrite=overwrite)
     outputs = [
         SubtitleExtractionOutput(
             kind=SubtitleExtractionOutputKind.SUBTITLE,
@@ -348,10 +322,7 @@ def _extract_sup_file(
 
 
 def _copy_sup_file(
-    infile_path: Path,
-    outfile_path: Path,
-    *,
-    overwrite: bool,
+    infile_path: Path, outfile_path: Path, *, overwrite: bool
 ) -> SubtitleExtractionOutputStatus:
     """Copy a SUP input file into place and return its output status.
 
@@ -397,11 +368,7 @@ def _get_subtitle_output_path(output_dir_path: Path, outfile_name: str) -> Path:
 
 
 def _extract_sup_image_series(
-    stream: SubtitleStream,
-    infile_path: Path,
-    output_dir_path: Path,
-    *,
-    overwrite: bool,
+    stream: SubtitleStream, infile_path: Path, output_dir_path: Path, *, overwrite: bool
 ) -> SubtitleExtractionOutput:
     """Convert a SUP subtitle file to an image directory.
 
@@ -433,11 +400,7 @@ def _extract_sup_image_series(
 
 
 def _try_extract_sup_image_series(
-    stream: SubtitleStream,
-    infile_path: Path,
-    output_dir_path: Path,
-    *,
-    overwrite: bool,
+    stream: SubtitleStream, infile_path: Path, output_dir_path: Path, *, overwrite: bool
 ) -> SubtitleExtractionOutput | None:
     """Convert a SUP subtitle file to images, warning on parse failures.
 
@@ -451,10 +414,7 @@ def _try_extract_sup_image_series(
     """
     try:
         return _extract_sup_image_series(
-            stream,
-            infile_path,
-            output_dir_path,
-            overwrite=overwrite,
+            stream, infile_path, output_dir_path, overwrite=overwrite
         )
     except (OSError, RuntimeError, ScinoephileError, ValueError) as exc:
         logger.warning(

--- a/scinoephile/workflows/transcription.py
+++ b/scinoephile/workflows/transcription.py
@@ -75,10 +75,7 @@ def transcribe_series_guided(
         ScinoephileError: if the guide language cannot be resolved or the pair is
             unsupported
     """
-    resolved_guide_language = resolve_language(
-        reference_series,
-        guide_language,
-    )
+    resolved_guide_language = resolve_language(reference_series, guide_language)
     if transcriber is None:
         transcriber = get_guided_transcriber(
             language,

--- a/scinoephile/workflows/translation.py
+++ b/scinoephile/workflows/translation.py
@@ -24,11 +24,7 @@ from scinoephile.llms.translation import TranslationProcessor, TranslationPrompt
 
 from .helpers import resolve_language
 
-__all__ = [
-    "translate_series",
-    "translate_series_gaps",
-    "translate_series_guided",
-]
+__all__ = ["translate_series", "translate_series_gaps", "translate_series_guided"]
 
 
 def translate_series(
@@ -74,9 +70,7 @@ def translate_series(
             **kwargs,
         )
     return translator.process(
-        source,
-        stop_at_idx=stop_at_idx,
-        start_at_idx=start_at_idx,
+        source, stop_at_idx=stop_at_idx, start_at_idx=start_at_idx
     )
 
 
@@ -126,10 +120,7 @@ def translate_series_gaps(
             **kwargs,
         )
     return translator.process(
-        target,
-        source,
-        stop_at_idx=stop_at_idx,
-        start_at_idx=start_at_idx,
+        target, source, stop_at_idx=stop_at_idx, start_at_idx=start_at_idx
     )
 
 
@@ -179,8 +170,5 @@ def translate_series_guided(
             **kwargs,
         )
     return translator.process(
-        source,
-        guide,
-        stop_at_idx=stop_at_idx,
-        start_at_idx=start_at_idx,
+        source, guide, stop_at_idx=stop_at_idx, start_at_idx=start_at_idx
     )

--- a/skills/audit-module-hierarchy/scripts/audit_module_hierarchy.py
+++ b/skills/audit-module-hierarchy/scripts/audit_module_hierarchy.py
@@ -120,9 +120,7 @@ def get_top_owner_name(package_dir_path: Path, file_path: Path) -> str | None:
 
 
 def get_sibling_import_edges(
-    package_dir_path: Path,
-    package_dotted: str,
-    child_names: list[str],
+    package_dir_path: Path, package_dotted: str, child_names: list[str]
 ) -> dict[str, set[str]]:
     """Build sibling import graph for one package.
 
@@ -159,20 +157,14 @@ def get_sibling_import_edges(
         for node in ast.walk(tree):
             if isinstance(node, ast.ImportFrom):
                 imported_name = get_imported_sibling_from_import_from(
-                    node,
-                    owner_name,
-                    child_names,
-                    package_prefix_parts,
+                    node, owner_name, child_names, package_prefix_parts
                 )
                 if imported_name is not None:
                     edges[owner_name].add(imported_name)
             elif isinstance(node, ast.Import):
                 for alias in node.names:
                     imported_name = get_imported_sibling_from_import(
-                        alias.name,
-                        owner_name,
-                        child_names,
-                        package_prefix_parts,
+                        alias.name, owner_name, child_names, package_prefix_parts
                     )
                     if imported_name is not None:
                         edges[owner_name].add(imported_name)
@@ -450,8 +442,7 @@ def main():
         )
 
     package_dir_paths = iter_package_dirs(
-        target_dir_path=target_dir_path,
-        min_children=args.min_children,
+        target_dir_path=target_dir_path, min_children=args.min_children
     )
     for package_dir_path in package_dir_paths:
         dotted_name = to_dotted_name(target_dir_path, package_dir_path)

--- a/skills/audit-style/scripts/audit_style.py
+++ b/skills/audit-style/scripts/audit_style.py
@@ -262,9 +262,7 @@ def _arg_nodes(node: ast.FunctionDef | ast.AsyncFunctionDef) -> list[ast.arg]:
 
 
 def _audit_class_attributes(
-    class_node: ast.ClassDef,
-    file_path: Path,
-    notes: dict[str, list[StyleNote]],
+    class_node: ast.ClassDef, file_path: Path, notes: dict[str, list[StyleNote]]
 ):
     """Audit documented class attribute declarations.
 
@@ -293,13 +291,7 @@ def _audit_class_attributes(
                 f"class attribute `{class_node.name}.{name}` lacks immediate "
                 "triple-quoted docstring"
             )
-            _add_note(
-                notes,
-                file_path,
-                "Documentation",
-                item.lineno,
-                message,
-            )
+            _add_note(notes, file_path, "Documentation", item.lineno, message)
 
 
 def _audit_function_annotations(
@@ -323,11 +315,7 @@ def _audit_function_annotations(
                 f"`{function_node.name}`"
             )
             _add_note(
-                notes,
-                file_path,
-                "Type Annotations",
-                function_node.lineno,
-                message,
+                notes, file_path, "Type Annotations", function_node.lineno, message
             )
     if function_node.returns is None:
         value_returns = [
@@ -425,19 +413,11 @@ def _audit_init_export(
                 "`__init__.py` imports non-class-looking public name "
                 f"`{public_name}`; verify class-only rule"
             )
-            _add_note(
-                notes,
-                file_path,
-                "Exports",
-                node.lineno,
-                message,
-            )
+            _add_note(notes, file_path, "Exports", node.lineno, message)
 
 
 def _audit_nomenclature(
-    node: ast.AST,
-    file_path: Path,
-    notes: dict[str, list[StyleNote]],
+    node: ast.AST, file_path: Path, notes: dict[str, list[StyleNote]]
 ):
     """Audit path-related variable and parameter names.
 
@@ -503,10 +483,7 @@ def _audit_nomenclature(
 
 
 def _audit_required_header(
-    text: str,
-    lines: Sequence[str],
-    file_path: Path,
-    notes: dict[str, list[StyleNote]],
+    text: str, lines: Sequence[str], file_path: Path, notes: dict[str, list[StyleNote]]
 ):
     """Audit file-level copyright and future import requirements.
 
@@ -531,9 +508,7 @@ def _audit_required_header(
 
 
 def _audit_string_interpolation(
-    node: ast.AST,
-    file_path: Path,
-    notes: dict[str, list[StyleNote]],
+    node: ast.AST, file_path: Path, notes: dict[str, list[StyleNote]]
 ):
     """Audit non-f-string interpolation.
 
@@ -578,9 +553,7 @@ def _audit_string_interpolation(
 
 
 def _audit_print_call(
-    node: ast.AST,
-    file_path: Path,
-    notes: dict[str, list[StyleNote]],
+    node: ast.AST, file_path: Path, notes: dict[str, list[StyleNote]]
 ):
     """Audit `print` calls outside CLI command output and pytest modules.
 
@@ -606,9 +579,7 @@ def _audit_print_call(
 
 
 def _audit_text_lines(
-    lines: Sequence[str],
-    file_path: Path,
-    notes: dict[str, list[StyleNote]],
+    lines: Sequence[str], file_path: Path, notes: dict[str, list[StyleNote]]
 ):
     """Audit line-oriented text style rules.
 
@@ -658,9 +629,7 @@ def _audit_tree(
 
 
 def _audit_tree_header(
-    tree: ast.Module,
-    file_path: Path,
-    notes: dict[str, list[StyleNote]],
+    tree: ast.Module, file_path: Path, notes: dict[str, list[StyleNote]]
 ):
     """Audit module docstring and export requirements.
 
@@ -723,9 +692,7 @@ def _audit_all_format(
 
 
 def _audit_class(
-    class_node: ast.ClassDef,
-    file_path: Path,
-    notes: dict[str, list[StyleNote]],
+    class_node: ast.ClassDef, file_path: Path, notes: dict[str, list[StyleNote]]
 ):
     """Audit a class definition.
 

--- a/skills/audit-zho-conversion-exclusions/scripts/audit_zho_conversion_exclusions.py
+++ b/skills/audit-zho-conversion-exclusions/scripts/audit_zho_conversion_exclusions.py
@@ -10,10 +10,7 @@ from dataclasses import dataclass
 from difflib import SequenceMatcher
 from pathlib import Path
 
-from scinoephile.lang.zho.script.conversion import (
-    OpenCCConfig,
-    get_zho_text_converted,
-)
+from scinoephile.lang.zho.script.conversion import OpenCCConfig, get_zho_text_converted
 
 type _KnownExceptionKey = tuple[str, str, str]
 

--- a/test/analysis/character_error_rate/test_character_error_rate.py
+++ b/test/analysis/character_error_rate/test_character_error_rate.py
@@ -179,8 +179,7 @@ def test_line_cer_string_uses_na_for_empty_reference():
     ],
 )
 def test_series_cer_ignores_separator_only_line_wrapping(
-    reference: Series,
-    candidate: Series,
+    reference: Series, candidate: Series
 ):
     """Test separator-only line wrapping does not affect series CER."""
     result = SeriesCER(reference, candidate)
@@ -222,15 +221,9 @@ def test_series_cer_string_uses_na_for_empty_reference():
 def test_series_cer_handles_one_sided_span_after_shorter_side_is_exhausted():
     """A trailing one-sided span should not overrun the shorter series."""
     reference = get_text_series(
-        "係嗰度呀⋯⋯",
-        "係嗰邊呀，快點去⋯⋯",
-        "呢度仲有一隻",
-        "呢隻細隻啲",
+        "係嗰度呀⋯⋯", "係嗰邊呀，快點去⋯⋯", "呢度仲有一隻", "呢隻細隻啲"
     )
-    candidate = get_text_series(
-        "係嗰邊呀，快點去⋯⋯",
-        "呢度仲有一隻",
-    )
+    candidate = get_text_series("係嗰邊呀，快點去⋯⋯", "呢度仲有一隻")
 
     result = SeriesCER(reference, candidate)
 

--- a/test/analysis/diff/test_line_diff.py
+++ b/test/analysis/diff/test_line_diff.py
@@ -34,17 +34,11 @@ def test_line_diff_get_aligned_texts_for_non_edit_kinds():
             ("same lines", "same lines"),
         ),
         (
-            LineDiff(
-                kind=LineDiffKind.INSERT,
-                two_texts=("new", "line"),
-            ),
+            LineDiff(kind=LineDiffKind.INSERT, two_texts=("new", "line")),
             ("", "new line"),
         ),
         (
-            LineDiff(
-                kind=LineDiffKind.DELETE,
-                one_texts=("廣東", "話"),
-            ),
+            LineDiff(kind=LineDiffKind.DELETE, one_texts=("廣東", "話")),
             ("廣東　話", ""),
         ),
     ]

--- a/test/analysis/diff/test_series_diff.py
+++ b/test/analysis/diff/test_series_diff.py
@@ -151,23 +151,16 @@ def test_series_diff_get_event_indices():
     cases = [
         (
             SeriesDiff(
-                get_text_series("first second"),
-                get_text_series("first\\Nsecond"),
+                get_text_series("first second"), get_text_series("first\\Nsecond")
             ),
             ((0,), (0,)),
         ),
         (
-            SeriesDiff(
-                get_text_series("same"),
-                get_text_series("same", "insert"),
-            ),
+            SeriesDiff(get_text_series("same"), get_text_series("same", "insert")),
             ((), (1,)),
         ),
         (
-            SeriesDiff(
-                get_text_series("same", "delete"),
-                get_text_series("same"),
-            ),
+            SeriesDiff(get_text_series("same", "delete"), get_text_series("same")),
             ((1,), ()),
         ),
     ]
@@ -228,9 +221,7 @@ def test_series_diff_get_stacked_str_can_include_equal_lines():
     three = get_text_series("source same", "source before", "source changed")
 
     rendered = SeriesDiff(one, two).get_stacked_str(
-        color=False,
-        three=three,
-        include_equal=True,
+        color=False, three=three, include_equal=True
     )
 
     assert rendered.splitlines() == [
@@ -267,9 +258,7 @@ def test_series_diff_get_stacked_str_can_include_equal_lines():
     ],
 )
 def test_series_diff_get_stacked_str_keeps_equal_lines_around_one_sided_changes(
-    one_texts: tuple[str, ...],
-    two_texts: tuple[str, ...],
-    expected_lines: list[str],
+    one_texts: tuple[str, ...], two_texts: tuple[str, ...], expected_lines: list[str]
 ):
     """Test equal stacked lines stay aligned around inserts and deletes.
 
@@ -279,8 +268,7 @@ def test_series_diff_get_stacked_str_keeps_equal_lines_around_one_sided_changes(
         expected_lines: expected stacked output lines
     """
     rendered = SeriesDiff(
-        get_text_series(*one_texts),
-        get_text_series(*two_texts),
+        get_text_series(*one_texts), get_text_series(*two_texts)
     ).get_stacked_str(color=False, include_equal=True)
 
     assert rendered.splitlines() == expected_lines
@@ -309,10 +297,7 @@ def test_series_diff_keeps_uncovered_insert_separate():
 def test_series_diff_represents_line_before_one_sided_span():
     """Test every line is represented after splitting one-to-many changes."""
     one = get_text_series(
-        "師爺，少爺寫乜嘢呀？",
-        "名呀",
-        "嘩，好叻呀！原來少爺識寫自己個名喎！",
-        "係呀。",
+        "師爺，少爺寫乜嘢呀？", "名呀", "嘩，好叻呀！原來少爺識寫自己個名喎！", "係呀。"
     )
     two = get_text_series(
         "師爺，少爺寫乜嘢呀？",
@@ -346,34 +331,19 @@ def test_series_diff_represents_line_before_one_sided_span():
 def test_series_diff_represents_line_before_shifted_changed_span():
     """Test lines before a shifted changed span are not dropped."""
     messages = SeriesDiff(
-        get_text_series("a", "b"),
-        get_text_series("a", "ab"),
+        get_text_series("a", "b"), get_text_series("a", "ab")
     ).get_messages(include_equal=True)
 
     assert [
         (message.kind, message.one_idxs, message.two_idxs) for message in messages
-    ] == [
-        (LineDiffKind.INSERT, None, (0,)),
-        (LineDiffKind.MERGE_EDIT, (0, 1), (1,)),
-    ]
+    ] == [(LineDiffKind.INSERT, None, (0,)), (LineDiffKind.MERGE_EDIT, (0, 1), (1,))]
 
 
 def test_series_diff_represents_deleted_repeated_line_before_equal_lines():
     """Test repeated lines do not offset subsequent equal-line matches."""
     messages = SeriesDiff(
-        get_text_series(
-            "pre",
-            "打賞⋯打賞",
-            "打賞⋯打賞",
-            "恭喜蘇翁生辰快樂",
-            "post",
-        ),
-        get_text_series(
-            "pre",
-            "打賞⋯打賞",
-            "恭喜蘇翁生辰快樂",
-            "post",
-        ),
+        get_text_series("pre", "打賞⋯打賞", "打賞⋯打賞", "恭喜蘇翁生辰快樂", "post"),
+        get_text_series("pre", "打賞⋯打賞", "恭喜蘇翁生辰快樂", "post"),
     ).get_messages(include_equal=True)
 
     assert [
@@ -426,8 +396,7 @@ def test_series_diff_discards_out_of_order_span_indices(
         expected_message_indices: expected diff message kinds and line indices
     """
     messages = SeriesDiff(
-        get_text_series(*one_texts),
-        get_text_series(*two_texts),
+        get_text_series(*one_texts), get_text_series(*two_texts)
     ).get_messages(include_equal=True)
 
     assert [

--- a/test/analysis/diff/test_series_diff_alignment.py
+++ b/test/analysis/diff/test_series_diff_alignment.py
@@ -78,14 +78,10 @@ def test_series_diff_pairs_same_position_delete_insert():
     """Test same-position delete and insert spans merge into one edit."""
     diff = SeriesDiff(
         get_text_series(
-            "阿灿,你没事　吧?",
-            "你睇我姿势，你话我有冇事？",
-            "你的姿势　很有型　",
+            "阿灿,你没事　吧?", "你睇我姿势，你话我有冇事？", "你的姿势　很有型　"
         ),
         get_text_series(
-            "阿灿，你冇事呀嘛？",
-            "你睇我姿势你话有冇事呀？",
-            "你个姿势仲好有型！",
+            "阿灿，你冇事呀嘛？", "你睇我姿势你话有冇事呀？", "你个姿势仲好有型！"
         ),
     )
     messages = list(diff)
@@ -102,14 +98,10 @@ def test_series_diff_pairs_adjacent_similar_insert_delete():
     """Test adjacent similar insert and delete spans merge into one edit."""
     diff = SeriesDiff(
         get_text_series(
-            "靠你了",
-            "莫大叔！莲花落阵你都冇有把握",
-            "以我现在打狗棒法的功力",
+            "靠你了", "莫大叔！莲花落阵你都冇有把握", "以我现在打狗棒法的功力"
         ),
         get_text_series(
-            "靠你喇！",
-            "莫大叔呀！莲花落阵你都冇把握",
-            "以我而家打狗棍法嘅功力",
+            "靠你喇！", "莫大叔呀！莲花落阵你都冇把握", "以我而家打狗棍法嘅功力"
         ),
     )
     messages = list(diff)
@@ -231,19 +223,11 @@ def test_series_diff_does_not_pair_dissimilar_bracketed_span():
     one = get_text_series("editA", "qqqq", "editB")
     two = get_text_series("editZ", "real insert", "editY")
     diff = SeriesDiff(one, two)
-    one_side = diff._get_block_side(
-        (0, 1, 2),
-        diff._get_series_event_line_records(one),
-    )
-    two_side = diff._get_block_side(
-        (0, 1, 2),
-        diff._get_series_event_line_records(two),
-    )
+    one_side = diff._get_block_side((0, 1, 2), diff._get_series_event_line_records(one))
+    two_side = diff._get_block_side((0, 1, 2), diff._get_series_event_line_records(two))
 
     paired = diff._pair_one_sided_spans_with_implicit_lines(
-        [((0,), (0,)), ((), (1,)), ((2,), (2,))],
-        one_side,
-        two_side,
+        [((0,), (0,)), ((), (1,)), ((2,), (2,))], one_side, two_side
     )
 
     assert paired == [((0,), (0,)), ((), (1,)), ((2,), (2,))]
@@ -255,21 +239,14 @@ def test_series_diff_does_not_merge_sparse_one_sided_spans():
     two = get_text_series("start", "same1", "same2", "alpha!", "end")
     diff = SeriesDiff(one, two)
     one_side = diff._get_block_side(
-        (0, 1, 2, 3, 4),
-        diff._get_series_event_line_records(one),
+        (0, 1, 2, 3, 4), diff._get_series_event_line_records(one)
     )
     two_side = diff._get_block_side(
-        (0, 1, 2, 3, 4),
-        diff._get_series_event_line_records(two),
+        (0, 1, 2, 3, 4), diff._get_series_event_line_records(two)
     )
 
     should_merge = diff._should_merge_adjacent_one_sided_spans(
-        one_side,
-        two_side,
-        (1,),
-        (),
-        (),
-        (3,),
+        one_side, two_side, (1,), (), (), (3,)
     )
 
     assert should_merge is False
@@ -280,22 +257,11 @@ def test_series_diff_merges_adjacent_one_sided_spans():
     one = get_text_series("靠你了", "莫大叔！莲花落阵你都冇有把握")
     two = get_text_series("靠你喇！", "莫大叔呀！莲花落阵你都冇把握")
     diff = SeriesDiff(one, two)
-    one_side = diff._get_block_side(
-        (0, 1),
-        diff._get_series_event_line_records(one),
-    )
-    two_side = diff._get_block_side(
-        (0, 1),
-        diff._get_series_event_line_records(two),
-    )
+    one_side = diff._get_block_side((0, 1), diff._get_series_event_line_records(one))
+    two_side = diff._get_block_side((0, 1), diff._get_series_event_line_records(two))
 
     should_merge = diff._should_merge_adjacent_one_sided_spans(
-        one_side,
-        two_side,
-        (1,),
-        (),
-        (),
-        (1,),
+        one_side, two_side, (1,), (), (), (1,)
     )
 
     assert should_merge is True

--- a/test/analysis/line_alignment/test_line_alignment.py
+++ b/test/analysis/line_alignment/test_line_alignment.py
@@ -6,10 +6,7 @@ from __future__ import annotations
 
 import numpy as np
 
-from scinoephile.analysis.line_alignment import (
-    LineAlignment,
-    LineAlignmentOperation,
-)
+from scinoephile.analysis.line_alignment import LineAlignment, LineAlignmentOperation
 from test.helpers import parametrize
 
 

--- a/test/analysis/test_aligned_diff_audit.py
+++ b/test/analysis/test_aligned_diff_audit.py
@@ -20,9 +20,7 @@ def test_audit_aligned_diff_defaults_to_changes_with_optional_tracks():
     transcription = _get_series((0, 500, "甲錯"), (1000, 1500, "相同"))
     reference = _get_series((0, 500, "甲正"), (1000, 1500, "相同"))
     guide = _get_series(
-        (0, 500, "指南一"),
-        (700, 800, "額外指南"),
-        (1000, 1500, "指南二"),
+        (0, 500, "指南一"), (700, 800, "額外指南"), (1000, 1500, "指南二")
     )
 
     report = audit_aligned_diff(transcription, reference, guide, original=original)
@@ -49,9 +47,7 @@ def test_audit_aligned_diff_all_includes_equal_multiline_event():
     reference = _get_series((0, 500, "甲\\N丙"), (1000, 1500, "相同"))
 
     report = audit_aligned_diff(
-        transcription,
-        reference,
-        row_filter=AlignedDiffAuditFilter.all,
+        transcription, reference, row_filter=AlignedDiffAuditFilter.all
     )
 
     assert "- table rows: 3" in report
@@ -62,14 +58,9 @@ def test_audit_aligned_diff_all_includes_equal_multiline_event():
 def test_audit_aligned_diff_range_includes_reference_only_insertions():
     """Test reference insertions overlapping the transcription range are included."""
     original = _get_series((1200, 1300, "漏譯原文"))
-    transcription = _get_series(
-        (0, 500, "相同一"),
-        (1000, 2000, "相同二"),
-    )
+    transcription = _get_series((0, 500, "相同一"), (1000, 2000, "相同二"))
     reference = _get_series(
-        (0, 500, "相同一"),
-        (1200, 1300, "新增"),
-        (1500, 2000, "相同二"),
+        (0, 500, "相同一"), (1200, 1300, "新增"), (1500, 2000, "相同二")
     )
 
     report = audit_aligned_diff(
@@ -94,32 +85,21 @@ def test_audit_aligned_diff_range_includes_reference_only_insertions():
 def test_audit_aligned_diff_rejects_mixed_subtitle_and_block_ranges():
     """Test subtitle-index and block ranges are mutually exclusive."""
     transcription = _get_series(
-        (0, 500, "第一"),
-        (1000, 1500, "第二"),
-        (6000, 6500, "第三錯"),
+        (0, 500, "第一"), (1000, 1500, "第二"), (6000, 6500, "第三錯")
     )
     reference = _get_series(
-        (0, 500, "第一"),
-        (1000, 1500, "第二"),
-        (6000, 6500, "第三正"),
+        (0, 500, "第一"), (1000, 1500, "第二"), (6000, 6500, "第三正")
     )
 
     with raises(ScinoephileError, match="mutually exclusive"):
         audit_aligned_diff(
-            transcription,
-            reference,
-            first_index=2,
-            first_block=2,
-            last_block=2,
+            transcription, reference, first_index=2, first_block=2, last_block=2
         )
 
 
 def test_audit_aligned_diff_rejects_reused_guide_match():
     """Test one guide subtitle cannot match multiple transcription events."""
-    transcription = _get_series(
-        (0, 500, "甲"),
-        (0, 500, "乙"),
-    )
+    transcription = _get_series((0, 500, "甲"), (0, 500, "乙"))
     reference = _get_series((0, 500, "甲乙"))
     guide = _get_series((0, 500, "指南"))
 
@@ -134,21 +114,12 @@ def test_audit_aligned_diff_rejects_invalid_range_and_track_alignment():
     guide = _get_series((501, 1000, "指南"))
 
     with raises(ScinoephileError, match="less than or equal"):
-        audit_aligned_diff(
-            transcription,
-            reference,
-            first_index=2,
-            last_index=1,
-        )
+        audit_aligned_diff(transcription, reference, first_index=2, last_index=1)
     with raises(ScinoephileError, match="First block must be at least 1"):
         audit_aligned_diff(transcription, reference, first_block=0)
     with raises(ScinoephileError, match="no exact timing match"):
         audit_aligned_diff(transcription, reference, guide)
-    original_report = audit_aligned_diff(
-        transcription,
-        reference,
-        original=guide,
-    )
+    original_report = audit_aligned_diff(transcription, reference, original=guide)
     assert "<pre>O │ <br>T │ 甲<br>R │ 乙</pre>" in original_report
 
 

--- a/test/analysis/test_delineation_audit.py
+++ b/test/analysis/test_delineation_audit.py
@@ -35,9 +35,7 @@ def test_audit_delineation_formats_shift_and_no_shift_rows():
         ),
         DelineationTestCase(
             query=DelineationQuery(
-                reference_one="參考二",
-                reference_two="參考三",
-                target_one="丁",
+                reference_one="參考二", reference_two="參考三", target_one="丁"
             ),
             answer=DelineationAnswer(),
         ),
@@ -91,9 +89,7 @@ def test_audit_delineation_formats_unanswered_case():
     """Test an unanswered logged case is identified without inventing output."""
     test_case = DelineationTestCase(
         query=DelineationQuery(
-            reference_one="參考一",
-            reference_two="參考二",
-            target_one="甲",
+            reference_one="參考一", reference_two="參考二", target_one="甲"
         )
     )
 
@@ -118,9 +114,7 @@ def test_audit_delineation_filters_rows_and_subtitle_range():
         ),
         DelineationTestCase(
             query=DelineationQuery(
-                reference_one="參考二",
-                reference_two="參考三",
-                target_one="丁",
+                reference_one="參考二", reference_two="參考三", target_one="丁"
             ),
             answer=DelineationAnswer(),
             verified=True,
@@ -128,20 +122,13 @@ def test_audit_delineation_filters_rows_and_subtitle_range():
     )
 
     changed_report = audit_delineation(
-        reference,
-        test_cases,
-        row_filter=DelineationAuditFilter.changes,
+        reference, test_cases, row_filter=DelineationAuditFilter.changes
     )
     unverified_report = audit_delineation(
-        reference,
-        test_cases,
-        row_filter=DelineationAuditFilter.unverified,
+        reference, test_cases, row_filter=DelineationAuditFilter.unverified
     )
     ranged_report = audit_delineation(
-        reference,
-        test_cases,
-        first_index=1,
-        last_index=2,
+        reference, test_cases, first_index=1, last_index=2
     )
 
     assert "- logged cases: 2" in changed_report
@@ -173,28 +160,19 @@ def test_audit_delineation_filters_reference_blocks():
     test_cases = (
         DelineationTestCase(
             query=DelineationQuery(
-                reference_one="一",
-                reference_two="二",
-                target_one="甲",
+                reference_one="一", reference_two="二", target_one="甲"
             ),
             answer=DelineationAnswer(),
         ),
         DelineationTestCase(
             query=DelineationQuery(
-                reference_one="三",
-                reference_two="四",
-                target_one="乙",
+                reference_one="三", reference_two="四", target_one="乙"
             ),
             answer=DelineationAnswer(),
         ),
     )
 
-    report = audit_delineation(
-        reference,
-        test_cases,
-        first_block=2,
-        last_block=2,
-    )
+    report = audit_delineation(reference, test_cases, first_block=2, last_block=2)
 
     assert "- block range: 2 through 2" in report
     assert "| 1<br>2 |" not in report
@@ -209,10 +187,7 @@ def test_audit_delineation_rejects_invalid_range():
         audit_delineation(_get_series("參考一", "參考二"), (), first_block=0)
     with raises(ScinoephileError, match="ranges are mutually exclusive"):
         audit_delineation(
-            _get_series("參考一", "參考二"),
-            (),
-            first_index=1,
-            first_block=1,
+            _get_series("參考一", "參考二"), (), first_index=1, first_block=1
         )
 
 
@@ -220,9 +195,7 @@ def test_audit_delineation_rejects_unmatched_reference_pair():
     """Test a logged pair absent from the reference cannot be indexed."""
     test_case = DelineationTestCase(
         query=DelineationQuery(
-            reference_one="不同一",
-            reference_two="不同二",
-            target_one="甲",
+            reference_one="不同一", reference_two="不同二", target_one="甲"
         )
     )
 
@@ -264,10 +237,7 @@ def test_audit_delineation_ignores_superseded_reference_revision():
 
     report = audit_delineation(reference, test_cases)
     excluded_report = audit_delineation(
-        reference,
-        test_cases,
-        first_index=3,
-        last_index=3,
+        reference, test_cases, first_index=3, last_index=3
     )
 
     assert "- logged cases: 1" in report
@@ -321,49 +291,37 @@ def test_audit_delineation_progressively_resolves_repeated_sequence():
     test_cases = (
         DelineationTestCase(
             query=DelineationQuery(
-                reference_one="之前",
-                reference_two="乙",
-                target_one="前",
+                reference_one="之前", reference_two="乙", target_one="前"
             ),
             answer=DelineationAnswer(),
         ),
         DelineationTestCase(
             query=DelineationQuery(
-                reference_one="甲",
-                reference_two="乙",
-                target_one="一",
+                reference_one="甲", reference_two="乙", target_one="一"
             ),
             answer=DelineationAnswer(),
         ),
         DelineationTestCase(
             query=DelineationQuery(
-                reference_one="甲",
-                reference_two="乙",
-                target_one="二",
+                reference_one="甲", reference_two="乙", target_one="二"
             ),
             answer=DelineationAnswer(),
         ),
         DelineationTestCase(
             query=DelineationQuery(
-                reference_one="乙",
-                reference_two="甲",
-                target_one="三",
+                reference_one="乙", reference_two="甲", target_one="三"
             ),
             answer=DelineationAnswer(),
         ),
         DelineationTestCase(
             query=DelineationQuery(
-                reference_one="甲",
-                reference_two="乙",
-                target_one="四",
+                reference_one="甲", reference_two="乙", target_one="四"
             ),
             answer=DelineationAnswer(),
         ),
         DelineationTestCase(
             query=DelineationQuery(
-                reference_one="乙",
-                reference_two="之後",
-                target_one="後",
+                reference_one="乙", reference_two="之後", target_one="後"
             ),
             answer=DelineationAnswer(),
         ),
@@ -382,25 +340,19 @@ def test_audit_delineation_resolves_context_before_logged_restart():
     test_cases = (
         DelineationTestCase(
             query=DelineationQuery(
-                reference_one="之前",
-                reference_two="甲",
-                target_one="前",
+                reference_one="之前", reference_two="甲", target_one="前"
             ),
             answer=DelineationAnswer(),
         ),
         DelineationTestCase(
             query=DelineationQuery(
-                reference_one="甲",
-                reference_two="乙",
-                target_one="中",
+                reference_one="甲", reference_two="乙", target_one="中"
             ),
             answer=DelineationAnswer(),
         ),
         DelineationTestCase(
             query=DelineationQuery(
-                reference_one="之前",
-                reference_two="甲",
-                target_one="重啟",
+                reference_one="之前", reference_two="甲", target_one="重啟"
             ),
             answer=DelineationAnswer(),
         ),
@@ -418,33 +370,25 @@ def test_audit_delineation_resolves_reverse_traversal_before_restart():
     test_cases = (
         DelineationTestCase(
             query=DelineationQuery(
-                reference_one="之前",
-                reference_two="乙",
-                target_one="前",
+                reference_one="之前", reference_two="乙", target_one="前"
             ),
             answer=DelineationAnswer(),
         ),
         DelineationTestCase(
             query=DelineationQuery(
-                reference_one="甲",
-                reference_two="乙",
-                target_one="右",
+                reference_one="甲", reference_two="乙", target_one="右"
             ),
             answer=DelineationAnswer(),
         ),
         DelineationTestCase(
             query=DelineationQuery(
-                reference_one="乙",
-                reference_two="甲",
-                target_one="左",
+                reference_one="乙", reference_two="甲", target_one="左"
             ),
             answer=DelineationAnswer(),
         ),
         DelineationTestCase(
             query=DelineationQuery(
-                reference_one="之前",
-                reference_two="乙",
-                target_one="重啟",
+                reference_one="之前", reference_two="乙", target_one="重啟"
             ),
             answer=DelineationAnswer(),
         ),
@@ -460,19 +404,15 @@ def test_audit_delineation_rejects_ambiguous_reference_pair():
     """Test a repeated reference pair cannot be assigned misleading indexes."""
     test_case = DelineationTestCase(
         query=DelineationQuery(
-            reference_one="參考一",
-            reference_two="參考二",
-            target_one="甲",
+            reference_one="參考一", reference_two="參考二", target_one="甲"
         )
     )
 
     with raises(
-        ScinoephileError,
-        match="test case 1 reference pair is ambiguous.*1, 3",
+        ScinoephileError, match="test case 1 reference pair is ambiguous.*1, 3"
     ):
         audit_delineation(
-            _get_series("參考一", "參考二", "參考一", "參考二"),
-            (test_case,),
+            _get_series("參考一", "參考二", "參考一", "參考二"), (test_case,)
         )
 
 
@@ -481,25 +421,15 @@ def test_audit_delineation_rejects_range_based_disambiguation():
     reference = _get_series("參考一", "參考二", "參考一", "參考二")
     test_case = DelineationTestCase(
         query=DelineationQuery(
-            reference_one="參考一",
-            reference_two="參考二",
-            target_one="甲",
+            reference_one="參考一", reference_two="參考二", target_one="甲"
         ),
         answer=DelineationAnswer(),
     )
 
     with raises(ScinoephileError, match="reference pair is ambiguous.*1, 3"):
-        audit_delineation(
-            reference,
-            (test_case,),
-            first_index=1,
-            last_index=2,
-        )
+        audit_delineation(reference, (test_case,), first_index=1, last_index=2)
     excluded_report = audit_delineation(
-        reference,
-        (test_case,),
-        first_index=5,
-        last_index=6,
+        reference, (test_case,), first_index=5, last_index=6
     )
 
     assert "- logged cases: 0" in excluded_report
@@ -512,17 +442,13 @@ def test_audit_delineation_resolves_repeated_pair_before_range_filtering():
     test_cases = (
         DelineationTestCase(
             query=DelineationQuery(
-                reference_one="之前",
-                reference_two="重複一",
-                target_one="前",
+                reference_one="之前", reference_two="重複一", target_one="前"
             ),
             answer=DelineationAnswer(),
         ),
         DelineationTestCase(
             query=DelineationQuery(
-                reference_one="重複一",
-                reference_two="重複二",
-                target_one="中",
+                reference_one="重複一", reference_two="重複二", target_one="中"
             ),
             answer=DelineationAnswer(),
         ),
@@ -530,10 +456,7 @@ def test_audit_delineation_resolves_repeated_pair_before_range_filtering():
 
     report = audit_delineation(reference, test_cases)
     ranged_report = audit_delineation(
-        reference,
-        test_cases,
-        first_index=1,
-        last_index=2,
+        reference, test_cases, first_index=1, last_index=2
     )
 
     assert "| 4<br>5 | 重複一<br>重複二 | 中<br>— |" in report

--- a/test/analysis/test_dual_review_audit.py
+++ b/test/analysis/test_dual_review_audit.py
@@ -57,10 +57,7 @@ def test_audit_dual_review_filters_and_includes_json_notes(tmp_path: Path):
     """
     inputs = _get_audit_inputs(tmp_path)
 
-    report = audit_dual_review(
-        **inputs,
-        row_filter=DualReviewAuditFilter.changes,
-    )
+    report = audit_dual_review(**inputs, row_filter=DualReviewAuditFilter.changes)
 
     assert "- simplified review edits: 1" in report
     assert "- traditional review edits: 1" in report
@@ -79,19 +76,14 @@ def test_audit_dual_review_filters_and_includes_json_notes(tmp_path: Path):
     assert "Traditional review: 修正繁體字。" in report
     assert "Traditional simplification review: 修正簡化結果。" in report
 
-    report = audit_dual_review(
-        **inputs,
-        row_filter=DualReviewAuditFilter.discrepancies,
-    )
+    report = audit_dual_review(**inputs, row_filter=DualReviewAuditFilter.discrepancies)
     assert "- table rows: 2" in report
     assert "| 2 |" in report
     assert "| 3 |" not in report
     assert "| 4 |" in report
 
     report = audit_dual_review(
-        **inputs,
-        row_filter=DualReviewAuditFilter.all,
-        characters=("著", "丙"),
+        **inputs, row_filter=DualReviewAuditFilter.all, characters=("著", "丙")
     )
     assert "- character filter: 著, 丙" in report
     assert "- table rows: 1" in report
@@ -99,10 +91,7 @@ def test_audit_dual_review_filters_and_includes_json_notes(tmp_path: Path):
     assert "| 3 |" in report
 
     report = audit_dual_review(
-        **inputs,
-        row_filter=DualReviewAuditFilter.all,
-        first_index=2,
-        last_index=3,
+        **inputs, row_filter=DualReviewAuditFilter.all, first_index=2, last_index=3
     )
     assert "- final text discrepancies: 1" in report
     assert "- subtitle range: 2 through 3" in report
@@ -186,9 +175,7 @@ def _get_audit_inputs(tmp_path: Path) -> _AuditInputs:
     )
     simplified_json_path = tmp_path / "simplified.json"
     _write_review_json(
-        simplified_json_path,
-        texts_by_name["simplified"],
-        {2: ("简正", "修正简体字。")},
+        simplified_json_path, texts_by_name["simplified"], {2: ("简正", "修正简体字。")}
     )
     return _AuditInputs(
         traditional=series["traditional"],
@@ -225,16 +212,12 @@ def _load_review_cases(json_path: Path) -> list[TestCase]:
         deserialized review test cases
     """
     return load_test_cases_from_json(
-        json_path,
-        ReviewManager,
-        ReviewManager.base_prompt,
+        json_path, ReviewManager, ReviewManager.base_prompt
     )
 
 
 def _write_review_json(
-    json_path: Path,
-    texts: tuple[str, ...],
-    revisions: dict[int, tuple[str, str]],
+    json_path: Path, texts: tuple[str, ...], revisions: dict[int, tuple[str, str]]
 ):
     """Write one block-based review JSON fixture.
 

--- a/test/analysis/test_gap_translation_audit.py
+++ b/test/analysis/test_gap_translation_audit.py
@@ -20,14 +20,9 @@ from scinoephile.llms.gap_translation import (
 
 def test_audit_gap_translation_formats_answer_and_context():
     """Test one translated gap is rendered with global and local context."""
-    target = _get_series(
-        (0, 1000, "現有|一"),
-        (2000, 3000, "現有三"),
-    )
+    target = _get_series((0, 1000, "現有|一"), (2000, 3000, "現有三"))
     guide = _get_series(
-        (0, 1000, "參考一"),
-        (1000, 2000, "參|考二"),
-        (2000, 3000, "參考三"),
+        (0, 1000, "參考一"), (1000, 2000, "參|考二"), (2000, 3000, "參考三")
     )
     test_case = _get_test_case(
         targets=((1, "現有|一"), (3, "現有三")),
@@ -50,10 +45,7 @@ def test_audit_gap_translation_formats_answer_and_context():
 
 def test_audit_gap_translation_formats_empty_and_unanswered_gaps():
     """Test empty answers and missing answers remain distinguishable."""
-    target = _get_series(
-        (0, 1000, "現有一"),
-        (6000, 7000, "現有三"),
-    )
+    target = _get_series((0, 1000, "現有一"), (6000, 7000, "現有三"))
     guide = _get_series(
         (0, 1000, "參考一"),
         (1000, 2000, "參考二"),
@@ -67,32 +59,18 @@ def test_audit_gap_translation_formats_empty_and_unanswered_gaps():
             outputs=((2, ""),),
             verified=True,
         ),
-        _get_test_case(
-            targets=((1, "現有三"),),
-            guides=((1, "參考三"), (2, "參考四")),
-        ),
+        _get_test_case(targets=((1, "現有三"),), guides=((1, "參考三"), (2, "參考四"))),
     )
 
     report = audit_gap_translation(target, guide, test_cases)
     unverified_report = audit_gap_translation(
-        target,
-        guide,
-        test_cases,
-        row_filter=TranslationAuditFilter.unverified,
+        target, guide, test_cases, row_filter=TranslationAuditFilter.unverified
     )
     ranged_report = audit_gap_translation(
-        target,
-        guide,
-        test_cases,
-        first_index=4,
-        last_index=4,
+        target, guide, test_cases, first_index=4, last_index=4
     )
     block_report = audit_gap_translation(
-        target,
-        guide,
-        test_cases,
-        first_block=2,
-        last_block=2,
+        target, guide, test_cases, first_block=2, last_block=2
     )
 
     assert "- empty translations: 1" in report
@@ -117,10 +95,7 @@ def test_audit_gap_translation_formats_empty_and_unanswered_gaps():
 def test_audit_gap_translation_ignores_superseded_guide_revision():
     """Test a current query supersedes retained history with old guide text."""
     target = _get_series((0, 1000, "現有"))
-    guide = _get_series(
-        (0, 1000, "新參考一"),
-        (1000, 2000, "新參考二"),
-    )
+    guide = _get_series((0, 1000, "新參考一"), (1000, 2000, "新參考二"))
     historical_case = _get_test_case(
         targets=((1, "現有"),),
         guides=((1, "舊參考一"), (2, "舊參考二")),
@@ -132,11 +107,7 @@ def test_audit_gap_translation_ignores_superseded_guide_revision():
         outputs=((2, "新翻譯"),),
     )
 
-    report = audit_gap_translation(
-        target,
-        guide,
-        (historical_case, current_case),
-    )
+    report = audit_gap_translation(target, guide, (historical_case, current_case))
 
     assert "C 1" not in report
     assert "| G 2<br>Q 2 | C 2<br>B 1 |" in report
@@ -147,10 +118,7 @@ def test_audit_gap_translation_ignores_superseded_guide_revision():
 def test_audit_gap_translation_ignores_superseded_target_revision():
     """Test a current query supersedes retained history for the same guide block."""
     target = _get_series((0, 1000, "目前"))
-    guide = _get_series(
-        (0, 1000, "參考一"),
-        (1000, 2000, "參考二"),
-    )
+    guide = _get_series((0, 1000, "參考一"), (1000, 2000, "參考二"))
     historical_case = _get_test_case(
         targets=((1, "舊文"),),
         guides=((1, "參考一"), (2, "參考二")),
@@ -162,11 +130,7 @@ def test_audit_gap_translation_ignores_superseded_target_revision():
         outputs=((2, "目前翻譯"),),
     )
 
-    report = audit_gap_translation(
-        target,
-        guide,
-        (historical_case, current_case),
-    )
+    report = audit_gap_translation(target, guide, (historical_case, current_case))
 
     assert "- logged cases: 1" in report
     assert "C 1" not in report
@@ -184,24 +148,14 @@ def test_audit_gap_translation_rejects_invalid_range():
         audit_gap_translation(Series(), Series(), (), first_block=0)
 
     with raises(
-        ScinoephileError,
-        match="Subtitle-index and block ranges are mutually exclusive",
+        ScinoephileError, match="Subtitle-index and block ranges are mutually exclusive"
     ):
-        audit_gap_translation(
-            Series(),
-            Series(),
-            (),
-            first_index=1,
-            first_block=1,
-        )
+        audit_gap_translation(Series(), Series(), (), first_index=1, first_block=1)
 
 
 def test_audit_gap_translation_rejects_missing_current_case():
     """Test every selected current gap block requires a logged case."""
-    target = _get_series(
-        (0, 1000, "現有一"),
-        (6000, 7000, "現有二"),
-    )
+    target = _get_series((0, 1000, "現有一"), (6000, 7000, "現有二"))
     guide = _get_series(
         (0, 1000, "參考一"),
         (1000, 2000, "缺口一"),
@@ -218,11 +172,7 @@ def test_audit_gap_translation_rejects_missing_current_case():
         audit_gap_translation(target, guide, (first_case,))
 
     first_block_report = audit_gap_translation(
-        target,
-        guide,
-        (first_case,),
-        first_block=1,
-        last_block=1,
+        target, guide, (first_case,), first_block=1, last_block=1
     )
     assert "| G 2<br>Q 2 | C 1<br>B 1 |" in first_block_report
 
@@ -245,10 +195,7 @@ def test_audit_gap_translation_rejects_unmatched_case():
 
 def test_audit_gap_translation_reuses_case_for_repeated_blocks():
     """Test one deduplicated case applies to every identical current block."""
-    target = _get_series(
-        (0, 1000, "現有"),
-        (6000, 7000, "現有"),
-    )
+    target = _get_series((0, 1000, "現有"), (6000, 7000, "現有"))
     guide = _get_series(
         (0, 1000, "重複一"),
         (1000, 2000, "重複二"),
@@ -264,11 +211,7 @@ def test_audit_gap_translation_reuses_case_for_repeated_blocks():
     report = audit_gap_translation(target, guide, (test_case,))
 
     block_report = audit_gap_translation(
-        target,
-        guide,
-        (test_case,),
-        first_block=2,
-        last_block=2,
+        target, guide, (test_case,), first_block=2, last_block=2
     )
     assert "- logged cases: 1" in report
     assert "- gaps: 2" in report

--- a/test/analysis/test_guided_review_audit.py
+++ b/test/analysis/test_guided_review_audit.py
@@ -106,16 +106,9 @@ def test_audit_guided_review_filters_rows_and_target_range():
         ),
     )
 
-    changed_report = audit_guided_review(
-        target,
-        guide,
-        test_cases,
-    )
+    changed_report = audit_guided_review(target, guide, test_cases)
     unverified_report = audit_guided_review(
-        target,
-        guide,
-        test_cases,
-        row_filter=ReviewAuditFilter.unverified,
+        target, guide, test_cases, row_filter=ReviewAuditFilter.unverified
     )
     ranged_report = audit_guided_review(
         target,
@@ -168,10 +161,7 @@ def test_audit_guided_review_formats_and_sorts_subtitles():
     first_case = GuidedReviewTestCase.model_validate(
         {
             "query": {
-                "targets": [
-                    {"index": 1, "text": "甲|乙"},
-                    {"index": 2, "text": "丙"},
-                ],
+                "targets": [{"index": 1, "text": "甲|乙"}, {"index": 2, "text": "丙"}],
                 "guides": [{"index": 1, "text": "參考一"}],
             },
             "answer": {
@@ -191,10 +181,7 @@ def test_audit_guided_review_formats_and_sorts_subtitles():
     )
 
     report = audit_guided_review(
-        target,
-        guide,
-        (second_case, first_case),
-        row_filter=ReviewAuditFilter.all,
+        target, guide, (second_case, first_case), row_filter=ReviewAuditFilter.all
     )
 
     assert "- subtitles: 3" in report
@@ -224,10 +211,7 @@ def test_audit_guided_review_formats_unanswered_case():
     )
 
     report = audit_guided_review(
-        target,
-        guide,
-        (test_case,),
-        row_filter=ReviewAuditFilter.all,
+        target, guide, (test_case,), row_filter=ReviewAuditFilter.all
     )
 
     assert "- revised subtitles: 0" in report
@@ -262,10 +246,7 @@ def test_audit_guided_review_ignores_superseded_guide_revision():
     )
 
     report = audit_guided_review(
-        target,
-        guide,
-        (stale_case, current_case),
-        row_filter=ReviewAuditFilter.all,
+        target, guide, (stale_case, current_case), row_filter=ReviewAuditFilter.all
     )
 
     assert "舊修訂" not in report
@@ -297,10 +278,7 @@ def test_audit_guided_review_ignores_superseded_segmentation_case():
     current_case = GuidedReviewTestCase.model_validate(
         {
             "query": {
-                "targets": [
-                    {"index": 1, "text": "甲"},
-                    {"index": 2, "text": "乙丙"},
-                ],
+                "targets": [{"index": 1, "text": "甲"}, {"index": 2, "text": "乙丙"}],
                 "guides": [{"index": 1, "text": "參考"}],
             },
             "answer": {
@@ -310,10 +288,7 @@ def test_audit_guided_review_ignores_superseded_segmentation_case():
     )
 
     report = audit_guided_review(
-        target,
-        guide,
-        (stale_case, current_case),
-        row_filter=ReviewAuditFilter.all,
+        target, guide, (stale_case, current_case), row_filter=ReviewAuditFilter.all
     )
 
     assert "| 1 | 1 | 參考 | 甲 |  |  |" in report
@@ -383,10 +358,7 @@ def test_audit_guided_review_matches_after_punctuation_changes():
     )
 
     report = audit_guided_review(
-        target,
-        guide,
-        (test_case,),
-        row_filter=ReviewAuditFilter.all,
+        target, guide, (test_case,), row_filter=ReviewAuditFilter.all
     )
 
     assert "| 1 | 1 | 參考 | 原文。 |  |  |" in report
@@ -486,13 +458,7 @@ def test_audit_guided_review_rejects_selected_changed_segmentation():
     with raises(
         ScinoephileError, match="segmentation no longer matches subtitle index 2"
     ):
-        audit_guided_review(
-            target,
-            guide,
-            (test_case,),
-            first_index=2,
-            last_index=2,
-        )
+        audit_guided_review(target, guide, (test_case,), first_index=2, last_index=2)
 
 
 def test_audit_guided_review_rejects_stale_target_only_case():
@@ -501,22 +467,13 @@ def test_audit_guided_review_rejects_stale_target_only_case():
     guide = Series(events=[Subtitle(start=0, end=1000, text="目前參考")])
     stale_case = GuidedReviewTestCase.model_validate(
         {
-            "query": {
-                "targets": [{"index": 1, "text": "舊文"}],
-                "guides": [],
-            },
+            "query": {"targets": [{"index": 1, "text": "舊文"}], "guides": []},
             "answer": {"revisions": []},
         }
     )
 
     with raises(ScinoephileError, match="test case 1 was not found"):
-        audit_guided_review(
-            target,
-            guide,
-            (stale_case,),
-            first_index=1,
-            last_index=1,
-        )
+        audit_guided_review(target, guide, (stale_case,), first_index=1, last_index=1)
 
 
 def test_audit_guided_review_reuses_case_for_repeated_blocks():
@@ -543,10 +500,7 @@ def test_audit_guided_review_reuses_case_for_repeated_blocks():
     )
 
     all_report = audit_guided_review(
-        target,
-        guide,
-        (test_case,),
-        row_filter=ReviewAuditFilter.all,
+        target, guide, (test_case,), row_filter=ReviewAuditFilter.all
     )
 
     report = audit_guided_review(
@@ -569,10 +523,7 @@ def test_audit_guided_review_supports_target_only_block_in_range():
     guide = Series()
     test_case = GuidedReviewTestCase.model_validate(
         {
-            "query": {
-                "targets": [{"index": 1, "text": "原文"}],
-                "guides": [],
-            },
+            "query": {"targets": [{"index": 1, "text": "原文"}], "guides": []},
             "answer": {"revisions": []},
         }
     )
@@ -615,10 +566,7 @@ def test_audit_guided_review_uses_latest_case_per_subtitle():
     )
 
     report = audit_guided_review(
-        target,
-        guide,
-        (revised_case, unchanged_case),
-        row_filter=ReviewAuditFilter.all,
+        target, guide, (revised_case, unchanged_case), row_filter=ReviewAuditFilter.all
     )
 
     assert "- subtitles: 1" in report

--- a/test/analysis/test_ocr_fusion_audit.py
+++ b/test/analysis/test_ocr_fusion_audit.py
@@ -6,10 +6,7 @@ from __future__ import annotations
 
 from pytest import raises
 
-from scinoephile.analysis.audit.ocr_fusion import (
-    OcrFusionAuditFilter,
-    audit_ocr_fusion,
-)
+from scinoephile.analysis.audit.ocr_fusion import OcrFusionAuditFilter, audit_ocr_fusion
 from scinoephile.core.exceptions import ScinoephileError
 from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.llms.ocr_fusion import OcrFusionTestCase
@@ -61,11 +58,7 @@ def test_audit_ocr_fusion_filters_unverified_and_automatic_rows():
     )
 
     report = audit_ocr_fusion(
-        source_one,
-        source_two,
-        fused,
-        (test_case,),
-        row_filter=OcrFusionAuditFilter.all,
+        source_one, source_two, fused, (test_case,), row_filter=OcrFusionAuditFilter.all
     )
     unverified_report = audit_ocr_fusion(
         source_one,
@@ -98,11 +91,7 @@ def test_audit_ocr_fusion_formats_llm_decision_and_validated_discrepancy():
     )
 
     report = audit_ocr_fusion(
-        source_one,
-        source_two,
-        fused,
-        (test_case,),
-        validated=validated,
+        source_one, source_two, fused, (test_case,), validated=validated
     )
     discrepancy_report = audit_ocr_fusion(
         source_one,
@@ -134,10 +123,7 @@ def test_audit_ocr_fusion_keeps_notes_without_test_cases():
     fused = _get_series("甲正")
 
     report = audit_ocr_fusion(
-        source_one,
-        source_two,
-        fused,
-        row_filter=OcrFusionAuditFilter.all,
+        source_one, source_two, fused, row_filter=OcrFusionAuditFilter.all
     )
 
     assert "- decision log: omitted" in report
@@ -166,21 +152,10 @@ def test_audit_ocr_fusion_rejects_invalid_inputs():
     with raises(ScinoephileError, match="First block must be at least 1"):
         audit_ocr_fusion(one, two, one, (test_case,), first_block=0)
     with raises(ScinoephileError, match="mutually exclusive"):
-        audit_ocr_fusion(
-            one,
-            two,
-            one,
-            (test_case,),
-            first_index=1,
-            first_block=1,
-        )
+        audit_ocr_fusion(one, two, one, (test_case,), first_index=1, first_block=1)
     with raises(ScinoephileError, match="requires a validated"):
         audit_ocr_fusion(
-            one,
-            two,
-            one,
-            (test_case,),
-            row_filter=OcrFusionAuditFilter.discrepancies,
+            one, two, one, (test_case,), row_filter=OcrFusionAuditFilter.discrepancies
         )
 
     misaligned = Series(events=[Subtitle(start=1000, end=1500, text="甲")])

--- a/test/analysis/test_punctuation_audit.py
+++ b/test/analysis/test_punctuation_audit.py
@@ -25,10 +25,7 @@ def test_audit_punctuation_formats_changed_and_unchanged_rows():
     target = _get_series("甲，乙丙", "丁")
     test_cases = (
         PunctuationTestCase(
-            query=PunctuationQuery(
-                guide="參|考一",
-                subtitles=["甲", "乙丙"],
-            ),
+            query=PunctuationQuery(guide="參|考一", subtitles=["甲", "乙丙"]),
             answer=PunctuationAnswer(output="甲，乙丙"),
             verified=True,
         ),
@@ -55,11 +52,7 @@ def test_audit_punctuation_formats_unanswered_case():
         query=PunctuationQuery(guide="參考", subtitles=["原文"])
     )
 
-    report = audit_punctuation(
-        _get_series("參考"),
-        _get_series("原文"),
-        (test_case,),
-    )
+    report = audit_punctuation(_get_series("參考"), _get_series("原文"), (test_case,))
 
     assert "- unanswered cases: 1" in report
     assert "| 1 | 參考 | 原文 | (unanswered) |  |  |" in report
@@ -82,23 +75,13 @@ def test_audit_punctuation_filters_rows_and_subtitle_range():
     )
 
     changed_report = audit_punctuation(
-        reference,
-        target,
-        test_cases,
-        row_filter=PunctuationAuditFilter.changes,
+        reference, target, test_cases, row_filter=PunctuationAuditFilter.changes
     )
     unverified_report = audit_punctuation(
-        reference,
-        target,
-        test_cases,
-        row_filter=PunctuationAuditFilter.unverified,
+        reference, target, test_cases, row_filter=PunctuationAuditFilter.unverified
     )
     ranged_report = audit_punctuation(
-        reference,
-        target,
-        test_cases,
-        first_index=2,
-        last_index=3,
+        reference, target, test_cases, first_index=2, last_index=3
     )
 
     assert "- logged cases: 2" in changed_report
@@ -143,11 +126,7 @@ def test_audit_punctuation_filters_reference_blocks():
     )
 
     report = audit_punctuation(
-        reference,
-        target,
-        test_cases,
-        first_block=2,
-        last_block=2,
+        reference, target, test_cases, first_block=2, last_block=2
     )
 
     assert "- block range: 2 through 2" in report
@@ -158,26 +137,12 @@ def test_audit_punctuation_filters_reference_blocks():
 def test_audit_punctuation_rejects_invalid_range():
     """Test direct callers receive a domain error for an invalid range."""
     with raises(ScinoephileError, match="First index must be at least 1"):
-        audit_punctuation(
-            _get_series("參考"),
-            _get_series("甲"),
-            (),
-            first_index=0,
-        )
+        audit_punctuation(_get_series("參考"), _get_series("甲"), (), first_index=0)
     with raises(ScinoephileError, match="First block must be at least 1"):
-        audit_punctuation(
-            _get_series("參考"),
-            _get_series("甲"),
-            (),
-            first_block=0,
-        )
+        audit_punctuation(_get_series("參考"), _get_series("甲"), (), first_block=0)
     with raises(ScinoephileError, match="ranges are mutually exclusive"):
         audit_punctuation(
-            _get_series("參考"),
-            _get_series("甲"),
-            (),
-            first_index=1,
-            first_block=1,
+            _get_series("參考"), _get_series("甲"), (), first_index=1, first_block=1
         )
 
 
@@ -254,11 +219,7 @@ def test_audit_punctuation_resolves_repeated_reference_before_range_filtering():
     )
 
     report = audit_punctuation(
-        reference,
-        target,
-        test_cases,
-        first_index=1,
-        last_index=2,
+        reference, target, test_cases, first_index=1, last_index=2
     )
 
     assert "- logged cases: 0" in report
@@ -276,11 +237,7 @@ def test_audit_punctuation_ignores_ambiguity_outside_range():
     )
 
     report = audit_punctuation(
-        reference,
-        target,
-        (test_case,),
-        first_index=1,
-        last_index=1,
+        reference, target, (test_case,), first_index=1, last_index=1
     )
 
     assert "- logged cases: 0" in report
@@ -294,11 +251,7 @@ def test_audit_punctuation_rejects_unmatched_reference():
     )
 
     with raises(ScinoephileError, match="test case 1 reference subtitle was not found"):
-        audit_punctuation(
-            _get_series("參考"),
-            _get_series("甲"),
-            (test_case,),
-        )
+        audit_punctuation(_get_series("參考"), _get_series("甲"), (test_case,))
 
 
 def test_audit_punctuation_ignores_superseded_reference_revision():
@@ -317,11 +270,7 @@ def test_audit_punctuation_ignores_superseded_reference_revision():
 
     report = audit_punctuation(reference, target, test_cases)
     excluded_report = audit_punctuation(
-        reference,
-        target,
-        test_cases,
-        first_index=2,
-        last_index=2,
+        reference, target, test_cases, first_index=2, last_index=2
     )
 
     assert "- logged cases: 1" in report
@@ -351,15 +300,8 @@ def test_audit_punctuation_does_not_transitively_ignore_unmatched_reference():
         ),
     )
 
-    with raises(
-        ScinoephileError,
-        match="test case 4 reference subtitle was not found",
-    ):
-        audit_punctuation(
-            _get_series("目前參考"),
-            _get_series("共用"),
-            test_cases,
-        )
+    with raises(ScinoephileError, match="test case 4 reference subtitle was not found"):
+        audit_punctuation(_get_series("目前參考"), _get_series("共用"), test_cases)
 
 
 def test_audit_punctuation_rejects_ambiguous_reference():
@@ -369,10 +311,7 @@ def test_audit_punctuation_rejects_ambiguous_reference():
         answer=PunctuationAnswer(output="甲"),
     )
 
-    with raises(
-        ScinoephileError,
-        match="test case 1 is ambiguous.*1, 3",
-    ):
+    with raises(ScinoephileError, match="test case 1 is ambiguous.*1, 3"):
         audit_punctuation(
             _get_series("重複", "其他", "重複"),
             _get_series("甲", "中", "甲"),

--- a/test/analysis/test_review_audit.py
+++ b/test/analysis/test_review_audit.py
@@ -134,13 +134,7 @@ def test_audit_review_ignores_retained_historical_cases():
 def test_audit_review_rejects_unsupported_filter():
     """Test unrelated filter enums cannot silently select unverified rows."""
     original = _get_series(("Input",))
-    reviews = (
-        ReviewAuditPair(
-            label="Test",
-            original=original,
-            reviewed=original,
-        ),
-    )
+    reviews = (ReviewAuditPair(label="Test", original=original, reviewed=original),)
 
     with raises(ScinoephileError, match="unsupported row filter 'unsupported'"):
         audit_review(
@@ -167,19 +161,10 @@ def test_audit_review_selects_blocks():
             Subtitle(start=5_000, end=5_500, text="Third revised"),
         ]
     )
-    reviews = (
-        ReviewAuditPair(
-            label="Test",
-            original=original,
-            reviewed=reviewed,
-        ),
-    )
+    reviews = (ReviewAuditPair(label="Test", original=original, reviewed=reviewed),)
 
     report = audit_review(
-        reviews=reviews,
-        row_filter=ReviewAuditFilter.all,
-        first_block=2,
-        last_block=2,
+        reviews=reviews, row_filter=ReviewAuditFilter.all, first_block=2, last_block=2
     )
 
     assert "- block range: 2 through 2" in report
@@ -188,17 +173,10 @@ def test_audit_review_selects_blocks():
     assert "| 3 | Third<br>Third revised |" in report
 
     with raises(ScinoephileError, match="mutually exclusive"):
-        audit_review(
-            reviews=reviews,
-            first_index=1,
-            first_block=2,
-        )
+        audit_review(reviews=reviews, first_index=1, first_block=2)
 
     with raises(ScinoephileError, match="requires at least one comparison"):
-        audit_review(
-            reviews=reviews,
-            row_filter=DualReviewAuditFilter.discrepancies,
-        )
+        audit_review(reviews=reviews, row_filter=DualReviewAuditFilter.discrepancies)
 
 
 def test_audit_review_uses_latest_duplicate_case():
@@ -235,8 +213,7 @@ def test_audit_review_uses_latest_duplicate_case():
 
     report = audit_review(reviews=reviews, row_filter=ReviewAuditFilter.all)
     unverified_report = audit_review(
-        reviews=reviews,
-        row_filter=ReviewAuditFilter.unverified,
+        reviews=reviews, row_filter=ReviewAuditFilter.unverified
     )
 
     assert "Historical note." not in report

--- a/test/analysis/test_translation_audit.py
+++ b/test/analysis/test_translation_audit.py
@@ -24,31 +24,21 @@ def test_audit_guided_translation_formats_guide_and_filters_range():
     test_case = GuidedTranslationTestCase.model_validate(
         {
             "query": {
-                "subtitles": [
-                    {"index": 1, "text": "甲"},
-                    {"index": 2, "text": "乙"},
-                ],
+                "subtitles": [{"index": 1, "text": "甲"}, {"index": 2, "text": "乙"}],
                 "guides": [
                     {"index": 1, "text": "Guide one"},
                     {"index": 2, "text": "Guide two"},
                 ],
             },
             "answer": {
-                "outputs": [
-                    {"index": 1, "text": "A"},
-                    {"index": 2, "text": "B"},
-                ]
+                "outputs": [{"index": 1, "text": "A"}, {"index": 2, "text": "B"}]
             },
             "difficulty": 2,
         }
     )
 
     report = audit_guided_translation(
-        source,
-        guide,
-        (test_case,),
-        first_index=2,
-        last_index=2,
+        source, guide, (test_case,), first_index=2, last_index=2
     )
 
     assert report.startswith("# Guided Translation Audit\n")
@@ -91,10 +81,7 @@ def test_audit_translation_formats_standard_blocks_and_unanswered_case():
                     ]
                 },
                 "answer": {
-                    "outputs": [
-                        {"index": 1, "text": "A"},
-                        {"index": 2, "text": "B"},
-                    ]
+                    "outputs": [{"index": 1, "text": "A"}, {"index": 2, "text": "B"}]
                 },
                 "verified": True,
             }
@@ -106,16 +93,9 @@ def test_audit_translation_formats_standard_blocks_and_unanswered_case():
 
     report = audit_translation(source, test_cases)
     unverified_report = audit_translation(
-        source,
-        test_cases,
-        row_filter=TranslationAuditFilter.unverified,
+        source, test_cases, row_filter=TranslationAuditFilter.unverified
     )
-    block_report = audit_translation(
-        source,
-        test_cases,
-        first_block=2,
-        last_block=2,
-    )
+    block_report = audit_translation(source, test_cases, first_block=2, last_block=2)
 
     assert report.startswith("# Standard Translation Audit\n")
     assert "- logged cases: 2" in report
@@ -143,10 +123,7 @@ def test_audit_translation_reuses_case_for_repeated_blocks():
     report = audit_translation(source, (test_case,))
 
     second_block_report = audit_translation(
-        source,
-        (test_case,),
-        first_block=2,
-        last_block=2,
+        source, (test_case,), first_block=2, last_block=2
     )
     assert "- logged cases: 1" in report
     assert "- subtitles: 2" in report
@@ -183,15 +160,9 @@ def test_audit_translation_uses_latest_case_and_rejects_invalid_selection():
     with raises(ScinoephileError, match="no matching logged test case"):
         audit_translation(source, ())
     with raises(
-        ScinoephileError,
-        match="Subtitle-index and block ranges are mutually exclusive",
+        ScinoephileError, match="Subtitle-index and block ranges are mutually exclusive"
     ):
-        audit_translation(
-            source,
-            (new_case,),
-            first_index=1,
-            first_block=1,
-        )
+        audit_translation(source, (new_case,), first_index=1, first_block=1)
 
 
 def _get_series(*events: tuple[int, str]) -> Series:

--- a/test/audio/subtitles/test_audio_series.py
+++ b/test/audio/subtitles/test_audio_series.py
@@ -24,8 +24,7 @@ def test_audio_series_load_wraps_input_path_errors(tmp_path: Path):
     input_path = tmp_path / "missing"
 
     with raises(
-        ScinoephileError,
-        match="Unable to load AudioSeries from .*missing",
+        ScinoephileError, match="Unable to load AudioSeries from .*missing"
     ) as excinfo:
         AudioSeries.load(input_path)
 
@@ -69,8 +68,7 @@ def test_audio_series_save_wraps_output_path_errors(tmp_path: Path):
     series = AudioSeries(audio=AudioSegment.silent(duration=1000))
 
     with raises(
-        ScinoephileError,
-        match="Unable to save AudioSeries to .*audio_output",
+        ScinoephileError, match="Unable to save AudioSeries to .*audio_output"
     ) as excinfo:
         series.save(output_path)
 
@@ -82,14 +80,7 @@ def test_audio_series_slice_preserves_audio_subtitle_payloads():
     event_audio = AudioSegment.silent(duration=1000)
     series = AudioSeries(
         audio=AudioSegment.silent(duration=4000),
-        events=[
-            AudioSubtitle(
-                start=1000,
-                end=2000,
-                text="Text",
-                audio=event_audio,
-            )
-        ],
+        events=[AudioSubtitle(start=1000, end=2000, text="Text", audio=event_audio)],
     )
     series.info["Title"] = "Example"
 

--- a/test/audio/subtitles/test_audio_series_load_from_media.py
+++ b/test/audio/subtitles/test_audio_series_load_from_media.py
@@ -74,8 +74,7 @@ def test_audio_series_load_from_media_defaults_to_first_audio_stream():
                     side_effect=_write_selected_audio,
                 ):
                     yuewen_series = AudioSeries.load_from_media(
-                        media_path=media_path,
-                        subtitle_path=subtitle_path,
+                        media_path=media_path, subtitle_path=subtitle_path
                     )
 
     assert isinstance(yuewen_series, AudioSeries)
@@ -90,12 +89,10 @@ def test_audio_series_load_from_media_wraps_input_path_errors(tmp_path: Path):
         tmp_path: pytest temporary directory path
     """
     with raises(
-        ScinoephileError,
-        match="Unable to load AudioSeries from media .*missing.mkv",
+        ScinoephileError, match="Unable to load AudioSeries from media .*missing.mkv"
     ) as excinfo:
         AudioSeries.load_from_media(
-            media_path=tmp_path / "missing.mkv",
-            subtitle_path=tmp_path / "missing.srt",
+            media_path=tmp_path / "missing.mkv", subtitle_path=tmp_path / "missing.srt"
         )
 
     assert isinstance(excinfo.value.__cause__, OSError)
@@ -125,8 +122,7 @@ def test_audio_series_load_from_media_wraps_decode_errors():
                             match="Unable to load AudioSeries from media",
                         ) as excinfo:
                             AudioSeries.load_from_media(
-                                media_path=media_path,
-                                subtitle_path=subtitle_path,
+                                media_path=media_path, subtitle_path=subtitle_path
                             )
 
     assert isinstance(excinfo.value.__cause__, CouldntDecodeError)
@@ -167,8 +163,7 @@ def test_audio_series_load_from_media_normalizes_wav_through_extraction():
                 side_effect=_write_selected_audio,
             ) as extract:
                 series = AudioSeries.load_from_media(
-                    media_path=media_path,
-                    subtitle_path=subtitle_path,
+                    media_path=media_path, subtitle_path=subtitle_path
                 )
 
     extract.assert_called_once()
@@ -225,6 +220,5 @@ def _write_selected_audio(
         stream_index = 1
     channels = 6 if stream_index == 12 else 2
     AudioSegment.silent(duration=3000 + stream_index * 10 + channels).export(
-        outfile_path,
-        format="wav",
+        outfile_path, format="wav"
     )

--- a/test/audio/transcription/demucs/test_demucs_cache.py
+++ b/test/audio/transcription/demucs/test_demucs_cache.py
@@ -39,27 +39,20 @@ def test_get_path_separates_model_configuration(tmp_path: Path):
     assert first_cache_path != second_cache_path
 
 
-def test_get_path_includes_cache_version(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
-):
+def test_get_path_includes_cache_version(tmp_path: Path, monkeypatch: MonkeyPatch):
     """Test Demucs cache paths differ between cache versions."""
     audio = AudioSegment.silent(duration=100)
     cache = DemucsCache(tmp_path, "model")
     first_cache_path = cache.get_path(audio)
 
     monkeypatch.setattr(
-        "scinoephile.audio.transcription.demucs.cache._CACHE_VERSION",
-        2,
+        "scinoephile.audio.transcription.demucs.cache._CACHE_VERSION", 2
     )
 
     assert cache.get_path(audio) != first_cache_path
 
 
-def test_load_discards_decode_failure(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
-):
+def test_load_discards_decode_failure(tmp_path: Path, monkeypatch: MonkeyPatch):
     """Test malformed cached vocals are discarded as a cache miss."""
     audio = AudioSegment.silent(duration=100)
     cache = DemucsCache(tmp_path, "model")
@@ -114,8 +107,7 @@ def test_demucs_cache_overwrites_matching_entry_once(tmp_path: Path):
 
 
 def test_save_failure_preserves_existing_cached_vocals(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test failed replacement leaves an existing cache file intact."""
     audio = AudioSegment.silent(duration=100)

--- a/test/audio/transcription/demucs/test_demucs_separator.py
+++ b/test/audio/transcription/demucs/test_demucs_separator.py
@@ -72,8 +72,7 @@ def test_separate_vocals_uses_default_demucs_shifts():
 
 
 def test_separate_vocals_overwrites_matching_cache(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test cache overwrite regenerates a matching Demucs separation."""
     input_audio = AudioSegment.silent(duration=1000, frame_rate=16000)
@@ -81,16 +80,11 @@ def test_separate_vocals_overwrites_matching_cache(
     fresh_audio = AudioSegment.silent(duration=800, frame_rate=16000)
     cached_separator = DemucsSeparator(cache_root_path=tmp_path)
     monkeypatch.setattr(
-        cached_separator,
-        "_separate_vocals",
-        Mock(return_value=cached_audio),
+        cached_separator, "_separate_vocals", Mock(return_value=cached_audio)
     )
     cached_separator.separate_vocals(input_audio)
 
-    separator = DemucsSeparator(
-        cache_root_path=tmp_path,
-        overwrite_cache=True,
-    )
+    separator = DemucsSeparator(cache_root_path=tmp_path, overwrite_cache=True)
     separate = Mock(return_value=fresh_audio)
     monkeypatch.setattr(separator, "_separate_vocals", separate)
     result = separator.separate_vocals(input_audio)
@@ -101,8 +95,7 @@ def test_separate_vocals_overwrites_matching_cache(
 
 
 def test_separate_vocals_recovers_from_corrupt_cache(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test malformed cached vocals are replaced by fresh separation output."""
     separator = DemucsSeparator(cache_root_path=tmp_path)

--- a/test/audio/transcription/mlx_audio/test_backend.py
+++ b/test/audio/transcription/mlx_audio/test_backend.py
@@ -42,9 +42,7 @@ from scinoephile.core.dependencies import transcription as transcription_depende
     ],
 )
 def test_init_derives_mlx_audio_languages(
-    model_name: str,
-    language: Language,
-    mlx_audio_language: str,
+    model_name: str, language: Language, mlx_audio_language: str
 ):
     """Test each model family derives its language identifier."""
     mlx_audio_backend = MlxAudioBackend(model_name=model_name, language=language)
@@ -67,17 +65,12 @@ def test_init_matches_model_name_case_insensitively():
     ],
 )
 def test_init_reads_local_model_metadata(
-    tmp_path: Path,
-    metadata: dict[str, object],
-    expected_family: str,
+    tmp_path: Path, metadata: dict[str, object], expected_family: str
 ):
     """Test arbitrary local directories are identified from model metadata."""
     model_path = tmp_path / "asr"
     model_path.mkdir()
-    (model_path / "config.json").write_text(
-        json.dumps(metadata),
-        encoding="utf-8",
-    )
+    (model_path / "config.json").write_text(json.dumps(metadata), encoding="utf-8")
 
     mlx_audio_backend = MlxAudioBackend(str(model_path))
 
@@ -86,16 +79,11 @@ def test_init_reads_local_model_metadata(
 
 def test_init_rejects_untested_family():
     """Test unknown MLX-Audio model families fail clearly."""
-    with pytest.raises(
-        TranscriptionError,
-        match="supported families: mimo, qwen3-asr",
-    ):
+    with pytest.raises(TranscriptionError, match="supported families: mimo, qwen3-asr"):
         MlxAudioBackend("mlx-community/Whisper-Large-v3-MLX")
 
 
-def test_transcribe_reads_mapping_result(
-    tmp_path: Path,
-):
+def test_transcribe_reads_mapping_result(tmp_path: Path):
     """Test mapping output and generation arguments are normalized.
 
     Arguments:
@@ -107,25 +95,15 @@ def test_transcribe_reads_mapping_result(
     mlx_audio_backend = MlxAudioBackend()
     mlx_audio_backend._model = model
 
-    result = mlx_audio_backend.transcribe(
-        audio_path,
-        128,
-    )
+    result = mlx_audio_backend.transcribe(audio_path, 128)
 
-    assert result == MlxAudioInferenceResult(
-        text="你好",
-        generation_tokens=7,
-    )
+    assert result == MlxAudioInferenceResult(text="你好", generation_tokens=7)
     model.generate.assert_called_once_with(
-        str(audio_path),
-        language="zh",
-        max_tokens=128,
+        str(audio_path), language="zh", max_tokens=128
     )
 
 
-def test_transcribe_reads_object_result(
-    tmp_path: Path,
-):
+def test_transcribe_reads_object_result(tmp_path: Path):
     """Test attribute-based output and omitted token limits are normalized.
 
     Arguments:
@@ -144,9 +122,7 @@ def test_transcribe_reads_object_result(
     model.generate.assert_called_once_with(str(audio_path), language="en")
 
 
-def test_transcribe_rejects_missing_text(
-    tmp_path: Path,
-):
+def test_transcribe_rejects_missing_text(tmp_path: Path):
     """Test output without transcript text is rejected.
 
     Arguments:
@@ -164,8 +140,7 @@ def test_transcribe_rejects_missing_text(
 
 @pytest.mark.parametrize("generation_tokens", [True, -1, 1.5, "1"])
 def test_transcribe_rejects_invalid_generation_tokens(
-    tmp_path: Path,
-    generation_tokens: object,
+    tmp_path: Path, generation_tokens: object
 ):
     """Test malformed generation token counts are rejected.
 
@@ -186,9 +161,7 @@ def test_transcribe_rejects_invalid_generation_tokens(
         mlx_audio_backend.transcribe(audio_path)
 
 
-def test_model_is_shared_by_reference(
-    monkeypatch: pytest.MonkeyPatch,
-):
+def test_model_is_shared_by_reference(monkeypatch: pytest.MonkeyPatch):
     """Test a model is loaded once per resolved reference.
 
     Arguments:
@@ -213,10 +186,7 @@ def test_model_is_shared_by_reference(
     assert load.call_args_list[1].kwargs == {"model_type": "qwen3_asr"}
 
 
-def test_model_validates_local_path(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-):
+def test_model_validates_local_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     """Test local model paths are resolved before loading.
 
     Arguments:
@@ -226,8 +196,7 @@ def test_model_validates_local_path(
     model_path = tmp_path / "model"
     model_path.mkdir()
     (model_path / "config.json").write_text(
-        json.dumps({"architectures": ["MiMoV2ASRForCausalLM"]}),
-        encoding="utf-8",
+        json.dumps({"architectures": ["MiMoV2ASRForCausalLM"]}), encoding="utf-8"
     )
     load = Mock(return_value=object())
     monkeypatch.setattr(MlxAudioBackend, "_models_by_reference", {})

--- a/test/audio/transcription/test_ctc_aligner.py
+++ b/test/audio/transcription/test_ctc_aligner.py
@@ -12,24 +12,18 @@ import numpy as np
 import pytest
 from pydub import AudioSegment
 
-from scinoephile.audio.transcription import (
-    CtcAligner,
-    TranscriptionAlignmentError,
-)
+from scinoephile.audio.transcription import CtcAligner, TranscriptionAlignmentError
 from scinoephile.core import Language
 
 
-def test_ctc_aligner_allows_model_override(
-    monkeypatch: pytest.MonkeyPatch,
-):
+def test_ctc_aligner_allows_model_override(monkeypatch: pytest.MonkeyPatch):
     """Test an explicit CTC model does not require a language default.
 
     Arguments:
         monkeypatch: pytest monkeypatch fixture
     """
     monkeypatch.setattr(
-        "scinoephile.audio.transcription.ctc_aligner._DEFAULT_MODEL_NAMES",
-        {},
+        "scinoephile.audio.transcription.ctc_aligner._DEFAULT_MODEL_NAMES", {}
     )
     aligner = CtcAligner(Language.eng, "organization/model", "mps")
 
@@ -47,9 +41,7 @@ def test_ctc_aligner_groups_english_character_timings_into_words():
     }
 
     words = CtcAligner(Language.eng)._get_transcribed_words(
-        text,
-        timed_chars,
-        len(text) / 10,
+        text, timed_chars, len(text) / 10
     )
 
     assert [word.text for word in words] == ["HI", " THERE"]
@@ -59,9 +51,7 @@ def test_ctc_aligner_groups_english_character_timings_into_words():
     assert [word.confidence for word in words] == pytest.approx([0.8, 0.8])
 
 
-def test_ctc_aligner_expands_token_spans(
-    monkeypatch: pytest.MonkeyPatch,
-):
+def test_ctc_aligner_expands_token_spans(monkeypatch: pytest.MonkeyPatch):
     """Test CTC alignment expands token spans."""
     log_probs = np.log(
         np.array(
@@ -80,10 +70,7 @@ def test_ctc_aligner_expands_token_spans(
         lambda _audio, _text: (log_probs, [1, 2], [0, 1], 0),
     )
 
-    segments = aligner(
-        AudioSegment.silent(duration=1000),
-        "你好",
-    )
+    segments = aligner(AudioSegment.silent(duration=1000), "你好")
 
     assert len(segments) == 1
     assert segments[0].text == "你好"
@@ -104,19 +91,12 @@ def test_ctc_aligner_expands_token_spans(
         (Language.eng, "facebook/wav2vec2-base-960h"),
         (Language.yue_hans, "ctl/wav2vec2-large-xlsr-cantonese"),
         (Language.yue_hant, "ctl/wav2vec2-large-xlsr-cantonese"),
-        (
-            Language.zho_hans,
-            "jonatasgrosman/wav2vec2-large-xlsr-53-chinese-zh-cn",
-        ),
-        (
-            Language.zho_hant,
-            "jonatasgrosman/wav2vec2-large-xlsr-53-chinese-zh-cn",
-        ),
+        (Language.zho_hans, "jonatasgrosman/wav2vec2-large-xlsr-53-chinese-zh-cn"),
+        (Language.zho_hant, "jonatasgrosman/wav2vec2-large-xlsr-53-chinese-zh-cn"),
     ],
 )
 def test_ctc_aligner_selects_language_default_model(
-    language: Language,
-    expected_model_name: str,
+    language: Language, expected_model_name: str
 ):
     """Test each transcription language selects its default CTC model.
 
@@ -152,9 +132,7 @@ def test_ctc_audio_samples_reject_empty_audio():
         CtcAligner._get_audio_samples(AudioSegment.empty(), 16000)
 
 
-def test_ctc_alignment_uses_processor_sampling_rate(
-    monkeypatch: pytest.MonkeyPatch,
-):
+def test_ctc_alignment_uses_processor_sampling_rate(monkeypatch: pytest.MonkeyPatch):
     """Test CTC alignment uses the configured processor's sampling rate."""
     aligner = CtcAligner(Language.yue_hant)
     aligner._processor = SimpleNamespace(
@@ -173,33 +151,15 @@ def test_ctc_alignment_uses_processor_sampling_rate(
 
 def test_ctc_best_path_requires_blank_between_repeated_labels():
     """Test adjacent repeated labels cannot advance on consecutive frames."""
-    log_probs = np.log(
-        np.array(
-            [
-                [0.01, 0.99],
-                [0.01, 0.99],
-            ]
-        )
-    )
+    log_probs = np.log(np.array([[0.01, 0.99], [0.01, 0.99]]))
 
-    with pytest.raises(
-        TranscriptionAlignmentError,
-        match="did not reach all tokens",
-    ):
+    with pytest.raises(TranscriptionAlignmentError, match="did not reach all tokens"):
         CtcAligner._get_best_path(log_probs, [1, 1], 0)
 
 
 def test_ctc_best_path_accepts_blank_between_repeated_labels():
     """Test a blank-separated path can align adjacent repeated labels."""
-    log_probs = np.log(
-        np.array(
-            [
-                [0.01, 0.99],
-                [0.99, 0.01],
-                [0.01, 0.99],
-            ]
-        )
-    )
+    log_probs = np.log(np.array([[0.01, 0.99], [0.99, 0.01], [0.01, 0.99]]))
 
     path = CtcAligner._get_best_path(log_probs, [1, 1], 0)
 
@@ -281,10 +241,7 @@ def test_ctc_aligner_attaches_trailing_unaligned_punctuation(
         lambda _audio, _text: (log_probs, [1, 2], [0, 1], 0),
     )
 
-    segments = aligner.align(
-        AudioSegment.silent(duration=1200),
-        "你好。",
-    )
+    segments = aligner.align(AudioSegment.silent(duration=1200), "你好。")
 
     assert segments[0].text == "你好。"
     assert segments[0].words is not None
@@ -295,31 +252,17 @@ def test_ctc_aligner_attaches_trailing_unaligned_punctuation(
     assert segments[0].words[1].confidence == pytest.approx(0.9)
 
 
-def test_ctc_aligner_times_trailing_unsupported_speech(
-    monkeypatch: pytest.MonkeyPatch,
-):
+def test_ctc_aligner_times_trailing_unsupported_speech(monkeypatch: pytest.MonkeyPatch):
     """Test trailing unsupported speech retains fallback timing."""
     log_probs = np.log(
-        np.array(
-            [
-                [0.85, 0.15],
-                [0.05, 0.95],
-                [0.85, 0.15],
-                [0.85, 0.15],
-            ]
-        )
+        np.array([[0.85, 0.15], [0.05, 0.95], [0.85, 0.15], [0.85, 0.15]])
     )
     aligner = CtcAligner(Language.yue_hant)
     monkeypatch.setattr(
-        aligner,
-        "_get_alignment_inputs",
-        lambda _audio, _text: (log_probs, [1], [0], 0),
+        aligner, "_get_alignment_inputs", lambda _audio, _text: (log_probs, [1], [0], 0)
     )
 
-    segments = aligner.align(
-        AudioSegment.silent(duration=1000),
-        "你嘅",
-    )
+    segments = aligner.align(AudioSegment.silent(duration=1000), "你嘅")
 
     assert segments[0].words is not None
     assert [word.text for word in segments[0].words] == ["你", "嘅"]
@@ -330,9 +273,7 @@ def test_ctc_aligner_times_trailing_unsupported_speech(
     assert segments[0].end == pytest.approx(1.0)
 
 
-def test_ctc_aligner_preserves_boundary_whitespace(
-    monkeypatch: pytest.MonkeyPatch,
-):
+def test_ctc_aligner_preserves_boundary_whitespace(monkeypatch: pytest.MonkeyPatch):
     """Test CTC alignment preserves whitespace around the transcript."""
     log_probs = np.log(
         np.array(
@@ -351,10 +292,7 @@ def test_ctc_aligner_preserves_boundary_whitespace(
         lambda _audio, _text: (log_probs, [1, 2], [1, 2], 0),
     )
 
-    segments = aligner.align(
-        AudioSegment.silent(duration=1000),
-        " 你好 ",
-    )
+    segments = aligner.align(AudioSegment.silent(duration=1000), " 你好 ")
 
     assert segments[0].text == " 你好 "
     assert segments[0].words is not None
@@ -364,9 +302,7 @@ def test_ctc_aligner_preserves_boundary_whitespace(
     assert segments[0].end == pytest.approx(1.0)
 
 
-def test_ctc_aligner_preserves_all_unknown_characters(
-    monkeypatch: pytest.MonkeyPatch,
-):
+def test_ctc_aligner_preserves_all_unknown_characters(monkeypatch: pytest.MonkeyPatch):
     """Test a transcript outside the CTC vocabulary receives fallback timings."""
     aligner = CtcAligner(Language.yue_hant)
     monkeypatch.setattr(
@@ -375,10 +311,7 @@ def test_ctc_aligner_preserves_all_unknown_characters(
         lambda _audio, _text: (np.empty((1, 1)), [], [], 0),
     )
 
-    segments = aligner.align(
-        AudioSegment.silent(duration=1500),
-        "佢哋嘅",
-    )
+    segments = aligner.align(AudioSegment.silent(duration=1500), "佢哋嘅")
 
     assert segments[0].text == "佢哋嘅"
     assert segments[0].start == pytest.approx(0.0)
@@ -422,10 +355,7 @@ def test_ctc_aligner_attaches_internal_unaligned_characters(
         lambda _audio, _text: (log_probs, [1, 2], char_indices, 0),
     )
 
-    segments = aligner.align(
-        AudioSegment.silent(duration=1000),
-        text,
-    )
+    segments = aligner.align(AudioSegment.silent(duration=1000), text)
 
     assert segments[0].words is not None
     assert [word.text for word in segments[0].words] == expected_words
@@ -456,11 +386,7 @@ def test_ctc_token_ids_normalize_case_and_skip_unknown_chars():
             Returns:
                 fake token ID
             """
-            return {
-                "你": 1,
-                "說": 2,
-                "A": 4,
-            }.get(token, 3)
+            return {"你": 1, "說": 2, "A": 4}.get(token, 3)
 
     aligner = CtcAligner(Language.yue_hant)
     aligner._processor = SimpleNamespace(tokenizer=FakeTokenizer())
@@ -482,10 +408,7 @@ def test_ctc_token_ids_normalize_case_and_skip_unknown_chars():
     ],
 )
 def test_ctc_token_ids_use_default_model_script_conversion(
-    language: Language,
-    text: str,
-    recognized_token: str,
-    expected_token_ids: list[int],
+    language: Language, text: str, recognized_token: str, expected_token_ids: list[int]
 ):
     """Test token lookup converts only toward the default model's script.
 
@@ -625,19 +548,14 @@ def test_ctc_models_and_processors_are_cached_independently(
         sys.modules,
         "transformers",
         SimpleNamespace(
-            AutoModelForCTC=FakeAutoModelForCTC,
-            AutoProcessor=FakeAutoProcessor,
+            AutoModelForCTC=FakeAutoModelForCTC, AutoProcessor=FakeAutoProcessor
         ),
     )
 
     first_aligner = CtcAligner(Language.eng, "organization/model-a")
     second_aligner = CtcAligner(Language.eng, "organization/model-a")
     other_model_aligner = CtcAligner(Language.eng, "organization/model-b")
-    other_device_aligner = CtcAligner(
-        Language.eng,
-        "organization/model-a",
-        "mps",
-    )
+    other_device_aligner = CtcAligner(Language.eng, "organization/model-a", "mps")
 
     assert second_aligner.processor is first_aligner.processor
     assert second_aligner.model is first_aligner.model
@@ -656,9 +574,7 @@ def test_ctc_models_and_processors_are_cached_independently(
     ]
 
 
-def test_ctc_aligner_rounds_timings(
-    monkeypatch: pytest.MonkeyPatch,
-):
+def test_ctc_aligner_rounds_timings(monkeypatch: pytest.MonkeyPatch):
     """Test CTC alignment rounds character timings."""
     log_probs = np.log(
         np.array(
@@ -677,10 +593,7 @@ def test_ctc_aligner_rounds_timings(
         lambda _audio, _text: (log_probs, [1, 2], [0, 1], 0),
     )
 
-    segments = aligner.align(
-        AudioSegment.silent(duration=1234),
-        "你好",
-    )
+    segments = aligner.align(AudioSegment.silent(duration=1234), "你好")
 
     assert segments[0].words is not None
     assert segments[0].words[0].start == round(1.234 / 4, 3)
@@ -691,33 +604,22 @@ def test_ctc_aligner_rounds_timings(
 def test_ctc_aligner_rejects_empty_text():
     """Test empty text is not sent through forced alignment."""
     with pytest.raises(TranscriptionAlignmentError, match="empty transcript"):
-        CtcAligner(Language.yue_hant).align(
-            AudioSegment.empty(),
-            "   ",
-        )
+        CtcAligner(Language.yue_hant).align(AudioSegment.empty(), "   ")
 
 
 @pytest.mark.parametrize(
-    "backend_error",
-    [OSError("model unavailable"), RuntimeError("backend failed")],
+    "backend_error", [OSError("model unavailable"), RuntimeError("backend failed")]
 )
 def test_ctc_aligner_wraps_backend_errors(
-    monkeypatch: pytest.MonkeyPatch,
-    backend_error: Exception,
+    monkeypatch: pytest.MonkeyPatch, backend_error: Exception
 ):
     """Test low-level CTC failures are exposed as alignment errors."""
     aligner = CtcAligner(Language.yue_hant)
     monkeypatch.setattr(
-        aligner,
-        "_get_alignment_inputs",
-        Mock(side_effect=backend_error),
+        aligner, "_get_alignment_inputs", Mock(side_effect=backend_error)
     )
 
     with pytest.raises(
-        TranscriptionAlignmentError,
-        match="Unable to run CTC transcription alignment",
+        TranscriptionAlignmentError, match="Unable to run CTC transcription alignment"
     ):
-        aligner.align(
-            AudioSegment.silent(duration=1000),
-            "你好",
-        )
+        aligner.align(AudioSegment.silent(duration=1000), "你好")

--- a/test/audio/transcription/test_transcription_cache.py
+++ b/test/audio/transcription/test_transcription_cache.py
@@ -9,10 +9,7 @@ from pathlib import Path
 
 from pydub import AudioSegment
 
-from scinoephile.audio.transcription import (
-    TranscribedSegment,
-    TranscriptionCache,
-)
+from scinoephile.audio.transcription import TranscribedSegment, TranscriptionCache
 
 
 def test_transcription_cache_round_trip(tmp_path: Path):
@@ -24,15 +21,7 @@ def test_transcription_cache_round_trip(tmp_path: Path):
     cache = TranscriptionCache(tmp_path, "test", "Test")
     audio = AudioSegment.silent(duration=100)
     metadata = {"model_name": "test/model"}
-    segments = [
-        TranscribedSegment(
-            id=0,
-            seek=0,
-            start=0.0,
-            end=0.1,
-            text="test",
-        )
-    ]
+    segments = [TranscribedSegment(id=0, seek=0, start=0.0, end=0.1, text="test")]
 
     cache_path = cache.save(audio, metadata, segments)
     cached_transcription = cache.load(audio, metadata)
@@ -95,9 +84,7 @@ def test_transcription_cache_overwrites_matching_entry_once(tmp_path: Path):
     assert overwrite_cache.load(audio, metadata) == (cache_path, [])
 
 
-def test_transcription_cache_uses_runtime_default(
-    runtime_cache_root_path: Path,
-):
+def test_transcription_cache_uses_runtime_default(runtime_cache_root_path: Path):
     """Test a missing configured root selects the runtime cache root.
 
     Arguments:

--- a/test/audio/transcription/test_transcription_transcriber.py
+++ b/test/audio/transcription/test_transcription_transcriber.py
@@ -48,24 +48,16 @@ class _TestTranscriber(Transcriber):
             list[TranscribedSegment] | TranscriptionError,
         ] = {}
         self.calls: list[tuple[AudioSegment, TranscriptionPreprocessingSettings]] = []
-        super().__init__(
-            cache_root_path,
-            demucs_mode,
-            vad_mode,
-            overwrite_cache,
-        )
+        super().__init__(cache_root_path, demucs_mode, vad_mode, overwrite_cache)
 
     def _get_backend_cache_metadata(
-        self,
-        settings: TranscriptionPreprocessingSettings,
+        self, settings: TranscriptionPreprocessingSettings
     ) -> Mapping[str, object]:
         """Get test backend cache metadata."""
         return {}
 
     def _transcribe_attempt(
-        self,
-        audio: AudioSegment,
-        settings: TranscriptionPreprocessingSettings,
+        self, audio: AudioSegment, settings: TranscriptionPreprocessingSettings
     ) -> list[TranscribedSegment]:
         """Return or raise the configured outcome for preprocessing settings."""
         self.calls.append((audio, settings))
@@ -120,39 +112,27 @@ def test_fallback_cache_is_checked_before_demucs(tmp_path: Path):
     assert transcriber.calls == []
 
 
-def test_overwrite_removes_all_configuration_caches_before_transcribing(
-    tmp_path: Path,
-):
+def test_overwrite_removes_all_configuration_caches_before_transcribing(tmp_path: Path):
     """Test cache overwrite clears every fallback variant before inference."""
     audio = AudioSegment.silent(duration=100)
     transcriber = _TestTranscriber(
-        tmp_path,
-        DemucsMode.AUTO,
-        VADMode.AUTO,
-        overwrite_cache=True,
+        tmp_path, DemucsMode.AUTO, VADMode.AUTO, overwrite_cache=True
     )
     preprocessing_settings = transcriber._get_preprocessing_settings()
     stale_cache = TranscriptionCache(tmp_path, "test", "Test")
     cache_paths = []
     for settings in preprocessing_settings:
         cache_path = stale_cache.save(
-            audio,
-            transcriber._get_cache_metadata(settings),
-            [_get_segment("old")],
+            audio, transcriber._get_cache_metadata(settings), [_get_segment("old")]
         )
         cache_paths.append(cache_path)
         transcriber.outcomes[settings] = [_get_segment("new")]
-    transcriber.demucs_separator = Mock(
-        model_name="htdemucs_ft",
-        return_value=audio,
-    )
+    transcriber.demucs_separator = Mock(model_name="htdemucs_ft", return_value=audio)
 
     assert transcriber(audio) == [_get_segment("new")]
     assert cache_paths[0].exists()
     assert not any(cache_path.exists() for cache_path in cache_paths[1:])
-    transcriber.demucs_separator.assert_called_once_with(
-        audio,
-    )
+    transcriber.demucs_separator.assert_called_once_with(audio)
 
 
 def test_auto_demucs_failure_uses_original_audio(tmp_path: Path):
@@ -162,8 +142,7 @@ def test_auto_demucs_failure_uses_original_audio(tmp_path: Path):
     segments = [_get_segment("fallback")]
     transcriber = _TestTranscriber(tmp_path, DemucsMode.AUTO, VADMode.OFF)
     transcriber.demucs_separator = Mock(
-        model_name="htdemucs_ft",
-        side_effect=ScinoephileError("failed"),
+        model_name="htdemucs_ft", side_effect=ScinoephileError("failed")
     )
     transcriber.outcomes[settings] = segments
 
@@ -176,8 +155,7 @@ def test_forced_demucs_failure_propagates(tmp_path: Path):
     audio = AudioSegment.silent(duration=100)
     transcriber = _TestTranscriber(tmp_path, DemucsMode.ON, VADMode.OFF)
     transcriber.demucs_separator = Mock(
-        model_name="htdemucs_ft",
-        side_effect=ScinoephileError("failed"),
+        model_name="htdemucs_ft", side_effect=ScinoephileError("failed")
     )
 
     with raises(ScinoephileError, match="failed"):
@@ -193,10 +171,7 @@ def test_unusable_vad_result_retries_without_vad(tmp_path: Path):
     transcriber.outcomes[vad_settings] = [_get_segment("bad")]
     transcriber.outcomes[no_vad_settings] = [_get_segment("good")]
 
-    segments = transcriber(
-        audio,
-        is_usable=lambda value: value[0].text == "good",
-    )
+    segments = transcriber(audio, is_usable=lambda value: value[0].text == "good")
 
     assert segments == [_get_segment("good")]
     assert [settings for _, settings in transcriber.calls] == [
@@ -212,16 +187,11 @@ def test_rejected_cached_configuration_is_not_repeated(tmp_path: Path):
     no_vad_settings = TranscriptionPreprocessingSettings(False, False)
     transcriber = _TestTranscriber(tmp_path, DemucsMode.OFF, VADMode.AUTO)
     transcriber._cache.save(
-        audio,
-        transcriber._get_cache_metadata(vad_settings),
-        [_get_segment("bad")],
+        audio, transcriber._get_cache_metadata(vad_settings), [_get_segment("bad")]
     )
     transcriber.outcomes[no_vad_settings] = [_get_segment("good")]
 
-    segments = transcriber(
-        audio,
-        is_usable=lambda value: value[0].text == "good",
-    )
+    segments = transcriber(audio, is_usable=lambda value: value[0].text == "good")
 
     assert segments == [_get_segment("good")]
     assert transcriber.calls == [(audio, no_vad_settings)]
@@ -236,26 +206,16 @@ def test_rejected_cached_final_configuration_is_retried(tmp_path: Path):
     audio = AudioSegment.silent(duration=100)
     settings = TranscriptionPreprocessingSettings(True, False)
     transcriber = _TestTranscriber(tmp_path, DemucsMode.ON, VADMode.OFF)
-    transcriber.demucs_separator = Mock(
-        model_name="htdemucs_ft",
-        return_value=audio,
-    )
+    transcriber.demucs_separator = Mock(model_name="htdemucs_ft", return_value=audio)
     transcriber._cache.save(
-        audio,
-        transcriber._get_cache_metadata(settings),
-        [_get_segment("bad")],
+        audio, transcriber._get_cache_metadata(settings), [_get_segment("bad")]
     )
     transcriber.outcomes[settings] = [_get_segment("good")]
 
-    segments = transcriber(
-        audio,
-        is_usable=lambda value: value[0].text == "good",
-    )
+    segments = transcriber(audio, is_usable=lambda value: value[0].text == "good")
 
     assert segments == [_get_segment("good")]
-    transcriber.demucs_separator.assert_called_once_with(
-        audio,
-    )
+    transcriber.demucs_separator.assert_called_once_with(audio)
     assert transcriber.calls == [(audio, settings)]
 
 
@@ -268,9 +228,7 @@ def test_rejected_cached_configuration_takes_precedence_over_other_error(
     no_vad_settings = TranscriptionPreprocessingSettings(False, False)
     transcriber = _TestTranscriber(tmp_path, DemucsMode.OFF, VADMode.AUTO)
     transcriber._cache.save(
-        audio,
-        transcriber._get_cache_metadata(vad_settings),
-        [_get_segment("bad")],
+        audio, transcriber._get_cache_metadata(vad_settings), [_get_segment("bad")]
     )
     transcriber.outcomes[no_vad_settings] = TranscriptionInferenceError("failed")
 

--- a/test/audio/transcription/test_whisper_transcriber.py
+++ b/test/audio/transcription/test_whisper_transcriber.py
@@ -49,15 +49,11 @@ def test_init_defaults_preprocessing_to_auto():
     assert transcriber.vad_mode is VADMode.AUTO
 
 
-def _get_cache_path(
-    transcriber: WhisperTranscriber,
-    audio: AudioSegment,
-) -> Path:
+def _get_cache_path(transcriber: WhisperTranscriber, audio: AudioSegment) -> Path:
     """Get the cache path for the transcriber's first preprocessing settings."""
     settings = transcriber._get_preprocessing_settings()[0]
     cache_path = transcriber._cache.get_path(
-        audio,
-        transcriber._get_cache_metadata(settings),
+        audio, transcriber._get_cache_metadata(settings)
     )
     return cache_path
 
@@ -73,10 +69,7 @@ def _get_cache_path(
     ],
 )
 def test_get_cache_path_separates_configuration(
-    tmp_path: Path,
-    field_name: str,
-    first_value: object,
-    second_value: object,
+    tmp_path: Path, field_name: str, first_value: object, second_value: object
 ):
     """Test Whisper cache paths differ by cache-relevant configuration.
 
@@ -86,19 +79,12 @@ def test_get_cache_path_separates_configuration(
         first_value: first transcriber field value
         second_value: second transcriber field value
     """
-    audio = AudioSegment(
-        data=b"audio",
-        sample_width=1,
-        frame_rate=8000,
-        channels=1,
-    )
+    audio = AudioSegment(data=b"audio", sample_width=1, frame_rate=8000, channels=1)
     first_transcriber = WhisperTranscriber(
-        cache_root_path=tmp_path,
-        model_name="custom/model",
+        cache_root_path=tmp_path, model_name="custom/model"
     )
     second_transcriber = WhisperTranscriber(
-        cache_root_path=tmp_path,
-        model_name="custom/model",
+        cache_root_path=tmp_path, model_name="custom/model"
     )
     setattr(first_transcriber, field_name, first_value)
     setattr(second_transcriber, field_name, second_value)
@@ -114,50 +100,32 @@ def test_get_cache_path_separates_audio_formats(tmp_path: Path):
     """Test Whisper cache paths include audio format metadata."""
     raw_data = b"\0\1" * 100
     first_audio = AudioSegment(
-        data=raw_data,
-        sample_width=2,
-        frame_rate=16000,
-        channels=1,
+        data=raw_data, sample_width=2, frame_rate=16000, channels=1
     )
     second_audio = AudioSegment(
-        data=raw_data,
-        sample_width=2,
-        frame_rate=8000,
-        channels=1,
+        data=raw_data, sample_width=2, frame_rate=8000, channels=1
     )
     transcriber = WhisperTranscriber(
-        cache_root_path=tmp_path,
-        model_name="custom/model",
+        cache_root_path=tmp_path, model_name="custom/model"
     )
 
     assert _get_cache_path(transcriber, first_audio) != _get_cache_path(
-        transcriber,
-        second_audio,
+        transcriber, second_audio
     )
 
 
 def test_get_cache_path_accepts_list_temperature_schedule(tmp_path: Path):
     """Test list and tuple temperature schedules use the same cache key."""
-    audio = AudioSegment(
-        data=b"audio",
-        sample_width=1,
-        frame_rate=8000,
-        channels=1,
-    )
+    audio = AudioSegment(data=b"audio", sample_width=1, frame_rate=8000, channels=1)
     list_transcriber = WhisperTranscriber(
-        cache_root_path=tmp_path,
-        model_name="custom/model",
-        temperature=[0.0, 0.2, 0.4],
+        cache_root_path=tmp_path, model_name="custom/model", temperature=[0.0, 0.2, 0.4]
     )
     tuple_transcriber = WhisperTranscriber(
-        cache_root_path=tmp_path,
-        model_name="custom/model",
-        temperature=(0.0, 0.2, 0.4),
+        cache_root_path=tmp_path, model_name="custom/model", temperature=(0.0, 0.2, 0.4)
     )
 
     assert _get_cache_path(list_transcriber, audio) == _get_cache_path(
-        tuple_transcriber,
-        audio,
+        tuple_transcriber, audio
     )
 
 
@@ -189,17 +157,10 @@ def test_transcribe_forwards_recovery_decoding_options(monkeypatch: MonkeyPatch)
 
 @parametrize(
     ("duration_ms", "expected"),
-    [
-        (100, 32),
-        (1000, 32),
-        (6530, 105),
-        (14000, 224),
-        (30000, 224),
-    ],
+    [(100, 32), (1000, 32), (6530, 105), (14000, 224), (30000, 224)],
 )
 def test_get_sample_len_bounds_decode_by_audio_duration(
-    duration_ms: int,
-    expected: int,
+    duration_ms: int, expected: int
 ):
     """Bound the decode token budget while leaving room for dense speech.
 
@@ -228,14 +189,10 @@ def test_model_is_shared_across_decoding_configurations(monkeypatch: MonkeyPatch
     )
     WhisperTranscriber._models.clear()
     vad_transcriber = WhisperTranscriber(
-        model_name="custom/model",
-        demucs_mode=DemucsMode.OFF,
-        vad_mode=VADMode.ON,
+        model_name="custom/model", demucs_mode=DemucsMode.OFF, vad_mode=VADMode.ON
     )
     no_vad_transcriber = WhisperTranscriber(
-        model_name="custom/model",
-        demucs_mode=DemucsMode.OFF,
-        vad_mode=VADMode.OFF,
+        model_name="custom/model", demucs_mode=DemucsMode.OFF, vad_mode=VADMode.OFF
     )
 
     try:
@@ -246,10 +203,7 @@ def test_model_is_shared_across_decoding_configurations(monkeypatch: MonkeyPatch
         WhisperTranscriber._models.clear()
 
 
-def test_transcribe_overwrites_matching_cache(
-    monkeypatch: MonkeyPatch,
-    tmp_path: Path,
-):
+def test_transcribe_overwrites_matching_cache(monkeypatch: MonkeyPatch, tmp_path: Path):
     """Test cache overwrite removes the matching file before transcription.
 
     Arguments:
@@ -286,8 +240,7 @@ def test_transcribe_overwrites_matching_cache(
 
 
 def test_transcribe_recovers_from_malformed_cache(
-    monkeypatch: MonkeyPatch,
-    tmp_path: Path,
+    monkeypatch: MonkeyPatch, tmp_path: Path
 ):
     """Test malformed cached output is replaced by a fresh transcription.
 
@@ -318,8 +271,7 @@ def test_transcribe_recovers_from_malformed_cache(
 
 
 def test_transcribe_discards_invalid_cache_when_atomic_write_fails(
-    monkeypatch: MonkeyPatch,
-    tmp_path: Path,
+    monkeypatch: MonkeyPatch, tmp_path: Path
 ):
     """Test an invalid cache remains discarded when serialization fails.
 
@@ -365,9 +317,7 @@ def test_transcribe_discards_invalid_cache_when_atomic_write_fails(
     ],
 )
 def test_model_name_is_huggingface_repo_id_rejects_local_paths(
-    monkeypatch: MonkeyPatch,
-    model_name: str,
-    expected: bool,
+    monkeypatch: MonkeyPatch, model_name: str, expected: bool
 ):
     """Test HuggingFace retry is skipped for local filesystem paths.
 
@@ -384,8 +334,7 @@ def test_model_name_is_huggingface_repo_id_rejects_local_paths(
         "scinoephile.audio.transcription.whisper_transcriber."
         "import_huggingface_hub_utils",
         lambda: SimpleNamespace(
-            HFValidationError=ValueError,
-            validate_repo_id=validate_repo_id,
+            HFValidationError=ValueError, validate_repo_id=validate_repo_id
         ),
     )
     transcriber = WhisperTranscriber(model_name=model_name)
@@ -410,8 +359,7 @@ def test_model_name_is_huggingface_repo_id_rejects_validation_errors(
         "scinoephile.audio.transcription.whisper_transcriber."
         "import_huggingface_hub_utils",
         lambda: SimpleNamespace(
-            HFValidationError=ValueError,
-            validate_repo_id=validate_repo_id,
+            HFValidationError=ValueError, validate_repo_id=validate_repo_id
         ),
     )
     transcriber = WhisperTranscriber(model_name="invalid/repository/id")
@@ -456,9 +404,7 @@ def test_transcription_imports_without_optional_runtime_dependencies():
         [str(package_root.parent), env.get("PYTHONPATH", "")]
     )
     exitcode, _, _ = run_command(
-        [sys.executable, "-c", script],
-        cwd_path=package_root.parent,
-        env=env,
+        [sys.executable, "-c", script], cwd_path=package_root.parent, env=env
     )
 
     assert exitcode == 0
@@ -503,17 +449,9 @@ def test_normalize_transcription_segments_coalesces_malformed_duplicate_pair():
             no_speech_prob=1.11e-6,
             words=[
                 TranscribedWord(text="照", start=156.4, end=156.85, confidence=0.385),
+                TranscribedWord(text="先生", start=156.85, end=157.19, confidence=0.99),
                 TranscribedWord(
-                    text="先生",
-                    start=156.85,
-                    end=157.19,
-                    confidence=0.99,
-                ),
-                TranscribedWord(
-                    text="你就",
-                    start=157.19,
-                    end=158.31,
-                    confidence=0.686,
+                    text="你就", start=157.19, end=158.31, confidence=0.686
                 ),
             ],
         ),
@@ -533,10 +471,7 @@ def test_normalize_transcription_segments_coalesces_malformed_duplicate_pair():
     ]
 
     normalized_segments = transcriber._normalize_transcription_segments(
-        segments,
-        source="cache",
-        cache_path=Path("/tmp/whisper.json"),
-        use_vad=True,
+        segments, source="cache", cache_path=Path("/tmp/whisper.json"), use_vad=True
     )
 
     assert len(normalized_segments) == 1

--- a/test/cli/dictionary/build/test_dictionary_build_cuhk_cli.py
+++ b/test/cli/dictionary/build/test_dictionary_build_cuhk_cli.py
@@ -19,8 +19,7 @@ from test.helpers import skip_if_ci
 
 
 def test_dictionary_build_cuhk_cli_passes_cache_root_to_service(
-    monkeypatch: MonkeyPatch,
-    tmp_path: Path,
+    monkeypatch: MonkeyPatch, tmp_path: Path
 ):
     """Test CUHK CLI forwards the parsed cache root without creating it.
 
@@ -62,10 +61,7 @@ def test_dictionary_build_cuhk_cli_passes_cache_root_to_service(
             self.database_path = database_path
 
         def build(
-            self,
-            *,
-            overwrite: bool = False,
-            max_words: int | None = None,
+            self, *, overwrite: bool = False, max_words: int | None = None
         ) -> Path:
             """Build the dictionary."""
             build_calls.append({"overwrite": overwrite, "max_words": max_words})

--- a/test/cli/dictionary/test_dictionary_search_cli.py
+++ b/test/cli/dictionary/test_dictionary_search_cli.py
@@ -57,10 +57,7 @@ def dictionary_database_dir_path() -> Generator[Path]:
                         frequency=2.0,
                         definitions=[
                             DictionaryDefinition(text="gully"),
-                            DictionaryDefinition(
-                                text="mountain stream",
-                                label="noun",
-                            ),
+                            DictionaryDefinition(text="mountain stream", label="noun"),
                         ],
                     ),
                     DictionaryEntry(
@@ -129,11 +126,7 @@ def dictionary_database_dir_path() -> Generator[Path]:
         ("shān'kēng", "shān'kēng", nullcontext()),
         ("saan1haang1", "saan1haang1", nullcontext()),
         ("山坑水", "山坑水", nullcontext()),
-        (
-            "gully",
-            "Unsupported query 'gully'",
-            raises(SystemExit, match="1"),
-        ),
+        ("gully", "Unsupported query 'gully'", raises(SystemExit, match="1")),
     ],
 )
 def test_dictionary_search_cli(
@@ -223,8 +216,7 @@ def test_dictionary_search_cli_all_dictionaries_database_path_is_usage_error():
 
 
 def test_dictionary_search_cli_prints_no_matches(
-    dictionary_database_dir_path: Path,
-    capsys: CaptureFixture,
+    dictionary_database_dir_path: Path, capsys: CaptureFixture
 ):
     """Test dictionary search reports no matches on stdout.
 

--- a/test/cli/media/test_media_extract_audio_cli.py
+++ b/test/cli/media/test_media_extract_audio_cli.py
@@ -16,8 +16,7 @@ from scinoephile.core.media.audio_stream import AudioStream
 
 
 def test_media_extract_audio_cli_extracts_selected_stream(
-    tmp_path: Path,
-    capsys: CaptureFixture[str],
+    tmp_path: Path, capsys: CaptureFixture[str]
 ):
     """Test extract-audio forwards its options and reports the output.
 
@@ -29,11 +28,7 @@ def test_media_extract_audio_cli_extracts_selected_stream(
     infile_path.touch()
     outfile_path = tmp_path / "audio.wav"
     stream = AudioStream(
-        index=3,
-        codec_type="audio",
-        codec_name="aac",
-        language="yue",
-        channels=6,
+        index=3, codec_type="audio", codec_name="aac", language="yue", channels=6
     )
 
     with patch(
@@ -47,10 +42,7 @@ def test_media_extract_audio_cli_extracts_selected_stream(
         )
 
     extract.assert_called_once_with(
-        infile_path.resolve(),
-        outfile_path.resolve(),
-        stream_index=3,
-        overwrite=True,
+        infile_path.resolve(), outfile_path.resolve(), stream_index=3, overwrite=True
     )
     assert capsys.readouterr().out.strip() == (
         f"Extracted audio: {stream.description} -> {outfile_path.resolve()}"
@@ -77,8 +69,7 @@ def test_media_extract_audio_cli_maps_extraction_errors_to_parser_errors(
         raises(SystemExit) as excinfo,
     ):
         run_cli_with_args(
-            MediaExtractAudioCli,
-            f"--infile {infile_path} --outfile {outfile_path}",
+            MediaExtractAudioCli, f"--infile {infile_path} --outfile {outfile_path}"
         )
 
     assert excinfo.value.code == 2

--- a/test/cli/media/test_media_extract_subs_cli.py
+++ b/test/cli/media/test_media_extract_subs_cli.py
@@ -22,8 +22,7 @@ from scinoephile.workflows.subtitle_extraction import (
 
 
 def test_media_extract_subs_cli_renders_grouped_outputs(
-    tmp_path: Path,
-    capsys: CaptureFixture[str],
+    tmp_path: Path, capsys: CaptureFixture[str]
 ):
     """Test media extract-subs CLI renders workflow output groups.
 

--- a/test/cli/media/test_media_offset_cli.py
+++ b/test/cli/media/test_media_offset_cli.py
@@ -30,16 +30,10 @@ def test_media_offset_cli_reports_offset(tmp_path: Path, capsys: CaptureFixture[
         offset=1.25,
         confidence="high",
         best=SimpleNamespace(
-            offset=1.25,
-            matched_count=24,
-            score=0.5,
-            offset_frames=30,
+            offset=1.25, matched_count=24, score=0.5, offset_frames=30
         ),
         second_best=SimpleNamespace(
-            offset=1.0,
-            matched_count=24,
-            score=4.0,
-            offset_frames=24,
+            offset=1.0, matched_count=24, score=4.0, offset_frames=24
         ),
         offset_frames=30,
         windows=(),
@@ -47,8 +41,7 @@ def test_media_offset_cli_reports_offset(tmp_path: Path, capsys: CaptureFixture[
     )
 
     with patch(
-        "scinoephile.cli.media.media_offset_cli.get_video_offset",
-        return_value=result,
+        "scinoephile.cli.media.media_offset_cli.get_video_offset", return_value=result
     ):
         run_cli_with_args(
             MediaOffsetCli,
@@ -69,8 +62,7 @@ def test_media_offset_cli_reports_offset(tmp_path: Path, capsys: CaptureFixture[
 
 
 def test_media_offset_cli_reports_window_aggregate(
-    tmp_path: Path,
-    capsys: CaptureFixture[str],
+    tmp_path: Path, capsys: CaptureFixture[str]
 ):
     """Test media offset CLI reports multi-window aggregate results.
 
@@ -83,16 +75,10 @@ def test_media_offset_cli_reports_window_aggregate(
     reference_infile_path.touch()
     target_infile_path.touch()
     window_best = SimpleNamespace(
-        offset=-0.8341666666666666,
-        matched_count=48,
-        score=0.1,
-        offset_frames=-20,
+        offset=-0.8341666666666666, matched_count=48, score=0.1, offset_frames=-20
     )
     window_next = SimpleNamespace(
-        offset=-0.7924583333333333,
-        matched_count=48,
-        score=0.5,
-        offset_frames=-19,
+        offset=-0.7924583333333333, matched_count=48, score=0.5, offset_frames=-19
     )
     result = SimpleNamespace(
         offset=-0.8341666666666666,
@@ -132,8 +118,7 @@ def test_media_offset_cli_reports_window_aggregate(
     )
 
     with patch(
-        "scinoephile.cli.media.media_offset_cli.get_video_offset",
-        return_value=result,
+        "scinoephile.cli.media.media_offset_cli.get_video_offset", return_value=result
     ):
         run_cli_with_args(
             MediaOffsetCli,
@@ -160,8 +145,7 @@ def test_media_offset_cli_reports_window_aggregate(
 
 
 def test_media_offset_cli_rejects_start_time_argument(
-    tmp_path: Path,
-    capsys: CaptureFixture[str],
+    tmp_path: Path, capsys: CaptureFixture[str]
 ):
     """Test media offset CLI no longer accepts a start time argument.
 
@@ -196,9 +180,7 @@ def test_media_offset_cli_rejects_start_time_argument(
     ],
 )
 def test_media_offset_cli_rejects_zero_positive_arguments(
-    argument: str,
-    tmp_path: Path,
-    capsys: CaptureFixture[str],
+    argument: str, tmp_path: Path, capsys: CaptureFixture[str]
 ):
     """Test media offset CLI rejects zero for positive arguments.
 

--- a/test/cli/media/test_media_probe_cli.py
+++ b/test/cli/media/test_media_probe_cli.py
@@ -12,9 +12,7 @@ from pytest import CaptureFixture, raises
 from scinoephile.cli.media.media_probe_cli import MediaProbeCli
 from scinoephile.common.testing import run_cli_with_args
 from scinoephile.core.media import AudioStream, SubtitleStream, VideoStream
-from scinoephile.lang.zho.subtitles.analysis.result import (
-    ZhoScriptAnalysisResult,
-)
+from scinoephile.lang.zho.subtitles.analysis.result import ZhoScriptAnalysisResult
 from scinoephile.media.subtitles.cache import SubtitleCache
 from test.helpers import parametrize
 
@@ -53,7 +51,7 @@ def test_media_probe_cli_lists_all_streams(tmp_path: Path, capsys: CaptureFixtur
                     "codec_name": "subrip",
                     "tags": {"language": "eng", "title": "SDH"},
                 },
-            ],
+            ]
         },
     ):
         run_cli_with_args(MediaProbeCli, f"--infile {infile_path}")
@@ -65,18 +63,9 @@ def test_media_probe_cli_lists_all_streams(tmp_path: Path, capsys: CaptureFixtur
     ]
 
 
-@parametrize(
-    ("script", "language"),
-    [
-        ("zho-Hant", "zho-Hant"),
-        (None, "zho-Unknown"),
-    ],
-)
+@parametrize(("script", "language"), [("zho-Hant", "zho-Hant"), (None, "zho-Unknown")])
 def test_media_probe_cli_details_includes_chinese_script_in_stream_id(
-    tmp_path: Path,
-    capsys: CaptureFixture[str],
-    script: str | None,
-    language: str,
+    tmp_path: Path, capsys: CaptureFixture[str], script: str | None, language: str
 ):
     """Test media probe CLI includes Chinese script analysis in stream ID.
 
@@ -99,8 +88,8 @@ def test_media_probe_cli_details_includes_chinese_script_in_stream_id(
                         "codec_type": "subtitle",
                         "codec_name": "subrip",
                         "tags": {"language": "zho"},
-                    },
-                ],
+                    }
+                ]
             },
         ),
         patch(
@@ -119,13 +108,12 @@ def test_media_probe_cli_details_includes_chinese_script_in_stream_id(
         (
             f"Stream #0:2({language}): Subtitle: subrip "
             "(subtitles=12, span=00:01:02-01:02:05)"
-        ),
+        )
     ]
 
 
 def test_media_probe_cli_details_preserves_non_subtitle_streams(
-    tmp_path: Path,
-    capsys: CaptureFixture[str],
+    tmp_path: Path, capsys: CaptureFixture[str]
 ):
     """Test media probe CLI detail mode still lists non-subtitle streams.
 
@@ -155,10 +143,7 @@ def test_media_probe_cli_details_preserves_non_subtitle_streams(
                     channels=2,
                 ),
                 SubtitleStream(
-                    index=2,
-                    codec_type="subtitle",
-                    codec_name="subrip",
-                    language="zho",
+                    index=2, codec_type="subtitle", codec_name="subrip", language="zho"
                 ),
             ],
         ),
@@ -173,7 +158,7 @@ def test_media_probe_cli_details_preserves_non_subtitle_streams(
                     subtitle_count=12,
                     first_start_ms=62_500,
                     last_end_ms=3_725_250,
-                ),
+                )
             ],
         ),
     ):
@@ -190,8 +175,7 @@ def test_media_probe_cli_details_preserves_non_subtitle_streams(
 
 
 def test_media_probe_cli_details_omits_unreadable_subtitle_stats(
-    tmp_path: Path,
-    capsys: CaptureFixture[str],
+    tmp_path: Path, capsys: CaptureFixture[str]
 ):
     """Test media probe CLI survives unreadable subtitle stats.
 
@@ -212,8 +196,8 @@ def test_media_probe_cli_details_omits_unreadable_subtitle_stats(
                         "codec_type": "subtitle",
                         "codec_name": "hdmv_pgs_subtitle",
                         "tags": {"language": "ita", "title": "SDH"},
-                    },
-                ],
+                    }
+                ]
             },
         ),
         patch(
@@ -225,13 +209,12 @@ def test_media_probe_cli_details_omits_unreadable_subtitle_stats(
         run_cli_with_args(MediaProbeCli, f"--infile {infile_path} --details")
 
     assert capsys.readouterr().out.splitlines() == [
-        "Stream #0:2(ita): Subtitle: hdmv_pgs_subtitle (title=SDH)",
+        "Stream #0:2(ita): Subtitle: hdmv_pgs_subtitle (title=SDH)"
     ]
 
 
 def test_media_probe_cli_force_check_script_checks_standalone_sup(
-    tmp_path: Path,
-    capsys: CaptureFixture[str],
+    tmp_path: Path, capsys: CaptureFixture[str]
 ):
     """Test forced script checking treats a standalone SUP file as Chinese.
 
@@ -277,14 +260,13 @@ def test_media_probe_cli_force_check_script_checks_standalone_sup(
         )
 
     assert capsys.readouterr().out.splitlines() == [
-        "Stream #0:0(zho-Hant): Subtitle: hdmv_pgs_subtitle",
+        "Stream #0:0(zho-Hant): Subtitle: hdmv_pgs_subtitle"
     ]
     analyze.assert_called_once()
 
 
 def test_media_probe_cli_force_check_script_rejects_non_sup(
-    tmp_path: Path,
-    capsys: CaptureFixture[str],
+    tmp_path: Path, capsys: CaptureFixture[str]
 ):
     """Test forced script checking rejects non-SUP inputs.
 
@@ -296,9 +278,6 @@ def test_media_probe_cli_force_check_script_rejects_non_sup(
     infile_path.touch()
 
     with raises(SystemExit, match="2"):
-        run_cli_with_args(
-            MediaProbeCli,
-            f"--infile {infile_path} --force-check-script",
-        )
+        run_cli_with_args(MediaProbeCli, f"--infile {infile_path} --force-check-script")
 
     assert "--force-check-script requires a SUP infile" in capsys.readouterr().err

--- a/test/cli/multi/test_multi_cer_cli.py
+++ b/test/cli/multi/test_multi_cer_cli.py
@@ -22,12 +22,10 @@ def test_multi_cer_cli(tmp_path: Path, capsys: CaptureFixture[str]):
     reference_infile_path = tmp_path / "reference.srt"
     candidate_infile_path = tmp_path / "candidate.srt"
     reference_infile_path.write_text(
-        "1\n00:00:00,000 --> 00:00:01,000\nabc\n",
-        encoding="utf-8",
+        "1\n00:00:00,000 --> 00:00:01,000\nabc\n", encoding="utf-8"
     )
     candidate_infile_path.write_text(
-        "1\n00:00:00,000 --> 00:00:01,000\naxc\n",
-        encoding="utf-8",
+        "1\n00:00:00,000 --> 00:00:01,000\naxc\n", encoding="utf-8"
     )
 
     run_cli_with_args(

--- a/test/cli/multi/test_multi_diff_cli.py
+++ b/test/cli/multi/test_multi_diff_cli.py
@@ -22,12 +22,10 @@ def test_multi_diff_cli(tmp_path: Path, capsys: CaptureFixture):
     reference_infile_path = tmp_path / "reference.srt"
     candidate_infile_path = tmp_path / "candidate.srt"
     reference_infile_path.write_text(
-        "1\n00:00:00,000 --> 00:00:01,000\n靠你了\n",
-        encoding="utf-8",
+        "1\n00:00:00,000 --> 00:00:01,000\n靠你了\n", encoding="utf-8"
     )
     candidate_infile_path.write_text(
-        "1\n00:00:00,000 --> 00:00:01,000\n靠你喇！\n",
-        encoding="utf-8",
+        "1\n00:00:00,000 --> 00:00:01,000\n靠你喇！\n", encoding="utf-8"
     )
 
     run_cli_with_args(
@@ -51,8 +49,7 @@ def test_multi_diff_cli_multiline_split_edit(tmp_path: Path, capsys: CaptureFixt
     reference_infile_path = tmp_path / "reference.srt"
     candidate_infile_path = tmp_path / "candidate.srt"
     reference_infile_path.write_text(
-        "1\n00:00:00,000 --> 00:00:02,000\nalpha beta\n",
-        encoding="utf-8",
+        "1\n00:00:00,000 --> 00:00:02,000\nalpha beta\n", encoding="utf-8"
     )
     candidate_infile_path.write_text(
         "1\n00:00:00,000 --> 00:00:01,000\nalpha\n\n"
@@ -75,8 +72,7 @@ def test_multi_diff_cli_multiline_split_edit(tmp_path: Path, capsys: CaptureFixt
 
 
 def test_multi_diff_cli_identical_series_prints_no_differences(
-    tmp_path: Path,
-    capsys: CaptureFixture,
+    tmp_path: Path, capsys: CaptureFixture
 ):
     """Test multi diff reports when there are no differences.
 

--- a/test/cli/multi/test_multi_stack_cli.py
+++ b/test/cli/multi/test_multi_stack_cli.py
@@ -52,8 +52,7 @@ def test_multi_stack_cli_stacks_without_sync_by_default(tmp_path: Path):
     )
 
     expected = Series.from_string(
-        "1\n00:00:01,000 --> 00:00:02,250\nA\\NB\n",
-        format_="srt",
+        "1\n00:00:01,000 --> 00:00:02,250\nA\\NB\n", format_="srt"
     )
     assert_series_equal(Series.load(output_path), expected)
 
@@ -77,8 +76,7 @@ def test_multi_stack_cli_can_sync_bottom_to_top_anchor(tmp_path: Path):
     )
 
     expected = Series.from_string(
-        "1\n00:00:01,000 --> 00:00:02,000\nA\\NB\n",
-        format_="srt",
+        "1\n00:00:01,000 --> 00:00:02,000\nA\\NB\n", format_="srt"
     )
     assert_series_equal(Series.load(output_path), expected)
 
@@ -97,9 +95,7 @@ def test_multi_stack_cli_can_sync_bottom_to_top_anchor(tmp_path: Path):
     ],
 )
 def test_multi_stack_cli_rejects_invalid_tuning_options(
-    args: str,
-    expected_error: str,
-    tmp_path: Path,
+    args: str, expected_error: str, tmp_path: Path
 ):
     """Test multi stack CLI rejects invalid synchronization tuning options.
 

--- a/test/cli/multi/test_multi_sync_cli.py
+++ b/test/cli/multi/test_multi_sync_cli.py
@@ -17,8 +17,7 @@ from test.helpers import assert_series_equal, parametrize
 
 
 def test_multi_sync_cli_shifts_mobile_to_anchor_and_writes_file(
-    tmp_path: Path,
-    capsys: CaptureFixture[str],
+    tmp_path: Path, capsys: CaptureFixture[str]
 ):
     """Test multi sync estimates offset, shifts mobile subtitles, and writes output.
 
@@ -39,8 +38,7 @@ def test_multi_sync_cli_shifts_mobile_to_anchor_and_writes_file(
     )
 
     expected = Series.from_string(
-        "1\n00:00:01,000 --> 00:00:02,000\nB\n",
-        format_="srt",
+        "1\n00:00:01,000 --> 00:00:02,000\nB\n", format_="srt"
     )
     assert_series_equal(Series.load(output_path), expected)
     captured = capsys.readouterr()
@@ -63,13 +61,11 @@ def test_multi_sync_cli_pipe(tmp_path: Path):
     with MonkeyPatch.context() as monkeypatch:
         monkeypatch.setattr("scinoephile.cli.helpers.io.stdout", stdout_stream)
         run_cli_with_args(
-            MultiSyncCli,
-            f"--anchor-infile {anchor_path} --mobile-infile {mobile_path}",
+            MultiSyncCli, f"--anchor-infile {anchor_path} --mobile-infile {mobile_path}"
         )
 
     expected = Series.from_string(
-        "1\n00:00:01,000 --> 00:00:02,000\nB\n",
-        format_="srt",
+        "1\n00:00:01,000 --> 00:00:02,000\nB\n", format_="srt"
     )
     output = Series.from_string(stdout_stream.getvalue(), format_="srt")
     assert_series_equal(output, expected)
@@ -84,9 +80,7 @@ def test_multi_sync_cli_pipe(tmp_path: Path):
     ],
 )
 def test_multi_sync_cli_rejects_invalid_tuning_options(
-    args: str,
-    expected_error: str,
-    tmp_path: Path,
+    args: str, expected_error: str, tmp_path: Path
 ):
     """Test multi sync CLI rejects invalid synchronization tuning options.
 

--- a/test/cli/multi/test_multi_timewarp_cli.py
+++ b/test/cli/multi/test_multi_timewarp_cli.py
@@ -30,8 +30,7 @@ def test_multi_timewarp_cli_passes_arguments_and_writes_file(tmp_path: Path):
     anchor_series = Series.from_string(anchor_path.read_text(encoding="utf-8"))
     mobile_series = Series.from_string(mobile_path.read_text(encoding="utf-8"))
     timewarped_series = Series.from_string(
-        "1\n00:00:00,000 --> 00:00:01,000\nB\n",
-        format_="srt",
+        "1\n00:00:00,000 --> 00:00:01,000\nB\n", format_="srt"
     )
     timewarp_calls = 0
 
@@ -55,11 +54,9 @@ def test_multi_timewarp_cli_passes_arguments_and_writes_file(tmp_path: Path):
         assert two_end_idx == 4
         return timewarped_series
 
-    with (
-        patch(
-            "scinoephile.cli.multi.multi_timewarp_cli.get_series_timewarped",
-            side_effect=get_timewarped,
-        ),
+    with patch(
+        "scinoephile.cli.multi.multi_timewarp_cli.get_series_timewarped",
+        side_effect=get_timewarped,
     ):
         run_cli_with_args(
             MultiTimewarpCli,
@@ -84,8 +81,7 @@ def test_multi_timewarp_cli_pipe(tmp_path: Path):
     anchor_path.write_text("1\n00:00:00,000 --> 00:00:01,000\nA\n", encoding="utf-8")
     mobile_path.write_text("1\n00:00:02,000 --> 00:00:03,000\nB\n", encoding="utf-8")
     timewarped_series = Series.from_string(
-        "1\n00:00:00,000 --> 00:00:01,000\nB\n",
-        format_="srt",
+        "1\n00:00:00,000 --> 00:00:01,000\nB\n", format_="srt"
     )
 
     stdout_stream = StringIO()

--- a/test/cli/ocr/test_ocr_cli.py
+++ b/test/cli/ocr/test_ocr_cli.py
@@ -11,11 +11,7 @@ from pathlib import Path
 
 from pytest import MonkeyPatch, raises
 
-from scinoephile.cli.ocr import (
-    OcrLensCli,
-    OcrPaddleCli,
-    OcrTesseractCli,
-)
+from scinoephile.cli.ocr import OcrLensCli, OcrPaddleCli, OcrTesseractCli
 from scinoephile.common import CommandLineInterface
 from scinoephile.common.file import get_temp_file_path
 from scinoephile.common.testing import run_cli_with_args
@@ -34,9 +30,7 @@ OCR_LANGUAGE_METAVAR = "{eng,yue-Hans,yue-Hant,zho-Hans,zho-Hant}"
 
 
 def _patch_image_series_load(
-    monkeypatch: MonkeyPatch,
-    target: str,
-    image_series: ImageSeries,
+    monkeypatch: MonkeyPatch, target: str, image_series: ImageSeries
 ) -> list[Path]:
     """Patch image subtitle loading and return captured input paths.
 
@@ -102,9 +96,7 @@ def test_ocr_lens_cli_help_lists_language_and_retry_options_only():
 
 
 def test_ocr_lens_cli_converts_image_subtitles_to_srt(
-    monkeypatch: MonkeyPatch,
-    tmp_path: Path,
-    tiny_image_series: ImageSeries,
+    monkeypatch: MonkeyPatch, tmp_path: Path, tiny_image_series: ImageSeries
 ):
     """Test Google Lens CLI writes OCR output to SRT.
 
@@ -114,9 +106,7 @@ def test_ocr_lens_cli_converts_image_subtitles_to_srt(
         tiny_image_series: small image subtitle series
     """
     input_paths = _patch_image_series_load(
-        monkeypatch,
-        "scinoephile.cli.helpers.io.ImageSeries.load",
-        tiny_image_series,
+        monkeypatch, "scinoephile.cli.helpers.io.ImageSeries.load", tiny_image_series
     )
     input_path = _write_placeholder_sup_path(tmp_path)
     observed_kwargs = []
@@ -195,9 +185,7 @@ def test_ocr_tesseract_cli_help_lists_language_options():
 
 
 def test_ocr_paddle_cli_converts_image_subtitles_to_srt(
-    monkeypatch: MonkeyPatch,
-    tmp_path: Path,
-    tiny_image_series: ImageSeries,
+    monkeypatch: MonkeyPatch, tmp_path: Path, tiny_image_series: ImageSeries
 ):
     """Test PaddleOCR CLI writes OCR output to SRT.
 
@@ -207,9 +195,7 @@ def test_ocr_paddle_cli_converts_image_subtitles_to_srt(
         tiny_image_series: small image subtitle series
     """
     input_paths = _patch_image_series_load(
-        monkeypatch,
-        "scinoephile.cli.helpers.io.ImageSeries.load",
-        tiny_image_series,
+        monkeypatch, "scinoephile.cli.helpers.io.ImageSeries.load", tiny_image_series
     )
     input_path = _write_placeholder_sup_path(tmp_path)
     observed_kwargs = []
@@ -255,9 +241,7 @@ def test_ocr_paddle_cli_converts_image_subtitles_to_srt(
 
 
 def test_ocr_tesseract_cli_converts_image_subtitles_to_srt(
-    monkeypatch: MonkeyPatch,
-    tmp_path: Path,
-    tiny_image_series: ImageSeries,
+    monkeypatch: MonkeyPatch, tmp_path: Path, tiny_image_series: ImageSeries
 ):
     """Test Tesseract OCR CLI writes OCR output to SRT.
 
@@ -267,9 +251,7 @@ def test_ocr_tesseract_cli_converts_image_subtitles_to_srt(
         tiny_image_series: small image subtitle series
     """
     input_paths = _patch_image_series_load(
-        monkeypatch,
-        "scinoephile.cli.helpers.io.ImageSeries.load",
-        tiny_image_series,
+        monkeypatch, "scinoephile.cli.helpers.io.ImageSeries.load", tiny_image_series
     )
     input_path = _write_placeholder_sup_path(tmp_path)
 
@@ -310,9 +292,7 @@ def test_ocr_tesseract_cli_converts_image_subtitles_to_srt(
 
 
 def test_ocr_tesseract_cli_passes_italic_detection_options(
-    monkeypatch: MonkeyPatch,
-    tmp_path: Path,
-    tiny_image_series: ImageSeries,
+    monkeypatch: MonkeyPatch, tmp_path: Path, tiny_image_series: ImageSeries
 ):
     """Test Tesseract OCR CLI passes italic detection options.
 
@@ -322,9 +302,7 @@ def test_ocr_tesseract_cli_passes_italic_detection_options(
         tiny_image_series: small image subtitle series
     """
     input_paths = _patch_image_series_load(
-        monkeypatch,
-        "scinoephile.cli.helpers.io.ImageSeries.load",
-        tiny_image_series,
+        monkeypatch, "scinoephile.cli.helpers.io.ImageSeries.load", tiny_image_series
     )
     input_path = _write_placeholder_sup_path(tmp_path)
     cache_root_path = tmp_path / "cache"
@@ -366,8 +344,7 @@ def test_ocr_tesseract_cli_passes_italic_detection_options(
 
 
 def test_ocr_tesseract_cli_rejects_italic_detection_for_non_english(
-    monkeypatch: MonkeyPatch,
-    tmp_path: Path,
+    monkeypatch: MonkeyPatch, tmp_path: Path
 ):
     """Test Tesseract OCR CLI rejects italic detection for non-English OCR."""
     input_path = test_data_root / "mlamd/input/zho-Hans_ocr/source.sup"
@@ -414,11 +391,7 @@ def test_ocr_tesseract_cli_rejects_italic_detection_for_non_english(
             "scinoephile.cli.ocr.ocr_lens_cli.ocr_image_series_with_lens",
             "scinoephile.cli.ocr.ocr_lens_cli.write_series",
             "--language zho-Hans --retries 5",
-            {
-                "language": Language.zho_hans,
-                "overwrite_cache": True,
-                "retries": 5,
-            },
+            {"language": Language.zho_hans, "overwrite_cache": True, "retries": 5},
         ),
         (
             OcrPaddleCli,
@@ -434,11 +407,7 @@ def test_ocr_tesseract_cli_rejects_italic_detection_for_non_english(
             "scinoephile.cli.ocr.ocr_tesseract_cli.ocr_image_series_with_tesseract",
             "scinoephile.cli.ocr.ocr_tesseract_cli.write_series",
             "--detect-italics",
-            {
-                "detect_italics": True,
-                "language": Language.eng,
-                "overwrite_cache": True,
-            },
+            {"detect_italics": True, "language": Language.eng, "overwrite_cache": True},
         ),
     ],
 )
@@ -466,11 +435,7 @@ def test_ocr_engine_clis_delegate_subtitle_outputs_to_writer(
         extra_args: operation arguments for the CLI under test
         expected_ocr_kwargs: expected keyword arguments passed to OCR operation
     """
-    input_paths = _patch_image_series_load(
-        monkeypatch,
-        load_target,
-        tiny_image_series,
-    )
+    input_paths = _patch_image_series_load(monkeypatch, load_target, tiny_image_series)
     input_path = _write_placeholder_sup_path(tmp_path)
     recognized_series = Series(
         events=[Subtitle(start=1000, end=2000, text="recognized")]
@@ -491,10 +456,7 @@ def test_ocr_engine_clis_delegate_subtitle_outputs_to_writer(
         return recognized_series
 
     def fake_write_series(
-        parser: object,
-        series: Series,
-        outfile: str | Path,
-        overwrite: bool,
+        parser: object, series: Series, outfile: str | Path, overwrite: bool
     ):
         """Fake subtitle output writing.
 
@@ -539,8 +501,7 @@ def test_ocr_engine_clis_delegate_subtitle_outputs_to_writer(
     ),
 )
 def test_ocr_lens_cli_matches_mlamd_sup_ocr_fixture(
-    monkeypatch: MonkeyPatch,
-    tmp_path: Path,
+    monkeypatch: MonkeyPatch, tmp_path: Path
 ):
     """Test Google Lens CLI against a full MLAMD SUP subtitle fixture.
 
@@ -572,11 +533,7 @@ def test_ocr_lens_cli_matches_mlamd_sup_ocr_fixture(
     reason="Set SCINOEPHILE_RUN_MLAMD_PADDLE_OCR=1 to run full MLAMD PaddleOCR tests",
 )
 @parametrize(
-    (
-        "sup_path",
-        "language",
-        "expected_path",
-    ),
+    ("sup_path", "language", "expected_path"),
     [
         (
             "mlamd/input/zho-Hans_ocr/source.sup",

--- a/test/cli/ocr/test_ocr_fuse_cli.py
+++ b/test/cli/ocr/test_ocr_fuse_cli.py
@@ -53,10 +53,7 @@ def test_ocr_fuse_cli_uses_concise_json_help():
     ],
 )
 def test_ocr_fuse_cli(
-    lens_path: str,
-    secondary_path: str,
-    args: str,
-    expected_path: str,
+    lens_path: str, secondary_path: str, args: str, expected_path: str
 ):
     """Test OCR fusion CLI with file arguments.
 
@@ -101,10 +98,7 @@ def test_ocr_fuse_cli(
     ],
 )
 def test_ocr_fuse_cli_pipe(
-    lens_path: str,
-    secondary_path: str,
-    args: str,
-    expected_path: str,
+    lens_path: str, secondary_path: str, args: str, expected_path: str
 ):
     """Test OCR fusion CLI via stdin and stdout.
 
@@ -146,14 +140,12 @@ def test_ocr_fuse_cli_passes_test_case_path(tmp_path: Path):
     cache_root_path = tmp_path / "cache"
     lens_path.write_text("1\n00:00:00,000 --> 00:00:00,500\nLens\n", encoding="utf-8")
     tesseract_path.write_text(
-        "1\n00:00:00,000 --> 00:00:00,500\nTesseract\n",
-        encoding="utf-8",
+        "1\n00:00:00,000 --> 00:00:00,500\nTesseract\n", encoding="utf-8"
     )
     fused = Series(events=[Subtitle(start=0, end=500, text="Fused")])
 
     with patch(
-        "scinoephile.cli.ocr.ocr_fuse_cli.fuse_ocr_series",
-        return_value=fused,
+        "scinoephile.cli.ocr.ocr_fuse_cli.fuse_ocr_series", return_value=fused
     ) as fuse:
         run_cli_with_args(
             OcrFuseCli,

--- a/test/cli/ocr/test_ocr_process_cli.py
+++ b/test/cli/ocr/test_ocr_process_cli.py
@@ -85,8 +85,7 @@ def test_ocr_process_cli_passes_eng_arguments_to_workflow(tmp_path: Path):
 
     with (
         patch(
-            "scinoephile.cli.ocr.ocr_process_cli.get_provider",
-            side_effect=get_provider,
+            "scinoephile.cli.ocr.ocr_process_cli.get_provider", side_effect=get_provider
         ),
         patch(
             "scinoephile.cli.ocr.ocr_process_cli.OcrProcessingWorkflow",

--- a/test/cli/ocr/test_ocr_validate_cli.py
+++ b/test/cli/ocr/test_ocr_validate_cli.py
@@ -53,8 +53,7 @@ def test_ocr_validate_cli(monkeypatch: MonkeyPatch, tmp_path: Path):
         outfile_path_arg.write_text("validated", encoding="utf-8")
 
     monkeypatch.setattr(
-        "scinoephile.cli.ocr.ocr_validate_cli.validate_ocr",
-        fake_validate_ocr,
+        "scinoephile.cli.ocr.ocr_validate_cli.validate_ocr", fake_validate_ocr
     )
 
     outfile_path = tmp_path / "validated.srt"
@@ -118,8 +117,7 @@ def test_ocr_validate_cli_web(monkeypatch: MonkeyPatch, tmp_path: Path):
         )
 
     monkeypatch.setattr(
-        "scinoephile.cli.ocr.ocr_validate_cli.validate_ocr",
-        fake_validate_ocr,
+        "scinoephile.cli.ocr.ocr_validate_cli.validate_ocr", fake_validate_ocr
     )
 
     outfile_path = tmp_path / "validated.srt"
@@ -156,8 +154,7 @@ def test_ocr_validate_cli_names_persistent_data_separately_from_cache():
 
 
 def test_ocr_validate_cli_web_rejects_sup_input(
-    capsys: CaptureFixture[str],
-    tmp_path: Path,
+    capsys: CaptureFixture[str], tmp_path: Path
 ):
     """Test OCR validate web mode requires a prepared OCR image directory.
 
@@ -180,9 +177,7 @@ def test_ocr_validate_cli_web_rejects_sup_input(
 
 
 def test_ocr_validate_cli_web_delegates_image_dir_validation(
-    capsys: CaptureFixture[str],
-    monkeypatch: MonkeyPatch,
-    tmp_path: Path,
+    capsys: CaptureFixture[str], monkeypatch: MonkeyPatch, tmp_path: Path
 ):
     """Test web mode lets the session validate OCR image directory contents.
 
@@ -199,8 +194,7 @@ def test_ocr_validate_cli_web_delegates_image_dir_validation(
         raise ScinoephileError("session checked OCR image directory")
 
     monkeypatch.setattr(
-        "scinoephile.cli.ocr.ocr_validate_cli.validate_ocr",
-        fake_validate_ocr,
+        "scinoephile.cli.ocr.ocr_validate_cli.validate_ocr", fake_validate_ocr
     )
 
     with raises(SystemExit, match="2"):

--- a/test/cli/test_argument_group_order.py
+++ b/test/cli/test_argument_group_order.py
@@ -26,10 +26,7 @@ _GROUP_ORDER = (
 
 def test_cli_argument_groups_follow_canonical_order():
     """Test every command's populated argument groups use canonical order."""
-    for path, parser in _iter_parsers(
-        ScinoephileCli.argparser(),
-        ("scinoephile",),
-    ):
+    for path, parser in _iter_parsers(ScinoephileCli.argparser(), ("scinoephile",)):
         titles = [
             group.title
             for group in parser._action_groups  # noqa: SLF001
@@ -40,8 +37,7 @@ def test_cli_argument_groups_follow_canonical_order():
 
 
 def _iter_parsers(
-    parser: ArgumentParser,
-    path: tuple[str, ...],
+    parser: ArgumentParser, path: tuple[str, ...]
 ) -> Iterator[tuple[tuple[str, ...], ArgumentParser]]:
     """Iterate over a parser and all of its subcommand parsers.
 
@@ -56,7 +52,4 @@ def _iter_parsers(
         if not isinstance(action, _SubParsersAction):
             continue
         for name, subparser in sorted(action.choices.items()):
-            yield from _iter_parsers(
-                cast(ArgumentParser, subparser),
-                (*path, name),
-            )
+            yield from _iter_parsers(cast(ArgumentParser, subparser), (*path, name))

--- a/test/cli/test_audit_aligned_diff_cli.py
+++ b/test/cli/test_audit_aligned_diff_cli.py
@@ -48,10 +48,7 @@ def test_audit_aligned_diff_cli_track_help_describes_alignment():
     )
 
 
-def test_audit_aligned_diff_cli_writes_report(
-    tmp_path: Path,
-    capsys: CaptureFixture,
-):
+def test_audit_aligned_diff_cli_writes_report(tmp_path: Path, capsys: CaptureFixture):
     """Test aligned diff audit output to stdout and a file.
 
     Arguments:
@@ -74,10 +71,7 @@ def test_audit_aligned_diff_cli_writes_report(
     assert "| T 1<br>R 1 | <pre>T │ 甲錯<br>R │ 甲正</pre> |  |" in stdout
 
     outfile_path = tmp_path / "audit.md"
-    run_cli_with_args(
-        AuditAlignedDiffCli,
-        f"{arguments} --outfile {outfile_path}",
-    )
+    run_cli_with_args(AuditAlignedDiffCli, f"{arguments} --outfile {outfile_path}")
     assert capsys.readouterr().out == ""
     assert outfile_path.read_text(encoding="utf-8") == stdout
 

--- a/test/cli/test_audit_cli.py
+++ b/test/cli/test_audit_cli.py
@@ -112,14 +112,8 @@ def test_audit_cli_uses_subtitle_block_help():
 @mark.parametrize(
     ("texts", "label"),
     (
-        (
-            ("他们正在这里", "我们没有这个东西", "她说这是真的吗"),
-            "Simplified Chinese",
-        ),
-        (
-            ("他們正在這裡", "我們沒有這個東西", "她說這是真的嗎"),
-            "Traditional Chinese",
-        ),
+        (("他们正在这里", "我们没有这个东西", "她说这是真的吗"), "Simplified Chinese"),
+        (("他們正在這裡", "我們沒有這個東西", "她說這是真的嗎"), "Traditional Chinese"),
         (
             ("我唔知点解你冇这个", "佢哋系咪想睇这个", "咁样冇嘢喺这边"),
             "Simplified Cantonese",
@@ -131,10 +125,7 @@ def test_audit_cli_uses_subtitle_block_help():
     ),
 )
 def test_audit_review_cli_detects_chinese_language_and_script(
-    tmp_path: Path,
-    capsys: CaptureFixture,
-    texts: tuple[str, ...],
-    label: str,
+    tmp_path: Path, capsys: CaptureFixture, texts: tuple[str, ...], label: str
 ):
     """Test single reviews detect Chinese language and script combinations.
 
@@ -150,8 +141,7 @@ def test_audit_review_cli_detects_chinese_language_and_script(
     _write_srt(reviewed_path, (f"{texts[0]}！", *texts[1:]))
 
     run_cli_with_args(
-        AuditReviewCli,
-        f"--original {original_path} --reviewed {reviewed_path}",
+        AuditReviewCli, f"--original {original_path} --reviewed {reviewed_path}"
     )
 
     stdout = capsys.readouterr().out
@@ -182,8 +172,7 @@ def test_audit_review_cli_detects_language(tmp_path: Path, capsys: CaptureFixtur
     )
 
     run_cli_with_args(
-        AuditReviewCli,
-        f"--original {original_path} --reviewed {reviewed_path}",
+        AuditReviewCli, f"--original {original_path} --reviewed {reviewed_path}"
     )
 
     stdout = capsys.readouterr().out
@@ -240,8 +229,7 @@ def test_audit_review_cli_detects_language(tmp_path: Path, capsys: CaptureFixtur
 
 
 def test_audit_review_cli_guided_mode_stdout_and_outfile(
-    tmp_path: Path,
-    capsys: CaptureFixture,
+    tmp_path: Path, capsys: CaptureFixture
 ):
     """Test guided-review audit output to stdout and a file.
 
@@ -264,11 +252,7 @@ def test_audit_review_cli_guided_mode_stdout_and_outfile(
                     },
                     "answer": {
                         "revisions": [
-                            {
-                                "index": 1,
-                                "text": "修訂",
-                                "note": "correction",
-                            }
+                            {"index": 1, "text": "修訂", "note": "correction"}
                         ]
                     },
                 }
@@ -280,8 +264,7 @@ def test_audit_review_cli_guided_mode_stdout_and_outfile(
     arguments = f"--original {target_path} --guide {guide_path} --json {json_path}"
 
     run_cli_with_args(
-        AuditReviewCli,
-        f"{arguments} --first-index 1 --last-index 1 --filter changes",
+        AuditReviewCli, f"{arguments} --first-index 1 --last-index 1 --filter changes"
     )
     stdout = capsys.readouterr().out
     assert stdout.startswith("# Guided Subtitle Review Audit\n")
@@ -291,36 +274,26 @@ def test_audit_review_cli_guided_mode_stdout_and_outfile(
     assert "| 1 | 1 | 參考 | 原文<br>修訂 | correction |  |" in stdout
 
     outfile_path = tmp_path / "audit.md"
-    run_cli_with_args(
-        AuditReviewCli,
-        f"{arguments} --outfile {outfile_path}",
-    )
+    run_cli_with_args(AuditReviewCli, f"{arguments} --outfile {outfile_path}")
     assert capsys.readouterr().out == ""
     assert outfile_path.read_text(encoding="utf-8").startswith(
         "# Guided Subtitle Review Audit\n"
     )
 
     with raises(SystemExit):
-        run_cli_with_args(
-            AuditReviewCli,
-            f"{arguments} --first-index 2 --last-index 1",
-        )
+        run_cli_with_args(AuditReviewCli, f"{arguments} --first-index 2 --last-index 1")
     assert "First index must be less than or equal to last index" in (
         capsys.readouterr().err
     )
 
     with raises(SystemExit):
         run_cli_with_args(
-            AuditReviewCli,
-            f"{arguments} --first-index 1 --first-block 1",
+            AuditReviewCli, f"{arguments} --first-index 1 --first-block 1"
         )
     assert "mutually exclusive" in capsys.readouterr().err
 
     with raises(SystemExit):
-        run_cli_with_args(
-            AuditReviewCli,
-            f"{arguments} --reviewed {target_path}",
-        )
+        run_cli_with_args(AuditReviewCli, f"{arguments} --reviewed {target_path}")
     assert "not allowed with argument --guide" in capsys.readouterr().err
 
     with raises(SystemExit):
@@ -369,8 +342,7 @@ def test_audit_review_cli_help_is_consistent():
 
 
 def test_audit_review_dual_cli_stdout_outfile_and_validation(
-    tmp_path: Path,
-    capsys: CaptureFixture,
+    tmp_path: Path, capsys: CaptureFixture
 ):
     """Test audit output and input validation.
 
@@ -380,14 +352,8 @@ def test_audit_review_dual_cli_stdout_outfile_and_validation(
     """
     original_path = tmp_path / "original.srt"
     reviewed_path = tmp_path / "reviewed.srt"
-    original_path.write_text(
-        "1\n00:00:01,000 --> 00:00:01,500\n錯\n",
-        encoding="utf-8",
-    )
-    reviewed_path.write_text(
-        "1\n00:00:01,000 --> 00:00:01,500\n正\n",
-        encoding="utf-8",
-    )
+    original_path.write_text("1\n00:00:01,000 --> 00:00:01,500\n錯\n", encoding="utf-8")
+    reviewed_path.write_text("1\n00:00:01,000 --> 00:00:01,500\n正\n", encoding="utf-8")
     arguments = (
         f"--traditional {original_path} "
         f"--traditional-reviewed {reviewed_path} "
@@ -397,19 +363,13 @@ def test_audit_review_dual_cli_stdout_outfile_and_validation(
         f"--simplified-reviewed {reviewed_path}"
     )
 
-    run_cli_with_args(
-        AuditReviewDualCli,
-        f"{arguments} --first-index 1 --last-index 1",
-    )
+    run_cli_with_args(AuditReviewDualCli, f"{arguments} --first-index 1 --last-index 1")
     stdout = capsys.readouterr().out
     assert stdout.startswith("# Review Audit\n")
     assert "- subtitle range: 1 through 1" in stdout
     assert "- table rows: 1" in stdout
 
-    run_cli_with_args(
-        AuditReviewDualCli,
-        f"{arguments} --first-block 1 --last-block 1",
-    )
+    run_cli_with_args(AuditReviewDualCli, f"{arguments} --first-block 1 --last-block 1")
     assert "- block range: 1 through 1" in capsys.readouterr().out
 
     run_cli_with_args(AuditReviewDualCli, f"{arguments} --characters 错这")
@@ -468,8 +428,7 @@ def test_audit_review_dual_cli_stdout_outfile_and_validation(
     assert "use --overwrite to replace it" in capsys.readouterr().err
 
     run_cli_with_args(
-        AuditReviewDualCli,
-        f"{arguments} --outfile {outfile_path} --overwrite",
+        AuditReviewDualCli, f"{arguments} --outfile {outfile_path} --overwrite"
     )
     assert capsys.readouterr().out == ""
 
@@ -479,8 +438,7 @@ def test_audit_review_dual_cli_stdout_outfile_and_validation(
 
     with raises(SystemExit):
         run_cli_with_args(
-            AuditReviewDualCli,
-            f"{arguments} --first-index 2 --last-index 1",
+            AuditReviewDualCli, f"{arguments} --first-index 2 --last-index 1"
         )
     assert "First index must be less than or equal to last index" in (
         capsys.readouterr().err
@@ -488,8 +446,7 @@ def test_audit_review_dual_cli_stdout_outfile_and_validation(
 
     with raises(SystemExit):
         run_cli_with_args(
-            AuditReviewDualCli,
-            f"{arguments} --first-index 1 --first-block 1",
+            AuditReviewDualCli, f"{arguments} --first-index 1 --first-block 1"
         )
     assert "Subtitle-index and block ranges are mutually exclusive" in (
         capsys.readouterr().err
@@ -529,20 +486,16 @@ def test_audit_review_trad_cli(tmp_path: Path, capsys: CaptureFixture):
     simplified_path = tmp_path / "simplified.srt"
     simplified_reviewed_path = tmp_path / "simplified_reviewed.srt"
     traditional_path.write_text(
-        "1\n00:00:01,000 --> 00:00:01,500\n傳錯\n",
-        encoding="utf-8",
+        "1\n00:00:01,000 --> 00:00:01,500\n傳錯\n", encoding="utf-8"
     )
     traditional_reviewed_path.write_text(
-        "1\n00:00:01,000 --> 00:00:01,500\n傳正\n",
-        encoding="utf-8",
+        "1\n00:00:01,000 --> 00:00:01,500\n傳正\n", encoding="utf-8"
     )
     simplified_path.write_text(
-        "1\n00:00:01,000 --> 00:00:01,500\n传错\n",
-        encoding="utf-8",
+        "1\n00:00:01,000 --> 00:00:01,500\n传错\n", encoding="utf-8"
     )
     simplified_reviewed_path.write_text(
-        "1\n00:00:01,000 --> 00:00:01,500\n传正\n",
-        encoding="utf-8",
+        "1\n00:00:01,000 --> 00:00:01,500\n传正\n", encoding="utf-8"
     )
 
     arguments = (
@@ -597,8 +550,7 @@ def test_audit_review_trad_cli(tmp_path: Path, capsys: CaptureFixture):
         f"--traditional-simplified-json {traditional_simplified_json_path}"
     )
     run_cli_with_args(
-        AuditReviewTradCli,
-        f"{arguments} {json_arguments} --filter unverified",
+        AuditReviewTradCli, f"{arguments} {json_arguments} --filter unverified"
     )
     stdout = capsys.readouterr().out
     assert "- row filter: unverified" in stdout
@@ -619,8 +571,7 @@ def test_audit_review_trad_cli(tmp_path: Path, capsys: CaptureFixture):
 
 
 def test_audit_translation_cli_infers_workflow_from_inputs(
-    tmp_path: Path,
-    capsys: CaptureFixture,
+    tmp_path: Path, capsys: CaptureFixture
 ):
     """Test translation audit workflow inference and input validation.
 
@@ -638,22 +589,17 @@ def test_audit_translation_cli_infers_workflow_from_inputs(
 
     # Infer standard translation from a source alone
     with patch.object(
-        AuditTranslationCli,
-        "_audit_standard",
-        return_value="standard\n",
+        AuditTranslationCli, "_audit_standard", return_value="standard\n"
     ) as audit_standard:
         run_cli_with_args(
-            AuditTranslationCli,
-            f"--source {source_path} --json {json_path}",
+            AuditTranslationCli, f"--source {source_path} --json {json_path}"
         )
     audit_standard.assert_called_once()
     assert capsys.readouterr().out == "standard\n"
 
     # Infer guided translation from a source and guide
     with patch.object(
-        AuditTranslationCli,
-        "_audit_guided",
-        return_value="guided\n",
+        AuditTranslationCli, "_audit_guided", return_value="guided\n"
     ) as audit_guided:
         run_cli_with_args(
             AuditTranslationCli,
@@ -664,9 +610,7 @@ def test_audit_translation_cli_infers_workflow_from_inputs(
 
     # Infer gapped translation from a target and guide
     with patch.object(
-        AuditTranslationCli,
-        "_audit_gapped",
-        return_value="gapped\n",
+        AuditTranslationCli, "_audit_gapped", return_value="gapped\n"
     ) as audit_gapped:
         run_cli_with_args(
             AuditTranslationCli,
@@ -678,8 +622,7 @@ def test_audit_translation_cli_infers_workflow_from_inputs(
     # Reject an incomplete gapped-translation input set
     with raises(SystemExit):
         run_cli_with_args(
-            AuditTranslationCli,
-            f"--target {target_path} --json {json_path}",
+            AuditTranslationCli, f"--target {target_path} --json {json_path}"
         )
     assert "--guide is required with --target" in capsys.readouterr().err
 
@@ -701,11 +644,7 @@ def test_audit_translation_cli_infers_workflow_from_inputs(
 
 def test_transcription_audit_cli_help_describes_subtitle_indexes():
     """Test transcription audit range help describes subtitle indexes."""
-    for cli_class in (
-        AuditAlignedDiffCli,
-        AuditDelineationCli,
-        AuditPunctuationCli,
-    ):
+    for cli_class in (AuditAlignedDiffCli, AuditDelineationCli, AuditPunctuationCli):
         actions = {
             action.dest: action
             for action in cli_class.argparser()._actions  # noqa: SLF001

--- a/test/cli/test_audit_ocr_fusion_cli.py
+++ b/test/cli/test_audit_ocr_fusion_cli.py
@@ -35,8 +35,7 @@ def test_audit_ocr_fusion_cli_filter_help_is_consistent():
 
 
 def test_audit_ocr_fusion_cli_writes_validated_discrepancy_report(
-    tmp_path: Path,
-    capsys: CaptureFixture,
+    tmp_path: Path, capsys: CaptureFixture
 ):
     """Test OCR-fusion audits write reports to stdout and explicit files.
 
@@ -80,29 +79,21 @@ def test_audit_ocr_fusion_cli_writes_validated_discrepancy_report(
 
     with raises(SystemExit):
         run_cli_with_args(
-            AuditOcrFusionCli,
-            f"{arguments} --first-index 1 --first-block 1",
+            AuditOcrFusionCli, f"{arguments} --first-index 1 --first-block 1"
         )
     assert "mutually exclusive" in capsys.readouterr().err
 
     outfile_path = tmp_path / "audit.md"
-    run_cli_with_args(
-        AuditOcrFusionCli,
-        f"{arguments} --outfile {outfile_path}",
-    )
+    run_cli_with_args(AuditOcrFusionCli, f"{arguments} --outfile {outfile_path}")
     assert capsys.readouterr().out == ""
     assert outfile_path.read_text(encoding="utf-8").startswith("# OCR Fusion Audit\n")
 
     with raises(SystemExit):
-        run_cli_with_args(
-            AuditOcrFusionCli,
-            f"{arguments} --outfile {outfile_path}",
-        )
+        run_cli_with_args(AuditOcrFusionCli, f"{arguments} --outfile {outfile_path}")
     assert "File exists" in capsys.readouterr().err
 
     run_cli_with_args(
-        AuditOcrFusionCli,
-        f"{arguments} --outfile {outfile_path} --overwrite",
+        AuditOcrFusionCli, f"{arguments} --outfile {outfile_path} --overwrite"
     )
     assert capsys.readouterr().out == ""
 
@@ -110,10 +101,7 @@ def test_audit_ocr_fusion_cli_writes_validated_discrepancy_report(
         f"--source-one {source_one_path} --source-two {source_two_path} "
         f"--fused {fused_path}"
     )
-    run_cli_with_args(
-        AuditOcrFusionCli,
-        f"{no_json_arguments} --filter unverified",
-    )
+    run_cli_with_args(AuditOcrFusionCli, f"{no_json_arguments} --filter unverified")
     report = capsys.readouterr().out
     assert "- row filter: unverified" in report
     assert "- table rows: 1" in report
@@ -121,15 +109,11 @@ def test_audit_ocr_fusion_cli_writes_validated_discrepancy_report(
 
     with raises(SystemExit):
         run_cli_with_args(
-            AuditOcrFusionCli,
-            f"{no_json_arguments} --filter discrepancies",
+            AuditOcrFusionCli, f"{no_json_arguments} --filter discrepancies"
         )
     assert "--filter discrepancies requires --validated" in capsys.readouterr().err
 
-    run_cli_with_args(
-        AuditOcrFusionCli,
-        no_json_arguments,
-    )
+    run_cli_with_args(AuditOcrFusionCli, no_json_arguments)
     report = capsys.readouterr().out
     assert "- decision log: omitted" in report
     assert (
@@ -146,6 +130,5 @@ def _write_srt(file_path: Path, text: str):
         text: subtitle text
     """
     file_path.write_text(
-        f"1\n00:00:00,000 --> 00:00:00,500\n{text}\n",
-        encoding="utf-8",
+        f"1\n00:00:00,000 --> 00:00:00,500\n{text}\n", encoding="utf-8"
     )

--- a/test/cli/test_cache_arguments.py
+++ b/test/cli/test_cache_arguments.py
@@ -39,9 +39,7 @@ from test.helpers import parametrize
         TranslateCli,
     ),
 )
-def test_cache_producing_cli_uses_shared_cache_arguments(
-    cli: type[ScinoephileCliBase],
-):
+def test_cache_producing_cli_uses_shared_cache_arguments(cli: type[ScinoephileCliBase]):
     """Test each cache-producing CLI exposes one shared cache section.
 
     Arguments:

--- a/test/cli/test_process_cli.py
+++ b/test/cli/test_process_cli.py
@@ -29,11 +29,7 @@ def test_process_cli_uses_concise_language_help():
 @parametrize(
     ("input_path", "args", "expected_path"),
     [
-        (
-            "mnt/output/eng_ocr/fuse.srt",
-            "--clean",
-            "mnt/output/eng_ocr/fuse_clean.srt",
-        ),
+        ("mnt/output/eng_ocr/fuse.srt", "--clean", "mnt/output/eng_ocr/fuse_clean.srt"),
         (
             "mnt/output/zho-Hans_ocr/fuse.srt",
             "--clean",
@@ -64,8 +60,7 @@ def test_process_cli(input_path: str, args: str, expected_path: str):
 
     with get_temp_file_path(".srt") as output_path:
         run_cli_with_args(
-            ProcessCli,
-            f"--infile {full_input_path} {args} --outfile {output_path}",
+            ProcessCli, f"--infile {full_input_path} {args} --outfile {output_path}"
         )
         output = Series.load(output_path)
         expected = Series.load(full_expected_path)
@@ -80,7 +75,7 @@ def test_process_cli(input_path: str, args: str, expected_path: str):
             "mnt/output/zho-Hans_ocr/fuse.srt",
             "--clean",
             "mnt/output/zho-Hans_ocr/fuse_clean.srt",
-        ),
+        )
     ],
 )
 def test_process_cli_pipe(input_path: str, args: str, expected_path: str):

--- a/test/cli/test_review_cli.py
+++ b/test/cli/test_review_cli.py
@@ -59,7 +59,7 @@ def test_review_cli_uses_guide_terminology():
             "kob/output/yue-Hant/clean.srt",
             "--language yue-Hant",
             "kob/output/yue-Hant/clean_review.srt",
-        ),
+        )
     ],
 )
 def test_review_cli(input_path: str, args: str, expected_path: str):
@@ -75,8 +75,7 @@ def test_review_cli(input_path: str, args: str, expected_path: str):
 
     with get_temp_file_path(".srt") as output_path:
         run_cli_with_args(
-            ReviewCli,
-            f"{full_input_path} {args} --outfile {output_path}",
+            ReviewCli, f"{full_input_path} {args} --outfile {output_path}"
         )
         output = Series.load(output_path)
         expected = Series.load(full_expected_path)
@@ -91,7 +90,7 @@ def test_review_cli(input_path: str, args: str, expected_path: str):
             "mnt/output/eng_ocr/fuse_clean_validate.srt",
             "",
             "mnt/output/eng_ocr/fuse_clean_validate_review.srt",
-        ),
+        )
     ],
 )
 def test_review_cli_pipe(input_path: str, args: str, expected_path: str):
@@ -120,15 +119,10 @@ def test_review_cli_pipe(input_path: str, args: str, expected_path: str):
 
 @parametrize(
     ("workflow_name", "guide_argument"),
-    [
-        ("review_series", ""),
-        ("review_series_guided", "--guide-infile"),
-    ],
+    [("review_series", ""), ("review_series_guided", "--guide-infile")],
 )
 def test_review_cli_passes_block_range(
-    workflow_name: str,
-    guide_argument: str,
-    tmp_path: Path,
+    workflow_name: str, guide_argument: str, tmp_path: Path
 ):
     """Test block ranges and JSON paths are forwarded through every review mode.
 
@@ -145,8 +139,7 @@ def test_review_cli_passes_block_range(
     cache_root_path = tmp_path / "cache"
 
     with patch(
-        f"scinoephile.cli.review_cli.{workflow_name}",
-        return_value=Series(),
+        f"scinoephile.cli.review_cli.{workflow_name}", return_value=Series()
     ) as workflow:
         with patch("scinoephile.cli.review_cli.write_series"):
             run_cli_with_args(
@@ -170,19 +163,10 @@ def test_review_cli_rejects_reversed_block_range():
     input_path = test_data_root / "mnt/output/eng_ocr/fuse_clean_validate.srt"
 
     with raises(SystemExit, match="2"):
-        run_cli_with_args(
-            ReviewCli,
-            f"{input_path} --first-block 3 --last-block 2",
-        )
+        run_cli_with_args(ReviewCli, f"{input_path} --first-block 3 --last-block 2")
 
 
-@parametrize(
-    "guide_args",
-    (
-        "",
-        "--guide-infile {input_path}",
-    ),
-)
+@parametrize("guide_args", ("", "--guide-infile {input_path}"))
 def test_review_cli_rejects_oversized_last_block(guide_args: str):
     """Test the last selected block cannot exceed the available block count.
 
@@ -195,6 +179,5 @@ def test_review_cli_rejects_oversized_last_block(guide_args: str):
 
     with raises(SystemExit, match="2"):
         run_cli_with_args(
-            ReviewCli,
-            f"{input_path} {guide_args} --last-block {block_count + 1}",
+            ReviewCli, f"{input_path} {guide_args} --last-block {block_count + 1}"
         )

--- a/test/cli/test_transcribe_cli.py
+++ b/test/cli/test_transcribe_cli.py
@@ -34,10 +34,7 @@ def audio_series() -> Mock:
 @fixture
 def expected_series() -> Series:
     """Get the expected transcribed subtitle series."""
-    return Series.from_string(
-        "1\n00:00:00,000 --> 00:00:01,000\n你好\n",
-        format_="srt",
-    )
+    return Series.from_string("1\n00:00:00,000 --> 00:00:01,000\n你好\n", format_="srt")
 
 
 def test_transcribe_cli_is_top_level_command():
@@ -118,10 +115,7 @@ def test_transcribe_cli_defaults_audio_preprocessing_to_auto():
     assert vad_action.default is VADMode.AUTO
 
 
-def test_transcribe_cli_writes_file(
-    audio_series: Mock,
-    expected_series: Series,
-):
+def test_transcribe_cli_writes_file(audio_series: Mock, expected_series: Series):
     """Test generic transcription CLI writes file output.
 
     Arguments:
@@ -148,10 +142,7 @@ def test_transcribe_cli_writes_file(
     assert_series_equal(output_series, expected_series)
 
 
-def test_transcribe_cli_writes_stdout(
-    audio_series: Mock,
-    expected_series: Series,
-):
+def test_transcribe_cli_writes_stdout(audio_series: Mock, expected_series: Series):
     """Test generic transcription CLI writes stdout output.
 
     Arguments:
@@ -181,9 +172,7 @@ def test_transcribe_cli_writes_stdout(
 
 
 def test_transcribe_cli_passes_generic_configuration(
-    audio_series: Mock,
-    expected_series: Series,
-    tmp_path: Path,
+    audio_series: Mock, expected_series: Series, tmp_path: Path
 ):
     """Test transcription CLI passes generic language and model configuration.
 
@@ -344,8 +333,7 @@ def test_transcribe_cli_workflow_errors_are_user_facing(audio_series: Mock):
 
 
 def test_transcribe_cli_allows_stdin_guide_infile(
-    audio_series: Mock,
-    expected_series: Series,
+    audio_series: Mock, expected_series: Series
 ):
     """Test transcription CLI allows stdin guide subtitle input.
 
@@ -358,10 +346,7 @@ def test_transcribe_cli_allows_stdin_guide_infile(
     subtitle_paths: list[object] = []
 
     def load_from_media(
-        *,
-        media_path: str,
-        subtitle_path: object,
-        stream_index: int | None,
+        *, media_path: str, subtitle_path: object, stream_index: int | None
     ) -> AudioSeries:
         """Record media loading inputs."""
         assert media_path == _MEDIA_INFILE_PATH

--- a/test/cli/test_translate_cli.py
+++ b/test/cli/test_translate_cli.py
@@ -53,9 +53,7 @@ def test_translate_cli_help_includes_block_range():
     ),
 )
 def test_translate_cli_passes_block_range(
-    workflow_name: str,
-    mode_arguments: str,
-    tmp_path: Path,
+    workflow_name: str, mode_arguments: str, tmp_path: Path
 ):
     """Test block ranges and JSON paths reach every translation mode.
 
@@ -70,8 +68,7 @@ def test_translate_cli_passes_block_range(
     cache_root_path = tmp_path / "cache"
 
     with patch(
-        f"scinoephile.cli.translate_cli.{workflow_name}",
-        return_value=Series(),
+        f"scinoephile.cli.translate_cli.{workflow_name}", return_value=Series()
     ) as workflow:
         with patch("scinoephile.cli.translate_cli.write_series"):
             run_cli_with_args(

--- a/test/cli/utility/optimization/test_optimization_cli.py
+++ b/test/cli/utility/optimization/test_optimization_cli.py
@@ -28,10 +28,7 @@ def test_optimization_subcommand_help():
         assert_cli_help((ScinoephileCli, UtilityCli, OptimizationCli, cli_class))
 
 
-def test_sync_prompts_cli_dry_run(
-    tmp_path: Path,
-    capsys: CaptureFixture[str],
-):
+def test_sync_prompts_cli_dry_run(tmp_path: Path, capsys: CaptureFixture[str]):
     """The prompt synchronization CLI should report a read-only dry run.
 
     Arguments:
@@ -51,8 +48,7 @@ def test_sync_prompts_cli_dry_run(
 
 
 def test_sync_prompts_cli_writes_selected_alias(
-    tmp_path: Path,
-    capsys: CaptureFixture[str],
+    tmp_path: Path, capsys: CaptureFixture[str]
 ):
     """The prompt synchronization CLI should persist an explicit alias.
 
@@ -63,8 +59,7 @@ def test_sync_prompts_cli_writes_selected_alias(
     database_path = tmp_path / "optimization.sqlite"
 
     run_cli_with_args(
-        OptimizationSyncPromptsCli,
-        f"--prompt review-eng --outfile {database_path}",
+        OptimizationSyncPromptsCli, f"--prompt review-eng --outfile {database_path}"
     )
 
     assert "'prompts': 1" in capsys.readouterr().out

--- a/test/common/argument_parsing/test_arg_groups.py
+++ b/test/common/argument_parsing/test_arg_groups.py
@@ -96,9 +96,7 @@ def test_get_arg_groups_by_name_preserves_unspecified_group_order():
     parser.add_argument_group("output arguments")
 
     get_arg_groups_by_name(
-        parser,
-        "input arguments",
-        optional_arguments_name="additional arguments",
+        parser, "input arguments", optional_arguments_name="additional arguments"
     )
 
     group_titles = [ag.title for ag in parser._action_groups]

--- a/test/common/argument_parsing/test_integration.py
+++ b/test/common/argument_parsing/test_integration.py
@@ -7,10 +7,7 @@ from __future__ import annotations
 from argparse import ArgumentParser
 from pathlib import Path
 
-from scinoephile.common.argument_parsing import (
-    input_file_arg,
-    int_arg,
-)
+from scinoephile.common.argument_parsing import input_file_arg, int_arg
 
 
 def test_validators_in_argparse(tmp_path: Path):

--- a/test/common/cli/test_list_all_commands_action.py
+++ b/test/common/cli/test_list_all_commands_action.py
@@ -84,9 +84,7 @@ def test_format_command_row_wraps_long_command_description_readably():
     """Test long command names do not break description wrapping."""
     command_name = "command-name-that-is-longer-than-the-help-position"
     output = ListAllCommandsAction.format_command_row(
-        command_name,
-        "description text that should stay readable",
-        len(command_name),
+        command_name, "description text that should stay readable", len(command_name)
     )
 
     assert output.startswith(f"{command_name}\n")

--- a/test/common/subprocess/test_run_command.py
+++ b/test/common/subprocess/test_run_command.py
@@ -22,8 +22,7 @@ from test.helpers.subprocess_cases import SUBPROCESS_SUCCESS_CASES
     ids=[name for name, _, _ in SUBPROCESS_SUCCESS_CASES],
 )
 def test_run_command_success_cases(
-    command: list[str],
-    expected_stdout_fragments: tuple[str, ...],
+    command: list[str], expected_stdout_fragments: tuple[str, ...]
 ):
     """Test running successful commands.
 
@@ -62,8 +61,7 @@ def test_run_command_failure_default():
 def test_run_command_failure_custom_acceptable():
     """Test running a command with custom acceptable exitcodes."""
     exitcode, stdout, stderr = run_command(
-        [sys.executable, "-c", "import sys; sys.exit(42)"],
-        acceptable_exitcodes=[42],
+        [sys.executable, "-c", "import sys; sys.exit(42)"], acceptable_exitcodes=[42]
     )
 
     assert exitcode == 42
@@ -76,11 +74,7 @@ def test_run_command_with_cwd_path(tmp_path: Path):
         tmp_path: temporary directory provided by pytest
     """
     exitcode, stdout, stderr = run_command(
-        [
-            sys.executable,
-            "-c",
-            "from pathlib import Path; print(Path.cwd())",
-        ],
+        [sys.executable, "-c", "from pathlib import Path; print(Path.cwd())"],
         cwd_path=tmp_path,
     )
 
@@ -128,8 +122,7 @@ def test_run_command_unicode_output():
     env["PYTHONIOENCODING"] = "utf-8"
 
     exitcode, stdout, stderr = run_command(
-        [sys.executable, "-c", "print('Hello 世界')"],
-        env=env,
+        [sys.executable, "-c", "print('Hello 世界')"], env=env
     )
 
     assert exitcode == 0

--- a/test/common/subprocess/test_run_command_live.py
+++ b/test/common/subprocess/test_run_command_live.py
@@ -23,8 +23,7 @@ from test.helpers.subprocess_cases import SUBPROCESS_SUCCESS_CASES
     ids=[name for name, _, _ in SUBPROCESS_SUCCESS_CASES],
 )
 def test_run_command_live_success_cases(
-    command: list[str],
-    expected_stdout_fragments: tuple[str, ...],
+    command: list[str], expected_stdout_fragments: tuple[str, ...]
 ):
     """Test running successful commands with live output.
 
@@ -62,8 +61,7 @@ def test_run_command_live_failure_default():
 def test_run_command_live_failure_custom_acceptable():
     """Test running a command with custom acceptable exitcodes."""
     exitcode, stdout, stderr = run_command_live(
-        [sys.executable, "-c", "import sys; sys.exit(42)"],
-        acceptable_exitcodes=[42],
+        [sys.executable, "-c", "import sys; sys.exit(42)"], acceptable_exitcodes=[42]
     )
 
     assert exitcode == 42
@@ -76,11 +74,7 @@ def test_run_command_live_with_cwd_path(tmp_path: Path):
         tmp_path: temporary directory provided by pytest
     """
     exitcode, stdout, stderr = run_command_live(
-        [
-            sys.executable,
-            "-c",
-            "from pathlib import Path; print(Path.cwd())",
-        ],
+        [sys.executable, "-c", "from pathlib import Path; print(Path.cwd())"],
         cwd_path=tmp_path,
     )
 

--- a/test/common/test_command_line_interface.py
+++ b/test/common/test_command_line_interface.py
@@ -11,9 +11,7 @@ from unittest.mock import patch
 
 from pytest import MonkeyPatch, raises
 
-from scinoephile.common.command_line_interface import (
-    CommandLineInterface,
-)
+from scinoephile.common.command_line_interface import CommandLineInterface
 from scinoephile.common.testing import run_cli_with_args
 from test import helpers
 from test.helpers import parametrize
@@ -101,11 +99,7 @@ class ReportTool(CommandLineInterface):
 
 @parametrize(
     ("cli_cls", "expected_name"),
-    [
-        (TestCli, "test"),
-        (AnotherTestCli, "anothertest"),
-        (ReportTool, "reporttool"),
-    ],
+    [(TestCli, "test"), (AnotherTestCli, "anothertest"), (ReportTool, "reporttool")],
 )
 def test_name(cli_cls: type[CommandLineInterface], expected_name: str):
     """Test CLI name derivation.
@@ -259,9 +253,7 @@ def test_assert_cli_usage_failure_reports_streams(monkeypatch: MonkeyPatch):
         monkeypatch: pytest monkeypatch fixture
     """
     monkeypatch.setattr(
-        helpers,
-        "get_usage_prefix",
-        lambda cli: "usage: intentionally-wrong.py",
+        helpers, "get_usage_prefix", lambda cli: "usage: intentionally-wrong.py"
     )
 
     with raises(AssertionError) as excinfo:

--- a/test/common/test_csv.py
+++ b/test/common/test_csv.py
@@ -6,10 +6,7 @@ from __future__ import annotations
 
 from pytest import raises
 
-from scinoephile.common.csv import (
-    parse_csv_int_list,
-    parse_csv_str_list,
-)
+from scinoephile.common.csv import parse_csv_int_list, parse_csv_str_list
 
 
 def test_parse_csv_int_list_empty():

--- a/test/common/test_exceptions.py
+++ b/test/common/test_exceptions.py
@@ -33,8 +33,7 @@ from test.helpers import parametrize
     ],
 )
 def test_exception_inheritance(
-    exception_cls: type[Exception],
-    base_cls: type[Exception],
+    exception_cls: type[Exception], base_cls: type[Exception]
 ):
     """Test custom exception inheritance.
 

--- a/test/common/test_logs.py
+++ b/test/common/test_logs.py
@@ -12,13 +12,7 @@ from test.helpers import parametrize
 
 @parametrize(
     ("verbosity", "expected_level"),
-    [
-        (0, ERROR),
-        (1, WARNING),
-        (2, INFO),
-        (3, DEBUG),
-        (10, DEBUG),
-    ],
+    [(0, ERROR), (1, WARNING), (2, INFO), (3, DEBUG), (10, DEBUG)],
 )
 def test_set_logging_verbosity(verbosity: int, expected_level: int):
     """Test logging level for verbosity values.

--- a/test/common/validation/test_val_child_path.py
+++ b/test/common/validation/test_val_child_path.py
@@ -42,8 +42,7 @@ def test_val_child_path_accepts_contained_filename(tmp_path: Path):
     ],
 )
 def test_val_child_path_rejects_non_filename_components(
-    child_name: str,
-    tmp_path: Path,
+    child_name: str, tmp_path: Path
 ):
     """Test child path validation rejects paths and special components.
 

--- a/test/common/validation/test_val_float.py
+++ b/test/common/validation/test_val_float.py
@@ -15,13 +15,7 @@ from test.helpers import parametrize
 
 
 @parametrize(
-    ("value", "expected"),
-    [
-        (3.14, 3.14),
-        (5, 5.0),
-        ("3.14", 3.14),
-        (-1.5, -1.5),
-    ],
+    ("value", "expected"), [(3.14, 3.14), (5, 5.0), ("3.14", 3.14), (-1.5, -1.5)]
 )
 def test_val_float_accepts_scalar_values(value: float | int | str, expected: float):
     """Test float validation accepts scalar values."""
@@ -30,10 +24,7 @@ def test_val_float_accepts_scalar_values(value: float | int | str, expected: flo
 
 @parametrize(
     ("constraint", "value", "expected_error"),
-    [
-        ("min", -1.0, "less than minimum"),
-        ("max", 11.0, "greater than maximum"),
-    ],
+    [("min", -1.0, "less than minimum"), ("max", 11.0, "greater than maximum")],
 )
 def test_val_float_rejects_scalar_constraint_violations(
     constraint: str, value: float, expected_error: str

--- a/test/common/validation/test_val_int.py
+++ b/test/common/validation/test_val_int.py
@@ -14,15 +14,7 @@ from scinoephile.common.validation import val_int
 from test.helpers import parametrize
 
 
-@parametrize(
-    ("value", "expected"),
-    [
-        (5, 5),
-        (5.0, 5),
-        ("5", 5),
-        (-3, -3),
-    ],
-)
+@parametrize(("value", "expected"), [(5, 5), (5.0, 5), ("5", 5), (-3, -3)])
 def test_val_int_accepts_scalar_values(value: float | int | str, expected: int):
     """Test int validation accepts scalar values."""
     assert val_int(value) == expected

--- a/test/common/validation/test_val_str.py
+++ b/test/common/validation/test_val_str.py
@@ -43,8 +43,7 @@ def test_val_str_invalid_type():
     This doesn't match any of the provided options, so ValueError is raised.
     """
     with raises(
-        ValueError,
-        match="'none' is not one of the supported values: option1, option2",
+        ValueError, match="'none' is not one of the supported values: option1, option2"
     ):
         val_str(None, ["option1", "option2"])
 

--- a/test/core/cache/test_operations.py
+++ b/test/core/cache/test_operations.py
@@ -60,8 +60,7 @@ def test_get_cache_entries_supports_nested_media_namespaces(tmp_path: Path):
     write_cache_file(tmp_path / "media/subtitles/first/2.srt", "one")
     write_cache_file(tmp_path / "media/subtitles/second/3.sup", "two")
     write_cache_file(
-        tmp_path / "media/subtitles/second/image-series/index.html",
-        "index",
+        tmp_path / "media/subtitles/second/image-series/index.html", "index"
     )
     write_cache_file(tmp_path / "media/subtitles/analysis/first.json", "analysis")
 
@@ -71,10 +70,7 @@ def test_get_cache_entries_supports_nested_media_namespaces(tmp_path: Path):
     ]
 
     subtitle_entries = get_cache_entries(tmp_path, namespace="media/subtitles")
-    analysis_entries = get_cache_entries(
-        tmp_path,
-        namespace="media/subtitles/analysis",
-    )
+    analysis_entries = get_cache_entries(tmp_path, namespace="media/subtitles/analysis")
 
     assert [entry.relative_path for entry in subtitle_entries] == [
         Path("media/subtitles/first"),
@@ -130,9 +126,7 @@ def test_prune_cache_prunes_individual_nested_namespace_entries(tmp_path: Path):
     set_mtime(old_path.parent, old_timestamp)
 
     deleted_entries = prune_cache(
-        tmp_path,
-        older_than=timedelta(days=30),
-        namespace="media/subtitles",
+        tmp_path, older_than=timedelta(days=30), namespace="media/subtitles"
     )
 
     assert [entry.relative_path for entry in deleted_entries] == [

--- a/test/core/cli/test_localizations.py
+++ b/test/core/cli/test_localizations.py
@@ -11,36 +11,19 @@ from scinoephile.core.cli.localization import merge_localizations
 def test_merge_localizations_merges_locale_text_in_order():
     """Test localization maps merge with later maps taking precedence."""
     shared = {
-        "zh-hans": {
-            "shared": "共享",
-            "override": "共享覆盖",
-        },
-        "zh-hant": {
-            "shared": "共享",
-        },
+        "zh-hans": {"shared": "共享", "override": "共享覆盖"},
+        "zh-hant": {"shared": "共享"},
     }
     cli_specific = {
-        "zh-hans": {
-            "override": "本地覆盖",
-            "specific": "本地",
-        },
-        "zh-hant": {
-            "specific": "本地",
-        },
+        "zh-hans": {"override": "本地覆盖", "specific": "本地"},
+        "zh-hant": {"specific": "本地"},
     }
 
     merged = merge_localizations(shared, cli_specific)
 
     assert merged == {
-        "zh-hans": {
-            "shared": "共享",
-            "override": "本地覆盖",
-            "specific": "本地",
-        },
-        "zh-hant": {
-            "shared": "共享",
-            "specific": "本地",
-        },
+        "zh-hans": {"shared": "共享", "override": "本地覆盖", "specific": "本地"},
+        "zh-hant": {"shared": "共享", "specific": "本地"},
     }
 
 
@@ -62,12 +45,12 @@ def test_merge_localizations_allows_cli_cache_text_override():
         "zh-hans": {
             "cache root directory path (default: %(default)s)": (
                 "命令专用缓存目录（默认：%(default)s）"
-            ),
+            )
         },
         "zh-hant": {
             "cache root directory path (default: %(default)s)": (
                 "命令專用快取目錄（預設：%(default)s）"
-            ),
+            )
         },
     }
 

--- a/test/core/dependencies/test_dependencies.py
+++ b/test/core/dependencies/test_dependencies.py
@@ -15,8 +15,7 @@ def test_dependency_exports_use_lazy_import_naming():
     module_names = sorted(
         module_info.name
         for module_info in iter_modules(
-            dependencies.__path__,
-            f"{dependencies.__name__}.",
+            dependencies.__path__, f"{dependencies.__name__}."
         )
         if not module_info.name.rsplit(".", 1)[-1].startswith("_")
     )

--- a/test/core/dictionaries/test_sqlite_store.py
+++ b/test/core/dictionaries/test_sqlite_store.py
@@ -40,9 +40,7 @@ def sample_entries() -> list[DictionaryEntry]:
             pinyin="shan1 keng1 shui3",
             jyutping="saan1 haang1 seoi2",
             frequency=1.0,
-            definitions=[
-                DictionaryDefinition(text="stream water"),
-            ],
+            definitions=[DictionaryDefinition(text="stream water")],
         ),
     ]
 
@@ -116,8 +114,7 @@ def test_sqlite_store_preserves_expected_schema(
 
 
 def test_sqlite_store_literal_like_lookups(
-    database_path: Path,
-    sample_source: DictionarySource,
+    database_path: Path, sample_source: DictionarySource
 ):
     """Test literal matching of LIKE wildcard characters in romanization."""
     entries = [
@@ -180,8 +177,7 @@ def test_sqlite_store_preserves_existing_database_when_rebuild_fails(
 
 
 def test_sqlite_store_collapses_duplicate_entries_and_definitions(
-    database_path: Path,
-    sample_source: DictionarySource,
+    database_path: Path, sample_source: DictionarySource
 ):
     """Test duplicate entries and definitions collapse through uniqueness rules."""
     definition = DictionaryDefinition(text="duplicate definition", label="noun")

--- a/test/core/llms/test_llm_cache.py
+++ b/test/core/llms/test_llm_cache.py
@@ -31,8 +31,7 @@ def test_llm_cache_uses_runtime_default(runtime_cache_root_path: Path):
 
 
 def test_llm_cache_path_includes_cache_version(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test LLM cache paths differ between cache versions."""
     cache = LlmCache(tmp_path, "translation")

--- a/test/core/llms/test_manager.py
+++ b/test/core/llms/test_manager.py
@@ -24,11 +24,7 @@ from scinoephile.llms.review import ReviewManager, ReviewPrompt, ReviewTestCase
 from scinoephile.llms.translation import TranslationManager, TranslationPrompt
 
 _LOCALIZED_REVIEW_PROMPT = ReviewPrompt(
-    subtitles="zimu",
-    revisions="xiugai",
-    index="xuhao",
-    text="wenben",
-    note="beizhu",
+    subtitles="zimu", revisions="xiugai", index="xuhao", text="wenben", note="beizhu"
 )
 """Review prompt using localized correspondence field names."""
 
@@ -42,9 +38,7 @@ _ALTERNATIVE_REVIEW_PROMPT = ReviewPrompt(
 """Review prompt using alternative correspondence field names."""
 
 _LOCALIZED_PUNCTUATION_PROMPT = PunctuationPrompt(
-    ref_sub="source_two",
-    target_subs="source_one",
-    target_sub_punctuated="result",
+    ref_sub="source_two", target_subs="source_one", target_sub_punctuated="result"
 )
 """Punctuation prompt using non-default correspondence field names."""
 
@@ -70,8 +64,7 @@ def test_manager_reuses_static_test_case_prompt(manager_cls: type[Manager]):
 def test_manager_rejects_incompatible_prompt_type():
     """Managers should reject prompts belonging to another operation."""
     with raises(
-        TypeError,
-        match="ReviewManager requires ReviewPrompt; got TranslationPrompt",
+        TypeError, match="ReviewManager requires ReviewPrompt; got TranslationPrompt"
     ):
         ReviewManager.get_test_case_cls(TranslationPrompt())
 
@@ -112,13 +105,7 @@ def test_prompt_specific_classes_revalidate_by_semantic_field_name():
         {
             "query": {"zimu": [{"xuhao": 1, "wenben": "original"}]},
             "answer": {
-                "xiugai": [
-                    {
-                        "xuhao": 1,
-                        "wenben": "corrected",
-                        "beizhu": "typo",
-                    }
-                ]
+                "xiugai": [{"xuhao": 1, "wenben": "corrected", "beizhu": "typo"}]
             },
         }
     )
@@ -131,13 +118,7 @@ def test_prompt_specific_classes_revalidate_by_semantic_field_name():
     }
     assert alternative.answer is not None
     assert alternative.answer.model_dump(by_alias=True) == {
-        "corrections": [
-            {
-                "position": 1,
-                "content": "corrected",
-                "explanation": "typo",
-            }
-        ]
+        "corrections": [{"position": 1, "content": "corrected", "explanation": "typo"}]
     }
 
 
@@ -162,10 +143,7 @@ def test_punctuation_factory_uses_static_fields_with_prompt_aliases():
             "answer": {"output": "Hello"},
         }
     )
-    assert test_case.query.model_dump() == {
-        "subtitles": ["Hello"],
-        "guide": "Hello",
-    }
+    assert test_case.query.model_dump() == {"subtitles": ["Hello"], "guide": "Hello"}
     assert test_case.answer is not None
     assert test_case.answer.model_dump() == {"output": "Hello"}
     assert test_case.query.model_dump(by_alias=True) == {

--- a/test/core/llms/test_openai_provider_base.py
+++ b/test/core/llms/test_openai_provider_base.py
@@ -106,10 +106,7 @@ class _DummyClient:
         self._round = 0
 
         def create(
-            *,
-            messages: list[dict[str, object]],
-            model: str,
-            **kwargs: Any,
+            *, messages: list[dict[str, object]], model: str, **kwargs: Any
         ) -> _Completion:
             """Create one dummy chat completion.
 
@@ -133,10 +130,7 @@ class _DummyClient:
             return _Completion(_Message(content="done", tool_calls=[]))
 
         def parse(
-            *,
-            messages: list[dict[str, object]],
-            model: str,
-            **kwargs: Any,
+            *, messages: list[dict[str, object]], model: str, **kwargs: Any
         ) -> _Completion:
             """Parse one structured dummy chat completion.
 
@@ -231,8 +225,7 @@ def test_structured_response_validation_error_is_wrapped():
 
     with raises(ScinoephileError, match="failed structured response validation"):
         provider.chat_completion(
-            messages=[{"role": "user", "content": "hi"}],
-            response_format=_Answer,
+            messages=[{"role": "user", "content": "hi"}], response_format=_Answer
         )
 
 
@@ -286,20 +279,14 @@ def test_build_openai_tools_enables_strict_tools_by_default():
 
 def test_tool_box_run_returns_error_for_unsupported_tool():
     """Test unknown tool names produce an error payload."""
-    result = ToolBox().run(
-        tool_name="missing",
-        raw_arguments="{}",
-    )
+    result = ToolBox().run(tool_name="missing", raw_arguments="{}")
 
     assert result == {"error": "Unsupported tool 'missing'."}
 
 
 def test_tool_box_run_returns_error_for_invalid_json_arguments():
     """Test invalid tool-call JSON produces an error payload."""
-    result = _get_tool_box(lambda args: args).run(
-        tool_name="do",
-        raw_arguments="{",
-    )
+    result = _get_tool_box(lambda args: args).run(tool_name="do", raw_arguments="{")
 
     assert result == {"error": "Tool 'do' arguments are not valid JSON."}
 
@@ -318,7 +305,4 @@ def test_tool_box_run_allows_handler_exceptions_to_propagate():
         raise RuntimeError(f"bad args: {args}")
 
     with raises(RuntimeError, match=r"bad args: \{'x': 1\}"):
-        _get_tool_box(handler).run(
-            tool_name="do",
-            raw_arguments='{"x": 1}',
-        )
+        _get_tool_box(handler).run(tool_name="do", raw_arguments='{"x": 1}')

--- a/test/core/llms/test_provider_injection.py
+++ b/test/core/llms/test_provider_injection.py
@@ -322,9 +322,7 @@ def test_queryer_normalizes_input_into_configured_test_case_class():
     """Test compatible inputs are returned using the configured test-case class."""
     provider = Mock(spec=LLMProvider, cache_identity={"implementation": "test"})
     verified = _TestCase(
-        query=_Query(text="input"),
-        answer=_Answer(output="done"),
-        verified=True,
+        query=_Query(text="input"), answer=_Answer(output="done"), verified=True
     )
     queryer = Queryer(_TestCase, verified_test_cases=[verified], provider=provider)
 
@@ -339,9 +337,7 @@ def test_queryer_requires_answers_for_verified_test_cases():
     """Test verified inputs cannot omit their answers."""
     provider = Mock(spec=LLMProvider, cache_identity={"implementation": "test"})
     incomplete = _TestCase.model_construct(
-        query=_Query(text="input"),
-        answer=None,
-        verified=True,
+        query=_Query(text="input"), answer=None, verified=True
     )
 
     with raises(ValidationError):
@@ -351,10 +347,7 @@ def test_queryer_requires_answers_for_verified_test_cases():
 def test_queryer_requires_test_cases_to_be_verified():
     """Test Queryer rejects unverified test cases."""
     provider = Mock(spec=LLMProvider, cache_identity={"implementation": "test"})
-    unverified = _TestCase(
-        query=_Query(text="input"),
-        answer=_Answer(output="done"),
-    )
+    unverified = _TestCase(query=_Query(text="input"), answer=_Answer(output="done"))
 
     with raises(ValueError, match="must be verified"):
         Queryer(_TestCase, verified_test_cases=[unverified], provider=provider)
@@ -370,9 +363,7 @@ def test_test_case_requires_few_shot_to_be_verified():
     """Test few-shot metadata requires verified metadata."""
     with raises(ValidationError, match="must be verified"):
         _TestCase(
-            query=_Query(text="input"),
-            answer=_Answer(output="done"),
-            few_shot=True,
+            query=_Query(text="input"), answer=_Answer(output="done"), few_shot=True
         )
 
 
@@ -394,9 +385,7 @@ def test_queryer_merges_identical_verified_duplicates():
     )
 
     queryer = Queryer(
-        _TestCase,
-        verified_test_cases=[few_shot, verified],
-        provider=provider,
+        _TestCase, verified_test_cases=[few_shot, verified], provider=provider
     )
 
     merged = queryer.verified_test_cases[verified.query.key]
@@ -410,31 +399,21 @@ def test_queryer_rejects_conflicting_verified_duplicates():
     """Test duplicate queries cannot silently choose one of two answers."""
     provider = Mock(spec=LLMProvider, cache_identity={"implementation": "test"})
     first = _TestCase(
-        query=_Query(text="input"),
-        answer=_Answer(output="first"),
-        verified=True,
+        query=_Query(text="input"), answer=_Answer(output="first"), verified=True
     )
     second = _TestCase(
-        query=_Query(text="input"),
-        answer=_Answer(output="second"),
-        verified=True,
+        query=_Query(text="input"), answer=_Answer(output="second"), verified=True
     )
 
     with raises(ValueError, match="Conflicting verified answers"):
-        Queryer(
-            _TestCase,
-            verified_test_cases=[first, second],
-            provider=provider,
-        )
+        Queryer(_TestCase, verified_test_cases=[first, second], provider=provider)
 
 
 def test_queryer_snapshots_verified_test_cases():
     """Test later mutation of caller-owned cases does not alter queryer state."""
     provider = Mock(spec=LLMProvider, cache_identity={"implementation": "test"})
     verified = _TestCase(
-        query=_Query(text="input"),
-        answer=_Answer(output="original"),
-        verified=True,
+        query=_Query(text="input"), answer=_Answer(output="original"), verified=True
     )
     queryer = Queryer(_TestCase, verified_test_cases=[verified], provider=provider)
 
@@ -450,10 +429,7 @@ def test_queryer_cache_is_namespaced_by_provider_model(tmp_path):
     """Test one provider model cannot load another model's cached answer."""
     provider_one = _RecordingProvider('{"output":"one"}', model="model-one")
     queryer_one = Queryer(
-        _TestCase,
-        provider=provider_one,
-        cache_root_path=tmp_path,
-        max_attempts=1,
+        _TestCase, provider=provider_one, cache_root_path=tmp_path, max_attempts=1
     )
     test_case = _TestCase(query=_Query(text="input"))
 
@@ -461,10 +437,7 @@ def test_queryer_cache_is_namespaced_by_provider_model(tmp_path):
 
     provider_two = _RecordingProvider('{"output":"two"}', model="model-two")
     queryer_two = Queryer(
-        _TestCase,
-        provider=provider_two,
-        cache_root_path=tmp_path,
-        max_attempts=1,
+        _TestCase, provider=provider_two, cache_root_path=tmp_path, max_attempts=1
     )
     result_two = queryer_two(test_case)
 
@@ -478,10 +451,7 @@ def test_queryer_cache_stores_only_answer_and_preserves_current_metadata(tmp_pat
     """Test cached answers are attached to the current normalized test case."""
     provider = _RecordingProvider('{"output":"cached"}')
     queryer = Queryer(
-        _TestCase,
-        provider=provider,
-        cache_root_path=tmp_path,
-        max_attempts=1,
+        _TestCase, provider=provider, cache_root_path=tmp_path, max_attempts=1
     )
 
     first = queryer(_TestCase(query=_Query(text="input")))
@@ -514,10 +484,7 @@ def test_queryer_overwrites_matching_cache(tmp_path):
     cached_provider = _RecordingProvider('{"output":"cached"}')
     test_case = _TestCase(query=_Query(text="input"))
     Queryer(
-        _TestCase,
-        provider=cached_provider,
-        cache_root_path=tmp_path,
-        max_attempts=1,
+        _TestCase, provider=cached_provider, cache_root_path=tmp_path, max_attempts=1
     )(test_case)
 
     fresh_provider = _RecordingProvider('{"output":"fresh"}')
@@ -540,10 +507,7 @@ def test_queryer_cache_is_namespaced_by_test_case_class(tmp_path):
     """Test compatible test-case classes do not share cached answers."""
     provider_one = _RecordingProvider('{"output":"one"}')
     queryer_one = Queryer(
-        _TestCase,
-        provider=provider_one,
-        cache_root_path=tmp_path,
-        max_attempts=1,
+        _TestCase, provider=provider_one, cache_root_path=tmp_path, max_attempts=1
     )
     test_case = _TestCase(query=_Query(text="input"))
 
@@ -567,14 +531,10 @@ def test_queryer_cache_is_namespaced_by_test_case_class(tmp_path):
 def test_queryer_cache_is_namespaced_by_provider_implementation(tmp_path):
     """Test different provider implementations have different cache paths."""
     queryer_one = Queryer(
-        _TestCase,
-        provider=_RecordingProvider(),
-        cache_root_path=tmp_path,
+        _TestCase, provider=_RecordingProvider(), cache_root_path=tmp_path
     )
     queryer_two = Queryer(
-        _TestCase,
-        provider=_AlternateRecordingProvider(),
-        cache_root_path=tmp_path,
+        _TestCase, provider=_AlternateRecordingProvider(), cache_root_path=tmp_path
     )
 
     cache_path_one = queryer_one._get_cache_path("system", "tools", "query")
@@ -588,26 +548,18 @@ def test_queryer_cache_is_namespaced_by_provider_implementation(tmp_path):
 def test_queryer_cache_is_namespaced_by_provider_base_url(tmp_path):
     """Test OpenAI-compatible endpoints do not share cached answers."""
     provider_one = _RecordingProvider(
-        '{"output":"one"}',
-        base_url="https://one.example/v1",
+        '{"output":"one"}', base_url="https://one.example/v1"
     )
     provider_two = _RecordingProvider(
-        '{"output":"two"}',
-        base_url="https://two.example/v1",
+        '{"output":"two"}', base_url="https://two.example/v1"
     )
     test_case = _TestCase(query=_Query(text="input"))
 
     result_one = Queryer(
-        _TestCase,
-        provider=provider_one,
-        cache_root_path=tmp_path,
-        max_attempts=1,
+        _TestCase, provider=provider_one, cache_root_path=tmp_path, max_attempts=1
     )(test_case)
     result_two = Queryer(
-        _TestCase,
-        provider=provider_two,
-        cache_root_path=tmp_path,
-        max_attempts=1,
+        _TestCase, provider=provider_two, cache_root_path=tmp_path, max_attempts=1
     )(test_case)
 
     assert result_one.answer == _Answer(output="one")
@@ -619,9 +571,7 @@ def test_queryer_cache_is_namespaced_by_provider_base_url(tmp_path):
 def test_cache_path_does_not_retain_queryer(tmp_path):
     """Test calculating a cache path does not retain the Queryer instance."""
     queryer = Queryer(
-        _TestCase,
-        provider=_RecordingProvider(),
-        cache_root_path=tmp_path,
+        _TestCase, provider=_RecordingProvider(), cache_root_path=tmp_path
     )
     queryer_ref = ref(queryer)
     assert queryer._get_cache_path("system", "tools", "query") is not None

--- a/test/core/llms/test_test_case_json_fixtures.py
+++ b/test/core/llms/test_test_case_json_fixtures.py
@@ -27,22 +27,10 @@ _TEST_CASE_FAMILIES: tuple[tuple[str, type[Manager]], ...] = (
     ("*/output/*/lang/*/ocr_fusion.json", OcrFusionManager),
     ("*/output/*/lang/*/review.json", ReviewManager),
     ("*/output/*/lang/*/simplify_review.json", ReviewManager),
-    (
-        "*/output/*/lang/yue_zho/gap_translation/*.json",
-        GapTranslationManager,
-    ),
-    (
-        "*/output/*/lang/yue_zho/guided_review/*.json",
-        GuidedReviewManager,
-    ),
-    (
-        "*/output/*/lang/yue_zho/transcription/delineation/*.json",
-        DelineationManager,
-    ),
-    (
-        "*/output/*/lang/yue_zho/transcription/punctuation/*.json",
-        PunctuationManager,
-    ),
+    ("*/output/*/lang/yue_zho/gap_translation/*.json", GapTranslationManager),
+    ("*/output/*/lang/yue_zho/guided_review/*.json", GuidedReviewManager),
+    ("*/output/*/lang/yue_zho/transcription/delineation/*.json", DelineationManager),
+    ("*/output/*/lang/yue_zho/transcription/punctuation/*.json", PunctuationManager),
 )
 
 
@@ -84,9 +72,7 @@ def _localize_prompt_text(text: str) -> str:
     ],
 )
 def test_tracked_test_case_json_round_trips_canonically(
-    input_path: Path,
-    manager_cls: type[Manager],
-    tmp_path: Path,
+    input_path: Path, manager_cls: type[Manager], tmp_path: Path
 ):
     """Tracked JSON should round-trip canonically through localized models.
 
@@ -97,22 +83,17 @@ def test_tracked_test_case_json_round_trips_canonically(
     """
     raw_test_cases = json.loads(input_path.read_text(encoding="utf-8"))
     localized_prompt = manager_cls.base_prompt.transformed(
-        Language.zho_hans,
-        _localize_prompt_text,
+        Language.zho_hans, _localize_prompt_text
     )
     localized_test_cases = load_test_cases_from_json(
-        input_path,
-        manager_cls,
-        prompt=localized_prompt,
+        input_path, manager_cls, prompt=localized_prompt
     )
     assert localized_test_cases
 
     base_test_case_cls = manager_cls.get_test_case_cls(manager_cls.base_prompt)
     base_test_cases = []
     for raw_test_case, localized_test_case in zip(
-        raw_test_cases,
-        localized_test_cases,
-        strict=True,
+        raw_test_cases, localized_test_cases, strict=True
     ):
         base_test_case = base_test_case_cls.model_validate(raw_test_case)
         base_test_cases.append(base_test_case)
@@ -122,26 +103,16 @@ def test_tracked_test_case_json_round_trips_canonically(
         assert round_tripped_test_case == base_test_case
 
     output_path = tmp_path / input_path.name
-    save_test_cases_to_json(
-        output_path,
-        localized_test_cases,
-        manager_cls,
-    )
+    save_test_cases_to_json(output_path, localized_test_cases, manager_cls)
     saved_data = json.loads(output_path.read_text(encoding="utf-8"))
     canonical_data = [
-        test_case.model_dump(
-            mode="json",
-            by_alias=True,
-            exclude_defaults=True,
-        )
+        test_case.model_dump(mode="json", by_alias=True, exclude_defaults=True)
         for test_case in base_test_cases
     ]
     assert saved_data == canonical_data
 
     reloaded_test_cases = load_test_cases_from_json(
-        output_path,
-        manager_cls,
-        prompt=manager_cls.base_prompt,
+        output_path, manager_cls, prompt=manager_cls.base_prompt
     )
     assert [test_case.model_dump(mode="json") for test_case in reloaded_test_cases] == [
         test_case.model_dump(mode="json") for test_case in base_test_cases

--- a/test/core/llms/test_test_case_subtitle.py
+++ b/test/core/llms/test_test_case_subtitle.py
@@ -7,12 +7,8 @@ from __future__ import annotations
 from pydantic import ValidationError
 from pytest import raises
 
-from scinoephile.core.llms import (
-    AnnotatedTestCaseSubtitle as AnnotatedSubtitle,
-)
-from scinoephile.core.llms import (
-    TestCaseSubtitle as Subtitle,
-)
+from scinoephile.core.llms import AnnotatedTestCaseSubtitle as AnnotatedSubtitle
+from scinoephile.core.llms import TestCaseSubtitle as Subtitle
 
 
 def test_test_case_subtitle_requires_positive_index():
@@ -30,10 +26,6 @@ def test_annotated_test_case_subtitle_includes_note():
     """Annotated test-case subtitles should include explanatory notes."""
     subtitle = AnnotatedSubtitle(index=1, text="revision", note="typo")
 
-    assert subtitle.model_dump() == {
-        "index": 1,
-        "text": "revision",
-        "note": "typo",
-    }
+    assert subtitle.model_dump() == {"index": 1, "text": "revision", "note": "typo"}
     with raises(ValidationError, match="at least 1 character"):
         AnnotatedSubtitle(index=1, text="revision", note="")

--- a/test/core/llms/test_utils.py
+++ b/test/core/llms/test_utils.py
@@ -64,15 +64,7 @@ def _get_test_case(original: str, corrected: str):
     return test_case_cls.model_validate(
         {
             "query": {"subtitles": [{"index": 1, "text": original}]},
-            "answer": {
-                "revisions": [
-                    {
-                        "index": 1,
-                        "text": corrected,
-                        "note": "typo",
-                    }
-                ]
-            },
+            "answer": {"revisions": [{"index": 1, "text": corrected, "note": "typo"}]},
         }
     )
 
@@ -86,13 +78,7 @@ def test_json_uses_base_prompt_fields(tmp_path: Path):
         {
             "query": {"zimu": [{"xuhao": 1, "wenben": "original"}]},
             "answer": {
-                "xiugai": [
-                    {
-                        "xuhao": 1,
-                        "wenben": "corrected",
-                        "beizhu": "typo",
-                    }
-                ]
+                "xiugai": [{"xuhao": 1, "wenben": "corrected", "beizhu": "typo"}]
             },
             "verified": True,
         }
@@ -106,11 +92,7 @@ def test_json_uses_base_prompt_fields(tmp_path: Path):
             "query": {"base_subtitles": [{"base_index": 1, "base_text": "original"}]},
             "answer": {
                 "base_revisions": [
-                    {
-                        "base_index": 1,
-                        "base_text": "corrected",
-                        "base_note": "typo",
-                    }
+                    {"base_index": 1, "base_text": "corrected", "base_note": "typo"}
                 ]
             },
             "difficulty": 1,
@@ -118,9 +100,7 @@ def test_json_uses_base_prompt_fields(tmp_path: Path):
         }
     ]
     loaded = load_test_cases_from_json(
-        output_path,
-        _AliasedBaseReviewManager,
-        _LOCALIZED_REVIEW_PROMPT,
+        output_path, _AliasedBaseReviewManager, _LOCALIZED_REVIEW_PROMPT
     )
     assert loaded[0].query.model_dump(by_alias=True) == {
         "zimu": [{"xuhao": 1, "wenben": "original"}]
@@ -136,11 +116,7 @@ def test_load_test_cases_prefers_json_cases(tmp_path: Path):
     supplied_test_case = _get_test_case("original", "supplied correction")
     json_test_case = _get_test_case("original", "JSON correction")
     test_case_path = tmp_path / "test_cases.json"
-    save_test_cases_to_json(
-        test_case_path,
-        [json_test_case],
-        _AliasedBaseReviewManager,
-    )
+    save_test_cases_to_json(test_case_path, [json_test_case], _AliasedBaseReviewManager)
 
     test_cases, normalized_test_case_path = load_test_cases(
         _AliasedBaseReviewManager,
@@ -176,11 +152,7 @@ def test_load_test_cases_normalizes_optional_arguments(tmp_path: Path):
         {
             "query": {
                 "base_subtitles": [
-                    {
-                        "base_index": 1,
-                        "base_text": "original",
-                        "unexpected": True,
-                    }
+                    {"base_index": 1, "base_text": "original", "unexpected": True}
                 ]
             }
         },
@@ -203,22 +175,16 @@ def test_load_test_cases_normalizes_optional_arguments(tmp_path: Path):
         "unknown-test-case-field",
     ],
 )
-def test_json_loading_rejects_non_base_fields(
-    tmp_path: Path,
-    test_case_data: dict,
-):
+def test_json_loading_rejects_non_base_fields(tmp_path: Path, test_case_data: dict):
     """Repository JSON should contain only base prompt aliases."""
     input_path = tmp_path / "test_cases.json"
     input_path.write_text(
-        json.dumps([test_case_data], ensure_ascii=False),
-        encoding="utf-8",
+        json.dumps([test_case_data], ensure_ascii=False), encoding="utf-8"
     )
 
     with raises(ValidationError):
         load_test_cases_from_json(
-            input_path,
-            _AliasedBaseReviewManager,
-            _LOCALIZED_REVIEW_PROMPT,
+            input_path, _AliasedBaseReviewManager, _LOCALIZED_REVIEW_PROMPT
         )
 
 
@@ -238,9 +204,7 @@ def test_json_loading_is_strict(tmp_path: Path, test_case_data: dict):
 
     with raises(ValidationError):
         load_test_cases_from_json(
-            input_path,
-            _AliasedBaseReviewManager,
-            _LOCALIZED_REVIEW_PROMPT,
+            input_path, _AliasedBaseReviewManager, _LOCALIZED_REVIEW_PROMPT
         )
 
 
@@ -252,9 +216,7 @@ def test_json_loading_requires_an_array_of_objects(tmp_path: Path, contents: obj
 
     with raises(ValidationError):
         load_test_cases_from_json(
-            input_path,
-            _AliasedBaseReviewManager,
-            _LOCALIZED_REVIEW_PROMPT,
+            input_path, _AliasedBaseReviewManager, _LOCALIZED_REVIEW_PROMPT
         )
 
 
@@ -264,40 +226,26 @@ def test_save_preserves_existing_cases_unless_pruning(tmp_path: Path):
     existing_test_case = _get_test_case("existing", "existing corrected")
     encountered_test_case = _get_test_case("encountered", "encountered corrected")
     save_test_cases_to_json(
-        output_path,
-        [existing_test_case],
-        _AliasedBaseReviewManager,
+        output_path, [existing_test_case], _AliasedBaseReviewManager
     )
 
     save_test_cases_to_json(
-        output_path,
-        [encountered_test_case],
-        _AliasedBaseReviewManager,
+        output_path, [encountered_test_case], _AliasedBaseReviewManager
     )
 
     loaded = load_test_cases_from_json(
-        output_path,
-        _AliasedBaseReviewManager,
-        _LOCALIZED_REVIEW_PROMPT,
+        output_path, _AliasedBaseReviewManager, _LOCALIZED_REVIEW_PROMPT
     )
     assert [
         test_case.query.model_dump()["subtitles"][0]["text"] for test_case in loaded
-    ] == [
-        "existing",
-        "encountered",
-    ]
+    ] == ["existing", "encountered"]
 
     save_test_cases_to_json(
-        output_path,
-        [encountered_test_case],
-        _AliasedBaseReviewManager,
-        prune=True,
+        output_path, [encountered_test_case], _AliasedBaseReviewManager, prune=True
     )
 
     loaded = load_test_cases_from_json(
-        output_path,
-        _AliasedBaseReviewManager,
-        _LOCALIZED_REVIEW_PROMPT,
+        output_path, _AliasedBaseReviewManager, _LOCALIZED_REVIEW_PROMPT
     )
     assert [
         test_case.query.model_dump()["subtitles"][0]["text"] for test_case in loaded
@@ -316,8 +264,7 @@ def test_save_replaces_existing_file_atomically(tmp_path: Path):
 
     with (
         patch(
-            "scinoephile.core.llms.utils.json.dump",
-            side_effect=OSError("write failed"),
+            "scinoephile.core.llms.utils.json.dump", side_effect=OSError("write failed")
         ),
         raises(OSError, match="write failed"),
     ):

--- a/test/core/media/test_streams.py
+++ b/test/core/media/test_streams.py
@@ -16,18 +16,10 @@ from scinoephile.core.media.video_stream import VideoStream
 def test_stream_descriptions():
     """Test stream descriptions."""
     video = VideoStream(
-        index=0,
-        codec_type="video",
-        codec_name="hevc",
-        width=3840,
-        height=2160,
+        index=0, codec_type="video", codec_name="hevc", width=3840, height=2160
     )
     audio = AudioStream(
-        index=1,
-        codec_type="audio",
-        codec_name="flac",
-        channels=2,
-        language="jpn",
+        index=1, codec_type="audio", codec_name="flac", channels=2, language="jpn"
     )
     subtitle = SubtitleStream(index=2, language="eng", codec_name="subrip")
     generic = Stream(index=3, codec_type="data", codec_name="bin_data")

--- a/test/core/subtitles/test_series.py
+++ b/test/core/subtitles/test_series.py
@@ -36,10 +36,7 @@ def test_series_blocks_refresh_after_event_list_mutation():
 
     assert refreshed_blocks is not initial_blocks
     assert len(refreshed_blocks) == 2
-    assert [block.events[0].text for block in refreshed_blocks] == [
-        "First",
-        "Second",
-    ]
+    assert [block.events[0].text for block in refreshed_blocks] == ["First", "Second"]
 
 
 def test_series_blocks_refresh_after_direct_event_mutation():
@@ -71,8 +68,7 @@ def test_series_load_wraps_input_path_errors(tmp_path: Path):
     path = tmp_path / "missing.srt"
 
     with raises(
-        ScinoephileError,
-        match="Unable to load Series from .*missing.srt",
+        ScinoephileError, match="Unable to load Series from .*missing.srt"
     ) as excinfo:
         Series.load(path)
 
@@ -81,10 +77,7 @@ def test_series_load_wraps_input_path_errors(tmp_path: Path):
 
 def test_series_from_string_wraps_parser_errors():
     """Test subtitle parsing errors are user-facing."""
-    with raises(
-        ScinoephileError,
-        match="Unable to parse Series from string",
-    ):
+    with raises(ScinoephileError, match="Unable to parse Series from string"):
         Series.from_string("text", format_="unsupported")
 
 
@@ -96,10 +89,7 @@ def test_series_save_wraps_output_path_errors(tmp_path: Path):
     """
     series = Series(events=[Subtitle(start=1000, end=2000, text="Text")])
 
-    with raises(
-        ScinoephileError,
-        match="Unable to save Series to ",
-    ) as excinfo:
+    with raises(ScinoephileError, match="Unable to save Series to ") as excinfo:
         series.save(tmp_path)
 
     assert isinstance(excinfo.value.__cause__, OSError)
@@ -140,8 +130,5 @@ def test_series_to_string_wraps_serializer_errors():
     """Test subtitle string serialization errors are user-facing."""
     series = Series(events=[Subtitle(start=1000, end=2000, text="Text")])
 
-    with raises(
-        ScinoephileError,
-        match="Unable to serialize Series to string",
-    ):
+    with raises(ScinoephileError, match="Unable to serialize Series to string"):
         series.to_string(format_="unsupported")

--- a/test/core/synchronization/test_get_sync_groups.py
+++ b/test/core/synchronization/test_get_sync_groups.py
@@ -93,9 +93,4 @@ def test_get_sync_groups_sorts_unpaired_groups_by_timing():
 
     sync_groups = get_sync_groups(one, two)
 
-    assert sync_groups == [
-        ([0], [0]),
-        ([], [1]),
-        ([1], []),
-        ([2], [2]),
-    ]
+    assert sync_groups == [([0], [0]), ([], [1]), ([1], []), ([2], [2])]

--- a/test/core/test_stacking.py
+++ b/test/core/test_stacking.py
@@ -65,8 +65,7 @@ def test_get_stacked_series_does_not_overlap_union_timing():
     ],
 )
 def test_get_stacked_series_uses_requested_timing_mode(
-    timing_mode: StackTimingMode,
-    expected_times: list[tuple[int, int]],
+    timing_mode: StackTimingMode, expected_times: list[tuple[int, int]]
 ):
     """Test stack uses the requested timing mode for paired subtitles."""
     one = Series(
@@ -114,8 +113,7 @@ def test_get_stacked_series_timing_mode_uses_available_timing_for_unpaired_subti
     ],
 )
 def test_get_stacked_series_splits_selected_timing_for_one_to_many_groups(
-    timing_mode: StackTimingMode,
-    expected_times: list[tuple[int, int]],
+    timing_mode: StackTimingMode, expected_times: list[tuple[int, int]]
 ):
     """Test one-to-many stack splits the selected timing interval."""
     one = Series(events=[Subtitle(start=1000, end=2000, text="A")])
@@ -228,10 +226,7 @@ def test_get_stacked_series_overlap_error_includes_event_context():
     ],
 )
 def test_get_stacked_series(
-    request: FixtureRequest,
-    one_fixture: str,
-    two_fixture: str,
-    expected_fixture: str,
+    request: FixtureRequest, one_fixture: str, two_fixture: str, expected_fixture: str
 ):
     """Test get_stacked_series against expected stacked outputs.
 
@@ -242,7 +237,6 @@ def test_get_stacked_series(
         expected_fixture: fixture name for expected output series
     """
     output = get_stacked_series(
-        request.getfixturevalue(one_fixture),
-        request.getfixturevalue(two_fixture),
+        request.getfixturevalue(one_fixture), request.getfixturevalue(two_fixture)
     )
     assert_series_equal(output, request.getfixturevalue(expected_fixture))

--- a/test/core/test_text.py
+++ b/test/core/test_text.py
@@ -76,23 +76,13 @@ def test_normalize_text(text: str, expected: str) -> None:
     assert normalize_text(text) == expected
 
 
-@parametrize(
-    ("text", "expected"),
-    [
-        ("Don't stop 佢", ["Don't", "stop"]),
-    ],
-)
+@parametrize(("text", "expected"), [("Don't stop 佢", ["Don't", "stop"])])
 def test_re_latin_word(text: str, expected: list[str]) -> None:
     """Latin word regex matches word-like tokens."""
     assert RE_LATIN_WORD.findall(text) == expected
 
 
-@parametrize(
-    ("text", "expected"),
-    [
-        ("one\ntwo\tthree\r", "one\ntwo\tthree\r"),
-    ],
-)
+@parametrize(("text", "expected"), [("one\ntwo\tthree\r", "one\ntwo\tthree\r")])
 def test_replace_control_characters_preserves_text_whitespace(
     text: str, expected: str
 ) -> None:

--- a/test/core/timing/test_get_series_timewarped.py
+++ b/test/core/timing/test_get_series_timewarped.py
@@ -88,10 +88,7 @@ def test_get_series_timewarped(
         param({"two_end_idx": 0}, "source two end", id="source-two-end"),
     ],
 )
-def test_get_series_timewarped_rejects_zero_indexes(
-    kwargs: dict[str, int],
-    label: str,
-):
+def test_get_series_timewarped_rejects_zero_indexes(kwargs: dict[str, int], label: str):
     """Test explicit zero indexes are rejected instead of defaulted.
 
     Arguments:
@@ -101,31 +98,19 @@ def test_get_series_timewarped_rejects_zero_indexes(
     source_one = _get_series()
     source_two = _get_series()
 
-    with raises(
-        ScinoephileError,
-        match=f"Invalid {label} index 0",
-    ):
+    with raises(ScinoephileError, match=f"Invalid {label} index 0"):
         get_series_timewarped(source_one, source_two, **kwargs)
 
 
 @parametrize(
     "kwargs, label",
     [
-        param(
-            {"one_start_idx": 2, "one_end_idx": 1},
-            "source one",
-            id="source-one",
-        ),
-        param(
-            {"two_start_idx": 2, "two_end_idx": 1},
-            "source two",
-            id="source-two",
-        ),
+        param({"one_start_idx": 2, "one_end_idx": 1}, "source one", id="source-one"),
+        param({"two_start_idx": 2, "two_end_idx": 1}, "source two", id="source-two"),
     ],
 )
 def test_get_series_timewarped_rejects_reversed_ranges(
-    kwargs: dict[str, int],
-    label: str,
+    kwargs: dict[str, int], label: str
 ):
     """Test timewarp anchor ranges must be ordered from start to end.
 
@@ -136,10 +121,7 @@ def test_get_series_timewarped_rejects_reversed_ranges(
     source_one = _get_series()
     source_two = _get_series()
 
-    with raises(
-        ScinoephileError,
-        match=f"Invalid {label} range 2-1",
-    ):
+    with raises(ScinoephileError, match=f"Invalid {label} range 2-1"):
         get_series_timewarped(source_one, source_two, **kwargs)
 
 

--- a/test/data/acopopb/__init__.py
+++ b/test/data/acopopb/__init__.py
@@ -113,8 +113,7 @@ output_dir = title_root / "output"
 
 @cache
 def get_acopopb_eng_ocr_fusion_test_cases(
-    prompt: OcrFusionPrompt = OcrFusionPromptEng,
-    **kwargs: Any,
+    prompt: OcrFusionPrompt = OcrFusionPromptEng, **kwargs: Any
 ) -> list[TestCase]:
     """Get ACOPOPB English OCR fusion test cases.
 
@@ -146,8 +145,7 @@ def get_acopopb_eng_review_test_cases(
 
 @cache
 def get_acopopb_yue_hans_ocr_fusion_test_cases(
-    prompt: OcrFusionPrompt = OcrFusionPromptYueHans,
-    **kwargs: Any,
+    prompt: OcrFusionPrompt = OcrFusionPromptYueHans, **kwargs: Any
 ) -> list[TestCase]:
     """Get ACOPOPB yue-Hans OCR fusion test cases.
 
@@ -179,8 +177,7 @@ def get_acopopb_yue_hans_review_test_cases(
 
 @cache
 def get_acopopb_yue_hant_ocr_fusion_test_cases(
-    prompt: OcrFusionPrompt = OcrFusionPromptYueHant,
-    **kwargs: Any,
+    prompt: OcrFusionPrompt = OcrFusionPromptYueHant, **kwargs: Any
 ) -> list[TestCase]:
     """Get ACOPOPB yue-Hant OCR fusion test cases.
 
@@ -228,8 +225,7 @@ def get_acopopb_yue_hant_simplify_review_test_cases(
 
 @cache
 def get_acopopb_zho_hans_ocr_fusion_test_cases(
-    prompt: OcrFusionPrompt = OcrFusionPromptZhoHans,
-    **kwargs: Any,
+    prompt: OcrFusionPrompt = OcrFusionPromptZhoHans, **kwargs: Any
 ) -> list[TestCase]:
     """Get ACOPOPB zho-Hans OCR fusion test cases.
 
@@ -261,8 +257,7 @@ def get_acopopb_zho_hans_review_test_cases(
 
 @cache
 def get_acopopb_zho_hant_ocr_fusion_test_cases(
-    prompt: OcrFusionPrompt = OcrFusionPromptZhoHant,
-    **kwargs: Any,
+    prompt: OcrFusionPrompt = OcrFusionPromptZhoHant, **kwargs: Any
 ) -> list[TestCase]:
     """Get ACOPOPB zho-Hant OCR fusion test cases.
 

--- a/test/data/acopopb/create_output.py
+++ b/test/data/acopopb/create_output.py
@@ -60,7 +60,7 @@ actions = {
     # "zho-Hant_ocr",
     # "yue-Hans_eng",
     # "zho-Hans_eng",
-    "yue-Hant_transcribe",
+    "yue-Hant_transcribe"
 }
 
 if "eng_ocr" in actions:

--- a/test/data/acoptc/__init__.py
+++ b/test/data/acoptc/__init__.py
@@ -131,8 +131,7 @@ def acoptc_zho_hant() -> Series:
 
 @cache
 def get_acoptc_eng_ocr_fusion_test_cases(
-    prompt: OcrFusionPrompt = OcrFusionPromptEng,
-    **kwargs: Any,
+    prompt: OcrFusionPrompt = OcrFusionPromptEng, **kwargs: Any
 ) -> list[TestCase]:
     """Get ACOPTC English OCR fusion test cases.
 
@@ -164,8 +163,7 @@ def get_acoptc_eng_review_test_cases(
 
 @cache
 def get_acoptc_yue_hans_ocr_fusion_test_cases(
-    prompt: OcrFusionPrompt = OcrFusionPromptYueHans,
-    **kwargs: Any,
+    prompt: OcrFusionPrompt = OcrFusionPromptYueHans, **kwargs: Any
 ) -> list[TestCase]:
     """Get ACOPTC yue-Hans OCR fusion test cases.
 
@@ -197,8 +195,7 @@ def get_acoptc_yue_hans_review_test_cases(
 
 @cache
 def get_acoptc_yue_hant_ocr_fusion_test_cases(
-    prompt: OcrFusionPrompt = OcrFusionPromptYueHant,
-    **kwargs: Any,
+    prompt: OcrFusionPrompt = OcrFusionPromptYueHant, **kwargs: Any
 ) -> list[TestCase]:
     """Get ACOPTC yue-Hant OCR fusion test cases.
 
@@ -246,8 +243,7 @@ def get_acoptc_yue_hant_simplify_review_test_cases(
 
 @cache
 def get_acoptc_zho_hans_ocr_fusion_test_cases(
-    prompt: OcrFusionPrompt = OcrFusionPromptZhoHans,
-    **kwargs: Any,
+    prompt: OcrFusionPrompt = OcrFusionPromptZhoHans, **kwargs: Any
 ) -> list[TestCase]:
     """Get ACOPTC zho-Hans OCR fusion test cases.
 
@@ -279,8 +275,7 @@ def get_acoptc_zho_hans_review_test_cases(
 
 @cache
 def get_acoptc_zho_hant_ocr_fusion_test_cases(
-    prompt: OcrFusionPrompt = OcrFusionPromptZhoHant,
-    **kwargs: Any,
+    prompt: OcrFusionPrompt = OcrFusionPromptZhoHant, **kwargs: Any
 ) -> list[TestCase]:
     """Get ACOPTC zho-Hant OCR fusion test cases.
 

--- a/test/data/helpers.py
+++ b/test/data/helpers.py
@@ -27,10 +27,7 @@ __all__ = [
 
 
 def load_or_clean_series(
-    series: Series,
-    output_path: Path,
-    language: Language,
-    overwrite: bool = False,
+    series: Series, output_path: Path, language: Language, overwrite: bool = False
 ) -> Series:
     """Load or create a cleaned subtitle series.
 
@@ -51,10 +48,7 @@ def load_or_clean_series(
 
 
 def load_or_flatten_series(
-    series: Series,
-    output_path: Path,
-    language: Language,
-    overwrite: bool = False,
+    series: Series, output_path: Path, language: Language, overwrite: bool = False
 ) -> Series:
     """Load or create a flattened subtitle series.
 
@@ -108,10 +102,7 @@ def load_or_review_series(
 
 
 def load_or_romanize_series(
-    series: Series,
-    output_path: Path,
-    language: Language,
-    overwrite: bool = False,
+    series: Series, output_path: Path, language: Language, overwrite: bool = False
 ) -> Series:
     """Load or create a romanized subtitle series.
 
@@ -132,9 +123,7 @@ def load_or_romanize_series(
 
 
 def load_or_simplify_series(
-    series: Series,
-    output_path: Path,
-    overwrite: bool = False,
+    series: Series, output_path: Path, overwrite: bool = False
 ) -> Series:
     """Load or create a simplified Chinese-script subtitle series.
 

--- a/test/data/kob/__init__.py
+++ b/test/data/kob/__init__.py
@@ -122,8 +122,7 @@ def kob_yue_hant() -> Series:
 
 @cache
 def get_kob_eng_ocr_fusion_test_cases(
-    prompt: OcrFusionPrompt = OcrFusionPromptEng,
-    **kwargs: Unpack[_KobTestCaseKwargs],
+    prompt: OcrFusionPrompt = OcrFusionPromptEng, **kwargs: Unpack[_KobTestCaseKwargs]
 ) -> list[TestCase]:
     """Get KOB English OCR fusion test cases.
 
@@ -139,8 +138,7 @@ def get_kob_eng_ocr_fusion_test_cases(
 
 @cache
 def get_kob_eng_review_test_cases(
-    prompt: ReviewPrompt = ReviewPromptEng,
-    **kwargs: Unpack[_KobTestCaseKwargs],
+    prompt: ReviewPrompt = ReviewPromptEng, **kwargs: Unpack[_KobTestCaseKwargs]
 ) -> list[TestCase]:
     """Get KOB English review test cases.
 
@@ -212,8 +210,7 @@ def get_kob_yue_hant_guided_review_test_cases(
 
 @cache
 def get_kob_yue_hans_review_test_cases(
-    prompt: ReviewPrompt = ReviewPromptYueHans,
-    **kwargs: Unpack[_KobTestCaseKwargs],
+    prompt: ReviewPrompt = ReviewPromptYueHans, **kwargs: Unpack[_KobTestCaseKwargs]
 ) -> list[TestCase]:
     """Get KOB yue-Hans review test cases.
 
@@ -232,8 +229,7 @@ def get_kob_yue_hans_review_test_cases(
 
 @cache
 def get_kob_yue_hant_review_test_cases(
-    prompt: ReviewPrompt = ReviewPromptYueHant,
-    **kwargs: Unpack[_KobTestCaseKwargs],
+    prompt: ReviewPrompt = ReviewPromptYueHant, **kwargs: Unpack[_KobTestCaseKwargs]
 ) -> list[TestCase]:
     """Get KOB yue-Hant review test cases.
 
@@ -252,8 +248,7 @@ def get_kob_yue_hant_review_test_cases(
 
 @cache
 def get_kob_yue_hant_simplify_review_test_cases(
-    prompt: ReviewPrompt = ReviewPromptYueHans,
-    **kwargs: Unpack[_KobTestCaseKwargs],
+    prompt: ReviewPrompt = ReviewPromptYueHans, **kwargs: Unpack[_KobTestCaseKwargs]
 ) -> list[TestCase]:
     """Get KOB yue-Hant simplification review test cases.
 
@@ -314,8 +309,7 @@ def get_kob_zho_hant_ocr_fusion_test_cases(
 
 @cache
 def get_kob_zho_hant_review_test_cases(
-    prompt: ReviewPrompt = ReviewPromptZhoHant,
-    **kwargs: Unpack[_KobTestCaseKwargs],
+    prompt: ReviewPrompt = ReviewPromptZhoHant, **kwargs: Unpack[_KobTestCaseKwargs]
 ) -> list[TestCase]:
     """Get KOB zho-Hant review test cases.
 
@@ -331,8 +325,7 @@ def get_kob_zho_hant_review_test_cases(
 
 @cache
 def get_kob_zho_hant_simplify_review_test_cases(
-    prompt: ReviewPrompt = ReviewPromptZhoHans,
-    **kwargs: Unpack[_KobTestCaseKwargs],
+    prompt: ReviewPrompt = ReviewPromptZhoHans, **kwargs: Unpack[_KobTestCaseKwargs]
 ) -> list[TestCase]:
     """Get KOB zho-Hant simplification review test cases.
 
@@ -674,7 +667,7 @@ def kob_yue_hant_clean_review_flatten_timewarp_simplify_review_romanize() -> Ser
 def kob_yue_simplify_expected_series_diff() -> list[str]:
     """Expected differences for KOB Yue Simplified vs Traditional subtitles."""
     return [
-        "edit: SIMP[1229] -> TRAD[1229]: '但系第十八式〝杀龙有悔〞' -> '但系第十八式「杀龙有悔」'",
+        "edit: SIMP[1229] -> TRAD[1229]: '但系第十八式〝杀龙有悔〞' -> '但系第十八式「杀龙有悔」'"
     ]
 
 

--- a/test/data/kob/create_output.py
+++ b/test/data/kob/create_output.py
@@ -70,7 +70,7 @@ actions = {
     # "zho-Hans_eng",
     # "yue-Hans_eng",
     # "yue-Hant_transcribe",
-    "yue-Hant_diff",
+    "yue-Hant_diff"
 }
 
 if "eng_ocr" in actions:
@@ -146,10 +146,5 @@ if "yue-Hant_diff" in actions:
         one_lbl="GAP TRANSLATION",
         two_lbl="REFERENCE",
     )
-    print(
-        diff.get_stacked_str(
-            three=aligned_zho_hant_guide,
-            include_equal=True,
-        )
-    )
+    print(diff.get_stacked_str(three=aligned_zho_hant_guide, include_equal=True))
     print(SeriesCER(yue_hant_reference, yue_hant_transcribe))

--- a/test/data/mlamd/__init__.py
+++ b/test/data/mlamd/__init__.py
@@ -25,19 +25,14 @@ from scinoephile.lang.yue_zho.transcription import (
     YueZhoDelineationPromptYueHans,
     YueZhoPunctuationPromptYueHans,
 )
-from scinoephile.lang.yue_zho.translation import (
-    YueZhoGapTranslationPromptYueHans,
-)
+from scinoephile.lang.yue_zho.translation import YueZhoGapTranslationPromptYueHans
 from scinoephile.lang.zho.ocr_fusion import (
     OcrFusionPromptZhoHans,
     OcrFusionPromptZhoHant,
 )
 from scinoephile.lang.zho.review import ReviewPromptZhoHans, ReviewPromptZhoHant
 from scinoephile.llms.delineation import DelineationManager, DelineationPrompt
-from scinoephile.llms.gap_translation import (
-    GapTranslationManager,
-    GapTranslationPrompt,
-)
+from scinoephile.llms.gap_translation import GapTranslationManager, GapTranslationPrompt
 from scinoephile.llms.guided_review import GuidedReviewManager, GuidedReviewPrompt
 from scinoephile.llms.ocr_fusion import OcrFusionManager, OcrFusionPrompt
 from scinoephile.llms.punctuation import PunctuationManager, PunctuationPrompt
@@ -133,8 +128,7 @@ def mlamd_zho_hant_ocr_sup_path() -> Path:
 
 @cache
 def get_mlamd_eng_ocr_fusion_test_cases(
-    prompt: OcrFusionPrompt = OcrFusionPromptEng,
-    **kwargs: Any,
+    prompt: OcrFusionPrompt = OcrFusionPromptEng, **kwargs: Any
 ) -> list[TestCase]:
     """Get MLAMD English OCR fusion test cases.
 
@@ -166,8 +160,7 @@ def get_mlamd_eng_review_test_cases(
 
 @cache
 def get_mlamd_yue_delineation_test_cases(
-    prompt: DelineationPrompt = YueZhoDelineationPromptYueHans,
-    **kwargs: Any,
+    prompt: DelineationPrompt = YueZhoDelineationPromptYueHans, **kwargs: Any
 ) -> list[TestCase]:
     """Get MLAMD yue-Hans delineation test cases.
 
@@ -191,8 +184,7 @@ def get_mlamd_yue_delineation_test_cases(
 
 @cache
 def get_mlamd_yue_from_zho_gap_translation_test_cases(
-    prompt: GapTranslationPrompt = YueZhoGapTranslationPromptYueHans,
-    **kwargs: Any,
+    prompt: GapTranslationPrompt = YueZhoGapTranslationPromptYueHans, **kwargs: Any
 ) -> list[TestCase]:
     """Get MLAMD yue-Hans from zho-Hans gap translation test cases.
 
@@ -217,8 +209,7 @@ def get_mlamd_yue_from_zho_gap_translation_test_cases(
 
 @cache
 def get_mlamd_yue_punctuation_test_cases(
-    prompt: PunctuationPrompt = YueZhoPunctuationPromptYueHans,
-    **kwargs: Any,
+    prompt: PunctuationPrompt = YueZhoPunctuationPromptYueHans, **kwargs: Any
 ) -> list[TestCase]:
     """Get MLAMD yue-Hans punctuation test cases.
 
@@ -242,8 +233,7 @@ def get_mlamd_yue_punctuation_test_cases(
 
 @cache
 def get_mlamd_yue_vs_zho_guided_review_test_cases(
-    prompt: GuidedReviewPrompt = YueZhoGuidedReviewPromptYueHans,
-    **kwargs: Any,
+    prompt: GuidedReviewPrompt = YueZhoGuidedReviewPromptYueHans, **kwargs: Any
 ) -> list[TestCase]:
     """Get MLAMD yue-Hans vs zho-Hans guided review test cases.
 
@@ -266,8 +256,7 @@ def get_mlamd_yue_vs_zho_guided_review_test_cases(
 
 @cache
 def get_mlamd_zho_hans_ocr_fusion_test_cases(
-    prompt: OcrFusionPrompt = OcrFusionPromptZhoHans,
-    **kwargs: Any,
+    prompt: OcrFusionPrompt = OcrFusionPromptZhoHans, **kwargs: Any
 ) -> list[TestCase]:
     """Get MLAMD zho-Hans OCR fusion test cases.
 
@@ -299,8 +288,7 @@ def get_mlamd_zho_hans_review_test_cases(
 
 @cache
 def get_mlamd_zho_hant_ocr_fusion_test_cases(
-    prompt: OcrFusionPrompt = OcrFusionPromptZhoHant,
-    **kwargs: Any,
+    prompt: OcrFusionPrompt = OcrFusionPromptZhoHant, **kwargs: Any
 ) -> list[TestCase]:
     """Get MLAMD zho-Hant OCR fusion test cases.
 
@@ -502,8 +490,7 @@ def mlamd_zho_hans_fuse_clean_validate_review_flatten_merged_539(
 ) -> Series:
     """MLAMD zho-Hans flattened subtitles with subtitle 539 merged."""
     return get_series_with_subs_merged(
-        mlamd_zho_hans_fuse_clean_validate_review_flatten,
-        539,
+        mlamd_zho_hans_fuse_clean_validate_review_flatten, 539
     )
 
 

--- a/test/data/mlamd/create_output.py
+++ b/test/data/mlamd/create_output.py
@@ -135,9 +135,7 @@ if "yue-Hans_transcribe" in actions:
         auto_verify=True,
     )
     yue_hans_translate_guided_review = review_series_guided(
-        yue_hans_translate,
-        zho_hans,
-        reviewer=reviewer,
+        yue_hans_translate, zho_hans, reviewer=reviewer
     )
     outfile_path = (
         output_path / "yue-Hans_transcribe" / "transcribe_translate_guided_review.srt"

--- a/test/data/mnt/__init__.py
+++ b/test/data/mnt/__init__.py
@@ -105,8 +105,7 @@ def mnt_zho_hant() -> Series:
 
 @cache
 def get_mnt_eng_ocr_fusion_test_cases(
-    prompt: OcrFusionPrompt = OcrFusionPromptEng,
-    **kwargs: Any,
+    prompt: OcrFusionPrompt = OcrFusionPromptEng, **kwargs: Any
 ) -> list[TestCase]:
     """Get MNT English OCR fusion test cases.
 
@@ -138,8 +137,7 @@ def get_mnt_eng_review_test_cases(
 
 @cache
 def get_mnt_eng_zho_guided_translation_test_cases(
-    prompt: GuidedTranslationPrompt = EngZhoYueGuidedTranslationPrompt,
-    **kwargs: Any,
+    prompt: GuidedTranslationPrompt = EngZhoYueGuidedTranslationPrompt, **kwargs: Any
 ) -> list[TestCase]:
     """Get MNT English-from-Cantonese guided translation test cases.
 
@@ -157,8 +155,7 @@ def get_mnt_eng_zho_guided_translation_test_cases(
 
 @cache
 def get_mnt_zho_hans_ocr_fusion_test_cases(
-    prompt: OcrFusionPrompt = OcrFusionPromptZhoHans,
-    **kwargs: Any,
+    prompt: OcrFusionPrompt = OcrFusionPromptZhoHans, **kwargs: Any
 ) -> list[TestCase]:
     """Get MNT zho-Hans OCR fusion test cases.
 
@@ -190,8 +187,7 @@ def get_mnt_zho_hans_review_test_cases(
 
 @cache
 def get_mnt_zho_hant_ocr_fusion_test_cases(
-    prompt: OcrFusionPrompt = OcrFusionPromptZhoHant,
-    **kwargs: Any,
+    prompt: OcrFusionPrompt = OcrFusionPromptZhoHant, **kwargs: Any
 ) -> list[TestCase]:
     """Get MNT zho-Hant OCR fusion test cases.
 

--- a/test/data/ocr.py
+++ b/test/data/ocr.py
@@ -19,9 +19,7 @@ from .helpers import (
     load_or_simplify_series,
 )
 
-__all__ = [
-    "process_ocr",
-]
+__all__ = ["process_ocr"]
 
 
 def process_ocr(
@@ -71,21 +69,12 @@ def process_ocr(
     # Review series
     reviewed_path = output_dir_path / "fuse_clean_validate_review.srt"
     reviewed = load_or_review_series(
-        validated,
-        reviewed_path,
-        language,
-        overwrite,
-        reviewer_kw,
+        validated, reviewed_path, language, overwrite, reviewer_kw
     )
 
     # Flatten series
     flattened_path = output_dir_path / "fuse_clean_validate_review_flatten.srt"
-    flattened = load_or_flatten_series(
-        reviewed,
-        flattened_path,
-        language,
-        overwrite,
-    )
+    flattened = load_or_flatten_series(reviewed, flattened_path, language, overwrite)
 
     if language.script == "Hans":
         romanized_path = (
@@ -123,10 +112,7 @@ def process_ocr(
             / "fuse_clean_validate_review_flatten_simplify_review_romanize.srt"
         )
         load_or_romanize_series(
-            simplified_reviewed,
-            romanized_path,
-            simplified_language,
-            overwrite,
+            simplified_reviewed, romanized_path, simplified_language, overwrite
         )
 
     return flattened

--- a/test/data/prompts.py
+++ b/test/data/prompts.py
@@ -7,9 +7,7 @@ from __future__ import annotations
 from dataclasses import replace
 
 from scinoephile.core.text import dedent_and_compact
-from scinoephile.lang.eng_zho.translation import (
-    EngZhoGuidedTranslationPrompt,
-)
+from scinoephile.lang.eng_zho.translation import EngZhoGuidedTranslationPrompt
 
 __all__ = ["EngZhoYueGuidedTranslationPrompt"]
 

--- a/test/data/srt.py
+++ b/test/data/srt.py
@@ -20,9 +20,7 @@ from .helpers import (
     load_or_timewarp_series,
 )
 
-__all__ = [
-    "process_srt",
-]
+__all__ = ["process_srt"]
 
 
 def process_srt(
@@ -62,11 +60,7 @@ def process_srt(
     Raises:
         ScinoephileError: if the language is unsupported
     """
-    if language not in (
-        Language.eng,
-        Language.yue_hans,
-        Language.yue_hant,
-    ):
+    if language not in (Language.eng, Language.yue_hans, Language.yue_hant):
         raise ScinoephileError(
             "SRT processing only supports eng, yue-Hans, and yue-Hant"
         )
@@ -92,20 +86,11 @@ def process_srt(
 
     reviewed_path = output_dir_path / "clean_review.srt"
     reviewed = load_or_review_series(
-        cleaned,
-        reviewed_path,
-        language,
-        overwrite,
-        reviewer_kw,
+        cleaned, reviewed_path, language, overwrite, reviewer_kw
     )
 
     flattened_path = output_dir_path / "clean_review_flatten.srt"
-    flattened = load_or_flatten_series(
-        reviewed,
-        flattened_path,
-        language,
-        overwrite,
-    )
+    flattened = load_or_flatten_series(reviewed, flattened_path, language, overwrite)
 
     timewarped_path = output_dir_path / "clean_review_flatten_timewarp.srt"
     timewarped = load_or_timewarp_series(
@@ -150,10 +135,7 @@ def process_srt(
             / "clean_review_flatten_timewarp_simplify_review_romanize.srt"
         )
         load_or_romanize_series(
-            simplified_reviewed,
-            romanized_path,
-            Language.yue_hans,
-            overwrite,
+            simplified_reviewed, romanized_path, Language.yue_hans, overwrite
         )
 
     return timewarped

--- a/test/data/stacking.py
+++ b/test/data/stacking.py
@@ -12,10 +12,7 @@ from scinoephile.core.subtitles import Series
 from scinoephile.workflows.clean import clean_series
 from scinoephile.workflows.flatten import flatten_series
 
-__all__ = [
-    "process_yue_hans_eng",
-    "process_zho_hans_eng",
-]
+__all__ = ["process_yue_hans_eng", "process_zho_hans_eng"]
 
 
 def process_yue_hans_eng(

--- a/test/data/t/__init__.py
+++ b/test/data/t/__init__.py
@@ -97,8 +97,7 @@ def t_zho_hant() -> Series:
 
 @cache
 def get_t_eng_ocr_fusion_test_cases(
-    prompt: OcrFusionPrompt = OcrFusionPromptEng,
-    **kwargs: Any,
+    prompt: OcrFusionPrompt = OcrFusionPromptEng, **kwargs: Any
 ) -> list[TestCase]:
     """Get T English OCR fusion test cases.
 
@@ -130,8 +129,7 @@ def get_t_eng_review_test_cases(
 
 @cache
 def get_t_zho_hans_ocr_fusion_test_cases(
-    prompt: OcrFusionPrompt = OcrFusionPromptZhoHans,
-    **kwargs: Any,
+    prompt: OcrFusionPrompt = OcrFusionPromptZhoHans, **kwargs: Any
 ) -> list[TestCase]:
     """Get T zho-Hans OCR fusion test cases.
 
@@ -163,8 +161,7 @@ def get_t_zho_hans_review_test_cases(
 
 @cache
 def get_t_zho_hant_ocr_fusion_test_cases(
-    prompt: OcrFusionPrompt = OcrFusionPromptZhoHant,
-    **kwargs: Any,
+    prompt: OcrFusionPrompt = OcrFusionPromptZhoHant, **kwargs: Any
 ) -> list[TestCase]:
     """Get T zho-Hant OCR fusion test cases.
 

--- a/test/data/t/create_output.py
+++ b/test/data/t/create_output.py
@@ -16,12 +16,7 @@ title_root = test_data_root / Path(__file__).parent.name
 output_path = title_root / "output"
 set_logging_verbosity(2)
 
-actions = {
-    "eng_ocr",
-    "zho-Hans_ocr",
-    "zho-Hant_ocr",
-    "zho-Hans_eng",
-}
+actions = {"eng_ocr", "zho-Hans_ocr", "zho-Hant_ocr", "zho-Hans_eng"}
 
 if "eng_ocr" in actions:
     process_ocr(title_root, Language.eng, overwrite=False, interactive=True)

--- a/test/data/test_transcription.py
+++ b/test/data/test_transcription.py
@@ -32,11 +32,7 @@ def test_get_reference_for_guide_blocks_limits_reference_prefix():
         ]
     )
 
-    limited = transcription_data.get_reference_for_guide_blocks(
-        reference,
-        guide,
-        1,
-    )
+    limited = transcription_data.get_reference_for_guide_blocks(reference, guide, 1)
 
     assert [subtitle.text for subtitle in limited] == ["甲", "乙"]
 
@@ -135,21 +131,11 @@ def test_process_transcription_orders_stages_and_relogs_expected_mismatch(
     )
     monkeypatch.setattr(transcription_data, "_stage_audio_series", stage_audio)
     monkeypatch.setattr(
-        transcription_data,
-        "_load_or_transcribe_series_guided",
-        transcribe,
+        transcription_data, "_load_or_transcribe_series_guided", transcribe
     )
     monkeypatch.setattr(transcription_data, "load_or_clean_series", clean)
-    monkeypatch.setattr(
-        transcription_data,
-        "_load_or_review_series_guided",
-        review,
-    )
-    monkeypatch.setattr(
-        transcription_data,
-        "_load_or_translate_series_gaps",
-        translate,
-    )
+    monkeypatch.setattr(transcription_data, "_load_or_review_series_guided", review)
+    monkeypatch.setattr(transcription_data, "_load_or_translate_series_gaps", translate)
 
     with caplog.at_level(INFO):
         output = transcription_data.process_transcription(
@@ -180,8 +166,7 @@ def test_process_transcription_orders_stages_and_relogs_expected_mismatch(
 
 
 def test_process_transcription_can_stop_after_cleaning(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Skip guided review and gap translation when they are disabled.
 
@@ -202,9 +187,7 @@ def test_process_transcription_can_stop_after_cleaning(
         Mock(side_effect=lambda series, explicit_language: explicit_language),
     )
     monkeypatch.setattr(
-        transcription_data,
-        "_stage_audio_series",
-        Mock(return_value=reference),
+        transcription_data, "_stage_audio_series", Mock(return_value=reference)
     )
     monkeypatch.setattr(
         transcription_data,
@@ -212,20 +195,10 @@ def test_process_transcription_can_stop_after_cleaning(
         Mock(return_value=reference),
     )
     monkeypatch.setattr(
-        transcription_data,
-        "load_or_clean_series",
-        Mock(return_value=reference),
+        transcription_data, "load_or_clean_series", Mock(return_value=reference)
     )
-    monkeypatch.setattr(
-        transcription_data,
-        "_load_or_review_series_guided",
-        review,
-    )
-    monkeypatch.setattr(
-        transcription_data,
-        "_load_or_translate_series_gaps",
-        translate,
-    )
+    monkeypatch.setattr(transcription_data, "_load_or_review_series_guided", review)
+    monkeypatch.setattr(transcription_data, "_load_or_translate_series_gaps", translate)
 
     output = transcription_data.process_transcription(
         tmp_path,
@@ -242,8 +215,7 @@ def test_process_transcription_can_stop_after_cleaning(
 
 
 def test_process_transcription_can_stop_before_cleaning(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Return the transcription without running later stages.
 
@@ -265,9 +237,7 @@ def test_process_transcription_can_stop_before_cleaning(
         Mock(side_effect=lambda series, explicit_language: explicit_language),
     )
     monkeypatch.setattr(
-        transcription_data,
-        "_stage_audio_series",
-        Mock(return_value=reference),
+        transcription_data, "_stage_audio_series", Mock(return_value=reference)
     )
     monkeypatch.setattr(
         transcription_data,
@@ -275,16 +245,8 @@ def test_process_transcription_can_stop_before_cleaning(
         Mock(return_value=reference),
     )
     monkeypatch.setattr(transcription_data, "load_or_clean_series", clean)
-    monkeypatch.setattr(
-        transcription_data,
-        "_load_or_review_series_guided",
-        review,
-    )
-    monkeypatch.setattr(
-        transcription_data,
-        "_load_or_translate_series_gaps",
-        translate,
-    )
+    monkeypatch.setattr(transcription_data, "_load_or_review_series_guided", review)
+    monkeypatch.setattr(transcription_data, "_load_or_translate_series_gaps", translate)
 
     output = transcription_data.process_transcription(
         tmp_path,

--- a/test/data/tmm/__init__.py
+++ b/test/data/tmm/__init__.py
@@ -109,8 +109,7 @@ output_dir = title_root / "output"
 
 @cache
 def get_tmm_eng_ocr_fusion_test_cases(
-    prompt: OcrFusionPrompt = OcrFusionPromptEng,
-    **kwargs: Any,
+    prompt: OcrFusionPrompt = OcrFusionPromptEng, **kwargs: Any
 ) -> list[TestCase]:
     """Get TMM English OCR fusion test cases.
 
@@ -142,8 +141,7 @@ def get_tmm_eng_review_test_cases(
 
 @cache
 def get_tmm_yue_hans_ocr_fusion_test_cases(
-    prompt: OcrFusionPrompt = OcrFusionPromptYueHans,
-    **kwargs: Any,
+    prompt: OcrFusionPrompt = OcrFusionPromptYueHans, **kwargs: Any
 ) -> list[TestCase]:
     """Get TMM yue-Hans OCR fusion test cases.
 
@@ -175,8 +173,7 @@ def get_tmm_yue_hans_review_test_cases(
 
 @cache
 def get_tmm_yue_hant_ocr_fusion_test_cases(
-    prompt: OcrFusionPrompt = OcrFusionPromptYueHant,
-    **kwargs: Any,
+    prompt: OcrFusionPrompt = OcrFusionPromptYueHant, **kwargs: Any
 ) -> list[TestCase]:
     """Get TMM yue-Hant OCR fusion test cases.
 
@@ -224,8 +221,7 @@ def get_tmm_yue_hant_simplify_review_test_cases(
 
 @cache
 def get_tmm_zho_hans_ocr_fusion_test_cases(
-    prompt: OcrFusionPrompt = OcrFusionPromptZhoHans,
-    **kwargs: Any,
+    prompt: OcrFusionPrompt = OcrFusionPromptZhoHans, **kwargs: Any
 ) -> list[TestCase]:
     """Get TMM zho-Hans OCR fusion test cases.
 
@@ -257,8 +253,7 @@ def get_tmm_zho_hans_review_test_cases(
 
 @cache
 def get_tmm_zho_hant_ocr_fusion_test_cases(
-    prompt: OcrFusionPrompt = OcrFusionPromptZhoHant,
-    **kwargs: Any,
+    prompt: OcrFusionPrompt = OcrFusionPromptZhoHant, **kwargs: Any
 ) -> list[TestCase]:
     """Get TMM zho-Hant OCR fusion test cases.
 

--- a/test/data/transcription.py
+++ b/test/data/transcription.py
@@ -24,10 +24,7 @@ from scinoephile.workflows.translation import translate_series_gaps
 
 from .helpers import load_or_clean_series
 
-__all__ = [
-    "get_reference_for_guide_blocks",
-    "process_transcription",
-]
+__all__ = ["get_reference_for_guide_blocks", "process_transcription"]
 
 logger = getLogger(__name__)
 
@@ -59,9 +56,7 @@ class _RelogLanguageMismatchFilter(Filter):
 
 
 def get_reference_for_guide_blocks(
-    reference: Series,
-    guide: Series,
-    stop_at_idx: int | None,
+    reference: Series, guide: Series, stop_at_idx: int | None
 ) -> Series:
     """Limit an evaluation reference to a prefix of guide blocks.
 
@@ -156,11 +151,7 @@ def process_transcription(
         output_dir_path = title_root_path / "output" / f"{language.code}_transcribe"
     output_dir_path.mkdir(parents=True, exist_ok=True)
 
-    evaluation_reference = get_reference_for_guide_blocks(
-        reference,
-        guide,
-        stop_at_idx,
-    )
+    evaluation_reference = get_reference_for_guide_blocks(reference, guide, stop_at_idx)
 
     # Stage guide subtitles and audio under the transcription output
     audio = _stage_audio_series(
@@ -195,12 +186,7 @@ def process_transcription(
     # Clean transcription
     clean_path = output_dir_path / "transcribe_clean.srt"
     with _relog_cantonese_transcription_mismatch(language):
-        cleaned = load_or_clean_series(
-            transcribe,
-            clean_path,
-            language,
-            overwrite,
-        )
+        cleaned = load_or_clean_series(transcribe, clean_path, language, overwrite)
     logger.info(
         f"{language.code} transcription CER after cleaning:\n"
         f"{SeriesCER(evaluation_reference, cleaned)}"
@@ -405,9 +391,7 @@ def _load_or_translate_series_gaps(
 
 
 @contextmanager
-def _relog_cantonese_transcription_mismatch(
-    language: Language,
-) -> Iterator[None]:
+def _relog_cantonese_transcription_mismatch(language: Language) -> Iterator[None]:
     """Relog expected same-script Cantonese-to-Mandarin detection at info.
 
     Arguments:

--- a/test/dictionaries/cuhk/test_cuhk_dictionary_service.py
+++ b/test/dictionaries/cuhk/test_cuhk_dictionary_service.py
@@ -22,8 +22,7 @@ from test.helpers import parametrize
 def test_cuhk_service_keeps_cache_paths_on_scraper(tmp_path: Path):
     """Test resolved CUHK cache paths remain owned by the scraper."""
     service = CuhkDictionaryService(
-        database_path=tmp_path / "cuhk.db",
-        cache_root_path=tmp_path / "cache",
+        database_path=tmp_path / "cuhk.db", cache_root_path=tmp_path / "cache"
     )
 
     assert service.scraper.discovery_cache.cache_dir_path == (
@@ -115,10 +114,7 @@ def service(
         (
             "gully",
             None,
-            raises(
-                ValueError,
-                match="Could not infer a supported lookup format",
-            ),
+            raises(ValueError, match="Could not infer a supported lookup format"),
         ),
     ],
 )

--- a/test/dictionaries/cuhk/test_scraper.py
+++ b/test/dictionaries/cuhk/test_scraper.py
@@ -59,10 +59,7 @@ def test_response_cache_namespaces_are_flat(tmp_path: Path):
     assert scraper.scraped_cache.cache_dir_path == tmp_path / "cuhk-pages"
 
 
-def test_response_cache_paths_include_version(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
-):
+def test_response_cache_paths_include_version(tmp_path: Path, monkeypatch: MonkeyPatch):
     """Test CUHK response cache paths differ between cache versions."""
     cache = CuhkResponseCache(tmp_path, "cuhk-discovery")
     first_cache_path = cache.get_path("terms")
@@ -81,8 +78,7 @@ def test_response_cache_rejects_unsafe_stem(tmp_path: Path):
 
 
 def test_parse_scraped_pages_loads_through_cache(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test cached CUHK pages are validated and marked used before parsing."""
     scraper = CuhkDictionaryScraper(cache_root_path=tmp_path)
@@ -93,11 +89,7 @@ def test_parse_scraped_pages_loads_through_cache(
     old_timestamp = time() - 60 * 60 * 24 * 40
     set_mtime(valid_path, old_timestamp)
     parse_word_html = Mock(return_value=None)
-    monkeypatch.setattr(
-        scraper,
-        "parse_word_html",
-        parse_word_html,
-    )
+    monkeypatch.setattr(scraper, "parse_word_html", parse_word_html)
 
     assert scraper.parse_scraped_pages() == []
     assert valid_path.stat().st_mtime > old_timestamp

--- a/test/dictionaries/gzzj/test_gzzj_dictionary_service.py
+++ b/test/dictionaries/gzzj/test_gzzj_dictionary_service.py
@@ -39,8 +39,7 @@ def source_json_path() -> Generator[Path]:
 def service(database_path: Path, source_json_path: Path) -> GzzjDictionaryService:
     """Provide a GZZJ service backed by deterministic JSON fixture data."""
     service = GzzjDictionaryService(
-        database_path=database_path,
-        source_json_path=source_json_path,
+        database_path=database_path, source_json_path=source_json_path
     )
     service.build(overwrite=True)
     return service
@@ -56,10 +55,7 @@ def service(database_path: Path, source_json_path: Path) -> GzzjDictionaryServic
         (
             "gully",
             None,
-            raises(
-                ValueError,
-                match="Could not infer a supported lookup format",
-            ),
+            raises(ValueError, match="Could not infer a supported lookup format"),
         ),
     ],
 )

--- a/test/dictionaries/kaifangcidian/test_kaifangcidian_dictionary_service.py
+++ b/test/dictionaries/kaifangcidian/test_kaifangcidian_dictionary_service.py
@@ -61,9 +61,7 @@ def _write_fixture_csv(csv_path: Path):
 
 
 def test_build_uses_local_csv_data(
-    database_path: Path,
-    local_data_dir_path: Path,
-    runtime_data_dir_path: Path,
+    database_path: Path, local_data_dir_path: Path, runtime_data_dir_path: Path
 ):
     """Build Kaifangcidian DB from local canonical CSV when available.
 
@@ -126,9 +124,7 @@ def test_build_downloads_when_local_csv_missing(
 
 
 def test_build_updates_local_data_from_existing_runtime_csv(
-    database_path: Path,
-    local_data_dir_path: Path,
-    runtime_data_dir_path: Path,
+    database_path: Path, local_data_dir_path: Path, runtime_data_dir_path: Path
 ):
     """Update local canonical CSV from an existing runtime CSV.
 

--- a/test/dictionaries/kaifangcidian/test_kaifangcidian_downloader.py
+++ b/test/dictionaries/kaifangcidian/test_kaifangcidian_downloader.py
@@ -63,8 +63,4 @@ def test_parse_js_vars_supports_optional_semicolon():
 
     parsed = downloader._parse_js_vars(js_text)
 
-    assert parsed == {
-        "zi": "han payload",
-        "ci": "ci payload",
-        "jpzi": "jp payload",
-    }
+    assert parsed == {"zi": "han payload", "ci": "ci payload", "jpzi": "jp payload"}

--- a/test/dictionaries/test_dictionary_tools.py
+++ b/test/dictionaries/test_dictionary_tools.py
@@ -128,10 +128,7 @@ def test_dictionary_definition_to_dict():
     """Serialize one dictionary definition payload."""
     assert dictionary_definition_to_dict(
         DictionaryDefinition(label="noun", text="stream water")
-    ) == {
-        "label": "noun",
-        "text": "stream water",
-    }
+    ) == {"label": "noun", "text": "stream water"}
 
 
 def test_dictionary_entry_to_dict():
@@ -155,14 +152,8 @@ def test_dictionary_entry_to_dict():
         "jyutping": "saan1 haang1",
         "frequency": 2.0,
         "definitions": [
-            {
-                "label": "",
-                "text": "gully",
-            },
-            {
-                "label": "noun",
-                "text": "mountain stream",
-            },
+            {"label": "", "text": "gully"},
+            {"label": "noun", "text": "mountain stream"},
         ],
     }
 
@@ -189,9 +180,7 @@ def test_get_dictionary_tools_uses_prompt_text():
     )
 
 
-def test_lookup_dictionary_defaults_to_all_dictionaries(
-    dictionary_data_dir_path: Path,
-):
+def test_lookup_dictionary_defaults_to_all_dictionaries(dictionary_data_dir_path: Path):
     """Search all available local dictionaries by default."""
     with patch.dict(environ, {"SCINOEPHILE_DATA_DIR": str(dictionary_data_dir_path)}):
         response = lookup_dictionary(query="共享")

--- a/test/dictionaries/unihan/test_unihan_dictionary_service.py
+++ b/test/dictionaries/unihan/test_unihan_dictionary_service.py
@@ -21,8 +21,7 @@ def _write_fixture_sources(base_dir_path: Path):
     """
     base_dir_path.mkdir(parents=True, exist_ok=True)
     (base_dir_path / "Unihan_Variants.txt").write_text(
-        "U+4E07\tkTraditionalVariant\tU+842C\n",
-        encoding="utf-8",
+        "U+4E07\tkTraditionalVariant\tU+842C\n", encoding="utf-8"
     )
     (base_dir_path / "Unihan_Readings.txt").write_text(
         (
@@ -36,15 +35,12 @@ def _write_fixture_sources(base_dir_path: Path):
         encoding="utf-8",
     )
     (base_dir_path / "Unihan_DictionaryLikeData.txt").write_text(
-        ("U+4E00\tkCangjie\tM\nU+842C\tkCangjie\tDQ\n"),
-        encoding="utf-8",
+        ("U+4E00\tkCangjie\tM\nU+842C\tkCangjie\tDQ\n"), encoding="utf-8"
     )
 
 
 def test_build_uses_local_source_data(
-    database_path: Path,
-    local_data_dir_path: Path,
-    runtime_data_dir_path: Path,
+    database_path: Path, local_data_dir_path: Path, runtime_data_dir_path: Path
 ):
     """Build Unihan DB from local source files when available.
 
@@ -101,9 +97,7 @@ def test_build_downloads_when_local_sources_missing(
         }
 
     monkeypatch.setattr(
-        service,
-        "_download_and_extract_to_runtime",
-        _download_and_extract_to_runtime,
+        service, "_download_and_extract_to_runtime", _download_and_extract_to_runtime
     )
 
     service.build(overwrite=True)
@@ -113,9 +107,7 @@ def test_build_downloads_when_local_sources_missing(
 
 
 def test_build_updates_local_data_from_existing_runtime_files(
-    database_path: Path,
-    local_data_dir_path: Path,
-    runtime_data_dir_path: Path,
+    database_path: Path, local_data_dir_path: Path, runtime_data_dir_path: Path
 ):
     """Update local source files from existing runtime source files.
 
@@ -146,8 +138,7 @@ def test_build_updates_local_data_from_existing_runtime_files(
 
 
 def test_download_and_extract_raises_file_not_found_for_missing_archive_member(
-    runtime_data_dir_path: Path,
-    monkeypatch: MonkeyPatch,
+    runtime_data_dir_path: Path, monkeypatch: MonkeyPatch
 ):
     """Raise FileNotFoundError when Unihan.zip is missing a required source file.
 

--- a/test/dictionaries/unihan/test_unihan_parser.py
+++ b/test/dictionaries/unihan/test_unihan_parser.py
@@ -80,10 +80,7 @@ def test_parse_variants_readings_and_dictionary_like_data(source_dir_path: Path)
         definition.text
         for definition in one_entry.definitions
         if definition.label == "釋義"
-    ] == [
-        "one",
-        "single",
-    ]
+    ] == ["one", "single"]
 
     assert ("萬", "万", "wan4", "maan6") in entries_by_key
     variant_entry = entries_by_key[("萬", "万", "wan4", "maan6")]
@@ -107,8 +104,7 @@ def test_parse_readings_preserves_simplified_only_source_rows(source_dir_path: P
         source_dir_path: fixture source directory path
     """
     (source_dir_path / "Unihan_Variants.txt").write_text(
-        "U+4E07\tkTraditionalVariant\tU+842C\n",
-        encoding="utf-8",
+        "U+4E07\tkTraditionalVariant\tU+842C\n", encoding="utf-8"
     )
     (source_dir_path / "Unihan_Readings.txt").write_text(
         (
@@ -118,10 +114,7 @@ def test_parse_readings_preserves_simplified_only_source_rows(source_dir_path: P
         ),
         encoding="utf-8",
     )
-    (source_dir_path / "Unihan_DictionaryLikeData.txt").write_text(
-        "",
-        encoding="utf-8",
-    )
+    (source_dir_path / "Unihan_DictionaryLikeData.txt").write_text("", encoding="utf-8")
 
     _, entries = UnihanDictionaryParser().parse(
         dictionary_like_data_path=source_dir_path / "Unihan_DictionaryLikeData.txt",

--- a/test/dictionaries/wiktionary/test_wiktionary_dictionary_service.py
+++ b/test/dictionaries/wiktionary/test_wiktionary_dictionary_service.py
@@ -25,10 +25,7 @@ def _write_fixture_jsonl(jsonl_path: Path):
             "word": "學生",
             "pos": "noun",
             "sounds": [
-                {
-                    "tags": ["Mandarin", "Pinyin", "standard"],
-                    "zh_pron": "xuéshēng",
-                },
+                {"tags": ["Mandarin", "Pinyin", "standard"], "zh_pron": "xuéshēng"},
                 {
                     "tags": ["Cantonese", "Guangzhou", "Jyutping"],
                     "zh_pron": "hok⁶ saang¹",
@@ -40,14 +37,8 @@ def _write_fixture_jsonl(jsonl_path: Path):
             "word": "行",
             "pos": "verb",
             "sounds": [
-                {
-                    "tags": ["Mandarin", "Pinyin", "standard"],
-                    "zh_pron": "háng",
-                },
-                {
-                    "tags": ["Cantonese", "Guangzhou", "Jyutping"],
-                    "zh_pron": "ha⁴ng",
-                },
+                {"tags": ["Mandarin", "Pinyin", "standard"], "zh_pron": "háng"},
+                {"tags": ["Cantonese", "Guangzhou", "Jyutping"], "zh_pron": "ha⁴ng"},
             ],
             "senses": [{"glosses": ["to go"]}],
         },
@@ -59,9 +50,7 @@ def _write_fixture_jsonl(jsonl_path: Path):
 
 
 def test_build_uses_local_jsonl_data(
-    database_path: Path,
-    local_data_dir_path: Path,
-    runtime_data_dir_path: Path,
+    database_path: Path, local_data_dir_path: Path, runtime_data_dir_path: Path
 ):
     """Build Wiktionary DB from local canonical JSONL when available.
 
@@ -84,9 +73,7 @@ def test_build_uses_local_jsonl_data(
 
 
 def test_build_updates_local_data_from_existing_local_jsonl(
-    database_path: Path,
-    local_data_dir_path: Path,
-    runtime_data_dir_path: Path,
+    database_path: Path, local_data_dir_path: Path, runtime_data_dir_path: Path
 ):
     """Avoid copying a local JSONL file onto itself during build.
 
@@ -112,9 +99,7 @@ def test_build_updates_local_data_from_existing_local_jsonl(
 
 
 def test_build_uses_explicit_source_jsonl_path(
-    database_path: Path,
-    local_data_dir_path: Path,
-    runtime_data_dir_path: Path,
+    database_path: Path, local_data_dir_path: Path, runtime_data_dir_path: Path
 ):
     """Build Wiktionary DB from an explicit Kaikki JSONL source path.
 
@@ -138,9 +123,7 @@ def test_build_uses_explicit_source_jsonl_path(
 
 
 def test_build_updates_local_data_from_existing_runtime_jsonl(
-    database_path: Path,
-    local_data_dir_path: Path,
-    runtime_data_dir_path: Path,
+    database_path: Path, local_data_dir_path: Path, runtime_data_dir_path: Path
 ):
     """Update local canonical JSONL from an existing runtime canonical JSONL.
 
@@ -208,9 +191,7 @@ def test_build_downloads_when_no_source_jsonl_available(
 
 
 def test_lookup_finds_entries_using_fallback_jyutping(
-    database_path: Path,
-    local_data_dir_path: Path,
-    runtime_data_dir_path: Path,
+    database_path: Path, local_data_dir_path: Path, runtime_data_dir_path: Path
 ):
     """Find entries built from fallback Jyutping with normalized queries.
 
@@ -222,11 +203,7 @@ def test_lookup_finds_entries_using_fallback_jyutping(
     source_jsonl_path = local_data_dir_path / "entries.jsonl"
     source_jsonl_path.write_text(
         json.dumps(
-            {
-                "word": "學生",
-                "pos": "noun",
-                "senses": [{"glosses": ["student"]}],
-            },
+            {"word": "學生", "pos": "noun", "senses": [{"glosses": ["student"]}]},
             ensure_ascii=False,
         )
         + "\n",

--- a/test/dictionaries/wiktionary/test_wiktionary_parser.py
+++ b/test/dictionaries/wiktionary/test_wiktionary_parser.py
@@ -29,11 +29,7 @@ def test_parse_uses_pronunciation_fallback_when_sounds_missing(source_jsonl_path
     """
     source_jsonl_path.write_text(
         json.dumps(
-            {
-                "word": "學生",
-                "pos": "noun",
-                "senses": [{"glosses": ["student"]}],
-            },
+            {"word": "學生", "pos": "noun", "senses": [{"glosses": ["student"]}]},
             ensure_ascii=False,
         )
         + "\n",
@@ -62,10 +58,7 @@ def test_parse_deduplicates_duplicate_glosses(source_jsonl_path: Path):
                 "word": "芒",
                 "pos": "noun",
                 "sounds": [
-                    {
-                        "tags": ["Mandarin", "Pinyin", "standard"],
-                        "zh_pron": "máng",
-                    },
+                    {"tags": ["Mandarin", "Pinyin", "standard"], "zh_pron": "máng"},
                     {
                         "tags": ["Cantonese", "Guangzhou", "Jyutping"],
                         "zh_pron": "mong⁴",
@@ -115,10 +108,7 @@ def test_parse_supports_mixed_cantonese_and_mandarin_pronunciations(
                 "word": "行",
                 "pos": "verb",
                 "sounds": [
-                    {
-                        "tags": ["Mandarin", "Pinyin", "standard"],
-                        "zh_pron": "háng",
-                    },
+                    {"tags": ["Mandarin", "Pinyin", "standard"], "zh_pron": "háng"},
                     {
                         "tags": [
                             "Mandarin",

--- a/test/helpers/__init__.py
+++ b/test/helpers/__init__.py
@@ -191,10 +191,7 @@ def skip_if_ci() -> Any:
     Returns:
         pytest mark decorator
     """
-    return skipif(
-        bool(getenv("CI")),
-        reason="Skip when running in CI",
-    )
+    return skipif(bool(getenv("CI")), reason="Skip when running in CI")
 
 
 def skip_if_codex() -> Any:

--- a/test/helpers/cli.py
+++ b/test/helpers/cli.py
@@ -8,11 +8,7 @@ from argparse import Action, ArgumentParser
 
 from scinoephile.common import CommandLineInterface
 
-__all__ = [
-    "get_cli_action",
-    "get_cli_action_group_title",
-    "get_parser_action",
-]
+__all__ = ["get_cli_action", "get_cli_action_group_title", "get_parser_action"]
 
 
 def get_cli_action(cli: type[CommandLineInterface], option: str) -> Action:

--- a/test/helpers/files.py
+++ b/test/helpers/files.py
@@ -7,10 +7,7 @@ from __future__ import annotations
 from os import utime
 from pathlib import Path
 
-__all__ = [
-    "set_mtime",
-    "write_cache_file",
-]
+__all__ = ["set_mtime", "write_cache_file"]
 
 
 def set_mtime(path: Path, timestamp: float) -> None:

--- a/test/helpers/media_subtitles.py
+++ b/test/helpers/media_subtitles.py
@@ -36,9 +36,7 @@ def cache_image_subtitles(
     """
     cache_subtitle_stream(infile_path, stream, cache_root_path, b"not a real sup")
     image_dir_path = get_image_subtitle_dir_path(
-        infile_path,
-        stream,
-        cache_root_path=cache_root_path,
+        infile_path, stream, cache_root_path=cache_root_path
     )
     events: list[ImageSubtitle] = []
     for index in range(event_count):
@@ -60,10 +58,7 @@ def cache_image_subtitles(
 
 
 def cache_subtitle_stream(
-    infile_path: Path,
-    stream: SubtitleStream,
-    cache_root_path: Path,
-    data: bytes | str,
+    infile_path: Path, stream: SubtitleStream, cache_root_path: Path, data: bytes | str
 ) -> Path:
     """Write a cached extracted subtitle stream.
 
@@ -85,10 +80,7 @@ def cache_subtitle_stream(
 
 
 def get_image_subtitle_dir_path(
-    infile_path: Path,
-    stream: SubtitleStream,
-    *,
-    cache_root_path: Path,
+    infile_path: Path, stream: SubtitleStream, *, cache_root_path: Path
 ) -> Path:
     """Get the image subtitle cache directory path used by the media cache.
 

--- a/test/helpers/ocr_recognizers.py
+++ b/test/helpers/ocr_recognizers.py
@@ -8,10 +8,7 @@ from typing import ClassVar
 
 from PIL import Image
 
-__all__ = [
-    "FailingOcrRecognizer",
-    "RecordingOcrRecognizer",
-]
+__all__ = ["FailingOcrRecognizer", "RecordingOcrRecognizer"]
 
 
 class FailingOcrRecognizer:

--- a/test/helpers/ocr_validation.py
+++ b/test/helpers/ocr_validation.py
@@ -36,10 +36,7 @@ def clear_validation_data(session: OcrValidationSession):
 
 
 def make_ocr_html_dir(
-    tmp_path: Path,
-    *,
-    text: str,
-    image_pixels: list[tuple[int, int]] | None = None,
+    tmp_path: Path, *, text: str, image_pixels: list[tuple[int, int]] | None = None
 ) -> Path:
     """Create an OCR image HTML directory with one subtitle image.
 
@@ -57,18 +54,7 @@ def make_ocr_html_dir(
         image_pixels = [(255, 255), (0, 255), (255, 255), (0, 255)]
     image.putdata(image_pixels)
     image.save(html_dir_path / "0001.png")
-    _write_html_index(
-        html_dir_path,
-        [
-            (
-                1,
-                "1,000",
-                "2,000",
-                "0001.png",
-                text,
-            )
-        ],
-    )
+    _write_html_index(html_dir_path, [(1, "1,000", "2,000", "0001.png", text)])
     return html_dir_path
 
 
@@ -138,8 +124,7 @@ def prepared_gap_session(
         prepared OCR validation session
     """
     session = OcrValidationSession.from_dir_path(
-        html_dir_path,
-        validation_data_dir_path=tmp_path / "validation-data",
+        html_dir_path, validation_data_dir_path=tmp_path / "validation-data"
     )
     clear_validation_data(session)
     session.manager.char_dims_by_n[1][char_1] = {(10, 20)}

--- a/test/helpers/series_files.py
+++ b/test/helpers/series_files.py
@@ -8,11 +8,7 @@ from pathlib import Path
 
 from scinoephile.core.subtitles import Series, Subtitle
 
-__all__ = [
-    "get_ocr_text_series",
-    "get_text_series",
-    "write_srt_series",
-]
+__all__ = ["get_ocr_text_series", "get_text_series", "write_srt_series"]
 
 
 def get_ocr_text_series(*texts: str) -> Series:
@@ -23,19 +19,11 @@ def get_ocr_text_series(*texts: str) -> Series:
     Returns:
         subtitle series with one event per text
     """
-    return get_text_series(
-        *texts,
-        start_ms=1000,
-        duration_ms=1000,
-        step_ms=2000,
-    )
+    return get_text_series(*texts, start_ms=1000, duration_ms=1000, step_ms=2000)
 
 
 def get_text_series(
-    *texts: str,
-    start_ms: int = 0,
-    duration_ms: int = 500,
-    step_ms: int = 1000,
+    *texts: str, start_ms: int = 0, duration_ms: int = 500, step_ms: int = 1000
 ) -> Series:
     """Build a compact subtitle series from text events.
 

--- a/test/image/ocr/lens/test_lens_recognizer.py
+++ b/test/image/ocr/lens/test_lens_recognizer.py
@@ -45,8 +45,7 @@ class CountingLensRecognizer(LensRecognizer):
             overwrite_cache: whether to replace matching OCR cache files
         """
         super().__init__(
-            cache_root_path=cache_root_path,
-            overwrite_cache=overwrite_cache,
+            cache_root_path=cache_root_path, overwrite_cache=overwrite_cache
         )
         self.predict_count = 0
         self.exceptions = exceptions
@@ -107,8 +106,7 @@ def patch_google_lens_sleep(monkeypatch: MonkeyPatch) -> list[float]:
         delays.append(delay)
 
     monkeypatch.setattr(
-        "scinoephile.image.ocr.lens.lens_recognizer.asyncio.sleep",
-        fake_sleep,
+        "scinoephile.image.ocr.lens.lens_recognizer.asyncio.sleep", fake_sleep
     )
     return delays
 
@@ -142,10 +140,7 @@ def test_normalize_lens_result_prefers_line_blocks():
     """Test normalization prefers line block text when available."""
     result: dict[str, Any] = {
         "ocr_text": "fallback",
-        "line_blocks": [
-            {"text": "first"},
-            {"text": "second"},
-        ],
+        "line_blocks": [{"text": "first"}, {"text": "second"}],
     }
 
     lines = LensRecognizer._normalize_lens_result(result)
@@ -157,10 +152,7 @@ def test_normalize_lens_result_supports_object_results():
     """Test normalization supports object-like chrome-lens-py results."""
     result = SimpleNamespace(
         ocr_text="fallback",
-        line_blocks=[
-            SimpleNamespace(text="first"),
-            SimpleNamespace(text="second"),
-        ],
+        line_blocks=[SimpleNamespace(text="first"), SimpleNamespace(text="second")],
     )
 
     lines = LensRecognizer._normalize_lens_result(result)
@@ -185,8 +177,7 @@ def test_lens_recognizer_rejects_unsupported_languages():
     ],
 )
 def test_lens_recognizer_maps_supported_languages_to_engine_codes(
-    language: Language,
-    expected_code: str,
+    language: Language, expected_code: str
 ):
     """Test Google Lens recognizer maps supported languages to engine codes.
 
@@ -201,8 +192,7 @@ def test_lens_recognizer_maps_supported_languages_to_engine_codes(
 
 
 def test_lens_recognizer_caches_results_by_image(
-    monkeypatch: MonkeyPatch,
-    tmp_path: Path,
+    monkeypatch: MonkeyPatch, tmp_path: Path
 ):
     """Test Google Lens recognizer caches OCR results by image content.
 
@@ -222,8 +212,7 @@ def test_lens_recognizer_caches_results_by_image(
 
 
 def test_lens_recognizer_regenerates_invalid_cache(
-    monkeypatch: MonkeyPatch,
-    tmp_path: Path,
+    monkeypatch: MonkeyPatch, tmp_path: Path
 ):
     """Test structurally invalid Google Lens cache data is treated as a miss."""
     recognizer = CountingLensRecognizer(cache_root_path=tmp_path)
@@ -239,8 +228,7 @@ def test_lens_recognizer_regenerates_invalid_cache(
 
 
 def test_lens_recognizer_overwrites_matching_cache(
-    monkeypatch: MonkeyPatch,
-    tmp_path: Path,
+    monkeypatch: MonkeyPatch, tmp_path: Path
 ):
     """Test Google Lens cache overwrite recognizes matching images again.
 
@@ -251,9 +239,7 @@ def test_lens_recognizer_overwrites_matching_cache(
     image = Image.new("RGBA", (10, 8), (255, 255, 255, 0))
     cached = CountingLensRecognizer(cache_root_path=tmp_path)
     fresh = CountingLensRecognizer(
-        cache_root_path=tmp_path,
-        overwrite_cache=True,
-        results=[["fresh"]],
+        cache_root_path=tmp_path, overwrite_cache=True, results=[["fresh"]]
     )
 
     patch_chrome_lens_py(monkeypatch, cached)
@@ -264,8 +250,7 @@ def test_lens_recognizer_overwrites_matching_cache(
 
 
 def test_lens_recognizer_formats_cached_results(
-    monkeypatch: MonkeyPatch,
-    tmp_path: Path,
+    monkeypatch: MonkeyPatch, tmp_path: Path
 ):
     """Test cached Google Lens results are formatted after loading.
 
@@ -281,8 +266,7 @@ def test_lens_recognizer_formats_cached_results(
 
     cache_path = next((tmp_path / "google-lens").glob("*.json"))
     cache_path.write_text(
-        '{"cache_version": 1, "result": {"lines": ["cached", "..."]}}',
-        encoding="utf-8",
+        '{"cache_version": 1, "result": {"lines": ["cached", "..."]}}', encoding="utf-8"
     )
 
     assert recognizer.recognize_image(image) == "cached ..."
@@ -290,8 +274,7 @@ def test_lens_recognizer_formats_cached_results(
 
 
 def test_lens_recognizer_does_not_cache_request_errors(
-    monkeypatch: MonkeyPatch,
-    tmp_path: Path,
+    monkeypatch: MonkeyPatch, tmp_path: Path
 ):
     """Test transient Google Lens request errors are not cached as empty OCR.
 
@@ -301,8 +284,7 @@ def test_lens_recognizer_does_not_cache_request_errors(
     """
     patch_google_lens_sleep(monkeypatch)
     recognizer = CountingLensRecognizer(
-        cache_root_path=tmp_path,
-        results=[["Request error (possibly proxy-related)"]],
+        cache_root_path=tmp_path, results=[["Request error (possibly proxy-related)"]]
     )
     patch_chrome_lens_py(monkeypatch, recognizer)
     image = Image.new("RGBA", (10, 8), (255, 255, 255, 0))
@@ -315,8 +297,7 @@ def test_lens_recognizer_does_not_cache_request_errors(
 
 
 def test_lens_recognizer_retries_request_errors_before_caching(
-    monkeypatch: MonkeyPatch,
-    tmp_path: Path,
+    monkeypatch: MonkeyPatch, tmp_path: Path
 ):
     """Test Google Lens retries transient request errors before caching success.
 
@@ -344,8 +325,7 @@ def test_lens_recognizer_retries_request_errors_before_caching(
 
 
 def test_lens_recognizer_raises_last_request_error_after_retries(
-    monkeypatch: MonkeyPatch,
-    tmp_path: Path,
+    monkeypatch: MonkeyPatch, tmp_path: Path
 ):
     """Test Google Lens raises the last request error after retry exhaustion.
 
@@ -397,15 +377,14 @@ def test_lens_recognizer_retries_in_one_asyncio_run(monkeypatch: MonkeyPatch):
         return real_asyncio_run(main, **kwargs)
 
     monkeypatch.setattr(
-        "scinoephile.image.ocr.lens.lens_recognizer.asyncio.run",
-        counting_run,
+        "scinoephile.image.ocr.lens.lens_recognizer.asyncio.run", counting_run
     )
     recognizer = CountingLensRecognizer(
         results=[
             ["Request error (possibly proxy-related): 502 Bad Gateway"],
             ["Request error (possibly proxy-related): 502 Bad Gateway"],
             ["recognized"],
-        ],
+        ]
     )
     patch_chrome_lens_py(monkeypatch, recognizer)
     image = Image.new("RGBA", (10, 8), (255, 255, 255, 0))
@@ -428,7 +407,7 @@ def test_lens_recognizer_waits_between_transient_retries(monkeypatch: MonkeyPatc
             ["Request error (possibly proxy-related): 502 Bad Gateway"],
             ["Request error (possibly proxy-related): 502 Bad Gateway"],
             ["recognized"],
-        ],
+        ]
     )
     patch_chrome_lens_py(monkeypatch, recognizer)
     image = Image.new("RGBA", (10, 8), (255, 255, 255, 0))
@@ -461,16 +440,14 @@ def test_lens_recognizer_retries_lens_api_errors(monkeypatch: MonkeyPatch):
     assert recognizer.predict_count == 3
 
 
-def test_lens_recognizer_does_not_retry_nontransient_errors(
-    monkeypatch: MonkeyPatch,
-):
+def test_lens_recognizer_does_not_retry_nontransient_errors(monkeypatch: MonkeyPatch):
     """Test Google Lens does not retry deterministic API errors.
 
     Arguments:
         monkeypatch: pytest monkeypatch fixture
     """
     recognizer = CountingLensRecognizer(
-        exceptions=[ValueError("deterministic failure")],
+        exceptions=[ValueError("deterministic failure")]
     )
     patch_chrome_lens_py(monkeypatch, recognizer)
     image = Image.new("RGBA", (10, 8), (255, 255, 255, 0))
@@ -548,7 +525,7 @@ def test_lens_recognizer_imports_chrome_lens_py_only_when_needed():
                 "LensRecognizer();"
                 "raise SystemExit('chrome_lens_py' in sys.modules)"
             ),
-        ],
+        ]
     )
 
     assert exitcode == 0

--- a/test/image/ocr/lens/test_lens_series.py
+++ b/test/image/ocr/lens/test_lens_series.py
@@ -25,21 +25,16 @@ def test_ocr_image_series_with_lens_preserves_timings_and_sets_text(
     image_series = ImageSeries(
         events=[
             ImageSubtitle(
-                start=1000,
-                end=2000,
-                img=Image.new("RGBA", (10, 8), (255, 255, 255, 0)),
+                start=1000, end=2000, img=Image.new("RGBA", (10, 8), (255, 255, 255, 0))
             ),
             ImageSubtitle(
-                start=3000,
-                end=4000,
-                img=Image.new("RGBA", (12, 9), (255, 255, 255, 0)),
+                start=3000, end=4000, img=Image.new("RGBA", (12, 9), (255, 255, 255, 0))
             ),
         ]
     )
     RecordingOcrRecognizer.reset("first", "second")
     monkeypatch.setattr(
-        "scinoephile.image.ocr.lens.LensRecognizer",
-        RecordingOcrRecognizer,
+        "scinoephile.image.ocr.lens.LensRecognizer", RecordingOcrRecognizer
     )
 
     text_series = ocr_image_series_with_lens(image_series)
@@ -53,8 +48,7 @@ def test_ocr_image_series_with_lens_preserves_timings_and_sets_text(
 
 
 def test_ocr_image_series_with_lens_logs_progress(
-    caplog: LogCaptureFixture,
-    monkeypatch: MonkeyPatch,
+    caplog: LogCaptureFixture, monkeypatch: MonkeyPatch
 ):
     """Test Google Lens image series processing logs OCR progress.
 
@@ -65,21 +59,16 @@ def test_ocr_image_series_with_lens_logs_progress(
     image_series = ImageSeries(
         events=[
             ImageSubtitle(
-                start=1000,
-                end=2000,
-                img=Image.new("RGBA", (10, 8), (255, 255, 255, 0)),
+                start=1000, end=2000, img=Image.new("RGBA", (10, 8), (255, 255, 255, 0))
             ),
             ImageSubtitle(
-                start=3000,
-                end=4000,
-                img=Image.new("RGBA", (12, 9), (255, 255, 255, 0)),
+                start=3000, end=4000, img=Image.new("RGBA", (12, 9), (255, 255, 255, 0))
             ),
         ]
     )
     RecordingOcrRecognizer.reset("first", "second")
     monkeypatch.setattr(
-        "scinoephile.image.ocr.lens.LensRecognizer",
-        RecordingOcrRecognizer,
+        "scinoephile.image.ocr.lens.LensRecognizer", RecordingOcrRecognizer
     )
 
     with caplog.at_level("INFO", logger="scinoephile.image.ocr.lens"):
@@ -106,24 +95,18 @@ def test_ocr_image_series_with_lens_defers_default_cache_resolution(
     RecordingOcrRecognizer.reset(Language.zho_hans.code)
 
     monkeypatch.setattr(
-        "scinoephile.image.ocr.lens.LensRecognizer",
-        RecordingOcrRecognizer,
+        "scinoephile.image.ocr.lens.LensRecognizer", RecordingOcrRecognizer
     )
     image_series = ImageSeries(
         events=[
             ImageSubtitle(
-                start=1000,
-                end=2000,
-                img=Image.new("RGBA", (10, 8), (255, 255, 255, 0)),
-            ),
+                start=1000, end=2000, img=Image.new("RGBA", (10, 8), (255, 255, 255, 0))
+            )
         ]
     )
 
     text_series = ocr_image_series_with_lens(
-        image_series,
-        cache_root_path=None,
-        language=Language.zho_hans,
-        retries=5,
+        image_series, cache_root_path=None, language=Language.zho_hans, retries=5
     )
 
     assert [event.text for event in text_series] == ["zho-Hans"]
@@ -144,8 +127,7 @@ def test_ocr_image_series_with_lens_defers_default_cache_resolution(
     ],
 )
 def test_ocr_image_series_with_lens_wraps_processing_errors(
-    monkeypatch: MonkeyPatch,
-    exception: Exception,
+    monkeypatch: MonkeyPatch, exception: Exception
 ):
     """Test Lens image series processing wraps implementation errors.
 
@@ -155,22 +137,18 @@ def test_ocr_image_series_with_lens_wraps_processing_errors(
     """
     FailingOcrRecognizer.exception = exception
     monkeypatch.setattr(
-        "scinoephile.image.ocr.lens.LensRecognizer",
-        FailingOcrRecognizer,
+        "scinoephile.image.ocr.lens.LensRecognizer", FailingOcrRecognizer
     )
     image_series = ImageSeries(
         events=[
             ImageSubtitle(
-                start=1000,
-                end=2000,
-                img=Image.new("RGBA", (10, 8), (255, 255, 255, 0)),
-            ),
+                start=1000, end=2000, img=Image.new("RGBA", (10, 8), (255, 255, 255, 0))
+            )
         ]
     )
 
     with raises(
-        ScinoephileError,
-        match="Unable to OCR image series with Google Lens",
+        ScinoephileError, match="Unable to OCR image series with Google Lens"
     ) as excinfo:
         ocr_image_series_with_lens(image_series)
 

--- a/test/image/ocr/paddle/test_paddle_recognizer.py
+++ b/test/image/ocr/paddle/test_paddle_recognizer.py
@@ -28,10 +28,7 @@ class CountingPaddleRecognizer(PaddleRecognizer):
     """PaddleOCR recognizer that counts uncached predictions."""
 
     def __init__(
-        self,
-        cache_root_path: Path | None = None,
-        *,
-        overwrite_cache: bool = False,
+        self, cache_root_path: Path | None = None, *, overwrite_cache: bool = False
     ):
         """Initialize.
 
@@ -93,10 +90,7 @@ def test_paddle_recognizer_overwrites_matching_cache(tmp_path: Path):
     """Test PaddleOCR cache overwrite recognizes matching images again."""
     image = Image.new("RGBA", (10, 8), (255, 255, 255, 0))
     cached = CountingPaddleRecognizer(cache_root_path=tmp_path)
-    fresh = CountingPaddleRecognizer(
-        cache_root_path=tmp_path,
-        overwrite_cache=True,
-    )
+    fresh = CountingPaddleRecognizer(cache_root_path=tmp_path, overwrite_cache=True)
 
     assert cached.recognize_image(image) == "cached text"
     assert fresh.recognize_image(image) == "cached text"
@@ -128,8 +122,7 @@ def test_paddle_recognizer_uses_server_models_and_disables_mkldnn_on_windows(
     setattr(paddleocr, "PaddleOCR", FakePaddleOCR)
     monkeypatch.setitem(sys.modules, "paddleocr", paddleocr)
     monkeypatch.setattr(
-        "scinoephile.image.ocr.paddle.paddle_recognizer.system",
-        lambda: "Windows",
+        "scinoephile.image.ocr.paddle.paddle_recognizer.system", lambda: "Windows"
     )
 
     PaddleRecognizer(language=Language.zho_hans)
@@ -163,8 +156,7 @@ def test_paddle_recognizer_keeps_mkldnn_enabled_off_windows(monkeypatch: MonkeyP
     setattr(paddleocr, "PaddleOCR", FakePaddleOCR)
     monkeypatch.setitem(sys.modules, "paddleocr", paddleocr)
     monkeypatch.setattr(
-        "scinoephile.image.ocr.paddle.paddle_recognizer.system",
-        lambda: "Linux",
+        "scinoephile.image.ocr.paddle.paddle_recognizer.system", lambda: "Linux"
     )
 
     PaddleRecognizer(language=Language.zho_hans)
@@ -221,7 +213,7 @@ def test_paddle_recognizer_imports_paddleocr_only_when_needed():
                 "import scinoephile.image.ocr.paddle.paddle_recognizer;"
                 "raise SystemExit('paddleocr' in sys.modules)"
             ),
-        ],
+        ]
     )
 
     assert exitcode == 0
@@ -278,9 +270,7 @@ def test_paddle_recognizer_rejects_unsupported_languages():
     ],
 )
 def test_paddle_recognizer_maps_supported_languages_to_engine_codes(
-    monkeypatch: MonkeyPatch,
-    language: Language,
-    expected_code: str,
+    monkeypatch: MonkeyPatch, language: Language, expected_code: str
 ):
     """Test PaddleOCR recognizer maps supported languages to engine codes.
 

--- a/test/image/ocr/paddle/test_paddle_series.py
+++ b/test/image/ocr/paddle/test_paddle_series.py
@@ -25,21 +25,16 @@ def test_ocr_image_series_with_paddle_preserves_timings_and_sets_text(
     image_series = ImageSeries(
         events=[
             ImageSubtitle(
-                start=1000,
-                end=2000,
-                img=Image.new("RGBA", (10, 8), (255, 255, 255, 0)),
+                start=1000, end=2000, img=Image.new("RGBA", (10, 8), (255, 255, 255, 0))
             ),
             ImageSubtitle(
-                start=3000,
-                end=4000,
-                img=Image.new("RGBA", (12, 9), (255, 255, 255, 0)),
+                start=3000, end=4000, img=Image.new("RGBA", (12, 9), (255, 255, 255, 0))
             ),
         ]
     )
     RecordingOcrRecognizer.reset("first", "second")
     monkeypatch.setattr(
-        "scinoephile.image.ocr.paddle.PaddleRecognizer",
-        RecordingOcrRecognizer,
+        "scinoephile.image.ocr.paddle.PaddleRecognizer", RecordingOcrRecognizer
     )
 
     text_series = ocr_image_series_with_paddle(image_series)
@@ -53,8 +48,7 @@ def test_ocr_image_series_with_paddle_preserves_timings_and_sets_text(
 
 
 def test_ocr_image_series_with_paddle_logs_progress(
-    caplog: LogCaptureFixture,
-    monkeypatch: MonkeyPatch,
+    caplog: LogCaptureFixture, monkeypatch: MonkeyPatch
 ):
     """Test PaddleOCR image series processing logs OCR progress.
 
@@ -65,21 +59,16 @@ def test_ocr_image_series_with_paddle_logs_progress(
     image_series = ImageSeries(
         events=[
             ImageSubtitle(
-                start=1000,
-                end=2000,
-                img=Image.new("RGBA", (10, 8), (255, 255, 255, 0)),
+                start=1000, end=2000, img=Image.new("RGBA", (10, 8), (255, 255, 255, 0))
             ),
             ImageSubtitle(
-                start=3000,
-                end=4000,
-                img=Image.new("RGBA", (12, 9), (255, 255, 255, 0)),
+                start=3000, end=4000, img=Image.new("RGBA", (12, 9), (255, 255, 255, 0))
             ),
         ]
     )
     RecordingOcrRecognizer.reset("first", "second")
     monkeypatch.setattr(
-        "scinoephile.image.ocr.paddle.PaddleRecognizer",
-        RecordingOcrRecognizer,
+        "scinoephile.image.ocr.paddle.PaddleRecognizer", RecordingOcrRecognizer
     )
 
     with caplog.at_level("INFO", logger="scinoephile.image.ocr.paddle"):
@@ -89,10 +78,7 @@ def test_ocr_image_series_with_paddle_logs_progress(
         record.message
         for record in caplog.records
         if record.name == "scinoephile.image.ocr.paddle"
-    ] == [
-        "OCRing subtitle 1/2 with PaddleOCR",
-        "OCRing subtitle 2/2 with PaddleOCR",
-    ]
+    ] == ["OCRing subtitle 1/2 with PaddleOCR", "OCRing subtitle 2/2 with PaddleOCR"]
 
 
 def test_ocr_image_series_with_paddle_defers_default_cache_resolution(
@@ -106,16 +92,13 @@ def test_ocr_image_series_with_paddle_defers_default_cache_resolution(
     RecordingOcrRecognizer.reset(Language.zho_hans.code)
 
     monkeypatch.setattr(
-        "scinoephile.image.ocr.paddle.PaddleRecognizer",
-        RecordingOcrRecognizer,
+        "scinoephile.image.ocr.paddle.PaddleRecognizer", RecordingOcrRecognizer
     )
     image_series = ImageSeries(
         events=[
             ImageSubtitle(
-                start=1000,
-                end=2000,
-                img=Image.new("RGBA", (10, 8), (255, 255, 255, 0)),
-            ),
+                start=1000, end=2000, img=Image.new("RGBA", (10, 8), (255, 255, 255, 0))
+            )
         ]
     )
 
@@ -143,8 +126,7 @@ def test_ocr_image_series_with_paddle_defers_default_cache_resolution(
     ],
 )
 def test_ocr_image_series_with_paddle_wraps_processing_errors(
-    monkeypatch: MonkeyPatch,
-    exception: Exception,
+    monkeypatch: MonkeyPatch, exception: Exception
 ):
     """Test PaddleOCR image series processing wraps implementation errors.
 
@@ -154,22 +136,18 @@ def test_ocr_image_series_with_paddle_wraps_processing_errors(
     """
     FailingOcrRecognizer.exception = exception
     monkeypatch.setattr(
-        "scinoephile.image.ocr.paddle.PaddleRecognizer",
-        FailingOcrRecognizer,
+        "scinoephile.image.ocr.paddle.PaddleRecognizer", FailingOcrRecognizer
     )
     image_series = ImageSeries(
         events=[
             ImageSubtitle(
-                start=1000,
-                end=2000,
-                img=Image.new("RGBA", (10, 8), (255, 255, 255, 0)),
-            ),
+                start=1000, end=2000, img=Image.new("RGBA", (10, 8), (255, 255, 255, 0))
+            )
         ]
     )
 
     with raises(
-        ScinoephileError,
-        match="Unable to OCR image series with PaddleOCR",
+        ScinoephileError, match="Unable to OCR image series with PaddleOCR"
     ) as excinfo:
         ocr_image_series_with_paddle(image_series)
 

--- a/test/image/ocr/tesseract/test_legacy_data_cache.py
+++ b/test/image/ocr/tesseract/test_legacy_data_cache.py
@@ -9,9 +9,7 @@ from time import time
 
 from pytest import MonkeyPatch, raises
 
-from scinoephile.image.ocr.tesseract.legacy_data_cache import (
-    TesseractLegacyDataCache,
-)
+from scinoephile.image.ocr.tesseract.legacy_data_cache import TesseractLegacyDataCache
 from test.helpers.files import set_mtime
 
 
@@ -47,25 +45,21 @@ def test_tesseract_legacy_data_cache_round_trip(tmp_path: Path):
 
 
 def test_tesseract_legacy_data_cache_path_includes_version(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test legacy data from another cache version is not reused."""
     cache = TesseractLegacyDataCache(tmp_path)
     traineddata_path = cache.save("eng", b"traineddata")
 
     monkeypatch.setattr(
-        "scinoephile.image.ocr.tesseract.legacy_data_cache._CACHE_VERSION",
-        2,
+        "scinoephile.image.ocr.tesseract.legacy_data_cache._CACHE_VERSION", 2
     )
 
     assert cache.load("eng") is None
     assert traineddata_path.exists()
 
 
-def test_tesseract_legacy_data_cache_overwrites_matching_entry_once(
-    tmp_path: Path,
-):
+def test_tesseract_legacy_data_cache_overwrites_matching_entry_once(tmp_path: Path):
     """Test overwrite refreshes matching traineddata once per instance."""
     TesseractLegacyDataCache(tmp_path).save("eng", b"stale")
     overwrite_cache = TesseractLegacyDataCache(tmp_path, True)

--- a/test/image/ocr/tesseract/test_tesseract_preprocessing.py
+++ b/test/image/ocr/tesseract/test_tesseract_preprocessing.py
@@ -6,9 +6,7 @@ from __future__ import annotations
 
 from PIL import Image
 
-from scinoephile.image.ocr.tesseract.preprocessing import (
-    preprocess_tesseract_ocr_image,
-)
+from scinoephile.image.ocr.tesseract.preprocessing import preprocess_tesseract_ocr_image
 
 
 def test_preprocess_tesseract_ocr_image_makes_opaque_white_background():

--- a/test/image/ocr/tesseract/test_tesseract_recognizer.py
+++ b/test/image/ocr/tesseract/test_tesseract_recognizer.py
@@ -85,10 +85,7 @@ def test_tesseract_recognizer_overwrites_matching_cache(tmp_path: Path):
     """Test Tesseract cache overwrite recognizes matching images again."""
     image = Image.new("RGBA", (10, 8), (255, 255, 255, 0))
     cached = CountingTesseractRecognizer(cache_root_path=tmp_path)
-    fresh = CountingTesseractRecognizer(
-        cache_root_path=tmp_path,
-        overwrite_cache=True,
-    )
+    fresh = CountingTesseractRecognizer(cache_root_path=tmp_path, overwrite_cache=True)
 
     assert cached.recognize_image(image) == "cached text eng"
     assert fresh.recognize_image(image) == "cached text eng"
@@ -106,8 +103,7 @@ def test_tesseract_recognizer_overwrites_matching_cache(tmp_path: Path):
     ],
 )
 def test_tesseract_recognizer_maps_supported_languages_to_engine_codes(
-    language: Language,
-    expected_code: str,
+    language: Language, expected_code: str
 ):
     """Test Tesseract recognizer maps supported languages to engine codes.
 
@@ -128,12 +124,10 @@ def test_tesseract_recognizer_maps_supported_languages_to_engine_codes(
 def test_tesseract_recognizer_caches_by_configuration(tmp_path: Path):
     """Test Tesseract recognizer includes configuration in cache keys."""
     english_recognizer = CountingTesseractRecognizer(
-        cache_root_path=tmp_path,
-        language=Language.eng,
+        cache_root_path=tmp_path, language=Language.eng
     )
     chinese_recognizer = CountingTesseractRecognizer(
-        cache_root_path=tmp_path,
-        language=Language.zho_hans,
+        cache_root_path=tmp_path, language=Language.zho_hans
     )
     image = Image.new("RGBA", (10, 8), (255, 255, 255, 0))
 
@@ -328,8 +322,7 @@ def test_tesseract_detect_italics_rejects_non_english_language():
 
 
 def test_tesseract_detect_italics_downloads_missing_legacy_tessdata(
-    monkeypatch: MonkeyPatch,
-    tmp_path: Path,
+    monkeypatch: MonkeyPatch, tmp_path: Path
 ):
     """Test italic detection downloads missing legacy traineddata lazily.
 
@@ -399,8 +392,7 @@ def test_tesseract_detect_italics_downloads_missing_legacy_tessdata(
 
 
 def test_tesseract_detect_italics_reuses_existing_legacy_tessdata(
-    monkeypatch: MonkeyPatch,
-    tmp_path: Path,
+    monkeypatch: MonkeyPatch, tmp_path: Path
 ):
     """Test italic detection reuses cached legacy traineddata.
 

--- a/test/image/ocr/tesseract/test_tesseract_series.py
+++ b/test/image/ocr/tesseract/test_tesseract_series.py
@@ -10,9 +10,7 @@ from PIL import Image
 from pytest import LogCaptureFixture, MonkeyPatch, raises
 
 from scinoephile.core import Language, ScinoephileError
-from scinoephile.image.ocr.tesseract import (
-    ocr_image_series_with_tesseract,
-)
+from scinoephile.image.ocr.tesseract import ocr_image_series_with_tesseract
 from scinoephile.image.subtitles import ImageSeries, ImageSubtitle
 from test.helpers import parametrize
 from test.helpers.ocr_recognizers import FailingOcrRecognizer, RecordingOcrRecognizer
@@ -29,21 +27,16 @@ def test_ocr_image_series_with_tesseract_preserves_timings_and_sets_text(
     image_series = ImageSeries(
         events=[
             ImageSubtitle(
-                start=1000,
-                end=2000,
-                img=Image.new("RGBA", (10, 8), (255, 255, 255, 0)),
+                start=1000, end=2000, img=Image.new("RGBA", (10, 8), (255, 255, 255, 0))
             ),
             ImageSubtitle(
-                start=3000,
-                end=4000,
-                img=Image.new("RGBA", (12, 9), (255, 255, 255, 0)),
+                start=3000, end=4000, img=Image.new("RGBA", (12, 9), (255, 255, 255, 0))
             ),
         ]
     )
     RecordingOcrRecognizer.reset("first", "second")
     monkeypatch.setattr(
-        "scinoephile.image.ocr.tesseract.TesseractRecognizer",
-        RecordingOcrRecognizer,
+        "scinoephile.image.ocr.tesseract.TesseractRecognizer", RecordingOcrRecognizer
     )
 
     text_series = ocr_image_series_with_tesseract(image_series)
@@ -57,8 +50,7 @@ def test_ocr_image_series_with_tesseract_preserves_timings_and_sets_text(
 
 
 def test_ocr_image_series_with_tesseract_logs_progress(
-    caplog: LogCaptureFixture,
-    monkeypatch: MonkeyPatch,
+    caplog: LogCaptureFixture, monkeypatch: MonkeyPatch
 ):
     """Test Tesseract image series processing logs OCR progress.
 
@@ -69,21 +61,16 @@ def test_ocr_image_series_with_tesseract_logs_progress(
     image_series = ImageSeries(
         events=[
             ImageSubtitle(
-                start=1000,
-                end=2000,
-                img=Image.new("RGBA", (10, 8), (255, 255, 255, 0)),
+                start=1000, end=2000, img=Image.new("RGBA", (10, 8), (255, 255, 255, 0))
             ),
             ImageSubtitle(
-                start=3000,
-                end=4000,
-                img=Image.new("RGBA", (12, 9), (255, 255, 255, 0)),
+                start=3000, end=4000, img=Image.new("RGBA", (12, 9), (255, 255, 255, 0))
             ),
         ]
     )
     RecordingOcrRecognizer.reset("first", "second")
     monkeypatch.setattr(
-        "scinoephile.image.ocr.tesseract.TesseractRecognizer",
-        RecordingOcrRecognizer,
+        "scinoephile.image.ocr.tesseract.TesseractRecognizer", RecordingOcrRecognizer
     )
 
     with caplog.at_level("INFO", logger="scinoephile.image.ocr.tesseract"):
@@ -93,15 +80,11 @@ def test_ocr_image_series_with_tesseract_logs_progress(
         record.message
         for record in caplog.records
         if record.name == "scinoephile.image.ocr.tesseract"
-    ] == [
-        "OCRing subtitle 1/2 with Tesseract",
-        "OCRing subtitle 2/2 with Tesseract",
-    ]
+    ] == ["OCRing subtitle 1/2 with Tesseract", "OCRing subtitle 2/2 with Tesseract"]
 
 
 def test_ocr_image_series_with_tesseract_defers_default_cache_resolution(
-    monkeypatch: MonkeyPatch,
-    tmp_path: Path,
+    monkeypatch: MonkeyPatch, tmp_path: Path
 ):
     """Test Tesseract image series processing defers default cache resolution.
 
@@ -113,16 +96,13 @@ def test_ocr_image_series_with_tesseract_defers_default_cache_resolution(
     RecordingOcrRecognizer.reset(Language.eng.code)
 
     monkeypatch.setattr(
-        "scinoephile.image.ocr.tesseract.TesseractRecognizer",
-        RecordingOcrRecognizer,
+        "scinoephile.image.ocr.tesseract.TesseractRecognizer", RecordingOcrRecognizer
     )
     image_series = ImageSeries(
         events=[
             ImageSubtitle(
-                start=1000,
-                end=2000,
-                img=Image.new("RGBA", (10, 8), (255, 255, 255, 0)),
-            ),
+                start=1000, end=2000, img=Image.new("RGBA", (10, 8), (255, 255, 255, 0))
+            )
         ]
     )
 
@@ -162,8 +142,7 @@ def test_ocr_image_series_with_tesseract_defers_default_cache_resolution(
     ],
 )
 def test_ocr_image_series_with_tesseract_wraps_processing_errors(
-    monkeypatch: MonkeyPatch,
-    exception: Exception,
+    monkeypatch: MonkeyPatch, exception: Exception
 ):
     """Test Tesseract image series processing wraps implementation errors.
 
@@ -173,22 +152,18 @@ def test_ocr_image_series_with_tesseract_wraps_processing_errors(
     """
     FailingOcrRecognizer.exception = exception
     monkeypatch.setattr(
-        "scinoephile.image.ocr.tesseract.TesseractRecognizer",
-        FailingOcrRecognizer,
+        "scinoephile.image.ocr.tesseract.TesseractRecognizer", FailingOcrRecognizer
     )
     image_series = ImageSeries(
         events=[
             ImageSubtitle(
-                start=1000,
-                end=2000,
-                img=Image.new("RGBA", (10, 8), (255, 255, 255, 0)),
-            ),
+                start=1000, end=2000, img=Image.new("RGBA", (10, 8), (255, 255, 255, 0))
+            )
         ]
     )
 
     with raises(
-        ScinoephileError,
-        match="Unable to OCR image series with Tesseract",
+        ScinoephileError, match="Unable to OCR image series with Tesseract"
     ) as excinfo:
         ocr_image_series_with_tesseract(image_series)
 

--- a/test/image/ocr/validation/test_data_storage.py
+++ b/test/image/ocr/validation/test_data_storage.py
@@ -45,16 +45,8 @@ def test_validation_manager_layers_runtime_data_over_repo_data(tmp_path, monkeyp
 
     manager = ValidationManager(validation_data_dir_path=validation_data_dir_path)
 
-    assert manager.char_dims_by_n[1] == {
-        "A": {(10, 20), (11, 21)},
-        "B": {(30, 40)},
-    }
-    assert manager.char_grp_dims_by_n == {
-        2: {
-            "AB": {(50, 20)},
-            "CD": {(60, 20)},
-        }
-    }
+    assert manager.char_dims_by_n[1] == {"A": {(10, 20), (11, 21)}, "B": {(30, 40)}}
+    assert manager.char_grp_dims_by_n == {2: {"AB": {(50, 20)}, "CD": {(60, 20)}}}
     assert manager.char_pair_gaps == {
         ("A", "B"): (9, 10, 11, 12),
         ("B", "C"): (5, 6, 7, 8),
@@ -93,15 +85,8 @@ def test_validation_manager_uses_only_repo_data_in_dev_mode(tmp_path, monkeypatc
         validation_data_dir_path=validation_data_dir_path, dev=True
     )
 
-    assert manager.char_dims_by_n[1] == {
-        "A": {(10, 20)},
-        "B": {(30, 40)},
-    }
-    assert manager.char_grp_dims_by_n == {
-        2: {
-            "AB": {(50, 20)},
-        }
-    }
+    assert manager.char_dims_by_n[1] == {"A": {(10, 20)}, "B": {(30, 40)}}
+    assert manager.char_grp_dims_by_n == {2: {"AB": {(50, 20)}}}
     assert manager.char_pair_gaps == {
         ("A", "B"): (1, 2, 3, 4),
         ("B", "C"): (5, 6, 7, 8),
@@ -195,8 +180,7 @@ def test_validation_manager_does_not_persist_new_default_pair_gaps_in_dev_mode(
         side_effect=AssertionError("default pair gap should not be saved"),
     ):
         manager.update_pair_gaps(
-            ("你", "本"),
-            get_default_char_pair_cutoffs("你", "本"),
+            ("你", "本"), get_default_char_pair_cutoffs("你", "本")
         )
 
     assert manager.char_pair_gaps[("你", "本")] == get_default_char_pair_cutoffs(
@@ -274,8 +258,7 @@ def test_validation_manager_wraps_data_path_errors(tmp_path):
     validation_data_dir_path.write_text("not a directory", encoding="utf-8")
 
     with raises(
-        ScinoephileError,
-        match="Unable to initialize OCR validation data",
+        ScinoephileError, match="Unable to initialize OCR validation data"
     ) as excinfo:
         ValidationManager(validation_data_dir_path=validation_data_dir_path)
 

--- a/test/image/ocr/validation/test_validation_manager.py
+++ b/test/image/ocr/validation/test_validation_manager.py
@@ -16,9 +16,7 @@ from scinoephile.image.subtitles import ImageSeries, ImageSubtitle
 
 
 def test_validate_confident_space_gap_updates_text(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
-    caplog: LogCaptureFixture,
+    tmp_path: Path, monkeypatch: MonkeyPatch, caplog: LogCaptureFixture
 ):
     """Test confident space gap mismatches are corrected without warning."""
     monkeypatch.setattr(
@@ -36,9 +34,7 @@ def test_validate_confident_space_gap_updates_text(
 
 
 def test_validate_confident_adjacent_gap_updates_text(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
-    caplog: LogCaptureFixture,
+    tmp_path: Path, monkeypatch: MonkeyPatch, caplog: LogCaptureFixture
 ):
     """Test confident adjacent gap mismatches are corrected without warning."""
     monkeypatch.setattr(
@@ -56,9 +52,7 @@ def test_validate_confident_adjacent_gap_updates_text(
 
 
 def test_validate_confident_tab_gap_updates_newline_to_tab(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
-    caplog: LogCaptureFixture,
+    tmp_path: Path, monkeypatch: MonkeyPatch, caplog: LogCaptureFixture
 ):
     """Test confident tab gap replaces an OCR newline without warning."""
     monkeypatch.setattr(
@@ -76,9 +70,7 @@ def test_validate_confident_tab_gap_updates_newline_to_tab(
 
 
 def test_validate_ambiguous_gap_warns_without_updating_text(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
-    caplog: LogCaptureFixture,
+    tmp_path: Path, monkeypatch: MonkeyPatch, caplog: LogCaptureFixture
 ):
     """Test ambiguous gaps warn and leave the subtitle text unchanged."""
     monkeypatch.setattr(

--- a/test/image/subtitles/test_image_series.py
+++ b/test/image/subtitles/test_image_series.py
@@ -20,14 +20,7 @@ from test.helpers import parametrize
 
 @parametrize(
     "input_path_fixture, expected_event_count, expected_first_size",
-    [
-        param(
-            "mlamd_eng_ocr_sup_path",
-            942,
-            (953, 63),
-            id="mlamd-eng-sup",
-        ),
-    ],
+    [param("mlamd_eng_ocr_sup_path", 942, (953, 63), id="mlamd-eng-sup")],
 )
 def test_load_sup(
     input_path_fixture: str,
@@ -58,14 +51,7 @@ def test_load_sup(
 
 @parametrize(
     "input_path_fixture, expected_event_count, expected_first_size",
-    [
-        param(
-            "mlamd_eng_image_path",
-            942,
-            (953, 63),
-            id="mlamd-eng-html",
-        ),
-    ],
+    [param("mlamd_eng_image_path", 942, (953, 63), id="mlamd-eng-html")],
 )
 def test_load_html(
     input_path_fixture: str,
@@ -105,11 +91,7 @@ def test_load_html_does_not_modify_source_images(tmp_path: Path):
     Image.new("RGBA", (2, 2), (64, 64, 64, 128)).save(image_path)
     original_image_bytes = image_path.read_bytes()
     html_text = ImageSeries.format_html_entry(
-        index=1,
-        start=0,
-        end=1000,
-        image_name=image_path.name,
-        text="Text",
+        index=1, start=0, end=1000, image_name=image_path.name, text="Text"
     )
     (input_dir_path / "index.html").write_text(html_text, encoding="utf-8")
 
@@ -132,17 +114,12 @@ def test_load_html_rejects_image_path_outside_directory(tmp_path: Path):
     outside_path = tmp_path / "outside.png"
     Image.new("RGBA", (2, 2), (255, 255, 255, 255)).save(outside_path)
     html_text = ImageSeries.format_html_entry(
-        index=1,
-        start=0,
-        end=1000,
-        image_name="../outside.png",
-        text="",
+        index=1, start=0, end=1000, image_name="../outside.png", text=""
     )
     (input_dir_path / "index.html").write_text(html_text, encoding="utf-8")
 
     with raises(
-        ScinoephileError,
-        match="Unable to load ImageSeries.*single contained filename",
+        ScinoephileError, match="Unable to load ImageSeries.*single contained filename"
     ):
         ImageSeries.load(input_dir_path)
 
@@ -169,8 +146,7 @@ def test_image_series_load_wraps_input_path_errors(tmp_path: Path):
     input_path = tmp_path / "missing"
 
     with raises(
-        ScinoephileError,
-        match="Unable to load ImageSeries from .*missing",
+        ScinoephileError, match="Unable to load ImageSeries from .*missing"
     ) as excinfo:
         ImageSeries.load(input_path)
 
@@ -202,11 +178,7 @@ def test_copy_text_from_rejects_length_mismatch():
     """Test copying text rejects length mismatches."""
     image_series = ImageSeries(
         events=[
-            ImageSubtitle(
-                start=1000,
-                end=2000,
-                img=Image.new("LA", (2, 2), (0, 255)),
-            )
+            ImageSubtitle(start=1000, end=2000, img=Image.new("LA", (2, 2), (0, 255)))
         ]
     )
     text_series = Series(
@@ -282,8 +254,7 @@ def test_save_html(tiny_image_series: ImageSeries):
 
 
 def test_save_html_preserves_unrelated_directory_contents(
-    tiny_image_series: ImageSeries,
-    tmp_path: Path,
+    tiny_image_series: ImageSeries, tmp_path: Path
 ):
     """Test saving HTML preserves unrelated files and nested directories.
 
@@ -308,8 +279,7 @@ def test_save_html_preserves_unrelated_directory_contents(
 
 
 def test_save_html_preserves_existing_output_when_staging_fails(
-    tiny_image_series: ImageSeries,
-    tmp_path: Path,
+    tiny_image_series: ImageSeries, tmp_path: Path
 ):
     """Test a staging failure leaves existing managed output unchanged.
 
@@ -370,8 +340,7 @@ def test_image_series_save_wraps_output_path_errors(
     output_path.touch()
 
     with raises(
-        ScinoephileError,
-        match="Unable to save ImageSeries to .*image_output",
+        ScinoephileError, match="Unable to save ImageSeries to .*image_output"
     ) as excinfo:
         tiny_image_series.save(output_path)
 
@@ -393,10 +362,7 @@ def test_text_font_size_defaults_when_no_bboxes():
     series = ImageSeries(
         events=[
             ImageSubtitle(
-                start=0,
-                end=1000,
-                img=Image.new("LA", (4, 4), (255, 255)),
-                bboxes=[],
+                start=0, end=1000, img=Image.new("LA", (4, 4), (255, 255)), bboxes=[]
             )
         ]
     )
@@ -439,19 +405,13 @@ def test_text_font_size_uses_upper_weighted_useful_bbox_height():
                 start=0,
                 end=1000,
                 img=Image.new("LA", (2, 2), (255, 255)),
-                bboxes=[
-                    Bbox(0, 10, 0, 52),
-                    Bbox(0, 4, 0, 10),
-                ],
+                bboxes=[Bbox(0, 10, 0, 52), Bbox(0, 4, 0, 10)],
             ),
             ImageSubtitle(
                 start=1000,
                 end=2000,
                 img=Image.new("LA", (3, 3), (255, 255)),
-                bboxes=[
-                    Bbox(0, 10, 0, 60),
-                    Bbox(12, 22, 0, 60),
-                ],
+                bboxes=[Bbox(0, 10, 0, 60), Bbox(12, 22, 0, 60)],
             ),
         ]
     )
@@ -474,7 +434,7 @@ def test_text_font_size_uses_ascender_height_for_latin_bboxes():
                     Bbox(36, 46, 0, 39),
                     Bbox(48, 58, 0, 39),
                 ],
-            ),
+            )
         ]
     )
 

--- a/test/image/subtitles/test_sup.py
+++ b/test/image/subtitles/test_sup.py
@@ -50,21 +50,7 @@ def test_read_sup_image_array_rejects_row_overflow():
 def test_read_sup_series_rejects_truncated_segment_data():
     """Test SUP segments cannot declare more bytes than are available."""
     data = np.array(
-        [
-            0x50,
-            0x47,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x99,
-            0x00,
-            0x04,
-        ],
+        [0x50, 0x47, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x99, 0x00, 0x04],
         dtype=np.uint8,
     )
 

--- a/test/image/test_bboxes.py
+++ b/test/image/test_bboxes.py
@@ -12,26 +12,14 @@ from scinoephile.image.bboxes import get_bboxes
 
 def test_get_bboxes_merges_line_components_at_minimum_gap():
     """Test component lines separated by the minimum gap are grouped together."""
-    img = _make_mask_img(
-        size=(10, 70),
-        rects=[
-            (2, 0, 7, 4),
-            (2, 10, 7, 64),
-        ],
-    )
+    img = _make_mask_img(size=(10, 70), rects=[(2, 0, 7, 4), (2, 10, 7, 64)])
 
     assert get_bboxes(img) == [Bbox(x1=2, x2=8, y1=0, y2=65)]
 
 
 def test_get_bboxes_preserves_full_height_lines_at_minimum_gap():
     """Test full-height lines separated by the minimum gap remain separate."""
-    img = _make_mask_img(
-        size=(10, 70),
-        rects=[
-            (2, 0, 7, 29),
-            (2, 35, 7, 64),
-        ],
-    )
+    img = _make_mask_img(size=(10, 70), rects=[(2, 0, 7, 29), (2, 35, 7, 64)])
 
     assert get_bboxes(img) == [
         Bbox(x1=2, x2=8, y1=0, y2=30),
@@ -42,12 +30,7 @@ def test_get_bboxes_preserves_full_height_lines_at_minimum_gap():
 def test_get_bboxes_preserves_chained_small_line_merges():
     """Test chained line merges preserve all accumulated stroke bands."""
     img = _make_mask_img(
-        size=(10, 60),
-        rects=[
-            (2, 0, 7, 4),
-            (2, 9, 7, 13),
-            (2, 18, 7, 54),
-        ],
+        size=(10, 60), rects=[(2, 0, 7, 4), (2, 9, 7, 13), (2, 18, 7, 54)]
     )
 
     assert get_bboxes(img) == [Bbox(x1=2, x2=8, y1=0, y2=55)]

--- a/test/lang/id/test_get_series_language.py
+++ b/test/lang/id/test_get_series_language.py
@@ -14,15 +14,9 @@ from test.helpers import parametrize
 @parametrize(
     ("series_fixture", "expected"),
     [
+        param("acopopb_eng", Language.eng, id="acopopb-eng"),
         param(
-            "acopopb_eng",
-            Language.eng,
-            id="acopopb-eng",
-        ),
-        param(
-            "acopopb_eng_ocr_fuse_clean_validate",
-            Language.eng,
-            id="acopopb-eng-ocr",
+            "acopopb_eng_ocr_fuse_clean_validate", Language.eng, id="acopopb-eng-ocr"
         ),
         param(
             "acopopb_yue_hans_ocr_fuse_clean_validate",
@@ -34,36 +28,20 @@ from test.helpers import parametrize
             Language.yue_hant,
             id="acopopb-yue-hant-ocr",
         ),
-        param(
-            "acopopb_zho_hans",
-            Language.zho_hans,
-            id="acopopb-zho-hans",
-        ),
+        param("acopopb_zho_hans", Language.zho_hans, id="acopopb-zho-hans"),
         param(
             "acopopb_zho_hans_ocr_fuse_clean_validate",
             Language.zho_hans,
             id="acopopb-zho-hans-ocr",
         ),
-        param(
-            "acopopb_zho_hant",
-            Language.zho_hant,
-            id="acopopb-zho-hant",
-        ),
+        param("acopopb_zho_hant", Language.zho_hant, id="acopopb-zho-hant"),
         param(
             "acopopb_zho_hant_ocr_fuse_clean_validate",
             Language.zho_hant,
             id="acopopb-zho-hant-ocr",
         ),
-        param(
-            "acoptc_eng",
-            Language.eng,
-            id="acoptc-eng",
-        ),
-        param(
-            "acoptc_eng_ocr_fuse_clean_validate",
-            Language.eng,
-            id="acoptc-eng-ocr",
-        ),
+        param("acoptc_eng", Language.eng, id="acoptc-eng"),
+        param("acoptc_eng_ocr_fuse_clean_validate", Language.eng, id="acoptc-eng-ocr"),
         param(
             "acoptc_yue_hans_ocr_fuse_clean_validate",
             Language.yue_hans,
@@ -74,56 +52,28 @@ from test.helpers import parametrize
             Language.yue_hant,
             id="acoptc-yue-hant-ocr",
         ),
-        param(
-            "acoptc_zho_hans",
-            Language.zho_hans,
-            id="acoptc-zho-hans",
-        ),
+        param("acoptc_zho_hans", Language.zho_hans, id="acoptc-zho-hans"),
         param(
             "acoptc_zho_hans_ocr_fuse_clean_validate",
             Language.zho_hans,
             id="acoptc-zho-hans-ocr",
         ),
-        param(
-            "acoptc_zho_hant",
-            Language.zho_hant,
-            id="acoptc-zho-hant",
-        ),
+        param("acoptc_zho_hant", Language.zho_hant, id="acoptc-zho-hant"),
         param(
             "acoptc_zho_hant_ocr_fuse_clean_validate",
             Language.zho_hant,
             id="acoptc-zho-hant-ocr",
         ),
-        param(
-            "kob_eng",
-            Language.eng,
-            id="kob-eng",
-        ),
-        param(
-            "kob_eng_ocr_fuse_clean_validate",
-            Language.eng,
-            id="kob-eng-ocr",
-        ),
-        param(
-            "kob_yue_hans",
-            Language.yue_hans,
-            id="kob-yue-hans",
-        ),
-        param(
-            "kob_yue_hant",
-            Language.yue_hant,
-            id="kob-yue-hant-input",
-        ),
+        param("kob_eng", Language.eng, id="kob-eng"),
+        param("kob_eng_ocr_fuse_clean_validate", Language.eng, id="kob-eng-ocr"),
+        param("kob_yue_hans", Language.yue_hans, id="kob-yue-hans"),
+        param("kob_yue_hant", Language.yue_hant, id="kob-yue-hant-input"),
         param(
             "kob_zho_hant_ocr_fuse_clean_validate",
             Language.zho_hant,
             id="kob-zho-hant-ocr",
         ),
-        param(
-            "mlamd_eng_fuse_clean_validate",
-            Language.eng,
-            id="mlamd-eng-ocr",
-        ),
+        param("mlamd_eng_fuse_clean_validate", Language.eng, id="mlamd-eng-ocr"),
         param(
             "mlamd_zho_hans_fuse_clean_validate",
             Language.zho_hans,
@@ -134,71 +84,23 @@ from test.helpers import parametrize
             Language.zho_hant,
             id="mlamd-zho-hant-ocr",
         ),
+        param("mnt_eng_fuse_clean_validate", Language.eng, id="mnt-eng-ocr"),
+        param("mnt_jpn_eng", Language.eng, id="mnt-jpn-eng"),
+        param("mnt_yue_zho_hant", Language.zho_hant, id="mnt-yue-zho-hant"),
         param(
-            "mnt_eng_fuse_clean_validate",
-            Language.eng,
-            id="mnt-eng-ocr",
+            "mnt_zho_hans_fuse_clean_validate", Language.zho_hans, id="mnt-zho-hans-ocr"
         ),
+        param("mnt_zho_hant", Language.zho_hant, id="mnt-zho-hant"),
         param(
-            "mnt_jpn_eng",
-            Language.eng,
-            id="mnt-jpn-eng",
+            "mnt_zho_hant_fuse_clean_validate", Language.zho_hant, id="mnt-zho-hant-ocr"
         ),
-        param(
-            "mnt_yue_zho_hant",
-            Language.zho_hant,
-            id="mnt-yue-zho-hant",
-        ),
-        param(
-            "mnt_zho_hans_fuse_clean_validate",
-            Language.zho_hans,
-            id="mnt-zho-hans-ocr",
-        ),
-        param(
-            "mnt_zho_hant",
-            Language.zho_hant,
-            id="mnt-zho-hant",
-        ),
-        param(
-            "mnt_zho_hant_fuse_clean_validate",
-            Language.zho_hant,
-            id="mnt-zho-hant-ocr",
-        ),
-        param(
-            "t_eng",
-            Language.eng,
-            id="t-eng",
-        ),
-        param(
-            "t_eng_fuse_clean_validate",
-            Language.eng,
-            id="t-eng-ocr",
-        ),
-        param(
-            "t_zho_hans",
-            Language.zho_hans,
-            id="t-zho-hans",
-        ),
-        param(
-            "t_zho_hans_fuse_clean_validate",
-            Language.zho_hans,
-            id="t-zho-hans-ocr",
-        ),
-        param(
-            "t_zho_hant",
-            Language.zho_hant,
-            id="t-zho-hant",
-        ),
-        param(
-            "t_zho_hant_fuse_clean_validate",
-            Language.zho_hant,
-            id="t-zho-hant-ocr",
-        ),
-        param(
-            "tmm_eng_ocr_fuse_clean_validate",
-            Language.eng,
-            id="tmm-eng-ocr",
-        ),
+        param("t_eng", Language.eng, id="t-eng"),
+        param("t_eng_fuse_clean_validate", Language.eng, id="t-eng-ocr"),
+        param("t_zho_hans", Language.zho_hans, id="t-zho-hans"),
+        param("t_zho_hans_fuse_clean_validate", Language.zho_hans, id="t-zho-hans-ocr"),
+        param("t_zho_hant", Language.zho_hant, id="t-zho-hant"),
+        param("t_zho_hant_fuse_clean_validate", Language.zho_hant, id="t-zho-hant-ocr"),
+        param("tmm_eng_ocr_fuse_clean_validate", Language.eng, id="tmm-eng-ocr"),
         param(
             "tmm_yue_hans_ocr_fuse_clean_validate",
             Language.yue_hans,
@@ -222,9 +124,7 @@ from test.helpers import parametrize
     ],
 )
 def test_get_series_language(
-    request: FixtureRequest,
-    series_fixture: str,
-    expected: Language | None,
+    request: FixtureRequest, series_fixture: str, expected: Language | None
 ):
     """Detect language of subtitle series.
 

--- a/test/lang/test_flattening.py
+++ b/test/lang/test_flattening.py
@@ -234,8 +234,5 @@ def test_flatten_series_excludes_indexes():
 
 def test_flatten_series_rejects_nonpositive_exclusions():
     """Test series flattening rejects nonpositive exclusion indexes."""
-    with raises(
-        ScinoephileError,
-        match="Exclusion indexes must be positive",
-    ):
+    with raises(ScinoephileError, match="Exclusion indexes must be positive"):
         flatten_series(get_text_series("text"), language=Language.eng, exclusions=[0])

--- a/test/lang/test_ocr_fusion.py
+++ b/test/lang/test_ocr_fusion.py
@@ -301,17 +301,10 @@ def test_fuse_ocr_series(
 
     provider = Mock(spec=LLMProvider, cache_identity={"implementation": "test"})
     processor = get_ocr_fuser(
-        language,
-        test_cases=test_case_loader(),
-        provider=provider,
+        language, test_cases=test_case_loader(), provider=provider
     )
     expected = request.getfixturevalue(expected_fixture)
-    output = fuse_ocr_series(
-        lens,
-        secondary,
-        language=language,
-        fuser=processor,
-    )
+    output = fuse_ocr_series(lens, secondary, language=language, fuser=processor)
 
     assert len(output) == len(expected)
     assert_series_equal(output, expected)

--- a/test/lang/test_review_series.py
+++ b/test/lang/test_review_series.py
@@ -74,13 +74,7 @@ from test.helpers import assert_series_equal, parametrize
 
 
 @parametrize(
-    (
-        "series_fixture",
-        "expected_fixture",
-        "test_case_loader",
-        "language",
-        "prompt",
-    ),
+    ("series_fixture", "expected_fixture", "test_case_loader", "language", "prompt"),
     [
         param(
             "acopopb_eng_ocr_fuse_clean_validate",
@@ -424,16 +418,11 @@ def test_review_series(
     """
     provider = Mock(spec=LLMProvider, cache_identity={"implementation": "test"})
     reviewer = get_reviewer(
-        language,
-        prompt=prompt,
-        test_cases=test_case_loader(),
-        provider=provider,
+        language, prompt=prompt, test_cases=test_case_loader(), provider=provider
     )
     expected = request.getfixturevalue(expected_fixture)
     output = review_series(
-        request.getfixturevalue(series_fixture),
-        language=language,
-        reviewer=reviewer,
+        request.getfixturevalue(series_fixture), language=language, reviewer=reviewer
     )
 
     assert len(output) == len(expected)

--- a/test/lang/test_romanize_series.py
+++ b/test/lang/test_romanize_series.py
@@ -158,9 +158,7 @@ def test_romanize_series(
         language: language whose romanization system to use
     """
     output = romanize_series(
-        request.getfixturevalue(series_fixture),
-        language=language,
-        append=True,
+        request.getfixturevalue(series_fixture), language=language, append=True
     )
     assert_series_equal(output, request.getfixturevalue(expected_fixture))
 
@@ -169,11 +167,7 @@ def test_romanize_series_replaces_text():
     """Test romanize_series replaces source text when append is false."""
     source = get_text_series("你好")
 
-    output = romanize_series(
-        source,
-        language=Language.zho_hans,
-        append=False,
-    )
+    output = romanize_series(source, language=Language.zho_hans, append=False)
 
     assert output.events[0].text == "nǐhǎo"
     assert source.events[0].text == "你好"
@@ -181,8 +175,5 @@ def test_romanize_series_replaces_text():
 
 def test_romanize_series_rejects_unsupported_language():
     """Test romanize_series rejects unsupported languages."""
-    with raises(
-        ScinoephileError,
-        match="Romanization does not support language eng",
-    ):
+    with raises(ScinoephileError, match="Romanization does not support language eng"):
         romanize_series(get_text_series("Hello"), language=Language.eng)

--- a/test/lang/transcription/test_delineation_alignment.py
+++ b/test/lang/transcription/test_delineation_alignment.py
@@ -36,7 +36,7 @@ def _get_alignment() -> TranscriptionAlignment:
         events=[
             Subtitle(start=0, end=1000, text="參考一"),
             Subtitle(start=1000, end=2000, text="參考二"),
-        ],
+        ]
     )
     transcription = AudioSeries(
         audio=AudioSegment.silent(duration=2000),
@@ -84,10 +84,7 @@ def test_aligner_uses_queryer_prompt_and_semantic_shift_output():
     def add_answer(test_case: DelineationTestCase) -> DelineationTestCase:
         """Move the second target subtitle into the first sync group."""
         return type(test_case).model_validate(
-            {
-                **test_case.model_dump(),
-                "answer": {"output_one": "甲乙"},
-            }
+            {**test_case.model_dump(), "answer": {"output_one": "甲乙"}}
         )
 
     delineation_queryer.side_effect = add_answer
@@ -111,7 +108,7 @@ def test_aligner_restarts_to_propagate_text_across_multiple_boundaries():
             Subtitle(start=0, end=1000, text="參考一"),
             Subtitle(start=1000, end=2000, text="參考二"),
             Subtitle(start=2000, end=3000, text="參考三"),
-        ],
+        ]
     )
     transcription = AudioSeries(
         audio=AudioSegment.silent(duration=3000),
@@ -136,10 +133,7 @@ def test_aligner_restarts_to_propagate_text_across_multiple_boundaries():
         elif test_case.query.target_two == "乙丙":
             answer = {"output_one": "甲乙丙"}
         return type(test_case).model_validate(
-            {
-                **test_case.model_dump(),
-                "answer": answer,
-            }
+            {**test_case.model_dump(), "answer": answer}
         )
 
     delineation_queryer.side_effect = shift_left
@@ -168,10 +162,7 @@ def test_aligner_stops_when_delineation_states_repeat():
         if not test_case.query.target_two:
             answer = {"output_one": "甲", "output_two": "乙"}
         return type(test_case).model_validate(
-            {
-                **test_case.model_dump(),
-                "answer": answer,
-            }
+            {**test_case.model_dump(), "answer": answer}
         )
 
     delineation_queryer.side_effect = oscillate

--- a/test/lang/transcription/test_guided.py
+++ b/test/lang/transcription/test_guided.py
@@ -15,10 +15,7 @@ from scinoephile.audio.transcription import DemucsMode, VADMode
 from scinoephile.core import Language, ScinoephileError
 from scinoephile.core.llms import LLMProvider
 from scinoephile.core.llms.utils import save_test_cases_to_json
-from scinoephile.lang.transcription.guided import (
-    DEFAULT_SPECS,
-    get_guided_transcriber,
-)
+from scinoephile.lang.transcription.guided import DEFAULT_SPECS, get_guided_transcriber
 from scinoephile.lang.yue.prompts import YUE_HANT_PROMPT_FIELDS
 from scinoephile.lang.yue_zho.transcription import (
     YueZhoDelineationPromptYueHant,
@@ -140,9 +137,7 @@ def test_get_guided_transcriber_uses_registered_language_configuration(tmp_path)
     assert transcriber.aligner.punctuation_processor.queryer._cache.overwrite
 
 
-def test_get_guided_transcriber_prunes_stale_cases_when_requested(
-    tmp_path: Path,
-):
+def test_get_guided_transcriber_prunes_stale_cases_when_requested(tmp_path: Path):
     """Test requested pruning retains only cases encountered by the current run."""
     delineation_json_path = tmp_path / "custom" / "delineation.json"
     punctuation_json_path = tmp_path / "other" / "punctuation.json"
@@ -186,10 +181,7 @@ def test_get_guided_transcriber_prunes_stale_cases_when_requested(
         json.dumps(
             [
                 {
-                    "query": {
-                        "ref_sub": "參考",
-                        "target_subs": ["目標"],
-                    },
+                    "query": {"ref_sub": "參考", "target_subs": ["目標"]},
                     "answer": {"target_sub_punctuated": "目標。"},
                 }
             ]
@@ -203,9 +195,7 @@ def test_get_guided_transcriber_prunes_stale_cases_when_requested(
     assert json.loads(punctuation_json_path.read_text(encoding="utf-8")) == []
 
 
-def test_get_guided_transcriber_preserves_cases_in_default_json_paths(
-    tmp_path: Path,
-):
+def test_get_guided_transcriber_preserves_cases_in_default_json_paths(tmp_path: Path):
     """Test default JSON test cases are preserved between runs."""
     with (
         patch(
@@ -241,21 +231,16 @@ def test_get_guided_transcriber_preserves_cases_in_default_json_paths(
     ]
     punctuation_test_case_data = [
         {
-            "query": {
-                "ref_sub": "參考",
-                "target_subs": ["目標"],
-            },
+            "query": {"ref_sub": "參考", "target_subs": ["目標"]},
             "answer": {"target_sub_punctuated": "目標。"},
             "difficulty": 2,
         }
     ]
     delineation_json_path.write_text(
-        json.dumps(delineation_test_case_data),
-        encoding="utf-8",
+        json.dumps(delineation_test_case_data), encoding="utf-8"
     )
     punctuation_json_path.write_text(
-        json.dumps(punctuation_test_case_data),
-        encoding="utf-8",
+        json.dumps(punctuation_test_case_data), encoding="utf-8"
     )
 
     transcriber.aligner.update_all_test_cases()
@@ -285,9 +270,7 @@ def test_get_guided_transcriber_loads_verified_cases_from_exact_json(tmp_path: P
     )
     delineation_json_path = tmp_path / "delineation.json"
     save_test_cases_to_json(
-        delineation_json_path,
-        [verified_test_case],
-        DelineationManager,
+        delineation_json_path, [verified_test_case], DelineationManager
     )
     provider = Mock(spec=LLMProvider, cache_identity={"implementation": "test"})
     transcriber = get_guided_transcriber(
@@ -322,9 +305,6 @@ def test_get_guided_transcriber_rejects_unsupported_language_pair():
 
 def test_transcription_prompts_use_yue_hant_correspondence_fields():
     """Test Yue-Hant transcription prompts use Yue-Hant shared text."""
-    for prompt in (
-        YueZhoDelineationPromptYueHant,
-        YueZhoPunctuationPromptYueHant,
-    ):
+    for prompt in (YueZhoDelineationPromptYueHant, YueZhoPunctuationPromptYueHant):
         for field_name, expected in YUE_HANT_PROMPT_FIELDS.items():
             assert getattr(prompt, field_name) == expected

--- a/test/lang/transcription/test_punctuation_alignment.py
+++ b/test/lang/transcription/test_punctuation_alignment.py
@@ -22,18 +22,14 @@ from scinoephile.llms.punctuation import (
 )
 
 _LOCALIZED_PROMPT = PunctuationPrompt(
-    ref_sub="cankao",
-    target_subs="zimu",
-    target_sub_punctuated="jieguo",
+    ref_sub="cankao", target_subs="zimu", target_sub_punctuated="jieguo"
 )
 """Punctuation prompt using non-default correspondence field names."""
 
 
 def _get_alignment() -> TranscriptionAlignment:
     """Get a one-group alignment that requires punctuation."""
-    reference = Series(
-        events=[Subtitle(start=0, end=1000, text="你好！")],
-    )
+    reference = Series(events=[Subtitle(start=0, end=1000, text="你好！")])
     transcription = AudioSeries(
         audio=AudioSegment.silent(duration=1000),
         events=[AudioSubtitle(start=0, end=1000, text="你好")],
@@ -44,18 +40,12 @@ def _get_alignment() -> TranscriptionAlignment:
 
 
 def _get_merged_subtitle(
-    subtitles: list[AudioSubtitle],
-    *,
-    text: str | None = None,
+    subtitles: list[AudioSubtitle], *, text: str | None = None
 ) -> AudioSubtitle:
     """Get a merged subtitle without requiring transcription segment fixtures."""
     if text is None:
         text = "".join(subtitle.text for subtitle in subtitles)
-    return AudioSubtitle(
-        start=subtitles[0].start,
-        end=subtitles[-1].end,
-        text=text,
-    )
+    return AudioSubtitle(start=subtitles[0].start, end=subtitles[-1].end, text=text)
 
 
 def test_alignment_constructs_semantic_fields_with_configured_prompt():
@@ -67,10 +57,7 @@ def test_alignment_constructs_semantic_fields_with_configured_prompt():
     assert test_case is not None
     assert isinstance(test_case, PunctuationTestCase)
     assert test_case.prompt is _LOCALIZED_PROMPT
-    assert test_case.query.model_dump() == {
-        "guide": "你好！",
-        "subtitles": ["你好"],
-    }
+    assert test_case.query.model_dump() == {"guide": "你好！", "subtitles": ["你好"]}
     assert test_case.query.model_dump(by_alias=True) == {
         "cankao": "你好！",
         "zimu": ["你好"],
@@ -85,15 +72,10 @@ def test_aligner_uses_queryer_prompt_and_semantic_output(monkeypatch: MonkeyPatc
     punctuation_processor = Mock(spec=PunctuationProcessor)
     punctuation_processor.queryer = punctuation_queryer
 
-    def add_answer(
-        test_case: PunctuationTestCase,
-    ) -> PunctuationTestCase:
+    def add_answer(test_case: PunctuationTestCase) -> PunctuationTestCase:
         """Add a valid punctuation answer to a test case."""
         result = type(test_case).model_validate(
-            {
-                **test_case.model_dump(),
-                "answer": {"output": "你好！"},
-            }
+            {**test_case.model_dump(), "answer": {"output": "你好！"}}
         )
         return result
 
@@ -121,15 +103,10 @@ def test_aligner_falls_back_to_concatenation_after_invalid_answer(
     punctuation_processor = Mock(spec=PunctuationProcessor)
     punctuation_processor.queryer = punctuation_queryer
 
-    def reject_answer(
-        test_case: PunctuationTestCase,
-    ) -> PunctuationTestCase:
+    def reject_answer(test_case: PunctuationTestCase) -> PunctuationTestCase:
         """Attempt to add an answer that changes subtitle characters."""
         result = type(test_case).model_validate(
-            {
-                **test_case.model_dump(),
-                "answer": {"output": "你壞"},
-            }
+            {**test_case.model_dump(), "answer": {"output": "你壞"}}
         )
         return result
 

--- a/test/lang/transcription/test_transcriber.py
+++ b/test/lang/transcription/test_transcriber.py
@@ -99,12 +99,7 @@ def _get_segment(
 
 def test_segments_are_usable_rejects_repetitive_whisper_output():
     """Test highly compressible Whisper loops are unusable for alignment."""
-    segments = [
-        _get_segment(
-            compression_ratio=16.24,
-            with_words=True,
-        )
-    ]
+    segments = [_get_segment(compression_ratio=16.24, with_words=True)]
 
     assert not GuidedTranscriber._segments_are_usable(segments)
 
@@ -125,12 +120,7 @@ def test_segments_are_usable_reports_missing_word_timings_concisely(
 
 def test_segments_are_usable_rejects_nonpositive_word_duration():
     """Test text-bearing words must remain positive after ms conversion."""
-    segment = _get_segment(
-        start=4.02,
-        end=4.04,
-        text=" 啊",
-        compression_ratio=1.0,
-    )
+    segment = _get_segment(start=4.02, end=4.04, text=" 啊", compression_ratio=1.0)
     segment.words = [
         TranscribedWord(text=" ", start=4.02, end=4.04, confidence=1.0),
         TranscribedWord(text="啊", start=4.04, end=4.04, confidence=1.0),
@@ -141,34 +131,16 @@ def test_segments_are_usable_rejects_nonpositive_word_duration():
 
 def test_segments_are_usable_rejects_timestamp_beyond_audio():
     """Test Whisper timestamps extending beyond source audio are unusable."""
-    segments = [
-        _get_segment(
-            end=12.0,
-            compression_ratio=1.0,
-            with_words=True,
-        )
-    ]
+    segments = [_get_segment(end=12.0, compression_ratio=1.0, with_words=True)]
 
-    assert not GuidedTranscriber._segments_are_usable(
-        segments,
-        audio_duration=10.0,
-    )
+    assert not GuidedTranscriber._segments_are_usable(segments, audio_duration=10.0)
 
 
 def test_segments_are_usable_accepts_partial_guided_tail():
     """Test guide coverage does not determine transcription validity."""
-    segments = [
-        _get_segment(
-            end=4.0,
-            compression_ratio=1.0,
-            with_words=True,
-        )
-    ]
+    segments = [_get_segment(end=4.0, compression_ratio=1.0, with_words=True)]
 
-    assert GuidedTranscriber._segments_are_usable(
-        segments,
-        audio_duration=10.0,
-    )
+    assert GuidedTranscriber._segments_are_usable(segments, audio_duration=10.0)
 
 
 def test_missing_guided_tail_runs_focused_recovery():
@@ -177,11 +149,7 @@ def test_missing_guided_tail_runs_focused_recovery():
     initial_segments = [_get_segment(end=4.0, compression_ratio=1.0, with_words=True)]
     recovered_segments = [
         _get_segment(
-            start=0.2,
-            end=0.8,
-            text="tail",
-            compression_ratio=1.0,
-            with_words=True,
+            start=0.2, end=0.8, text="tail", compression_ratio=1.0, with_words=True
         )
     ]
     recovered_segments[0].no_speech_prob = 0.1
@@ -199,8 +167,7 @@ def test_missing_guided_tail_runs_focused_recovery():
     assert output[1].end == 5.8
     normalized_tail_audio = transcriber.tail_recovery_transcriber.call_args.args[0]
     transcriber.tail_recovery_transcriber.assert_called_once_with(
-        normalized_tail_audio,
-        is_usable=ANY,
+        normalized_tail_audio, is_usable=ANY
     )
     assert transcriber.tail_recovery_transcriber.call_args.kwargs["is_usable"](
         recovered_segments
@@ -226,8 +193,7 @@ def test_missing_guided_tail_keeps_base_after_unusable_recovery():
     assert len(normalized_tail_audio) == 5000
     assert normalized_tail_audio.max_dBFS == approx(-1.0, abs=0.01)
     transcriber.tail_recovery_transcriber.assert_called_once_with(
-        normalized_tail_audio,
-        is_usable=ANY,
+        normalized_tail_audio, is_usable=ANY
     )
     assert not transcriber.tail_recovery_transcriber.call_args.kwargs["is_usable"](
         repetitive_segments
@@ -239,10 +205,7 @@ def test_missing_guided_tail_keeps_valid_base_without_credible_recovery():
     transcriber, _ = _get_transcriber(vad_mode=VADMode.OFF)
     initial_segments = [_get_segment(end=4.0, compression_ratio=1.0, with_words=True)]
     stretched_segment = _get_segment(
-        end=5.0,
-        text="x",
-        compression_ratio=1.0,
-        with_words=True,
+        end=5.0, text="x", compression_ratio=1.0, with_words=True
     )
     stretched_segment.no_speech_prob = 0.1
     no_speech_segment = _get_segment(
@@ -311,10 +274,7 @@ def test_standard_transcriber_runs_shared_fallbacks():
     output = transcriber._transcribe_block_audio(audio)
 
     assert output == segments
-    transcriber.transcriber.assert_called_once_with(
-        audio,
-        is_usable=ANY,
-    )
+    transcriber.transcriber.assert_called_once_with(audio, is_usable=ANY)
     transcriber.recovery_transcriber.assert_not_called()
 
 
@@ -331,10 +291,7 @@ def test_unusable_standard_output_uses_defensive_recovery():
     output = transcriber._transcribe_block_audio(audio)
 
     assert output == segments
-    transcriber.recovery_transcriber.assert_called_once_with(
-        audio,
-        is_usable=ANY,
-    )
+    transcriber.recovery_transcriber.assert_called_once_with(audio, is_usable=ANY)
 
 
 def test_standard_error_uses_defensive_recovery():
@@ -378,17 +335,12 @@ def test_overwrite_cache_is_owned_by_transcriber_caches():
 
     assert transcriber._transcribe_block_audio(audio) == segments
     transcriber.transcriber.get_cached_transcription.assert_called_once_with(
-        audio,
-        is_usable=ANY,
+        audio, is_usable=ANY
     )
     transcriber.recovery_transcriber.get_cached_transcription.assert_called_once_with(
-        audio,
-        is_usable=ANY,
+        audio, is_usable=ANY
     )
-    transcriber.transcriber.assert_called_once_with(
-        audio,
-        is_usable=ANY,
-    )
+    transcriber.transcriber.assert_called_once_with(audio, is_usable=ANY)
 
 
 def test_process_block_preserves_raw_segments_and_uses_buffered_offset():
@@ -403,9 +355,7 @@ def test_process_block_preserves_raw_segments_and_uses_buffered_offset():
     segment = _get_segment()
 
     with patch.object(
-        transcriber,
-        "_transcribe_block_audio",
-        return_value=[segment],
+        transcriber, "_transcribe_block_audio", return_value=[segment]
     ) as transcribe_block_audio:
         output = transcriber.process_block(audio_block, reference_block)
 
@@ -414,8 +364,7 @@ def test_process_block_preserves_raw_segments_and_uses_buffered_offset():
     assert output[0].start == 350
     assert output[0].end == 450
     transcribe_block_audio.assert_called_once_with(
-        audio_block.audio,
-        expected_last_start=0.75,
+        audio_block.audio, expected_last_start=0.75
     )
     aligner.update_all_test_cases.assert_not_called()
 
@@ -437,11 +386,7 @@ def test_process_block_applies_configured_segment_splitter():
     reference_block = Series(events=[Subtitle(start=0, end=1000, text="reference")])
     segment = _get_segment()
 
-    with patch.object(
-        transcriber,
-        "_transcribe_block_audio",
-        return_value=[segment],
-    ):
+    with patch.object(transcriber, "_transcribe_block_audio", return_value=[segment]):
         transcriber.process_block(audio_block, reference_block)
 
     transcriber.segment_splitter.assert_called_once_with(segment)
@@ -513,11 +458,7 @@ def test_process_uses_inclusive_start_index(caplog: LogCaptureFixture):
         "process_block",
         side_effect=lambda audio_block, reference_block: audio_block,
     ) as process_block:
-        output = transcriber.process(
-            audio_series,
-            reference_series,
-            start_at_idx=1,
-        )
+        output = transcriber.process(audio_series, reference_series, start_at_idx=1)
 
     assert process_block.call_count == 1
     assert len(output) == 1

--- a/test/lang/yue/test_get_yue_converted.py
+++ b/test/lang/yue/test_get_yue_converted.py
@@ -18,22 +18,12 @@ from test.helpers import parametrize
     [
         ("舂暈\ue527", "舂暈鷄", nullcontext()),
         ("蜞\ueb06", "蜞乸", nullcontext()),
-        (
-            "過樹\uefbe",
-            None,
-            raises(UnsupportedCharacterError),
-        ),
-        (
-            "蝦\ueec9",
-            None,
-            raises(UnsupportedCharacterError),
-        ),
+        ("過樹\uefbe", None, raises(UnsupportedCharacterError)),
+        ("蝦\ueec9", None, raises(UnsupportedCharacterError)),
     ],
 )
 def test_get_yue_converted(
-    text: str,
-    expected: str | None,
-    expectation: AbstractContextManager[object],
+    text: str, expected: str | None, expectation: AbstractContextManager[object]
 ):
     """Test get_yue_converted converts or rejects HKSCS characters.
 

--- a/test/lang/yue/test_get_yue_romanized.py
+++ b/test/lang/yue/test_get_yue_romanized.py
@@ -26,10 +26,7 @@ from test.helpers import parametrize
         ("rock'n'roll你好", "rock'n'roll néih hóu"),
         ('"t i"你好', '"t i" néih hóu'),
         ("你好　世界", "néih hóu  saigaai"),
-        (
-            "乱讲，啫啫一 fling fling 吖嘛",
-            "lyuhn góng, jē jē yāt fling fling ā ma",
-        ),
+        ("乱讲，啫啫一 fling fling 吖嘛", "lyuhn góng, jē jē yāt fling fling ā ma"),
         (
             "骑呢怪，做咩搞到咁乌 where ？",
             "kèh nē gwaai, jouh mē gáau dou gam wū where ?",
@@ -48,14 +45,7 @@ def test_get_yue_text_romanized(text: str, expected: str):
     assert get_yue_text_romanized(text) == expected
 
 
-@parametrize(
-    ("text", "expected"),
-    [
-        ("你", "néih"),
-        ("，", ""),
-        ("？", ""),
-    ],
-)
+@parametrize(("text", "expected"), [("你", "néih"), ("，", ""), ("？", "")])
 def test_get_yue_char_romanized(text: str, expected: str):
     """Test get_yue_char_romanized.
 

--- a/test/lang/yue_zho/test_get_yue_gap_translator_from_zho.py
+++ b/test/lang/yue_zho/test_get_yue_gap_translator_from_zho.py
@@ -32,7 +32,7 @@ from test.helpers import assert_series_equal, parametrize
             get_mlamd_yue_from_zho_gap_translation_test_cases,
             "test.data.mlamd.get_torch_device",
             id="mlamd",
-        ),
+        )
     ],
 )
 def test_gap_translator_zho_to_yue(
@@ -60,10 +60,7 @@ def test_gap_translator_zho_to_yue(
     with patch(device_patch_target, return_value="cuda"):
         test_cases = test_case_loader()
     translator = get_gap_translator(
-        Language.zho_hans,
-        Language.yue_hans,
-        test_cases=test_cases,
-        provider=provider,
+        Language.zho_hans, Language.yue_hans, test_cases=test_cases, provider=provider
     )
     output = translator.process(yuewen, zhongwen)
     assert_series_equal(output, expected)

--- a/test/lang/yue_zho/test_guided_review.py
+++ b/test/lang/yue_zho/test_guided_review.py
@@ -35,7 +35,7 @@ from test.helpers import assert_series_equal, parametrize
             "test.data.mlamd.get_torch_device",
             "cuda",
             id="mlamd",
-        ),
+        )
     ],
 )
 def test_review_series_guided_yue_zho(

--- a/test/lang/zho/script/test_conversion.py
+++ b/test/lang/zho/script/test_conversion.py
@@ -141,9 +141,7 @@ def test_t2s_exclusions_are_raw_opencc_changes(text: str):
     ],
 )
 def test_get_zho_converted(
-    request: FixtureRequest,
-    series_fixture: str,
-    expected_fixture: str,
+    request: FixtureRequest, series_fixture: str, expected_fixture: str
 ):
     """Test get_zho_converted with traditional standard Chinese subtitles.
 
@@ -154,15 +152,9 @@ def test_get_zho_converted(
     """
     series = request.getfixturevalue(series_fixture)
     expected = request.getfixturevalue(expected_fixture)
-    output = get_zho_converted(
-        series,
-        OpenCCConfig.t2s,
-    )
+    output = get_zho_converted(series, OpenCCConfig.t2s)
     assert len(series) == len(output)
-    assert_series_equal(
-        output,
-        expected,
-    )
+    assert_series_equal(output, expected)
 
 
 @parametrize(

--- a/test/lang/zho/subtitles/analysis/test_subtitle_analysis_cache.py
+++ b/test/lang/zho/subtitles/analysis/test_subtitle_analysis_cache.py
@@ -38,30 +38,14 @@ def test_subtitle_script_analysis_cache_round_trip(tmp_path: Path):
     infile_path.write_bytes(b"video")
     stream = SubtitleStream(index=2, language="zho", codec_name="subrip")
     analysis = ZhoScriptAnalysisResult(
-        script="zho-Hant",
-        traditional_count=4,
-        shared_count=2,
+        script="zho-Hant", traditional_count=4, shared_count=2
     )
     cache = ZhoScriptAnalysisCache(tmp_path / "cache")
 
-    cache_path = cache.save(
-        infile_path,
-        stream,
-        4,
-        ("zho-Hans", "zho-Hant"),
-        analysis,
-    )
+    cache_path = cache.save(infile_path, stream, 4, ("zho-Hans", "zho-Hant"), analysis)
 
     assert cache_path.parent == tmp_path / "cache/media/subtitles/analysis"
-    assert (
-        cache.load(
-            infile_path,
-            stream,
-            4,
-            ("zho-Hans", "zho-Hant"),
-        )
-        == analysis
-    )
+    assert cache.load(infile_path, stream, 4, ("zho-Hans", "zho-Hant")) == analysis
     payload = json.loads(cache_path.read_text(encoding="utf-8"))
     assert payload["cache_version"] == 1
     assert payload["analysis"]["script"] == "zho-Hant"
@@ -77,29 +61,14 @@ def test_subtitle_script_analysis_cache_discards_invalid_entry(tmp_path: Path):
     infile_path.write_bytes(b"video")
     stream = SubtitleStream(index=2, language="zho", codec_name="subrip")
     cache = ZhoScriptAnalysisCache(tmp_path / "cache")
-    cache_path = cache.get_path(
-        infile_path,
-        stream,
-        4,
-        ("zho-Hans", "zho-Hant"),
-    )
+    cache_path = cache.get_path(infile_path, stream, 4, ("zho-Hans", "zho-Hant"))
     cache_path.write_text("{", encoding="utf-8")
 
-    assert (
-        cache.load(
-            infile_path,
-            stream,
-            4,
-            ("zho-Hans", "zho-Hant"),
-        )
-        is None
-    )
+    assert cache.load(infile_path, stream, 4, ("zho-Hans", "zho-Hant")) is None
     assert not cache_path.exists()
 
 
-def test_subtitle_script_analysis_cache_discards_mismatched_version(
-    tmp_path: Path,
-):
+def test_subtitle_script_analysis_cache_discards_mismatched_version(tmp_path: Path):
     """Test script analysis cache version mismatches are discarded."""
     infile_path = tmp_path / "video.mkv"
     infile_path.write_bytes(b"video")
@@ -142,13 +111,7 @@ def test_subtitle_script_analysis_cache_overwrite_removes_entry(tmp_path: Path):
     overwrite_cache = ZhoScriptAnalysisCache(cache_root_path, overwrite=True)
 
     assert (
-        overwrite_cache.load(
-            infile_path,
-            stream,
-            4,
-            ("zho-Hans", "zho-Hant"),
-        )
-        is None
+        overwrite_cache.load(infile_path, stream, 4, ("zho-Hans", "zho-Hant")) is None
     )
     assert not cache_path.exists()
 
@@ -161,21 +124,13 @@ def test_subtitle_script_analysis_cache_overwrites_entry_once(tmp_path: Path):
     cache_root_path = tmp_path / "cache"
     languages = ("zho-Hans", "zho-Hant")
     ZhoScriptAnalysisCache(cache_root_path).save(
-        infile_path,
-        stream,
-        4,
-        languages,
-        ZhoScriptAnalysisResult(script="zho-Hant"),
+        infile_path, stream, 4, languages, ZhoScriptAnalysisResult(script="zho-Hant")
     )
     overwrite_cache = ZhoScriptAnalysisCache(cache_root_path, True)
 
     assert overwrite_cache.load(infile_path, stream, 4, languages) is None
     overwrite_cache.save(
-        infile_path,
-        stream,
-        4,
-        languages,
-        ZhoScriptAnalysisResult(script="zho-Hans"),
+        infile_path, stream, 4, languages, ZhoScriptAnalysisResult(script="zho-Hans")
     )
 
     assert overwrite_cache.load(infile_path, stream, 4, languages) == (

--- a/test/lang/zho/subtitles/analysis/test_subtitle_script_analysis.py
+++ b/test/lang/zho/subtitles/analysis/test_subtitle_script_analysis.py
@@ -41,9 +41,7 @@ def test_analyze_text_subtitle_stream_uses_cached_stream(tmp_path: Path):
 
     with patch("scinoephile.media.subtitles.extractor.ffmpeg.input") as ffmpeg_input:
         analysis = analyze_zho_subtitle_stream_script(
-            infile_path,
-            stream,
-            subtitle_cache=subtitle_cache,
+            infile_path, stream, subtitle_cache=subtitle_cache
         )
 
     ffmpeg_input.assert_not_called()
@@ -64,9 +62,7 @@ def test_analyze_text_subtitle_stream_marks_cached_analysis_used(tmp_path: Path)
     )
     subtitle_cache = SubtitleCache(cache_root_path)
     analyze_zho_subtitle_stream_script(
-        infile_path,
-        stream,
-        subtitle_cache=subtitle_cache,
+        infile_path, stream, subtitle_cache=subtitle_cache
     )
     cache_path = next(
         (cache_root_path / "media" / "subtitles" / "analysis").glob("*.json")
@@ -78,9 +74,7 @@ def test_analyze_text_subtitle_stream_marks_cached_analysis_used(tmp_path: Path)
         "scinoephile.lang.zho.subtitles.analysis.script.SubtitleExtractor.extract"
     ) as extract:
         analysis = analyze_zho_subtitle_stream_script(
-            infile_path,
-            stream,
-            subtitle_cache=subtitle_cache,
+            infile_path, stream, subtitle_cache=subtitle_cache
         )
 
     extract.assert_not_called()
@@ -104,9 +98,7 @@ def test_analyze_text_subtitle_stream_regenerates_invalid_analysis_cache(
     )
     subtitle_cache = SubtitleCache(cache_root_path)
     analyze_zho_subtitle_stream_script(
-        infile_path,
-        stream,
-        subtitle_cache=subtitle_cache,
+        infile_path, stream, subtitle_cache=subtitle_cache
     )
     cache_path = next(
         (cache_root_path / "media" / "subtitles" / "analysis").glob("*.json")
@@ -114,9 +106,7 @@ def test_analyze_text_subtitle_stream_regenerates_invalid_analysis_cache(
     cache_path.write_text("{", encoding="utf-8")
 
     analysis = analyze_zho_subtitle_stream_script(
-        infile_path,
-        stream,
-        subtitle_cache=subtitle_cache,
+        infile_path, stream, subtitle_cache=subtitle_cache
     )
 
     assert analysis.script == "zho-Hans"
@@ -146,21 +136,15 @@ def test_analyze_text_subtitle_stream_overwrites_cached_stream(tmp_path: Path):
         return_value=[stream_path],
     ) as extract:
         analysis = analyze_zho_subtitle_stream_script(
-            infile_path,
-            stream,
-            subtitle_cache=subtitle_cache,
+            infile_path, stream, subtitle_cache=subtitle_cache
         )
 
-    extract.assert_called_once_with(
-        infile_path,
-        [stream],
-    )
+    extract.assert_called_once_with(infile_path, [stream])
     assert analysis.script == "zho-Hans"
 
 
 def test_analyze_image_subtitle_stream_uses_cached_sampled_pngs(
-    tmp_path: Path,
-    monkeypatch,
+    tmp_path: Path, monkeypatch
 ):
     """Test image subtitle analysis OCRs sampled cached PNGs.
 
@@ -172,12 +156,7 @@ def test_analyze_image_subtitle_stream_uses_cached_sampled_pngs(
     infile_path.write_bytes(b"video")
     stream = SubtitleStream(index=2, language="zho", codec_name="hdmv_pgs_subtitle")
     cache_root_path = tmp_path / "cache"
-    cache_image_subtitles(
-        infile_path,
-        stream,
-        cache_root_path,
-        event_count=7,
-    )
+    cache_image_subtitles(infile_path, stream, cache_root_path, event_count=7)
     subtitle_cache = SubtitleCache(cache_root_path)
     ocr_sizes: list[list[tuple[int, int]]] = []
 
@@ -206,9 +185,7 @@ def test_analyze_image_subtitle_stream_uses_cached_sampled_pngs(
         fake_ocr_image_series_with_paddle,
     )
     analysis = analyze_zho_subtitle_stream_script(
-        infile_path,
-        stream,
-        subtitle_cache=subtitle_cache,
+        infile_path, stream, subtitle_cache=subtitle_cache
     )
 
     assert analysis.script == "zho-Hant"

--- a/test/lang/zho/subtitles/test_subtitle_streams.py
+++ b/test/lang/zho/subtitles/test_subtitle_streams.py
@@ -37,10 +37,7 @@ def test_get_zho_subtitle_streams_adds_script_and_regular_details(tmp_path: Path
                     last_end_ms=3_725_250,
                 ),
                 SubtitleStream(
-                    index=3,
-                    codec_name="subrip",
-                    language="eng",
-                    subtitle_count=8,
+                    index=3, codec_name="subrip", language="eng", subtitle_count=8
                 ),
             ],
         ) as details_mock,
@@ -49,20 +46,13 @@ def test_get_zho_subtitle_streams_adds_script_and_regular_details(tmp_path: Path
             return_value=SimpleNamespace(script="zho-Hant"),
         ) as analysis_mock,
     ):
-        streams = get_zho_subtitle_streams(
-            infile_path,
-            subtitle_cache=subtitle_cache,
-        )
+        streams = get_zho_subtitle_streams(infile_path, subtitle_cache=subtitle_cache)
 
     details_mock.assert_called_once_with(
-        infile_path,
-        streams=None,
-        subtitle_cache=subtitle_cache,
+        infile_path, streams=None, subtitle_cache=subtitle_cache
     )
     analysis_mock.assert_called_once_with(
-        infile_path,
-        streams[0],
-        subtitle_cache=subtitle_cache,
+        infile_path, streams[0], subtitle_cache=subtitle_cache
     )
     assert [stream.index for stream in streams] == [2, 3]
     assert streams[0].language == "zho-Hant"
@@ -84,13 +74,7 @@ def test_get_zho_subtitle_streams_preserves_yue_language(tmp_path: Path):
     with (
         patch(
             "scinoephile.lang.zho.subtitles.streams.get_detailed_subtitle_streams",
-            return_value=[
-                SubtitleStream(
-                    index=2,
-                    codec_name="subrip",
-                    language="yue",
-                ),
-            ],
+            return_value=[SubtitleStream(index=2, codec_name="subrip", language="yue")],
         ),
         patch(
             "scinoephile.lang.zho.subtitles.streams.analyze_zho_subtitle_stream_script",
@@ -125,21 +109,14 @@ def test_get_zho_subtitle_streams_does_not_overwrite_subtitle_cache_twice(
             return_value=SimpleNamespace(script="zho-Hant"),
         ) as analysis_mock,
     ):
-        get_zho_subtitle_streams(
-            infile_path,
-            subtitle_cache=subtitle_cache,
-        )
+        get_zho_subtitle_streams(infile_path, subtitle_cache=subtitle_cache)
 
     details_mock.assert_called_once_with(
-        infile_path,
-        streams=None,
-        subtitle_cache=subtitle_cache,
+        infile_path, streams=None, subtitle_cache=subtitle_cache
     )
     assert subtitle_cache.overwrite
     analysis_mock.assert_called_once_with(
-        infile_path,
-        stream,
-        subtitle_cache=subtitle_cache,
+        infile_path, stream, subtitle_cache=subtitle_cache
     )
 
 
@@ -155,13 +132,7 @@ def test_get_zho_subtitle_streams_normalizes_chi_language(tmp_path: Path):
     with (
         patch(
             "scinoephile.lang.zho.subtitles.streams.get_detailed_subtitle_streams",
-            return_value=[
-                SubtitleStream(
-                    index=2,
-                    codec_name="subrip",
-                    language="chi",
-                ),
-            ],
+            return_value=[SubtitleStream(index=2, codec_name="subrip", language="chi")],
         ),
         patch(
             "scinoephile.lang.zho.subtitles.streams.analyze_zho_subtitle_stream_script",
@@ -185,10 +156,7 @@ def test_get_zho_subtitle_streams_uses_provided_streams(tmp_path: Path):
         VideoStream(index=0, codec_type="video", codec_name="h264"),
         AudioStream(index=1, codec_type="audio", codec_name="aac"),
         SubtitleStream(
-            index=2,
-            codec_type="subtitle",
-            codec_name="subrip",
-            language="zho",
+            index=2, codec_type="subtitle", codec_name="subrip", language="zho"
         ),
     ]
 

--- a/test/llms/providers/test_openai_provider.py
+++ b/test/llms/providers/test_openai_provider.py
@@ -19,10 +19,7 @@ def test_openai_constructs_client_with_explicit_api_key_and_base_url(
     """Test OpenAIProvider forwards explicit client overrides to OpenAI."""
     monkeypatch.setattr(openai_provider_base, "OpenAI", DummyOpenAI)
 
-    provider = OpenAIProvider(
-        api_key="explicit",
-        base_url="https://example.invalid/v1",
-    )
+    provider = OpenAIProvider(api_key="explicit", base_url="https://example.invalid/v1")
     client = cast(DummyOpenAI, provider.sync_client)
 
     assert isinstance(client, DummyOpenAI)

--- a/test/llms/test_delineation.py
+++ b/test/llms/test_delineation.py
@@ -17,9 +17,7 @@ from scinoephile.core.llms.utils import (
     load_test_cases_from_json,
     save_test_cases_to_json,
 )
-from scinoephile.lang.yue_zho.transcription import (
-    YueZhoDelineationPromptYueHans,
-)
+from scinoephile.lang.yue_zho.transcription import YueZhoDelineationPromptYueHans
 from scinoephile.llms.delineation import (
     DelineationManager,
     DelineationPrompt,
@@ -86,10 +84,7 @@ def test_prompt_aliases_are_used_for_llm_correspondence():
         "mubiao_er": "乙",
     }
     assert test_case.answer is not None
-    assert test_case.answer.model_dump() == {
-        "output_one": "甲乙",
-        "output_two": "",
-    }
+    assert test_case.answer.model_dump() == {"output_one": "甲乙", "output_two": ""}
     assert test_case.answer.model_dump(by_alias=True) == {
         "shuchu_yi": "甲乙",
         "shuchu_er": "",
@@ -134,18 +129,14 @@ def test_queryer_corresponds_using_prompt_aliases():
     )
     provider = Mock(spec=LLMProvider, cache_identity={"implementation": "test"})
     provider.chat_completion.return_value = json.dumps(
-        {"shuchu_yi": "甲乙"},
-        ensure_ascii=False,
+        {"shuchu_yi": "甲乙"}, ensure_ascii=False
     )
     queryer = Queryer(test_case_cls, provider=provider, max_attempts=1)
 
     result = queryer(test_case)
 
     assert result.answer is not None
-    assert result.answer.model_dump() == {
-        "output_one": "甲乙",
-        "output_two": "",
-    }
+    assert result.answer.model_dump() == {"output_one": "甲乙", "output_two": ""}
     messages, answer_cls, _ = provider.chat_completion.call_args.args
     assert answer_cls is test_case_cls.answer_cls
     assert json.loads(messages[1]["content"]) == {
@@ -158,10 +149,7 @@ def test_queryer_corresponds_using_prompt_aliases():
 
 @mark.parametrize(
     "answer",
-    [
-        {"output_one": "甲乙"},
-        {"shuchu_yii": "甲乙"},
-    ],
+    [{"output_one": "甲乙"}, {"shuchu_yii": "甲乙"}],
     ids=["semantic-name", "misspelled-alias"],
 )
 def test_queryer_rejects_noncanonical_answer_fields(answer: dict[str, str]):
@@ -195,10 +183,7 @@ def test_static_models_validate_target_presence_and_boundary_shifts():
     }
     no_shift = DelineationTestCase.model_validate({"query": query, "answer": {}})
     shifted = DelineationTestCase.model_validate(
-        {
-            "query": query,
-            "answer": {"output_one": "abc", "output_two": "d"},
-        }
+        {"query": query, "answer": {"output_one": "abc", "output_two": "d"}}
     )
     explicitly_difficult = DelineationTestCase.model_validate(
         {"query": query, "difficulty": 3}
@@ -208,8 +193,7 @@ def test_static_models_validate_target_presence_and_boundary_shifts():
     assert shifted.difficulty == 1
     assert explicitly_difficult.difficulty == 3
     with raises(
-        ValidationError,
-        match=DelineationManager.base_prompt.target_subs_missing_err,
+        ValidationError, match=DelineationManager.base_prompt.target_subs_missing_err
     ):
         DelineationTestCase.model_validate(
             {
@@ -220,21 +204,14 @@ def test_static_models_validate_target_presence_and_boundary_shifts():
             }
         )
     with raises(
-        ValidationError,
-        match=DelineationManager.base_prompt.target_subs_unchanged_err,
+        ValidationError, match=DelineationManager.base_prompt.target_subs_unchanged_err
     ):
         DelineationTestCase.model_validate(
-            {
-                "query": query,
-                "answer": {"output_one": "ab", "output_two": "cd"},
-            }
+            {"query": query, "answer": {"output_one": "ab", "output_two": "cd"}}
         )
     with raises(ValidationError, match="Expected: abcd"):
         DelineationTestCase.model_validate(
-            {
-                "query": query,
-                "answer": {"output_one": "ab", "output_two": "changed"},
-            }
+            {"query": query, "answer": {"output_one": "ab", "output_two": "changed"}}
         )
 
 
@@ -248,34 +225,17 @@ def test_generated_models_use_prompt_specific_validation_errors():
         "target_two": "乙",
     }
 
-    with raises(
-        ValidationError,
-        match=_LOCALIZED_PROMPT.target_subs_missing_err,
-    ):
+    with raises(ValidationError, match=_LOCALIZED_PROMPT.target_subs_missing_err):
         test_case_cls.model_validate(
-            {
-                "query": {
-                    "reference_one": "參考一",
-                    "reference_two": "參考二",
-                }
-            }
+            {"query": {"reference_one": "參考一", "reference_two": "參考二"}}
         )
-    with raises(
-        ValidationError,
-        match=_LOCALIZED_PROMPT.target_subs_unchanged_err,
-    ):
+    with raises(ValidationError, match=_LOCALIZED_PROMPT.target_subs_unchanged_err):
         test_case_cls.model_validate(
-            {
-                "query": query,
-                "answer": {"output_one": "甲", "output_two": "乙"},
-            }
+            {"query": query, "answer": {"output_one": "甲", "output_two": "乙"}}
         )
     with raises(ValidationError, match="調整後目標字幕字元不一致"):
         test_case_cls.model_validate(
-            {
-                "query": query,
-                "answer": {"output_one": "甲", "output_two": "丙"},
-            }
+            {"query": query, "answer": {"output_one": "甲", "output_two": "丙"}}
         )
 
 
@@ -322,9 +282,7 @@ def test_persistence_uses_base_prompt_aliases_and_omits_defaults(tmp_path: Path)
     }
 
     loaded = load_test_cases_from_json(
-        output_path,
-        DelineationManager,
-        _LOCALIZED_PROMPT,
+        output_path, DelineationManager, _LOCALIZED_PROMPT
     )
     assert loaded[0].model_dump() == test_case.model_dump()
 
@@ -349,23 +307,18 @@ def test_tracked_fixture_count():
     ],
 )
 def test_tracked_fixture_round_trips_without_migration(
-    input_path: Path,
-    tmp_path: Path,
+    input_path: Path, tmp_path: Path
 ):
     """Tracked JSON should round-trip exactly and to equivalent static models."""
     raw_data = json.loads(input_path.read_text(encoding="utf-8"))
     test_cases = load_test_cases_from_json(
-        input_path,
-        DelineationManager,
-        YueZhoDelineationPromptYueHans,
+        input_path, DelineationManager, YueZhoDelineationPromptYueHans
     )
     output_path = tmp_path / input_path.name
 
     save_test_cases_to_json(output_path, test_cases, DelineationManager)
     reloaded = load_test_cases_from_json(
-        output_path,
-        DelineationManager,
-        YueZhoDelineationPromptYueHans,
+        output_path, DelineationManager, YueZhoDelineationPromptYueHans
     )
 
     assert json.loads(output_path.read_text(encoding="utf-8")) == raw_data

--- a/test/llms/test_gap_translation.py
+++ b/test/llms/test_gap_translation.py
@@ -61,10 +61,7 @@ def test_prompt_aliases_are_used_for_llm_correspondence():
     )
 
     assert test_case.query.model_dump(by_alias=True) == {
-        "mubiao": [
-            {"xuhao": 1, "wenben": "現有一"},
-            {"xuhao": 3, "wenben": "現有三"},
-        ],
+        "mubiao": [{"xuhao": 1, "wenben": "現有一"}, {"xuhao": 3, "wenben": "現有三"}],
         "cankao": [
             {"xuhao": 1, "wenben": "參考一"},
             {"xuhao": 2, "wenben": "參考二"},
@@ -109,10 +106,7 @@ def test_queryer_corresponds_using_prompt_aliases():
     assert answer_cls is test_case_cls.answer_cls
     assert json.loads(messages[1]["content"]) == {
         "mubiao": [{"xuhao": 1, "wenben": "現有"}],
-        "cankao": [
-            {"xuhao": 1, "wenben": "參考一"},
-            {"xuhao": 2, "wenben": "參考二"},
-        ],
+        "cankao": [{"xuhao": 1, "wenben": "參考一"}, {"xuhao": 2, "wenben": "參考二"}],
     }
 
 
@@ -126,10 +120,7 @@ def test_query_requires_nonempty_consecutive_guides():
         query_cls.model_validate(
             {
                 "targets": [],
-                "guides": [
-                    {"index": 1, "text": "one"},
-                    {"index": 3, "text": "three"},
-                ],
+                "guides": [{"index": 1, "text": "one"}, {"index": 3, "text": "three"}],
             }
         )
 
@@ -141,10 +132,7 @@ def test_query_requires_ordered_unique_target_indexes():
     with raises(ValidationError, match="unique and in ascending order"):
         query_cls.model_validate(
             {
-                "targets": [
-                    {"index": 2, "text": "two"},
-                    {"index": 1, "text": "one"},
-                ],
+                "targets": [{"index": 2, "text": "two"}, {"index": 1, "text": "one"}],
                 "guides": [
                     {"index": 1, "text": "one"},
                     {"index": 2, "text": "two"},
@@ -157,25 +145,16 @@ def test_query_requires_ordered_unique_target_indexes():
 def test_query_requires_targets_to_be_sparse_guide_subset():
     """Targets should be a proper subset of guide indexes."""
     query_cls = GapTranslationManager.get_query_cls(GapTranslationManager.base_prompt)
-    guides = [
-        {"index": 1, "text": "one"},
-        {"index": 2, "text": "two"},
-    ]
+    guides = [{"index": 1, "text": "one"}, {"index": 2, "text": "two"}]
 
     with raises(ValidationError, match="correspond to a guide index"):
         query_cls.model_validate(
-            {
-                "targets": [{"index": 3, "text": "three"}],
-                "guides": guides,
-            }
+            {"targets": [{"index": 3, "text": "three"}], "guides": guides}
         )
     with raises(ValidationError, match="omit at least one guide index"):
         query_cls.model_validate(
             {
-                "targets": [
-                    {"index": 1, "text": "one"},
-                    {"index": 2, "text": "two"},
-                ],
+                "targets": [{"index": 1, "text": "one"}, {"index": 2, "text": "two"}],
                 "guides": guides,
             }
         )
@@ -187,12 +166,7 @@ def test_answer_requires_ordered_unique_outputs():
 
     with raises(ValidationError, match="unique and in ascending order"):
         answer_cls.model_validate(
-            {
-                "outputs": [
-                    {"index": 2, "text": "two"},
-                    {"index": 1, "text": "one"},
-                ]
-            }
+            {"outputs": [{"index": 2, "text": "two"}, {"index": 1, "text": "one"}]}
         )
 
 
@@ -346,16 +320,11 @@ def test_json_persistence_uses_base_prompt_fields(tmp_path: Path):
         }
     ]
     loaded = load_test_cases_from_json(
-        output_path,
-        GapTranslationManager,
-        _LOCALIZED_PROMPT,
+        output_path, GapTranslationManager, _LOCALIZED_PROMPT
     )
     assert loaded[0].query.model_dump(by_alias=True) == {
         "mubiao": [{"xuhao": 1, "wenben": "現有"}],
-        "cankao": [
-            {"xuhao": 1, "wenben": "參考一"},
-            {"xuhao": 2, "wenben": "參考二"},
-        ],
+        "cankao": [{"xuhao": 1, "wenben": "參考一"}, {"xuhao": 2, "wenben": "參考二"}],
     }
     assert loaded[0].answer is not None
     assert loaded[0].answer.model_dump(by_alias=True) == {
@@ -406,9 +375,7 @@ def test_processor_maps_targets_and_outputs_by_index():
     )
     provider = Mock(spec=LLMProvider, cache_identity={"implementation": "test"})
     processor = GapTranslationProcessor(
-        prompt,
-        test_cases=[test_case],
-        provider=provider,
+        prompt, test_cases=[test_case], provider=provider
     )
 
     output = processor.process(source_one, source_two)
@@ -421,8 +388,7 @@ def test_processor_honors_zero_stop_index():
     """A zero stop index should process no gap-translation blocks."""
     provider = Mock(spec=LLMProvider, cache_identity={"implementation": "test"})
     processor = GapTranslationProcessor(
-        GapTranslationManager.base_prompt,
-        provider=provider,
+        GapTranslationManager.base_prompt, provider=provider
     )
     source_one = Series(events=[Subtitle(start=0, end=100, text="existing one")])
     source_two = Series(
@@ -442,8 +408,7 @@ def test_processor_honors_start_index():
     """An inclusive start index should skip earlier gap-translation blocks."""
     provider = Mock(spec=LLMProvider, cache_identity={"implementation": "test"})
     processor = GapTranslationProcessor(
-        GapTranslationManager.base_prompt,
-        provider=provider,
+        GapTranslationManager.base_prompt, provider=provider
     )
     source = Series(
         events=[
@@ -477,19 +442,13 @@ def test_processing_preserves_unencountered_few_shot_cases(tmp_path: Path):
         }
     )
     test_case_path = tmp_path / "gap_translation.json"
-    save_test_cases_to_json(
-        test_case_path,
-        [old_test_case],
-        GapTranslationManager,
-    )
+    save_test_cases_to_json(test_case_path, [old_test_case], GapTranslationManager)
     provider = Mock(spec=LLMProvider, cache_identity={"implementation": "test"})
     provider.chat_completion.return_value = json.dumps(
         {"outputs": [{"index": 2, "text": "new translation"}]}
     )
     processor = GapTranslationProcessor(
-        prompt,
-        test_case_path=test_case_path,
-        provider=provider,
+        prompt, test_case_path=test_case_path, provider=provider
     )
     target = Series(events=[Subtitle(start=0, end=100, text="new target")])
     guide = Series(
@@ -501,11 +460,7 @@ def test_processing_preserves_unencountered_few_shot_cases(tmp_path: Path):
 
     processor.process(target, guide)
 
-    persisted = load_test_cases_from_json(
-        test_case_path,
-        GapTranslationManager,
-        prompt,
-    )
+    persisted = load_test_cases_from_json(test_case_path, GapTranslationManager, prompt)
     assert len(persisted) == 2
     persisted_cases = cast("list[GapTranslationTestCase]", persisted)
     assert [item.query.targets[0].text for item in persisted_cases] == [
@@ -538,9 +493,7 @@ def test_repository_json_fixtures_load():
         test_case
         for fixture_path in fixture_paths
         for test_case in load_test_cases_from_json(
-            fixture_path,
-            GapTranslationManager,
-            GapTranslationManager.base_prompt,
+            fixture_path, GapTranslationManager, GapTranslationManager.base_prompt
         )
     ]
 

--- a/test/llms/test_guided_review_models.py
+++ b/test/llms/test_guided_review_models.py
@@ -51,22 +51,13 @@ def test_prompt_aliases_are_used_for_llm_correspondence():
                 "zhinan": [{"xuhao": 1, "wenben": "參考"}],
             },
             "answer": {
-                "xiugai": [
-                    {
-                        "xuhao": 2,
-                        "wenben": "修改二",
-                        "beizhu": "修正錯字",
-                    }
-                ]
+                "xiugai": [{"xuhao": 2, "wenben": "修改二", "beizhu": "修正錯字"}]
             },
         }
     )
 
     assert test_case.query.model_dump(by_alias=True) == {
-        "mubiao": [
-            {"xuhao": 1, "wenben": "原文一"},
-            {"xuhao": 2, "wenben": "原文二"},
-        ],
+        "mubiao": [{"xuhao": 1, "wenben": "原文一"}, {"xuhao": 2, "wenben": "原文二"}],
         "zhinan": [{"xuhao": 1, "wenben": "參考"}],
     }
     assert test_case.answer is not None
@@ -121,17 +112,11 @@ def test_processing_preserves_unencountered_few_shot_cases(tmp_path: Path):
         }
     )
     test_case_path = tmp_path / "guided_review.json"
-    save_test_cases_to_json(
-        test_case_path,
-        [old_test_case],
-        GuidedReviewManager,
-    )
+    save_test_cases_to_json(test_case_path, [old_test_case], GuidedReviewManager)
     provider = Mock(spec=LLMProvider, cache_identity={"implementation": "test"})
     provider.chat_completion.return_value = '{"xiugai": []}'
     processor = GuidedReviewProcessor(
-        _LOCALIZED_PROMPT,
-        test_case_path=test_case_path,
-        provider=provider,
+        _LOCALIZED_PROMPT, test_case_path=test_case_path, provider=provider
     )
     target = Series(events=[Subtitle(start=0, end=100, text="新原文")])
     guide = Series(events=[Subtitle(start=0, end=100, text="參考")])
@@ -139,9 +124,7 @@ def test_processing_preserves_unencountered_few_shot_cases(tmp_path: Path):
     processor.process(target, guide)
 
     persisted = load_test_cases_from_json(
-        test_case_path,
-        GuidedReviewManager,
-        _LOCALIZED_PROMPT,
+        test_case_path, GuidedReviewManager, _LOCALIZED_PROMPT
     )
     assert len(persisted) == 2
     persisted_cases = cast("list[GuidedReviewTestCase]", persisted)
@@ -232,10 +215,7 @@ def test_query_lists_require_items_and_consecutive_ordered_indexes():
     with raises(ValidationError, match="target indexes must be consecutive"):
         query_cls.model_validate(
             {
-                "targets": [
-                    {"index": 1, "text": "one"},
-                    {"index": 3, "text": "three"},
-                ],
+                "targets": [{"index": 1, "text": "one"}, {"index": 3, "text": "three"}],
                 "guides": [{"index": 1, "text": "guide"}],
             }
         )
@@ -243,10 +223,7 @@ def test_query_lists_require_items_and_consecutive_ordered_indexes():
         query_cls.model_validate(
             {
                 "targets": [{"index": 1, "text": "target"}],
-                "guides": [
-                    {"index": 2, "text": "two"},
-                    {"index": 1, "text": "one"},
-                ],
+                "guides": [{"index": 2, "text": "two"}, {"index": 1, "text": "one"}],
             }
         )
 
@@ -316,16 +293,11 @@ def test_test_case_rejects_missing_and_unmodified_revision_indexes(
     ],
     ids=["static", "generated"],
 )
-def test_revisions_raise_minimum_difficulty(
-    test_case_cls: type[GuidedReviewTestCase],
-):
+def test_revisions_raise_minimum_difficulty(test_case_cls: type[GuidedReviewTestCase]):
     """A nonempty revisions list should require difficulty one."""
     test_case = test_case_cls.model_validate(
         {
-            "query": {
-                "targets": [{"index": 1, "text": "original"}],
-                "guides": [],
-            },
+            "query": {"targets": [{"index": 1, "text": "original"}], "guides": []},
             "answer": {"revisions": [{"index": 1, "text": "revised", "note": "typo"}]},
         }
     )
@@ -400,9 +372,7 @@ def test_json_uses_base_prompt_fields_and_loads_localized_aliases(tmp_path: Path
         }
     ]
     loaded = load_test_cases_from_json(
-        output_path,
-        GuidedReviewManager,
-        _LOCALIZED_PROMPT,
+        output_path, GuidedReviewManager, _LOCALIZED_PROMPT
     )
     assert loaded[0].query.model_dump(by_alias=True) == {
         "mubiao": [{"xuhao": 1, "wenben": "原文"}],
@@ -435,9 +405,6 @@ def test_processor_uses_indexed_lists_and_applies_sparse_revisions():
     assert [subtitle.text for subtitle in output] == ["原文一", "修改二"]
     messages = provider.chat_completion.call_args.args[0]
     assert json.loads(messages[1]["content"]) == {
-        "mubiao": [
-            {"xuhao": 1, "wenben": "原文一"},
-            {"xuhao": 2, "wenben": "原文二"},
-        ],
+        "mubiao": [{"xuhao": 1, "wenben": "原文一"}, {"xuhao": 2, "wenben": "原文二"}],
         "zhinan": [{"xuhao": 1, "wenben": "參考"}],
     }

--- a/test/llms/test_guided_translation.py
+++ b/test/llms/test_guided_translation.py
@@ -45,9 +45,7 @@ def test_prompt_aliases_are_used_for_llm_correspondence():
                 "zimu": [{"xuhao": 1, "wenben": "原文"}],
                 "cankao": [{"xuhao": 1, "wenben": "參考"}],
             },
-            "answer": {
-                "shuchu": [{"xuhao": 1, "wenben": "譯文"}],
-            },
+            "answer": {"shuchu": [{"xuhao": 1, "wenben": "譯文"}]},
         }
     )
 
@@ -57,7 +55,7 @@ def test_prompt_aliases_are_used_for_llm_correspondence():
     }
     assert test_case.answer is not None
     assert test_case.answer.model_dump(by_alias=True) == {
-        "shuchu": [{"xuhao": 1, "wenben": "譯文"}],
+        "shuchu": [{"xuhao": 1, "wenben": "譯文"}]
     }
     assert set(test_case_cls.query_cls.model_json_schema()["properties"]) == {
         "zimu",
@@ -166,10 +164,7 @@ def test_processor_maps_indexed_outputs_to_subtitle_timing():
     messages, answer_cls, _ = provider.chat_completion.call_args.args
     assert answer_cls is processor.queryer.test_case_cls.answer_cls
     assert json.loads(messages[1]["content"]) == {
-        "zimu": [
-            {"xuhao": 1, "wenben": "原文一"},
-            {"xuhao": 2, "wenben": "原文二"},
-        ],
+        "zimu": [{"xuhao": 1, "wenben": "原文一"}, {"xuhao": 2, "wenben": "原文二"}],
         "cankao": [{"xuhao": 1, "wenben": "參考"}],
     }
 
@@ -179,34 +174,22 @@ def test_persistence_uses_base_prompt_field_names(tmp_path: Path):
     test_case_cls = GuidedTranslationManager.get_test_case_cls(_LOCALIZED_PROMPT)
     test_case = test_case_cls.model_validate(
         {
-            "query": {
-                "subtitles": [{"index": 1, "text": "原文"}],
-                "guides": [],
-            },
+            "query": {"subtitles": [{"index": 1, "text": "原文"}], "guides": []},
             "answer": {"outputs": [{"index": 1, "text": "譯文"}]},
         }
     )
     output_path = tmp_path / "guided_translation.json"
 
-    save_test_cases_to_json(
-        output_path,
-        [test_case],
-        GuidedTranslationManager,
-    )
+    save_test_cases_to_json(output_path, [test_case], GuidedTranslationManager)
 
     assert json.loads(output_path.read_text(encoding="utf-8")) == [
         {
-            "query": {
-                "subtitles": [{"index": 1, "text": "原文"}],
-                "guides": [],
-            },
+            "query": {"subtitles": [{"index": 1, "text": "原文"}], "guides": []},
             "answer": {"outputs": [{"index": 1, "text": "譯文"}]},
         }
     ]
     loaded = load_test_cases_from_json(
-        output_path,
-        GuidedTranslationManager,
-        _LOCALIZED_PROMPT,
+        output_path, GuidedTranslationManager, _LOCALIZED_PROMPT
     )
     assert loaded[0].query.model_dump(by_alias=True) == {
         "zimu": [{"xuhao": 1, "wenben": "原文"}],
@@ -218,8 +201,7 @@ def test_processor_honors_start_index():
     """An inclusive start index should skip earlier guided-translation blocks."""
     provider = Mock(spec=LLMProvider, cache_identity={"implementation": "test"})
     provider.chat_completion.return_value = json.dumps(
-        {"shuchu": [{"xuhao": 1, "wenben": "譯文二"}]},
-        ensure_ascii=False,
+        {"shuchu": [{"xuhao": 1, "wenben": "譯文二"}]}, ensure_ascii=False
     )
     processor = GuidedTranslationProcessor(_LOCALIZED_PROMPT, provider=provider)
     source = Series(

--- a/test/llms/test_ocr_fusion_models.py
+++ b/test/llms/test_ocr_fusion_models.py
@@ -92,16 +92,8 @@ def test_generated_models_preserve_aliases_and_llm_schemas():
     assert query_schema == {
         "additionalProperties": False,
         "properties": {
-            "yilai": {
-                "description": "來源一字幕",
-                "title": "Yilai",
-                "type": "string",
-            },
-            "erlai": {
-                "description": "來源二字幕",
-                "title": "Erlai",
-                "type": "string",
-            },
+            "yilai": {"description": "來源一字幕", "title": "Yilai", "type": "string"},
+            "erlai": {"description": "來源二字幕", "title": "Erlai", "type": "string"},
         },
         "required": ["yilai", "erlai"],
         "title": get_model_name(Query.__name__, _LOCALIZED_PROMPT.name),
@@ -233,16 +225,10 @@ def test_queryer_corresponds_using_prompt_aliases():
     result = queryer(test_case)
 
     assert result.answer is not None
-    assert result.answer.model_dump() == {
-        "output": "來源一",
-        "note": "採用來源一",
-    }
+    assert result.answer.model_dump() == {"output": "來源一", "note": "採用來源一"}
     messages, answer_cls, _ = provider.chat_completion.call_args.args
     assert answer_cls is test_case_cls.answer_cls
-    assert json.loads(messages[1]["content"]) == {
-        "yilai": "來源一",
-        "erlai": "來源二",
-    }
+    assert json.loads(messages[1]["content"]) == {"yilai": "來源一", "erlai": "來源二"}
 
 
 def test_processor_uses_semantic_fields_at_runtime():
@@ -259,10 +245,7 @@ def test_processor_uses_semantic_fields_at_runtime():
 
     assert [subtitle.text for subtitle in result] == ["融合結果"]
     messages = provider.chat_completion.call_args.args[0]
-    assert json.loads(messages[1]["content"]) == {
-        "yilai": "來源一",
-        "erlai": "來源二",
-    }
+    assert json.loads(messages[1]["content"]) == {"yilai": "來源一", "erlai": "來源二"}
 
 
 def test_processor_honors_zero_stop_index():
@@ -312,11 +295,7 @@ def test_json_persistence_uses_base_prompt_aliases(tmp_path: Path):
             "verified": True,
         }
     ]
-    loaded = load_test_cases_from_json(
-        output_path,
-        OcrFusionManager,
-        _LOCALIZED_PROMPT,
-    )
+    loaded = load_test_cases_from_json(output_path, OcrFusionManager, _LOCALIZED_PROMPT)
     assert loaded[0].query.model_dump(by_alias=True) == {
         "yilai": "來源一",
         "erlai": "來源二",
@@ -345,9 +324,7 @@ def test_persisted_test_case_and_sqlite_use_base_prompt_aliases(tmp_path: Path):
 
     store = TestCaseSqliteStore(tmp_path / "test_cases.sqlite")
     store.sync_source_paths(
-        {"ocr_fusion.json": [persisted]},
-        manager_cls=OcrFusionManager,
-        dry_run=False,
+        {"ocr_fusion.json": [persisted]}, manager_cls=OcrFusionManager, dry_run=False
     )
     loaded = store.get_test_case(persisted.test_case_id)
     assert loaded is not None
@@ -366,26 +343,20 @@ def test_repository_json_fixtures_round_trip_without_rewrite():
     for input_path in input_paths:
         raw_test_cases = json.loads(input_path.read_text(encoding="utf-8"))
         localized_test_cases = load_test_cases_from_json(
-            input_path,
-            OcrFusionManager,
-            _LOCALIZED_PROMPT,
+            input_path, OcrFusionManager, _LOCALIZED_PROMPT
         )
         assert len(localized_test_cases) == len(raw_test_cases)
         total_test_cases += len(localized_test_cases)
 
         for raw_test_case, localized_test_case in zip(
-            raw_test_cases,
-            localized_test_cases,
-            strict=True,
+            raw_test_cases, localized_test_cases, strict=True
         ):
             base_test_case = base_test_case_cls.model_validate(
                 localized_test_case.model_dump(mode="json")
             )
             assert (
                 base_test_case.model_dump(
-                    mode="json",
-                    by_alias=True,
-                    exclude_defaults=True,
+                    mode="json", by_alias=True, exclude_defaults=True
                 )
                 == raw_test_case
             )

--- a/test/llms/test_prompt_metadata.py
+++ b/test/llms/test_prompt_metadata.py
@@ -29,9 +29,7 @@ _LEGACY_TEST_CASE_PROMPT_FIELDS: Final = {
 """Prompt fields removed when test-case metadata became static."""
 
 
-def test_registered_prompt_model_and_cache_identities_change_once(
-    tmp_path: Path,
-):
+def test_registered_prompt_model_and_cache_identities_change_once(tmp_path: Path):
     """Removing metadata should change prompt, model, and cache identities."""
     provider = Mock(spec=LLMProvider)
     provider.cache_identity = {"implementation": "test.provider"}
@@ -53,9 +51,7 @@ def test_registered_prompt_model_and_cache_identities_change_once(
 
         queryer = Queryer(test_case_cls, provider=provider, cache_root_path=tmp_path)
         legacy_queryer = Queryer(
-            legacy_test_case_cls,
-            provider=provider,
-            cache_root_path=tmp_path,
+            legacy_test_case_cls, provider=provider, cache_root_path=tmp_path
         )
         system_prompt = queryer.system_prompt
         legacy_system_prompt = legacy_queryer.system_prompt
@@ -66,9 +62,7 @@ def test_registered_prompt_model_and_cache_identities_change_once(
         query_json = '{"same":"query"}'
         cache_path = queryer._get_cache_path(system_prompt, tools_json, query_json)
         legacy_cache_path = legacy_queryer._get_cache_path(
-            legacy_system_prompt,
-            tools_json,
-            query_json,
+            legacy_system_prompt, tools_json, query_json
         )
 
         assert cache_path != legacy_cache_path
@@ -113,18 +107,12 @@ def test_registered_review_prompts_specify_note_language():
         Language.zho_hans: "中文",
         Language.zho_hant: "中文",
     }
-    review_manager_classes = {
-        GuidedReviewManager,
-        ReviewManager,
-    }
+    review_manager_classes = {GuidedReviewManager, ReviewManager}
 
     for alias, prompt_spec in PROMPT_SPECS.items():
         if prompt_spec.manager_cls not in review_manager_classes:
             continue
-        review_prompt = cast(
-            "GuidedReviewPrompt | ReviewPrompt",
-            prompt_spec.prompt,
-        )
+        review_prompt = cast("GuidedReviewPrompt | ReviewPrompt", prompt_spec.prompt)
         note_language = note_language_markers[review_prompt.language]
         assert note_language in review_prompt.base_system_prompt, alias
         assert note_language in review_prompt.note_desc, alias
@@ -195,10 +183,7 @@ def _get_registered_prompts() -> list[tuple[type[Manager], Prompt]]:
         (prompt_spec.manager_cls, prompt_spec.prompt)
         for prompt_spec in PROMPT_SPECS.values()
     }
-    return sorted(
-        prompt_pairs,
-        key=lambda pair: (pair[0].operation, pair[1].name),
-    )
+    return sorted(prompt_pairs, key=lambda pair: (pair[0].operation, pair[1].name))
 
 
 def _normalize_schema_identifiers(schema: dict[str, Any]) -> dict[str, Any]:

--- a/test/llms/test_punctuation.py
+++ b/test/llms/test_punctuation.py
@@ -97,10 +97,7 @@ def test_queryer_corresponds_using_prompt_aliases():
     assert result.answer.model_dump() == {"output": "原文"}
     messages, answer_cls, _ = provider.chat_completion.call_args.args
     assert answer_cls is test_case_cls.answer_cls
-    assert json.loads(messages[1]["content"]) == {
-        "cankao": "參考",
-        "zimu": ["原文"],
-    }
+    assert json.loads(messages[1]["content"]) == {"cankao": "參考", "zimu": ["原文"]}
 
 
 def test_queryer_localizes_test_case_validation_retry():
@@ -109,12 +106,7 @@ def test_queryer_localizes_test_case_validation_retry():
     test_case_cls = PunctuationManager.get_test_case_cls(prompt)
     subtitles = ["係", "洋文嚟嘅", "蝦即係有鬥心噉解"]
     test_case = test_case_cls.model_validate(
-        {
-            "query": {
-                "subtitles": subtitles,
-                "guide": "是洋文！即是有鬥心",
-            }
-        }
+        {"query": {"subtitles": subtitles, "guide": "是洋文！即是有鬥心"}}
     )
     provider = Mock(spec=LLMProvider, cache_identity={"implementation": "test"})
     provider.chat_completion.side_effect = [
@@ -130,8 +122,7 @@ def test_queryer_localizes_test_case_validation_retry():
         (
             prompt.test_case_invalid_pre,
             prompt.target_chars_changed_err(
-                "".join(subtitles),
-                "係洋文嚟嘅蝦即係有鬥心",
+                "".join(subtitles), "係洋文嚟嘅蝦即係有鬥心"
             ),
             prompt.test_case_invalid_post,
         )
@@ -148,8 +139,7 @@ def test_query_and_answer_require_nonempty_fields():
     with raises(ValidationError, match=_LOCALIZED_PROMPT.ref_sub_missing_err):
         query_cls.model_validate({"subtitles": ["原文"], "guide": ""})
     with raises(
-        ValidationError,
-        match=_LOCALIZED_PROMPT.target_sub_punctuated_missing_err,
+        ValidationError, match=_LOCALIZED_PROMPT.target_sub_punctuated_missing_err
     ):
         answer_cls.model_validate({"output": ""})
 
@@ -221,9 +211,7 @@ def test_persistence_uses_base_prompt_aliases(tmp_path: Path):
     assert persisted.answer == {"target_sub_punctuated": "原文"}
 
     loaded = load_test_cases_from_json(
-        output_path,
-        PunctuationManager,
-        _LOCALIZED_PROMPT,
+        output_path, PunctuationManager, _LOCALIZED_PROMPT
     )
     assert loaded[0].query.model_dump(by_alias=True) == {
         "cankao": "參考",
@@ -253,22 +241,15 @@ def test_tracked_fixture_count():
     ],
 )
 def test_tracked_fixture_round_trips_without_migration(
-    input_path: Path,
-    tmp_path: Path,
+    input_path: Path, tmp_path: Path
 ):
     """Tracked punctuation JSON should round-trip without schema changes."""
     raw_data = json.loads(input_path.read_text(encoding="utf-8"))
     test_cases = load_test_cases_from_json(
-        input_path,
-        PunctuationManager,
-        YueZhoPunctuationPromptYueHans,
+        input_path, PunctuationManager, YueZhoPunctuationPromptYueHans
     )
     output_path = tmp_path / input_path.name
 
-    save_test_cases_to_json(
-        output_path,
-        test_cases,
-        PunctuationManager,
-    )
+    save_test_cases_to_json(output_path, test_cases, PunctuationManager)
 
     assert json.loads(output_path.read_text(encoding="utf-8")) == raw_data

--- a/test/llms/test_review.py
+++ b/test/llms/test_review.py
@@ -49,22 +49,13 @@ def test_prompt_aliases_are_used_for_llm_correspondence():
                 ]
             },
             "answer": {
-                "xiugai": [
-                    {
-                        "xuhao": 2,
-                        "wenben": "修改二",
-                        "beizhu": "修正錯字",
-                    }
-                ]
+                "xiugai": [{"xuhao": 2, "wenben": "修改二", "beizhu": "修正錯字"}]
             },
         }
     )
 
     assert test_case.query.model_dump(by_alias=True) == {
-        "zimu": [
-            {"xuhao": 1, "wenben": "原文一"},
-            {"xuhao": 2, "wenben": "原文二"},
-        ]
+        "zimu": [{"xuhao": 1, "wenben": "原文一"}, {"xuhao": 2, "wenben": "原文二"}]
     }
     assert test_case.answer is not None
     assert test_case.answer.model_dump(by_alias=True) == {
@@ -273,12 +264,7 @@ def test_query_requires_consecutive_ordered_indexes():
 
     with raises(ValidationError, match="consecutive, ordered, and begin at 1"):
         query_cls.model_validate(
-            {
-                "subtitles": [
-                    {"index": 1, "text": "one"},
-                    {"index": 3, "text": "three"},
-                ]
-            }
+            {"subtitles": [{"index": 1, "text": "one"}, {"index": 3, "text": "three"}]}
         )
 
 
@@ -299,10 +285,7 @@ def test_answer_requires_unique_ordered_revision_indexes():
 
 @mark.parametrize(
     "test_case_cls",
-    [
-        ReviewTestCase,
-        ReviewManager.get_test_case_cls(ReviewManager.base_prompt),
-    ],
+    [ReviewTestCase, ReviewManager.get_test_case_cls(ReviewManager.base_prompt)],
     ids=["static", "generated"],
 )
 def test_test_case_rejects_missing_and_unmodified_revision_indexes(
@@ -333,15 +316,10 @@ def test_test_case_rejects_missing_and_unmodified_revision_indexes(
 
 @mark.parametrize(
     "test_case_cls",
-    [
-        ReviewTestCase,
-        ReviewManager.get_test_case_cls(ReviewManager.base_prompt),
-    ],
+    [ReviewTestCase, ReviewManager.get_test_case_cls(ReviewManager.base_prompt)],
     ids=["static", "generated"],
 )
-def test_revisions_raise_minimum_difficulty(
-    test_case_cls: type[ReviewTestCase],
-):
+def test_revisions_raise_minimum_difficulty(test_case_cls: type[ReviewTestCase]):
     """A nonempty revisions list should require difficulty one."""
     unchanged = test_case_cls.model_validate(
         {

--- a/test/llms/test_translation.py
+++ b/test/llms/test_translation.py
@@ -56,17 +56,11 @@ def test_prompt_aliases_are_used_for_llm_correspondence():
     )
 
     assert test_case.query.model_dump(by_alias=True) == {
-        "zimu": [
-            {"xuhao": 1, "wenben": "原文一"},
-            {"xuhao": 2, "wenben": "原文二"},
-        ]
+        "zimu": [{"xuhao": 1, "wenben": "原文一"}, {"xuhao": 2, "wenben": "原文二"}]
     }
     assert test_case.answer is not None
     assert test_case.answer.model_dump(by_alias=True) == {
-        "fanyi": [
-            {"xuhao": 1, "wenben": "譯文一"},
-            {"xuhao": 2, "wenben": "譯文二"},
-        ]
+        "fanyi": [{"xuhao": 1, "wenben": "譯文一"}, {"xuhao": 2, "wenben": "譯文二"}]
     }
     assert set(test_case_cls.query_cls.model_json_schema()["properties"]) == {"zimu"}
     assert set(test_case_cls.answer_cls.model_json_schema()["properties"]) == {"fanyi"}
@@ -103,23 +97,13 @@ def test_query_and_answer_require_nonempty_consecutive_indexes():
         query_cls.model_validate({"subtitles": []})
     with raises(ValidationError, match="consecutive, ordered, and begin at 1"):
         query_cls.model_validate(
-            {
-                "subtitles": [
-                    {"index": 1, "text": "one"},
-                    {"index": 3, "text": "three"},
-                ]
-            }
+            {"subtitles": [{"index": 1, "text": "one"}, {"index": 3, "text": "three"}]}
         )
     with raises(ValidationError, match="at least 1 item"):
         answer_cls.model_validate({"outputs": []})
     with raises(ValidationError, match="consecutive, ordered, and begin at 1"):
         answer_cls.model_validate(
-            {
-                "outputs": [
-                    {"index": 2, "text": "two"},
-                    {"index": 1, "text": "one"},
-                ]
-            }
+            {"outputs": [{"index": 2, "text": "two"}, {"index": 1, "text": "one"}]}
         )
 
 
@@ -184,9 +168,7 @@ def test_json_uses_base_prompt_fields(tmp_path: Path):
         }
     ]
     loaded = load_test_cases_from_json(
-        output_path,
-        TranslationManager,
-        _LOCALIZED_PROMPT,
+        output_path, TranslationManager, _LOCALIZED_PROMPT
     )
     assert loaded[0].query.model_dump(by_alias=True) == {
         "zimu": [{"xuhao": 1, "wenben": "原文"}]
@@ -226,11 +208,7 @@ def test_processor_uses_indexed_subtitles_and_outputs():
     series = Series(list(block.events))
     series.blocks = [block]
     provider = Mock(spec=LLMProvider, cache_identity={"implementation": "test"})
-    processor = TranslationProcessor(
-        _LOCALIZED_PROMPT,
-        [test_case],
-        provider=provider,
-    )
+    processor = TranslationProcessor(_LOCALIZED_PROMPT, [test_case], provider=provider)
 
     output = processor.process(series)
 
@@ -271,8 +249,7 @@ def test_processor_honors_start_index():
     """An inclusive start index should skip earlier translation blocks."""
     provider = Mock(spec=LLMProvider, cache_identity={"implementation": "test"})
     provider.chat_completion.return_value = json.dumps(
-        {"fanyi": [{"xuhao": 1, "wenben": "譯文二"}]},
-        ensure_ascii=False,
+        {"fanyi": [{"xuhao": 1, "wenben": "譯文二"}]}, ensure_ascii=False
     )
     processor = TranslationProcessor(_LOCALIZED_PROMPT, provider=provider)
     series = Series(

--- a/test/media/offset/video/test_detection.py
+++ b/test/media/offset/video/test_detection.py
@@ -79,12 +79,10 @@ def test_get_video_offset_uses_reference_frame_grid_for_fine_search():
     """Test fine video offset search uses reference frame-grid candidates."""
     frame_duration = float(Fraction(1001, 24000))
     reference_samples = _get_samples(
-        [frame * frame_duration for frame in range(100, 160)],
-        list(range(60)),
+        [frame * frame_duration for frame in range(100, 160)], list(range(60))
     )
     target_samples = _get_samples(
-        [(frame - 20) * frame_duration for frame in range(100, 160)],
-        list(range(60)),
+        [(frame - 20) * frame_duration for frame in range(100, 160)], list(range(60))
     )
 
     with (
@@ -118,24 +116,12 @@ def test_get_video_offset_uses_reference_frame_grid_for_fine_search():
 def test_get_video_offset_tolerates_brightness_shift():
     """Test video offset search normalizes brightness differences."""
     reference_samples = [
-        _get_sample(
-            time=0.0,
-            frame=np.array([[0, 1], [2, 3]], dtype=np.float32),
-        ),
-        _get_sample(
-            time=1.0,
-            frame=np.array([[4, 5], [6, 7]], dtype=np.float32),
-        ),
+        _get_sample(time=0.0, frame=np.array([[0, 1], [2, 3]], dtype=np.float32)),
+        _get_sample(time=1.0, frame=np.array([[4, 5], [6, 7]], dtype=np.float32)),
     ]
     target_samples = [
-        _get_sample(
-            time=1.0,
-            frame=np.array([[10, 12], [14, 16]], dtype=np.float32),
-        ),
-        _get_sample(
-            time=2.0,
-            frame=np.array([[18, 20], [22, 24]], dtype=np.float32),
-        ),
+        _get_sample(time=1.0, frame=np.array([[10, 12], [14, 16]], dtype=np.float32)),
+        _get_sample(time=2.0, frame=np.array([[18, 20], [22, 24]], dtype=np.float32)),
     ]
 
     with (
@@ -223,8 +209,7 @@ def test_get_video_offset_samples_multiple_windows_and_aggregates_frames():
     side_effect = []
     for offset_frames in [-20, -20, -21]:
         reference_samples, target_samples = _get_shifted_sample_pair(
-            offset_frames=offset_frames,
-            frame_duration=frame_duration,
+            offset_frames=offset_frames, frame_duration=frame_duration
         )
         side_effect.extend([reference_samples, target_samples])
 
@@ -238,8 +223,7 @@ def test_get_video_offset_samples_multiple_windows_and_aggregates_frames():
             ],
         ),
         patch(
-            "scinoephile.media.offset.video.detection._sample_video_frames",
-            new=sampler,
+            "scinoephile.media.offset.video.detection._sample_video_frames", new=sampler
         ),
     ):
         result = get_video_offset(
@@ -280,14 +264,10 @@ def test_get_video_offset_clamps_duration_to_shared_runtime():
     with (
         patch(
             "scinoephile.media.offset.video.detection.ffmpeg.probe",
-            side_effect=[
-                _get_probe(duration=20.0),
-                _get_probe(duration=20.0),
-            ],
+            side_effect=[_get_probe(duration=20.0), _get_probe(duration=20.0)],
         ),
         patch(
-            "scinoephile.media.offset.video.detection._sample_video_frames",
-            new=sampler,
+            "scinoephile.media.offset.video.detection._sample_video_frames", new=sampler
         ),
     ):
         result = get_video_offset(
@@ -298,14 +278,8 @@ def test_get_video_offset_clamps_duration_to_shared_runtime():
         )
 
     assert result.offset_frames == 0
-    assert [call["start_time"] for call in sampler.calls] == [
-        0.0,
-        0.0,
-    ]
-    assert [call["duration"] for call in sampler.calls] == [
-        20.0,
-        20.0,
-    ]
+    assert [call["start_time"] for call in sampler.calls] == [0.0, 0.0]
+    assert [call["duration"] for call in sampler.calls] == [20.0, 20.0]
 
 
 def test_get_video_offset_handles_aggregate_without_exact_window_match():
@@ -314,8 +288,7 @@ def test_get_video_offset_handles_aggregate_without_exact_window_match():
     side_effect = []
     for offset_frames in [0, 1, 3, 4]:
         reference_samples, target_samples = _get_shifted_sample_pair(
-            offset_frames=offset_frames,
-            frame_duration=frame_duration,
+            offset_frames=offset_frames, frame_duration=frame_duration
         )
         side_effect.extend([reference_samples, target_samples])
 
@@ -391,11 +364,7 @@ def test_get_offsets_clamps_to_requested_end():
 def test_sample_video_frames_normalizes_brightness():
     """Test sampled video frames normalize brightness during sampling."""
     output = np.array(
-        [
-            [[0, 1], [2, 3]],
-            [[10, 12], [14, 16]],
-        ],
-        dtype=np.uint8,
+        [[[0, 1], [2, 3]], [[10, 12], [14, 16]]], dtype=np.uint8
     ).tobytes()
 
     with patch(
@@ -420,35 +389,16 @@ def test_sample_video_frames_normalizes_brightness():
 @parametrize(
     ("kwargs", "message"),
     [
-        (
-            {"max_offset": 0.0},
-            "0.0 is less than minimum value",
-        ),
-        (
-            {"sample_rate": 0.0},
-            "0.0 is less than minimum value",
-        ),
-        (
-            {"coarse_step": 0.0},
-            "0.0 is less than minimum value",
-        ),
-        (
-            {"sample_windows": 0},
-            "0 is less than minimum value of 1",
-        ),
-        (
-            {"width": 0},
-            "0 is less than minimum value of 1",
-        ),
-        (
-            {"height": 0},
-            "0 is less than minimum value of 1",
-        ),
+        ({"max_offset": 0.0}, "0.0 is less than minimum value"),
+        ({"sample_rate": 0.0}, "0.0 is less than minimum value"),
+        ({"coarse_step": 0.0}, "0.0 is less than minimum value"),
+        ({"sample_windows": 0}, "0 is less than minimum value of 1"),
+        ({"width": 0}, "0 is less than minimum value of 1"),
+        ({"height": 0}, "0 is less than minimum value of 1"),
     ],
 )
 def test_get_video_offset_rejects_invalid_numeric_parameters(
-    kwargs: _VideoOffsetKwargs,
-    message: str,
+    kwargs: _VideoOffsetKwargs, message: str
 ):
     """Test video offset rejects invalid numeric parameters.
 
@@ -497,7 +447,7 @@ def test_video_offset_package_imports_detection_only_when_needed():
                 "raise SystemExit("
                 "'scinoephile.media.offset.video.detection' in sys.modules)"
             ),
-        ],
+        ]
     )
 
     assert exitcode == 0
@@ -563,9 +513,7 @@ class _FakeFfmpegInput:
 
 
 def _get_probe(
-    *,
-    duration: float = 100.0,
-    frame_rate: str = "1/1",
+    *, duration: float = 100.0, frame_rate: str = "1/1"
 ) -> dict[str, object]:
     """Return synthetic ffprobe output.
 
@@ -644,18 +592,13 @@ def _get_samples(times: list[float], values: list[int]) -> list[SimpleNamespace]
         synthetic frame samples
     """
     return [
-        _get_sample(
-            time=time,
-            frame=np.full((2, 2), value, dtype=np.float32),
-        )
+        _get_sample(time=time, frame=np.full((2, 2), value, dtype=np.float32))
         for time, value in zip(times, values, strict=True)
     ]
 
 
 def _get_shifted_sample_pair(
-    *,
-    offset_frames: int,
-    frame_duration: float,
+    *, offset_frames: int, frame_duration: float
 ) -> tuple[list[SimpleNamespace], list[SimpleNamespace]]:
     """Return synthetic reference and shifted target samples.
 
@@ -668,11 +611,9 @@ def _get_shifted_sample_pair(
     frame_numbers = list(range(100, 160))
     values = list(range(60))
     reference_samples = _get_samples(
-        [frame * frame_duration for frame in frame_numbers],
-        values,
+        [frame * frame_duration for frame in frame_numbers], values
     )
     target_samples = _get_samples(
-        [(frame + offset_frames) * frame_duration for frame in frame_numbers],
-        values,
+        [(frame + offset_frames) * frame_duration for frame in frame_numbers], values
     )
     return reference_samples, target_samples

--- a/test/media/subtitles/test_cache.py
+++ b/test/media/subtitles/test_cache.py
@@ -49,16 +49,13 @@ def test_get_cached_subtitle_stream_path_changes_by_stream(tmp_path: Path):
     assert cache.cache_dir_path == (tmp_path / "cache" / "media" / "subtitles")
 
     first = cache.get_path(
-        infile_path,
-        SubtitleStream(index=2, language="zho", codec_name="subrip"),
+        infile_path, SubtitleStream(index=2, language="zho", codec_name="subrip")
     )
     second = cache.get_path(
-        infile_path,
-        SubtitleStream(index=3, language="zho", codec_name="subrip"),
+        infile_path, SubtitleStream(index=3, language="zho", codec_name="subrip")
     )
     same_stream_with_script = cache.get_path(
-        infile_path,
-        SubtitleStream(index=2, language="zho-Hant", codec_name="subrip"),
+        infile_path, SubtitleStream(index=2, language="zho-Hant", codec_name="subrip")
     )
 
     assert first != second
@@ -68,8 +65,7 @@ def test_get_cached_subtitle_stream_path_changes_by_stream(tmp_path: Path):
 
 
 def test_get_cached_subtitle_stream_path_resolves_infile(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test relative and absolute input paths share one cache identity."""
     infile_path = tmp_path / "video.mkv"
@@ -85,8 +81,7 @@ def test_get_cached_subtitle_stream_path_resolves_infile(
 
 
 def test_get_cached_subtitle_stream_path_includes_cache_version(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test subtitle stream cache paths differ between cache versions."""
     infile_path = tmp_path / "video.mkv"
@@ -125,10 +120,7 @@ def test_cache_subtitle_streams_marks_existing_stream_used(tmp_path: Path):
     stream = SubtitleStream(index=2, language="zho", codec_name="subrip")
     cache = SubtitleCache(tmp_path / "cache")
     stream_path = cache_subtitle_stream(
-        infile_path,
-        stream,
-        tmp_path / "cache",
-        b"cached",
+        infile_path, stream, tmp_path / "cache", b"cached"
     )
     old_timestamp = time() - 60 * 60 * 24 * 40
     set_mtime(stream_path, old_timestamp)
@@ -147,12 +139,7 @@ def test_cache_subtitle_streams_overwrites_existing_stream(tmp_path: Path):
     stream = SubtitleStream(index=2, language="zho", codec_name="subrip")
     cache = SubtitleCache(tmp_path / "cache", overwrite=True)
     stream_path = cache.get_path(infile_path, stream)
-    cache_subtitle_stream(
-        infile_path,
-        stream,
-        tmp_path / "cache",
-        b"stale",
-    )
+    cache_subtitle_stream(infile_path, stream, tmp_path / "cache", b"stale")
     input_stream = _RecordingFfmpegInput()
     merged_streams: list[_RecordingMergedFfmpegStream] = []
 
@@ -259,10 +246,8 @@ def test_cache_subtitles_builds_image_cache_for_sup_stream(tmp_path: Path):
     image_series = ImageSeries(
         events=[
             ImageSubtitle(
-                start=1000,
-                end=2000,
-                img=Image.new("RGBA", (10, 8), (255, 255, 255, 0)),
-            ),
+                start=1000, end=2000, img=Image.new("RGBA", (10, 8), (255, 255, 255, 0))
+            )
         ]
     )
 
@@ -273,9 +258,7 @@ def test_cache_subtitles_builds_image_cache_for_sup_stream(tmp_path: Path):
         SubtitleExtractor(cache).extract(infile_path, [stream])
 
     image_dir_path = get_image_subtitle_dir_path(
-        infile_path,
-        stream,
-        cache_root_path=tmp_path / "cache",
+        infile_path, stream, cache_root_path=tmp_path / "cache"
     )
     assert (image_dir_path / "index.html").exists()
 
@@ -288,9 +271,7 @@ def test_cache_subtitles_marks_existing_image_series_used(tmp_path: Path):
     cache = SubtitleCache(tmp_path / "cache")
     cache_subtitle_stream(infile_path, stream, tmp_path / "cache", b"cached")
     image_dir_path = get_image_subtitle_dir_path(
-        infile_path,
-        stream,
-        cache_root_path=tmp_path / "cache",
+        infile_path, stream, cache_root_path=tmp_path / "cache"
     )
     image_dir_path.mkdir()
     index_path = image_dir_path / "index.html"
@@ -313,18 +294,14 @@ def test_cache_subtitles_replaces_malformed_image_index(tmp_path: Path):
     cache = SubtitleCache(tmp_path / "cache")
     cache_subtitle_stream(infile_path, stream, tmp_path / "cache", b"cached")
     image_dir_path = get_image_subtitle_dir_path(
-        infile_path,
-        stream,
-        cache_root_path=tmp_path / "cache",
+        infile_path, stream, cache_root_path=tmp_path / "cache"
     )
     (image_dir_path / "index.html").mkdir(parents=True)
     image_series = ImageSeries(
         events=[
             ImageSubtitle(
-                start=1000,
-                end=2000,
-                img=Image.new("RGBA", (10, 8), (255, 255, 255, 0)),
-            ),
+                start=1000, end=2000, img=Image.new("RGBA", (10, 8), (255, 255, 255, 0))
+            )
         ]
     )
 
@@ -403,7 +380,7 @@ def test_cache_subtitle_streams_extracts_missing_streams(tmp_path: Path):
         (second_stream_path.name, "0:3", "subrip"),
     }
     assert {Path(path).parent.parent for path, _, _ in input_stream.output_calls} == {
-        cache.cache_dir_path,
+        cache.cache_dir_path
     }
     assert len(merged_streams) == 1
     assert len(merged_streams[0].outputs) == 2

--- a/test/media/subtitles/test_details.py
+++ b/test/media/subtitles/test_details.py
@@ -19,9 +19,7 @@ def test_get_detailed_subtitle_streams_enriches_subtitle_stats(tmp_path: Path):
     infile_path.touch()
     cache_root_path = tmp_path / "cache"
     subtitle_cache = SubtitleCache(cache_root_path)
-    subtitle_streams = [
-        SubtitleStream(index=2, codec_name="subrip", language="zho"),
-    ]
+    subtitle_streams = [SubtitleStream(index=2, codec_name="subrip", language="zho")]
 
     with (
         patch(
@@ -35,15 +33,12 @@ def test_get_detailed_subtitle_streams_enriches_subtitle_stats(tmp_path: Path):
         patch(
             "scinoephile.media.subtitles.details.get_subtitle_stream_stats",
             return_value=SimpleNamespace(
-                event_count=12,
-                first_start_ms=62_500,
-                last_end_ms=3_725_250,
+                event_count=12, first_start_ms=62_500, last_end_ms=3_725_250
             ),
         ),
     ):
         detailed_streams = get_detailed_subtitle_streams(
-            infile_path,
-            subtitle_cache=subtitle_cache,
+            infile_path, subtitle_cache=subtitle_cache
         )
 
     assert len(detailed_streams) == 1
@@ -52,9 +47,7 @@ def test_get_detailed_subtitle_streams_enriches_subtitle_stats(tmp_path: Path):
     assert detailed_streams[0].span == "00:01:02-01:02:05"
 
 
-def test_get_detailed_subtitle_streams_uses_provided_subtitle_streams(
-    tmp_path: Path,
-):
+def test_get_detailed_subtitle_streams_uses_provided_subtitle_streams(tmp_path: Path):
     """Test detailed subtitle enrichment can reuse provided mixed streams.
 
     Arguments:
@@ -65,9 +58,7 @@ def test_get_detailed_subtitle_streams_uses_provided_subtitle_streams(
     cache_root_path = tmp_path / "cache"
     subtitle_cache = SubtitleCache(cache_root_path)
     subtitle_stream = SubtitleStream(
-        index=2,
-        codec_type="subtitle",
-        codec_name="subrip",
+        index=2, codec_type="subtitle", codec_name="subrip"
     )
     streams = [
         VideoStream(index=0, codec_type="video", codec_name="h264"),
@@ -76,9 +67,7 @@ def test_get_detailed_subtitle_streams_uses_provided_subtitle_streams(
     ]
 
     with (
-        patch(
-            "scinoephile.media.subtitles.details.get_subtitle_streams",
-        ),
+        patch("scinoephile.media.subtitles.details.get_subtitle_streams"),
         patch(
             "scinoephile.media.subtitles.details.SubtitleExtractor.extract",
             return_value=[subtitle_cache.get_path(infile_path, subtitle_stream)],
@@ -86,16 +75,12 @@ def test_get_detailed_subtitle_streams_uses_provided_subtitle_streams(
         patch(
             "scinoephile.media.subtitles.details.get_subtitle_stream_stats",
             return_value=SimpleNamespace(
-                event_count=12,
-                first_start_ms=62_500,
-                last_end_ms=3_725_250,
+                event_count=12, first_start_ms=62_500, last_end_ms=3_725_250
             ),
         ),
     ):
         detailed_streams = get_detailed_subtitle_streams(
-            infile_path,
-            streams=streams,
-            subtitle_cache=subtitle_cache,
+            infile_path, streams=streams, subtitle_cache=subtitle_cache
         )
 
     assert [stream.index for stream in detailed_streams] == [2]

--- a/test/media/subtitles/test_extraction.py
+++ b/test/media/subtitles/test_extraction.py
@@ -58,10 +58,7 @@ def test_extract_subtitle_stream_caches_missing_stream(tmp_path: Path):
     stream_path = SubtitleCache(cache_root_path).get_path(infile_path, stream)
 
     def cache_streams(
-        infile_path: Path,
-        streams: list[SubtitleStream],
-        *,
-        render_images: bool = True,
+        infile_path: Path, streams: list[SubtitleStream], *, render_images: bool = True
     ) -> list[Path]:
         """Create and return a cached subtitle stream."""
         _ = infile_path, streams, render_images

--- a/test/media/subtitles/test_selection.py
+++ b/test/media/subtitles/test_selection.py
@@ -34,10 +34,7 @@ def test_get_media_subtitle_stream_requires_stream_index(tmp_path: Path):
     infile_path = tmp_path / "video.mkv"
     infile_path.touch()
 
-    with raises(
-        ScinoephileError,
-        match="stream index is required for media OCR input",
-    ):
+    with raises(ScinoephileError, match="stream index is required for media OCR input"):
         get_media_subtitle_stream(infile_path, None)
 
 
@@ -52,8 +49,7 @@ def test_get_media_subtitle_stream_rejects_non_sup_stream(tmp_path: Path):
             return_value=[SubtitleStream(index=5, codec_name="subrip")],
         ),
         raises(
-            ScinoephileError,
-            match="Subtitle stream 5 is not an image-based SUP stream",
+            ScinoephileError, match="Subtitle stream 5 is not an image-based SUP stream"
         ),
     ):
         get_media_subtitle_stream(infile_path, 5)

--- a/test/media/subtitles/test_stats.py
+++ b/test/media/subtitles/test_stats.py
@@ -35,9 +35,7 @@ def test_get_text_subtitle_stream_stats_from_cached_stream(tmp_path: Path):
 
     with patch("scinoephile.media.subtitles.extractor.ffmpeg.input") as ffmpeg_input:
         stats = get_subtitle_stream_stats(
-            infile_path,
-            stream,
-            subtitle_cache=subtitle_cache,
+            infile_path, stream, subtitle_cache=subtitle_cache
         )
 
     ffmpeg_input.assert_not_called()
@@ -66,9 +64,7 @@ def test_get_image_subtitle_stream_stats_from_cached_images(tmp_path: Path):
     subtitle_cache = SubtitleCache(tmp_path / "cache")
 
     stats = get_subtitle_stream_stats(
-        infile_path,
-        stream,
-        subtitle_cache=subtitle_cache,
+        infile_path, stream, subtitle_cache=subtitle_cache
     )
 
     assert stats.event_count == 7

--- a/test/media/test_audio.py
+++ b/test/media/test_audio.py
@@ -65,18 +65,11 @@ def test_extract_audio_selects_stream_and_extracts_track(tmp_path: Path):
         patch("scinoephile.media.audio.get_streams", return_value=[stream]),
         patch("scinoephile.media.audio._extract_audio_track") as extract_track,
     ):
-        selected = extract_audio(
-            infile_path,
-            outfile_path,
-            stream_index=3,
-        )
+        selected = extract_audio(infile_path, outfile_path, stream_index=3)
 
     assert selected is stream
     extract_track.assert_called_once_with(
-        infile_path.resolve(),
-        outfile_path.resolve(),
-        3,
-        6,
+        infile_path.resolve(), outfile_path.resolve(), 3, 6
     )
 
 
@@ -95,10 +88,7 @@ def test_extract_audio_track_filters_overall_stream_index(tmp_path: Path):
             "scinoephile.media.audio.get_streams",
             return_value=[AudioStream(index=12, codec_type="audio", channels=6)],
         ),
-        patch(
-            "scinoephile.media.audio.ffmpeg.input",
-            return_value=fake_ffmpeg_input,
-        ),
+        patch("scinoephile.media.audio.ffmpeg.input", return_value=fake_ffmpeg_input),
     ):
         extract_audio(infile_path, tmp_path / "audio.wav")
 
@@ -123,10 +113,7 @@ def test_extract_audio_track_maps_overall_stream_index(tmp_path: Path):
             "scinoephile.media.audio.get_streams",
             return_value=[AudioStream(index=12, codec_type="audio", channels=2)],
         ),
-        patch(
-            "scinoephile.media.audio.ffmpeg.input",
-            return_value=fake_ffmpeg_input,
-        ),
+        patch("scinoephile.media.audio.ffmpeg.input", return_value=fake_ffmpeg_input),
     ):
         extract_audio(infile_path, tmp_path / "audio.wav")
 
@@ -142,23 +129,15 @@ def test_extract_audio_track_wraps_ffmpeg_errors(tmp_path: Path):
     """
     infile_path = tmp_path / "video.mkv"
     infile_path.touch()
-    fake_ffmpeg_input = FakeFfmpegInput(
-        ffmpeg.Error("ffmpeg", b"", b"failed"),
-    )
+    fake_ffmpeg_input = FakeFfmpegInput(ffmpeg.Error("ffmpeg", b"", b"failed"))
 
     with (
         patch(
             "scinoephile.media.audio.get_streams",
             return_value=[AudioStream(index=12, codec_type="audio", channels=2)],
         ),
-        patch(
-            "scinoephile.media.audio.ffmpeg.input",
-            return_value=fake_ffmpeg_input,
-        ),
-        raises(
-            ScinoephileError,
-            match="Could not extract audio stream 12",
-        ) as excinfo,
+        patch("scinoephile.media.audio.ffmpeg.input", return_value=fake_ffmpeg_input),
+        raises(ScinoephileError, match="Could not extract audio stream 12") as excinfo,
     ):
         extract_audio(infile_path, tmp_path / "audio.wav")
 

--- a/test/media/test_probe.py
+++ b/test/media/test_probe.py
@@ -29,7 +29,7 @@ def test_get_subtitle_streams(tmp_path: Path):
                     "disposition": {"forced": 0, "hearing_impaired": 1},
                     "nb_read_packets": "123",
                 },
-            ],
+            ]
         },
     ):
         streams = get_subtitle_streams(infile_path)
@@ -62,8 +62,8 @@ def test_get_subtitle_streams_accepts_unknown_packet_count(tmp_path: Path):
                     "codec_type": "subtitle",
                     "codec_name": "subrip",
                     "nb_read_packets": "N/A",
-                },
-            ],
+                }
+            ]
         },
     ):
         streams = get_subtitle_streams(infile_path)
@@ -103,7 +103,7 @@ def test_get_streams_returns_all_typed_streams(tmp_path: Path):
                 },
                 {"index": 3, "codec_type": "data", "codec_name": "bin_data"},
                 "not a stream",
-            ],
+            ]
         },
     ):
         streams = get_streams(infile_path)
@@ -135,7 +135,7 @@ def test_get_streams_skips_streams_without_nonnegative_index(tmp_path: Path):
                 {"index": -1, "codec_type": "audio", "channels": 2},
                 {"index": "bad", "codec_type": "audio", "channels": 2},
                 {"index": 1, "codec_type": "audio", "channels": 2},
-            ],
+            ]
         },
     ):
         streams = get_streams(infile_path)
@@ -151,12 +151,7 @@ def test_get_streams_normalizes_missing_codecs(tmp_path: Path):
 
     with patch(
         "scinoephile.media.probe.ffmpeg.probe",
-        return_value={
-            "streams": [
-                {"index": 0},
-                {"index": 1, "codec_type": "data"},
-            ],
-        },
+        return_value={"streams": [{"index": 0}, {"index": 1, "codec_type": "data"}]},
     ):
         streams = get_streams(infile_path)
 

--- a/test/optimization/persistence/models/test_optimization_models_id.py
+++ b/test/optimization/persistence/models/test_optimization_models_id.py
@@ -16,39 +16,22 @@ def test_model_id_is_content_addressed():
         "temperature": 0.2,
     }
     model_id = get_model_id(
-        "openai",
-        "gpt-5.4-mini",
-        "https://api.openai.com/v1",
-        settings,
+        "openai", "gpt-5.4-mini", "https://api.openai.com/v1", settings
     )
 
     assert model_id == get_model_id(
         "openai",
         "gpt-5.4-mini",
         "https://api.openai.com/v1",
-        {
-            "temperature": 0.2,
-            "reasoning": {"effort": "medium"},
-        },
+        {"temperature": 0.2, "reasoning": {"effort": "medium"}},
     )
     assert model_id != get_model_id(
-        "deepseek",
-        "gpt-5.4-mini",
-        "https://api.openai.com/v1",
-        settings,
+        "deepseek", "gpt-5.4-mini", "https://api.openai.com/v1", settings
     )
     assert model_id != get_model_id(
-        "openai",
-        "gpt-5.4",
-        "https://api.openai.com/v1",
-        settings,
+        "openai", "gpt-5.4", "https://api.openai.com/v1", settings
     )
-    assert model_id != get_model_id(
-        "openai",
-        "gpt-5.4-mini",
-        None,
-        settings,
-    )
+    assert model_id != get_model_id("openai", "gpt-5.4-mini", None, settings)
     assert model_id != get_model_id(
         "openai",
         "gpt-5.4-mini",

--- a/test/optimization/persistence/models/test_optimization_models_sqlite_store.py
+++ b/test/optimization/persistence/models/test_optimization_models_sqlite_store.py
@@ -14,10 +14,7 @@ from pytest import raises
 from scinoephile.core import ScinoephileError
 from scinoephile.lang.eng.review import ReviewPromptEng
 from scinoephile.llms.review import ReviewManager
-from scinoephile.optimization.persistence.models import (
-    ModelSqliteStore,
-    PersistedModel,
-)
+from scinoephile.optimization.persistence.models import ModelSqliteStore, PersistedModel
 from scinoephile.optimization.persistence.prompts import (
     PersistedPrompt,
     PromptSqliteStore,
@@ -48,13 +45,7 @@ def test_store_round_trips_and_is_idempotent(tmp_path: Path):
         columns = {
             str(row[1]) for row in connection.execute("PRAGMA table_info(models)")
         }
-    assert columns == {
-        "base_url",
-        "model",
-        "model_id",
-        "provider",
-        "settings_json",
-    }
+    assert columns == {"base_url", "model", "model_id", "provider", "settings_json"}
 
 
 def test_store_rejects_invalid_content_addressed_id(tmp_path: Path):

--- a/test/optimization/persistence/models/test_optimization_persisted_model.py
+++ b/test/optimization/persistence/models/test_optimization_persisted_model.py
@@ -24,10 +24,7 @@ def test_creation_normalizes_effective_configuration():
     assert model.provider_name == "openai"
     assert model.model_name == "gpt-5.4-mini"
     assert model.base_url == "https://api.openai.com/v1"
-    assert model.settings == {
-        "reasoning": {"effort": "medium"},
-        "seed": 1,
-    }
+    assert model.settings == {"reasoning": {"effort": "medium"}, "seed": 1}
 
 
 def test_creation_rejects_credentials_in_base_url():
@@ -53,10 +50,7 @@ def test_creation_rejects_credentials_in_base_url():
 )
 def test_creation_rejects_credentials_in_nested_settings(credential_name: str):
     """Settings should not persist credential-bearing fields."""
-    with raises(
-        ScinoephileError,
-        match=rf"settings.headers.{credential_name}",
-    ):
+    with raises(ScinoephileError, match=rf"settings.headers.{credential_name}"):
         PersistedModel.from_config(
             "openai-compatible",
             "model",
@@ -68,7 +62,5 @@ def test_creation_rejects_non_json_settings():
     """Settings should be finite JSON values."""
     with raises(ScinoephileError, match="valid JSON"):
         PersistedModel.from_config(
-            "openai",
-            "gpt-5.4-mini",
-            settings={"temperature": nan},
+            "openai", "gpt-5.4-mini", settings={"temperature": nan}
         )

--- a/test/optimization/persistence/prompts/test_optimization_persisted_prompt.py
+++ b/test/optimization/persistence/prompts/test_optimization_persisted_prompt.py
@@ -10,9 +10,7 @@ from pytest import raises
 
 from scinoephile.core import Language, ScinoephileError
 from scinoephile.lang.eng.review import ReviewPromptEng
-from scinoephile.lang.yue_eng.translation import (
-    YueEngTranslationPromptYueHans,
-)
+from scinoephile.lang.yue_eng.translation import YueEngTranslationPromptYueHans
 from scinoephile.llms.review import ReviewManager
 from scinoephile.llms.translation import TranslationManager
 from scinoephile.optimization.persistence.prompts import PersistedPrompt
@@ -30,8 +28,7 @@ def test_conversion_includes_all_string_fields():
     """Every string field should contribute to persisted prompt identity."""
     baseline = PersistedPrompt.from_prompt(ReviewPromptEng, ReviewManager)
     alternative = PersistedPrompt.from_prompt(
-        _ALTERNATIVE_FEW_SHOT_REVIEW_PROMPT,
-        ReviewManager,
+        _ALTERNATIVE_FEW_SHOT_REVIEW_PROMPT, ReviewManager
     )
 
     alternative_attributes = dict(alternative.attributes)
@@ -52,15 +49,11 @@ def test_conversion_includes_operation_and_tool_attributes():
     """Operation instructions and dictionary tool text should be persisted."""
     baseline = PersistedPrompt.from_prompt(ReviewPromptEng, ReviewManager)
     alternative = PersistedPrompt.from_prompt(
-        replace(
-            ReviewPromptEng,
-            base_system_prompt="Review every subtitle carefully.",
-        ),
+        replace(ReviewPromptEng, base_system_prompt="Review every subtitle carefully."),
         ReviewManager,
     )
     translation = PersistedPrompt.from_prompt(
-        YueEngTranslationPromptYueHans,
-        TranslationManager,
+        YueEngTranslationPromptYueHans, TranslationManager
     )
     translation_attributes = dict(translation.attributes)
 

--- a/test/optimization/persistence/prompts/test_optimization_prompts_id.py
+++ b/test/optimization/persistence/prompts/test_optimization_prompts_id.py
@@ -17,7 +17,5 @@ def test_prompt_id_is_content_addressed():
     assert prompt_id != get_prompt_id(attributes, "translation", Language.eng)
     assert prompt_id != get_prompt_id(attributes, "review", Language.zho_hant)
     assert prompt_id != get_prompt_id(
-        {"base_system_prompt": "Carefully review subtitles."},
-        "review",
-        Language.eng,
+        {"base_system_prompt": "Carefully review subtitles."}, "review", Language.eng
     )

--- a/test/optimization/persistence/prompts/test_optimization_prompts_sqlite_store.py
+++ b/test/optimization/persistence/prompts/test_optimization_prompts_sqlite_store.py
@@ -25,8 +25,7 @@ from scinoephile.optimization.persistence.test_cases import (
 from scinoephile.optimization.persistence.test_cases.id import get_test_case_id
 
 _UPDATED_REVIEW_PROMPT = replace(
-    ReviewPromptEng,
-    base_system_prompt="Review subtitles with exceptional care.",
+    ReviewPromptEng, base_system_prompt="Review subtitles with exceptional care."
 )
 """English review prompt with updated instructions."""
 
@@ -75,9 +74,7 @@ def test_store_shares_database_with_test_cases(tmp_path: Path):
 
     prompt_store.sync_aliases({"review-eng": prompt}, dry_run=False)
     test_case_store.sync_source_paths(
-        {"cases.json": [test_case]},
-        manager_cls=TranslationManager,
-        dry_run=False,
+        {"cases.json": [test_case]}, manager_cls=TranslationManager, dry_run=False
     )
 
     assert prompt_store.get_prompt_by_alias("review-eng") == prompt
@@ -112,8 +109,7 @@ def test_store_rejects_invalid_content_addressed_id(tmp_path: Path):
 
     with raises(ScinoephileError, match="content-addressed ID"):
         store.sync_aliases(
-            {"review-eng": replace(prompt, prompt_id="incorrect")},
-            dry_run=False,
+            {"review-eng": replace(prompt, prompt_id="incorrect")}, dry_run=False
         )
     assert not database_path.exists()
 

--- a/test/optimization/persistence/prompts/test_optimization_prompts_sync.py
+++ b/test/optimization/persistence/prompts/test_optimization_prompts_sync.py
@@ -15,8 +15,7 @@ from scinoephile.optimization.prompt_spec import PromptSpec
 
 _PROMPT_SPECS = {
     "review-eng": PromptSpec(
-        manager_cls=ReviewManager,
-        prompt=DEFAULT_PROMPTS[Language.eng],
+        manager_cls=ReviewManager, prompt=DEFAULT_PROMPTS[Language.eng]
     )
 }
 """Minimal prompt specifications for persistence unit tests."""

--- a/test/optimization/persistence/test_cases/test_optimization_test_cases_id.py
+++ b/test/optimization/persistence/test_cases/test_optimization_test_cases_id.py
@@ -26,14 +26,8 @@ def test_get_test_case_id_stable_for_same_payload():
     query = _get_translation_query("a")
     answer = _get_translation_answer("b")
 
-    assert get_test_case_id(
-        query,
-        answer,
-        TranslationManager,
-    ) == get_test_case_id(
-        query,
-        answer,
-        TranslationManager,
+    assert get_test_case_id(query, answer, TranslationManager) == get_test_case_id(
+        query, answer, TranslationManager
     )
 
 
@@ -42,14 +36,8 @@ def test_get_test_case_id_changes_with_answer():
     query = _get_translation_query("a")
 
     assert get_test_case_id(
-        query,
-        _get_translation_answer("b"),
-        TranslationManager,
-    ) != get_test_case_id(
-        query,
-        _get_translation_answer("c"),
-        TranslationManager,
-    )
+        query, _get_translation_answer("b"), TranslationManager
+    ) != get_test_case_id(query, _get_translation_answer("c"), TranslationManager)
 
 
 def test_get_test_case_id_changes_with_operation():
@@ -57,12 +45,6 @@ def test_get_test_case_id_changes_with_operation():
     query = _get_translation_query("a")
     answer = _get_translation_answer("b")
 
-    assert get_test_case_id(
-        query,
-        answer,
-        TranslationManager,
-    ) != get_test_case_id(
-        query,
-        answer,
-        ReviewManager,
+    assert get_test_case_id(query, answer, TranslationManager) != get_test_case_id(
+        query, answer, ReviewManager
     )

--- a/test/optimization/persistence/test_cases/test_optimization_test_cases_sqlite_store.py
+++ b/test/optimization/persistence/test_cases/test_optimization_test_cases_sqlite_store.py
@@ -38,11 +38,7 @@ def get_test_case(
     if answer is None:
         answer = {"output": "same"}
     return PersistedTestCase(
-        test_case_id=get_test_case_id(
-            query,
-            answer,
-            manager_cls,
-        ),
+        test_case_id=get_test_case_id(query, answer, manager_cls),
         operation=manager_cls.operation,
         difficulty=difficulty,
         few_shot=few_shot,
@@ -61,17 +57,12 @@ def test_store_round_trips_normalized_json(tmp_path: Path):
         difficulty=1,
         few_shot=True,
         verified=True,
-        query={
-            "items": ["one", "two", {"nested": True}],
-            "literal_array": "[]",
-        },
+        query={"items": ["one", "two", {"nested": True}], "literal_array": "[]"},
         answer={"value": {"nested": [1, 2, 3]}},
     )
 
     store.sync_source_paths(
-        {"x.json": [test_case]},
-        manager_cls=TranslationManager,
-        dry_run=False,
+        {"x.json": [test_case]}, manager_cls=TranslationManager, dry_run=False
     )
 
     loaded = store.get_test_case(test_case.test_case_id)
@@ -127,10 +118,7 @@ def test_store_keeps_sql_owned_metadata_when_source_is_removed(tmp_path: Path):
     assert low_metadata.test_case_id == high_metadata.test_case_id
 
     store.sync_source_paths(
-        {
-            "low.json": [low_metadata],
-            "high.json": [high_metadata],
-        },
+        {"low.json": [low_metadata], "high.json": [high_metadata]},
         manager_cls=TranslationManager,
         dry_run=False,
     )
@@ -142,9 +130,7 @@ def test_store_keeps_sql_owned_metadata_when_source_is_removed(tmp_path: Path):
     assert loaded.source_paths == ("high.json", "low.json")
 
     store.sync_source_paths(
-        {"high.json": []},
-        manager_cls=TranslationManager,
-        dry_run=False,
+        {"high.json": []}, manager_cls=TranslationManager, dry_run=False
     )
     retained = store.get_test_case(low_metadata.test_case_id)
     assert retained is not None
@@ -158,42 +144,26 @@ def test_store_filters_source_lookup_by_operation(tmp_path: Path):
     """Source lookup should support catalog operation filters."""
     database_path = tmp_path / "test_cases.sqlite"
     store = TestCaseSqliteStore(database_path)
-    first = get_test_case(
-        manager_cls=ReviewManager,
-        query={"input": "first"},
-    )
-    second = get_test_case(
-        manager_cls=ReviewManager,
-        query={"input": "second"},
-    )
-    third = get_test_case(
-        manager_cls=TranslationManager,
-        query={"input": "third"},
-    )
+    first = get_test_case(manager_cls=ReviewManager, query={"input": "first"})
+    second = get_test_case(manager_cls=ReviewManager, query={"input": "second"})
+    third = get_test_case(manager_cls=TranslationManager, query={"input": "third"})
 
     store.sync_source_paths(
-        {
-            "first.json": [first],
-            "second.json": [second],
-        },
+        {"first.json": [first], "second.json": [second]},
         manager_cls=ReviewManager,
         dry_run=False,
     )
     store.sync_source_paths(
-        {"third.json": [third]},
-        manager_cls=TranslationManager,
-        dry_run=False,
+        {"third.json": [third]}, manager_cls=TranslationManager, dry_run=False
     )
 
     filtered = store.get_test_cases_by_source_path(
-        "second.json",
-        manager_cls=ReviewManager,
+        "second.json", manager_cls=ReviewManager
     )
     assert [test_case.test_case_id for test_case in filtered] == [second.test_case_id]
     assert (
         store.get_test_cases_by_source_path(
-            "second.json",
-            manager_cls=TranslationManager,
+            "second.json", manager_cls=TranslationManager
         )
         == []
     )
@@ -207,9 +177,7 @@ def test_store_rejects_mismatched_content_addressed_id(tmp_path: Path):
 
     with raises(ScinoephileError, match="does not match its content-addressed ID"):
         store.sync_source_paths(
-            {"source.json": [test_case]},
-            manager_cls=TranslationManager,
-            dry_run=False,
+            {"source.json": [test_case]}, manager_cls=TranslationManager, dry_run=False
         )
 
     assert not database_path.exists()
@@ -223,9 +191,7 @@ def test_store_rejects_mismatched_manager(tmp_path: Path):
 
     with raises(ScinoephileError, match="does not match synchronized operation"):
         store.sync_source_paths(
-            {"source.json": [test_case]},
-            manager_cls=ReviewManager,
-            dry_run=False,
+            {"source.json": [test_case]}, manager_cls=ReviewManager, dry_run=False
         )
 
     assert not database_path.exists()
@@ -239,19 +205,13 @@ def test_store_syncs_shared_source_path_within_operation(tmp_path: Path):
     translation = get_test_case(manager_cls=TranslationManager)
 
     store.sync_source_paths(
-        {"source.json": [review]},
-        manager_cls=ReviewManager,
-        dry_run=False,
+        {"source.json": [review]}, manager_cls=ReviewManager, dry_run=False
     )
     store.sync_source_paths(
-        {"source.json": [translation]},
-        manager_cls=TranslationManager,
-        dry_run=False,
+        {"source.json": [translation]}, manager_cls=TranslationManager, dry_run=False
     )
     store.sync_source_paths(
-        {"source.json": []},
-        manager_cls=ReviewManager,
-        dry_run=False,
+        {"source.json": []}, manager_cls=ReviewManager, dry_run=False
     )
 
     loaded_review = store.get_test_case(review.test_case_id)

--- a/test/optimization/persistence/test_cases/test_optimization_test_cases_sync.py
+++ b/test/optimization/persistence/test_cases/test_optimization_test_cases_sync.py
@@ -21,9 +21,7 @@ from scinoephile.optimization.persistence.test_cases import (
     TestCaseSqliteStore,
 )
 from scinoephile.optimization.persistence.test_cases.id import get_test_case_id
-from scinoephile.optimization.persistence.test_cases.sync import (
-    sync_test_cases,
-)
+from scinoephile.optimization.persistence.test_cases.sync import sync_test_cases
 
 _BASE_REVIEW_PROMPT = ReviewPrompt(
     subtitles="base_subtitles",
@@ -35,11 +33,7 @@ _BASE_REVIEW_PROMPT = ReviewPrompt(
 """Review prompt whose aliases intentionally differ from semantic field names."""
 
 _LOCALIZED_REVIEW_PROMPT = ReviewPrompt(
-    subtitles="zimu",
-    revisions="xiugai",
-    index="xuhao",
-    text="wenben",
-    note="beizhu",
+    subtitles="zimu", revisions="xiugai", index="xuhao", text="wenben", note="beizhu"
 )
 """Review prompt using localized correspondence field names."""
 
@@ -84,13 +78,7 @@ def test_normalization_makes_prompt_field_aliases_share_identity(tmp_path: Path)
         {
             "query": {"zimu": [{"xuhao": 1, "wenben": "original"}]},
             "answer": {
-                "xiugai": [
-                    {
-                        "xuhao": 1,
-                        "wenben": "corrected",
-                        "beizhu": "typo",
-                    }
-                ]
+                "xiugai": [{"xuhao": 1, "wenben": "corrected", "beizhu": "typo"}]
             },
         }
     )
@@ -99,22 +87,16 @@ def test_normalization_makes_prompt_field_aliases_share_identity(tmp_path: Path)
             "query": {"sources": [{"position": 1, "content": "original"}]},
             "answer": {
                 "corrections": [
-                    {
-                        "position": 1,
-                        "content": "corrected",
-                        "explanation": "typo",
-                    }
+                    {"position": 1, "content": "corrected", "explanation": "typo"}
                 ]
             },
         }
     )
     localized_persisted = PersistedTestCase.from_test_case(
-        localized,
-        _AliasedBaseReviewManager,
+        localized, _AliasedBaseReviewManager
     )
     alternative_persisted = PersistedTestCase.from_test_case(
-        alternative,
-        _AliasedBaseReviewManager,
+        alternative, _AliasedBaseReviewManager
     )
 
     assert localized_persisted.query == {
@@ -122,11 +104,7 @@ def test_normalization_makes_prompt_field_aliases_share_identity(tmp_path: Path)
     }
     assert localized_persisted.answer == {
         "base_revisions": [
-            {
-                "base_index": 1,
-                "base_text": "corrected",
-                "base_note": "typo",
-            }
+            {"base_index": 1, "base_text": "corrected", "base_note": "typo"}
         ]
     }
     assert localized_persisted.test_case_id == alternative_persisted.test_case_id
@@ -153,10 +131,7 @@ def test_sync_rejects_fields_outside_test_case_schema(tmp_path: Path):
             "unexpected": True,
         },
         {
-            "query": {
-                **_get_translation_query("a"),
-                "unexpected": True,
-            },
+            "query": {**_get_translation_query("a"), "unexpected": True},
             "answer": _get_translation_answer("b"),
         },
     ]
@@ -198,8 +173,7 @@ def test_sync_requires_base_prompt_aliases(tmp_path: Path):
 
 
 def test_sync_inserts_and_removes_provenance_by_source_path(
-    tmp_path: Path,
-    monkeypatch,
+    tmp_path: Path, monkeypatch
 ):
     """Sync should insert and remove provenance links per source JSON."""
     monkeypatch.chdir(tmp_path)
@@ -213,32 +187,19 @@ def test_sync_inserts_and_removes_provenance_by_source_path(
             "answer": _get_translation_answer("b"),
             "verified": True,
         },
-        {
-            "query": deleted_query,
-            "answer": deleted_answer,
-        },
+        {"query": deleted_query, "answer": deleted_answer},
     ]
     source_path.write_text(json.dumps(first_data), encoding="utf-8")
 
     first_report = sync_test_cases(
-        [source_path],
-        database_path,
-        TranslationManager,
-        dry_run=False,
+        [source_path], database_path, TranslationManager, dry_run=False
     )
     assert len(first_report.insert_ids) == 2
-    deleted_id = get_test_case_id(
-        deleted_query,
-        deleted_answer,
-        TranslationManager,
-    )
+    deleted_id = get_test_case_id(deleted_query, deleted_answer, TranslationManager)
 
     source_path.write_text(json.dumps(first_data[:1]), encoding="utf-8")
     second_report = sync_test_cases(
-        [source_path],
-        database_path,
-        TranslationManager,
-        dry_run=False,
+        [source_path], database_path, TranslationManager, dry_run=False
     )
 
     assert second_report.delete_ids == (deleted_id,)
@@ -264,18 +225,12 @@ def test_sync_canonicalizes_source_paths(tmp_path: Path, monkeypatch):
         encoding="utf-8",
     )
     first_report = sync_test_cases(
-        [source_path],
-        database_path,
-        TranslationManager,
-        dry_run=False,
+        [source_path], database_path, TranslationManager, dry_run=False
     )
 
     source_path.write_text("[]\n", encoding="utf-8")
     second_report = sync_test_cases(
-        [source_path.resolve()],
-        database_path,
-        TranslationManager,
-        dry_run=False,
+        [source_path.resolve()], database_path, TranslationManager, dry_run=False
     )
 
     assert second_report.delete_ids == first_report.insert_ids
@@ -294,10 +249,7 @@ def test_sync_does_not_overwrite_sql_owned_metadata(tmp_path: Path):
     ]
     source_path.write_text(json.dumps(data), encoding="utf-8")
     first_report = sync_test_cases(
-        [source_path],
-        database_path,
-        TranslationManager,
-        dry_run=False,
+        [source_path], database_path, TranslationManager, dry_run=False
     )
 
     data[0]["difficulty"] = 2
@@ -305,10 +257,7 @@ def test_sync_does_not_overwrite_sql_owned_metadata(tmp_path: Path):
     data[0]["verified"] = True
     source_path.write_text(json.dumps(data), encoding="utf-8")
     dry_run_report = sync_test_cases(
-        [source_path],
-        database_path,
-        TranslationManager,
-        dry_run=True,
+        [source_path], database_path, TranslationManager, dry_run=True
     )
 
     assert dry_run_report.insert_ids == ()
@@ -319,12 +268,7 @@ def test_sync_does_not_overwrite_sql_owned_metadata(tmp_path: Path):
     assert loaded_before_write is not None
     assert loaded_before_write.difficulty == 1
 
-    sync_test_cases(
-        [source_path],
-        database_path,
-        TranslationManager,
-        dry_run=False,
-    )
+    sync_test_cases([source_path], database_path, TranslationManager, dry_run=False)
     loaded = TestCaseSqliteStore(database_path).get_test_case(
         first_report.insert_ids[0]
     )
@@ -365,10 +309,7 @@ def test_sync_validates_all_inputs_before_writing(tmp_path: Path):
 
     with raises(ScinoephileError, match="valid integer"):
         sync_test_cases(
-            [valid_path, invalid_path],
-            database_path,
-            TranslationManager,
-            dry_run=False,
+            [valid_path, invalid_path], database_path, TranslationManager, dry_run=False
         )
 
     assert not database_path.exists()
@@ -383,15 +324,9 @@ def test_sync_loads_canonical_repository_data(tmp_path: Path):
     raw_data = json.loads(source_path.read_text(encoding="utf-8"))
     database_path = tmp_path / "test_cases.sqlite"
 
-    sync_test_cases(
-        [source_path],
-        database_path,
-        ReviewManager,
-        dry_run=False,
-    )
+    sync_test_cases([source_path], database_path, ReviewManager, dry_run=False)
     loaded = TestCaseSqliteStore(database_path).get_test_cases_by_source_path(
-        str(source_path.resolve()),
-        manager_cls=ReviewManager,
+        str(source_path.resolve()), manager_cls=ReviewManager
     )
 
     assert len(loaded) == len(raw_data)
@@ -418,10 +353,7 @@ def test_sync_round_trips_unbounded_lists(tmp_path: Path):
         json.dumps(
             [
                 {
-                    "query": {
-                        "ref_sub": "reference",
-                        "target_subs": lines,
-                    },
+                    "query": {"ref_sub": "reference", "target_subs": lines},
                     "answer": {"target_sub_punctuated": "".join(lines)},
                 }
             ]
@@ -430,12 +362,7 @@ def test_sync_round_trips_unbounded_lists(tmp_path: Path):
     )
     database_path = tmp_path / "test_cases.sqlite"
 
-    sync_test_cases(
-        [source_path],
-        database_path,
-        PunctuationManager,
-        dry_run=False,
-    )
+    sync_test_cases([source_path], database_path, PunctuationManager, dry_run=False)
     loaded = TestCaseSqliteStore(database_path).get_test_cases_by_source_path(
         str(source_path.resolve())
     )

--- a/test/test_module_hierarchy.py
+++ b/test/test_module_hierarchy.py
@@ -30,16 +30,11 @@ def test_declared_module_hierarchy_may_be_stricter_than_import_graph(tmp_path: P
         encoding="utf-8",
     )
     (package_dir_path / "foundation.py").write_text(
-        '"""Foundation module."""\n',
-        encoding="utf-8",
+        '"""Foundation module."""\n', encoding="utf-8"
     )
 
     assert (
-        get_module_hierarchy_violations(
-            init_path,
-            package_parent_path=tmp_path,
-        )
-        == []
+        get_module_hierarchy_violations(init_path, package_parent_path=tmp_path) == []
     )
 
 
@@ -49,18 +44,15 @@ def test_hierarchy_declarations_require_standard_heading(tmp_path: Path):
     package_dir_path.mkdir()
     init_path = package_dir_path / "__init__.py"
     init_path.write_text(
-        '"""Example package.\n\nHierarchy notes:\n* child\n"""\n',
-        encoding="utf-8",
+        '"""Example package.\n\nHierarchy notes:\n* child\n"""\n', encoding="utf-8"
     )
     (package_dir_path / "child.py").write_text(
-        '"""Child module."""\n',
-        encoding="utf-8",
+        '"""Child module."""\n', encoding="utf-8"
     )
 
-    assert get_module_hierarchy_violations(
-        init_path,
-        package_parent_path=tmp_path,
-    ) == ["example/__init__.py: missing hierarchy block"]
+    assert get_module_hierarchy_violations(init_path, package_parent_path=tmp_path) == [
+        "example/__init__.py: missing hierarchy block"
+    ]
 
 
 def test_module_hierarchy_docs_are_authoritative():
@@ -128,11 +120,7 @@ def test_module_import_style_rules(tmp_path: Path):
             "from example.feature.sibling import Sibling\n",
             "imports rooted in the current package must be relative",
         ),
-        (
-            "feature/sibling_relative.py",
-            "from .sibling import Sibling\n",
-            None,
-        ),
+        ("feature/sibling_relative.py", "from .sibling import Sibling\n", None),
         (
             "feature/sibling_module_relative.py",
             "from .sibling.models import MODEL\n",
@@ -148,21 +136,13 @@ def test_module_import_style_rules(tmp_path: Path):
             "from .sibling import HiddenSibling\n",
             "package facade imports must name exports listed in __all__",
         ),
-        (
-            "feature/child_alias_relative.py",
-            "from . import sibling\n",
-            None,
-        ),
+        ("feature/child_alias_relative.py", "from . import sibling\n", None),
         (
             "feature/child_alias_absolute.py",
             "from example.feature import sibling\n",
             "imports rooted in the current package must be relative",
         ),
-        (
-            "feature/public_facade.py",
-            "from example.core import PublicError\n",
-            None,
-        ),
+        ("feature/public_facade.py", "from example.core import PublicError\n", None),
         (
             "feature/private_facade.py",
             "from example.core import HiddenError\n",
@@ -188,8 +168,7 @@ def test_module_import_style_rules(tmp_path: Path):
         file_path = package_dir_path / relative_path
         file_path.write_text(source, encoding="utf-8")
         violations = get_import_style_violations(
-            file_path,
-            package_parent_path=tmp_path,
+            file_path, package_parent_path=tmp_path
         )
         if expected_reason is None:
             assert violations == []
@@ -249,14 +228,12 @@ def test_single_child_package_requires_hierarchy(tmp_path: Path):
     init_path = package_dir_path / "__init__.py"
     init_path.write_text('"""Example package."""\n', encoding="utf-8")
     (package_dir_path / "child.py").write_text(
-        '"""Child module."""\n',
-        encoding="utf-8",
+        '"""Child module."""\n', encoding="utf-8"
     )
 
-    assert get_module_hierarchy_violations(
-        init_path,
-        package_parent_path=tmp_path,
-    ) == ["example/__init__.py: missing hierarchy block"]
+    assert get_module_hierarchy_violations(init_path, package_parent_path=tmp_path) == [
+        "example/__init__.py: missing hierarchy block"
+    ]
 
 
 def get_child_names(package_dir_path: Path) -> list[str]:
@@ -279,9 +256,7 @@ def get_child_names(package_dir_path: Path) -> list[str]:
 
 
 def get_package_dotted(
-    package_dir_path: Path,
-    *,
-    package_parent_path: Path = package_root.parent,
+    package_dir_path: Path, *, package_parent_path: Path = package_root.parent
 ) -> str:
     """Get dotted package name for a package directory.
 
@@ -347,9 +322,7 @@ def parse_hierarchy_line(line: str) -> list[str]:
 
 
 def get_documented_level_violations(
-    init_path: Path,
-    child_names: list[str],
-    documented_levels: dict[int, list[str]],
+    init_path: Path, child_names: list[str], documented_levels: dict[int, list[str]]
 ) -> list[str]:
     """Get violations in the documented hierarchy block itself.
 
@@ -400,9 +373,7 @@ def get_documented_level_violations(
 
 
 def get_sibling_import_edges(
-    package_dir_path: Path,
-    package_dotted: str,
-    child_names: list[str],
+    package_dir_path: Path, package_dotted: str, child_names: list[str]
 ) -> dict[str, set[str]]:
     """Build sibling import edges for a package.
 
@@ -528,8 +499,7 @@ def get_absolute_import_from_style_violations(
         ]
 
     target_path = get_module_source_path(
-        module_name,
-        package_parent_path=package_parent_path,
+        module_name, package_parent_path=package_parent_path
     )
     if target_path is None:
         return []
@@ -544,8 +514,7 @@ def get_absolute_import_from_style_violations(
     violations: list[str] = []
     for alias in node.names:
         child_target_path = get_module_source_path(
-            f"{module_name}.{alias.name}",
-            package_parent_path=package_parent_path,
+            f"{module_name}.{alias.name}", package_parent_path=package_parent_path
         )
         if child_target_path is not None:
             if module_name == current_package_name:
@@ -619,8 +588,7 @@ def get_absolute_import_style_violations(
             continue
 
         target_path = get_module_source_path(
-            alias.name,
-            package_parent_path=package_parent_path,
+            alias.name, package_parent_path=package_parent_path
         )
         if target_path is None:
             continue
@@ -643,9 +611,7 @@ def get_absolute_import_style_violations(
 
 
 def get_import_style_violations(
-    file_path: Path,
-    *,
-    package_parent_path: Path = package_root.parent,
+    file_path: Path, *, package_parent_path: Path = package_root.parent
 ) -> list[str]:
     """Get violations of package import style rules in one Python file.
 
@@ -729,8 +695,7 @@ def get_relative_import_style_violations(
     if node.module:
         target_module_name = f"{target_module_name}.{node.module}"
     target_path = get_module_source_path(
-        target_module_name,
-        package_parent_path=package_parent_path,
+        target_module_name, package_parent_path=package_parent_path
     )
     package_exports: set[str] | None = None
     if target_path is not None and target_path.name == "__init__.py":
@@ -759,9 +724,7 @@ def get_relative_import_style_violations(
 
 
 def get_module_source_path(
-    module_name: str,
-    *,
-    package_parent_path: Path = package_root.parent,
+    module_name: str, *, package_parent_path: Path = package_root.parent
 ) -> Path | None:
     """Get the source path for an importable module or package.
 
@@ -813,9 +776,7 @@ def get_package_exports(init_path: Path) -> set[str] | None:
 
 
 def get_module_hierarchy_violations(
-    init_path: Path,
-    *,
-    package_parent_path: Path = package_root.parent,
+    init_path: Path, *, package_parent_path: Path = package_root.parent
 ) -> list[str]:
     """Get violations of one package's declared module hierarchy.
 
@@ -847,8 +808,7 @@ def get_module_hierarchy_violations(
     edges = get_sibling_import_edges(
         package_dir_path=package_dir_path,
         package_dotted=get_package_dotted(
-            package_dir_path,
-            package_parent_path=package_parent_path,
+            package_dir_path, package_parent_path=package_parent_path
         ),
         child_names=child_names,
     )
@@ -869,9 +829,7 @@ def get_module_hierarchy_violations(
 
 
 def resolve_import_from_modules(
-    file_path: Path,
-    node: ast.ImportFrom,
-    root_package_parts: list[str],
+    file_path: Path, node: ast.ImportFrom, root_package_parts: list[str]
 ) -> list[str]:
     """Resolve an `ImportFrom` node to absolute module name candidates.
 

--- a/test/test_package_data.py
+++ b/test/test_package_data.py
@@ -45,13 +45,7 @@ def test_installed_wheel_includes_runtime_data_files(tmp_path: Path):
     command_env["UV_CACHE_DIR"] = command_env.get("UV_CACHE_DIR", "/tmp/uv-cache")
 
     run_command(
-        [
-            uv_path,
-            "build",
-            "--wheel",
-            "--out-dir",
-            str(wheel_dir_path),
-        ],
+        [uv_path, "build", "--wheel", "--out-dir", str(wheel_dir_path)],
         cwd_path=build_source_dir_path,
         env=command_env,
     )

--- a/test/test_style.py
+++ b/test/test_style.py
@@ -62,8 +62,7 @@ def test_percent_interpolation_arguments_are_detected():
     tree = ast.parse('logger.warning("hello %s", name)')
 
     violations = get_string_interpolation_violations(
-        file_path=package_root.parent / "sample.py",
-        tree=tree,
+        file_path=package_root.parent / "sample.py", tree=tree
     )
 
     assert [violation.message for violation in violations] == [
@@ -103,8 +102,7 @@ class Example(TypedDict):
     )
 
     violations = get_typed_dict_field_documentation_violations(
-        file_path=Path("sample.py"),
-        tree=tree,
+        file_path=Path("sample.py"), tree=tree
     )
 
     assert violations == [
@@ -121,8 +119,7 @@ def test_typed_dict_fields_are_documented():
         )
         violations.extend(
             get_typed_dict_field_documentation_violations(
-                file_path=file_path.relative_to(package_root.parent),
-                tree=tree,
+                file_path=file_path.relative_to(package_root.parent), tree=tree
             )
         )
 
@@ -145,8 +142,7 @@ def get_python_files(target_dir_path: Path) -> list[Path]:
 
 
 def get_string_interpolation_violations(
-    file_path: Path,
-    tree: ast.Module,
+    file_path: Path, tree: ast.Module
 ) -> list[StringInterpolationViolation]:
     """Get string interpolation style violations in a parsed Python file.
 
@@ -178,8 +174,7 @@ def get_string_interpolation_violations(
 
 
 def get_typed_dict_field_documentation_violations(
-    file_path: Path,
-    tree: ast.Module,
+    file_path: Path, tree: ast.Module
 ) -> list[str]:
     """Get undocumented TypedDict fields from a parsed Python file.
 

--- a/test/web/ocr_validation/test_app.py
+++ b/test/web/ocr_validation/test_app.py
@@ -66,12 +66,10 @@ def test_create_app_import_error_is_actionable(monkeypatch: MonkeyPatch):
 def test_run_app_wraps_server_errors(monkeypatch: MonkeyPatch):
     """Test web app server errors are user-facing."""
     monkeypatch.setattr(
-        "scinoephile.web.ocr_validation.app._port_is_in_use",
-        lambda host, port: False,
+        "scinoephile.web.ocr_validation.app._port_is_in_use", lambda host, port: False
     )
     monkeypatch.setattr(
-        "scinoephile.web.ocr_validation.app.create_app",
-        lambda session: object(),
+        "scinoephile.web.ocr_validation.app.create_app", lambda session: object()
     )
     monkeypatch.setattr(
         "werkzeug.serving.make_server",
@@ -129,8 +127,7 @@ def test_run_app_import_error_is_actionable(monkeypatch: MonkeyPatch):
 
 
 def test_run_app_uses_available_port_when_requested_port_is_in_use(
-    caplog: LogCaptureFixture,
-    monkeypatch: MonkeyPatch,
+    caplog: LogCaptureFixture, monkeypatch: MonkeyPatch
 ):
     """Test web app falls back when the requested port is already occupied."""
 
@@ -166,12 +163,10 @@ def test_run_app_uses_available_port_when_requested_port_is_in_use(
 
     caplog.set_level(logging.INFO, logger="scinoephile.web.ocr_validation.app")
     monkeypatch.setattr(
-        "scinoephile.web.ocr_validation.app._port_is_in_use",
-        lambda host, port: True,
+        "scinoephile.web.ocr_validation.app._port_is_in_use", lambda host, port: True
     )
     monkeypatch.setattr(
-        "scinoephile.web.ocr_validation.app.create_app",
-        lambda session: FakeApp(),
+        "scinoephile.web.ocr_validation.app.create_app", lambda session: FakeApp()
     )
     monkeypatch.setattr("werkzeug.serving.make_server", fake_make_server)
 
@@ -193,7 +188,7 @@ def test_web_package_imports_flask_only_when_needed():
                 "import scinoephile.web.ocr_validation;"
                 "raise SystemExit('flask' in sys.modules)"
             ),
-        ],
+        ]
     )
 
     assert exitcode == 0

--- a/test/web/ocr_validation/test_routes.py
+++ b/test/web/ocr_validation/test_routes.py
@@ -58,8 +58,7 @@ def test_static_htmx_asset_is_served(tmp_path: Path):
 
 
 def test_index_renders_single_char_concern_image(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test character concerns render one focused image and table."""
     app = _char_concern_app(tmp_path, monkeypatch)
@@ -78,15 +77,13 @@ def test_index_renders_single_char_concern_image(
 
 
 def test_index_renders_char_concern_romanizations(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test character concern tables render romanizations below Hanzi."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="霆")
     patch_ocr_validation_bboxes(monkeypatch, [Bbox(0, 10, 0, 20)])
     session = OcrValidationSession.from_dir_path(
-        html_dir_path,
-        validation_data_dir_path=tmp_path / "cache",
+        html_dir_path, validation_data_dir_path=tmp_path / "cache"
     )
     clear_validation_data(session)
     app = create_app(session)
@@ -102,15 +99,13 @@ def test_index_renders_char_concern_romanizations(
 
 
 def test_index_omits_romanizations_for_unrecognized_symbol(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test character concern tables skip romanization for non-Hanzi symbols."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="▼")
     patch_ocr_validation_bboxes(monkeypatch, [Bbox(0, 10, 0, 20)])
     session = OcrValidationSession.from_dir_path(
-        html_dir_path,
-        validation_data_dir_path=tmp_path / "cache",
+        html_dir_path, validation_data_dir_path=tmp_path / "cache"
     )
     clear_validation_data(session)
     app = create_app(session)
@@ -124,15 +119,13 @@ def test_index_omits_romanizations_for_unrecognized_symbol(
 
 
 def test_index_reload_reassesses_cached_subtitles(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test index reloads rebuild cached validation states."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="A")
     patch_ocr_validation_bboxes(monkeypatch, [Bbox(0, 10, 0, 20)])
     session = OcrValidationSession.from_dir_path(
-        html_dir_path,
-        validation_data_dir_path=tmp_path / "cache",
+        html_dir_path, validation_data_dir_path=tmp_path / "cache"
     )
     clear_validation_data(session)
     app = create_app(session)
@@ -151,8 +144,7 @@ def test_index_reload_reassesses_cached_subtitles(
 
 
 def test_done_filter_route_toggles_ok_subtitles(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test the OK subtitle filter toggle updates the rendered list."""
     app = _done_app(tmp_path, monkeypatch)
@@ -209,8 +201,7 @@ def test_exit_route_saves_output_and_shuts_down_server(tmp_path: Path):
     html_dir_path = make_ocr_html_dir(tmp_path, text="recognized")
     outfile_path = tmp_path / "validated.srt"
     session = OcrValidationSession.from_dir_path(
-        html_dir_path,
-        outfile_path=outfile_path,
+        html_dir_path, outfile_path=outfile_path
     )
     app = create_app(session)
     app.testing = True
@@ -226,18 +217,13 @@ def test_exit_route_saves_output_and_shuts_down_server(tmp_path: Path):
 
 
 def test_char_concern_image_url_changes_after_accept(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test accepting one character returns a fresh next concern image URL."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="AB")
-    patch_ocr_validation_bboxes(
-        monkeypatch,
-        [Bbox(0, 10, 0, 20), Bbox(20, 30, 0, 20)],
-    )
+    patch_ocr_validation_bboxes(monkeypatch, [Bbox(0, 10, 0, 20), Bbox(20, 30, 0, 20)])
     session = OcrValidationSession.from_dir_path(
-        html_dir_path,
-        validation_data_dir_path=tmp_path / "cache",
+        html_dir_path, validation_data_dir_path=tmp_path / "cache"
     )
     clear_validation_data(session)
     app = create_app(session)
@@ -261,16 +247,9 @@ def test_char_concern_image_url_changes_after_accept(
 def test_index_renders_space_gap_choice_table(tmp_path: Path, monkeypatch: MonkeyPatch):
     """Test adjacent-or-space concerns render both choice actions."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="霆所")
-    patch_ocr_validation_bboxes(
-        monkeypatch,
-        [Bbox(0, 10, 0, 20), Bbox(50, 60, 0, 20)],
-    )
+    patch_ocr_validation_bboxes(monkeypatch, [Bbox(0, 10, 0, 20), Bbox(50, 60, 0, 20)])
     session = prepared_gap_session(
-        html_dir_path,
-        tmp_path,
-        char_1="霆",
-        char_2="所",
-        cutoffs=(22, 89, 90, 200),
+        html_dir_path, tmp_path, char_1="霆", char_2="所", cutoffs=(22, 89, 90, 200)
     )
     app = create_app(session)
 
@@ -291,8 +270,7 @@ def test_index_renders_space_gap_choice_table(tmp_path: Path, monkeypatch: Monke
 
 
 def test_validation_image_route_serves_bbox_png(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test validation row images are rendered with bbox overlays."""
     app = _done_app(tmp_path, monkeypatch)
@@ -307,8 +285,7 @@ def test_validation_image_route_serves_bbox_png(
 
 
 def test_validation_image_route_rejects_missing_subtitle(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test validation image route rejects an out-of-range subtitle index."""
     app = _done_app(tmp_path, monkeypatch)
@@ -324,9 +301,7 @@ def test_text_update_route_rewrites_row(tmp_path: Path):
     app = create_app(OcrValidationSession.from_dir_path(html_dir_path))
 
     response = app.test_client().post(
-        "/subtitles/0/text",
-        data={"text-0": "new"},
-        headers={"HX-Request": "true"},
+        "/subtitles/0/text", data={"text-0": "new"}, headers={"HX-Request": "true"}
     )
 
     assert response.status_code == 200
@@ -340,9 +315,7 @@ def test_text_update_route_rejects_missing_subtitle(tmp_path: Path):
     app = create_app(OcrValidationSession.from_dir_path(html_dir_path))
 
     response = app.test_client().post(
-        "/subtitles/1/text",
-        data={"text": "new"},
-        headers={"HX-Request": "true"},
+        "/subtitles/1/text", data={"text": "new"}, headers={"HX-Request": "true"}
     )
 
     assert response.status_code == 404
@@ -359,8 +332,7 @@ def test_concern_image_route_serves_png(tmp_path: Path, monkeypatch: MonkeyPatch
 
 
 def test_concern_image_route_rejects_missing_subtitle(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test concern image route rejects an out-of-range subtitle index."""
     app = _char_concern_app(tmp_path, monkeypatch)
@@ -385,8 +357,7 @@ def test_char_concern_route_resolves_row(tmp_path: Path, monkeypatch: MonkeyPatc
 
 
 def test_char_concern_route_rejects_invalid_action(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test character concern route rejects invalid actions."""
     app = _char_concern_app(tmp_path, monkeypatch)
@@ -401,8 +372,7 @@ def test_char_concern_route_rejects_invalid_action(
 
 
 def test_char_concern_route_rejects_missing_subtitle(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test character concern route rejects an out-of-range subtitle index."""
     app = _char_concern_app(tmp_path, monkeypatch)
@@ -419,10 +389,7 @@ def test_char_concern_route_rejects_missing_subtitle(
 def test_gap_concern_route_resolves_row(tmp_path: Path, monkeypatch: MonkeyPatch):
     """Test resolving the final gap concern persists text and omits the row."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="AB")
-    patch_ocr_validation_bboxes(
-        monkeypatch,
-        [Bbox(0, 10, 0, 20), Bbox(14, 24, 0, 20)],
-    )
+    patch_ocr_validation_bboxes(monkeypatch, [Bbox(0, 10, 0, 20), Bbox(14, 24, 0, 20)])
     session = prepared_gap_session(html_dir_path, tmp_path)
     app = create_app(session)
 
@@ -438,15 +405,11 @@ def test_gap_concern_route_resolves_row(tmp_path: Path, monkeypatch: MonkeyPatch
 
 
 def test_gap_concern_route_rejects_invalid_action(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test gap concern route rejects invalid actions."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="AB")
-    patch_ocr_validation_bboxes(
-        monkeypatch,
-        [Bbox(0, 10, 0, 20), Bbox(14, 24, 0, 20)],
-    )
+    patch_ocr_validation_bboxes(monkeypatch, [Bbox(0, 10, 0, 20), Bbox(14, 24, 0, 20)])
     session = prepared_gap_session(html_dir_path, tmp_path)
     app = create_app(session)
 
@@ -460,8 +423,7 @@ def test_gap_concern_route_rejects_invalid_action(
 
 
 def test_gap_concern_route_rejects_missing_subtitle(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test gap concern route rejects an out-of-range subtitle index."""
     app = _char_concern_app(tmp_path, monkeypatch)
@@ -487,8 +449,7 @@ def _char_concern_app(tmp_path: Path, monkeypatch: MonkeyPatch) -> Flask:
     html_dir_path = make_ocr_html_dir(tmp_path, text="A")
     patch_ocr_validation_bboxes(monkeypatch, [Bbox(0, 10, 0, 20)])
     session = OcrValidationSession.from_dir_path(
-        html_dir_path,
-        validation_data_dir_path=tmp_path / "cache",
+        html_dir_path, validation_data_dir_path=tmp_path / "cache"
     )
     clear_validation_data(session)
     return create_app(session)
@@ -545,10 +506,7 @@ def _assert_index_textarea(html: bytes):
 
 
 def _done_app(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
-    *,
-    include_done_subtitles: bool = False,
+    tmp_path: Path, monkeypatch: MonkeyPatch, *, include_done_subtitles: bool = False
 ) -> Flask:
     """Create an app with one subtitle that has no concerns.
 
@@ -572,10 +530,7 @@ def _done_app(
 
 
 def _session(
-    tmp_path: Path,
-    *,
-    text: str,
-    include_done_subtitles: bool = False,
+    tmp_path: Path, *, text: str, include_done_subtitles: bool = False
 ) -> OcrValidationSession:
     """Create a basic OCR validation session.
 

--- a/test/web/ocr_validation/test_session.py
+++ b/test/web/ocr_validation/test_session.py
@@ -34,9 +34,7 @@ def test_session_loads_rows_from_html_index(tmp_path: Path):
     html_dir_path = make_ocr_html_dir(tmp_path, text="recognized")
 
     session = OcrValidationSession.from_dir_path(
-        html_dir_path,
-        include_done_subtitles=True,
-        dev=False,
+        html_dir_path, include_done_subtitles=True, dev=False
     )
 
     rows = session.subtitle_rows()
@@ -60,8 +58,7 @@ def test_session_requires_index_html_file(tmp_path: Path):
 
 
 def test_session_wraps_image_series_load_errors(
-    monkeypatch: MonkeyPatch,
-    tmp_path: Path,
+    monkeypatch: MonkeyPatch, tmp_path: Path
 ):
     """Test session construction wraps image series loading errors.
 
@@ -76,8 +73,7 @@ def test_session_wraps_image_series_load_errors(
         raise ValueError(f"{path} could not be loaded")
 
     monkeypatch.setattr(
-        "scinoephile.web.ocr_validation.session.ImageSeries.load",
-        fake_load,
+        "scinoephile.web.ocr_validation.session.ImageSeries.load", fake_load
     )
 
     with raises(
@@ -95,8 +91,7 @@ def test_concern_kind_excludes_done_state():
 
 
 def test_session_uses_one_font_size_for_series(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test editable font size is detected once for the whole series."""
     html_dir_path = make_two_image_ocr_html_dir(tmp_path, text_1="A", text_2="B")
@@ -105,14 +100,10 @@ def test_session_uses_one_font_size_for_series(
         """Return bboxes that vary by image width."""
         if img.width == 2:
             return [Bbox(0, 10, 0, 52)]
-        return [
-            Bbox(0, 10, 0, 60),
-            Bbox(12, 22, 0, 60),
-        ]
+        return [Bbox(0, 10, 0, 60), Bbox(12, 22, 0, 60)]
 
     monkeypatch.setattr(
-        "scinoephile.image.subtitles.series.get_bboxes",
-        mock_get_bboxes,
+        "scinoephile.image.subtitles.series.get_bboxes", mock_get_bboxes
     )
     session = OcrValidationSession.from_dir_path(
         html_dir_path,
@@ -145,16 +136,11 @@ def test_session_uses_cjk_letter_spacing(tmp_path: Path):
 
 
 def test_session_rebuilds_raw_bboxes_for_validation_state(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test web validation state ignores stale pre-merged bboxes."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="A")
-    raw_bboxes = [
-        Bbox(0, 23, 0, 61),
-        Bbox(35, 40, 1, 61),
-        Bbox(43, 58, 18, 38),
-    ]
+    raw_bboxes = [Bbox(0, 23, 0, 61), Bbox(35, 40, 1, 61), Bbox(43, 58, 18, 38)]
     patch_ocr_validation_bboxes(monkeypatch, raw_bboxes)
     session = OcrValidationSession.from_dir_path(
         html_dir_path,
@@ -172,15 +158,13 @@ def test_session_rebuilds_raw_bboxes_for_validation_state(
 
 
 def test_session_omits_done_rows_from_list_by_default(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test session row lists omit subtitles with no concerns by default."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="A")
     patch_ocr_validation_bboxes(monkeypatch, [Bbox(0, 10, 0, 20)])
     session = OcrValidationSession.from_dir_path(
-        html_dir_path,
-        validation_data_dir_path=tmp_path / "cache",
+        html_dir_path, validation_data_dir_path=tmp_path / "cache"
     )
     clear_validation_data(session)
     session.manager.char_dims_by_n[1]["A"] = {(10, 20)}
@@ -191,8 +175,7 @@ def test_session_omits_done_rows_from_list_by_default(
 
 
 def test_session_includes_done_rows_in_list_when_enabled(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test the internal toggle can include subtitles with no concerns."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="A")
@@ -217,8 +200,7 @@ def test_session_update_text_rewrites_index(tmp_path: Path):
     html_dir_path = make_ocr_html_dir(tmp_path, text="recognized")
     outfile_path = tmp_path / "validated.srt"
     session = OcrValidationSession.from_dir_path(
-        html_dir_path,
-        outfile_path=outfile_path,
+        html_dir_path, outfile_path=outfile_path
     )
 
     row = session.update_text(0, "validated\\Nline")
@@ -246,8 +228,7 @@ def test_session_reports_char_dims_concern(tmp_path: Path, monkeypatch: MonkeyPa
     html_dir_path = make_ocr_html_dir(tmp_path, text="A")
     patch_ocr_validation_bboxes(monkeypatch, [Bbox(0, 10, 0, 20)])
     session = OcrValidationSession.from_dir_path(
-        html_dir_path,
-        validation_data_dir_path=tmp_path / "cache",
+        html_dir_path, validation_data_dir_path=tmp_path / "cache"
     )
     clear_validation_data(session)
 
@@ -261,15 +242,13 @@ def test_session_reports_char_dims_concern(tmp_path: Path, monkeypatch: MonkeyPa
 
 
 def test_session_reports_error_status_when_validation_cannot_continue(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test unrecoverable validation concerns produce an error row status."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="A")
     patch_ocr_validation_bboxes(monkeypatch, [])
     session = OcrValidationSession.from_dir_path(
-        html_dir_path,
-        validation_data_dir_path=tmp_path / "cache",
+        html_dir_path, validation_data_dir_path=tmp_path / "cache"
     )
     clear_validation_data(session)
 
@@ -280,15 +259,13 @@ def test_session_reports_error_status_when_validation_cannot_continue(
 
 
 def test_accept_char_dims_marks_single_char_done(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test accepting character dimensions resolves a single-character subtitle."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="A")
     patch_ocr_validation_bboxes(monkeypatch, [Bbox(0, 10, 0, 20)])
     session = OcrValidationSession.from_dir_path(
-        html_dir_path,
-        validation_data_dir_path=tmp_path / "cache",
+        html_dir_path, validation_data_dir_path=tmp_path / "cache"
     )
     clear_validation_data(session)
 
@@ -304,13 +281,9 @@ def test_accept_char_dims_marks_single_char_done(
 def test_contract_char_dims_reduces_selection(tmp_path: Path, monkeypatch: MonkeyPatch):
     """Test contracting character dimensions reduces the selected bbox count."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="A")
-    patch_ocr_validation_bboxes(
-        monkeypatch,
-        [Bbox(0, 10, 0, 20), Bbox(10, 20, 0, 20)],
-    )
+    patch_ocr_validation_bboxes(monkeypatch, [Bbox(0, 10, 0, 20), Bbox(10, 20, 0, 20)])
     session = OcrValidationSession.from_dir_path(
-        html_dir_path,
-        validation_data_dir_path=tmp_path / "cache",
+        html_dir_path, validation_data_dir_path=tmp_path / "cache"
     )
     clear_validation_data(session)
 
@@ -330,10 +303,7 @@ def test_contract_char_dims_reduces_selection(tmp_path: Path, monkeypatch: Monke
 def test_session_reports_space_gap_concern(tmp_path: Path, monkeypatch: MonkeyPatch):
     """Test ambiguous adjacent-or-space gaps produce a space concern."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="AB")
-    patch_ocr_validation_bboxes(
-        monkeypatch,
-        [Bbox(0, 10, 0, 20), Bbox(14, 24, 0, 20)],
-    )
+    patch_ocr_validation_bboxes(monkeypatch, [Bbox(0, 10, 0, 20), Bbox(14, 24, 0, 20)])
     session = prepared_gap_session(html_dir_path, tmp_path)
 
     row = session.subtitle_row(0)
@@ -351,10 +321,7 @@ def test_session_reports_space_gap_concern(tmp_path: Path, monkeypatch: MonkeyPa
 def test_space_gap_choice_updates_index_text(tmp_path: Path, monkeypatch: MonkeyPatch):
     """Test resolving a space gap writes the expected space into index.html."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="AB")
-    patch_ocr_validation_bboxes(
-        monkeypatch,
-        [Bbox(0, 10, 0, 20), Bbox(14, 24, 0, 20)],
-    )
+    patch_ocr_validation_bboxes(monkeypatch, [Bbox(0, 10, 0, 20), Bbox(14, 24, 0, 20)])
     session = prepared_gap_session(html_dir_path, tmp_path)
 
     row = session.resolve_gap_concern(0, action="space")
@@ -367,15 +334,11 @@ def test_space_gap_choice_updates_index_text(tmp_path: Path, monkeypatch: Monkey
 
 
 def test_existing_space_gap_does_not_update_cutoffs(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test stale whitespace does not train ambiguous gap cutoffs."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="A B")
-    patch_ocr_validation_bboxes(
-        monkeypatch,
-        [Bbox(0, 10, 0, 20), Bbox(14, 24, 0, 20)],
-    )
+    patch_ocr_validation_bboxes(monkeypatch, [Bbox(0, 10, 0, 20), Bbox(14, 24, 0, 20)])
     session = prepared_gap_session(html_dir_path, tmp_path)
 
     row = session.subtitle_row(0)
@@ -387,18 +350,13 @@ def test_existing_space_gap_does_not_update_cutoffs(
 
 
 def test_punctuation_ellipsis_gap_reports_existing_space_concern(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test punctuation before ellipsis keeps stale whitespace as a concern."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="！ ⋯")
-    patch_ocr_validation_bboxes(
-        monkeypatch,
-        [Bbox(0, 10, 0, 20), Bbox(67, 77, 0, 20)],
-    )
+    patch_ocr_validation_bboxes(monkeypatch, [Bbox(0, 10, 0, 20), Bbox(67, 77, 0, 20)])
     session = OcrValidationSession.from_dir_path(
-        html_dir_path,
-        validation_data_dir_path=tmp_path / "cache",
+        html_dir_path, validation_data_dir_path=tmp_path / "cache"
     )
     clear_validation_data(session)
     session.manager.char_dims_by_n[1]["！"] = {(10, 20)}
@@ -418,18 +376,13 @@ def test_punctuation_ellipsis_gap_reports_existing_space_concern(
 
 
 def test_known_adjacent_gap_mismatch_updates_text_without_concern(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test known adjacent gaps with wrong text update without a user concern."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="臭　　和")
-    patch_ocr_validation_bboxes(
-        monkeypatch,
-        [Bbox(0, 10, 0, 20), Bbox(21, 31, 0, 20)],
-    )
+    patch_ocr_validation_bboxes(monkeypatch, [Bbox(0, 10, 0, 20), Bbox(21, 31, 0, 20)])
     session = OcrValidationSession.from_dir_path(
-        html_dir_path,
-        validation_data_dir_path=tmp_path / "cache",
+        html_dir_path, validation_data_dir_path=tmp_path / "cache"
     )
     clear_validation_data(session)
     session.manager.char_dims_by_n[1]["臭"] = {(10, 20)}
@@ -446,18 +399,13 @@ def test_known_adjacent_gap_mismatch_updates_text_without_concern(
 
 
 def test_fullwidth_latin_gap_uses_default_cutoffs(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test fullwidth Latin characters use default full-width gap cutoffs."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="你Ｋ")
-    patch_ocr_validation_bboxes(
-        monkeypatch,
-        [Bbox(0, 10, 0, 20), Bbox(18, 28, 0, 20)],
-    )
+    patch_ocr_validation_bboxes(monkeypatch, [Bbox(0, 10, 0, 20), Bbox(18, 28, 0, 20)])
     session = OcrValidationSession.from_dir_path(
-        html_dir_path,
-        validation_data_dir_path=tmp_path / "cache",
+        html_dir_path, validation_data_dir_path=tmp_path / "cache"
     )
     clear_validation_data(session)
     session.manager.char_dims_by_n[1]["你"] = {(10, 20)}
@@ -473,13 +421,9 @@ def test_fullwidth_latin_gap_uses_default_cutoffs(
 def test_adjacent_gap_choice_updates_cutoff(tmp_path: Path, monkeypatch: MonkeyPatch):
     """Test adjacent choice for an ambiguous gap updates the gap cutoffs."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="白了")
-    patch_ocr_validation_bboxes(
-        monkeypatch,
-        [Bbox(0, 10, 0, 20), Bbox(14, 24, 0, 20)],
-    )
+    patch_ocr_validation_bboxes(monkeypatch, [Bbox(0, 10, 0, 20), Bbox(14, 24, 0, 20)])
     session = OcrValidationSession.from_dir_path(
-        html_dir_path,
-        validation_data_dir_path=tmp_path / "cache",
+        html_dir_path, validation_data_dir_path=tmp_path / "cache"
     )
     clear_validation_data(session)
     session.manager.char_dims_by_n[1]["白"] = {(10, 20)}
@@ -503,15 +447,11 @@ def test_adjacent_gap_choice_updates_cutoff(tmp_path: Path, monkeypatch: MonkeyP
 
 
 def test_boundary_space_gap_updates_cutoff_without_concern(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test boundary space text updates cutoffs without a user concern."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="A B")
-    patch_ocr_validation_bboxes(
-        monkeypatch,
-        [Bbox(0, 10, 0, 20), Bbox(15, 25, 0, 20)],
-    )
+    patch_ocr_validation_bboxes(monkeypatch, [Bbox(0, 10, 0, 20), Bbox(15, 25, 0, 20)])
     session = prepared_gap_session(html_dir_path, tmp_path)
 
     row = session.subtitle_row(0)
@@ -524,15 +464,11 @@ def test_boundary_space_gap_updates_cutoff_without_concern(
 
 
 def test_boundary_tab_gap_updates_cutoff_without_concern(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test boundary tab text updates cutoffs without a user concern."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="A    B")
-    patch_ocr_validation_bboxes(
-        monkeypatch,
-        [Bbox(0, 10, 0, 20), Bbox(29, 39, 0, 20)],
-    )
+    patch_ocr_validation_bboxes(monkeypatch, [Bbox(0, 10, 0, 20), Bbox(29, 39, 0, 20)])
     session = prepared_gap_session(html_dir_path, tmp_path)
 
     row = session.subtitle_row(0)
@@ -545,18 +481,13 @@ def test_boundary_tab_gap_updates_cutoff_without_concern(
 
 
 def test_known_space_gap_mismatch_updates_text_without_concern(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test known space gaps with wrong text update without a user concern."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="呀 你")
-    patch_ocr_validation_bboxes(
-        monkeypatch,
-        [Bbox(0, 10, 0, 20), Bbox(51, 61, 0, 20)],
-    )
+    patch_ocr_validation_bboxes(monkeypatch, [Bbox(0, 10, 0, 20), Bbox(51, 61, 0, 20)])
     session = OcrValidationSession.from_dir_path(
-        html_dir_path,
-        validation_data_dir_path=tmp_path / "cache",
+        html_dir_path, validation_data_dir_path=tmp_path / "cache"
     )
     clear_validation_data(session)
     session.manager.char_dims_by_n[1]["呀"] = {(10, 20)}
@@ -573,15 +504,11 @@ def test_known_space_gap_mismatch_updates_text_without_concern(
 
 
 def test_known_tab_gap_mismatch_updates_text_without_concern(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test known tab gaps with wrong text update without a user concern."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="AB")
-    patch_ocr_validation_bboxes(
-        monkeypatch,
-        [Bbox(0, 10, 0, 20), Bbox(32, 42, 0, 20)],
-    )
+    patch_ocr_validation_bboxes(monkeypatch, [Bbox(0, 10, 0, 20), Bbox(32, 42, 0, 20)])
     session = prepared_gap_session(html_dir_path, tmp_path)
 
     row = session.subtitle_row(0)
@@ -594,15 +521,11 @@ def test_known_tab_gap_mismatch_updates_text_without_concern(
 
 
 def test_known_tab_gap_replaces_newline_without_concern(
-    tmp_path: Path,
-    monkeypatch: MonkeyPatch,
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ):
     """Test known tab gaps with newline text update without a user concern."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="A<br />B")
-    patch_ocr_validation_bboxes(
-        monkeypatch,
-        [Bbox(0, 10, 0, 20), Bbox(32, 42, 0, 20)],
-    )
+    patch_ocr_validation_bboxes(monkeypatch, [Bbox(0, 10, 0, 20), Bbox(32, 42, 0, 20)])
     session = prepared_gap_session(html_dir_path, tmp_path)
 
     row = session.subtitle_row(0)
@@ -617,10 +540,7 @@ def test_known_tab_gap_replaces_newline_without_concern(
 def test_tab_gap_choice_updates_index_text(tmp_path: Path, monkeypatch: MonkeyPatch):
     """Test resolving a tab gap writes expected wide spacing into index.html."""
     html_dir_path = make_ocr_html_dir(tmp_path, text="AB")
-    patch_ocr_validation_bboxes(
-        monkeypatch,
-        [Bbox(0, 10, 0, 20), Bbox(25, 35, 0, 20)],
-    )
+    patch_ocr_validation_bboxes(monkeypatch, [Bbox(0, 10, 0, 20), Bbox(25, 35, 0, 20)])
     session = prepared_gap_session(html_dir_path, tmp_path)
 
     row = session.resolve_gap_concern(0, action="tab")

--- a/test/workflows/test_clean_series.py
+++ b/test/workflows/test_clean_series.py
@@ -68,17 +68,9 @@ from test.helpers import assert_series_equal, parametrize
             Language.eng,
             id="kob-eng-tesseract",
         ),
+        param("kob_eng", "kob_eng_clean", Language.eng, id="kob-eng-srt"),
         param(
-            "kob_eng",
-            "kob_eng_clean",
-            Language.eng,
-            id="kob-eng-srt",
-        ),
-        param(
-            "mlamd_eng_fuse",
-            "mlamd_eng_fuse_clean",
-            Language.eng,
-            id="mlamd-eng-fuse",
+            "mlamd_eng_fuse", "mlamd_eng_fuse_clean", Language.eng, id="mlamd-eng-fuse"
         ),
         param(
             "mlamd_eng_ocr_lens",
@@ -92,12 +84,7 @@ from test.helpers import assert_series_equal, parametrize
             Language.eng,
             id="mlamd-eng-tesseract",
         ),
-        param(
-            "mnt_eng_fuse",
-            "mnt_eng_fuse_clean",
-            Language.eng,
-            id="mnt-eng-fuse",
-        ),
+        param("mnt_eng_fuse", "mnt_eng_fuse_clean", Language.eng, id="mnt-eng-fuse"),
         param(
             "mnt_eng_ocr_lens",
             "mnt_eng_ocr_lens_clean",
@@ -110,18 +97,8 @@ from test.helpers import assert_series_equal, parametrize
             Language.eng,
             id="mnt-eng-tesseract",
         ),
-        param(
-            "t_eng_fuse",
-            "t_eng_fuse_clean",
-            Language.eng,
-            id="t-eng-fuse",
-        ),
-        param(
-            "t_eng_ocr_lens",
-            "t_eng_ocr_lens_clean",
-            Language.eng,
-            id="t-eng-lens",
-        ),
+        param("t_eng_fuse", "t_eng_fuse_clean", Language.eng, id="t-eng-fuse"),
+        param("t_eng_ocr_lens", "t_eng_ocr_lens_clean", Language.eng, id="t-eng-lens"),
         param(
             "t_eng_ocr_tesseract",
             "t_eng_ocr_tesseract_clean",
@@ -517,8 +494,6 @@ def test_clean_series(
         language: language to use for cleaning
     """
     output = clean_series(
-        request.getfixturevalue(series_fixture),
-        language=language,
-        remove_empty=False,
+        request.getfixturevalue(series_fixture), language=language, remove_empty=False
     )
     assert_series_equal(output, request.getfixturevalue(expected_fixture))

--- a/test/workflows/test_ocr_processing.py
+++ b/test/workflows/test_ocr_processing.py
@@ -27,18 +27,14 @@ def test_ocr_processing_workflow_keeps_cache_policy_on_cache(tmp_path: Path):
     assert not hasattr(workflow, "overwrite_cache")
 
 
-def test_ocr_processing_workflow_sets_default_fusion_test_case_path(
-    tmp_path: Path,
-):
+def test_ocr_processing_workflow_sets_default_fusion_test_case_path(tmp_path: Path):
     """Test OCR processing persists fusion decisions at its conventional path.
 
     Arguments:
         tmp_path: pytest temporary path fixture
     """
     workflow = OcrProcessingWorkflow(
-        tmp_path / "source.sup",
-        tmp_path / "output",
-        language=Language.yue_hant,
+        tmp_path / "source.sup", tmp_path / "output", language=Language.yue_hant
     )
 
     assert workflow.fuser_kw["test_case_path"] == (
@@ -46,9 +42,7 @@ def test_ocr_processing_workflow_sets_default_fusion_test_case_path(
     )
 
 
-def test_ocr_processing_workflow_preserves_fusion_test_case_path(
-    tmp_path: Path,
-):
+def test_ocr_processing_workflow_preserves_fusion_test_case_path(tmp_path: Path):
     """Test supplied OCR-fusion test-case paths take precedence.
 
     Arguments:

--- a/test/workflows/test_ocr_validation.py
+++ b/test/workflows/test_ocr_validation.py
@@ -13,9 +13,7 @@ from test.helpers.series_files import get_ocr_text_series
 
 
 def test_validate_ocr_runs_noninteractive_validation(
-    monkeypatch,
-    tmp_path: Path,
-    tiny_image_series: ImageSeries,
+    monkeypatch, tmp_path: Path, tiny_image_series: ImageSeries
 ):
     """Test path-based OCR validation loads, validates, and writes output."""
     infile_path = tmp_path / "source.sup"
@@ -51,12 +49,10 @@ def test_validate_ocr_runs_noninteractive_validation(
         return tiny_image_series
 
     monkeypatch.setattr(
-        "scinoephile.workflows.ocr_validation.ImageSeries.load",
-        fake_load,
+        "scinoephile.workflows.ocr_validation.ImageSeries.load", fake_load
     )
     monkeypatch.setattr(
-        "scinoephile.workflows.ocr_validation.ValidationManager",
-        FakeValidationManager,
+        "scinoephile.workflows.ocr_validation.ValidationManager", FakeValidationManager
     )
 
     validated = validate_ocr(
@@ -77,10 +73,7 @@ def test_validate_ocr_runs_noninteractive_validation(
     assert "validated" in outfile_path.read_text(encoding="utf-8")
 
 
-def test_validate_ocr_runs_interactive_validation(
-    monkeypatch,
-    tmp_path: Path,
-):
+def test_validate_ocr_runs_interactive_validation(monkeypatch, tmp_path: Path):
     """Test path-based OCR validation launches interactive validation."""
     infile_path = tmp_path / "image"
     infile_path.mkdir()
@@ -98,13 +91,7 @@ def test_validate_ocr_runs_interactive_validation(
     ) -> object:
         """Capture web session construction arguments."""
         run_calls.append(
-            (
-                "from_dir_path",
-                dir_path,
-                outfile_path,
-                validation_data_dir_path,
-                dev,
-            )
+            ("from_dir_path", dir_path, outfile_path, validation_data_dir_path, dev)
         )
         return session
 
@@ -117,10 +104,7 @@ def test_validate_ocr_runs_interactive_validation(
         "scinoephile.workflows.ocr_validation.OcrValidationSession.from_dir_path",
         fake_session_from_dir_path,
     )
-    monkeypatch.setattr(
-        "scinoephile.workflows.ocr_validation.run_app",
-        fake_run_app,
-    )
+    monkeypatch.setattr("scinoephile.workflows.ocr_validation.run_app", fake_run_app)
 
     validated = validate_ocr(
         infile_path,

--- a/test/workflows/test_prompt_catalog.py
+++ b/test/workflows/test_prompt_catalog.py
@@ -46,18 +46,14 @@ def test_prompt_catalog_is_stable_and_manager_compatible():
         assert OPERATIONS[prompt_spec.manager_cls.operation] is prompt_spec.manager_cls
         assert isinstance(prompt_spec.prompt, type(prompt_spec.manager_cls.base_prompt))
         persisted = PersistedPrompt.from_prompt(
-            prompt_spec.prompt,
-            prompt_spec.manager_cls,
+            prompt_spec.prompt, prompt_spec.manager_cls
         )
         assert isinstance(persisted.language, Language)
 
 
 def test_prompt_catalog_contains_registered_transcription_prompts():
     """Each guided transcription spec should contribute its prompts to the catalog."""
-    for (
-        language,
-        guide_language,
-    ), spec in guided_transcription.DEFAULT_SPECS.items():
+    for (language, guide_language), spec in guided_transcription.DEFAULT_SPECS.items():
         guide_code = guide_language.language.lower()
         delineation_alias = f"delineation-{language.code.lower()}-vs-{guide_code}"
         punctuation_alias = f"punctuation-{language.code.lower()}-vs-{guide_code}"

--- a/test/workflows/test_subtitle_extraction.py
+++ b/test/workflows/test_subtitle_extraction.py
@@ -92,14 +92,12 @@ def test_extract_subtitles_details_uses_detected_chinese_script(tmp_path: Path):
     with (
         patch(
             "scinoephile.workflows.subtitle_extraction.get_subtitle_streams",
-            return_value=[
-                SubtitleStream(index=4, language="zho", codec_name="subrip"),
-            ],
+            return_value=[SubtitleStream(index=4, language="zho", codec_name="subrip")],
         ),
         patch(
             "scinoephile.workflows.subtitle_extraction.get_zho_subtitle_streams",
             return_value=[
-                SubtitleStream(index=4, language="zho-Hant", codec_name="subrip"),
+                SubtitleStream(index=4, language="zho-Hant", codec_name="subrip")
             ],
         ) as get_zho_subtitle_streams,
         patch(
@@ -179,18 +177,14 @@ def test_extract_subtitles_reports_existing_outputs(tmp_path: Path):
     with (
         patch(
             "scinoephile.workflows.subtitle_extraction.get_subtitle_streams",
-            return_value=[
-                SubtitleStream(index=2, language="eng", codec_name="subrip"),
-            ],
+            return_value=[SubtitleStream(index=2, language="eng", codec_name="subrip")],
         ),
         patch(
             "scinoephile.workflows.subtitle_extraction.SubtitleExtractor.extract"
         ) as extract,
     ):
         result = extract_subtitles(
-            infile_path=infile_path,
-            languages=["eng"],
-            output_dir_path=output_dir_path,
+            infile_path=infile_path, languages=["eng"], output_dir_path=output_dir_path
         )
 
     extract.assert_not_called()
@@ -252,10 +246,8 @@ def test_extract_subtitles_rejects_unsafe_stream_language(tmp_path: Path):
             "scinoephile.workflows.subtitle_extraction.get_subtitle_streams",
             return_value=[
                 SubtitleStream(
-                    index=2,
-                    language="eng-../../../escaped",
-                    codec_name="subrip",
-                ),
+                    index=2, language="eng-../../../escaped", codec_name="subrip"
+                )
             ],
         ),
         patch(
@@ -264,9 +256,7 @@ def test_extract_subtitles_rejects_unsafe_stream_language(tmp_path: Path):
         raises(ScinoephileError, match="Unsafe subtitle output filename"),
     ):
         extract_subtitles(
-            infile_path=infile_path,
-            languages=["eng"],
-            output_dir_path=output_dir_path,
+            infile_path=infile_path, languages=["eng"], output_dir_path=output_dir_path
         )
 
     extract.assert_not_called()
@@ -377,8 +367,7 @@ def test_extract_subtitles_skips_sup_parsing_when_not_exporting_images(tmp_path:
 
 
 def test_extract_subtitles_warns_when_sup_image_export_fails(
-    tmp_path: Path,
-    caplog: LogCaptureFixture,
+    tmp_path: Path, caplog: LogCaptureFixture
 ):
     """Test extraction keeps subtitle files when SUP image export fails.
 
@@ -400,10 +389,7 @@ def test_extract_subtitles_warns_when_sup_image_export_fails(
         SubtitleStream(index=10, language="eng", codec_name="hdmv_pgs_subtitle"),
     ]
 
-    caplog.set_level(
-        "WARNING",
-        logger="scinoephile.workflows.subtitle_extraction",
-    )
+    caplog.set_level("WARNING", logger="scinoephile.workflows.subtitle_extraction")
     with (
         patch(
             "scinoephile.workflows.subtitle_extraction.get_subtitle_streams",
@@ -456,11 +442,7 @@ def test_extract_subtitles_extracts_sup_file_to_image_dir_in_place(tmp_path: Pat
         patch(
             "scinoephile.workflows.subtitle_extraction.get_subtitle_streams",
             return_value=[
-                SubtitleStream(
-                    index=0,
-                    language=None,
-                    codec_name="hdmv_pgs_subtitle",
-                ),
+                SubtitleStream(index=0, language=None, codec_name="hdmv_pgs_subtitle")
             ],
         ),
     ):
@@ -488,17 +470,11 @@ def test_extract_subtitles_skips_sup_file_with_nonmatching_language(tmp_path: Pa
     infile_path = tmp_path / "source.sup"
     infile_path.touch()
 
-    with (
-        patch(
-            "scinoephile.workflows.subtitle_extraction.get_subtitle_streams",
-            return_value=[
-                SubtitleStream(
-                    index=0,
-                    language="eng",
-                    codec_name="hdmv_pgs_subtitle",
-                ),
-            ],
-        ),
+    with patch(
+        "scinoephile.workflows.subtitle_extraction.get_subtitle_streams",
+        return_value=[
+            SubtitleStream(index=0, language="eng", codec_name="hdmv_pgs_subtitle")
+        ],
     ):
         result = extract_subtitles(
             infile_path=infile_path,
@@ -528,15 +504,13 @@ def test_extract_subtitles_rejects_unsafe_sup_language(tmp_path: Path):
                     index=0,
                     language="eng-../../../escaped",
                     codec_name="hdmv_pgs_subtitle",
-                ),
+                )
             ],
         ),
         raises(ScinoephileError, match="Unsafe subtitle output filename"),
     ):
         extract_subtitles(
-            infile_path=infile_path,
-            languages=["eng"],
-            output_dir_path=output_dir_path,
+            infile_path=infile_path, languages=["eng"], output_dir_path=output_dir_path
         )
 
     assert not (tmp_path / "escaped.sup").exists()
@@ -559,9 +533,7 @@ def test_extract_subtitles_rejects_sup_file_without_subtitle_streams(tmp_path: P
         raises(ScinoephileError, match="No subtitle streams found"),
     ):
         extract_subtitles(
-            infile_path=infile_path,
-            languages=["zho"],
-            output_dir_path=tmp_path,
+            infile_path=infile_path, languages=["zho"], output_dir_path=tmp_path
         )
 
 
@@ -574,9 +546,7 @@ def _image_series() -> ImageSeries:
     return ImageSeries(
         events=[
             ImageSubtitle(
-                start=1000,
-                end=2000,
-                img=Image.new("RGBA", (10, 8), (255, 255, 255, 0)),
+                start=1000, end=2000, img=Image.new("RGBA", (10, 8), (255, 255, 255, 0))
             )
         ]
     )

--- a/test/workflows/test_transcription.py
+++ b/test/workflows/test_transcription.py
@@ -48,10 +48,7 @@ def test_transcribe_series_guided_constructs_transcriber_for_language_pair(
         )
 
     assert output is expected
-    assert get_transcriber.call_args.args == (
-        Language.yue_hant,
-        Language.zho_hans,
-    )
+    assert get_transcriber.call_args.args == (Language.yue_hant, Language.zho_hans)
     assert get_transcriber.call_args.kwargs["demucs_mode"] is DemucsMode.AUTO
     assert get_transcriber.call_args.kwargs["vad_mode"] is VADMode.AUTO
     assert get_transcriber.call_args.kwargs["cache_root_path"] == tmp_path / "cache"
@@ -66,8 +63,5 @@ def test_transcribe_series_guided_constructs_transcriber_for_language_pair(
         == punctuation_json_path
     )
     transcriber.process.assert_called_once_with(
-        audio_series,
-        reference_series,
-        stop_at_idx=2,
-        start_at_idx=1,
+        audio_series, reference_series, stop_at_idx=2, start_at_idx=1
     )


### PR DESCRIPTION
## Summary

- Configure Ruff to ignore magic trailing commas when short constructs fit on one line.
- Keep isort's trailing-comma behavior aligned with the formatter.
- Apply the resulting repository-wide mechanical formatting update.
- Remove the former `__all__` layout rules from the style guide.

## Impact

Formatting-only change. Short imports, calls, signatures, literals, annotations, and other expressions now remain on one line when they fit within the 88-character limit. `ruff format --check` enforces the convention going forward.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format --check .`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix .`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check`
- Full test suite: 2,151 passed, 4 skipped