### PR TITLE
Scope OpenCC exclusions to s2hk

### DIFF
--- a/scinoephile/lang/zho/script/conversion.py
+++ b/scinoephile/lang/zho/script/conversion.py
@@ -15,7 +15,7 @@ from scinoephile.core.subtitles import Series
 
 __all__ = [
     "OpenCCConfig",
-    "S2T_EXCLUSIONS",
+    "S2HK_EXCLUSIONS",
     "SIMPLIFIED_CONFIGS",
     "T2S_EXCLUSIONS",
     "TRADITIONAL_CONFIGS",
@@ -25,7 +25,7 @@ __all__ = [
     "get_zho_text_converted",
 ]
 
-S2T_EXCLUSIONS: set[str] = {
+S2HK_EXCLUSIONS: set[str] = {
     "吓",  # 嚇
     "响",  # 響
     "床",  # 牀
@@ -37,7 +37,7 @@ S2T_EXCLUSIONS: set[str] = {
     "說",  # 説
     "郁",  # 鬱
 }
-"""Text spans to preserve when converting toward traditional."""
+"""Text spans to preserve when converting simplified Chinese toward Hong Kong."""
 
 T2S_EXCLUSIONS: set[str] = {
     "劏",  # 㓥
@@ -115,9 +115,6 @@ TRADITIONAL_CONFIGS = {
 }
 """OpenCC configurations that convert text toward traditional Chinese."""
 
-_S2T_EXCLUSION_CONFIGS = TRADITIONAL_CONFIGS - {OpenCCConfig.t2jp}
-"""OpenCC configurations to which traditional Chinese exclusions apply."""
-
 
 def get_zho_character_variants(texts: Iterable[str]) -> tuple[str, ...]:
     """Get characters and their simplified/traditional variants.
@@ -185,8 +182,8 @@ def get_zho_text_converted(
 
     if apply_exclusions and config in SIMPLIFIED_CONFIGS:
         return _get_zho_text_converted_with_exclusions(text, converter, T2S_EXCLUSIONS)
-    if apply_exclusions and config in _S2T_EXCLUSION_CONFIGS:
-        return _get_zho_text_converted_with_exclusions(text, converter, S2T_EXCLUSIONS)
+    if apply_exclusions and config == OpenCCConfig.s2hk:
+        return _get_zho_text_converted_with_exclusions(text, converter, S2HK_EXCLUSIONS)
     return converter.convert(text)
 
 

--- a/scinoephile/lang/zho/script/conversion.py
+++ b/scinoephile/lang/zho/script/conversion.py
@@ -115,6 +115,9 @@ TRADITIONAL_CONFIGS = {
 }
 """OpenCC configurations that convert text toward traditional Chinese."""
 
+_S2T_EXCLUSION_CONFIGS = TRADITIONAL_CONFIGS - {OpenCCConfig.t2jp}
+"""OpenCC configurations to which traditional Chinese exclusions apply."""
+
 
 def get_zho_character_variants(texts: Iterable[str]) -> tuple[str, ...]:
     """Get characters and their simplified/traditional variants.
@@ -182,7 +185,7 @@ def get_zho_text_converted(
 
     if apply_exclusions and config in SIMPLIFIED_CONFIGS:
         return _get_zho_text_converted_with_exclusions(text, converter, T2S_EXCLUSIONS)
-    if apply_exclusions and config in TRADITIONAL_CONFIGS:
+    if apply_exclusions and config in _S2T_EXCLUSION_CONFIGS:
         return _get_zho_text_converted_with_exclusions(text, converter, S2T_EXCLUSIONS)
     return converter.convert(text)
 

--- a/test/lang/zho/script/test_conversion.py
+++ b/test/lang/zho/script/test_conversion.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from pytest import FixtureRequest, param
 
 from scinoephile.lang.zho.script.conversion import (
-    S2T_EXCLUSIONS,
+    S2HK_EXCLUSIONS,
     T2S_EXCLUSIONS,
     OpenCCConfig,
     get_zho_character_variants,
@@ -22,10 +22,10 @@ from test.helpers import assert_series_equal, parametrize
     ("text", "config", "expected"),
     [
         ("台臺", OpenCCConfig.s2t, "臺臺"),
-        ("你吃吓晒啦", OpenCCConfig.s2t, "你喫吓晒啦"),
-        ("唔好郁，响邊扑你", OpenCCConfig.s2t, "唔好郁，响邊扑你"),
-        ("一群牛虱", OpenCCConfig.s2t, "一群牛蝨"),
-        ("萬里長城說，瞓床搵你", OpenCCConfig.s2t, "萬里長城說，瞓床搵你"),
+        ("你吃吓晒啦", OpenCCConfig.s2hk, "你吃吓晒啦"),
+        ("唔好郁，响邊扑你", OpenCCConfig.s2hk, "唔好郁，响邊扑你"),
+        ("一群牛虱", OpenCCConfig.s2hk, "一群牛蝨"),
+        ("萬里長城說，瞓床搵你", OpenCCConfig.s2hk, "萬里長城說，瞓床搵你"),
         ("台臺", OpenCCConfig.t2s, "台台"),
         ("呢個嗰度喎", OpenCCConfig.t2s, "呢个嗰度㖞"),
         ("劏唓嗰餸繁體", OpenCCConfig.t2s, "劏唓嗰餸繁体"),
@@ -44,12 +44,13 @@ def test_get_zho_text_converted_applies_exclusions(
     assert get_zho_text_converted(text, config) == expected
 
 
-def test_get_zho_text_converted_does_not_apply_chinese_exclusions_to_t2jp():
-    """Test Japanese conversion is not suppressed by Chinese exclusions."""
+def test_get_zho_text_converted_only_applies_s2hk_exclusions_to_s2hk():
+    """Test Hong Kong exclusions do not affect other conversion configurations."""
+    assert get_zho_text_converted("說", OpenCCConfig.s2t) == "說"
     assert get_zho_text_converted("萬里長城說", OpenCCConfig.t2jp) == "万里長城説"
 
 
-@parametrize("text", sorted(S2T_EXCLUSIONS))
+@parametrize("text", sorted(S2HK_EXCLUSIONS))
 def test_s2hk_exclusions_are_raw_opencc_changes(text: str):
     """Test every Hong Kong exclusion changes raw and is preserved when applied.
 

--- a/test/lang/zho/script/test_conversion.py
+++ b/test/lang/zho/script/test_conversion.py
@@ -44,15 +44,21 @@ def test_get_zho_text_converted_applies_exclusions(
     assert get_zho_text_converted(text, config) == expected
 
 
+def test_get_zho_text_converted_does_not_apply_chinese_exclusions_to_t2jp():
+    """Test Japanese conversion is not suppressed by Chinese exclusions."""
+    assert get_zho_text_converted("萬里長城說", OpenCCConfig.t2jp) == "万里長城説"
+
+
 @parametrize("text", sorted(S2T_EXCLUSIONS))
 def test_s2hk_exclusions_are_raw_opencc_changes(text: str):
-    """Test every Hong Kong exclusion changes under raw OpenCC.
+    """Test every Hong Kong exclusion changes raw and is preserved when applied.
 
     Arguments:
         text: excluded text span
     """
     converted_text = get_zho_converter(OpenCCConfig.s2hk).convert(text)
     assert converted_text != text
+    assert get_zho_text_converted(text, OpenCCConfig.s2hk) == text
 
 
 @parametrize("text", sorted(T2S_EXCLUSIONS))


### PR DESCRIPTION
## What changed

- Renamed `S2T_EXCLUSIONS` to `S2HK_EXCLUSIONS`.
- Applied that preservation table only for `OpenCCConfig.s2hk`.
- Left plain `s2t`, Taiwan, generic traditional, and Japanese conversion profiles fully under OpenCC control.
- Added regression coverage confirming `s2t` and `t2jp` do not receive the Hong Kong exclusions.

## Why

These exclusions preserve specific Cantonese/Hong Kong forms and compatibility characters. They should describe the `s2hk` policy directly rather than acting as generic simplified-to-traditional exceptions.

## Impact

Only `s2hk` uses `S2HK_EXCLUSIONS`. `t2s` behavior and its separate exclusions are unchanged. Every other conversion profile now follows OpenCC without the Hong Kong preservation layer.

## Checks

- Focused conversion tests: 37 passed
- Full test suite: 2,101 passed, 4 skipped
- Ruff format and check on changed Python files
- `ty check` on changed Python files