### PR TITLE
Clarify LLM test-case ownership

### DIFF
--- a/scinoephile/cli/ocr/ocr_fuse_cli.py
+++ b/scinoephile/cli/ocr/ocr_fuse_cli.py
@@ -270,7 +270,7 @@ class OcrFuseCli(ScinoephileCliBase):
                 cache_root_path=cache_args.root_path,
                 no_op=llm_args.no_op,
                 overwrite_cache=cache_args.overwrite,
-                test_case_path=json_path,
+                current_test_cases_path=json_path,
             )
         except ScinoephileError as exc:
             parser.error(str(exc))

--- a/scinoephile/cli/review_cli.py
+++ b/scinoephile/cli/review_cli.py
@@ -209,7 +209,7 @@ class ReviewCli(ScinoephileCliBase):
                     cache_root_path=cache_args.root_path,
                     no_op=llm_args.no_op,
                     overwrite_cache=cache_args.overwrite,
-                    test_case_path=json_path,
+                    current_test_cases_path=json_path,
                     start_at_idx=start_at_idx,
                     stop_at_idx=stop_at_idx,
                 )
@@ -222,7 +222,7 @@ class ReviewCli(ScinoephileCliBase):
                     cache_root_path=cache_args.root_path,
                     no_op=llm_args.no_op,
                     overwrite_cache=cache_args.overwrite,
-                    test_case_path=json_path,
+                    current_test_cases_path=json_path,
                     start_at_idx=start_at_idx,
                     stop_at_idx=stop_at_idx,
                 )

--- a/scinoephile/cli/translate_cli.py
+++ b/scinoephile/cli/translate_cli.py
@@ -240,7 +240,7 @@ class TranslateCli(ScinoephileCliBase):
             "cache_root_path": cache_args.root_path,
             "no_op": llm_args.no_op,
             "overwrite_cache": cache_args.overwrite,
-            "test_case_path": json_path,
+            "current_test_cases_path": json_path,
             "start_at_idx": start_at_idx,
             "stop_at_idx": stop_at_idx,
         }

--- a/scinoephile/core/llms/processor.py
+++ b/scinoephile/core/llms/processor.py
@@ -8,13 +8,15 @@ from abc import ABC
 from pathlib import Path
 from typing import TypedDict
 
+from scinoephile.common.validation import val_output_path
+
 from .llm_provider import LLMProvider
 from .manager import Manager
 from .prompt import Prompt
 from .queryer import Queryer
 from .test_case import TestCase
 from .tool_box import ToolBox
-from .utils import load_test_cases, save_test_cases_to_json
+from .utils import load_test_cases_from_json, save_test_cases_to_json
 
 __all__ = ["Processor", "ProcessorKwargs"]
 
@@ -40,8 +42,8 @@ class ProcessorKwargs(TypedDict, total=False):
     prune_test_cases: bool
     """Whether to remove persisted test cases not encountered in the current run."""
 
-    test_case_path: Path | None
-    """Path where test cases are persisted."""
+    current_test_cases_path: Path | None
+    """Current configuration's test-case JSON path."""
 
     tool_box: ToolBox | None
     """Available tools and handlers."""
