### PR TITLE
Default guided transcription Demucs to off

### DIFF
--- a/scinoephile/audio/transcription/mlx_audio/transcriber.py
+++ b/scinoephile/audio/transcription/mlx_audio/transcriber.py
@@ -82,7 +82,7 @@ class MlxAudioTranscriber(Transcriber):
         max_tokens: int | None = None,
         chunk_duration_seconds: float | None = None,
         chunk_overlap_seconds: float = 1.0,
-        demucs_mode: DemucsMode = DemucsMode.AUTO,
+        demucs_mode: DemucsMode = DemucsMode.OFF,
         vad_mode: VADMode = VADMode.OFF,
         cache_root_path: Path | None = None,
         overwrite_cache: bool = False,

--- a/scinoephile/audio/transcription/transcriber.py
+++ b/scinoephile/audio/transcription/transcriber.py
@@ -42,7 +42,7 @@ class Transcriber(ABC):
     def __init__(
         self,
         cache_root_path: Path | None,
-        demucs_mode: DemucsMode = DemucsMode.AUTO,
+        demucs_mode: DemucsMode = DemucsMode.OFF,
         vad_mode: VADMode = VADMode.OFF,
         overwrite_cache: bool = False,
         demucs_separator: DemucsSeparator | None = None,

--- a/scinoephile/audio/transcription/whisper_transcriber.py
+++ b/scinoephile/audio/transcription/whisper_transcriber.py
@@ -66,7 +66,7 @@ class WhisperTranscriber(Transcriber):
         self,
         model_name: str = "khleeloo/whisper-large-v3-cantonese",
         language: str = "yue",
-        demucs_mode: DemucsMode = DemucsMode.AUTO,
+        demucs_mode: DemucsMode = DemucsMode.OFF,
         vad_mode: VADMode = VADMode.OFF,
         cache_root_path: Path | None = None,
         overwrite_cache: bool = False,

--- a/scinoephile/cli/transcribe_cli.py
+++ b/scinoephile/cli/transcribe_cli.py
@@ -211,7 +211,7 @@ class TranscribeCli(ScinoephileCliBase):
         )
         arg_groups["operation arguments"].add_argument(
             "--demucs",
-            default=DemucsMode.AUTO,
+            default=DemucsMode.OFF,
             dest="demucs_mode",
             metavar=enum_metavar(DemucsMode),
             type=enum_arg(DemucsMode),

--- a/scinoephile/lang/transcription/guided.py
+++ b/scinoephile/lang/transcription/guided.py
@@ -186,7 +186,7 @@ def get_guided_transcriber(
     *,
     model_name: str | None = None,
     backend: TranscriptionBackend = TranscriptionBackend.WHISPER,
-    demucs_mode: DemucsMode = DemucsMode.AUTO,
+    demucs_mode: DemucsMode = DemucsMode.OFF,
     vad_mode: VADMode = VADMode.OFF,
     cache_root_path: Path | None = None,
     overwrite_cache: bool = False,

--- a/scinoephile/lang/transcription/transcriber.py
+++ b/scinoephile/lang/transcription/transcriber.py
@@ -141,7 +141,7 @@ class GuidedTranscriber:
         whisper_language: str,
         aligner: TranscriptionAligner,
         backend: TranscriptionBackend = TranscriptionBackend.WHISPER,
-        demucs_mode: DemucsMode = DemucsMode.AUTO,
+        demucs_mode: DemucsMode = DemucsMode.OFF,
         vad_mode: VADMode = VADMode.OFF,
         cache_root_path: Path | None = None,
         overwrite_cache: bool = False,

--- a/scinoephile/workflows/transcription.py
+++ b/scinoephile/workflows/transcription.py
@@ -33,7 +33,7 @@ def transcribe_series_guided(
     guide_language: Language | None = None,
     model_name: str | None = None,
     backend: TranscriptionBackend = TranscriptionBackend.WHISPER,
-    demucs_mode: DemucsMode = DemucsMode.AUTO,
+    demucs_mode: DemucsMode = DemucsMode.OFF,
     vad_mode: VADMode = VADMode.OFF,
     cache_root_path: Path | None = None,
     overwrite_cache: bool = False,

--- a/test/audio/transcription/mlx_audio/test_mlx_audio_transcriber.py
+++ b/test/audio/transcription/mlx_audio/test_mlx_audio_transcriber.py
@@ -60,12 +60,13 @@ def _get_cache_path(
     return cache_path
 
 
-def test_init_defaults_demucs_to_auto_and_vad_to_off():
-    """Test MLX-Audio defaults Demucs to automatic and VAD to off."""
+def test_init_defaults_demucs_and_vad_to_off():
+    """Test MLX-Audio defaults Demucs and VAD to off."""
     transcriber = MlxAudioTranscriber()
 
-    assert transcriber.demucs_mode is DemucsMode.AUTO
+    assert transcriber.demucs_mode is DemucsMode.OFF
     assert transcriber.vad_mode is VADMode.OFF
+    assert transcriber.demucs_separator is None
 
 
 def test_get_cache_path_separates_model_configuration():

--- a/test/audio/transcription/test_whisper_transcriber.py
+++ b/test/audio/transcription/test_whisper_transcriber.py
@@ -41,12 +41,13 @@ _OPTIONAL_TRANSCRIPTION_MODULES = (
 )
 
 
-def test_init_defaults_demucs_to_auto_and_vad_to_off():
-    """Test Whisper defaults Demucs to automatic and VAD to off."""
+def test_init_defaults_demucs_and_vad_to_off():
+    """Test Whisper defaults Demucs and VAD to off."""
     transcriber = WhisperTranscriber()
 
-    assert transcriber.demucs_mode is DemucsMode.AUTO
+    assert transcriber.demucs_mode is DemucsMode.OFF
     assert transcriber.vad_mode is VADMode.OFF
+    assert transcriber.demucs_separator is None
 
 
 def _get_cache_path(transcriber: WhisperTranscriber, audio: AudioSegment) -> Path:
@@ -80,14 +81,26 @@ def test_get_cache_path_separates_configuration(
         second_value: second transcriber field value
     """
     audio = AudioSegment(data=b"audio", sample_width=1, frame_rate=8000, channels=1)
-    first_transcriber = WhisperTranscriber(
-        cache_root_path=tmp_path, model_name="custom/model"
-    )
-    second_transcriber = WhisperTranscriber(
-        cache_root_path=tmp_path, model_name="custom/model"
-    )
-    setattr(first_transcriber, field_name, first_value)
-    setattr(second_transcriber, field_name, second_value)
+    if field_name == "demucs_mode":
+        assert isinstance(first_value, DemucsMode)
+        assert isinstance(second_value, DemucsMode)
+        first_transcriber = WhisperTranscriber(
+            cache_root_path=tmp_path, model_name="custom/model", demucs_mode=first_value
+        )
+        second_transcriber = WhisperTranscriber(
+            cache_root_path=tmp_path,
+            model_name="custom/model",
+            demucs_mode=second_value,
+        )
+    else:
+        first_transcriber = WhisperTranscriber(
+            cache_root_path=tmp_path, model_name="custom/model"
+        )
+        second_transcriber = WhisperTranscriber(
+            cache_root_path=tmp_path, model_name="custom/model"
+        )
+        setattr(first_transcriber, field_name, first_value)
+        setattr(second_transcriber, field_name, second_value)
     first_cache_path = _get_cache_path(first_transcriber, audio)
     second_cache_path = _get_cache_path(second_transcriber, audio)
 

--- a/test/cli/test_transcribe_cli.py
+++ b/test/cli/test_transcribe_cli.py
@@ -100,8 +100,8 @@ def test_transcribe_cli_defers_whisper_model_default_to_registry():
     assert model_action.default is None
 
 
-def test_transcribe_cli_defaults_demucs_to_auto_and_vad_to_off():
-    """Test transcription CLI defaults Demucs to automatic and disables VAD."""
+def test_transcribe_cli_defaults_demucs_and_vad_to_off():
+    """Test transcription CLI defaults Demucs and VAD to off."""
     parser = TranscribeCli.argparser()
     demucs_action = next(
         action
@@ -114,7 +114,7 @@ def test_transcribe_cli_defaults_demucs_to_auto_and_vad_to_off():
         if "--vad" in action.option_strings
     )
 
-    assert demucs_action.default is DemucsMode.AUTO
+    assert demucs_action.default is DemucsMode.OFF
     assert vad_action.default is VADMode.OFF
 
 

--- a/test/lang/transcription/test_guided.py
+++ b/test/lang/transcription/test_guided.py
@@ -94,7 +94,7 @@ def test_get_guided_transcriber_uses_registered_language_configuration(tmp_path)
     assert transcriber.language is Language.yue_hant
     assert transcriber.guide_language is Language.zho_hans
     assert transcriber.backend is TranscriptionBackend.WHISPER
-    assert transcriber.demucs_mode is DemucsMode.AUTO
+    assert transcriber.demucs_mode is DemucsMode.OFF
     assert transcriber.vad_mode is VADMode.OFF
     assert not hasattr(transcriber, "overwrite_cache")
     assert not hasattr(transcriber, "cache_root_path")
@@ -109,7 +109,7 @@ def test_get_guided_transcriber_uses_registered_language_configuration(tmp_path)
         YueZhoPunctuationPromptYueHant
     )
     assert transcriber.transcriber.language == "yue"
-    assert transcriber.transcriber.demucs_mode is DemucsMode.AUTO
+    assert transcriber.transcriber.demucs_mode is DemucsMode.OFF
     assert transcriber.transcriber.vad_mode is VADMode.OFF
     assert transcriber.recovery_transcriber is not None
     assert transcriber.tail_recovery_transcriber is not None
@@ -124,7 +124,7 @@ def test_get_guided_transcriber_uses_registered_language_configuration(tmp_path)
     assert transcriber.transcriber._cache.overwrite
     assert transcriber.recovery_transcriber._cache.overwrite
     assert transcriber.tail_recovery_transcriber._cache.overwrite
-    assert transcriber.transcriber.demucs_separator is not None
+    assert transcriber.transcriber.demucs_separator is None
     assert transcriber.recovery_transcriber.demucs_separator is None
     test_case_dir_path = tmp_path / "data/test_cases/lang/yue_zho/transcription"
     assert transcriber.aligner.delineation_processor.test_case_path == (
@@ -180,7 +180,7 @@ def test_get_guided_transcriber_configures_mlx_audio_backend(tmp_path: Path):
     mlx_audio_transcriber_class.assert_called_once_with(
         model_name=MIMO_MODEL_NAME,
         language=Language.yue_hant,
-        demucs_mode=DemucsMode.AUTO,
+        demucs_mode=DemucsMode.OFF,
         vad_mode=VADMode.OFF,
         cache_root_path=tmp_path,
         overwrite_cache=False,

--- a/test/workflows/test_transcription.py
+++ b/test/workflows/test_transcription.py
@@ -57,7 +57,7 @@ def test_transcribe_series_guided_constructs_transcriber_for_language_pair(
 
     assert output is expected
     assert get_transcriber.call_args.args == (Language.yue_hant, Language.zho_hans)
-    assert get_transcriber.call_args.kwargs["demucs_mode"] is DemucsMode.AUTO
+    assert get_transcriber.call_args.kwargs["demucs_mode"] is DemucsMode.OFF
     assert get_transcriber.call_args.kwargs["vad_mode"] is VADMode.OFF
     assert get_transcriber.call_args.kwargs["backend"] is (
         TranscriptionBackend.MLX_AUDIO


### PR DESCRIPTION
## Summary

- default Demucs preprocessing to off across guided transcription, including Whisper, MLX-Audio, the CLI, and the workflow
- preserve explicit `auto` and `on` behavior
- avoid constructing a Demucs separator when the default-off path is used
- leave VAD defaults and behavior unchanged

## Why

Guided transcription should not eagerly enable Demucs or pay its separator setup cost unless users explicitly request automatic or enabled preprocessing.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format` on all 12 changed Python files
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix` on all 12 changed Python files
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check` on all 12 changed Python files
- focused transcription, CLI, guided, and workflow tests: 84 passed
- full suite: 2,125 passed, 4 skipped