### PR TITLE
Add MLX phrase timing to guided transcription

### DIFF
--- a/scinoephile/audio/transcription/__init__.py
+++ b/scinoephile/audio/transcription/__init__.py
@@ -54,6 +54,7 @@ __all__ = [
     "get_segment_merged",
     "get_segment_split_at_idx",
     "get_segment_split_on_whitespace",
+    "get_segment_split_on_word_timings",
 ]
 
 logger = getLogger(__name__)
@@ -224,3 +225,32 @@ def get_segment_split_on_whitespace(
         split_segments.append(nascent_segment)
 
     return split_segments
+
+
+def get_segment_split_on_word_timings(
+    segment: TranscribedSegment,
+) -> list[TranscribedSegment]:
+    """Split a transcribed segment into its individually timed words.
+
+    Arguments:
+        segment: transcribed segment to split
+    Returns:
+        transcribed segments split using word timings
+    """
+    if not segment.words:
+        return [segment]
+
+    return [
+        segment.model_copy(
+            update={
+                "id": word_idx,
+                "start": word.start,
+                "end": word.end,
+                "text": word.text,
+                "words": [word.model_copy(deep=True)],
+            },
+            deep=True,
+        )
+        for word_idx, word in enumerate(segment.words)
+        if word.text
+    ]

--- a/scinoephile/lang/transcription/__init__.py
+++ b/scinoephile/lang/transcription/__init__.py
@@ -14,11 +14,12 @@ from __future__ import annotations
 from .aligner import TranscriptionAligner
 from .alignment import TranscriptionAlignment
 from .guided import GuidedTranscriptionSpec, TranscriptionLanguageSpec
-from .transcriber import GuidedTranscriber, TranscriptionBackend
+from .transcriber import GuidedTranscriber, MlxAudioTimingMode, TranscriptionBackend
 
 __all__ = [
     "GuidedTranscriber",
     "GuidedTranscriptionSpec",
+    "MlxAudioTimingMode",
     "TranscriptionAligner",
     "TranscriptionAlignment",
     "TranscriptionBackend",

--- a/scinoephile/lang/transcription/guided.py
+++ b/scinoephile/lang/transcription/guided.py
@@ -42,6 +42,7 @@ from scinoephile.llms.punctuation import (
 from .aligner import TranscriptionAligner
 from .transcriber import (
     GuidedTranscriber,
+    MlxAudioTimingMode,
     TranscribedSegmentSplitter,
     TranscriptionBackend,
 )
@@ -189,6 +190,8 @@ def get_guided_transcriber(
     vad_mode: VADMode = VADMode.AUTO,
     cache_root_path: Path | None = None,
     overwrite_cache: bool = False,
+    strip_generated_punctuation: bool = False,
+    mlx_audio_timing_mode: MlxAudioTimingMode = MlxAudioTimingMode.CTC_UNIT,
     provider: LLMProvider | None = None,
     additional_context: str | None = None,
     no_op: bool = False,
@@ -211,6 +214,9 @@ def get_guided_transcriber(
         vad_mode: voice activity detection mode
         cache_root_path: cache root directory path
         overwrite_cache: whether to replace matching generated cache files
+        strip_generated_punctuation: whether to remove generated sentence
+            punctuation after timing and before guided alignment
+        mlx_audio_timing_mode: granularity of MLX-Audio CTC timing units
         provider: provider to use for LLM queries
         additional_context: additional context to include in LLM prompts
         no_op: use neutral answers instead of querying an LLM
@@ -320,5 +326,7 @@ def get_guided_transcriber(
         cache_root_path=cache_root_path,
         overwrite_cache=overwrite_cache,
         mlx_audio_transcriber=mlx_audio_transcriber,
+        mlx_audio_timing_mode=mlx_audio_timing_mode,
         segment_splitter=language_spec.segment_splitter,
+        strip_generated_punctuation=strip_generated_punctuation,
     )

--- a/scinoephile/lang/transcription/transcriber.py
+++ b/scinoephile/lang/transcription/transcriber.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 from enum import StrEnum
 from logging import getLogger
 from pathlib import Path
+from statistics import median
 
 from pydub import AudioSegment
 from pydub.effects import normalize
@@ -17,17 +18,26 @@ from scinoephile.audio.transcription import (
     DemucsMode,
     MlxAudioTranscriber,
     TranscribedSegment,
+    TranscribedWord,
     TranscriptionError,
     VADMode,
     WhisperTranscriber,
+    get_segment_split_at_idx,
+    get_segment_split_on_word_timings,
 )
 from scinoephile.common.validation import val_index_range
 from scinoephile.core import Language, ScinoephileError
 from scinoephile.core.subtitles import Series
+from scinoephile.core.text import FULL_PUNC_CHARS, HALF_PUNC_CHARS
 
 from .aligner import TranscriptionAligner
 
-__all__ = ["GuidedTranscriber", "TranscribedSegmentSplitter", "TranscriptionBackend"]
+__all__ = [
+    "GuidedTranscriber",
+    "MlxAudioTimingMode",
+    "TranscribedSegmentSplitter",
+    "TranscriptionBackend",
+]
 
 
 TranscribedSegmentSplitter = Callable[[TranscribedSegment], list[TranscribedSegment]]
@@ -59,6 +69,56 @@ _TAIL_RECOVERY_MAX_NO_SPEECH_PROBABILITY = 0.6
 _TAIL_RECOVERY_MAX_SECONDS_PER_CHARACTER = 1.5
 """Maximum duration per character accepted from focused tail recovery."""
 
+_LEXICAL_INFIX_PUNCTUATION = {
+    "'",
+    "-",
+    ".",
+    "/",
+    ":",
+    "‐",
+    "–",
+    "’",
+    "．",
+    "：",
+    "－",
+    "／",
+    "＇",
+    "﹣",
+}
+"""Punctuation preserved between ASCII alphanumeric characters."""
+
+_MLX_PHRASE_MAX_CHARACTERS = 12
+"""Maximum characters retained in one phrase-level MLX timing unit."""
+
+_MLX_PHRASE_MIN_CHARACTERS = 2
+"""Minimum preferred characters in one phrase-level MLX timing unit."""
+
+_MLX_PHRASE_PAUSE_RATIO = 2.5
+"""Median-duration multiple treated as phrase-final CTC hold time."""
+
+_MLX_PHRASE_PAUSE_SECONDS = 0.6
+"""Minimum absolute CTC hold time treated as phrase-final."""
+
+_MLX_PHRASE_TARGET_CHARACTERS = 7
+"""Preferred characters in one phrase-level MLX timing unit."""
+
+_MLX_PHRASE_STRONG_PUNCTUATION = set(".!?;。！？；…")
+"""Sentence punctuation treated as a strong phrase boundary."""
+
+_MLX_PHRASE_WEAK_PUNCTUATION = set(",:，：、")
+"""Clause punctuation treated as a weak phrase boundary."""
+
+
+class MlxAudioTimingMode(StrEnum):
+    """Granularity of CTC timing units exposed for MLX-Audio alignment."""
+
+    SEGMENT = "segment"
+    """Retain complete MLX-Audio transcription segments."""
+    PHRASE = "phrase"
+    """Group CTC timing units into pause- and punctuation-aware phrases."""
+    CTC_UNIT = "ctc-unit"
+    """Expose every individually timed CTC unit."""
+
 
 class TranscriptionBackend(StrEnum):
     """Audio transcription backends."""
@@ -86,7 +146,9 @@ class GuidedTranscriber:
         cache_root_path: Path | None = None,
         overwrite_cache: bool = False,
         mlx_audio_transcriber: MlxAudioTranscriber | None = None,
+        mlx_audio_timing_mode: MlxAudioTimingMode = MlxAudioTimingMode.CTC_UNIT,
         segment_splitter: TranscribedSegmentSplitter | None = None,
+        strip_generated_punctuation: bool = False,
     ):
         """Initialize.
 
@@ -102,7 +164,10 @@ class GuidedTranscriber:
             cache_root_path: cache root directory path
             overwrite_cache: whether to replace matching generated cache files
             mlx_audio_transcriber: configured MLX-Audio transcriber, when selected
+            mlx_audio_timing_mode: granularity of MLX-Audio CTC timing units
             segment_splitter: optional strategy for splitting transcribed segments
+            strip_generated_punctuation: whether to remove generated sentence
+                punctuation after timing and before guided alignment
         """
         self.language = language
         self.guide_language = guide_language
@@ -113,7 +178,9 @@ class GuidedTranscriber:
         self.demucs_mode = demucs_mode
         self.vad_mode = vad_mode
         self.mlx_audio_transcriber = mlx_audio_transcriber
+        self.mlx_audio_timing_mode = mlx_audio_timing_mode
         self.segment_splitter = segment_splitter
+        self.strip_generated_punctuation = strip_generated_punctuation
 
         # Use MLX-Audio's shared preprocessing fallbacks without Whisper recovery
         if self.backend is TranscriptionBackend.MLX_AUDIO:
@@ -246,9 +313,30 @@ class GuidedTranscriber:
             for segment in segments:
                 split_segments.extend(self.segment_splitter(segment))
 
+        # Expose the configured MLX-Audio timing granularity to guided alignment
+        if self.backend is TranscriptionBackend.MLX_AUDIO:
+            timed_segments = []
+            for segment in split_segments:
+                if self.mlx_audio_timing_mode is MlxAudioTimingMode.SEGMENT:
+                    timed_segments.append(segment)
+                elif self.mlx_audio_timing_mode is MlxAudioTimingMode.PHRASE:
+                    timed_segments.extend(_get_segment_split_on_phrase_timings(segment))
+                else:
+                    timed_segments.extend(get_segment_split_on_word_timings(segment))
+            split_segments = [
+                segment.model_copy(update={"id": segment_idx})
+                for segment_idx, segment in enumerate(timed_segments)
+            ]
+
         transcription_block = get_series_from_segments(
             split_segments, audio=audio_block.audio, offset=offset
         )
+        if self.strip_generated_punctuation:
+            for event in transcription_block.events:
+                event.text = _strip_generated_punctuation(event.text)
+            transcription_block.events = [
+                event for event in transcription_block.events if event.text.strip()
+            ]
         alignment = self.aligner.align(reference_block, transcription_block)
         return alignment.transcription
 
@@ -538,3 +626,136 @@ class GuidedTranscriber:
         if not has_text:
             logger.warning("Rejecting empty Whisper transcription")
         return has_text
+
+
+def _get_phrase_boundary_scores(
+    text: str,
+    words: list[TranscribedWord],
+    durations: list[float],
+    pause_threshold: float,
+) -> dict[int, int]:
+    """Score phrase boundaries using punctuation and CTC hold durations."""
+    boundary_scores: dict[int, int] = {}
+    for character_index, character in enumerate(text, 1):
+        if character in _MLX_PHRASE_STRONG_PUNCTUATION:
+            boundary_scores[character_index] = 4
+        elif character in _MLX_PHRASE_WEAK_PUNCTUATION:
+            boundary_scores[character_index] = 2
+
+    character_offset = 0
+    for word, duration in zip(words, durations, strict=True):
+        character_offset += len(word.text)
+        boundary_scores.setdefault(character_offset, 1)
+        if duration >= pause_threshold:
+            boundary_scores[character_offset] = max(
+                boundary_scores[character_offset], 3
+            )
+    return boundary_scores
+
+
+def _get_segment_split_on_phrase_timings(
+    segment: TranscribedSegment,
+) -> list[TranscribedSegment]:
+    """Split an MLX-Audio segment into phrase-sized CTC timing groups.
+
+    CTC blank frames are represented as held duration on neighboring timing units,
+    so unusually long unit durations provide pause evidence even when consecutive
+    units have no literal timestamp gap.
+
+    Arguments:
+        segment: CTC-aligned MLX-Audio segment
+    Returns:
+        transcribed segments grouped into phrase-level timing units
+    """
+    words = segment.words
+    if not words or len(segment.text) <= _MLX_PHRASE_MIN_CHARACTERS:
+        return [segment]
+    if "".join(word.text for word in words) != segment.text:
+        return [segment]
+
+    durations = [max(word.end - word.start, 0.0) for word in words]
+    pause_threshold = max(
+        _MLX_PHRASE_PAUSE_SECONDS, median(durations) * _MLX_PHRASE_PAUSE_RATIO
+    )
+    boundary_scores = _get_phrase_boundary_scores(
+        segment.text, words, durations, pause_threshold
+    )
+
+    # Select phrase boundaries while retaining short genuine utterances
+    split_offsets: list[int] = []
+    phrase_start = 0
+    text_length = len(segment.text)
+    while text_length - phrase_start > _MLX_PHRASE_MIN_CHARACTERS:
+        minimum_offset = phrase_start + _MLX_PHRASE_MIN_CHARACTERS
+        maximum_offset = min(
+            phrase_start + _MLX_PHRASE_MAX_CHARACTERS,
+            text_length - _MLX_PHRASE_MIN_CHARACTERS,
+        )
+        hard_offsets = [
+            offset
+            for offset, score in boundary_scores.items()
+            if minimum_offset <= offset <= maximum_offset and score >= 3
+        ]
+        if hard_offsets:
+            split_offset = min(hard_offsets)
+        elif text_length - phrase_start <= _MLX_PHRASE_MAX_CHARACTERS:
+            break
+        else:
+            candidate_offsets = [
+                offset
+                for offset in boundary_scores
+                if minimum_offset <= offset <= maximum_offset
+            ]
+            if candidate_offsets:
+                split_offset = max(
+                    candidate_offsets,
+                    key=lambda offset: (
+                        boundary_scores[offset],
+                        -abs(offset - phrase_start - _MLX_PHRASE_TARGET_CHARACTERS),
+                    ),
+                )
+            else:
+                split_offset = phrase_start + _MLX_PHRASE_TARGET_CHARACTERS
+        split_offsets.append(split_offset)
+        phrase_start = split_offset
+    if not split_offsets:
+        return [segment]
+
+    # Split through the existing character-aware timing helper
+    output: list[TranscribedSegment] = []
+    remaining = segment
+    previous_offset = 0
+    for split_offset in split_offsets:
+        first, remaining = get_segment_split_at_idx(
+            remaining, split_offset - previous_offset
+        )
+        output.append(first)
+        previous_offset = split_offset
+    output.append(remaining)
+    return output
+
+
+def _strip_generated_punctuation(text: str) -> str:
+    """Remove generated punctuation while retaining ASCII lexical infixes.
+
+    Arguments:
+        text: timed transcription text
+    Returns:
+        text without generated sentence punctuation
+    """
+    punctuation = HALF_PUNC_CHARS | FULL_PUNC_CHARS
+    output: list[str] = []
+    for index, character in enumerate(text):
+        if character not in punctuation:
+            output.append(character)
+            continue
+        if (
+            character in _LEXICAL_INFIX_PUNCTUATION
+            and 0 < index < len(text) - 1
+            and text[index - 1].isascii()
+            and text[index - 1].isalnum()
+            and text[index + 1].isascii()
+            and text[index + 1].isalnum()
+        ):
+            output.append(character)
+    return "".join(output)

--- a/scinoephile/lang/transcription/transcriber.py
+++ b/scinoephile/lang/transcription/transcriber.py
@@ -328,15 +328,17 @@ class GuidedTranscriber:
                 for segment_idx, segment in enumerate(timed_segments)
             ]
 
+        if self.strip_generated_punctuation:
+            split_segments = [
+                _get_segment_without_generated_punctuation(segment)
+                for segment in split_segments
+            ]
+            split_segments = [
+                segment for segment in split_segments if segment.text.strip()
+            ]
         transcription_block = get_series_from_segments(
             split_segments, audio=audio_block.audio, offset=offset
         )
-        if self.strip_generated_punctuation:
-            for event in transcription_block.events:
-                event.text = _strip_generated_punctuation(event.text)
-            transcription_block.events = [
-                event for event in transcription_block.events if event.text.strip()
-            ]
         alignment = self.aligner.align(reference_block, transcription_block)
         return alignment.transcription
 
@@ -653,6 +655,54 @@ def _get_phrase_boundary_scores(
     return boundary_scores
 
 
+def _get_segment_without_generated_punctuation(
+    segment: TranscribedSegment,
+) -> TranscribedSegment:
+    """Remove generated punctuation from segment text and word timing data.
+
+    Arguments:
+        segment: timed transcription segment
+    Returns:
+        segment whose text and word data use matching character offsets
+    """
+    keep_characters = _get_text_character_retention(segment.text)
+    text = _strip_generated_punctuation(segment.text)
+    if not segment.words:
+        return segment.model_copy(update={"text": text})
+
+    # Apply the segment-level retention map to its corresponding timed words
+    word_text = "".join(word.text for word in segment.words)
+    if word_text == segment.text:
+        words: list[TranscribedWord] = []
+        character_offset = 0
+        for word in segment.words:
+            word_end = character_offset + len(word.text)
+            retained_word_text = "".join(
+                character
+                for character, keep_character in zip(
+                    word.text, keep_characters[character_offset:word_end], strict=True
+                )
+                if keep_character
+            )
+            if retained_word_text:
+                words.append(word.model_copy(update={"text": retained_word_text}))
+            character_offset = word_end
+        return segment.model_copy(update={"text": text, "words": words})
+
+    # Preserve safe offsets when backend word text cannot be mapped character-wise
+    words = []
+    if text:
+        words.append(
+            TranscribedWord(
+                text=text,
+                start=segment.start,
+                end=segment.end,
+                confidence=min(word.confidence for word in segment.words),
+            )
+        )
+    return segment.model_copy(update={"text": text, "words": words})
+
+
 def _get_segment_split_on_phrase_timings(
     segment: TranscribedSegment,
 ) -> list[TranscribedSegment]:
@@ -735,20 +785,18 @@ def _get_segment_split_on_phrase_timings(
     return output
 
 
-def _strip_generated_punctuation(text: str) -> str:
-    """Remove generated punctuation while retaining ASCII lexical infixes.
+def _get_text_character_retention(text: str) -> list[bool]:
+    """Identify characters retained when removing generated punctuation.
 
     Arguments:
         text: timed transcription text
     Returns:
-        text without generated sentence punctuation
+        whether each character should be retained
     """
     punctuation = HALF_PUNC_CHARS | FULL_PUNC_CHARS
-    output: list[str] = []
+    output: list[bool] = []
     for index, character in enumerate(text):
-        if character not in punctuation:
-            output.append(character)
-            continue
+        keep_character = character not in punctuation
         if (
             character in _LEXICAL_INFIX_PUNCTUATION
             and 0 < index < len(text) - 1
@@ -757,5 +805,23 @@ def _strip_generated_punctuation(text: str) -> str:
             and text[index + 1].isascii()
             and text[index + 1].isalnum()
         ):
-            output.append(character)
-    return "".join(output)
+            keep_character = True
+        output.append(keep_character)
+    return output
+
+
+def _strip_generated_punctuation(text: str) -> str:
+    """Remove generated punctuation while retaining ASCII lexical infixes.
+
+    Arguments:
+        text: timed transcription text
+    Returns:
+        text without generated sentence punctuation
+    """
+    return "".join(
+        character
+        for character, keep_character in zip(
+            text, _get_text_character_retention(text), strict=True
+        )
+        if keep_character
+    )

--- a/scinoephile/workflows/transcription.py
+++ b/scinoephile/workflows/transcription.py
@@ -14,6 +14,7 @@ from scinoephile.core.subtitles import Series
 from scinoephile.lang.transcription.guided import get_guided_transcriber
 from scinoephile.lang.transcription.transcriber import (
     GuidedTranscriber,
+    MlxAudioTimingMode,
     TranscriptionBackend,
 )
 from scinoephile.llms.delineation import DelineationPrompt
@@ -36,6 +37,8 @@ def transcribe_series_guided(
     vad_mode: VADMode = VADMode.AUTO,
     cache_root_path: Path | None = None,
     overwrite_cache: bool = False,
+    strip_generated_punctuation: bool = False,
+    mlx_audio_timing_mode: MlxAudioTimingMode = MlxAudioTimingMode.CTC_UNIT,
     provider: LLMProvider | None = None,
     additional_context: str | None = None,
     no_op: bool = False,
@@ -63,6 +66,9 @@ def transcribe_series_guided(
         vad_mode: Whisper VAD mode
         cache_root_path: cache root directory path
         overwrite_cache: whether to replace matching generated cache files
+        strip_generated_punctuation: whether to remove generated sentence
+            punctuation after timing and before guided alignment
+        mlx_audio_timing_mode: granularity of MLX-Audio CTC timing units
         provider: provider to use for LLM queries
         additional_context: additional context to include in LLM prompts
         no_op: use neutral answers instead of querying an LLM
@@ -93,6 +99,8 @@ def transcribe_series_guided(
             vad_mode=vad_mode,
             cache_root_path=cache_root_path,
             overwrite_cache=overwrite_cache,
+            strip_generated_punctuation=strip_generated_punctuation,
+            mlx_audio_timing_mode=mlx_audio_timing_mode,
             provider=provider,
             additional_context=additional_context,
             no_op=no_op,

--- a/test/lang/transcription/test_guided.py
+++ b/test/lang/transcription/test_guided.py
@@ -17,7 +17,10 @@ from scinoephile.core import Language, ScinoephileError
 from scinoephile.core.llms import LLMProvider
 from scinoephile.core.llms.utils import save_test_cases_to_json
 from scinoephile.lang.transcription.guided import DEFAULT_SPECS, get_guided_transcriber
-from scinoephile.lang.transcription.transcriber import TranscriptionBackend
+from scinoephile.lang.transcription.transcriber import (
+    MlxAudioTimingMode,
+    TranscriptionBackend,
+)
 from scinoephile.lang.yue.prompts import YUE_HANT_PROMPT_FIELDS
 from scinoephile.lang.yue_zho.transcription import (
     YueZhoDelineationPromptYueHant,
@@ -158,6 +161,8 @@ def test_get_guided_transcriber_configures_mlx_audio_backend(tmp_path: Path):
             Language.zho_hans,
             backend=TranscriptionBackend.MLX_AUDIO,
             cache_root_path=tmp_path,
+            strip_generated_punctuation=True,
+            mlx_audio_timing_mode=MlxAudioTimingMode.PHRASE,
             provider=Mock(spec=LLMProvider, cache_identity={"implementation": "test"}),
             delineation_json_path=tmp_path / "delineation.json",
             punctuation_json_path=tmp_path / "punctuation.json",
@@ -170,6 +175,8 @@ def test_get_guided_transcriber_configures_mlx_audio_backend(tmp_path: Path):
     assert transcriber.transcriber is mlx_audio_transcriber
     assert transcriber.recovery_transcriber is None
     assert transcriber.tail_recovery_transcriber is None
+    assert transcriber.strip_generated_punctuation
+    assert transcriber.mlx_audio_timing_mode is MlxAudioTimingMode.PHRASE
     mlx_audio_transcriber_class.assert_called_once_with(
         model_name=MIMO_MODEL_NAME,
         language=Language.yue_hant,

--- a/test/lang/transcription/test_transcriber.py
+++ b/test/lang/transcription/test_transcriber.py
@@ -12,7 +12,7 @@ from pydub import AudioSegment
 from pydub.generators import Sine
 from pytest import LogCaptureFixture, approx, raises
 
-from scinoephile.audio.subtitles import AudioSeries, AudioSubtitle
+from scinoephile.audio.subtitles import AudioSeries, AudioSubtitle, get_sub_split_at_idx
 from scinoephile.audio.transcription import (
     DemucsMode,
     MlxAudioTranscriber,
@@ -468,13 +468,65 @@ def test_process_block_strips_generated_punctuation_after_timing():
     )
     audio_block.buffered_start = 0
     reference_block = Series(events=[Subtitle(start=0, end=1000, text="reference")])
-    segment = _get_segment(text="你好！0.01、don't、re-entry，")
+    segment = _get_segment(text="你好！0.01、don't、re-entry，", with_words=True)
 
     with patch.object(transcriber, "_transcribe_block_audio", return_value=[segment]):
         transcriber.process_block(audio_block, reference_block)
 
     transcription = aligner.align.call_args.args[1]
     assert [subtitle.text for subtitle in transcription] == ["你好0.01don'tre-entry"]
+    assert transcription[0].segment.text == transcription[0].text
+    assert [word.text for word in transcription[0].segment.words or []] == [
+        "你好0.01don'tre-entry"
+    ]
+
+
+def test_process_block_synchronizes_stripped_punctuation_with_word_timings():
+    """Test stripped text indexes continue to target matching timed characters."""
+    transcriber, aligner = _get_transcriber(
+        backend=TranscriptionBackend.MLX_AUDIO,
+        mlx_audio_timing_mode=MlxAudioTimingMode.SEGMENT,
+        strip_generated_punctuation=True,
+    )
+    audio_block = AudioSeries(
+        audio=AudioSegment.silent(duration=1000),
+        events=[AudioSubtitle(start=0, end=1000, text="reference")],
+    )
+    audio_block.buffered_start = 0
+    reference_block = Series(events=[Subtitle(start=0, end=1000, text="reference")])
+    text = "甲，乙丙"
+    segment = TranscribedSegment(
+        id=0,
+        seek=0,
+        start=0.1,
+        end=0.5,
+        text=text,
+        words=[
+            TranscribedWord(
+                text=character,
+                start=(word_idx + 1) / 10,
+                end=(word_idx + 2) / 10,
+                confidence=1.0,
+            )
+            for word_idx, character in enumerate(text)
+        ],
+    )
+
+    with patch.object(transcriber, "_transcribe_block_audio", return_value=[segment]):
+        transcriber.process_block(audio_block, reference_block)
+
+    subtitle = aligner.align.call_args.args[1][0]
+    assert subtitle.text == "甲乙丙"
+    assert subtitle.segment.text == subtitle.text
+    assert "".join(word.text for word in subtitle.segment.words or []) == subtitle.text
+
+    first, second = get_sub_split_at_idx(subtitle, 2)
+    assert first.text == first.segment.text == "甲乙"
+    assert "".join(word.text for word in first.segment.words or []) == "甲乙"
+    assert first.end == 400
+    assert second.text == second.segment.text == "丙"
+    assert "".join(word.text for word in second.segment.words or []) == "丙"
+    assert second.start == 400
 
 
 def test_process_block_splits_mlx_audio_segments_on_ctc_unit_timings():

--- a/test/lang/transcription/test_transcriber.py
+++ b/test/lang/transcription/test_transcriber.py
@@ -27,7 +27,9 @@ from scinoephile.lang.transcription.aligner import TranscriptionAligner
 from scinoephile.lang.transcription.alignment import TranscriptionAlignment
 from scinoephile.lang.transcription.transcriber import (
     GuidedTranscriber,
+    MlxAudioTimingMode,
     TranscriptionBackend,
+    _get_segment_split_on_phrase_timings,
 )
 
 
@@ -37,6 +39,8 @@ def _get_transcriber(
     demucs_mode: DemucsMode = DemucsMode.OFF,
     vad_mode: VADMode = VADMode.OFF,
     overwrite_cache: bool = False,
+    mlx_audio_timing_mode: MlxAudioTimingMode = MlxAudioTimingMode.CTC_UNIT,
+    strip_generated_punctuation: bool = False,
 ) -> tuple[GuidedTranscriber, Mock]:
     """Get a transcriber with a passthrough alignment mock.
 
@@ -45,6 +49,9 @@ def _get_transcriber(
         demucs_mode: Demucs preprocessing mode
         vad_mode: Whisper VAD mode
         overwrite_cache: whether to replace matching transcription cache files
+        mlx_audio_timing_mode: granularity of MLX-Audio CTC timing units
+        strip_generated_punctuation: whether to remove generated punctuation before
+            guided alignment
     Returns:
         transcriber and alignment mock
     """
@@ -69,6 +76,8 @@ def _get_transcriber(
             vad_mode=vad_mode,
             overwrite_cache=overwrite_cache,
             mlx_audio_transcriber=mlx_audio_transcriber,
+            mlx_audio_timing_mode=mlx_audio_timing_mode,
+            strip_generated_punctuation=strip_generated_punctuation,
         ),
         aligner,
     )
@@ -448,6 +457,169 @@ def test_process_block_applies_configured_segment_splitter():
     transcriber.segment_splitter.assert_called_once_with(segment)
     transcription = aligner.align.call_args.args[1]
     assert [subtitle.text for subtitle in transcription] == ["one", "two"]
+
+
+def test_process_block_strips_generated_punctuation_after_timing():
+    """Test guided alignment can omit sentence but retain lexical punctuation."""
+    transcriber, aligner = _get_transcriber(strip_generated_punctuation=True)
+    audio_block = AudioSeries(
+        audio=AudioSegment.silent(duration=1000),
+        events=[AudioSubtitle(start=0, end=1000, text="reference")],
+    )
+    audio_block.buffered_start = 0
+    reference_block = Series(events=[Subtitle(start=0, end=1000, text="reference")])
+    segment = _get_segment(text="你好！0.01、don't、re-entry，")
+
+    with patch.object(transcriber, "_transcribe_block_audio", return_value=[segment]):
+        transcriber.process_block(audio_block, reference_block)
+
+    transcription = aligner.align.call_args.args[1]
+    assert [subtitle.text for subtitle in transcription] == ["你好0.01don'tre-entry"]
+
+
+def test_process_block_splits_mlx_audio_segments_on_ctc_unit_timings():
+    """Test MLX-Audio CTC timing units reach reference-guided alignment."""
+    transcriber, aligner = _get_transcriber(backend=TranscriptionBackend.MLX_AUDIO)
+    audio_block = AudioSeries(
+        audio=AudioSegment.silent(duration=1000),
+        events=[AudioSubtitle(start=0, end=1000, text="reference")],
+    )
+    audio_block.buffered_start = 0
+    reference_block = Series(
+        events=[
+            Subtitle(start=0, end=500, text="參考一"),
+            Subtitle(start=500, end=1000, text="參考二"),
+        ]
+    )
+    segment = TranscribedSegment(
+        id=0,
+        seek=0,
+        start=0.1,
+        end=0.8,
+        text="甲乙",
+        words=[
+            TranscribedWord(text="甲", start=0.1, end=0.2, confidence=1.0),
+            TranscribedWord(text="乙", start=0.7, end=0.8, confidence=1.0),
+        ],
+    )
+
+    with patch.object(transcriber, "_transcribe_block_audio", return_value=[segment]):
+        transcriber.process_block(audio_block, reference_block)
+
+    transcription = aligner.align.call_args.args[1]
+    assert [subtitle.text for subtitle in transcription] == ["甲", "乙"]
+    assert [(subtitle.start, subtitle.end) for subtitle in transcription] == [
+        (100, 200),
+        (700, 800),
+    ]
+    assert [subtitle.segment.id for subtitle in transcription] == [0, 1]
+    alignment = TranscriptionAlignment(reference_block, transcription)
+    assert alignment.sync_groups == [([0], [0]), ([1], [1])]
+
+
+def test_process_block_retains_complete_mlx_audio_segments():
+    """Test segment timing mode retains MLX-Audio segment granularity."""
+    transcriber, aligner = _get_transcriber(
+        backend=TranscriptionBackend.MLX_AUDIO,
+        mlx_audio_timing_mode=MlxAudioTimingMode.SEGMENT,
+    )
+    audio_block = AudioSeries(
+        audio=AudioSegment.silent(duration=1000),
+        events=[AudioSubtitle(start=0, end=1000, text="reference")],
+    )
+    audio_block.buffered_start = 0
+    reference_block = Series(events=[Subtitle(start=0, end=1000, text="參考")])
+    segment = TranscribedSegment(
+        id=4,
+        seek=0,
+        start=0.1,
+        end=0.8,
+        text="甲乙",
+        words=[
+            TranscribedWord(text="甲", start=0.1, end=0.2, confidence=1.0),
+            TranscribedWord(text="乙", start=0.7, end=0.8, confidence=1.0),
+        ],
+    )
+
+    with patch.object(transcriber, "_transcribe_block_audio", return_value=[segment]):
+        transcriber.process_block(audio_block, reference_block)
+
+    transcription = aligner.align.call_args.args[1]
+    assert [subtitle.text for subtitle in transcription] == ["甲乙"]
+    assert [(subtitle.start, subtitle.end) for subtitle in transcription] == [
+        (100, 800)
+    ]
+    assert transcription[0].segment.id == 0
+
+
+def test_process_block_groups_mlx_audio_segments_on_phrase_timings():
+    """Test phrase timing groups use punctuation before it may be stripped."""
+    transcriber, aligner = _get_transcriber(
+        backend=TranscriptionBackend.MLX_AUDIO,
+        mlx_audio_timing_mode=MlxAudioTimingMode.PHRASE,
+        strip_generated_punctuation=True,
+    )
+    audio_block = AudioSeries(
+        audio=AudioSegment.silent(duration=1500),
+        events=[AudioSubtitle(start=0, end=1500, text="reference")],
+    )
+    audio_block.buffered_start = 0
+    reference_block = Series(
+        events=[
+            Subtitle(start=0, end=500, text="參考一"),
+            Subtitle(start=500, end=1500, text="參考二"),
+        ]
+    )
+    text = "甲乙。丙丁戊己庚辛壬癸"
+    words = [
+        TranscribedWord(
+            text=character, start=word_idx / 10, end=(word_idx + 1) / 10, confidence=1.0
+        )
+        for word_idx, character in enumerate(text)
+    ]
+    segment = TranscribedSegment(
+        id=0, seek=0, start=0.0, end=len(text) / 10, text=text, words=words
+    )
+
+    with patch.object(transcriber, "_transcribe_block_audio", return_value=[segment]):
+        transcriber.process_block(audio_block, reference_block)
+
+    transcription = aligner.align.call_args.args[1]
+    assert [subtitle.text for subtitle in transcription] == ["甲乙", "丙丁戊己庚辛壬癸"]
+    assert [(subtitle.start, subtitle.end) for subtitle in transcription] == [
+        (0, 300),
+        (300, 1100),
+    ]
+
+
+def test_phrase_timing_groups_split_on_ctc_hold_time_and_size():
+    """Test acoustic holds and maximum size both produce phrase boundaries."""
+    text = "甲乙丙丁戊己庚辛壬癸子丑寅卯辰巳午未"
+    words = []
+    start = 0.0
+    for word_idx, character in enumerate(text):
+        duration = 0.1
+        if word_idx == 2:
+            duration = 0.7
+        words.append(
+            TranscribedWord(
+                text=character, start=start, end=start + duration, confidence=1.0
+            )
+        )
+        start += duration
+    segment = TranscribedSegment(
+        id=0, seek=0, start=0.0, end=start, text=text, words=words
+    )
+
+    output = _get_segment_split_on_phrase_timings(segment)
+
+    assert [item.text for item in output] == [
+        "甲乙丙",
+        "丁戊己庚辛壬癸",
+        "子丑寅卯辰巳午未",
+    ]
+    assert [item.start for item in output] == approx([0.0, 0.9, 1.6])
+    assert [item.end for item in output] == approx([0.9, 1.6, 2.4])
 
 
 def test_process_uses_exclusive_stop_index(caplog: LogCaptureFixture):

--- a/test/workflows/test_transcription.py
+++ b/test/workflows/test_transcription.py
@@ -15,6 +15,7 @@ from scinoephile.core import Language
 from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.lang.transcription.transcriber import (
     GuidedTranscriber,
+    MlxAudioTimingMode,
     TranscriptionBackend,
 )
 from scinoephile.workflows.transcription import transcribe_series_guided
@@ -44,6 +45,8 @@ def test_transcribe_series_guided_constructs_transcriber_for_language_pair(
             backend=TranscriptionBackend.MLX_AUDIO,
             cache_root_path=tmp_path / "cache",
             overwrite_cache=True,
+            strip_generated_punctuation=True,
+            mlx_audio_timing_mode=MlxAudioTimingMode.PHRASE,
             no_op=True,
             prune_test_cases=True,
             delineation_json_path=delineation_json_path,
@@ -61,6 +64,11 @@ def test_transcribe_series_guided_constructs_transcriber_for_language_pair(
     )
     assert get_transcriber.call_args.kwargs["cache_root_path"] == tmp_path / "cache"
     assert get_transcriber.call_args.kwargs["overwrite_cache"] is True
+    assert get_transcriber.call_args.kwargs["strip_generated_punctuation"] is True
+    assert (
+        get_transcriber.call_args.kwargs["mlx_audio_timing_mode"]
+        is MlxAudioTimingMode.PHRASE
+    )
     assert get_transcriber.call_args.kwargs["no_op"] is True
     assert get_transcriber.call_args.kwargs["prune_test_cases"] is True
     assert (


### PR DESCRIPTION
## Summary

- add selectable MLX-Audio timing granularity for complete segments, phrase groups, or individual CTC units
- build phrase-sized timing groups from generated punctuation, long CTC holds, and bounded target sizes
- optionally strip generated sentence punctuation after timing is established and before guided alignment, while preserving lexical ASCII infixes such as `don't`, `re-entry`, and `0.01`
- expose the timing and punctuation-cleanup options through the guided-transcriber factory and transcription workflow

## Why

Complete MLX-Audio sentences are too coarse for reliable guided alignment, while individual CTC units can be unnecessarily fragmented. Phrase timing provides a middle granularity that retains acoustic and punctuation boundary evidence without discarding detailed CTC timings.

## Impact

Guided MLX-Audio transcription now defaults to individual CTC timing units and can explicitly select `segment` for complete-segment behavior or `phrase` for phrase grouping. Generated-punctuation removal is opt-in and occurs only after timing, so punctuation remains available as phrase-boundary evidence. Whisper behavior is unchanged.

This PR intentionally excludes VAD-default changes, transcription cache/retry fixes, block delineation and punctuation modes, recovery changes, and dataset outputs.

## Checks

- `uv run ruff format` on changed Python files
- `uv run ruff check --fix` on changed Python files
- `uv run ty check` on changed Python files
- focused tests: 39 passed
- full suite: 2,197 passed, 4 skipped