@@ -61,8 +63,8 @@ class Processor(ABC):
     def __init__(
         self,
         prompt: Prompt,
-        test_cases: list[TestCase] | None = None,
-        test_case_path: Path | None = None,
+        shared_test_cases: list[TestCase] | None = None,
+        current_test_cases_path: Path | None = None,
         *,
         provider: LLMProvider,
         additional_context: str | None = None,
@@ -77,8 +79,8 @@ class Processor(ABC):
 
         Arguments:
             prompt: text for LLM correspondence
-            test_cases: test cases
-            test_case_path: path to file containing test cases
+            shared_test_cases: known test cases shared across configurations
+            current_test_cases_path: current configuration's test-case JSON path
             provider: provider to use for queries
             additional_context: additional context to include in the system prompt
             auto_verify: automatically verify test cases if they meet selected criteria
@@ -93,20 +95,28 @@ class Processor(ABC):
             raise ValueError("manager_cls must be set on Processor subclasses.")
         self.test_case_cls = self.manager_cls.get_test_case_cls(self.prompt)
 
-        test_cases, test_case_path = load_test_cases(
-            self.manager_cls,
-            self.prompt,
-            test_cases=test_cases,
-            test_case_path=test_case_path,
-        )
-        self.test_case_path = test_case_path
-        """Path to file containing test cases."""
+        if current_test_cases_path is not None:
+            current_test_cases_path = val_output_path(
+                current_test_cases_path, exist_ok=True
+            )
+        current_test_cases = []
+        if current_test_cases_path is not None and current_test_cases_path.exists():
+            current_test_cases = load_test_cases_from_json(
+                current_test_cases_path, self.manager_cls, self.prompt
+            )
+        verified_test_cases = [
+            test_case
+            for test_case in [*(shared_test_cases or []), *current_test_cases]
+            if test_case.verified
+        ]
+        self.current_test_cases_path = current_test_cases_path
+        """Current configuration's test-case JSON path."""
         self.prune_test_cases = prune_test_cases
         """Whether to remove persisted cases not encountered in the current run."""
 
         self.queryer = Queryer(
             self.test_case_cls,
-            verified_test_cases=[tc for tc in test_cases if tc.verified],
+            verified_test_cases=verified_test_cases,
             provider=provider,
             cache_root_path=cache_root_path,
             additional_context=additional_context,
@@ -117,12 +127,12 @@ class Processor(ABC):
         )
         """LLM queryer."""
 
-    def save_test_cases(self):
+    def save_encountered_test_cases(self):
         """Persist encountered test cases."""
-        if self.test_case_path is None or self.manager_cls is None:
+        if self.current_test_cases_path is None or self.manager_cls is None:
             return
         save_test_cases_to_json(
-            self.test_case_path,
+            self.current_test_cases_path,
             self.queryer.encountered_test_cases.values(),
             self.manager_cls,
             prune=self.prune_test_cases,

--- a/scinoephile/core/llms/queryer.py
+++ b/scinoephile/core/llms/queryer.py
@@ -339,17 +339,17 @@ class Queryer[TTestCase: TestCase]:
         return None
 
     def _get_verified_test_cases(
-        self, test_cases: list[TestCase]
+        self, verified_test_cases: list[TestCase]
     ) -> dict[tuple, TTestCase]:
         """Snapshot, validate, and merge verified test cases.
 
         Arguments:
-            test_cases: verified test cases to prepare
+            verified_test_cases: verified test cases to prepare
         Returns:
             verified test cases keyed by query
         """
-        verified_test_cases: dict[tuple, TTestCase] = {}
-        for test_case in test_cases:
+        verified_test_cases_by_query: dict[tuple, TTestCase] = {}
+        for test_case in verified_test_cases:
             normalized = self.test_case_cls.model_validate(
                 test_case.model_dump(mode="json")
             )
@@ -358,20 +358,22 @@ class Queryer[TTestCase: TestCase]:
             if normalized.answer is None:
                 raise ValueError("Verified test cases must include an answer.")
             key = normalized.query.key
-            existing = verified_test_cases.get(key)
+            existing = verified_test_cases_by_query.get(key)
             if existing is None:
-                verified_test_cases[key] = normalized
+                verified_test_cases_by_query[key] = normalized
                 continue
             assert existing.answer is not None
             if existing.answer != normalized.answer:
                 raise ValueError(
                     "Conflicting verified answers for query "
-                    f"{normalized.query.key_str}."
+                    f"{normalized.query.key_str}.\n"
+                    f"Existing answer:\n{existing.answer}\n"
+                    f"Conflicting answer:\n{normalized.answer}"
                 )
             existing.difficulty = max(existing.difficulty, normalized.difficulty)
             existing.few_shot |= normalized.few_shot
             existing.verified |= normalized.verified
-        return verified_test_cases
+        return verified_test_cases_by_query
 
     @staticmethod
     def _format_validation_errors(exc: ValidationError) -> str:

--- a/scinoephile/core/llms/utils.py
+++ b/scinoephile/core/llms/utils.py
@@ -12,45 +12,12 @@ from typing import cast
 from pydantic import TypeAdapter
 
 from scinoephile.common.file import open_atomic_text_file
-from scinoephile.common.validation import val_output_path
 
 from .manager import Manager
 from .prompt import Prompt
 from .test_case import TestCase
 
-__all__ = ["load_test_cases", "load_test_cases_from_json", "save_test_cases_to_json"]
-
-
-def load_test_cases[TTestCase: TestCase](
-    manager_cls: type[Manager[TTestCase]],
-    prompt: Prompt,
-    *,
-    test_cases: Iterable[TTestCase] | None = None,
-    test_case_path: Path | None = None,
-) -> tuple[list[TTestCase], Path | None]:
-    """Load test cases from supplied cases and an optional JSON file.
-
-    Test cases loaded from the JSON file replace supplied cases with matching queries.
-
-    Arguments:
-        manager_cls: manager used to load JSON test cases
-        prompt: prompt whose localized schema should be applied
-        test_cases: optional test cases to load before the JSON file
-        test_case_path: optional JSON file containing additional test cases
-    Returns:
-        test cases unique by query and normalized optional JSON path
-    """
-    if test_case_path is not None:
-        test_case_path = val_output_path(test_case_path, exist_ok=True)
-    if test_cases is None:
-        test_cases = []
-    test_cases_by_query_key = {
-        test_case.query.key: test_case for test_case in test_cases
-    }
-    if test_case_path is not None and test_case_path.exists():
-        for test_case in load_test_cases_from_json(test_case_path, manager_cls, prompt):
-            test_cases_by_query_key[test_case.query.key] = test_case
-    return list(test_cases_by_query_key.values()), test_case_path
+__all__ = ["load_test_cases_from_json", "save_test_cases_to_json"]
 
 
 def load_test_cases_from_json[TTestCase: TestCase](

--- a/scinoephile/lang/ocr_fusion.py
+++ b/scinoephile/lang/ocr_fusion.py
@@ -11,7 +11,7 @@ from typing import Unpack
 
 from scinoephile.core import Language, ScinoephileError
 from scinoephile.core.llms import LLMProvider, ProcessorKwargs, TestCase
-from scinoephile.llms import load_default_test_cases
+from scinoephile.llms import load_shared_test_cases
 from scinoephile.llms.ocr_fusion import (
     OcrFusionManager,
     OcrFusionProcessor,
@@ -86,7 +86,7 @@ DEFAULT_PROMPTS: Mapping[Language, OcrFusionPrompt] = MappingProxyType(
 def get_ocr_fuser(
     language: Language,
     prompt: OcrFusionPrompt | None = None,
-    test_cases: list[TestCase] | None = None,
+    shared_test_cases: list[TestCase] | None = None,
     provider: LLMProvider | None = None,
     **kwargs: Unpack[ProcessorKwargs],
 ) -> OcrFusionProcessor:
@@ -95,7 +95,7 @@ def get_ocr_fuser(
     Arguments:
         language: subtitle language
         prompt: text for LLM correspondence
-        test_cases: test cases
+        shared_test_cases: shared test cases
         provider: provider to use for queries
         **kwargs: additional keyword arguments for OcrFusionProcessor
     Returns:
@@ -108,9 +108,11 @@ def get_ocr_fuser(
 
     if prompt is None:
         prompt = DEFAULT_PROMPTS[language]
-    if test_cases is None:
+    if shared_test_cases is None:
         json_paths = _JSON_PATHS[language]
-        test_cases = list(load_default_test_cases(OcrFusionManager, prompt, json_paths))
+        shared_test_cases = list(
+            load_shared_test_cases(OcrFusionManager, prompt, json_paths)
+        )
     if provider is None:
         provider = get_provider()
-    return OcrFusionProcessor(prompt, test_cases, provider=provider, **kwargs)
+    return OcrFusionProcessor(prompt, shared_test_cases, provider=provider, **kwargs)

--- a/scinoephile/lang/review/guided.py
+++ b/scinoephile/lang/review/guided.py
@@ -29,7 +29,7 @@ from scinoephile.lang.zho_yue.review import (
     ZhoYueGuidedReviewPromptZhoHans,
     ZhoYueGuidedReviewPromptZhoHant,
 )
-from scinoephile.llms import load_default_test_cases
+from scinoephile.llms import load_shared_test_cases
 from scinoephile.llms.guided_review import (
     GuidedReviewManager,
     GuidedReviewProcessor,
@@ -86,7 +86,7 @@ def get_guided_reviewer(
     language: Language,
     guide_language: Language,
     prompt: GuidedReviewPrompt | None = None,
-    test_cases: list[TestCase] | None = None,
+    shared_test_cases: list[TestCase] | None = None,
     provider: LLMProvider | None = None,
     **kwargs: Unpack[ProcessorKwargs],
 ) -> GuidedReviewProcessor:
@@ -96,7 +96,7 @@ def get_guided_reviewer(
         language: language of subtitles to review
         guide_language: language of guide subtitles
         prompt: text for LLM correspondence
-        test_cases: test cases
+        shared_test_cases: shared test cases
         provider: provider to use for queries
         **kwargs: additional processor keyword arguments
     Returns:
@@ -112,10 +112,10 @@ def get_guided_reviewer(
         )
     if prompt is None:
         prompt = DEFAULT_PROMPTS[key]
-    if test_cases is None:
-        test_cases = list(
-            load_default_test_cases(GuidedReviewManager, prompt, _JSON_PATHS[key])
+    if shared_test_cases is None:
+        shared_test_cases = list(
+            load_shared_test_cases(GuidedReviewManager, prompt, _JSON_PATHS[key])
         )
     if provider is None:
         provider = get_provider()
-    return GuidedReviewProcessor(prompt, test_cases, provider=provider, **kwargs)
+    return GuidedReviewProcessor(prompt, shared_test_cases, provider=provider, **kwargs)

--- a/scinoephile/lang/review/standard.py
+++ b/scinoephile/lang/review/standard.py
@@ -14,7 +14,7 @@ from scinoephile.core.llms import LLMProvider, ProcessorKwargs, TestCase
 from scinoephile.lang.eng.review import ReviewPromptEng
 from scinoephile.lang.yue.review import ReviewPromptYueHans, ReviewPromptYueHant
 from scinoephile.lang.zho.review import ReviewPromptZhoHans, ReviewPromptZhoHant
-from scinoephile.llms import load_default_test_cases
+from scinoephile.llms import load_shared_test_cases
 from scinoephile.llms.providers.registry import get_provider
 from scinoephile.llms.review import ReviewManager, ReviewProcessor, ReviewPrompt
 
@@ -84,7 +84,7 @@ DEFAULT_PROMPTS: Mapping[Language, ReviewPrompt] = MappingProxyType(
 def get_reviewer(
     language: Language,
     prompt: ReviewPrompt | None = None,
-    test_cases: list[TestCase] | None = None,
+    shared_test_cases: list[TestCase] | None = None,
     provider: LLMProvider | None = None,
     **kwargs: Unpack[ProcessorKwargs],
 ) -> ReviewProcessor:
@@ -93,7 +93,7 @@ def get_reviewer(
     Arguments:
         language: subtitle language
         prompt: text for LLM correspondence
-        test_cases: test cases
+        shared_test_cases: shared test cases
         provider: provider to use for queries
         **kwargs: additional keyword arguments for ReviewProcessor
     Returns:
@@ -106,9 +106,11 @@ def get_reviewer(
 
     if prompt is None:
         prompt = DEFAULT_PROMPTS[language]
-    if test_cases is None:
+    if shared_test_cases is None:
         json_paths = _JSON_PATHS[language]
-        test_cases = list(load_default_test_cases(ReviewManager, prompt, json_paths))
+        shared_test_cases = list(
+            load_shared_test_cases(ReviewManager, prompt, json_paths)
+        )
     if provider is None:
         provider = get_provider()
-    return ReviewProcessor(prompt, test_cases, provider=provider, **kwargs)
+    return ReviewProcessor(prompt, shared_test_cases, provider=provider, **kwargs)

--- a/scinoephile/lang/transcription/aligner.py
+++ b/scinoephile/lang/transcription/aligner.py
@@ -94,8 +94,8 @@ class TranscriptionAligner:
 
     def update_all_test_cases(self):
         """Update all test cases encountered during the current run."""
-        self.delineation_processor.save_test_cases()
-        self.punctuation_processor.save_test_cases()
+        self.delineation_processor.save_encountered_test_cases()
+        self.punctuation_processor.save_encountered_test_cases()
 
     def _delineate(self, alignment: TranscriptionAlignment) -> bool:
         """Delineate transcribed text.

--- a/scinoephile/lang/transcription/guided.py
+++ b/scinoephile/lang/transcription/guided.py
@@ -26,7 +26,7 @@ from scinoephile.lang.yue_zho.transcription import (
     YueZhoPunctuationPromptYueHans,
     YueZhoPunctuationPromptYueHant,
 )
-from scinoephile.llms import load_default_test_cases
+from scinoephile.llms import load_shared_test_cases
 from scinoephile.llms.delineation import (
     DelineationManager,
     DelineationProcessor,
@@ -264,7 +264,7 @@ def get_guided_transcriber(
             )
     if delineation_test_cases is None:
         delineation_test_cases = list(
-            load_default_test_cases(
+            load_shared_test_cases(
                 DelineationManager, delineation_prompt, spec.delineation_json_paths
             )
         )
@@ -272,8 +272,8 @@ def get_guided_transcriber(
         provider = get_provider()
     delineation_processor = DelineationProcessor(
         delineation_prompt,
-        test_cases=delineation_test_cases,
-        test_case_path=delineation_json_path,
+        shared_test_cases=delineation_test_cases,
+        current_test_cases_path=delineation_json_path,
         provider=provider,
         additional_context=additional_context,
         cache_root_path=cache_root_path,
@@ -283,14 +283,14 @@ def get_guided_transcriber(
     )
     if punctuation_test_cases is None:
         punctuation_test_cases = list(
-            load_default_test_cases(
+            load_shared_test_cases(
                 PunctuationManager, punctuation_prompt, spec.punctuation_json_paths
             )
         )
     punctuation_processor = PunctuationProcessor(
         punctuation_prompt,
-        test_cases=punctuation_test_cases,
-        test_case_path=punctuation_json_path,
+        shared_test_cases=punctuation_test_cases,
+        current_test_cases_path=punctuation_json_path,
         provider=provider,
         additional_context=additional_context,
         cache_root_path=cache_root_path,

--- a/scinoephile/lang/translation/gap.py
+++ b/scinoephile/lang/translation/gap.py
@@ -29,7 +29,7 @@ from scinoephile.lang.zho_yue.translation import (
     ZhoYueGapTranslationPromptZhoHans,
     ZhoYueGapTranslationPromptZhoHant,
 )
-from scinoephile.llms import load_default_test_cases
+from scinoephile.llms import load_shared_test_cases
 from scinoephile.llms.gap_translation import (
     GapTranslationManager,
     GapTranslationProcessor,
@@ -110,7 +110,7 @@ def get_gap_translator(
     source_language: Language,
     target_language: Language,
     prompt: GapTranslationPrompt | None = None,
-    test_cases: list[TestCase] | None = None,
+    shared_test_cases: list[TestCase] | None = None,
     provider: LLMProvider | None = None,
     **kwargs: Unpack[ProcessorKwargs],
 ) -> GapTranslationProcessor:
@@ -120,7 +120,7 @@ def get_gap_translator(
         source_language: source language
         target_language: target language
         prompt: prompt override
-        test_cases: test cases
+        shared_test_cases: shared test cases
         provider: provider to use for queries
         **kwargs: processor initialization keyword arguments
     Returns:
@@ -137,12 +137,14 @@ def get_gap_translator(
 
     if prompt is None:
         prompt = DEFAULT_PROMPTS[key]
-    if test_cases is None:
+    if shared_test_cases is None:
         json_paths = _JSON_PATHS[key]
-        test_cases = list(
-            load_default_test_cases(GapTranslationManager, prompt, json_paths)
+        shared_test_cases = list(
+            load_shared_test_cases(GapTranslationManager, prompt, json_paths)
         )
     if provider is None:
         provider = get_provider()
 
-    return GapTranslationProcessor(prompt, test_cases, provider=provider, **kwargs)
+    return GapTranslationProcessor(
+        prompt, shared_test_cases, provider=provider, **kwargs
+    )

--- a/scinoephile/lang/translation/guided.py
+++ b/scinoephile/lang/translation/guided.py
@@ -29,7 +29,7 @@ from scinoephile.lang.zho_yue.translation import (
     ZhoYueGuidedTranslationPromptZhoHans,
     ZhoYueGuidedTranslationPromptZhoHant,
 )
-from scinoephile.llms import load_default_test_cases
+from scinoephile.llms import load_shared_test_cases
 from scinoephile.llms.guided_translation import (
     GuidedTranslationManager,
     GuidedTranslationProcessor,
@@ -130,7 +130,7 @@ def get_guided_translator(
     source_language: Language,
     target_language: Language,
     prompt: GuidedTranslationPrompt | None = None,
-    test_cases: list[TestCase] | None = None,
+    shared_test_cases: list[TestCase] | None = None,
     provider: LLMProvider | None = None,
     **kwargs: Unpack[ProcessorKwargs],
 ) -> GuidedTranslationProcessor:
@@ -140,7 +140,7 @@ def get_guided_translator(
         source_language: source language
         target_language: target language
         prompt: prompt override
-        test_cases: test cases
+        shared_test_cases: shared test cases
         provider: provider to use for queries
         **kwargs: processor initialization keyword arguments
     Returns:
@@ -157,12 +157,14 @@ def get_guided_translator(
 
     if prompt is None:
         prompt = DEFAULT_PROMPTS[key]
-    if test_cases is None:
+    if shared_test_cases is None:
         json_paths = _JSON_PATHS[key]
-        test_cases = list(
-            load_default_test_cases(GuidedTranslationManager, prompt, json_paths)
+        shared_test_cases = list(
+            load_shared_test_cases(GuidedTranslationManager, prompt, json_paths)
         )
     if provider is None:
         provider = get_provider()
 
-    return GuidedTranslationProcessor(prompt, test_cases, provider=provider, **kwargs)
+    return GuidedTranslationProcessor(
+        prompt, shared_test_cases, provider=provider, **kwargs
+    )

--- a/scinoephile/lang/translation/standard.py
+++ b/scinoephile/lang/translation/standard.py
@@ -29,7 +29,7 @@ from scinoephile.lang.zho_yue.translation import (
     ZhoYueTranslationPromptZhoHans,
     ZhoYueTranslationPromptZhoHant,
 )
-from scinoephile.llms import load_default_test_cases
+from scinoephile.llms import load_shared_test_cases
 from scinoephile.llms.providers.registry import get_provider
 from scinoephile.llms.translation import (
     TranslationManager,
@@ -106,7 +106,7 @@ def get_translator(
     source_language: Language,
     target_language: Language,
     prompt: TranslationPrompt | None = None,
-    test_cases: list[TestCase] | None = None,
+    shared_test_cases: list[TestCase] | None = None,
     provider: LLMProvider | None = None,
     **kwargs: Unpack[ProcessorKwargs],
 ) -> TranslationProcessor:
@@ -116,7 +116,7 @@ def get_translator(
         source_language: source language
         target_language: target language
         prompt: prompt override
-        test_cases: test cases
+        shared_test_cases: shared test cases
         provider: provider to use for queries
         **kwargs: processor initialization keyword arguments
     Returns:
@@ -133,12 +133,12 @@ def get_translator(
 
     if prompt is None:
         prompt = DEFAULT_PROMPTS[key]
-    if test_cases is None:
+    if shared_test_cases is None:
         json_paths = _JSON_PATHS[key]
-        test_cases = list(
-            load_default_test_cases(TranslationManager, prompt, json_paths)
+        shared_test_cases = list(
+            load_shared_test_cases(TranslationManager, prompt, json_paths)
         )
     if provider is None:
         provider = get_provider()
 
-    return TranslationProcessor(prompt, test_cases, provider=provider, **kwargs)
+    return TranslationProcessor(prompt, shared_test_cases, provider=provider, **kwargs)

--- a/scinoephile/llms/__init__.py
+++ b/scinoephile/llms/__init__.py
@@ -30,36 +30,37 @@ import scinoephile.core.llms.utils as llm_utils
 from scinoephile import common
 from scinoephile.core.llms import Manager, Prompt, TestCase
 
-__all__ = ["load_default_test_cases"]
+__all__ = ["load_shared_test_cases"]
 
 logger = logging.getLogger(__name__)
 
 
 @functools.cache
-def load_default_test_cases(
+def load_shared_test_cases(
     manager_cls: type[Manager], prompt: Prompt, relative_paths: tuple[Path, ...]
 ) -> tuple[TestCase, ...]:
-    """Load default test cases from repository JSON files and cache the result.
+    """Load shared test cases from explicit repository JSON files and cache them.
 
     Arguments:
         manager_cls: manager class used to construct test case models
         prompt: text for LLM correspondence
         relative_paths: paths relative to repository test data root
     Returns:
-        loaded test cases
+        shared test cases
     """
     test_data_root = common.package_root.parent / "test/data"
     if not test_data_root.is_dir():
         logger.info(f"Test data root {test_data_root} does not exist.")
         return tuple()
 
-    loaded_test_cases: list[TestCase] = []
+    shared_test_cases: list[TestCase] = []
     for relative_path in relative_paths:
         path = test_data_root / relative_path
         if not path.is_file():
             continue
-        loaded_test_cases.extend(
-            llm_utils.load_test_cases_from_json(path, manager_cls, prompt=prompt)
+        path_test_cases = llm_utils.load_test_cases_from_json(
+            path, manager_cls, prompt=prompt
         )
-        logger.info(f"Loaded {len(loaded_test_cases)} test cases from {path}.")
-    return tuple(loaded_test_cases)
+        shared_test_cases.extend(path_test_cases)
+        logger.info(f"Loaded {len(path_test_cases)} test cases from {path}.")
+    return tuple(shared_test_cases)

--- a/scinoephile/llms/gap_translation/processor.py
+++ b/scinoephile/llms/gap_translation/processor.py
@@ -119,7 +119,7 @@ class GapTranslationProcessor(Processor):
             logger.info(f"Block {blk_idx}:\n{one_blk.to_simple_string()}")
             output_series_to_concatenate[blk_idx] = output_series
 
-        self.save_test_cases()
+        self.save_encountered_test_cases()
 
         output_series_blocks = [
             series for series in output_series_to_concatenate if series is not None

--- a/scinoephile/llms/guided_review/processor.py
+++ b/scinoephile/llms/guided_review/processor.py
@@ -95,7 +95,7 @@ class GuidedReviewProcessor(Processor):
             logger.info(f"Block {block_idx}:\n{output_block.to_simple_string()}")
             output_blocks[block_idx] = output_block
 
-        self.save_test_cases()
+        self.save_encountered_test_cases()
 
         processed_blocks = [block for block in output_blocks if block is not None]
         if processed_blocks:

--- a/scinoephile/llms/guided_translation/processor.py
+++ b/scinoephile/llms/guided_translation/processor.py
@@ -89,7 +89,7 @@ class GuidedTranslationProcessor(Processor):
             logger.info(f"Block {blk_idx}:\n{output_series.to_simple_string()}")
             output_series_to_concatenate[blk_idx] = output_series
 
-        self.save_test_cases()
+        self.save_encountered_test_cases()
 
         output_series_blocks = [
             series for series in output_series_to_concatenate if series is not None

--- a/scinoephile/llms/ocr_fusion/processor.py
+++ b/scinoephile/llms/ocr_fusion/processor.py
@@ -109,7 +109,7 @@ class OcrFusionProcessor(Processor):
             )
             output_subtitles.append(sub)
 
-        self.save_test_cases()
+        self.save_encountered_test_cases()
 
         # Organize and return
         return Series(events=output_subtitles)

--- a/scinoephile/llms/review/processor.py
+++ b/scinoephile/llms/review/processor.py
@@ -87,7 +87,7 @@ class ReviewProcessor(Processor):
             )
             output_series_to_concatenate[block_idx] = output_series
 
-        self.save_test_cases()
+        self.save_encountered_test_cases()
 
         output_series_blocks = [
             series for series in output_series_to_concatenate if series is not None

--- a/scinoephile/llms/translation/processor.py
+++ b/scinoephile/llms/translation/processor.py
@@ -87,7 +87,7 @@ class TranslationProcessor(Processor):
             )
             output_series_to_concatenate[block_idx] = output_series
 
-        self.save_test_cases()
+        self.save_encountered_test_cases()
 
         # Organize and return
         output_series_blocks = [

--- a/scinoephile/workflows/ocr_fusion.py
+++ b/scinoephile/workflows/ocr_fusion.py
@@ -21,7 +21,7 @@ def fuse_ocr_series(
     *,
     language: Language,
     prompt: OcrFusionPrompt | None = None,
-    test_cases: list[TestCase] | None = None,
+    shared_test_cases: list[TestCase] | None = None,
     provider: LLMProvider | None = None,
     fuser: OcrFusionProcessor | None = None,
     stop_at_idx: int | None = None,
@@ -34,7 +34,7 @@ def fuse_ocr_series(
         source_two: Tesseract or PaddleOCR subtitle series
         language: subtitle language
         prompt: text for LLM correspondence
-        test_cases: test cases
+        shared_test_cases: shared test cases
         provider: provider to use for queries
         fuser: OCR fuser to use, or None to construct one
         stop_at_idx: exclusive subtitle index at which to stop processing
@@ -45,5 +45,5 @@ def fuse_ocr_series(
         ScinoephileError: if OCR fusion does not support the language
     """
     if fuser is None:
-        fuser = get_ocr_fuser(language, prompt, test_cases, provider, **kwargs)
+        fuser = get_ocr_fuser(language, prompt, shared_test_cases, provider, **kwargs)
     return fuser.process(source_one, source_two, stop_at_idx=stop_at_idx)

--- a/scinoephile/workflows/ocr_processing.py
+++ b/scinoephile/workflows/ocr_processing.py
@@ -105,7 +105,7 @@ class OcrProcessingWorkflow:
             self.fuser_kw = dict(fuser_kw)
         self.fuser_kw.setdefault("additional_context", additional_context)
         self.fuser_kw.setdefault(
-            "test_case_path",
+            "current_test_cases_path",
             self.output_dir_path / "lang" / self.language.language / "ocr_fusion.json",
         )
         self.host = host

--- a/scinoephile/workflows/review.py
+++ b/scinoephile/workflows/review.py
@@ -24,7 +24,7 @@ def review_series(
     *,
     language: Language | None = None,
     prompt: ReviewPrompt | None = None,
-    test_cases: list[TestCase] | None = None,
+    shared_test_cases: list[TestCase] | None = None,
     provider: LLMProvider | None = None,
     reviewer: ReviewProcessor | None = None,
     start_at_idx: int = 0,
@@ -37,7 +37,7 @@ def review_series(
         series: subtitle series to review
         language: explicit language, or None to detect it
         prompt: text for LLM correspondence
-        test_cases: test cases
+        shared_test_cases: shared test cases
         provider: provider to use for queries
         reviewer: reviewer to use, or None to construct one
         start_at_idx: inclusive zero-based block index at which to start processing
@@ -52,7 +52,7 @@ def review_series(
 
     if reviewer is None:
         reviewer = get_reviewer(
-            resolved_language, prompt, test_cases, provider, **kwargs
+            resolved_language, prompt, shared_test_cases, provider, **kwargs
         )
     return reviewer.process(series, stop_at_idx=stop_at_idx, start_at_idx=start_at_idx)
 
@@ -64,7 +64,7 @@ def review_series_guided(
     language: Language | None = None,
     guide_language: Language | None = None,
     prompt: GuidedReviewPrompt | None = None,
-    test_cases: list[TestCase] | None = None,
+    shared_test_cases: list[TestCase] | None = None,
     provider: LLMProvider | None = None,
     reviewer: GuidedReviewProcessor | None = None,
     start_at_idx: int = 0,
@@ -79,7 +79,7 @@ def review_series_guided(
         language: explicit target language, or None to detect it
         guide_language: explicit guide language, or None to detect it
         prompt: text for LLM correspondence
-        test_cases: test cases
+        shared_test_cases: shared test cases
         provider: provider to use for queries
         reviewer: reviewer to use, or None to construct one
         start_at_idx: inclusive zero-based block index at which to start processing
@@ -97,7 +97,7 @@ def review_series_guided(
             resolved_language,
             resolved_guide_language,
             prompt,
-            test_cases,
+            shared_test_cases,
             provider=provider,
             **kwargs,
         )

--- a/scinoephile/workflows/translation.py
+++ b/scinoephile/workflows/translation.py
@@ -33,7 +33,7 @@ def translate_series(
     target_language: Language,
     source_language: Language | None = None,
     prompt: TranslationPrompt | None = None,
-    test_cases: list[TestCase] | None = None,
+    shared_test_cases: list[TestCase] | None = None,
     provider: LLMProvider | None = None,
     translator: TranslationProcessor | None = None,
     start_at_idx: int = 0,
@@ -47,7 +47,7 @@ def translate_series(
         source_language: explicit source language, or None to detect it
         target_language: target language
         prompt: prompt override
-        test_cases: test cases
+        shared_test_cases: shared test cases
         provider: LLM provider to use
         translator: translator to use, or None to construct one
         start_at_idx: inclusive zero-based block index at which to start processing
@@ -65,7 +65,7 @@ def translate_series(
             resolved_source_language,
             target_language,
             prompt,
-            test_cases,
+            shared_test_cases,
             provider,
             **kwargs,
         )
@@ -81,7 +81,7 @@ def translate_series_gaps(
     source_language: Language | None = None,
     target_language: Language | None = None,
     prompt: GapTranslationPrompt | None = None,
-    test_cases: list[TestCase] | None = None,
+    shared_test_cases: list[TestCase] | None = None,
     provider: LLMProvider | None = None,
     translator: GapTranslationProcessor | None = None,
     start_at_idx: int = 0,
@@ -96,7 +96,7 @@ def translate_series_gaps(
         source_language: explicit source language, or None to detect it
         target_language: explicit target language, or None to detect it
         prompt: prompt override
-        test_cases: test cases
+        shared_test_cases: shared test cases
         provider: LLM provider to use
         translator: translator to use, or None to construct one
         start_at_idx: inclusive zero-based block index at which to start processing
@@ -115,7 +115,7 @@ def translate_series_gaps(
             resolved_source_language,
             resolved_target_language,
             prompt,
-            test_cases,
+            shared_test_cases,
             provider,
             **kwargs,
         )
@@ -131,7 +131,7 @@ def translate_series_guided(
     source_language: Language | None = None,
     target_language: Language | None = None,
     prompt: GuidedTranslationPrompt | None = None,
-    test_cases: list[TestCase] | None = None,
+    shared_test_cases: list[TestCase] | None = None,
     provider: LLMProvider | None = None,
     translator: GuidedTranslationProcessor | None = None,
     start_at_idx: int = 0,
@@ -146,7 +146,7 @@ def translate_series_guided(
         source_language: explicit source language, or None to detect it
         target_language: explicit target language, or None to detect it
         prompt: prompt override
-        test_cases: test cases
+        shared_test_cases: shared test cases
         provider: LLM provider to use
         translator: translator to use, or None to construct one
         start_at_idx: inclusive zero-based block index at which to start processing
@@ -165,7 +165,7 @@ def translate_series_guided(
             resolved_source_language,
             resolved_target_language,
             prompt,
-            test_cases,
+            shared_test_cases,
             provider,
             **kwargs,
         )

--- a/test/cli/ocr/test_ocr_fuse_cli.py
+++ b/test/cli/ocr/test_ocr_fuse_cli.py
@@ -129,7 +129,7 @@ def test_ocr_fuse_cli_pipe(
     assert_series_equal(output, expected)
 
 
-def test_ocr_fuse_cli_passes_test_case_path(tmp_path: Path):
+def test_ocr_fuse_cli_passes_current_test_cases_path(tmp_path: Path):
     """Test OCR-fusion CLI passes an optional test-case JSON path.
 
     Arguments:
@@ -156,7 +156,7 @@ def test_ocr_fuse_cli_passes_test_case_path(tmp_path: Path):
             f"--cache-dir {cache_root_path} --cache-overwrite --llm-no-op",
         )
 
-    assert fuse.call_args.kwargs["test_case_path"] == json_path.resolve()
+    assert fuse.call_args.kwargs["current_test_cases_path"] == json_path.resolve()
     assert fuse.call_args.kwargs["cache_root_path"] == cache_root_path.resolve()
     assert fuse.call_args.kwargs["overwrite_cache"] is True
     assert fuse.call_args.kwargs["no_op"] is True

--- a/test/cli/test_review_cli.py
+++ b/test/cli/test_review_cli.py
@@ -184,7 +184,7 @@ def test_review_cli_passes_block_range(
                 "--cache-overwrite --llm-no-op",
             )
 
-    assert workflow.call_args.kwargs["test_case_path"] == json_path
+    assert workflow.call_args.kwargs["current_test_cases_path"] == json_path
     assert workflow.call_args.kwargs["start_at_idx"] == 1
     assert workflow.call_args.kwargs["stop_at_idx"] == 3
     assert workflow.call_args.kwargs["cache_root_path"] == cache_root_path.resolve()

--- a/test/cli/test_translate_cli.py
+++ b/test/cli/test_translate_cli.py
@@ -79,7 +79,7 @@ def test_translate_cli_passes_block_range(
                 "--cache-overwrite --llm-no-op",
             )
 
-    assert workflow.call_args.kwargs["test_case_path"] == json_path
+    assert workflow.call_args.kwargs["current_test_cases_path"] == json_path
     assert workflow.call_args.kwargs["start_at_idx"] == 1
     assert workflow.call_args.kwargs["stop_at_idx"] == 3
     assert workflow.call_args.kwargs["cache_root_path"] == cache_root_path.resolve()

--- a/test/core/llms/test_provider_injection.py
+++ b/test/core/llms/test_provider_injection.py
@@ -28,6 +28,10 @@ from scinoephile.core.llms import (
 )
 from scinoephile.core.llms.llm_provider import ChatCompletionKwargs
 from scinoephile.core.llms.tool_box import ToolBox
+from scinoephile.core.llms.utils import (
+    load_test_cases_from_json,
+    save_test_cases_to_json,
+)
 
 _PROMPT = Prompt(
     language=Language.eng,
@@ -479,7 +483,13 @@ def test_queryer_rejects_conflicting_verified_duplicates():
         query=_Query(text="input"), answer=_Answer(output="second"), verified=True
     )
 
-    with raises(ValueError, match="Conflicting verified answers"):
+    with raises(
+        ValueError,
+        match=(
+            "(?s)Conflicting verified answers.*Existing answer.*first.*"
+            "Conflicting answer.*second"
+        ),
+    ):
         Queryer(_TestCase, verified_test_cases=[first, second], provider=provider)
 
 
@@ -654,6 +664,73 @@ def test_cache_path_does_not_retain_queryer(tmp_path):
     gc.collect()
 
     assert queryer_ref() is None
+
+
+def test_processor_preserves_shared_verified_cases_from_current_unverified_case(
+    tmp_path: Path,
+):
+    """All shared verified cases should reach the nascent Queryer."""
+    shared_verified = _TestCase(
+        query=_Query(text="input"), answer=_Answer(output="verified"), verified=True
+    )
+    current_unverified = _TestCase(
+        query=_Query(text="input"), answer=_Answer(output="unverified")
+    )
+    current_test_cases_path = tmp_path / "test_cases.json"
+    save_test_cases_to_json(current_test_cases_path, [current_unverified], _Manager)
+
+    processor = _Processor(
+        prompt=_PROMPT,
+        shared_test_cases=[shared_verified],
+        current_test_cases_path=current_test_cases_path,
+        provider=Mock(spec=LLMProvider, cache_identity={"implementation": "test"}),
+    )
+
+    loaded = processor.queryer.verified_test_cases[shared_verified.query.key]
+    assert loaded.answer == shared_verified.answer
+
+
+def test_processor_rejects_conflicting_shared_and_current_verified_cases(
+    tmp_path: Path,
+):
+    """Conflicting shared and current verified answers should abort construction."""
+    shared = _TestCase(
+        query=_Query(text="input"), answer=_Answer(output="shared"), verified=True
+    )
+    current = _TestCase(
+        query=_Query(text="input"), answer=_Answer(output="current"), verified=True
+    )
+    current_test_cases_path = tmp_path / "test_cases.json"
+    save_test_cases_to_json(current_test_cases_path, [current], _Manager)
+
+    with raises(ValueError, match="(?s)Existing answer.*shared.*Conflicting.*current"):
+        _Processor(
+            prompt=_PROMPT,
+            shared_test_cases=[shared],
+            current_test_cases_path=current_test_cases_path,
+            provider=Mock(spec=LLMProvider, cache_identity={"implementation": "test"}),
+        )
+
+
+def test_processor_saves_encountered_cases_to_current_json(tmp_path: Path):
+    """Encountered cases should be saved to the current configuration's JSON."""
+    shared = _TestCase(
+        query=_Query(text="input"), answer=_Answer(output="verified"), verified=True
+    )
+    current_test_cases_path = tmp_path / "test_cases.json"
+    processor = _Processor(
+        prompt=_PROMPT,
+        shared_test_cases=[shared],
+        current_test_cases_path=current_test_cases_path,
+        provider=Mock(spec=LLMProvider, cache_identity={"implementation": "test"}),
+    )
+
+    processor.queryer(_TestCase(query=_Query(text="input")))
+    processor.save_encountered_test_cases()
+
+    saved = load_test_cases_from_json(current_test_cases_path, _Manager, _PROMPT)
+    assert len(saved) == 1
+    assert saved[0].model_dump(mode="json") == shared.model_dump(mode="json")
 
 
 def test_processor_passes_injected_provider_to_queryer():

--- a/test/core/llms/test_utils.py
+++ b/test/core/llms/test_utils.py
@@ -14,7 +14,6 @@ from pytest import mark, raises
 
 from scinoephile.core import Language
 from scinoephile.core.llms.utils import (
-    load_test_cases,
     load_test_cases_from_json,
     save_test_cases_to_json,
 )
@@ -109,39 +108,6 @@ def test_json_uses_base_prompt_fields(tmp_path: Path):
     assert loaded[0].answer.model_dump(by_alias=True) == {
         "xiugai": [{"xuhao": 1, "wenben": "corrected", "beizhu": "typo"}]
     }
-
-
-def test_load_test_cases_prefers_json_cases(tmp_path: Path):
-    """Test JSON test cases replace supplied cases with matching queries."""
-    supplied_test_case = _get_test_case("original", "supplied correction")
-    json_test_case = _get_test_case("original", "JSON correction")
-    test_case_path = tmp_path / "test_cases.json"
-    save_test_cases_to_json(test_case_path, [json_test_case], _AliasedBaseReviewManager)
-
-    test_cases, normalized_test_case_path = load_test_cases(
-        _AliasedBaseReviewManager,
-        _LOCALIZED_REVIEW_PROMPT,
-        test_cases=[supplied_test_case],
-        test_case_path=test_case_path,
-    )
-
-    assert test_cases == [json_test_case]
-    assert normalized_test_case_path == test_case_path.resolve()
-
-
-def test_load_test_cases_normalizes_optional_arguments(tmp_path: Path):
-    """Test optional cases and paths are normalized during loading."""
-    test_case_path = tmp_path / "new" / "test_cases.json"
-
-    test_cases, normalized_test_case_path = load_test_cases(
-        _AliasedBaseReviewManager,
-        _LOCALIZED_REVIEW_PROMPT,
-        test_case_path=test_case_path,
-    )
-
-    assert test_cases == []
-    assert normalized_test_case_path == test_case_path.resolve()
-    assert test_case_path.parent.is_dir()
 
 
 @mark.parametrize(

--- a/test/data/helpers.py
+++ b/test/data/helpers.py
@@ -91,7 +91,7 @@ def load_or_review_series(
 
     reviewer_kw = dict(reviewer_kw or {})
     reviewer_kw.setdefault(
-        "test_case_path",
+        "current_test_cases_path",
         output_path.parent / "lang" / language.language / "review.json",
     )
     reviewer_kw.setdefault("auto_verify", True)

--- a/test/data/mlamd/create_output.py
+++ b/test/data/mlamd/create_output.py
@@ -104,7 +104,7 @@ if "yue-Hans_transcribe" in actions:
     translator = get_gap_translator(
         Language.zho_hans,
         Language.yue_hans,
-        test_case_path=output_path
+        current_test_cases_path=output_path
         / "yue-Hans_transcribe"
         / "lang"
         / "yue_zho"
@@ -126,7 +126,7 @@ if "yue-Hans_transcribe" in actions:
     reviewer = get_guided_reviewer(
         Language.yue_hans,
         Language.zho_hans,
-        test_case_path=output_path
+        current_test_cases_path=output_path
         / "yue-Hans_transcribe"
         / "lang"
         / "yue_zho"

--- a/test/data/mnt/create_output.py
+++ b/test/data/mnt/create_output.py
@@ -78,7 +78,9 @@ if "yue_eng" in actions:
         Language.zho_hant,
         Language.eng,
         prompt=EngZhoYueGuidedTranslationPrompt,
-        test_case_path=(output_path / "yue_eng/lang/eng_zho/guided_translation.json"),
+        current_test_cases_path=(
+            output_path / "yue_eng/lang/eng_zho/guided_translation.json"
+        ),
         additional_context=additional_context,
         auto_verify=True,
     )

--- a/test/data/ocr.py
+++ b/test/data/ocr.py
@@ -96,8 +96,8 @@ def process_ocr(
         simplify_reviewer_kw = dict(reviewer_kw or {})
         simplify_reviewer_kw.pop("prompt", None)
         simplify_reviewer_kw.pop("reviewer", None)
-        simplify_reviewer_kw.pop("test_cases", None)
-        simplify_reviewer_kw["test_case_path"] = (
+        simplify_reviewer_kw.pop("shared_test_cases", None)
+        simplify_reviewer_kw["current_test_cases_path"] = (
             output_dir_path / "lang" / language.language / "simplify_review.json"
         )
         simplified_reviewed = load_or_review_series(
@@ -155,7 +155,7 @@ def _ocr(
     # Prepare kwargs
     fuser_kw = dict(fuser_kw or {})
     fuser_kw.setdefault(
-        "test_case_path",
+        "current_test_cases_path",
         output_dir_path / "lang" / language.language / "ocr_fusion.json",
     )
     fuser_kw.setdefault("auto_verify", True)

--- a/test/data/srt.py
+++ b/test/data/srt.py
@@ -118,8 +118,8 @@ def process_srt(
         simplify_reviewer_kw = dict(reviewer_kw)
         simplify_reviewer_kw.pop("prompt", None)
         simplify_reviewer_kw.pop("reviewer", None)
-        simplify_reviewer_kw.pop("test_cases", None)
-        simplify_reviewer_kw["test_case_path"] = (
+        simplify_reviewer_kw.pop("shared_test_cases", None)
+        simplify_reviewer_kw["current_test_cases_path"] = (
             output_dir_path / "lang" / "yue" / "simplify_review.json"
         )
         simplified_reviewed = load_or_review_series(

--- a/test/data/transcription.py
+++ b/test/data/transcription.py
@@ -264,7 +264,7 @@ def _load_or_review_series_guided(
     reviewer_kw = dict(reviewer_kw or {})
     language_pair_name = f"{language.language}_{guide_language.language}"
     reviewer_kw.setdefault(
-        "test_case_path",
+        "current_test_cases_path",
         output_path.parent
         / "lang"
         / language_pair_name
@@ -371,7 +371,7 @@ def _load_or_translate_series_gaps(
     translator_kw = dict(translator_kw or {})
     language_pair_name = f"{target_language.language}_{source_language.language}"
     translator_kw.setdefault(
-        "test_case_path",
+        "current_test_cases_path",
         output_path.parent
         / "lang"
         / language_pair_name

--- a/test/lang/test_ocr_fusion.py
+++ b/test/lang/test_ocr_fusion.py
@@ -301,7 +301,7 @@ def test_fuse_ocr_series(
 
     provider = Mock(spec=LLMProvider, cache_identity={"implementation": "test"})
     processor = get_ocr_fuser(
-        language, test_cases=test_case_loader(), provider=provider
+        language, shared_test_cases=test_case_loader(), provider=provider
     )
     expected = request.getfixturevalue(expected_fixture)
     output = fuse_ocr_series(lens, secondary, language=language, fuser=processor)

--- a/test/lang/test_review_series.py
+++ b/test/lang/test_review_series.py
@@ -418,7 +418,7 @@ def test_review_series(
     """
     provider = Mock(spec=LLMProvider, cache_identity={"implementation": "test"})
     reviewer = get_reviewer(
-        language, prompt=prompt, test_cases=test_case_loader(), provider=provider
+        language, prompt=prompt, shared_test_cases=test_case_loader(), provider=provider
     )
     expected = request.getfixturevalue(expected_fixture)
     output = review_series(

--- a/test/lang/transcription/test_guided.py
+++ b/test/lang/transcription/test_guided.py
@@ -127,10 +127,10 @@ def test_get_guided_transcriber_uses_registered_language_configuration(tmp_path)
     assert transcriber.transcriber.demucs_separator is not None
     assert transcriber.recovery_transcriber.demucs_separator is None
     test_case_dir_path = tmp_path / "data/test_cases/lang/yue_zho/transcription"
-    assert transcriber.aligner.delineation_processor.test_case_path == (
+    assert transcriber.aligner.delineation_processor.current_test_cases_path == (
         test_case_dir_path / "delineation" / "test.json"
     )
-    assert transcriber.aligner.punctuation_processor.test_case_path == (
+    assert transcriber.aligner.punctuation_processor.current_test_cases_path == (
         test_case_dir_path / "punctuation" / "test.json"
     )
     assert not transcriber.aligner.delineation_processor.prune_test_cases
@@ -202,10 +202,10 @@ def test_get_guided_transcriber_prunes_stale_cases_when_requested(tmp_path: Path
         punctuation_test_cases=[],
     )
 
-    assert transcriber.aligner.delineation_processor.test_case_path == (
+    assert transcriber.aligner.delineation_processor.current_test_cases_path == (
         delineation_json_path
     )
-    assert transcriber.aligner.punctuation_processor.test_case_path == (
+    assert transcriber.aligner.punctuation_processor.current_test_cases_path == (
         punctuation_json_path
     )
 

--- a/test/lang/yue_zho/test_get_yue_gap_translator_from_zho.py
+++ b/test/lang/yue_zho/test_get_yue_gap_translator_from_zho.py
@@ -60,7 +60,10 @@ def test_gap_translator_zho_to_yue(
     with patch(device_patch_target, return_value="cuda"):
         test_cases = test_case_loader()
     translator = get_gap_translator(
-        Language.zho_hans, Language.yue_hans, test_cases=test_cases, provider=provider
+        Language.zho_hans,
+        Language.yue_hans,
+        shared_test_cases=test_cases,
+        provider=provider,
     )
     output = translator.process(yuewen, zhongwen)
     assert_series_equal(output, expected)

--- a/test/lang/yue_zho/test_guided_review.py
+++ b/test/lang/yue_zho/test_guided_review.py
@@ -65,7 +65,10 @@ def test_review_series_guided_yue_zho(
     with patch(device_patch_target, return_value=device_name):
         test_cases = test_case_loader()
     reviewer = get_guided_reviewer(
-        Language.yue_hans, Language.zho_hans, test_cases=test_cases, provider=provider
+        Language.yue_hans,
+        Language.zho_hans,
+        shared_test_cases=test_cases,
+        provider=provider,
     )
     output = review_series_guided(yuewen, zhongwen, reviewer=reviewer)
     assert_series_equal(output, expected)

--- a/test/llms/test_gap_translation.py
+++ b/test/llms/test_gap_translation.py
@@ -375,7 +375,7 @@ def test_processor_maps_targets_and_outputs_by_index():
     )
     provider = Mock(spec=LLMProvider, cache_identity={"implementation": "test"})
     processor = GapTranslationProcessor(
-        prompt, test_cases=[test_case], provider=provider
+        prompt, shared_test_cases=[test_case], provider=provider
     )
 
     output = processor.process(source_one, source_two)
@@ -441,14 +441,16 @@ def test_processing_preserves_unencountered_few_shot_cases(tmp_path: Path):
             "verified": True,
         }
     )
-    test_case_path = tmp_path / "gap_translation.json"
-    save_test_cases_to_json(test_case_path, [old_test_case], GapTranslationManager)
+    current_test_cases_path = tmp_path / "gap_translation.json"
+    save_test_cases_to_json(
+        current_test_cases_path, [old_test_case], GapTranslationManager
+    )
     provider = Mock(spec=LLMProvider, cache_identity={"implementation": "test"})
     provider.chat_completion.return_value = json.dumps(
         {"outputs": [{"index": 2, "text": "new translation"}]}
     )
     processor = GapTranslationProcessor(
-        prompt, test_case_path=test_case_path, provider=provider
+        prompt, current_test_cases_path=current_test_cases_path, provider=provider
     )
     target = Series(events=[Subtitle(start=0, end=100, text="new target")])
     guide = Series(
@@ -460,7 +462,9 @@ def test_processing_preserves_unencountered_few_shot_cases(tmp_path: Path):
 
     processor.process(target, guide)
 
-    persisted = load_test_cases_from_json(test_case_path, GapTranslationManager, prompt)
+    persisted = load_test_cases_from_json(
+        current_test_cases_path, GapTranslationManager, prompt
+    )
     assert len(persisted) == 2
     persisted_cases = cast("list[GapTranslationTestCase]", persisted)
     assert [item.query.targets[0].text for item in persisted_cases] == [

--- a/test/llms/test_guided_review_models.py
+++ b/test/llms/test_guided_review_models.py
@@ -111,12 +111,16 @@ def test_processing_preserves_unencountered_few_shot_cases(tmp_path: Path):
             "verified": True,
         }
     )
-    test_case_path = tmp_path / "guided_review.json"
-    save_test_cases_to_json(test_case_path, [old_test_case], GuidedReviewManager)
+    current_test_cases_path = tmp_path / "guided_review.json"
+    save_test_cases_to_json(
+        current_test_cases_path, [old_test_case], GuidedReviewManager
+    )
     provider = Mock(spec=LLMProvider, cache_identity={"implementation": "test"})
     provider.chat_completion.return_value = '{"xiugai": []}'
     processor = GuidedReviewProcessor(
-        _LOCALIZED_PROMPT, test_case_path=test_case_path, provider=provider
+        _LOCALIZED_PROMPT,
+        current_test_cases_path=current_test_cases_path,
+        provider=provider,
     )
     target = Series(events=[Subtitle(start=0, end=100, text="新原文")])
     guide = Series(events=[Subtitle(start=0, end=100, text="參考")])
@@ -124,7 +128,7 @@ def test_processing_preserves_unencountered_few_shot_cases(tmp_path: Path):
     processor.process(target, guide)
 
     persisted = load_test_cases_from_json(
-        test_case_path, GuidedReviewManager, _LOCALIZED_PROMPT
+        current_test_cases_path, GuidedReviewManager, _LOCALIZED_PROMPT
     )
     assert len(persisted) == 2
     persisted_cases = cast("list[GuidedReviewTestCase]", persisted)

--- a/test/llms/test_review.py
+++ b/test/llms/test_review.py
@@ -200,19 +200,21 @@ def test_partial_processing_preserves_unencountered_test_cases(tmp_path: Path):
             "verified": True,
         }
     )
-    test_case_path = tmp_path / "review.json"
-    save_test_cases_to_json(test_case_path, [existing_test_case], ReviewManager)
-    original_contents = test_case_path.read_bytes()
+    current_test_cases_path = tmp_path / "review.json"
+    save_test_cases_to_json(
+        current_test_cases_path, [existing_test_case], ReviewManager
+    )
+    original_contents = current_test_cases_path.read_bytes()
     processor = ReviewProcessor(
         ReviewManager.base_prompt,
-        test_case_path=test_case_path,
+        current_test_cases_path=current_test_cases_path,
         provider=Mock(spec=LLMProvider, cache_identity={"implementation": "test"}),
     )
     series = Series(events=[Subtitle(start=0, end=1000, text="existing")])
 
     processor.process(series, stop_at_idx=0)
 
-    assert test_case_path.read_bytes() == original_contents
+    assert current_test_cases_path.read_bytes() == original_contents
 
 
 def test_partial_processing_prunes_only_when_requested(tmp_path: Path):
@@ -225,11 +227,13 @@ def test_partial_processing_prunes_only_when_requested(tmp_path: Path):
             "verified": True,
         }
     )
-    test_case_path = tmp_path / "review.json"
-    save_test_cases_to_json(test_case_path, [existing_test_case], ReviewManager)
+    current_test_cases_path = tmp_path / "review.json"
+    save_test_cases_to_json(
+        current_test_cases_path, [existing_test_case], ReviewManager
+    )
     processor = ReviewProcessor(
         ReviewManager.base_prompt,
-        test_case_path=test_case_path,
+        current_test_cases_path=current_test_cases_path,
         provider=Mock(spec=LLMProvider, cache_identity={"implementation": "test"}),
         prune_test_cases=True,
     )
@@ -237,7 +241,7 @@ def test_partial_processing_prunes_only_when_requested(tmp_path: Path):
 
     processor.process(series, stop_at_idx=0)
 
-    assert json.loads(test_case_path.read_text(encoding="utf-8")) == []
+    assert json.loads(current_test_cases_path.read_text(encoding="utf-8")) == []
 
 
 def test_processor_honors_start_index():

--- a/test/workflows/test_ocr_processing.py
+++ b/test/workflows/test_ocr_processing.py
@@ -27,7 +27,9 @@ def test_ocr_processing_workflow_keeps_cache_policy_on_cache(tmp_path: Path):
     assert not hasattr(workflow, "overwrite_cache")
 
 
-def test_ocr_processing_workflow_sets_default_fusion_test_case_path(tmp_path: Path):
+def test_ocr_processing_workflow_sets_default_fusion_current_test_cases_path(
+    tmp_path: Path,
+):
     """Test OCR processing persists fusion decisions at its conventional path.
 
     Arguments:
@@ -37,23 +39,25 @@ def test_ocr_processing_workflow_sets_default_fusion_test_case_path(tmp_path: Pa
         tmp_path / "source.sup", tmp_path / "output", language=Language.yue_hant
     )
 
-    assert workflow.fuser_kw["test_case_path"] == (
+    assert workflow.fuser_kw["current_test_cases_path"] == (
         tmp_path / "output" / "lang" / "yue" / "ocr_fusion.json"
     )
 
 
-def test_ocr_processing_workflow_preserves_fusion_test_case_path(tmp_path: Path):
+def test_ocr_processing_workflow_preserves_fusion_current_test_cases_path(
+    tmp_path: Path,
+):
     """Test supplied OCR-fusion test-case paths take precedence.
 
     Arguments:
         tmp_path: pytest temporary path fixture
     """
-    test_case_path = tmp_path / "custom.json"
+    current_test_cases_path = tmp_path / "custom.json"
     workflow = OcrProcessingWorkflow(
         tmp_path / "source.sup",
         tmp_path / "output",
         language=Language.eng,
-        fuser_kw={"test_case_path": test_case_path},
+        fuser_kw={"current_test_cases_path": current_test_cases_path},
     )
 
-    assert workflow.fuser_kw["test_case_path"] == test_case_path
+    assert workflow.fuser_kw["current_test_cases_path"] == current_test_cases_path


### PR DESCRIPTION
## Summary

- distinguish shared test cases, the current configuration's JSON path and loaded cases, and cases encountered during execution
- populate each new Queryer from verified shared and current cases without allowing unverified current entries to suppress shared verified answers
- reject contradictory verified answers immediately with the query and both answers, while consolidating identical answers with the strongest metadata
- save only encountered cases to the current configuration JSON while preserving existing prune and non-prune behavior
- rename the related processor, factory, workflow, CLI, and pairwise transcription APIs

## Tests

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format <changed Python files>`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix <changed Python files>`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check <changed Python files>`
- focused pytest suite: 199 passed
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto`: 2126 passed, 4 skipped