### PR TITLE
Improve Whisper token-limit logging

### DIFF
--- a/scinoephile/audio/transcription/whisper_transcriber.py
+++ b/scinoephile/audio/transcription/whisper_transcriber.py
@@ -42,6 +42,8 @@ _MIN_SAMPLE_LEN = 32
 
 if TYPE_CHECKING:
     from pydub import AudioSegment
+    from torch import Tensor
+    from whisper.decoding import DecodingOptions, DecodingResult
 
     from scinoephile.core.dependencies.transcription import WhisperModel
 
@@ -347,15 +349,43 @@ class WhisperTranscriber(Transcriber):
                     f"Using a {sample_len}-token Whisper decoding budget per window "
                     f"for {len(audio) / 1000:.2f}s of audio"
                 )
-                result = whisper_timestamped.transcribe(
-                    self.model,
-                    str(temp_audio_path),
-                    language=self.language,
-                    vad=settings.use_vad,
-                    temperature=self.temperature,
-                    condition_on_previous_text=self.condition_on_previous_text,
-                    sample_len=sample_len,
-                )
+                model = self.model
+                decode_is_instance_attribute = "decode" in vars(model)
+                decode = model.decode
+                exhausted_windows: list[Tensor] = []
+
+                def decode_with_limit_tracking(
+                    mel: Tensor, options: DecodingOptions, **kwargs: object
+                ) -> DecodingResult | list[DecodingResult]:
+                    """Decode a window and record whether it exhausts its budget."""
+                    decode_result = decode(mel, options, **kwargs)
+                    decode_results = (
+                        decode_result
+                        if isinstance(decode_result, list)
+                        else [decode_result]
+                    )
+                    if any(
+                        len(result.tokens) >= sample_len for result in decode_results
+                    ) and all(mel is not window for window in exhausted_windows):
+                        exhausted_windows.append(mel)
+                    return decode_result
+
+                setattr(model, "decode", decode_with_limit_tracking)
+                try:
+                    result = whisper_timestamped.transcribe(
+                        model,
+                        str(temp_audio_path),
+                        language=self.language,
+                        vad=settings.use_vad,
+                        temperature=self.temperature,
+                        condition_on_previous_text=self.condition_on_previous_text,
+                        sample_len=sample_len,
+                    )
+                finally:
+                    if decode_is_instance_attribute:
+                        setattr(model, "decode", decode)
+                    else:
+                        delattr(model, "decode")
         except AssertionError as exc:
             raise TranscriptionInferenceError(
                 f"Whisper inference failed with an assertion: {exc}"
@@ -364,15 +394,7 @@ class WhisperTranscriber(Transcriber):
         segments = [
             TranscribedSegment.model_validate(segment) for segment in result["segments"]
         ]
-        token_counts_by_seek: dict[int, int] = {}
-        for segment in segments:
-            if segment.tokens is None:
-                continue
-            token_counts_by_seek.setdefault(segment.seek, 0)
-            token_counts_by_seek[segment.seek] += len(segment.tokens)
-        limit_hit_count = sum(
-            token_count >= sample_len for token_count in token_counts_by_seek.values()
-        )
+        limit_hit_count = len(exhausted_windows)
         if limit_hit_count:
             logger.info(
                 f"Whisper reached its {sample_len}-token decoding limit "

--- a/scinoephile/audio/transcription/whisper_transcriber.py
+++ b/scinoephile/audio/transcription/whisper_transcriber.py
@@ -343,9 +343,9 @@ class WhisperTranscriber(Transcriber):
             with get_temp_file_path(suffix=".wav") as temp_audio_path:
                 audio.export(temp_audio_path, format="wav")
                 sample_len = self._get_sample_len(audio)
-                logger.info(
-                    f"Limiting Whisper decoding to {sample_len} tokens for "
-                    f"{len(audio) / 1000:.2f}s of audio"
+                logger.debug(
+                    f"Using a {sample_len}-token Whisper decoding budget per window "
+                    f"for {len(audio) / 1000:.2f}s of audio"
                 )
                 result = whisper_timestamped.transcribe(
                     self.model,
@@ -364,6 +364,20 @@ class WhisperTranscriber(Transcriber):
         segments = [
             TranscribedSegment.model_validate(segment) for segment in result["segments"]
         ]
+        token_counts_by_seek: dict[int, int] = {}
+        for segment in segments:
+            if segment.tokens is None:
+                continue
+            token_counts_by_seek.setdefault(segment.seek, 0)
+            token_counts_by_seek[segment.seek] += len(segment.tokens)
+        limit_hit_count = sum(
+            token_count >= sample_len for token_count in token_counts_by_seek.values()
+        )
+        if limit_hit_count:
+            logger.info(
+                f"Whisper reached its {sample_len}-token decoding limit "
+                f"(affected windows: {limit_hit_count})"
+            )
         return self._normalize_transcription_segments(
             segments, source="whisper", cache_path=None, use_vad=settings.use_vad
         )

--- a/test/audio/transcription/test_whisper_transcriber.py
+++ b/test/audio/transcription/test_whisper_transcriber.py
@@ -170,12 +170,25 @@ def test_transcribe_forwards_recovery_decoding_options(
 def test_transcribe_logs_when_decoding_window_reaches_token_limit(
     monkeypatch: MonkeyPatch, caplog: LogCaptureFixture
 ):
-    """Log when a Whisper decoding window consumes its full token budget."""
+    """Log exhausted decoder state even when Whisper discards the unfinished tail."""
     caplog.set_level(
         "INFO", logger="scinoephile.audio.transcription.whisper_transcriber"
     )
-    transcribe = Mock(
-        return_value={
+    decode = Mock(
+        side_effect=[
+            SimpleNamespace(tokens=list(range(32))),
+            SimpleNamespace(tokens=list(range(32))),
+            SimpleNamespace(tokens=list(range(31))),
+        ]
+    )
+
+    def transcribe(model: Mock, *_args: object, **_kwargs: object) -> object:
+        """Decode two windows and discard the exhausted tail from returned segments."""
+        first_window = object()
+        model.decode(first_window, object())
+        model.decode(first_window, object())
+        model.decode(object(), object())
+        return {
             "segments": [
                 {
                     "id": 0,
@@ -183,40 +196,27 @@ def test_transcribe_logs_when_decoding_window_reaches_token_limit(
                     "start": 0.0,
                     "end": 0.5,
                     "text": "",
-                    "tokens": list(range(16)),
-                },
-                {
-                    "id": 1,
-                    "seek": 0,
-                    "start": 0.5,
-                    "end": 1.0,
-                    "text": "",
-                    "tokens": list(range(16)),
-                },
-                {
-                    "id": 2,
-                    "seek": 100,
-                    "start": 1.0,
-                    "end": 2.0,
-                    "text": "",
-                    "tokens": list(range(31)),
-                },
+                    "tokens": list(range(8)),
+                }
             ]
         }
-    )
+
+    model = Mock()
+    model.decode = decode
     transcriber = WhisperTranscriber(
         model_name="custom/model", demucs_mode=DemucsMode.OFF, vad_mode=VADMode.OFF
     )
-    transcriber._model = Mock()
+    transcriber._model = model
     monkeypatch.setattr(
         "scinoephile.audio.transcription.whisper_transcriber."
         "import_whisper_timestamped",
-        Mock(return_value=SimpleNamespace(transcribe=transcribe)),
+        Mock(return_value=SimpleNamespace(transcribe=Mock(side_effect=transcribe))),
     )
     audio = AudioSegment.silent(duration=1000)
 
     transcriber(audio)
 
+    assert model.decode is decode
     limit_record = next(
         record
         for record in caplog.records

--- a/test/audio/transcription/test_whisper_transcriber.py
+++ b/test/audio/transcription/test_whisper_transcriber.py
@@ -15,7 +15,7 @@ from types import SimpleNamespace
 from unittest.mock import Mock
 
 from pydub import AudioSegment
-from pytest import MonkeyPatch, raises
+from pytest import LogCaptureFixture, MonkeyPatch, raises
 
 from scinoephile.audio.transcription import (
     DemucsMode,
@@ -129,8 +129,13 @@ def test_get_cache_path_accepts_list_temperature_schedule(tmp_path: Path):
     )
 
 
-def test_transcribe_forwards_recovery_decoding_options(monkeypatch: MonkeyPatch):
+def test_transcribe_forwards_recovery_decoding_options(
+    monkeypatch: MonkeyPatch, caplog: LogCaptureFixture
+):
     """Test Whisper receives configured defensive decoding options."""
+    caplog.set_level(
+        "DEBUG", logger="scinoephile.audio.transcription.whisper_transcriber"
+    )
     transcribe = Mock(return_value={"segments": []})
     temperatures = (0.0, 0.2, 0.4)
     transcriber = WhisperTranscriber(
@@ -153,6 +158,72 @@ def test_transcribe_forwards_recovery_decoding_options(monkeypatch: MonkeyPatch)
     assert transcribe.call_args.kwargs["temperature"] == temperatures
     assert transcribe.call_args.kwargs["condition_on_previous_text"] is False
     assert transcribe.call_args.kwargs["sample_len"] == 32
+    budget_record = next(
+        record
+        for record in caplog.records
+        if "Whisper decoding budget per window" in record.message
+    )
+    assert budget_record.levelname == "DEBUG"
+    assert not any("Whisper reached its" in record.message for record in caplog.records)
+
+
+def test_transcribe_logs_when_decoding_window_reaches_token_limit(
+    monkeypatch: MonkeyPatch, caplog: LogCaptureFixture
+):
+    """Log when a Whisper decoding window consumes its full token budget."""
+    caplog.set_level(
+        "INFO", logger="scinoephile.audio.transcription.whisper_transcriber"
+    )
+    transcribe = Mock(
+        return_value={
+            "segments": [
+                {
+                    "id": 0,
+                    "seek": 0,
+                    "start": 0.0,
+                    "end": 0.5,
+                    "text": "",
+                    "tokens": list(range(16)),
+                },
+                {
+                    "id": 1,
+                    "seek": 0,
+                    "start": 0.5,
+                    "end": 1.0,
+                    "text": "",
+                    "tokens": list(range(16)),
+                },
+                {
+                    "id": 2,
+                    "seek": 100,
+                    "start": 1.0,
+                    "end": 2.0,
+                    "text": "",
+                    "tokens": list(range(31)),
+                },
+            ]
+        }
+    )
+    transcriber = WhisperTranscriber(
+        model_name="custom/model", demucs_mode=DemucsMode.OFF, vad_mode=VADMode.OFF
+    )
+    transcriber._model = Mock()
+    monkeypatch.setattr(
+        "scinoephile.audio.transcription.whisper_transcriber."
+        "import_whisper_timestamped",
+        Mock(return_value=SimpleNamespace(transcribe=transcribe)),
+    )
+    audio = AudioSegment.silent(duration=1000)
+
+    transcriber(audio)
+
+    limit_record = next(
+        record
+        for record in caplog.records
+        if "Whisper reached its 32-token decoding limit" in record.message
+    )
+    assert limit_record.levelname == "INFO"
+    assert "affected windows: 1" in limit_record.message
 
 
 @parametrize(


### PR DESCRIPTION
## What changed

- Move the routine per-window Whisper decoding-budget message from INFO to DEBUG.
- Inspect each OpenAI Whisper `DecodingResult` before whisper-timestamped constructs segments, and log at INFO when one or more unique decode windows consume the configured token budget.
- Count repeated temperature/fallback attempts for the same decode window only once.
- Add focused regression coverage for both the normal quiet path and an exhausted window whose unfinished tail is discarded from the returned segments.

## Why

The previous INFO message said Whisper was “limiting” decoding on every successful transcription, even when no window approached the budget. That sounded like an exceptional truncation event and made routine runs unnecessarily noisy.

Inferring exhaustion from returned segment tokens was incomplete because OpenAI Whisper can discard an unfinished tail after retaining completed timestamp-delimited segments. The selected decoder result still preserves the full sampled-token count, so inspecting it before segmentation reliably identifies the exceptional case.

## Impact

Normal Whisper transcription no longer emits an INFO-level budget warning. Operators still get an actionable INFO message, including the number of affected windows, when decoding reaches the configured limit. The decoding budget and transcription behavior themselves are unchanged.

## Checks

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/audio/transcription/whisper_transcriber.py test/audio/transcription/test_whisper_transcriber.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/audio/transcription/whisper_transcriber.py test/audio/transcription/test_whisper_transcriber.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/audio/transcription/whisper_transcriber.py test/audio/transcription/test_whisper_transcriber.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q test/audio/transcription/test_whisper_transcriber.py` — 29 passed
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` — 2,101 passed, 4 skipped
