### PR TITLE
Default transcription VAD to off

### DIFF
--- a/scinoephile/audio/transcription/mlx_audio/transcriber.py
+++ b/scinoephile/audio/transcription/mlx_audio/transcriber.py
@@ -82,7 +82,7 @@ class MlxAudioTranscriber(Transcriber):
         chunk_duration_seconds: float | None = None,
         chunk_overlap_seconds: float = 1.0,
         demucs_mode: DemucsMode = DemucsMode.AUTO,
-        vad_mode: VADMode = VADMode.AUTO,
+        vad_mode: VADMode = VADMode.OFF,
         cache_root_path: Path | None = None,
         overwrite_cache: bool = False,
         demucs_separator: DemucsSeparator | None = None,

--- a/scinoephile/audio/transcription/transcriber.py
+++ b/scinoephile/audio/transcription/transcriber.py
@@ -43,7 +43,7 @@ class Transcriber(ABC):
         self,
         cache_root_path: Path | None,
         demucs_mode: DemucsMode = DemucsMode.AUTO,
-        vad_mode: VADMode = VADMode.AUTO,
+        vad_mode: VADMode = VADMode.OFF,
         overwrite_cache: bool = False,
         demucs_separator: DemucsSeparator | None = None,
     ):

--- a/scinoephile/audio/transcription/whisper_transcriber.py
+++ b/scinoephile/audio/transcription/whisper_transcriber.py
@@ -65,7 +65,7 @@ class WhisperTranscriber(Transcriber):
         model_name: str = "khleeloo/whisper-large-v3-cantonese",
         language: str = "yue",
         demucs_mode: DemucsMode = DemucsMode.AUTO,
-        vad_mode: VADMode = VADMode.AUTO,
+        vad_mode: VADMode = VADMode.OFF,
         cache_root_path: Path | None = None,
         overwrite_cache: bool = False,
         temperature: float | Sequence[float] = 0.0,

