### PR TITLE
Add OpenAI request timeout

### DIFF
--- a/scinoephile/core/llms/openai_provider_base.py
+++ b/scinoephile/core/llms/openai_provider_base.py
@@ -37,6 +37,9 @@ class OpenAIProviderBase(LLMProvider):
     base_url: str | None = None
     """Default base URL for the OpenAI client."""
 
+    timeout_seconds: float
+    """Timeout for each provider request."""
+
     def __init__(
         self,
         client: OpenAI | None = None,
@@ -44,6 +47,7 @@ class OpenAIProviderBase(LLMProvider):
         api_key: str | None = None,
         base_url: str | None = None,
         model: str | None = None,
+        timeout_seconds: float = 120.0,
     ):
         """Initialize.
 
@@ -52,9 +56,15 @@ class OpenAIProviderBase(LLMProvider):
             api_key: explicit API key; if omitted, env var is used if configured
             base_url: explicit base URL; if omitted, provider default is used
             model: model identifier override
+            timeout_seconds: timeout for each provider request
+        Raises:
+            ValueError: if timeout_seconds is not positive
         """
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive.")
         self._sync_client: OpenAI | None = client
         self._api_key: str | None = api_key
+        self.timeout_seconds = timeout_seconds
         if base_url is not None:
             self.base_url = base_url
         if model is not None:
@@ -97,7 +107,11 @@ class OpenAIProviderBase(LLMProvider):
     def sync_client(self) -> OpenAI:
         """Synchronous OpenAI client."""
         if self._sync_client is None:
-            self._sync_client = OpenAI(api_key=self.api_key, base_url=self.base_url)
+            self._sync_client = OpenAI(
+                api_key=self.api_key,
+                base_url=self.base_url,
+                timeout=self.timeout_seconds,
+            )
         return self._sync_client
 
     @property
@@ -223,6 +237,7 @@ class OpenAIProviderBase(LLMProvider):
         return self.sync_client.beta.chat.completions.parse(
             messages=messages,  # ty:ignore[invalid-argument-type]
             model=self.model,
+            timeout=self.timeout_seconds,
             **request_kwargs,
         )
 

--- a/test/core/llms/test_openai_provider_base.py
+++ b/test/core/llms/test_openai_provider_base.py
@@ -8,11 +8,11 @@ import json
 from collections.abc import Callable
 from types import SimpleNamespace
 from typing import Any, cast
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from openai import OpenAI
 from pydantic import ValidationError
-from pytest import raises
+from pytest import mark, raises
 
 from scinoephile.core import ScinoephileError
 from scinoephile.core.llms import Answer, OpenAIProviderBase
@@ -215,6 +215,23 @@ def test_model_override_updates_provider_model():
     assert cast(str, client.calls[0]["model"]) == "override-model"
 
 
+def test_completion_requests_use_configured_timeout():
+    """Test completion requests forward the timeout to an injected client."""
+    client = _DummyClient()
+    provider = _DummyProvider(client=cast(OpenAI, client), timeout_seconds=45.0)
+
+    result = provider.chat_completion(
+        messages=[{"role": "user", "content": "hi"}],
+        response_format=_Answer,
+        tool_box=_get_tool_box(lambda args: args),
+    )
+
+    assert result == "done"
+    assert [
+        cast(dict[str, object], call["kwargs"])["timeout"] for call in client.calls
+    ] == [45.0, 45.0]
+
+
 def test_structured_response_validation_error_is_wrapped():
     """Test client-side structured validation failures become domain errors."""
     client = Mock()
@@ -226,6 +243,43 @@ def test_structured_response_validation_error_is_wrapped():
     with raises(ScinoephileError, match="failed structured response validation"):
         provider.chat_completion(
             messages=[{"role": "user", "content": "hi"}], response_format=_Answer
+        )
+
+
+def test_timeout_defaults_to_120_seconds():
+    """Test provider requests default to a 120-second timeout."""
+    provider = _DummyProvider(client=cast(OpenAI, _DummyClient()))
+
+    assert provider.timeout_seconds == 120.0
+
+
+def test_custom_timeout_is_stored():
+    """Test providers retain a custom request timeout."""
+    provider = _DummyProvider(client=cast(OpenAI, _DummyClient()), timeout_seconds=45.0)
+
+    assert provider.timeout_seconds == 45.0
+
+
+@mark.parametrize("timeout_seconds", [0.0, -1.0])
+def test_timeout_must_be_positive(timeout_seconds: float):
+    """Test provider request timeouts must be positive."""
+    with raises(ValueError, match="timeout_seconds must be positive"):
+        _DummyProvider(timeout_seconds=timeout_seconds)
+
+
+def test_sync_client_is_created_lazily_with_configured_timeout():
+    """Test lazy OpenAI client construction uses the configured timeout."""
+    with patch("scinoephile.core.llms.openai_provider_base.OpenAI") as openai:
+        provider = _DummyProvider(
+            api_key="test-api-key",
+            base_url="https://example.invalid/v1",
+            timeout_seconds=45.0,
+        )
+
+        openai.assert_not_called()
+        assert provider.sync_client is openai.return_value
+        openai.assert_called_once_with(
+            api_key="test-api-key", base_url="https://example.invalid/v1", timeout=45.0
         )
 
 


### PR DESCRIPTION
## Summary

- add a configurable `timeout_seconds` setting to `OpenAIProviderBase`, defaulting to 120 seconds
- reject zero and negative timeout values
- apply the configured timeout to lazy OpenAI client construction and every completion request, including requests made through injected clients
- add focused coverage for default and custom values, validation, lazy construction, and request forwarding

## Why

OpenAI-compatible providers need a consistent, explicit request timeout. Passing the timeout at both client construction and request time keeps lazy clients and injected clients aligned without changing existing completion or exception behavior.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format scinoephile/core/llms/openai_provider_base.py test/core/llms/test_openai_provider_base.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix scinoephile/core/llms/openai_provider_base.py test/core/llms/test_openai_provider_base.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check scinoephile/core/llms/openai_provider_base.py test/core/llms/test_openai_provider_base.py`
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest core/llms/test_openai_provider_base.py` (15 passed)
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto` (2,131 passed, 4 skipped)