### PR TITLE
Fix transcription retry caching

### DIFF
--- a/scinoephile/audio/transcription/__init__.py
+++ b/scinoephile/audio/transcription/__init__.py
@@ -20,6 +20,7 @@ from .ctc_aligner import CtcAligner
 from .demucs import DemucsSeparator
 from .exceptions import (
     TranscriptionAlignmentError,
+    TranscriptionAlignmentIncompleteError,
     TranscriptionEmptyError,
     TranscriptionError,
     TranscriptionInferenceError,
@@ -44,6 +45,7 @@ __all__ = [
     "TranscribedWord",
     "Transcriber",
     "TranscriptionAlignmentError",
+    "TranscriptionAlignmentIncompleteError",
     "TranscriptionCache",
     "TranscriptionEmptyError",
     "TranscriptionError",

--- a/scinoephile/audio/transcription/ctc_aligner.py
+++ b/scinoephile/audio/transcription/ctc_aligner.py
@@ -17,7 +17,10 @@ from scinoephile.core.dependencies.transcription import (
     import_transformers,
 )
 
-from .exceptions import TranscriptionAlignmentError
+from .exceptions import (
+    TranscriptionAlignmentError,
+    TranscriptionAlignmentIncompleteError,
+)
 from .transcribed_segment import TranscribedSegment
 from .transcribed_word import TranscribedWord
 
@@ -407,7 +410,9 @@ class CtcAligner:
         # Select the best completed alignment
         final_column = trellis[:, alignment_token_count]
         if np.all(np.isneginf(final_column)):
-            raise TranscriptionAlignmentError("CTC alignment did not reach all tokens.")
+            raise TranscriptionAlignmentIncompleteError(
+                "CTC alignment did not reach all tokens."
+            )
         frame_idx = int(np.argmax(final_column))
 
         # Backtrack through the trellis to recover token frame spans

--- a/scinoephile/audio/transcription/exceptions.py
+++ b/scinoephile/audio/transcription/exceptions.py
@@ -8,6 +8,7 @@ from scinoephile.core.exceptions import ScinoephileError
 
 __all__ = [
     "TranscriptionAlignmentError",
+    "TranscriptionAlignmentIncompleteError",
     "TranscriptionEmptyError",
     "TranscriptionError",
     "TranscriptionInferenceError",
@@ -20,6 +21,10 @@ class TranscriptionError(ScinoephileError):
 
 class TranscriptionAlignmentError(TranscriptionError):
     """Raised when transcription output cannot be timestamp-aligned."""
+
+
+class TranscriptionAlignmentIncompleteError(TranscriptionAlignmentError):
+    """Raised when CTC alignment cannot consume every transcript token."""
 
 
 class TranscriptionEmptyError(TranscriptionError):

--- a/scinoephile/audio/transcription/mlx_audio/transcriber.py
+++ b/scinoephile/audio/transcription/mlx_audio/transcriber.py
@@ -16,6 +16,7 @@ from scinoephile.audio.transcription.ctc_aligner import CtcAligner
 from scinoephile.audio.transcription.demucs import DemucsSeparator
 from scinoephile.audio.transcription.exceptions import (
     TranscriptionAlignmentError,
+    TranscriptionAlignmentIncompleteError,
     TranscriptionEmptyError,
     TranscriptionError,
     TranscriptionInferenceError,
@@ -287,36 +288,39 @@ class MlxAudioTranscriber(Transcriber):
                 raise TranscriptionEmptyError("MLX-Audio returned empty transcript.")
             content_characters = {char for char in text if char.isalnum()}
             if content_characters and content_characters <= _LOW_INFORMATION_CHARACTERS:
-                raise TranscriptionError(
+                raise TranscriptionEmptyError(
                     f"MLX-Audio returned only low-information vocalizations: {text!r}"
                 )
             return self.ctc_aligner(audio, text)
 
-    def _transcribe_audio_window_with_token_retry(
+    def _transcribe_audio_window_with_retry(
         self, audio: AudioSegment
     ) -> list[TranscribedSegment]:
-        """Transcribe a window, splitting it when generation exhausts its token limit.
+        """Transcribe a window, splitting it after recoverable length failures.
 
         Arguments:
             audio: audio window to transcribe
         Returns:
             timestamped transcription segments
         Raises:
-            TranscriptionInferenceError: if a one-millisecond window still exhausts
-                the generation token limit
+            TranscriptionError: if a one-millisecond window still fails
         """
         try:
             return self._transcribe_audio_window(audio)
-        except _MlxAudioTokenLimitError:
+        except (_MlxAudioTokenLimitError, TranscriptionAlignmentIncompleteError) as exc:
             if len(audio) <= 1:
                 raise
+            if isinstance(exc, _MlxAudioTokenLimitError):
+                retry_reason = "generation token exhaustion"
+            else:
+                retry_reason = "incomplete CTC alignment"
 
         chunk_duration_ms = max(1, len(audio) // 2)
         maximum_overlap_ms = max(0, (chunk_duration_ms - 1) // 2)
         configured_overlap_ms = int(round(self.chunk_overlap_seconds * 1000))
         chunk_overlap_ms = min(configured_overlap_ms, maximum_overlap_ms)
         logger.info(
-            "Retrying MLX-Audio after generation token exhaustion with "
+            f"Retrying MLX-Audio after {retry_reason} with "
             f"{chunk_duration_ms / 1000:.3f}s chunks"
         )
         return self._transcribe_chunked_audio(
@@ -343,9 +347,7 @@ class MlxAudioTranscriber(Transcriber):
             window_end_ms = min(len(audio), core_end_ms + chunk_overlap_ms)
             window_audio = audio[window_start_ms:window_end_ms]
             try:
-                window_segments = self._transcribe_audio_window_with_token_retry(
-                    window_audio
-                )
+                window_segments = self._transcribe_audio_window_with_retry(window_audio)
             except TranscriptionEmptyError:
                 logger.info(
                     f"Skipping empty MLX-Audio audio window "
@@ -379,10 +381,10 @@ class MlxAudioTranscriber(Transcriber):
             timestamped transcription segments
         """
         if self.chunk_duration_seconds is None:
-            return self._transcribe_audio_window_with_token_retry(audio)
+            return self._transcribe_audio_window_with_retry(audio)
         chunk_duration_ms = int(round(self.chunk_duration_seconds * 1000))
         if len(audio) <= chunk_duration_ms:
-            return self._transcribe_audio_window_with_token_retry(audio)
+            return self._transcribe_audio_window_with_retry(audio)
         chunk_overlap_ms = int(round(self.chunk_overlap_seconds * 1000))
         return self._transcribe_chunked_audio(
             audio, chunk_duration_ms, chunk_overlap_ms

--- a/scinoephile/audio/transcription/transcriber.py
+++ b/scinoephile/audio/transcription/transcriber.py
@@ -14,7 +14,7 @@ from scinoephile.core.exceptions import ScinoephileError
 
 from .cache import TranscriptionCache
 from .demucs import DemucsSeparator
-from .exceptions import TranscriptionError
+from .exceptions import TranscriptionEmptyError, TranscriptionError
 from .preprocessing_settings import (
     DemucsMode,
     TranscriptionPreprocessingSettings,
@@ -144,15 +144,12 @@ class Transcriber(ABC):
         if segments is not None:
             return segments
 
-        # Skip rejected intermediate caches but rerun the final fallback
+        # Run only configurations that do not already have a rejected cache
         settings_to_run = [
             settings
             for settings in preprocessing_settings
             if settings not in rejected_settings
         ]
-        final_settings = preprocessing_settings[-1]
-        if final_settings not in settings_to_run:
-            settings_to_run.append(final_settings)
 
         # Run Demucs once if any remaining configuration requires separated audio
         separated_audio = None
@@ -189,7 +186,7 @@ class Transcriber(ABC):
                 continue
             cache_path, segments = cached_transcription
             segments = self._prepare_cached_segments(segments, cache_path, settings)
-            if is_usable is None or is_usable(segments):
+            if segments and (is_usable is None or is_usable(segments)):
                 return segments, rejected_settings
             rejected_settings.add(settings)
         return None, rejected_settings
@@ -326,6 +323,11 @@ class Transcriber(ABC):
                 logger.info(f"Retrying {self.backend_label} without VAD")
             try:
                 segments = self._transcribe_attempt(transcription_audio, settings)
+            except TranscriptionEmptyError as exc:
+                logger.warning(f"{self.backend_label} attempt failed: {exc}")
+                self._cache.save(audio, self._get_cache_metadata(settings), [])
+                last_error = exc
+                continue
             except TranscriptionError as exc:
                 logger.warning(f"{self.backend_label} attempt failed: {exc}")
                 last_error = exc

--- a/test/audio/transcription/mlx_audio/test_mlx_audio_transcriber.py
+++ b/test/audio/transcription/mlx_audio/test_mlx_audio_transcriber.py
@@ -16,6 +16,8 @@ from scinoephile.audio.transcription import (
     DemucsMode,
     TranscribedSegment,
     TranscribedWord,
+    TranscriptionAlignmentError,
+    TranscriptionAlignmentIncompleteError,
     TranscriptionEmptyError,
     TranscriptionError,
     TranscriptionInferenceError,
@@ -395,6 +397,62 @@ def test_transcribe_splits_audio_after_generation_token_exhaustion(
     assert [segment.end for segment in segments] == pytest.approx([2.0, 4.0])
 
 
+def test_transcribe_splits_audio_after_incomplete_ctc_alignment(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test incomplete CTC paths are retried over smaller audio windows."""
+    audio = AudioSegment.silent(duration=4000)
+    transcriber = MlxAudioTranscriber(
+        demucs_mode=DemucsMode.OFF, vad_mode=VADMode.OFF, chunk_overlap_seconds=0.0
+    )
+    backend_transcribe = Mock(
+        side_effect=[
+            MlxAudioInferenceResult(text="whole"),
+            MlxAudioInferenceResult(text="one"),
+            MlxAudioInferenceResult(text="two"),
+        ]
+    )
+    transcriber.ctc_aligner = Mock(
+        model_name="ctc/test-model",
+        side_effect=[
+            TranscriptionAlignmentIncompleteError(
+                "CTC alignment did not reach all tokens."
+            ),
+            [_get_timed_segment("one", end=2.0)],
+            [_get_timed_segment("two", end=2.0)],
+        ],
+    )
+    monkeypatch.setattr(transcriber.backend, "transcribe", backend_transcribe)
+
+    segments = transcriber.transcribe(audio)
+
+    assert backend_transcribe.call_count == 3
+    assert transcriber.ctc_aligner.call_count == 3
+    assert [segment.text for segment in segments] == ["one", "two"]
+    assert [segment.start for segment in segments] == pytest.approx([0.0, 2.0])
+    assert [segment.end for segment in segments] == pytest.approx([2.0, 4.0])
+
+
+def test_transcribe_does_not_split_audio_after_other_ctc_errors(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test non-length CTC failures propagate without recursive retries."""
+    audio = AudioSegment.silent(duration=4000)
+    transcriber = MlxAudioTranscriber(demucs_mode=DemucsMode.OFF, vad_mode=VADMode.OFF)
+    backend_transcribe = Mock(return_value=MlxAudioInferenceResult(text="whole"))
+    transcriber.ctc_aligner = Mock(
+        model_name="ctc/test-model",
+        side_effect=TranscriptionAlignmentError("CTC backend unavailable."),
+    )
+    monkeypatch.setattr(transcriber.backend, "transcribe", backend_transcribe)
+
+    with pytest.raises(TranscriptionAlignmentError, match="backend unavailable"):
+        transcriber.transcribe(audio)
+
+    backend_transcribe.assert_called_once()
+    transcriber.ctc_aligner.assert_called_once()
+
+
 def test_transcribe_chunks_audio_skips_empty_windows(monkeypatch: pytest.MonkeyPatch):
     """Test an empty chunk does not discard speech from other chunks."""
     audio = AudioSegment.silent(duration=4500)
@@ -554,7 +612,7 @@ def test_transcribe_rejects_low_information_vocalizations(
     )
     transcriber.ctc_aligner = Mock(model_name="ctc/test-model")
 
-    with pytest.raises(TranscriptionError, match="low-information"):
+    with pytest.raises(TranscriptionEmptyError, match="low-information"):
         transcriber.transcribe(AudioSegment.silent(duration=1000))
 
     transcriber.ctc_aligner.assert_not_called()

--- a/test/audio/transcription/test_ctc_aligner.py
+++ b/test/audio/transcription/test_ctc_aligner.py
@@ -12,7 +12,11 @@ import numpy as np
 import pytest
 from pydub import AudioSegment
 
-from scinoephile.audio.transcription import CtcAligner, TranscriptionAlignmentError
+from scinoephile.audio.transcription import (
+    CtcAligner,
+    TranscriptionAlignmentError,
+    TranscriptionAlignmentIncompleteError,
+)
 from scinoephile.core import Language
 
 
@@ -153,7 +157,9 @@ def test_ctc_best_path_requires_blank_between_repeated_labels():
     """Test adjacent repeated labels cannot advance on consecutive frames."""
     log_probs = np.log(np.array([[0.01, 0.99], [0.01, 0.99]]))
 
-    with pytest.raises(TranscriptionAlignmentError, match="did not reach all tokens"):
+    with pytest.raises(
+        TranscriptionAlignmentIncompleteError, match="did not reach all tokens"
+    ):
         CtcAligner._get_best_path(log_probs, [1, 1], 0)
 
 

--- a/test/audio/transcription/test_transcription_transcriber.py
+++ b/test/audio/transcription/test_transcription_transcriber.py
@@ -16,6 +16,7 @@ from scinoephile.audio.transcription import (
     TranscribedSegment,
     Transcriber,
     TranscriptionCache,
+    TranscriptionEmptyError,
     TranscriptionError,
     TranscriptionInferenceError,
     TranscriptionPreprocessingSettings,
@@ -197,8 +198,8 @@ def test_rejected_cached_configuration_is_not_repeated(tmp_path: Path):
     assert transcriber.calls == [(audio, no_vad_settings)]
 
 
-def test_rejected_cached_final_configuration_is_retried(tmp_path: Path):
-    """Test rejected final cache output receives a fresh transcription attempt.
+def test_rejected_cached_final_configuration_is_not_repeated(tmp_path: Path):
+    """Test rejected final cache output prevents repeated transcription.
 
     Arguments:
         tmp_path: temporary directory provided by pytest
@@ -214,9 +215,51 @@ def test_rejected_cached_final_configuration_is_retried(tmp_path: Path):
 
     segments = transcriber(audio, is_usable=lambda value: value[0].text == "good")
 
-    assert segments == [_get_segment("good")]
-    transcriber.demucs_separator.assert_called_once_with(audio)
-    assert transcriber.calls == [(audio, settings)]
+    assert segments == []
+    transcriber.demucs_separator.assert_not_called()
+    assert transcriber.calls == []
+
+
+def test_empty_failures_are_cached(tmp_path: Path):
+    """Test completed attempts without usable speech are not repeated.
+
+    Arguments:
+        tmp_path: temporary directory provided by pytest
+    """
+    audio = AudioSegment.silent(duration=100)
+    vad_settings = TranscriptionPreprocessingSettings(False, True)
+    no_vad_settings = TranscriptionPreprocessingSettings(False, False)
+    transcriber = _TestTranscriber(tmp_path, DemucsMode.OFF, VADMode.AUTO)
+    transcriber.outcomes[vad_settings] = TranscriptionEmptyError("no VAD speech")
+    transcriber.outcomes[no_vad_settings] = TranscriptionEmptyError("empty transcript")
+
+    with raises(TranscriptionEmptyError, match="empty transcript"):
+        transcriber(audio, is_usable=bool)
+
+    expected_calls = [(audio, vad_settings), (audio, no_vad_settings)]
+    assert transcriber.calls == expected_calls
+    assert transcriber(audio) == []
+    assert transcriber.calls == expected_calls
+
+
+def test_cached_empty_attempt_does_not_shadow_cached_fallback(tmp_path: Path):
+    """Test an empty preferred cache advances to a successful fallback.
+
+    Arguments:
+        tmp_path: temporary directory provided by pytest
+    """
+    audio = AudioSegment.silent(duration=100)
+    vad_settings = TranscriptionPreprocessingSettings(False, True)
+    no_vad_settings = TranscriptionPreprocessingSettings(False, False)
+    expected_segments = [_get_segment("fallback")]
+    transcriber = _TestTranscriber(tmp_path, DemucsMode.OFF, VADMode.AUTO)
+    transcriber._cache.save(audio, transcriber._get_cache_metadata(vad_settings), [])
+    transcriber._cache.save(
+        audio, transcriber._get_cache_metadata(no_vad_settings), expected_segments
+    )
+
+    assert transcriber(audio) == expected_segments
+    assert transcriber.calls == []
 
 
 def test_rejected_cached_configuration_takes_precedence_over_other_error(


### PR DESCRIPTION
## Root cause

MLX-Audio treated every CTC alignment failure alike, so a transcript that was simply too long for the available CTC frames could not recover by using smaller windows. Separately, empty and caller-rejected transcription attempts were not consistently treated as durable negative cache results: empty failures were never saved, and the final rejected fallback was deliberately rerun on every invocation.

## Behavior

- Add `TranscriptionAlignmentIncompleteError` to distinguish a CTC path that cannot consume every transcript token from other alignment failures.
- Recursively split MLX-Audio windows after generation-token exhaustion or incomplete CTC alignment; unrelated CTC failures still propagate.
- Classify low-information-only MLX-Audio vocalizations as empty output.
- Persist empty attempts as empty cache entries and skip every configuration with a known rejected cache, including the final fallback.
- Treat cached empty entries as negative results so they do not hide a later successful fallback cache.

## Impact

Long MLX-Audio transcripts can recover timing alignment over smaller windows, while known-empty or unusable attempts no longer repeat expensive model inference indefinitely. Existing VAD defaults, phrase timing, punctuation handling, and block-alignment behavior are unchanged.

## Checks

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format` on changed Python files
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix` on changed Python files
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check` on changed Python files
- Focused transcription tests: 74 passed
- Full suite: 2,196 passed, 4 skipped