--- a/scinoephile/cli/transcribe_cli.py
+++ b/scinoephile/cli/transcribe_cli.py
@@ -222,7 +222,7 @@ class TranscribeCli(ScinoephileCliBase):
         )
         arg_groups["operation arguments"].add_argument(
             "--vad",
-            default=VADMode.AUTO,
+            default=VADMode.OFF,
             dest="vad_mode",
             metavar=enum_metavar(VADMode),
             type=enum_arg(VADMode),

--- a/scinoephile/lang/transcription/guided.py
+++ b/scinoephile/lang/transcription/guided.py
@@ -186,7 +186,7 @@ def get_guided_transcriber(
     model_name: str | None = None,
     backend: TranscriptionBackend = TranscriptionBackend.WHISPER,
     demucs_mode: DemucsMode = DemucsMode.AUTO,
-    vad_mode: VADMode = VADMode.AUTO,
+    vad_mode: VADMode = VADMode.OFF,
     cache_root_path: Path | None = None,
     overwrite_cache: bool = False,
     provider: LLMProvider | None = None,

--- a/scinoephile/lang/transcription/transcriber.py
+++ b/scinoephile/lang/transcription/transcriber.py
@@ -82,7 +82,7 @@ class GuidedTranscriber:
         aligner: TranscriptionAligner,
         backend: TranscriptionBackend = TranscriptionBackend.WHISPER,
         demucs_mode: DemucsMode = DemucsMode.AUTO,
-        vad_mode: VADMode = VADMode.AUTO,
+        vad_mode: VADMode = VADMode.OFF,
         cache_root_path: Path | None = None,
         overwrite_cache: bool = False,
         mlx_audio_transcriber: MlxAudioTranscriber | None = None,

--- a/scinoephile/workflows/transcription.py
+++ b/scinoephile/workflows/transcription.py
@@ -33,7 +33,7 @@ def transcribe_series_guided(
     model_name: str | None = None,
     backend: TranscriptionBackend = TranscriptionBackend.WHISPER,
     demucs_mode: DemucsMode = DemucsMode.AUTO,
-    vad_mode: VADMode = VADMode.AUTO,
+    vad_mode: VADMode = VADMode.OFF,
     cache_root_path: Path | None = None,
     overwrite_cache: bool = False,
     provider: LLMProvider | None = None,

--- a/test/audio/transcription/mlx_audio/test_mlx_audio_transcriber.py
+++ b/test/audio/transcription/mlx_audio/test_mlx_audio_transcriber.py
@@ -58,12 +58,12 @@ def _get_cache_path(
     return cache_path
 
 
-def test_init_defaults_preprocessing_to_auto():
-    """Test MLX-Audio defaults both preprocessing dimensions to automatic."""
+def test_init_defaults_demucs_to_auto_and_vad_to_off():
+    """Test MLX-Audio defaults Demucs to automatic and VAD to off."""
     transcriber = MlxAudioTranscriber()
 
     assert transcriber.demucs_mode is DemucsMode.AUTO
-    assert transcriber.vad_mode is VADMode.AUTO
+    assert transcriber.vad_mode is VADMode.OFF
 
 
 def test_get_cache_path_separates_model_configuration():

--- a/test/audio/transcription/test_whisper_transcriber.py
+++ b/test/audio/transcription/test_whisper_transcriber.py
@@ -41,12 +41,12 @@ _OPTIONAL_TRANSCRIPTION_MODULES = (
 )
 
 
-def test_init_defaults_preprocessing_to_auto():
-    """Test Whisper defaults both preprocessing dimensions to automatic."""
+def test_init_defaults_demucs_to_auto_and_vad_to_off():
+    """Test Whisper defaults Demucs to automatic and VAD to off."""
     transcriber = WhisperTranscriber()
 
     assert transcriber.demucs_mode is DemucsMode.AUTO
-    assert transcriber.vad_mode is VADMode.AUTO
+    assert transcriber.vad_mode is VADMode.OFF
 
 
 def _get_cache_path(transcriber: WhisperTranscriber, audio: AudioSegment) -> Path:

--- a/test/cli/test_transcribe_cli.py
+++ b/test/cli/test_transcribe_cli.py
@@ -100,8 +100,8 @@ def test_transcribe_cli_defers_whisper_model_default_to_registry():
     assert model_action.default is None
 
 
-def test_transcribe_cli_defaults_audio_preprocessing_to_auto():
-    """Test transcription CLI defaults Demucs and VAD to automatic modes."""
+def test_transcribe_cli_defaults_demucs_to_auto_and_vad_to_off():
+    """Test transcription CLI defaults Demucs to automatic and disables VAD."""
     parser = TranscribeCli.argparser()
     demucs_action = next(
         action
@@ -115,7 +115,7 @@ def test_transcribe_cli_defaults_audio_preprocessing_to_auto():
     )
 
     assert demucs_action.default is DemucsMode.AUTO
-    assert vad_action.default is VADMode.AUTO
+    assert vad_action.default is VADMode.OFF
 
 
 def test_transcribe_cli_writes_file(audio_series: Mock, expected_series: Series):

--- a/test/lang/transcription/test_guided.py
+++ b/test/lang/transcription/test_guided.py
@@ -92,7 +92,7 @@ def test_get_guided_transcriber_uses_registered_language_configuration(tmp_path)
     assert transcriber.guide_language is Language.zho_hans
     assert transcriber.backend is TranscriptionBackend.WHISPER
     assert transcriber.demucs_mode is DemucsMode.AUTO
-    assert transcriber.vad_mode is VADMode.AUTO
+    assert transcriber.vad_mode is VADMode.OFF
     assert not hasattr(transcriber, "overwrite_cache")
     assert not hasattr(transcriber, "cache_root_path")
     assert transcriber.whisper_language == "yue"
@@ -107,7 +107,7 @@ def test_get_guided_transcriber_uses_registered_language_configuration(tmp_path)
     )
     assert transcriber.transcriber.language == "yue"
     assert transcriber.transcriber.demucs_mode is DemucsMode.AUTO
-    assert transcriber.transcriber.vad_mode is VADMode.AUTO
+    assert transcriber.transcriber.vad_mode is VADMode.OFF
     assert transcriber.recovery_transcriber is not None
     assert transcriber.tail_recovery_transcriber is not None
     assert not hasattr(transcriber.transcriber, "cache_root_path")
@@ -174,7 +174,7 @@ def test_get_guided_transcriber_configures_mlx_audio_backend(tmp_path: Path):
         model_name=MIMO_MODEL_NAME,
         language=Language.yue_hant,
         demucs_mode=DemucsMode.AUTO,
-        vad_mode=VADMode.AUTO,
+        vad_mode=VADMode.OFF,
         cache_root_path=tmp_path,
         overwrite_cache=False,
     )

--- a/test/workflows/test_transcription.py
+++ b/test/workflows/test_transcription.py
@@ -55,7 +55,7 @@ def test_transcribe_series_guided_constructs_transcriber_for_language_pair(
     assert output is expected
     assert get_transcriber.call_args.args == (Language.yue_hant, Language.zho_hans)
     assert get_transcriber.call_args.kwargs["demucs_mode"] is DemucsMode.AUTO
-    assert get_transcriber.call_args.kwargs["vad_mode"] is VADMode.AUTO
+    assert get_transcriber.call_args.kwargs["vad_mode"] is VADMode.OFF
     assert get_transcriber.call_args.kwargs["backend"] is (
         TranscriptionBackend.MLX_AUDIO
     )


### PR DESCRIPTION
## Summary

- default voice activity detection to `off` in base, Whisper, MLX-Audio, guided transcription, workflow, and CLI entry points
- retain `auto` and `on` as explicit supported modes with their existing fallback behavior
- update focused tests to assert the new defaults across construction layers

## Why

Guided Cantonese transcription experiments found VAD to be a net accuracy loss. Making the unfiltered audio path the default avoids that regression while preserving VAD for explicit use and future unguided transcription work.

## Impact

Existing callers that omit `vad_mode` now transcribe without VAD. Callers that require the previous behavior can pass `VADMode.AUTO` or `--vad auto`; forced VAD remains available through `VADMode.ON` or `--vad on`.

## Checks

- `uv run ruff format` on changed Python files
- `uv run ruff check --fix` on changed Python files
- `uv run ty check` on changed Python files
- focused transcription and CLI tests: 93 passed
- full test suite: 2,192 passed, 4 skipped