### PR TITLE
Add aligned transcription test harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ scinoephile.egg-info
 !/test/data/*/output/*/lang/yue_zho/guided_review/*.json
 !/test/data/*/output/*/lang/yue_zho/transcription/delineation/*.json
 !/test/data/*/output/*/lang/yue_zho/transcription/punctuation/*.json
+!/test/data/*/output/*_transcribe/**/json/*.json
 /test/data/*/output/**/*.png
 /test/data/*/output/**/*.wav
 /test/data/cache/**

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ scinoephile.egg-info
 !/test/data/*/output/*/lang/yue_zho/guided_review/*.json
 !/test/data/*/output/*/lang/yue_zho/transcription/delineation/*.json
 !/test/data/*/output/*/lang/yue_zho/transcription/punctuation/*.json
-!/test/data/*/output/*_transcribe/**/json/*.json
+!/test/data/*/output/*_transcribe/json/*.json
 /test/data/*/output/**/*.png
 /test/data/*/output/**/*.wav
 /test/data/cache/**

--- a/scinoephile/analysis/__init__.py
+++ b/scinoephile/analysis/__init__.py
@@ -5,6 +5,7 @@
 Package hierarchy (modules may import from any above):
 * alignment
 * diff
-* character_error_rate / transcription
+* character_error_rate
+* transcription
 * audit
 """

--- a/scinoephile/analysis/audit/transcription/report.py
+++ b/scinoephile/analysis/audit/transcription/report.py
@@ -282,14 +282,14 @@ def _get_metric_summary(artifact: AlignmentArtifact, reference: Series) -> list[
     for name, result in evaluation.character_errors.items():
         lines.append(f"- {name} CER: {result.cer:.3%}")
     timing = evaluation.timing
+    group_counts = timing.candidate_to_reference_group_counts
     lines.extend(
         (
             f"- text-aligned timing groups: {len(timing.pairs)}",
             (
                 "- candidate:reference subtitle groups: "
                 + ", ".join(
-                    f"{shape} × {count}"
-                    for shape, count in evaluation.group_counts.items()
+                    f"{shape} × {count}" for shape, count in group_counts.items()
                 )
             ),
             f"- temporal micro IoU: {timing.micro_intersection_over_union:.3%}",

--- a/scinoephile/analysis/audit/transcription/report.py
+++ b/scinoephile/analysis/audit/transcription/report.py
@@ -4,22 +4,21 @@
 
 from __future__ import annotations
 
-from collections import Counter
 from collections.abc import Callable, Mapping, Sequence
 
 from scinoephile.analysis.alignment.timed_msa.aligner import Aligner
 from scinoephile.analysis.alignment.timed_msa.models import Token
 from scinoephile.analysis.audit.utils import format_index_range, validate_audit_range
-from scinoephile.analysis.character_error_rate import SeriesCER
 from scinoephile.analysis.transcription.artifact import (
     AlignmentArtifact,
     AlignmentBlock,
 )
+from scinoephile.analysis.transcription.evaluation import evaluate_transcription
 from scinoephile.analysis.transcription.timing import (
     evaluate_timing,
     get_reference_for_alignment,
 )
-from scinoephile.core.subtitles import Series, Subtitle
+from scinoephile.core.subtitles import Series
 from scinoephile.core.text import normalize_nfkc
 
 from .rendering import render_transcription_alignment_block
@@ -278,29 +277,11 @@ def _get_metric_summary(artifact: AlignmentArtifact, reference: Series) -> list[
     Returns:
         Markdown summary list items
     """
-    selected_reference = get_reference_for_alignment(artifact, reference)
-    source_events = {source.name: [] for source in artifact.sources}
-    for block in artifact.blocks:
-        rows = {row.name: row.text for row in block.rows}
-        for source in artifact.sources:
-            text = rows.get(source.name, "").replace("　", "").replace("・", "")
-            if text:
-                source_events[source.name].append(
-                    Subtitle(
-                        start=block.core_start_ms, end=block.core_end_ms, text=text
-                    )
-                )
-    candidates = {name: Series(events=events) for name, events in source_events.items()}
-    candidates["merged"] = artifact.get_series()
-    lines = [f"- reference subtitles: {len(selected_reference)}"]
-    for name, candidate in candidates.items():
-        result = SeriesCER(selected_reference, candidate)
+    evaluation = evaluate_transcription(artifact, reference)
+    lines = [f"- reference subtitles: {evaluation.reference_subtitles}"]
+    for name, result in evaluation.character_errors.items():
         lines.append(f"- {name} CER: {result.cer:.3%}")
-    timing = evaluate_timing(artifact, reference)
-    group_counts = Counter(
-        f"{len(pair.candidate_indexes)}:{len(pair.reference_indexes)}"
-        for pair in timing.pairs
-    )
+    timing = evaluation.timing
     lines.extend(
         (
             f"- text-aligned timing groups: {len(timing.pairs)}",
@@ -308,7 +289,7 @@ def _get_metric_summary(artifact: AlignmentArtifact, reference: Series) -> list[
                 "- candidate:reference subtitle groups: "
                 + ", ".join(
                     f"{shape} × {count}"
-                    for shape, count in sorted(group_counts.items())
+                    for shape, count in evaluation.group_counts.items()
                 )
             ),
             f"- temporal micro IoU: {timing.micro_intersection_over_union:.3%}",

--- a/scinoephile/analysis/transcription/__init__.py
+++ b/scinoephile/analysis/transcription/__init__.py
@@ -5,6 +5,7 @@
 Package hierarchy (modules may import from any above):
 * alignment_sequence / artifact
 * manifest / timing
+* evaluation
 """
 
 from __future__ import annotations
@@ -18,6 +19,7 @@ from .artifact import (
     AlignmentSubtitle,
     TimingSettings,
 )
+from .evaluation import CharacterErrorMetrics, TranscriptionEvaluation
 from .manifest import ProcessorIdentity, RunBlock, RunManifest
 from .timing import TimingMetrics, TimingPair
 
@@ -28,10 +30,12 @@ __all__ = [
     "AlignmentRow",
     "AlignmentSource",
     "AlignmentSubtitle",
+    "CharacterErrorMetrics",
     "ProcessorIdentity",
     "RunBlock",
     "RunManifest",
     "TimingMetrics",
     "TimingPair",
     "TimingSettings",
+    "TranscriptionEvaluation",
 ]

--- a/scinoephile/analysis/transcription/__init__.py
+++ b/scinoephile/analysis/transcription/__init__.py
@@ -1,6 +1,6 @@
 #  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
-"""Transcription alignment artifacts, reference adapters, and timing evaluation.
+"""Transcription alignment artifacts and lexical and timing evaluation.
 
 Package hierarchy (modules may import from any above):
 * alignment_sequence / artifact

--- a/scinoephile/analysis/transcription/evaluation.py
+++ b/scinoephile/analysis/transcription/evaluation.py
@@ -4,11 +4,10 @@
 
 from __future__ import annotations
 
-from collections import Counter
 from dataclasses import dataclass
 
-from scinoephile.analysis.character_error_rate.line_cer import LineCER
-from scinoephile.core.subtitles import Series
+from scinoephile.analysis.character_error_rate.series_cer import SeriesCER
+from scinoephile.core.subtitles import Series, Subtitle
 
 from .artifact import AlignmentArtifact
 from .timing import TimingMetrics, evaluate_timing, get_reference_for_alignment
@@ -46,8 +45,6 @@ class TranscriptionEvaluation:
     """Character-error metrics keyed by source name and `merged`."""
     timing: TimingMetrics
     """Merged candidate timing metrics."""
-    group_counts: dict[str, int]
-    """Candidate-to-reference subtitle alignment group counts."""
 
 
 def evaluate_transcription(
@@ -62,38 +59,33 @@ def evaluate_transcription(
         lexical and timing evaluation
     """
     selected_reference = get_reference_for_alignment(artifact, reference)
-    reference_text = "".join(
-        subtitle.text_with_newline for subtitle in selected_reference
-    )
-    candidate_texts = {source.name: [] for source in artifact.sources}
+    source_events = {source.name: [] for source in artifact.sources}
     for block in artifact.blocks:
         rows = {row.name: row.text for row in block.rows}
         for source in artifact.sources:
-            candidate_texts[source.name].append(
-                rows.get(source.name, "").replace("　", "").replace("・", "")
-            )
-    candidate_texts["merged"] = [
-        subtitle.text for block in artifact.blocks for subtitle in block.subtitles
-    ]
+            text = rows.get(source.name, "").replace("　", "").replace("・", "")
+            if text:
+                source_events[source.name].append(
+                    Subtitle(
+                        start=block.core_start_ms, end=block.core_end_ms, text=text
+                    )
+                )
+    candidates = {name: Series(events=events) for name, events in source_events.items()}
+    candidates["merged"] = artifact.get_series()
     character_errors = {
-        name: _get_character_error_metrics(LineCER(reference_text, "".join(text_parts)))
-        for name, text_parts in candidate_texts.items()
+        name: _get_character_error_metrics(SeriesCER(selected_reference, candidate))
+        for name, candidate in candidates.items()
     }
     timing = evaluate_timing(artifact, reference)
-    group_counts = Counter(
-        f"{len(pair.candidate_indexes)}:{len(pair.reference_indexes)}"
-        for pair in timing.pairs
-    )
     return TranscriptionEvaluation(
         reference_subtitles=len(selected_reference),
         candidate_subtitles=sum(len(block.subtitles) for block in artifact.blocks),
         character_errors=character_errors,
         timing=timing,
-        group_counts=dict(sorted(group_counts.items())),
     )
 
 
-def _get_character_error_metrics(result: LineCER) -> CharacterErrorMetrics:
+def _get_character_error_metrics(result: SeriesCER) -> CharacterErrorMetrics:
     """Copy one character-error result into a serializable value object.
 
     Arguments:

--- a/scinoephile/analysis/transcription/evaluation.py
+++ b/scinoephile/analysis/transcription/evaluation.py
@@ -1,0 +1,111 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Evaluate aligned multi-source transcriptions against independent references."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+
+from scinoephile.analysis.character_error_rate.line_cer import LineCER
+from scinoephile.core.subtitles import Series
+
+from .artifact import AlignmentArtifact
+from .timing import TimingMetrics, evaluate_timing, get_reference_for_alignment
+
+__all__ = ["CharacterErrorMetrics", "TranscriptionEvaluation", "evaluate_transcription"]
+
+
+@dataclass(frozen=True, slots=True)
+class CharacterErrorMetrics:
+    """Serializable character-error counts for one transcription candidate."""
+
+    cer: float
+    """Character error rate."""
+    correct: int
+    """Correctly matched reference characters."""
+    substitutions: int
+    """Character substitutions."""
+    insertions: int
+    """Character insertions."""
+    deletions: int
+    """Character deletions."""
+    reference_length: int
+    """Normalized reference character count."""
+
+
+@dataclass(frozen=True, slots=True)
+class TranscriptionEvaluation:
+    """Lexical and timing evaluation of one transcription alignment."""
+
+    reference_subtitles: int
+    """Reference subtitles overlapping the evaluated alignment."""
+    candidate_subtitles: int
+    """Merged candidate subtitles in the evaluated alignment."""
+    character_errors: dict[str, CharacterErrorMetrics]
+    """Character-error metrics keyed by source name and `merged`."""
+    timing: TimingMetrics
+    """Merged candidate timing metrics."""
+    group_counts: dict[str, int]
+    """Candidate-to-reference subtitle alignment group counts."""
+
+
+def evaluate_transcription(
+    artifact: AlignmentArtifact, reference: Series
+) -> TranscriptionEvaluation:
+    """Evaluate aligned ASR sources and merged output against one reference.
+
+    Arguments:
+        artifact: aligned multi-source transcription artifact
+        reference: independent evaluation reference
+    Returns:
+        lexical and timing evaluation
+    """
+    selected_reference = get_reference_for_alignment(artifact, reference)
+    reference_text = "".join(
+        subtitle.text_with_newline for subtitle in selected_reference
+    )
+    candidate_texts = {source.name: [] for source in artifact.sources}
+    for block in artifact.blocks:
+        rows = {row.name: row.text for row in block.rows}
+        for source in artifact.sources:
+            candidate_texts[source.name].append(
+                rows.get(source.name, "").replace("　", "").replace("・", "")
+            )
+    candidate_texts["merged"] = [
+        subtitle.text for block in artifact.blocks for subtitle in block.subtitles
+    ]
+    character_errors = {
+        name: _get_character_error_metrics(LineCER(reference_text, "".join(text_parts)))
+        for name, text_parts in candidate_texts.items()
+    }
+    timing = evaluate_timing(artifact, reference)
+    group_counts = Counter(
+        f"{len(pair.candidate_indexes)}:{len(pair.reference_indexes)}"
+        for pair in timing.pairs
+    )
+    return TranscriptionEvaluation(
+        reference_subtitles=len(selected_reference),
+        candidate_subtitles=sum(len(block.subtitles) for block in artifact.blocks),
+        character_errors=character_errors,
+        timing=timing,
+        group_counts=dict(sorted(group_counts.items())),
+    )
+
+
+def _get_character_error_metrics(result: LineCER) -> CharacterErrorMetrics:
+    """Copy one character-error result into a serializable value object.
+
+    Arguments:
+        result: calculated line-level character error
+    Returns:
+        serializable character-error metrics
+    """
+    return CharacterErrorMetrics(
+        cer=result.cer,
+        correct=result.correct,
+        substitutions=result.substitutions,
+        insertions=result.insertions,
+        deletions=result.deletions,
+        reference_length=result.reference_length,
+    )

--- a/scinoephile/analysis/transcription/timing.py
+++ b/scinoephile/analysis/transcription/timing.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from collections import Counter
 from collections.abc import Sequence
 from dataclasses import dataclass
 from math import isfinite
@@ -82,6 +83,15 @@ class TimingMetrics:
     """Candidate subtitles that could not be paired with reference text."""
     unmatched_reference_subtitles: int
     """Reference subtitles that could not be paired with candidate text."""
+
+    @property
+    def candidate_to_reference_group_counts(self) -> dict[str, int]:
+        """Get alignment-group counts keyed by candidate:reference shape."""
+        counts = Counter(
+            f"{len(pair.candidate_indexes)}:{len(pair.reference_indexes)}"
+            for pair in self.pairs
+        )
+        return dict(sorted(counts.items()))
 
     @property
     def mean_absolute_end_error_ms(self) -> float:

--- a/scinoephile/lang/transcription/__init__.py
+++ b/scinoephile/lang/transcription/__init__.py
@@ -15,6 +15,7 @@ from .aligner import TranscriptionAligner
 from .alignment import TranscriptionAlignment
 from .guided import GuidedTranscriptionSpec, TranscriptionLanguageSpec
 from .sources import TranscriptionSourceSpec
+from .standard import YueTranscriptionManager
 from .transcriber import GuidedTranscriber, MlxAudioTimingMode, TranscriptionModel
 
 __all__ = [
@@ -26,4 +27,5 @@ __all__ = [
     "TranscriptionLanguageSpec",
     "TranscriptionModel",
     "TranscriptionSourceSpec",
+    "YueTranscriptionManager",
 ]

--- a/scinoephile/lang/transcription/standard.py
+++ b/scinoephile/lang/transcription/standard.py
@@ -24,7 +24,7 @@ from scinoephile.llms.transcription import (
     TranscriptionPrompt,
 )
 
-__all__ = ["DEFAULT_PROMPTS", "get_transcriber"]
+__all__ = ["DEFAULT_PROMPTS", "YueTranscriptionManager", "get_transcriber"]
 
 _YUE_HANS_TRANSCRIPTION_JSON_PATHS: tuple[Path, ...] = ()
 """Default simplified Yue transcription JSON paths."""
@@ -39,7 +39,7 @@ _JSON_PATHS: dict[Language, tuple[Path, ...]] = {
 """Transcription JSON paths keyed by language."""
 
 
-class _YueTranscriptionManager(TranscriptionManager):
+class YueTranscriptionManager(TranscriptionManager):
     """Transcription models using Yue evidence scoring."""
 
     alignment_scorer = YueTranscriptionAlignmentScorer()
@@ -49,7 +49,7 @@ class _YueTranscriptionManager(TranscriptionManager):
 class _YueTranscriptionProcessor(TranscriptionProcessor):
     """Transcription processor using Yue evidence scoring."""
 
-    manager_cls = _YueTranscriptionManager
+    manager_cls = YueTranscriptionManager
     """Manager used to construct Yue-aware test-case models."""
 
 
@@ -89,7 +89,7 @@ def get_transcriber(
     if shared_test_cases is None:
         shared_test_cases = list(
             load_shared_test_cases(
-                _YueTranscriptionManager, prompt, _JSON_PATHS[language]
+                YueTranscriptionManager, prompt, _JSON_PATHS[language]
             )
         )
     if provider is None:

--- a/skills/author-test/SKILL.md
+++ b/skills/author-test/SKILL.md
@@ -20,7 +20,7 @@ description: Add or update pytest tests in Scinoephile's test/ suite, including 
 - Add type annotations to all function signatures; omit return type when the function returns `None`.
 - Prefer helper functions for repeated assertions; include Google-style docstrings using `Arguments:` and `Returns:`.
 - Use `pytest.mark.parametrize` for multiple inputs; use `Series` equality or per-event comparisons.
-- For temporary output files, use `get_temp_file_path` and compare against expected files via `Series.load`.
+- Use pytest's `tmp_path` for temporary output files and compare against expected files via `Series.load`.
 
 ## Fixtures and test data
 - Test data is grouped by title (examples: `kob`, `mlamd`, `mnt`, `t`).
@@ -32,7 +32,7 @@ description: Add or update pytest tests in Scinoephile's test/ suite, including 
 - If you introduce a new title namespace, add a `test/data/<title>/__init__.py` and update `test/conftest.py` to import it.
 
 ## Generating expected outputs
-- Use the existing helpers in `test/data/ocr.py` and `test/data/synchronization.py` to build consistent output artifacts.
+- Use the existing helpers in `test/data/ocr.py` and `test/data/stacking.py` to build consistent output artifacts.
 - Each title has a generation script under `test/data/<title>/`; extend it to generate any new outputs.
 - Keep expected outputs in `test/data/<title>/output` and inputs in `test/data/<title>/input`.
 

--- a/skills/author-test/SKILL.md
+++ b/skills/author-test/SKILL.md
@@ -8,7 +8,7 @@ description: Add or update pytest tests in Scinoephile's test/ suite, including 
 ## Quick steps
 - Identify the closest existing test module under `test/` and mirror its structure.
 - Reuse fixtures from `test/data/<title>/__init__.py`; add new fixtures there if needed.
-- If new expected outputs are required, update the matching `test/data/<title>/create_output.py` or helper functions in `test/data/ocr.py` or `test/data/synchronization.py`.
+- If new expected outputs are required, update the matching `test/data/<title>/<title>.py` or helper functions in `test/data/ocr.py` or `test/data/synchronization.py`.
 - Add or update test data files under `test/data/<title>/input` and `test/data/<title>/output`.
 - Run `uv run ruff format <changed.py>` and `uv run ruff check --fix <changed.py>` on changed Python files.
 - Run tests from `test/` with `cd test && uv run pytest <optional-path>`.
@@ -33,7 +33,7 @@ description: Add or update pytest tests in Scinoephile's test/ suite, including 
 
 ## Generating expected outputs
 - Use the existing helpers in `test/data/ocr.py` and `test/data/synchronization.py` to build consistent output artifacts.
-- Each title has a `test/data/<title>/create_output.py` script; extend it to generate any new outputs.
+- Each title has a `test/data/<title>/<title>.py` script; extend it to generate any new outputs.
 - Keep expected outputs in `test/data/<title>/output` and inputs in `test/data/<title>/input`.
 
 ## Data constraints

--- a/skills/author-test/SKILL.md
+++ b/skills/author-test/SKILL.md
@@ -8,7 +8,7 @@ description: Add or update pytest tests in Scinoephile's test/ suite, including 
 ## Quick steps
 - Identify the closest existing test module under `test/` and mirror its structure.
 - Reuse fixtures from `test/data/<title>/__init__.py`; add new fixtures there if needed.
-- If new expected outputs are required, update the matching `test/data/<title>/<title>.py` or helper functions in `test/data/ocr.py` or `test/data/synchronization.py`.
+- If new expected outputs are required, update the matching generation script under `test/data/<title>/` or the shared helpers in `test/data/`.
 - Add or update test data files under `test/data/<title>/input` and `test/data/<title>/output`.
 - Run `uv run ruff format <changed.py>` and `uv run ruff check --fix <changed.py>` on changed Python files.
 - Run tests from `test/` with `cd test && uv run pytest <optional-path>`.
@@ -33,7 +33,7 @@ description: Add or update pytest tests in Scinoephile's test/ suite, including 
 
 ## Generating expected outputs
 - Use the existing helpers in `test/data/ocr.py` and `test/data/synchronization.py` to build consistent output artifacts.
-- Each title has a `test/data/<title>/<title>.py` script; extend it to generate any new outputs.
+- Each title has a generation script under `test/data/<title>/`; extend it to generate any new outputs.
 - Keep expected outputs in `test/data/<title>/output` and inputs in `test/data/<title>/input`.
 
 ## Data constraints

--- a/skills/write-movie-context/SKILL.md
+++ b/skills/write-movie-context/SKILL.md
@@ -10,7 +10,7 @@ LLM verbatim; do not write a general film report or an exhaustive cast list.
 
 ## Determine the scope
 
-Identify these from the request, the dataset's title-named Python script, and the
+Identify these from the request, the dataset's generation script, and the
 available subtitle tracks:
 
 - The movie and dataset.
@@ -53,8 +53,8 @@ Use these repository examples as contrasts:
 ## Inspect subtitle evidence
 
 Locate the best available human-authored or human-reviewed reference subtitle
-tracks. Trace the workflow in the title-named script rather than choosing a file by
-its name alone. Do not treat generated LLM output as naming authority.
+tracks. Trace the workflow in the generation script rather than choosing a file
+by its name alone. Do not treat generated LLM output as naming authority.
 
 Search the reference subtitles and inspect occurrences in context. Collect only
 terms likely to help the requested LLM operation:
@@ -98,7 +98,7 @@ the supporting web pages in the final response instead.
 
 ## Draft the context
 
-Follow this plain-text shape, modeled on `test/data/mnt/mnt.py`:
+Follow this plain-text shape:
 
 ```text
 Movie context:
@@ -137,8 +137,9 @@ Keep the prose concise and operational:
 
 When the user names a code or configuration destination, update that destination
 and preserve its established representation. For a Scinoephile
-title-named dataset script, follow the existing `additional_context` multiline-string
-pattern and do not change which LLM calls receive it unless requested.
+dataset generation script, follow the existing `additional_context`
+multiline-string pattern and do not change which LLM calls receive it unless
+requested.
 
 Otherwise write prompt-ready UTF-8 text to:
 

--- a/skills/write-movie-context/SKILL.md
+++ b/skills/write-movie-context/SKILL.md
@@ -10,7 +10,7 @@ LLM verbatim; do not write a general film report or an exhaustive cast list.
 
 ## Determine the scope
 
-Identify these from the request, the dataset's `create_output.py`, and the
+Identify these from the request, the dataset's title-named Python script, and the
 available subtitle tracks:
 
 - The movie and dataset.
@@ -53,7 +53,7 @@ Use these repository examples as contrasts:
 ## Inspect subtitle evidence
 
 Locate the best available human-authored or human-reviewed reference subtitle
-tracks. Trace the workflow in `create_output.py` rather than choosing a file by
+tracks. Trace the workflow in the title-named script rather than choosing a file by
 its name alone. Do not treat generated LLM output as naming authority.
 
 Search the reference subtitles and inspect occurrences in context. Collect only
@@ -98,7 +98,7 @@ the supporting web pages in the final response instead.
 
 ## Draft the context
 
-Follow this plain-text shape, modeled on `test/data/mnt/create_output.py`:
+Follow this plain-text shape, modeled on `test/data/mnt/mnt.py`:
 
 ```text
 Movie context:
@@ -137,7 +137,7 @@ Keep the prose concise and operational:
 
 When the user names a code or configuration destination, update that destination
 and preserve its established representation. For a Scinoephile
-`create_output.py`, follow the existing `additional_context` multiline-string
+title-named dataset script, follow the existing `additional_context` multiline-string
 pattern and do not change which LLM calls receive it unless requested.
 
 Otherwise write prompt-ready UTF-8 text to:

--- a/test/analysis/transcription/test_artifact_and_timing.py
+++ b/test/analysis/transcription/test_artifact_and_timing.py
@@ -165,6 +165,7 @@ def test_timing_evaluation_pairs_text_before_scoring_overlap():
 
     metrics = evaluate_timing(artifact, reference)
 
+    assert metrics.candidate_to_reference_group_counts == {"1:1": 1}
     assert len(metrics.pairs) == 1
     assert metrics.micro_intersection_over_union == approx(1300 / 1500)
     assert metrics.pairs[0].start_error_ms == 100

--- a/test/core/llms/test_test_case_json_fixtures.py
+++ b/test/core/llms/test_test_case_json_fixtures.py
@@ -15,13 +15,13 @@ from scinoephile.core.llms.utils import (
     load_test_cases_from_json,
     save_test_cases_to_json,
 )
+from scinoephile.lang.transcription import YueTranscriptionManager
 from scinoephile.llms.delineation import DelineationManager
 from scinoephile.llms.gap_translation import GapTranslationManager
 from scinoephile.llms.guided_review import GuidedReviewManager
 from scinoephile.llms.ocr_fusion import OcrFusionManager
 from scinoephile.llms.punctuation import PunctuationManager
 from scinoephile.llms.review import ReviewManager
-from scinoephile.llms.transcription import TranscriptionManager
 from test.helpers import test_data_root
 
 _TEST_CASE_FAMILIES: tuple[tuple[str, type[Manager]], ...] = (
@@ -48,7 +48,7 @@ def _get_test_case_files() -> list[tuple[Path, type[Manager]]]:
             raise ValueError(f"Test-case family has no fixtures: {pattern}")
         test_case_files.extend((input_path, manager_cls) for input_path in input_paths)
     test_case_files.extend(
-        (input_path, TranscriptionManager)
+        (input_path, YueTranscriptionManager)
         for input_path in sorted(
             test_data_root.glob("*/output/*_transcribe/json/transcription.json")
         )

--- a/test/core/llms/test_test_case_json_fixtures.py
+++ b/test/core/llms/test_test_case_json_fixtures.py
@@ -15,10 +15,13 @@ from scinoephile.core.llms.utils import (
     load_test_cases_from_json,
     save_test_cases_to_json,
 )
+from scinoephile.llms.delineation import DelineationManager
 from scinoephile.llms.gap_translation import GapTranslationManager
 from scinoephile.llms.guided_review import GuidedReviewManager
 from scinoephile.llms.ocr_fusion import OcrFusionManager
+from scinoephile.llms.punctuation import PunctuationManager
 from scinoephile.llms.review import ReviewManager
+from scinoephile.llms.transcription import TranscriptionManager
 from test.helpers import test_data_root
 
 _TEST_CASE_FAMILIES: tuple[tuple[str, type[Manager]], ...] = (
@@ -27,6 +30,8 @@ _TEST_CASE_FAMILIES: tuple[tuple[str, type[Manager]], ...] = (
     ("*/output/*/lang/*/simplify_review.json", ReviewManager),
     ("*/output/*/lang/yue_zho/gap_translation/*.json", GapTranslationManager),
     ("*/output/*/lang/yue_zho/guided_review/*.json", GuidedReviewManager),
+    ("*/output/*/lang/yue_zho/transcription/delineation/*.json", DelineationManager),
+    ("*/output/*/lang/yue_zho/transcription/punctuation/*.json", PunctuationManager),
 )
 
 
@@ -42,6 +47,12 @@ def _get_test_case_files() -> list[tuple[Path, type[Manager]]]:
         if not input_paths:
             raise ValueError(f"Test-case family has no fixtures: {pattern}")
         test_case_files.extend((input_path, manager_cls) for input_path in input_paths)
+    test_case_files.extend(
+        (input_path, TranscriptionManager)
+        for input_path in sorted(
+            test_data_root.glob("*/output/*_transcribe/json/transcription.json")
+        )
+    )
     return test_case_files
 
 

--- a/test/core/llms/test_test_case_json_fixtures.py
+++ b/test/core/llms/test_test_case_json_fixtures.py
@@ -15,11 +15,9 @@ from scinoephile.core.llms.utils import (
     load_test_cases_from_json,
     save_test_cases_to_json,
 )
-from scinoephile.llms.delineation import DelineationManager
 from scinoephile.llms.gap_translation import GapTranslationManager
 from scinoephile.llms.guided_review import GuidedReviewManager
 from scinoephile.llms.ocr_fusion import OcrFusionManager
-from scinoephile.llms.punctuation import PunctuationManager
 from scinoephile.llms.review import ReviewManager
 from test.helpers import test_data_root
 
@@ -29,8 +27,6 @@ _TEST_CASE_FAMILIES: tuple[tuple[str, type[Manager]], ...] = (
     ("*/output/*/lang/*/simplify_review.json", ReviewManager),
     ("*/output/*/lang/yue_zho/gap_translation/*.json", GapTranslationManager),
     ("*/output/*/lang/yue_zho/guided_review/*.json", GuidedReviewManager),
-    ("*/output/*/lang/yue_zho/transcription/delineation/*.json", DelineationManager),
-    ("*/output/*/lang/yue_zho/transcription/punctuation/*.json", PunctuationManager),
 )
 
 
@@ -117,14 +113,3 @@ def test_tracked_test_case_json_round_trips_canonically(
     assert [test_case.model_dump(mode="json") for test_case in reloaded_test_cases] == [
         test_case.model_dump(mode="json") for test_case in base_test_cases
     ]
-
-
-def test_tracked_test_case_json_inventory_is_complete():
-    """Fixture contract should cover every tracked test case."""
-    test_case_count = sum(
-        len(json.loads(input_path.read_text(encoding="utf-8")))
-        for input_path, _ in _TEST_CASE_FILES
-    )
-
-    assert len(_TEST_CASE_FILES) == 84
-    assert test_case_count == 32_624

--- a/test/data/__init__.py
+++ b/test/data/__init__.py
@@ -7,6 +7,6 @@ subtitles. Each directory contains the following:
 * `input` directory - authoritative input subtitle files
 * `output` directory - processed output subtitle files
 * `__init__.py` - test fixtures for the test cases in the directory
-* `create_output.py` - script to read in the input files and process them to create the
-   output files
+* `<title>.py` - script to read in the input files and process them to create the output
+  files
 """

--- a/test/data/__init__.py
+++ b/test/data/__init__.py
@@ -7,6 +7,5 @@ subtitles. Each directory contains the following:
 * `input` directory - authoritative input subtitle files
 * `output` directory - processed output subtitle files
 * `__init__.py` - test fixtures for the test cases in the directory
-* `<title>.py` - script to read in the input files and process them to create the output
-  files
+* a Python generation script - reads the input files and creates the output files
 """

--- a/test/data/aligned_transcription.py
+++ b/test/data/aligned_transcription.py
@@ -83,7 +83,7 @@ def process_transcription(
     if stop_at_idx is None and target_reference_count <= 0:
         raise ValueError("target_reference_count must be positive.")
     output_dir_path = title_root_path / "output" / "yue-Hant_transcribe"
-    audio_path = output_dir_path / "audio.wav"
+    audio_path = output_dir_path / "audio" / "audio.wav"
     output_dir_path.mkdir(parents=True, exist_ok=True)
     json_dir_path = output_dir_path / "json"
     json_dir_path.mkdir(parents=True, exist_ok=True)
@@ -162,7 +162,18 @@ def _get_stop_at_idx_for_reference_count(
     reference: Series,
     target_count: int,
 ) -> int:
-    """Get the smallest block prefix covering the target reference count."""
+    """Get the smallest block prefix covering the target reference count.
+
+    Arguments:
+        pipeline: transcription pipeline used to plan blocks
+        audio: complete audio used for block planning
+        reference: independent reference whose subtitles are counted
+        target_count: minimum reference subtitle count to cover
+    Returns:
+        exclusive block index covering the requested number of subtitles
+    Raises:
+        ScinoephileError: if the complete block plan does not cover the target
+    """
     blocks = pipeline.plan_blocks(audio)
     covered = 0
     for stop_at_idx, block in enumerate(blocks, start=1):
@@ -189,7 +200,20 @@ def _load_audio_series(
     audio_extraction_mode: AudioExtractionMode = AudioExtractionMode.ORIGINAL,
     media_start_seconds: float,
 ) -> AudioSeries:
-    """Load staged complete audio without supplying subtitle events to ASR."""
+    """Load staged complete audio without supplying subtitle events to ASR.
+
+    Arguments:
+        audio_path: staged complete-audio WAV path
+        media_path: optional media from which to extract missing staged audio
+        stream_index: optional media audio-stream index
+        audio_extraction_mode: channel preparation used during media extraction
+        media_start_seconds: seconds trimmed from extracted media audio
+    Returns:
+        complete audio without subtitle events
+    Raises:
+        ScinoephileError: if staged audio cannot be loaded or generated
+        ValueError: if the media start time is negative
+    """
     if media_start_seconds < 0.0:
         raise ValueError("media_start_seconds must be non-negative.")
     if audio_path.exists():
@@ -223,7 +247,15 @@ def _save_evaluation(
     audit_references: Mapping[str, Series],
     terminal_authority: str | None = None,
 ):
-    """Save evaluation metrics and readable alignment audits."""
+    """Save evaluation metrics and readable alignment audits.
+
+    Arguments:
+        output_dir_path: transcription output directory
+        artifact: aligned multi-source transcription artifact
+        reference: independent reference used for metrics
+        audit_references: named independent references rendered in the audit
+        terminal_authority: optional authoritative row rendered in the terminal
+    """
     evaluation = evaluate_transcription(artifact, reference)
     cer = {
         name: asdict(character_errors)
@@ -297,5 +329,7 @@ def _serialize_timing(evaluation: TranscriptionEvaluation) -> dict[str, object]:
         "mean_absolute_end_error_ms": timing.mean_absolute_end_error_ms,
         "unmatched_candidate_subtitles": timing.unmatched_candidate_subtitles,
         "unmatched_reference_subtitles": timing.unmatched_reference_subtitles,
-        "candidate_to_reference_group_counts": evaluation.group_counts,
+        "candidate_to_reference_group_counts": (
+            timing.candidate_to_reference_group_counts
+        ),
     }

--- a/test/data/aligned_transcription.py
+++ b/test/data/aligned_transcription.py
@@ -5,22 +5,19 @@
 from __future__ import annotations
 
 import json
-from collections import Counter
 from collections.abc import Mapping
+from dataclasses import asdict
 from logging import getLogger
 from pathlib import Path
-
-from pydub import AudioSegment
 
 from scinoephile.analysis.audit.transcription.report import (
     audit_transcription_alignment,
     render_transcription_alignment_terminal,
 )
-from scinoephile.analysis.character_error_rate import LineCER
 from scinoephile.analysis.transcription import AlignmentArtifact
-from scinoephile.analysis.transcription.timing import (
-    evaluate_timing,
-    get_reference_for_alignment,
+from scinoephile.analysis.transcription.evaluation import (
+    TranscriptionEvaluation,
+    evaluate_transcription,
 )
 from scinoephile.audio.segment import load_audio_segment
 from scinoephile.audio.subtitles import AudioSeries
@@ -39,12 +36,12 @@ from scinoephile.workflows.transcription_pipeline.factory import (
     get_transcription_pipeline,
 )
 
-__all__ = ["process_transcription_pipeline"]
+__all__ = ["process_transcription"]
 
 logger = getLogger(__name__)
 
 
-def process_transcription_pipeline(  # noqa: PLR0912, PLR0915
+def process_transcription(
     title_root_path: Path,
     *,
     reference_path: Path,
@@ -53,11 +50,11 @@ def process_transcription_pipeline(  # noqa: PLR0912, PLR0915
     audio_extraction_mode: AudioExtractionMode = AudioExtractionMode.ORIGINAL,
     media_start_seconds: float = 0.0,
     stop_at_idx: int | None = None,
-    target_reference_subtitles: int = 100,
+    target_reference_count: int = 100,
     additional_context: str | None = None,
     additional_audit_references: Mapping[str, Series] | None = None,
     reference_name: str = "reference",
-    terminal_alignment_authority: str | None = None,
+    terminal_authority: str | None = None,
     overwrite: bool = False,
 ) -> Series:
     """Run one reference-free transcription experiment and save its evaluation.
@@ -74,17 +71,17 @@ def process_transcription_pipeline(  # noqa: PLR0912, PLR0915
         audio_extraction_mode: channel preparation used during media audio extraction
         media_start_seconds: seconds trimmed from extracted media audio
         stop_at_idx: explicit exclusive block index, overriding target count
-        target_reference_subtitles: minimum reference subtitles covered by blocks
+        target_reference_count: minimum reference subtitles covered by blocks
         additional_context: production consensus prompt context
         additional_audit_references: additional named references used only in audits
         reference_name: audit row name for the primary scoring reference
-        terminal_alignment_authority: merged or named reference row for ANSI output
+        terminal_authority: merged or named reference row for ANSI output
         overwrite: whether to regenerate an existing artifact and SRT
     Returns:
         merged transcription series
     """
-    if target_reference_subtitles <= 0:
-        raise ValueError("target_reference_subtitles must be positive.")
+    if stop_at_idx is None and target_reference_count <= 0:
+        raise ValueError("target_reference_count must be positive.")
     output_dir_path = title_root_path / "output" / "yue-Hant_transcribe"
     audio_path = output_dir_path / "audio.wav"
     output_dir_path.mkdir(parents=True, exist_ok=True)
@@ -110,7 +107,7 @@ def process_transcription_pipeline(  # noqa: PLR0912, PLR0915
             artifact,
             reference,
             audit_references=audit_references,
-            terminal_alignment_authority=terminal_alignment_authority,
+            terminal_authority=terminal_authority,
         )
         return output
 
@@ -131,7 +128,7 @@ def process_transcription_pipeline(  # noqa: PLR0912, PLR0915
     )
     if stop_at_idx is None:
         stop_at_idx = _get_stop_at_idx_for_reference_count(
-            pipeline, audio, reference, target_reference_subtitles
+            pipeline, audio, reference, target_reference_count
         )
     output = transcribe_series(
         audio,
@@ -154,7 +151,7 @@ def process_transcription_pipeline(  # noqa: PLR0912, PLR0915
         artifact,
         reference,
         audit_references=audit_references,
-        terminal_alignment_authority=terminal_alignment_authority,
+        terminal_authority=terminal_authority,
     )
     return output
 
@@ -196,7 +193,7 @@ def _load_audio_series(
     if media_start_seconds < 0.0:
         raise ValueError("media_start_seconds must be non-negative.")
     if audio_path.exists():
-        return AudioSeries(audio=AudioSegment.from_wav(audio_path), events=[])
+        return AudioSeries(audio=load_audio_segment(audio_path), events=[])
     if media_path is None:
         raise ScinoephileError(
             f"Staged audio is missing at {audio_path}; provide media_path."
@@ -224,16 +221,22 @@ def _save_evaluation(
     reference: Series,
     *,
     audit_references: Mapping[str, Series],
-    terminal_alignment_authority: str | None = None,
+    terminal_authority: str | None = None,
 ):
     """Save evaluation metrics and readable alignment audits."""
-    primary_metrics = _get_reference_metrics(artifact, reference)
-    cer = primary_metrics["cer"]
+    evaluation = evaluate_transcription(artifact, reference)
+    cer = {
+        name: asdict(character_errors)
+        for name, character_errors in evaluation.character_errors.items()
+    }
     metrics = {
         "format": "scinoephile-transcription-evaluation",
         "version": 1,
         "processed_blocks": len(artifact.blocks),
-        **primary_metrics,
+        "reference_subtitles": evaluation.reference_subtitles,
+        "candidate_subtitles": evaluation.candidate_subtitles,
+        "cer": cer,
+        "timing": _serialize_timing(evaluation),
     }
     json_dir_path = output_dir_path / "json"
     json_dir_path.mkdir(parents=True, exist_ok=True)
@@ -254,11 +257,11 @@ def _save_evaluation(
         ),
         encoding="utf-8",
     )
-    if terminal_alignment_authority is not None:
+    if terminal_authority is not None:
         terminal_alignment = render_transcription_alignment_terminal(
             artifact,
             audit_references,
-            authoritative_row_name=terminal_alignment_authority,
+            authoritative_row_name=terminal_authority,
             reference_similarity=reference_similarity,
             include_merge_support=True,
         )
@@ -269,65 +272,30 @@ def _save_evaluation(
     )
 
 
-def _get_reference_metrics(artifact: AlignmentArtifact, reference: Series) -> dict:
-    """Calculate lexical and timing metrics against one named reference."""
-    selected_reference = get_reference_for_alignment(artifact, reference)
-    reference_text = "".join(
-        subtitle.text_with_newline for subtitle in selected_reference
-    )
-    candidate_texts = {source.name: [] for source in artifact.sources}
-    for block in artifact.blocks:
-        rows = {row.name: row.text for row in block.rows}
-        for source in artifact.sources:
-            candidate_texts[source.name].append(
-                rows.get(source.name, "").replace("　", "").replace("・", "")
-            )
-    candidate_texts["merged"] = [
-        subtitle.text for block in artifact.blocks for subtitle in block.subtitles
-    ]
-    cer = {
-        name: _get_cer_dict(LineCER(reference_text, "".join(text_parts)))
-        for name, text_parts in candidate_texts.items()
-    }
-    timing = evaluate_timing(artifact, reference)
-    subtitle_alignment_groups = Counter(
-        f"{len(pair.candidate_indexes)}:{len(pair.reference_indexes)}"
-        for pair in timing.pairs
-    )
-    return {
-        "reference_subtitles": len(selected_reference),
-        "candidate_subtitles": sum(len(block.subtitles) for block in artifact.blocks),
-        "cer": cer,
-        "timing": {
-            "settings": timing.settings.model_dump(mode="json"),
-            "text_aligned_groups": len(timing.pairs),
-            "micro_intersection_over_union": timing.micro_intersection_over_union,
-            "one_to_one_groups": len(timing.one_to_one_pairs),
-            "one_to_one_micro_intersection_over_union": (
-                timing.one_to_one_micro_intersection_over_union
-            ),
-            "mean_intersection_over_union": timing.mean_intersection_over_union,
-            "mean_reference_coverage": timing.mean_reference_coverage,
-            "mean_start_error_ms": timing.mean_start_error_ms,
-            "mean_end_error_ms": timing.mean_end_error_ms,
-            "mean_absolute_start_error_ms": timing.mean_absolute_start_error_ms,
-            "mean_absolute_end_error_ms": timing.mean_absolute_end_error_ms,
-            "unmatched_candidate_subtitles": timing.unmatched_candidate_subtitles,
-            "unmatched_reference_subtitles": timing.unmatched_reference_subtitles,
-            "candidate_to_reference_group_counts": dict(
-                sorted(subtitle_alignment_groups.items())
-            ),
-        },
-    }
+def _serialize_timing(evaluation: TranscriptionEvaluation) -> dict[str, object]:
+    """Serialize timing metrics from one transcription evaluation.
 
-
-def _get_cer_dict(result: LineCER) -> dict[str, float | int]:
-    """Serialize one character-error result."""
+    Arguments:
+        evaluation: structured transcription evaluation
+    Returns:
+        JSON-compatible timing metrics
+    """
+    timing = evaluation.timing
     return {
-        "cer": result.cer,
-        "correct": result.correct,
-        "substitutions": result.substitutions,
-        "insertions": result.insertions,
-        "deletions": result.deletions,
-        "reference_length": result.reference_length,
+        "settings": timing.settings.model_dump(mode="json"),
+        "text_aligned_groups": len(timing.pairs),
+        "micro_intersection_over_union": timing.micro_intersection_over_union,
+        "one_to_one_groups": len(timing.one_to_one_pairs),
+        "one_to_one_micro_intersection_over_union": (
+            timing.one_to_one_micro_intersection_over_union
+        ),
+        "mean_intersection_over_union": timing.mean_intersection_over_union,
+        "mean_reference_coverage": timing.mean_reference_coverage,
+        "mean_start_error_ms": timing.mean_start_error_ms,
+        "mean_end_error_ms": timing.mean_end_error_ms,
+        "mean_absolute_start_error_ms": timing.mean_absolute_start_error_ms,
+        "mean_absolute_end_error_ms": timing.mean_absolute_end_error_ms,
+        "unmatched_candidate_subtitles": timing.unmatched_candidate_subtitles,
+        "unmatched_reference_subtitles": timing.unmatched_reference_subtitles,
+        "candidate_to_reference_group_counts": evaluation.group_counts,
     }

--- a/test/data/aligned_transcription.py
+++ b/test/data/aligned_transcription.py
@@ -1,0 +1,333 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Generate and evaluate aligned multi-source transcription test data."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from collections.abc import Mapping
+from logging import getLogger
+from pathlib import Path
+
+from pydub import AudioSegment
+
+from scinoephile.analysis.audit.transcription.report import (
+    audit_transcription_alignment,
+    render_transcription_alignment_terminal,
+)
+from scinoephile.analysis.character_error_rate import LineCER
+from scinoephile.analysis.transcription import AlignmentArtifact
+from scinoephile.analysis.transcription.timing import (
+    evaluate_timing,
+    get_reference_for_alignment,
+)
+from scinoephile.audio.segment import load_audio_segment
+from scinoephile.audio.subtitles import AudioSeries
+from scinoephile.core import Language, ScinoephileError
+from scinoephile.core.llms.metrics import (
+    format_chat_completion_metrics_report,
+    save_chat_completion_metrics_to_json,
+)
+from scinoephile.core.subtitles import Series
+from scinoephile.lang.yue.transcription import YueTokenSimilarity
+from scinoephile.llms.providers.registry import get_provider
+from scinoephile.media.audio import AudioExtractionMode
+from scinoephile.workflows.transcription import transcribe_series
+from scinoephile.workflows.transcription_pipeline import TranscriptionPipeline
+from scinoephile.workflows.transcription_pipeline.factory import (
+    get_transcription_pipeline,
+)
+
+__all__ = ["process_transcription_pipeline"]
+
+logger = getLogger(__name__)
+
+
+def process_transcription_pipeline(  # noqa: PLR0912, PLR0915
+    title_root_path: Path,
+    *,
+    reference_path: Path,
+    media_path: Path | None = None,
+    stream_index: int | None = None,
+    audio_extraction_mode: AudioExtractionMode = AudioExtractionMode.ORIGINAL,
+    media_start_seconds: float = 0.0,
+    stop_at_idx: int | None = None,
+    target_reference_subtitles: int = 100,
+    additional_context: str | None = None,
+    additional_audit_references: Mapping[str, Series] | None = None,
+    reference_name: str = "reference",
+    terminal_alignment_authority: str | None = None,
+    overwrite: bool = False,
+) -> Series:
+    """Run one reference-free transcription experiment and save its evaluation.
+
+    The Cantonese reference determines only how many leading blocks are run
+    and how the finished output is scored. It is never passed to ASR, alignment,
+    CTC timing, diarization, or the consensus LLM.
+
+    Arguments:
+        title_root_path: test title root directory
+        reference_path: independent Cantonese reference used only for evaluation
+        media_path: optional media from which to extract audio when not staged
+        stream_index: optional media audio-stream index
+        audio_extraction_mode: channel preparation used during media audio extraction
+        media_start_seconds: seconds trimmed from extracted media audio
+        stop_at_idx: explicit exclusive block index, overriding target count
+        target_reference_subtitles: minimum reference subtitles covered by blocks
+        additional_context: production consensus prompt context
+        additional_audit_references: additional named references used only in audits
+        reference_name: audit row name for the primary scoring reference
+        terminal_alignment_authority: merged or named reference row for ANSI output
+        overwrite: whether to regenerate an existing artifact and SRT
+    Returns:
+        merged transcription series
+    """
+    if target_reference_subtitles <= 0:
+        raise ValueError("target_reference_subtitles must be positive.")
+    output_dir_path = title_root_path / "output" / "yue-Hant_transcribe"
+    audio_path = output_dir_path / "audio.wav"
+    output_dir_path.mkdir(parents=True, exist_ok=True)
+    json_dir_path = output_dir_path / "json"
+    json_dir_path.mkdir(parents=True, exist_ok=True)
+    artifact_path = json_dir_path / "alignment.json"
+    run_manifest_path = json_dir_path / "run.json"
+    transcription_path = output_dir_path / "transcribe.srt"
+    reference = Series.load(reference_path)
+    audit_references = {reference_name: reference}
+    for name, audit_reference in (additional_audit_references or {}).items():
+        if name in audit_references:
+            raise ValueError(f"Duplicate audit reference name: {name}")
+        audit_references[name] = audit_reference
+
+    if artifact_path.exists() and not overwrite:
+        artifact = AlignmentArtifact.load(artifact_path)
+        output = artifact.get_series()
+        if not transcription_path.exists():
+            output.save(transcription_path)
+        _save_evaluation(
+            output_dir_path,
+            artifact,
+            reference,
+            audit_references=audit_references,
+            terminal_alignment_authority=terminal_alignment_authority,
+        )
+        return output
+
+    audio = _load_audio_series(
+        audio_path,
+        media_path=media_path,
+        stream_index=stream_index,
+        audio_extraction_mode=audio_extraction_mode,
+        media_start_seconds=media_start_seconds,
+    )
+    provider = get_provider()
+    initial_completion_count = len(provider.completion_metrics)
+    pipeline = get_transcription_pipeline(
+        Language.yue_hant,
+        provider=provider,
+        additional_context=additional_context,
+        current_test_cases_path=json_dir_path / "transcription.json",
+    )
+    if stop_at_idx is None:
+        stop_at_idx = _get_stop_at_idx_for_reference_count(
+            pipeline, audio, reference, target_reference_subtitles
+        )
+    output = transcribe_series(
+        audio,
+        language=Language.yue_hant,
+        pipeline=pipeline,
+        alignment_outfile_path=artifact_path,
+        run_manifest_outfile_path=run_manifest_path,
+        stop_at_idx=stop_at_idx,
+    )
+    output.save(transcription_path)
+    artifact = pipeline.last_alignment_artifact
+    if artifact is None:
+        raise RuntimeError("Transcription pipeline did not produce an artifact.")
+    completion_metrics = provider.completion_metrics[initial_completion_count:]
+    usage_path = json_dir_path / "llm_usage.json"
+    save_chat_completion_metrics_to_json(usage_path, completion_metrics)
+    logger.info(format_chat_completion_metrics_report(completion_metrics))
+    _save_evaluation(
+        output_dir_path,
+        artifact,
+        reference,
+        audit_references=audit_references,
+        terminal_alignment_authority=terminal_alignment_authority,
+    )
+    return output
+
+
+def _get_stop_at_idx_for_reference_count(
+    pipeline: TranscriptionPipeline,
+    audio: AudioSeries,
+    reference: Series,
+    target_count: int,
+) -> int:
+    """Get the smallest block prefix covering the target reference count."""
+    blocks = pipeline.plan_blocks(audio)
+    covered = 0
+    for stop_at_idx, block in enumerate(blocks, start=1):
+        covered += sum(
+            block.start_ms <= (subtitle.start + subtitle.end) / 2 < block.end_ms
+            for subtitle in reference
+        )
+        if covered >= target_count:
+            logger.info(
+                f"Selected {stop_at_idx} blocks covering {covered} reference subtitles."
+            )
+            return stop_at_idx
+    raise ScinoephileError(
+        f"The complete block plan covers only {covered} reference subtitles; "
+        f"cannot reach target {target_count}."
+    )
+
+
+def _load_audio_series(
+    audio_path: Path,
+    *,
+    media_path: Path | None,
+    stream_index: int | None,
+    audio_extraction_mode: AudioExtractionMode = AudioExtractionMode.ORIGINAL,
+    media_start_seconds: float,
+) -> AudioSeries:
+    """Load staged complete audio without supplying subtitle events to ASR."""
+    if media_start_seconds < 0.0:
+        raise ValueError("media_start_seconds must be non-negative.")
+    if audio_path.exists():
+        return AudioSeries(audio=AudioSegment.from_wav(audio_path), events=[])
+    if media_path is None:
+        raise ScinoephileError(
+            f"Staged audio is missing at {audio_path}; provide media_path."
+        )
+    audio = AudioSeries(
+        audio=load_audio_segment(
+            media_path, stream_index=stream_index, mode=audio_extraction_mode
+        )
+    )
+    trim_start_ms = round(media_start_seconds * 1000)
+    if trim_start_ms >= len(audio.audio):
+        raise ScinoephileError(
+            f"Audio trim start {media_start_seconds:.3f}s is outside the media."
+        )
+    if trim_start_ms:
+        audio = AudioSeries(audio=audio.audio[trim_start_ms:], events=[])
+    audio_path.parent.mkdir(parents=True, exist_ok=True)
+    audio.audio.export(audio_path, format="wav")
+    return audio
+
+
+def _save_evaluation(
+    output_dir_path: Path,
+    artifact: AlignmentArtifact,
+    reference: Series,
+    *,
+    audit_references: Mapping[str, Series],
+    terminal_alignment_authority: str | None = None,
+):
+    """Save evaluation metrics and readable alignment audits."""
+    primary_metrics = _get_reference_metrics(artifact, reference)
+    cer = primary_metrics["cer"]
+    metrics = {
+        "format": "scinoephile-transcription-evaluation",
+        "version": 1,
+        "processed_blocks": len(artifact.blocks),
+        **primary_metrics,
+    }
+    json_dir_path = output_dir_path / "json"
+    json_dir_path.mkdir(parents=True, exist_ok=True)
+    (json_dir_path / "metrics.json").write_text(
+        json.dumps(metrics, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    reference_similarity = None
+    if artifact.language in {Language.yue_hans, Language.yue_hant}:
+        reference_similarity = YueTokenSimilarity(
+            timing_weight=2.0, timing_tolerance_seconds=0.75
+        )
+    (output_dir_path / "audit.md").write_text(
+        audit_transcription_alignment(
+            artifact,
+            audit_references,
+            reference_similarity=reference_similarity,
+            include_merge_support=True,
+        ),
+        encoding="utf-8",
+    )
+    if terminal_alignment_authority is not None:
+        terminal_alignment = render_transcription_alignment_terminal(
+            artifact,
+            audit_references,
+            authoritative_row_name=terminal_alignment_authority,
+            reference_similarity=reference_similarity,
+            include_merge_support=True,
+        )
+        logger.info(f"\n{terminal_alignment.rstrip()}")
+    logger.info(
+        "Aligned transcription evaluation: "
+        + ", ".join(f"{name} CER {values['cer']:.3%}" for name, values in cer.items())
+    )
+
+
+def _get_reference_metrics(artifact: AlignmentArtifact, reference: Series) -> dict:
+    """Calculate lexical and timing metrics against one named reference."""
+    selected_reference = get_reference_for_alignment(artifact, reference)
+    reference_text = "".join(
+        subtitle.text_with_newline for subtitle in selected_reference
+    )
+    candidate_texts = {source.name: [] for source in artifact.sources}
+    for block in artifact.blocks:
+        rows = {row.name: row.text for row in block.rows}
+        for source in artifact.sources:
+            candidate_texts[source.name].append(
+                rows.get(source.name, "").replace("　", "").replace("・", "")
+            )
+    candidate_texts["merged"] = [
+        subtitle.text for block in artifact.blocks for subtitle in block.subtitles
+    ]
+    cer = {
+        name: _get_cer_dict(LineCER(reference_text, "".join(text_parts)))
+        for name, text_parts in candidate_texts.items()
+    }
+    timing = evaluate_timing(artifact, reference)
+    subtitle_alignment_groups = Counter(
+        f"{len(pair.candidate_indexes)}:{len(pair.reference_indexes)}"
+        for pair in timing.pairs
+    )
+    return {
+        "reference_subtitles": len(selected_reference),
+        "candidate_subtitles": sum(len(block.subtitles) for block in artifact.blocks),
+        "cer": cer,
+        "timing": {
+            "settings": timing.settings.model_dump(mode="json"),
+            "text_aligned_groups": len(timing.pairs),
+            "micro_intersection_over_union": timing.micro_intersection_over_union,
+            "one_to_one_groups": len(timing.one_to_one_pairs),
+            "one_to_one_micro_intersection_over_union": (
+                timing.one_to_one_micro_intersection_over_union
+            ),
+            "mean_intersection_over_union": timing.mean_intersection_over_union,
+            "mean_reference_coverage": timing.mean_reference_coverage,
+            "mean_start_error_ms": timing.mean_start_error_ms,
+            "mean_end_error_ms": timing.mean_end_error_ms,
+            "mean_absolute_start_error_ms": timing.mean_absolute_start_error_ms,
+            "mean_absolute_end_error_ms": timing.mean_absolute_end_error_ms,
+            "unmatched_candidate_subtitles": timing.unmatched_candidate_subtitles,
+            "unmatched_reference_subtitles": timing.unmatched_reference_subtitles,
+            "candidate_to_reference_group_counts": dict(
+                sorted(subtitle_alignment_groups.items())
+            ),
+        },
+    }
+
+
+def _get_cer_dict(result: LineCER) -> dict[str, float | int]:
+    """Serialize one character-error result."""
+    return {
+        "cer": result.cer,
+        "correct": result.correct,
+        "substitutions": result.substitutions,
+        "insertions": result.insertions,
+        "deletions": result.deletions,
+        "reference_length": result.reference_length,
+    }

--- a/test/data/helpers.py
+++ b/test/data/helpers.py
@@ -22,6 +22,7 @@ __all__ = [
     "load_or_review_series",
     "load_or_romanize_series",
     "load_or_simplify_series",
+    "load_or_traditionalize_series",
     "load_or_timewarp_series",
 ]
 
@@ -140,6 +141,26 @@ def load_or_simplify_series(
     simplified = get_zho_converted(series, OpenCCConfig.t2s)
     simplified.save(output_path)
     return simplified
+
+
+def load_or_traditionalize_series(
+    series: Series, output_path: Path, overwrite: bool = False
+) -> Series:
+    """Load or create a Hong Kong Traditional Chinese-script subtitle series.
+
+    Arguments:
+        series: series to traditionalize
+        output_path: traditionalized subtitle output path
+        overwrite: whether to overwrite an existing output
+    Returns:
+        traditionalized series
+    """
+    if output_path.exists() and not overwrite:
+        return Series.load(output_path)
+
+    traditionalized = get_zho_converted(series, OpenCCConfig.s2hk)
+    traditionalized.save(output_path)
+    return traditionalized
 
 
 def load_or_timewarp_series(

--- a/test/data/test_aligned_transcription.py
+++ b/test/data/test_aligned_transcription.py
@@ -1,0 +1,198 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests for aligned multi-source transcription test-data generation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from pydub import AudioSegment
+from pytest import LogCaptureFixture, raises
+
+import test.data.aligned_transcription as transcription_data
+from scinoephile.analysis.transcription import (
+    AlignmentArtifact,
+    AlignmentBlock,
+    AlignmentColumn,
+    AlignmentRow,
+    AlignmentSource,
+    AlignmentSubtitle,
+)
+from scinoephile.audio.subtitles import AudioSeries
+from scinoephile.audio.vad import SpeechBlock
+from scinoephile.core import Language, ScinoephileError
+from scinoephile.core.subtitles import Series, Subtitle
+from scinoephile.workflows.transcription_pipeline import TranscriptionPipeline
+
+
+def test_reference_count_selects_smallest_block_prefix():
+    """The evaluation harness should stop after the target reference count."""
+    pipeline = Mock(spec=TranscriptionPipeline)
+    pipeline.plan_blocks.return_value = (
+        SpeechBlock(
+            index=0,
+            start_ms=1_000,
+            end_ms=3_000,
+            buffered_start_ms=0,
+            buffered_end_ms=4_000,
+        ),
+        SpeechBlock(
+            index=1,
+            start_ms=5_000,
+            end_ms=8_000,
+            buffered_start_ms=4_000,
+            buffered_end_ms=9_000,
+        ),
+    )
+    audio = AudioSeries(audio=AudioSegment.silent(duration=10_000), events=[])
+    reference = Series(
+        events=[
+            Subtitle(start=1_100, end=1_500, text="甲"),
+            Subtitle(start=2_000, end=2_400, text="乙"),
+            Subtitle(start=5_200, end=5_600, text="丙"),
+        ]
+    )
+
+    assert (
+        transcription_data._get_stop_at_idx_for_reference_count(  # noqa: SLF001
+            pipeline, audio, reference, 3
+        )
+        == 2
+    )
+    with raises(ScinoephileError, match="covers only 3"):
+        transcription_data._get_stop_at_idx_for_reference_count(  # noqa: SLF001
+            pipeline, audio, reference, 4
+        )
+
+
+def test_media_audio_trim_is_applied_before_staging(tmp_path: Path):
+    """Media extraction should apply title-specific leading trim before staging."""
+    extracted = AudioSeries(
+        audio=AudioSegment.silent(duration=5_000, frame_rate=16_000), events=[]
+    )
+    with patch(
+        "test.data.aligned_transcription.load_audio_segment",
+        return_value=extracted.audio,
+    ) as load_audio:
+        audio_path = tmp_path / "audio.wav"
+        audio = transcription_data._load_audio_series(  # noqa: SLF001
+            audio_path,
+            media_path=tmp_path / "source.mkv",
+            stream_index=12,
+            media_start_seconds=1.0,
+        )
+        reloaded = transcription_data._load_audio_series(  # noqa: SLF001
+            audio_path,
+            media_path=tmp_path / "source.mkv",
+            stream_index=12,
+            media_start_seconds=1.0,
+        )
+
+    assert len(audio.audio) == 4_000
+    assert len(reloaded.audio) == 4_000
+    assert audio_path.exists()
+    assert not audio_path.with_suffix(".srt").exists()
+    load_audio.assert_called_once()
+
+
+def test_existing_alignment_recreates_srt_without_transcription(tmp_path: Path):
+    """A portable alignment alone should be sufficient to reuse test output."""
+    title_root_path = tmp_path / "title"
+    output_dir_path = title_root_path / "output/yue-Hant_transcribe"
+    artifact_path = output_dir_path / "json/alignment.json"
+    reference_path = tmp_path / "reference.srt"
+    artifact = _get_artifact()
+    artifact.save(artifact_path)
+    artifact.get_series().save(reference_path)
+
+    with (
+        patch("test.data.aligned_transcription._load_audio_series") as load_audio,
+        patch(
+            "test.data.aligned_transcription.get_transcription_pipeline"
+        ) as get_pipeline,
+    ):
+        output = transcription_data.process_transcription_pipeline(
+            title_root_path, reference_path=reference_path, reference_name="yue-Hant"
+        )
+
+    assert output == artifact.get_series()
+    assert (output_dir_path / "transcribe.srt").exists()
+    load_audio.assert_not_called()
+    get_pipeline.assert_not_called()
+
+
+def test_evaluation_writes_standardized_metrics_and_audit(
+    tmp_path: Path, caplog: LogCaptureFixture
+):
+    """Evaluation should report every source, merged CER, and display timing."""
+    artifact = _get_artifact()
+    reference = Series(events=[Subtitle(start=900, end=2_100, text="係呀")])
+    caplog.set_level("INFO", logger="test.data.aligned_transcription")
+
+    transcription_data._save_evaluation(  # noqa: SLF001
+        tmp_path,
+        artifact,
+        reference,
+        audit_references={"yue-Hant": reference},
+        terminal_alignment_authority="yue-Hant",
+    )
+
+    metrics = json.loads((tmp_path / "json/metrics.json").read_text(encoding="utf-8"))
+    assert metrics["format"] == "scinoephile-transcription-evaluation"
+    assert set(metrics["cer"]) == {"whisper", "mimo", "merged"}
+    assert metrics["candidate_subtitles"] == 1
+    assert metrics["reference_subtitles"] == 1
+    audit = (tmp_path / "audit.md").read_text(encoding="utf-8")
+    assert "# Transcription Alignment Audit" in audit
+    assert "yue-Hant" in audit
+    assert "support" in audit
+    assert "Authority: yue-Hant" in caplog.text
+    assert any("\x1b[32m" in record.getMessage() for record in caplog.records)
+
+
+def _get_artifact() -> AlignmentArtifact:
+    """Get a compact valid evaluation artifact."""
+    return AlignmentArtifact(
+        language=Language.yue_hant,
+        audio_duration_ms=3_000,
+        sources=(
+            AlignmentSource(name="whisper", backend="whisper", model="whisper"),
+            AlignmentSource(name="mimo", backend="mlx", model="mimo"),
+        ),
+        blocks=(
+            AlignmentBlock(
+                index=1,
+                core_start_ms=500,
+                core_end_ms=2_500,
+                buffered_start_ms=0,
+                buffered_end_ms=3_000,
+                columns=(
+                    AlignmentColumn(index=1, start_ms=1_000, end_ms=1_500, kind="text"),
+                    AlignmentColumn(index=2, start_ms=1_500, end_ms=2_000, kind="text"),
+                ),
+                rows=(
+                    AlignmentRow(name="whisper", text="係呀"),
+                    AlignmentRow(name="mimo", text="是呀"),
+                ),
+                speaker="ＡＡ",
+                language_trace="粵粵",
+                language_legend={"粵": "zh-yue"},
+                singing_trace="　唱",
+                music_trace="樂樂",
+                merged="係呀",
+                subtitles=(
+                    AlignmentSubtitle(
+                        index=1,
+                        text="係呀",
+                        speech_start_ms=1_000,
+                        speech_end_ms=2_000,
+                        timing_source="source",
+                        start_ms=1_000,
+                        end_ms=2_000,
+                    ),
+                ),
+            ),
+        ),
+    )

--- a/test/data/test_aligned_transcription.py
+++ b/test/data/test_aligned_transcription.py
@@ -24,6 +24,7 @@ from scinoephile.audio.subtitles import AudioSeries
 from scinoephile.audio.vad import SpeechBlock
 from scinoephile.core import Language, ScinoephileError
 from scinoephile.core.subtitles import Series, Subtitle
+from scinoephile.media.audio import AudioExtractionMode
 from scinoephile.workflows.transcription_pipeline import TranscriptionPipeline
 
 
@@ -72,9 +73,10 @@ def test_media_audio_trim_is_applied_before_staging(tmp_path: Path):
     extracted = AudioSeries(
         audio=AudioSegment.silent(duration=5_000, frame_rate=16_000), events=[]
     )
+    staged = AudioSegment.silent(duration=4_000, frame_rate=16_000)
     with patch(
         "test.data.aligned_transcription.load_audio_segment",
-        return_value=extracted.audio,
+        side_effect=(extracted.audio, staged),
     ) as load_audio:
         audio_path = tmp_path / "audio.wav"
         audio = transcription_data._load_audio_series(  # noqa: SLF001
@@ -94,7 +96,14 @@ def test_media_audio_trim_is_applied_before_staging(tmp_path: Path):
     assert len(reloaded.audio) == 4_000
     assert audio_path.exists()
     assert not audio_path.with_suffix(".srt").exists()
-    load_audio.assert_called_once()
+    assert load_audio.call_count == 2
+    assert load_audio.call_args_list[0].args == (tmp_path / "source.mkv",)
+    assert load_audio.call_args_list[0].kwargs == {
+        "stream_index": 12,
+        "mode": AudioExtractionMode.ORIGINAL,
+    }
+    assert load_audio.call_args_list[1].args == (audio_path,)
+    assert not load_audio.call_args_list[1].kwargs
 
 
 def test_existing_alignment_recreates_srt_without_transcription(tmp_path: Path):
@@ -113,7 +122,7 @@ def test_existing_alignment_recreates_srt_without_transcription(tmp_path: Path):
             "test.data.aligned_transcription.get_transcription_pipeline"
         ) as get_pipeline,
     ):
-        output = transcription_data.process_transcription_pipeline(
+        output = transcription_data.process_transcription(
             title_root_path, reference_path=reference_path, reference_name="yue-Hant"
         )
 
@@ -136,7 +145,7 @@ def test_evaluation_writes_standardized_metrics_and_audit(
         artifact,
         reference,
         audit_references={"yue-Hant": reference},
-        terminal_alignment_authority="yue-Hant",
+        terminal_authority="yue-Hant",
     )
 
     metrics = json.loads((tmp_path / "json/metrics.json").read_text(encoding="utf-8"))
@@ -148,8 +157,65 @@ def test_evaluation_writes_standardized_metrics_and_audit(
     assert "# Transcription Alignment Audit" in audit
     assert "yue-Hant" in audit
     assert "support" in audit
+    assert f"- whisper CER: {metrics['cer']['whisper']['cer']:.3%}" in audit
     assert "Authority: yue-Hant" in caplog.text
     assert any("\x1b[32m" in record.getMessage() for record in caplog.records)
+
+
+def test_fresh_run_routes_and_writes_outputs(tmp_path: Path):
+    """A fresh run should route provenance and write harness outputs."""
+    title_root_path = tmp_path / "title"
+    output_dir_path = title_root_path / "output/yue-Hant_transcribe"
+    reference_path = tmp_path / "reference.srt"
+    artifact = _get_artifact()
+    output = artifact.get_series()
+    output.save(reference_path)
+    audio = AudioSeries(audio=AudioSegment.silent(duration=3_000), events=[])
+    provider = Mock(completion_metrics=[])
+    pipeline = Mock(spec=TranscriptionPipeline)
+    pipeline.last_alignment_artifact = artifact
+
+    with (
+        patch("test.data.aligned_transcription._load_audio_series", return_value=audio),
+        patch("test.data.aligned_transcription.get_provider", return_value=provider),
+        patch(
+            "test.data.aligned_transcription.get_transcription_pipeline",
+            return_value=pipeline,
+        ) as get_pipeline,
+        patch(
+            "test.data.aligned_transcription.save_chat_completion_metrics_to_json"
+        ) as save_usage,
+        patch(
+            "test.data.aligned_transcription.transcribe_series", return_value=output
+        ) as transcribe,
+    ):
+        result = transcription_data.process_transcription(
+            title_root_path,
+            reference_path=reference_path,
+            stop_at_idx=1,
+            target_reference_count=0,
+        )
+
+    json_dir_path = output_dir_path / "json"
+    assert result == output
+    get_pipeline.assert_called_once_with(
+        Language.yue_hant,
+        provider=provider,
+        additional_context=None,
+        current_test_cases_path=json_dir_path / "transcription.json",
+    )
+    transcribe.assert_called_once_with(
+        audio,
+        language=Language.yue_hant,
+        pipeline=pipeline,
+        alignment_outfile_path=json_dir_path / "alignment.json",
+        run_manifest_outfile_path=json_dir_path / "run.json",
+        stop_at_idx=1,
+    )
+    save_usage.assert_called_once_with(json_dir_path / "llm_usage.json", [])
+    assert (output_dir_path / "transcribe.srt").exists()
+    assert (output_dir_path / "audit.md").exists()
+    assert (json_dir_path / "metrics.json").exists()
 
 
 def _get_artifact() -> AlignmentArtifact:

--- a/test/data/test_aligned_transcription.py
+++ b/test/data/test_aligned_transcription.py
@@ -12,6 +12,7 @@ from pydub import AudioSegment
 from pytest import LogCaptureFixture, raises
 
 import test.data.aligned_transcription as transcription_data
+from scinoephile.analysis.character_error_rate import SeriesCER
 from scinoephile.analysis.transcription import (
     AlignmentArtifact,
     AlignmentBlock,
@@ -26,6 +27,169 @@ from scinoephile.core import Language, ScinoephileError
 from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.media.audio import AudioExtractionMode
 from scinoephile.workflows.transcription_pipeline import TranscriptionPipeline
+
+
+def test_evaluation_writes_standardized_metrics_and_audit(
+    tmp_path: Path, caplog: LogCaptureFixture
+):
+    """Evaluation should report every source, merged CER, and display timing."""
+    artifact = _get_artifact()
+    reference = Series(events=[Subtitle(start=900, end=2_100, text="係呀")])
+    caplog.set_level("INFO", logger="test.data.aligned_transcription")
+
+    with patch(
+        "scinoephile.analysis.transcription.evaluation.SeriesCER", wraps=SeriesCER
+    ) as series_cer:
+        transcription_data._save_evaluation(  # noqa: SLF001
+            tmp_path,
+            artifact,
+            reference,
+            audit_references={"yue-Hant": reference},
+            terminal_authority="yue-Hant",
+        )
+
+    assert series_cer.call_count == 6
+    metrics = json.loads((tmp_path / "json/metrics.json").read_text(encoding="utf-8"))
+    assert metrics["format"] == "scinoephile-transcription-evaluation"
+    assert set(metrics["cer"]) == {"whisper", "mimo", "merged"}
+    assert metrics["candidate_subtitles"] == 1
+    assert metrics["reference_subtitles"] == 1
+    audit = (tmp_path / "audit.md").read_text(encoding="utf-8")
+    assert "# Transcription Alignment Audit" in audit
+    assert "yue-Hant" in audit
+    assert "support" in audit
+    assert f"- whisper CER: {metrics['cer']['whisper']['cer']:.3%}" in audit
+    assert "Authority: yue-Hant" in caplog.text
+    assert any("\x1b[32m" in record.getMessage() for record in caplog.records)
+
+
+def test_existing_alignment_recreates_srt_without_transcription(tmp_path: Path):
+    """A portable alignment alone should be sufficient to reuse test output."""
+    title_root_path = tmp_path / "title"
+    output_dir_path = title_root_path / "output/yue-Hant_transcribe"
+    artifact_path = output_dir_path / "json/alignment.json"
+    reference_path = tmp_path / "reference.srt"
+    artifact = _get_artifact()
+    artifact.save(artifact_path)
+    artifact.get_series().save(reference_path)
+
+    with (
+        patch("test.data.aligned_transcription._load_audio_series") as load_audio,
+        patch(
+            "test.data.aligned_transcription.get_transcription_pipeline"
+        ) as get_pipeline,
+    ):
+        output = transcription_data.process_transcription(
+            title_root_path, reference_path=reference_path, reference_name="yue-Hant"
+        )
+
+    assert output == artifact.get_series()
+    assert (output_dir_path / "transcribe.srt").exists()
+    load_audio.assert_not_called()
+    get_pipeline.assert_not_called()
+
+
+def test_fresh_run_routes_and_writes_outputs(tmp_path: Path):
+    """A fresh run should route provenance and write harness outputs."""
+    title_root_path = tmp_path / "title"
+    output_dir_path = title_root_path / "output/yue-Hant_transcribe"
+    reference_path = tmp_path / "reference.srt"
+    artifact = _get_artifact()
+    output = artifact.get_series()
+    output.save(reference_path)
+    audio = AudioSeries(audio=AudioSegment.silent(duration=3_000), events=[])
+    provider = Mock(completion_metrics=[])
+    pipeline = Mock(spec=TranscriptionPipeline)
+    pipeline.last_alignment_artifact = artifact
+
+    with (
+        patch(
+            "test.data.aligned_transcription._load_audio_series", return_value=audio
+        ) as load_audio,
+        patch("test.data.aligned_transcription.get_provider", return_value=provider),
+        patch(
+            "test.data.aligned_transcription.get_transcription_pipeline",
+            return_value=pipeline,
+        ) as get_pipeline,
+        patch(
+            "test.data.aligned_transcription.save_chat_completion_metrics_to_json"
+        ) as save_usage,
+        patch(
+            "test.data.aligned_transcription.transcribe_series", return_value=output
+        ) as transcribe,
+    ):
+        result = transcription_data.process_transcription(
+            title_root_path,
+            reference_path=reference_path,
+            stop_at_idx=1,
+            target_reference_count=0,
+        )
+
+    json_dir_path = output_dir_path / "json"
+    assert result == output
+    load_audio.assert_called_once_with(
+        output_dir_path / "audio/audio.wav",
+        media_path=None,
+        stream_index=None,
+        audio_extraction_mode=AudioExtractionMode.ORIGINAL,
+        media_start_seconds=0.0,
+    )
+    get_pipeline.assert_called_once_with(
+        Language.yue_hant,
+        provider=provider,
+        additional_context=None,
+        current_test_cases_path=json_dir_path / "transcription.json",
+    )
+    transcribe.assert_called_once_with(
+        audio,
+        language=Language.yue_hant,
+        pipeline=pipeline,
+        alignment_outfile_path=json_dir_path / "alignment.json",
+        run_manifest_outfile_path=json_dir_path / "run.json",
+        stop_at_idx=1,
+    )
+    save_usage.assert_called_once_with(json_dir_path / "llm_usage.json", [])
+    assert (output_dir_path / "transcribe.srt").exists()
+    assert (output_dir_path / "audit.md").exists()
+    assert (json_dir_path / "metrics.json").exists()
+
+
+def test_media_audio_trim_is_applied_before_staging(tmp_path: Path):
+    """Media extraction should apply title-specific leading trim before staging."""
+    extracted = AudioSeries(
+        audio=AudioSegment.silent(duration=5_000, frame_rate=16_000), events=[]
+    )
+    staged = AudioSegment.silent(duration=4_000, frame_rate=16_000)
+    with patch(
+        "test.data.aligned_transcription.load_audio_segment",
+        side_effect=(extracted.audio, staged),
+    ) as load_audio:
+        audio_path = tmp_path / "audio.wav"
+        audio = transcription_data._load_audio_series(  # noqa: SLF001
+            audio_path,
+            media_path=tmp_path / "source.mkv",
+            stream_index=12,
+            media_start_seconds=1.0,
+        )
+        reloaded = transcription_data._load_audio_series(  # noqa: SLF001
+            audio_path,
+            media_path=tmp_path / "source.mkv",
+            stream_index=12,
+            media_start_seconds=1.0,
+        )
+
+    assert len(audio.audio) == 4_000
+    assert len(reloaded.audio) == 4_000
+    assert audio_path.exists()
+    assert not audio_path.with_suffix(".srt").exists()
+    assert load_audio.call_count == 2
+    assert load_audio.call_args_list[0].args == (tmp_path / "source.mkv",)
+    assert load_audio.call_args_list[0].kwargs == {
+        "stream_index": 12,
+        "mode": AudioExtractionMode.ORIGINAL,
+    }
+    assert load_audio.call_args_list[1].args == (audio_path,)
+    assert not load_audio.call_args_list[1].kwargs
 
 
 def test_reference_count_selects_smallest_block_prefix():
@@ -68,158 +232,12 @@ def test_reference_count_selects_smallest_block_prefix():
         )
 
 
-def test_media_audio_trim_is_applied_before_staging(tmp_path: Path):
-    """Media extraction should apply title-specific leading trim before staging."""
-    extracted = AudioSeries(
-        audio=AudioSegment.silent(duration=5_000, frame_rate=16_000), events=[]
-    )
-    staged = AudioSegment.silent(duration=4_000, frame_rate=16_000)
-    with patch(
-        "test.data.aligned_transcription.load_audio_segment",
-        side_effect=(extracted.audio, staged),
-    ) as load_audio:
-        audio_path = tmp_path / "audio.wav"
-        audio = transcription_data._load_audio_series(  # noqa: SLF001
-            audio_path,
-            media_path=tmp_path / "source.mkv",
-            stream_index=12,
-            media_start_seconds=1.0,
-        )
-        reloaded = transcription_data._load_audio_series(  # noqa: SLF001
-            audio_path,
-            media_path=tmp_path / "source.mkv",
-            stream_index=12,
-            media_start_seconds=1.0,
-        )
-
-    assert len(audio.audio) == 4_000
-    assert len(reloaded.audio) == 4_000
-    assert audio_path.exists()
-    assert not audio_path.with_suffix(".srt").exists()
-    assert load_audio.call_count == 2
-    assert load_audio.call_args_list[0].args == (tmp_path / "source.mkv",)
-    assert load_audio.call_args_list[0].kwargs == {
-        "stream_index": 12,
-        "mode": AudioExtractionMode.ORIGINAL,
-    }
-    assert load_audio.call_args_list[1].args == (audio_path,)
-    assert not load_audio.call_args_list[1].kwargs
-
-
-def test_existing_alignment_recreates_srt_without_transcription(tmp_path: Path):
-    """A portable alignment alone should be sufficient to reuse test output."""
-    title_root_path = tmp_path / "title"
-    output_dir_path = title_root_path / "output/yue-Hant_transcribe"
-    artifact_path = output_dir_path / "json/alignment.json"
-    reference_path = tmp_path / "reference.srt"
-    artifact = _get_artifact()
-    artifact.save(artifact_path)
-    artifact.get_series().save(reference_path)
-
-    with (
-        patch("test.data.aligned_transcription._load_audio_series") as load_audio,
-        patch(
-            "test.data.aligned_transcription.get_transcription_pipeline"
-        ) as get_pipeline,
-    ):
-        output = transcription_data.process_transcription(
-            title_root_path, reference_path=reference_path, reference_name="yue-Hant"
-        )
-
-    assert output == artifact.get_series()
-    assert (output_dir_path / "transcribe.srt").exists()
-    load_audio.assert_not_called()
-    get_pipeline.assert_not_called()
-
-
-def test_evaluation_writes_standardized_metrics_and_audit(
-    tmp_path: Path, caplog: LogCaptureFixture
-):
-    """Evaluation should report every source, merged CER, and display timing."""
-    artifact = _get_artifact()
-    reference = Series(events=[Subtitle(start=900, end=2_100, text="係呀")])
-    caplog.set_level("INFO", logger="test.data.aligned_transcription")
-
-    transcription_data._save_evaluation(  # noqa: SLF001
-        tmp_path,
-        artifact,
-        reference,
-        audit_references={"yue-Hant": reference},
-        terminal_authority="yue-Hant",
-    )
-
-    metrics = json.loads((tmp_path / "json/metrics.json").read_text(encoding="utf-8"))
-    assert metrics["format"] == "scinoephile-transcription-evaluation"
-    assert set(metrics["cer"]) == {"whisper", "mimo", "merged"}
-    assert metrics["candidate_subtitles"] == 1
-    assert metrics["reference_subtitles"] == 1
-    audit = (tmp_path / "audit.md").read_text(encoding="utf-8")
-    assert "# Transcription Alignment Audit" in audit
-    assert "yue-Hant" in audit
-    assert "support" in audit
-    assert f"- whisper CER: {metrics['cer']['whisper']['cer']:.3%}" in audit
-    assert "Authority: yue-Hant" in caplog.text
-    assert any("\x1b[32m" in record.getMessage() for record in caplog.records)
-
-
-def test_fresh_run_routes_and_writes_outputs(tmp_path: Path):
-    """A fresh run should route provenance and write harness outputs."""
-    title_root_path = tmp_path / "title"
-    output_dir_path = title_root_path / "output/yue-Hant_transcribe"
-    reference_path = tmp_path / "reference.srt"
-    artifact = _get_artifact()
-    output = artifact.get_series()
-    output.save(reference_path)
-    audio = AudioSeries(audio=AudioSegment.silent(duration=3_000), events=[])
-    provider = Mock(completion_metrics=[])
-    pipeline = Mock(spec=TranscriptionPipeline)
-    pipeline.last_alignment_artifact = artifact
-
-    with (
-        patch("test.data.aligned_transcription._load_audio_series", return_value=audio),
-        patch("test.data.aligned_transcription.get_provider", return_value=provider),
-        patch(
-            "test.data.aligned_transcription.get_transcription_pipeline",
-            return_value=pipeline,
-        ) as get_pipeline,
-        patch(
-            "test.data.aligned_transcription.save_chat_completion_metrics_to_json"
-        ) as save_usage,
-        patch(
-            "test.data.aligned_transcription.transcribe_series", return_value=output
-        ) as transcribe,
-    ):
-        result = transcription_data.process_transcription(
-            title_root_path,
-            reference_path=reference_path,
-            stop_at_idx=1,
-            target_reference_count=0,
-        )
-
-    json_dir_path = output_dir_path / "json"
-    assert result == output
-    get_pipeline.assert_called_once_with(
-        Language.yue_hant,
-        provider=provider,
-        additional_context=None,
-        current_test_cases_path=json_dir_path / "transcription.json",
-    )
-    transcribe.assert_called_once_with(
-        audio,
-        language=Language.yue_hant,
-        pipeline=pipeline,
-        alignment_outfile_path=json_dir_path / "alignment.json",
-        run_manifest_outfile_path=json_dir_path / "run.json",
-        stop_at_idx=1,
-    )
-    save_usage.assert_called_once_with(json_dir_path / "llm_usage.json", [])
-    assert (output_dir_path / "transcribe.srt").exists()
-    assert (output_dir_path / "audit.md").exists()
-    assert (json_dir_path / "metrics.json").exists()
-
-
 def _get_artifact() -> AlignmentArtifact:
-    """Get a compact valid evaluation artifact."""
+    """Get a compact valid evaluation artifact.
+
+    Returns:
+        compact valid evaluation artifact
+    """
     return AlignmentArtifact(
         language=Language.yue_hant,
         audio_duration_ms=3_000,

--- a/test/data/test_transcription.py
+++ b/test/data/test_transcription.py
@@ -1,198 +1,263 @@
 #  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
-"""Tests for aligned multi-source transcription test-data generation."""
+"""Tests for guided-transcription test-data generation."""
 
 from __future__ import annotations
 
-import json
+from logging import INFO, WARNING, getLogger
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
-from pydub import AudioSegment
-from pytest import LogCaptureFixture, raises
+from pytest import LogCaptureFixture, MonkeyPatch, mark, param
 
-from scinoephile.analysis.transcription_alignment import (
-    TranscriptionAlignmentArtifact,
-    TranscriptionAlignmentBlock,
-    TranscriptionAlignmentColumn,
-    TranscriptionAlignmentRow,
-    TranscriptionAlignmentSource,
-    TranscriptionAlignmentSubtitle,
-)
-from scinoephile.audio.subtitles import AudioSeries
-from scinoephile.audio.transcription import SpeechBlock
-from scinoephile.core import Language, ScinoephileError
+import test.data.transcription as transcription_data
+from scinoephile.core import Language
 from scinoephile.core.subtitles import Series, Subtitle
-from scinoephile.lang.transcription.pipeline import TranscriptionPipeline
-from test.data.transcription import (
-    _get_stop_at_idx_for_reference_count,
-    _load_audio_series,
-    _save_evaluation,
-    process_transcription_pipeline,
-)
 
 
-def test_reference_count_selects_smallest_vad_block_prefix():
-    """The evaluation harness should stop after the target reference count."""
-    pipeline = Mock(spec=TranscriptionPipeline)
-    pipeline.plan_blocks.return_value = (
-        SpeechBlock(
-            index=0,
-            start_ms=1_000,
-            end_ms=3_000,
-            buffered_start_ms=0,
-            buffered_end_ms=4_000,
-        ),
-        SpeechBlock(
-            index=1,
-            start_ms=5_000,
-            end_ms=8_000,
-            buffered_start_ms=4_000,
-            buffered_end_ms=9_000,
-        ),
+def test_get_reference_for_guide_blocks_limits_reference_prefix():
+    """Limit an evaluation reference using the selected guide blocks."""
+    guide = Series(
+        events=[
+            Subtitle(start=0, end=1_000, text="一"),
+            Subtitle(start=5_000, end=6_000, text="二"),
+        ]
     )
-    audio = AudioSeries(audio=AudioSegment.silent(duration=10_000), events=[])
     reference = Series(
         events=[
-            Subtitle(start=1_100, end=1_500, text="甲"),
-            Subtitle(start=2_000, end=2_400, text="乙"),
-            Subtitle(start=5_200, end=5_600, text="丙"),
+            Subtitle(start=100, end=500, text="甲"),
+            Subtitle(start=999, end=1_500, text="乙"),
+            Subtitle(start=1_000, end=2_000, text="丙"),
+            Subtitle(start=5_500, end=6_000, text="丁"),
         ]
     )
 
-    assert _get_stop_at_idx_for_reference_count(pipeline, audio, reference, 3) == 2
-    with raises(ScinoephileError, match="covers only 3"):
-        _get_stop_at_idx_for_reference_count(pipeline, audio, reference, 4)
+    limited = transcription_data.get_reference_for_guide_blocks(reference, guide, 1)
+
+    assert [subtitle.text for subtitle in limited] == ["甲", "乙"]
 
 
-def test_media_audio_trim_is_applied_before_staging(tmp_path: Path):
-    """Media extraction should apply title-specific leading trim before staging."""
-    extracted = AudioSeries(
-        audio=AudioSegment.silent(duration=5_000, frame_rate=16_000), events=[]
-    )
-    with patch.object(
-        AudioSeries, "load_audio_from_media", return_value=extracted
-    ) as load_audio:
-        audio_path = tmp_path / "audio.wav"
-        audio = _load_audio_series(
-            audio_path,
-            media_path=tmp_path / "source.mkv",
-            stream_index=12,
-            media_start_seconds=1.0,
-        )
-        reloaded = _load_audio_series(
-            audio_path,
-            media_path=tmp_path / "source.mkv",
-            stream_index=12,
-            media_start_seconds=1.0,
-        )
-
-    assert len(audio.audio) == 4_000
-    assert len(reloaded.audio) == 4_000
-    assert audio_path.exists()
-    assert not audio_path.with_suffix(".srt").exists()
-    load_audio.assert_called_once()
-
-
-def test_existing_alignment_recreates_srt_without_transcription(tmp_path: Path):
-    """A portable alignment alone should be sufficient to reuse test output."""
-    title_root_path = tmp_path / "title"
-    output_dir_path = title_root_path / "output/yue-Hant_transcribe"
-    artifact_path = output_dir_path / "json/alignment.json"
-    reference_path = tmp_path / "reference.srt"
-    artifact = _get_artifact()
-    artifact.save(artifact_path)
-    artifact.get_series().save(reference_path)
-
-    with (
-        patch("test.data.transcription._load_audio_series") as load_audio,
-        patch("test.data.transcription.get_transcription_pipeline") as get_pipeline,
-    ):
-        output = process_transcription_pipeline(
-            title_root_path, reference_path=reference_path, reference_name="yue-Hant"
-        )
-
-    assert output == artifact.get_series()
-    assert (output_dir_path / "transcribe.srt").exists()
-    load_audio.assert_not_called()
-    get_pipeline.assert_not_called()
-
-
-def test_evaluation_writes_standardized_metrics_and_audit(
-    tmp_path: Path, caplog: LogCaptureFixture
+@mark.parametrize(
+    ("language", "guide_language", "detected_language", "expected_log_level"),
+    [
+        param(
+            Language.yue_hans,
+            Language.zho_hans,
+            Language.zho_hans,
+            INFO,
+            id="yue-hans-from-zho-hans",
+        ),
+        param(
+            Language.yue_hant,
+            Language.zho_hant,
+            Language.zho_hant,
+            INFO,
+            id="yue-hant-from-zho-hant",
+        ),
+        param(
+            Language.yue_hant,
+            Language.zho_hant,
+            Language.zho_hans,
+            WARNING,
+            id="different-script",
+        ),
+        param(
+            Language.eng,
+            Language.zho_hant,
+            Language.zho_hant,
+            WARNING,
+            id="non-cantonese",
+        ),
+    ],
+)
+def test_process_transcription_orders_stages_and_relogs_expected_mismatch(
+    tmp_path: Path,
+    caplog: LogCaptureFixture,
+    monkeypatch: MonkeyPatch,
+    language: Language,
+    guide_language: Language,
+    detected_language: Language,
+    expected_log_level: int,
 ):
-    """Evaluation should report every source, merged CER, and display timing."""
-    artifact = _get_artifact()
-    reference = Series(events=[Subtitle(start=900, end=2_100, text="係呀")])
-    caplog.set_level("INFO", logger="test.data.transcription")
+    """Run stages in order and relog only same-script Yue-to-Zho detection.
 
-    _save_evaluation(
+    Arguments:
+        tmp_path: temporary pipeline directory
+        caplog: captured log records
+        monkeypatch: pytest monkeypatch fixture
+        language: transcription language
+        guide_language: guide subtitle language
+        detected_language: language reported for the fresh transcription
+        expected_log_level: expected mismatch log level
+    """
+    reference = Series(events=[Subtitle(start=0, end=1_000, text="佢喺度")])
+    guide = Series(events=[Subtitle(start=0, end=1_000, text="他在這裡")])
+    reference_path = tmp_path / "reference.srt"
+    guide_path = tmp_path / "guide.srt"
+    reference.save(reference_path)
+    guide.save(guide_path)
+    stage_order: list[str] = []
+    stage_audio = Mock(
+        side_effect=lambda *args, **kwargs: stage_order.append("audio") or reference
+    )
+    transcribe = Mock(
+        side_effect=lambda *args, **kwargs: (
+            stage_order.append("transcribe") or reference
+        )
+    )
+    mismatch_message = (
+        f"Explicit language {language.code} does not "
+        f"match detected language {detected_language.code}; "
+        f"using {language.code}"
+    )
+    language_logger = getLogger("scinoephile.workflows.helpers")
+    clean = Mock(
+        side_effect=lambda *args, **kwargs: (
+            stage_order.append("clean")
+            or language_logger.warning(mismatch_message)
+            or reference
+        )
+    )
+    review = Mock(
+        side_effect=lambda *args, **kwargs: stage_order.append("review") or reference
+    )
+    translate = Mock(
+        side_effect=lambda *args, **kwargs: stage_order.append("translate") or reference
+    )
+    monkeypatch.setattr(
+        transcription_data,
+        "resolve_language",
+        Mock(side_effect=lambda series, explicit_language: explicit_language),
+    )
+    monkeypatch.setattr(transcription_data, "_stage_audio_series", stage_audio)
+    monkeypatch.setattr(
+        transcription_data, "_load_or_transcribe_series_guided", transcribe
+    )
+    monkeypatch.setattr(transcription_data, "load_or_clean_series", clean)
+    monkeypatch.setattr(transcription_data, "_load_or_review_series_guided", review)
+    monkeypatch.setattr(transcription_data, "_load_or_translate_series_gaps", translate)
+
+    with caplog.at_level(INFO):
+        output = transcription_data.process_transcription(
+            tmp_path,
+            guide_path,
+            reference_path=reference_path,
+            language=language,
+            guide_language=guide_language,
+            additional_context="Movie-specific context",
+        )
+
+    assert output is reference
+    assert stage_order == ["audio", "transcribe", "clean", "review", "translate"]
+    assert transcribe.call_args.kwargs["transcription_kw"] == {
+        "additional_context": "Movie-specific context"
+    }
+    assert review.call_args.kwargs["reviewer_kw"] == {
+        "additional_context": "Movie-specific context"
+    }
+    assert translate.call_args.kwargs["translator_kw"] == {
+        "additional_context": "Movie-specific context"
+    }
+    mismatch_records = [
+        record for record in caplog.records if record.getMessage() == mismatch_message
+    ]
+    assert len(mismatch_records) == 1
+    assert mismatch_records[0].levelno == expected_log_level
+
+
+def test_process_transcription_can_stop_after_cleaning(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+):
+    """Skip guided review and gap translation when they are disabled.
+
+    Arguments:
+        tmp_path: temporary pipeline directory
+        monkeypatch: pytest monkeypatch fixture
+    """
+    reference = Series(events=[Subtitle(start=0, end=1_000, text="佢喺度")])
+    reference_path = tmp_path / "reference.srt"
+    guide_path = tmp_path / "guide.srt"
+    reference.save(reference_path)
+    reference.save(guide_path)
+    review = Mock()
+    translate = Mock()
+    monkeypatch.setattr(
+        transcription_data,
+        "resolve_language",
+        Mock(side_effect=lambda series, explicit_language: explicit_language),
+    )
+    monkeypatch.setattr(
+        transcription_data, "_stage_audio_series", Mock(return_value=reference)
+    )
+    monkeypatch.setattr(
+        transcription_data,
+        "_load_or_transcribe_series_guided",
+        Mock(return_value=reference),
+    )
+    monkeypatch.setattr(
+        transcription_data, "load_or_clean_series", Mock(return_value=reference)
+    )
+    monkeypatch.setattr(transcription_data, "_load_or_review_series_guided", review)
+    monkeypatch.setattr(transcription_data, "_load_or_translate_series_gaps", translate)
+
+    output = transcription_data.process_transcription(
         tmp_path,
-        artifact,
-        reference,
-        audit_references={"yue-Hant": reference},
-        terminal_alignment_authority="yue-Hant",
-    )
-
-    metrics = json.loads((tmp_path / "json/metrics.json").read_text(encoding="utf-8"))
-    assert metrics["format"] == "scinoephile-transcription-evaluation"
-    assert set(metrics["cer"]) == {"whisper", "mimo", "merged"}
-    assert metrics["candidate_subtitles"] == 1
-    assert metrics["reference_subtitles"] == 1
-    audit = (tmp_path / "audit.md").read_text(encoding="utf-8")
-    assert "# Transcription Alignment Audit" in audit
-    assert "yue-Hant" in audit
-    assert "support" in audit
-    assert "Authority: yue-Hant" in caplog.text
-    assert any("\x1b[32m" in record.getMessage() for record in caplog.records)
-
-
-def _get_artifact() -> TranscriptionAlignmentArtifact:
-    """Get a compact valid evaluation artifact."""
-    return TranscriptionAlignmentArtifact(
+        guide_path,
+        reference_path=reference_path,
         language=Language.yue_hant,
-        audio_duration_ms=3_000,
-        sources=(
-            TranscriptionAlignmentSource(
-                name="whisper", backend="whisper", model="whisper"
-            ),
-            TranscriptionAlignmentSource(name="mimo", backend="mlx", model="mimo"),
-        ),
-        blocks=(
-            TranscriptionAlignmentBlock(
-                index=1,
-                core_start_ms=500,
-                core_end_ms=2_500,
-                buffered_start_ms=0,
-                buffered_end_ms=3_000,
-                columns=(
-                    TranscriptionAlignmentColumn(
-                        index=1, start_ms=1_000, end_ms=1_500, kind="text"
-                    ),
-                    TranscriptionAlignmentColumn(
-                        index=2, start_ms=1_500, end_ms=2_000, kind="text"
-                    ),
-                ),
-                rows=(
-                    TranscriptionAlignmentRow(name="whisper", text="係呀"),
-                    TranscriptionAlignmentRow(name="mimo", text="是呀"),
-                ),
-                speaker="ＡＡ",
-                language_trace="粵粵",
-                language_legend={"粵": "zh-yue"},
-                singing_trace="　唱",
-                music_trace="樂樂",
-                merged="係呀",
-                subtitles=(
-                    TranscriptionAlignmentSubtitle(
-                        index=1,
-                        text="係呀",
-                        speech_start_ms=1_000,
-                        speech_end_ms=2_000,
-                        start_ms=1_000,
-                        end_ms=2_000,
-                    ),
-                ),
-            ),
-        ),
+        guide_language=Language.zho_hant,
+        run_review_and_translation=False,
     )
+
+    assert output is reference
+    review.assert_not_called()
+    translate.assert_not_called()
+
+
+def test_process_transcription_can_stop_before_cleaning(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+):
+    """Return the transcription without running later stages.
+
+    Arguments:
+        tmp_path: temporary pipeline directory
+        monkeypatch: pytest monkeypatch fixture
+    """
+    reference = Series(events=[Subtitle(start=0, end=1_000, text="佢喺度")])
+    reference_path = tmp_path / "reference.srt"
+    guide_path = tmp_path / "guide.srt"
+    reference.save(reference_path)
+    reference.save(guide_path)
+    clean = Mock()
+    review = Mock()
+    translate = Mock()
+    monkeypatch.setattr(
+        transcription_data,
+        "resolve_language",
+        Mock(side_effect=lambda series, explicit_language: explicit_language),
+    )
+    monkeypatch.setattr(
+        transcription_data, "_stage_audio_series", Mock(return_value=reference)
+    )
+    monkeypatch.setattr(
+        transcription_data,
+        "_load_or_transcribe_series_guided",
+        Mock(return_value=reference),
+    )
+    monkeypatch.setattr(transcription_data, "load_or_clean_series", clean)
+    monkeypatch.setattr(transcription_data, "_load_or_review_series_guided", review)
+    monkeypatch.setattr(transcription_data, "_load_or_translate_series_gaps", translate)
+
+    output = transcription_data.process_transcription(
+        tmp_path,
+        guide_path,
+        reference_path=reference_path,
+        language=Language.yue_hant,
+        guide_language=Language.zho_hant,
+        run_cleaning=False,
+    )
+
+    assert output is reference
+    clean.assert_not_called()
+    review.assert_not_called()
+    translate.assert_not_called()

--- a/test/data/test_transcription.py
+++ b/test/data/test_transcription.py
@@ -1,263 +1,198 @@
 #  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
-"""Tests for guided-transcription test-data generation."""
+"""Tests for aligned multi-source transcription test-data generation."""
 
 from __future__ import annotations
 
-from logging import INFO, WARNING, getLogger
+import json
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
-from pytest import LogCaptureFixture, MonkeyPatch, mark, param
+from pydub import AudioSegment
+from pytest import LogCaptureFixture, raises
 
-import test.data.transcription as transcription_data
-from scinoephile.core import Language
+from scinoephile.analysis.transcription_alignment import (
+    TranscriptionAlignmentArtifact,
+    TranscriptionAlignmentBlock,
+    TranscriptionAlignmentColumn,
+    TranscriptionAlignmentRow,
+    TranscriptionAlignmentSource,
+    TranscriptionAlignmentSubtitle,
+)
+from scinoephile.audio.subtitles import AudioSeries
+from scinoephile.audio.transcription import SpeechBlock
+from scinoephile.core import Language, ScinoephileError
 from scinoephile.core.subtitles import Series, Subtitle
+from scinoephile.lang.transcription.pipeline import TranscriptionPipeline
+from test.data.transcription import (
+    _get_stop_at_idx_for_reference_count,
+    _load_audio_series,
+    _save_evaluation,
+    process_transcription_pipeline,
+)
 
 
-def test_get_reference_for_guide_blocks_limits_reference_prefix():
-    """Limit an evaluation reference using the selected guide blocks."""
-    guide = Series(
-        events=[
-            Subtitle(start=0, end=1_000, text="一"),
-            Subtitle(start=5_000, end=6_000, text="二"),
-        ]
+def test_reference_count_selects_smallest_vad_block_prefix():
+    """The evaluation harness should stop after the target reference count."""
+    pipeline = Mock(spec=TranscriptionPipeline)
+    pipeline.plan_blocks.return_value = (
+        SpeechBlock(
+            index=0,
+            start_ms=1_000,
+            end_ms=3_000,
+            buffered_start_ms=0,
+            buffered_end_ms=4_000,
+        ),
+        SpeechBlock(
+            index=1,
+            start_ms=5_000,
+            end_ms=8_000,
+            buffered_start_ms=4_000,
+            buffered_end_ms=9_000,
+        ),
     )
+    audio = AudioSeries(audio=AudioSegment.silent(duration=10_000), events=[])
     reference = Series(
         events=[
-            Subtitle(start=100, end=500, text="甲"),
-            Subtitle(start=999, end=1_500, text="乙"),
-            Subtitle(start=1_000, end=2_000, text="丙"),
-            Subtitle(start=5_500, end=6_000, text="丁"),
+            Subtitle(start=1_100, end=1_500, text="甲"),
+            Subtitle(start=2_000, end=2_400, text="乙"),
+            Subtitle(start=5_200, end=5_600, text="丙"),
         ]
     )
 
-    limited = transcription_data.get_reference_for_guide_blocks(reference, guide, 1)
+    assert _get_stop_at_idx_for_reference_count(pipeline, audio, reference, 3) == 2
+    with raises(ScinoephileError, match="covers only 3"):
+        _get_stop_at_idx_for_reference_count(pipeline, audio, reference, 4)
 
-    assert [subtitle.text for subtitle in limited] == ["甲", "乙"]
+
+def test_media_audio_trim_is_applied_before_staging(tmp_path: Path):
+    """Media extraction should apply title-specific leading trim before staging."""
+    extracted = AudioSeries(
+        audio=AudioSegment.silent(duration=5_000, frame_rate=16_000), events=[]
+    )
+    with patch.object(
+        AudioSeries, "load_audio_from_media", return_value=extracted
+    ) as load_audio:
+        audio_path = tmp_path / "audio.wav"
+        audio = _load_audio_series(
+            audio_path,
+            media_path=tmp_path / "source.mkv",
+            stream_index=12,
+            media_start_seconds=1.0,
+        )
+        reloaded = _load_audio_series(
+            audio_path,
+            media_path=tmp_path / "source.mkv",
+            stream_index=12,
+            media_start_seconds=1.0,
+        )
+
+    assert len(audio.audio) == 4_000
+    assert len(reloaded.audio) == 4_000
+    assert audio_path.exists()
+    assert not audio_path.with_suffix(".srt").exists()
+    load_audio.assert_called_once()
 
 
-@mark.parametrize(
-    ("language", "guide_language", "detected_language", "expected_log_level"),
-    [
-        param(
-            Language.yue_hans,
-            Language.zho_hans,
-            Language.zho_hans,
-            INFO,
-            id="yue-hans-from-zho-hans",
-        ),
-        param(
-            Language.yue_hant,
-            Language.zho_hant,
-            Language.zho_hant,
-            INFO,
-            id="yue-hant-from-zho-hant",
-        ),
-        param(
-            Language.yue_hant,
-            Language.zho_hant,
-            Language.zho_hans,
-            WARNING,
-            id="different-script",
-        ),
-        param(
-            Language.eng,
-            Language.zho_hant,
-            Language.zho_hant,
-            WARNING,
-            id="non-cantonese",
-        ),
-    ],
-)
-def test_process_transcription_orders_stages_and_relogs_expected_mismatch(
-    tmp_path: Path,
-    caplog: LogCaptureFixture,
-    monkeypatch: MonkeyPatch,
-    language: Language,
-    guide_language: Language,
-    detected_language: Language,
-    expected_log_level: int,
-):
-    """Run stages in order and relog only same-script Yue-to-Zho detection.
-
-    Arguments:
-        tmp_path: temporary pipeline directory
-        caplog: captured log records
-        monkeypatch: pytest monkeypatch fixture
-        language: transcription language
-        guide_language: guide subtitle language
-        detected_language: language reported for the fresh transcription
-        expected_log_level: expected mismatch log level
-    """
-    reference = Series(events=[Subtitle(start=0, end=1_000, text="佢喺度")])
-    guide = Series(events=[Subtitle(start=0, end=1_000, text="他在這裡")])
+def test_existing_alignment_recreates_srt_without_transcription(tmp_path: Path):
+    """A portable alignment alone should be sufficient to reuse test output."""
+    title_root_path = tmp_path / "title"
+    output_dir_path = title_root_path / "output/yue-Hant_transcribe"
+    artifact_path = output_dir_path / "json/alignment.json"
     reference_path = tmp_path / "reference.srt"
-    guide_path = tmp_path / "guide.srt"
-    reference.save(reference_path)
-    guide.save(guide_path)
-    stage_order: list[str] = []
-    stage_audio = Mock(
-        side_effect=lambda *args, **kwargs: stage_order.append("audio") or reference
-    )
-    transcribe = Mock(
-        side_effect=lambda *args, **kwargs: (
-            stage_order.append("transcribe") or reference
-        )
-    )
-    mismatch_message = (
-        f"Explicit language {language.code} does not "
-        f"match detected language {detected_language.code}; "
-        f"using {language.code}"
-    )
-    language_logger = getLogger("scinoephile.workflows.helpers")
-    clean = Mock(
-        side_effect=lambda *args, **kwargs: (
-            stage_order.append("clean")
-            or language_logger.warning(mismatch_message)
-            or reference
-        )
-    )
-    review = Mock(
-        side_effect=lambda *args, **kwargs: stage_order.append("review") or reference
-    )
-    translate = Mock(
-        side_effect=lambda *args, **kwargs: stage_order.append("translate") or reference
-    )
-    monkeypatch.setattr(
-        transcription_data,
-        "resolve_language",
-        Mock(side_effect=lambda series, explicit_language: explicit_language),
-    )
-    monkeypatch.setattr(transcription_data, "_stage_audio_series", stage_audio)
-    monkeypatch.setattr(
-        transcription_data, "_load_or_transcribe_series_guided", transcribe
-    )
-    monkeypatch.setattr(transcription_data, "load_or_clean_series", clean)
-    monkeypatch.setattr(transcription_data, "_load_or_review_series_guided", review)
-    monkeypatch.setattr(transcription_data, "_load_or_translate_series_gaps", translate)
+    artifact = _get_artifact()
+    artifact.save(artifact_path)
+    artifact.get_series().save(reference_path)
 
-    with caplog.at_level(INFO):
-        output = transcription_data.process_transcription(
-            tmp_path,
-            guide_path,
-            reference_path=reference_path,
-            language=language,
-            guide_language=guide_language,
-            additional_context="Movie-specific context",
+    with (
+        patch("test.data.transcription._load_audio_series") as load_audio,
+        patch("test.data.transcription.get_transcription_pipeline") as get_pipeline,
+    ):
+        output = process_transcription_pipeline(
+            title_root_path, reference_path=reference_path, reference_name="yue-Hant"
         )
 
-    assert output is reference
-    assert stage_order == ["audio", "transcribe", "clean", "review", "translate"]
-    assert transcribe.call_args.kwargs["transcription_kw"] == {
-        "additional_context": "Movie-specific context"
-    }
-    assert review.call_args.kwargs["reviewer_kw"] == {
-        "additional_context": "Movie-specific context"
-    }
-    assert translate.call_args.kwargs["translator_kw"] == {
-        "additional_context": "Movie-specific context"
-    }
-    mismatch_records = [
-        record for record in caplog.records if record.getMessage() == mismatch_message
-    ]
-    assert len(mismatch_records) == 1
-    assert mismatch_records[0].levelno == expected_log_level
+    assert output == artifact.get_series()
+    assert (output_dir_path / "transcribe.srt").exists()
+    load_audio.assert_not_called()
+    get_pipeline.assert_not_called()
 
 
-def test_process_transcription_can_stop_after_cleaning(
-    tmp_path: Path, monkeypatch: MonkeyPatch
+def test_evaluation_writes_standardized_metrics_and_audit(
+    tmp_path: Path, caplog: LogCaptureFixture
 ):
-    """Skip guided review and gap translation when they are disabled.
+    """Evaluation should report every source, merged CER, and display timing."""
+    artifact = _get_artifact()
+    reference = Series(events=[Subtitle(start=900, end=2_100, text="係呀")])
+    caplog.set_level("INFO", logger="test.data.transcription")
 
-    Arguments:
-        tmp_path: temporary pipeline directory
-        monkeypatch: pytest monkeypatch fixture
-    """
-    reference = Series(events=[Subtitle(start=0, end=1_000, text="佢喺度")])
-    reference_path = tmp_path / "reference.srt"
-    guide_path = tmp_path / "guide.srt"
-    reference.save(reference_path)
-    reference.save(guide_path)
-    review = Mock()
-    translate = Mock()
-    monkeypatch.setattr(
-        transcription_data,
-        "resolve_language",
-        Mock(side_effect=lambda series, explicit_language: explicit_language),
-    )
-    monkeypatch.setattr(
-        transcription_data, "_stage_audio_series", Mock(return_value=reference)
-    )
-    monkeypatch.setattr(
-        transcription_data,
-        "_load_or_transcribe_series_guided",
-        Mock(return_value=reference),
-    )
-    monkeypatch.setattr(
-        transcription_data, "load_or_clean_series", Mock(return_value=reference)
-    )
-    monkeypatch.setattr(transcription_data, "_load_or_review_series_guided", review)
-    monkeypatch.setattr(transcription_data, "_load_or_translate_series_gaps", translate)
-
-    output = transcription_data.process_transcription(
+    _save_evaluation(
         tmp_path,
-        guide_path,
-        reference_path=reference_path,
+        artifact,
+        reference,
+        audit_references={"yue-Hant": reference},
+        terminal_alignment_authority="yue-Hant",
+    )
+
+    metrics = json.loads((tmp_path / "json/metrics.json").read_text(encoding="utf-8"))
+    assert metrics["format"] == "scinoephile-transcription-evaluation"
+    assert set(metrics["cer"]) == {"whisper", "mimo", "merged"}
+    assert metrics["candidate_subtitles"] == 1
+    assert metrics["reference_subtitles"] == 1
+    audit = (tmp_path / "audit.md").read_text(encoding="utf-8")
+    assert "# Transcription Alignment Audit" in audit
+    assert "yue-Hant" in audit
+    assert "support" in audit
+    assert "Authority: yue-Hant" in caplog.text
+    assert any("\x1b[32m" in record.getMessage() for record in caplog.records)
+
+
+def _get_artifact() -> TranscriptionAlignmentArtifact:
+    """Get a compact valid evaluation artifact."""
+    return TranscriptionAlignmentArtifact(
         language=Language.yue_hant,
-        guide_language=Language.zho_hant,
-        run_review_and_translation=False,
+        audio_duration_ms=3_000,
+        sources=(
+            TranscriptionAlignmentSource(
+                name="whisper", backend="whisper", model="whisper"
+            ),
+            TranscriptionAlignmentSource(name="mimo", backend="mlx", model="mimo"),
+        ),
+        blocks=(
+            TranscriptionAlignmentBlock(
+                index=1,
+                core_start_ms=500,
+                core_end_ms=2_500,
+                buffered_start_ms=0,
+                buffered_end_ms=3_000,
+                columns=(
+                    TranscriptionAlignmentColumn(
+                        index=1, start_ms=1_000, end_ms=1_500, kind="text"
+                    ),
+                    TranscriptionAlignmentColumn(
+                        index=2, start_ms=1_500, end_ms=2_000, kind="text"
+                    ),
+                ),
+                rows=(
+                    TranscriptionAlignmentRow(name="whisper", text="係呀"),
+                    TranscriptionAlignmentRow(name="mimo", text="是呀"),
+                ),
+                speaker="ＡＡ",
+                language_trace="粵粵",
+                language_legend={"粵": "zh-yue"},
+                singing_trace="　唱",
+                music_trace="樂樂",
+                merged="係呀",
+                subtitles=(
+                    TranscriptionAlignmentSubtitle(
+                        index=1,
+                        text="係呀",
+                        speech_start_ms=1_000,
+                        speech_end_ms=2_000,
+                        start_ms=1_000,
+                        end_ms=2_000,
+                    ),
+                ),
+            ),
+        ),
     )
-
-    assert output is reference
-    review.assert_not_called()
-    translate.assert_not_called()
-
-
-def test_process_transcription_can_stop_before_cleaning(
-    tmp_path: Path, monkeypatch: MonkeyPatch
-):
-    """Return the transcription without running later stages.
-
-    Arguments:
-        tmp_path: temporary pipeline directory
-        monkeypatch: pytest monkeypatch fixture
-    """
-    reference = Series(events=[Subtitle(start=0, end=1_000, text="佢喺度")])
-    reference_path = tmp_path / "reference.srt"
-    guide_path = tmp_path / "guide.srt"
-    reference.save(reference_path)
-    reference.save(guide_path)
-    clean = Mock()
-    review = Mock()
-    translate = Mock()
-    monkeypatch.setattr(
-        transcription_data,
-        "resolve_language",
-        Mock(side_effect=lambda series, explicit_language: explicit_language),
-    )
-    monkeypatch.setattr(
-        transcription_data, "_stage_audio_series", Mock(return_value=reference)
-    )
-    monkeypatch.setattr(
-        transcription_data,
-        "_load_or_transcribe_series_guided",
-        Mock(return_value=reference),
-    )
-    monkeypatch.setattr(transcription_data, "load_or_clean_series", clean)
-    monkeypatch.setattr(transcription_data, "_load_or_review_series_guided", review)
-    monkeypatch.setattr(transcription_data, "_load_or_translate_series_gaps", translate)
-
-    output = transcription_data.process_transcription(
-        tmp_path,
-        guide_path,
-        reference_path=reference_path,
-        language=Language.yue_hant,
-        guide_language=Language.zho_hant,
-        run_cleaning=False,
-    )
-
-    assert output is reference
-    clean.assert_not_called()
-    review.assert_not_called()
-    translate.assert_not_called()

--- a/test/data/transcription.py
+++ b/test/data/transcription.py
@@ -1,471 +1,335 @@
 #  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
-"""Functions for generating reference-guided transcription test data."""
+"""Generate and evaluate aligned multi-source transcription test data."""
 
 from __future__ import annotations
 
-from collections.abc import Iterator
-from contextlib import contextmanager
-from logging import WARNING, Filter, LogRecord, getLogger
+import json
+from collections import Counter
+from collections.abc import Mapping
+from logging import getLogger
 from pathlib import Path
-from shutil import copy2
-from typing import Any
 
-from scinoephile.analysis.character_error_rate import SeriesCER
+from pydub import AudioSegment
+
+from scinoephile.analysis.audit.transcription_alignment import (
+    audit_transcription_alignment,
+    render_transcription_alignment_terminal,
+)
+from scinoephile.analysis.character_error_rate import LineCER
+from scinoephile.analysis.transcription_alignment import TranscriptionAlignmentArtifact
+from scinoephile.analysis.transcription_timing import (
+    evaluate_transcription_timing,
+    get_reference_for_alignment,
+)
 from scinoephile.audio.subtitles import AudioSeries
 from scinoephile.core import Language, ScinoephileError
-from scinoephile.core.ml import get_torch_device
-from scinoephile.core.subtitles import Series, Subtitle
-from scinoephile.lang.transcription.guided import DEFAULT_SPECS
-from scinoephile.workflows.helpers import resolve_language
-from scinoephile.workflows.review import review_series_guided
-from scinoephile.workflows.transcription import transcribe_series_guided
-from scinoephile.workflows.translation import translate_series_gaps
+from scinoephile.core.llms.metrics import (
+    format_chat_completion_metrics_report,
+    save_chat_completion_metrics_to_json,
+)
+from scinoephile.core.subtitles import Series
+from scinoephile.lang.transcription.multisource_alignment import (
+    CantoneseTimedTokenSimilarity,
+)
+from scinoephile.lang.transcription.pipeline import (
+    TranscriptionPipeline,
+    get_transcription_pipeline,
+)
+from scinoephile.llms.providers.registry import get_provider
+from scinoephile.media.audio import AudioExtractionMode
+from scinoephile.workflows.transcription import transcribe_series
 
-from .helpers import load_or_clean_series
-
-__all__ = ["get_reference_for_guide_blocks", "process_transcription"]
+__all__ = ["process_transcription_pipeline"]
 
 logger = getLogger(__name__)
 
 
-class _RelogLanguageMismatchFilter(Filter):
-    """Relog one expected language-mismatch warning at info level."""
-
-    def __init__(self, expected_message: str):
-        """Initialize.
-
-        Arguments:
-            expected_message: warning message to suppress and relog
-        """
-        super().__init__()
-        self.expected_message = expected_message
-
-    def filter(self, record: LogRecord) -> bool:
-        """Relog the expected warning and allow all other records.
-
-        Arguments:
-            record: log record to inspect
-        Returns:
-            whether the original record should continue to handlers
-        """
-        if record.levelno != WARNING or record.getMessage() != self.expected_message:
-            return True
-        logger.info(record.getMessage())
-        return False
-
-
-def get_reference_for_guide_blocks(
-    reference: Series, guide: Series, stop_at_idx: int | None
-) -> Series:
-    """Limit an evaluation reference to a prefix of guide blocks.
-
-    Arguments:
-        reference: evaluation reference to limit
-        guide: guide whose block boundaries define the processed prefix
-        stop_at_idx: exclusive guide block index, or None for the full reference
-    Returns:
-        reference covering only the processed guide block prefix
-    Raises:
-        ValueError: if stop_at_idx is negative
-    """
-    if stop_at_idx is None:
-        return reference
-    if stop_at_idx < 0:
-        raise ValueError("stop_at_idx must be greater than or equal to 0")
-
-    guide_blocks = guide.blocks[:stop_at_idx]
-    if not guide_blocks:
-        return type(reference)()
-    end_time = guide_blocks[-1].events[-1].end
-    return type(reference)(
-        events=[event for event in reference if event.start < end_time]
-    )
-
-
-def process_transcription(
+def process_transcription_pipeline(  # noqa: PLR0912, PLR0915
     title_root_path: Path,
-    guide_path: Path,
     *,
     reference_path: Path,
-    language: Language | None = None,
-    guide_language: Language | None = None,
-    output_dir_path: Path | None = None,
-    audio_source_path: Path | None = None,
     media_path: Path | None = None,
     stream_index: int | None = None,
+    audio_extraction_mode: AudioExtractionMode = AudioExtractionMode.ORIGINAL,
+    media_start_seconds: float = 0.0,
     stop_at_idx: int | None = None,
+    target_reference_subtitles: int = 100,
     additional_context: str | None = None,
-    transcription_kw: dict[str, Any] | None = None,
-    reviewer_kw: dict[str, Any] | None = None,
-    translator_kw: dict[str, Any] | None = None,
-    run_cleaning: bool = True,
-    run_review_and_translation: bool = True,
+    additional_audit_references: Mapping[str, Series] | None = None,
+    reference_name: str = "reference",
+    terminal_alignment_authority: str | None = None,
     overwrite: bool = False,
 ) -> Series:
-    """Generate and clean a guided transcription, with optional postprocessing.
+    """Run one reference-free transcription experiment and save its evaluation.
+
+    The Cantonese reference determines only how many leading VAD blocks are run
+    and how the finished output is scored. It is never passed to ASR, alignment,
+    CTC timing, diarization, or the consensus LLM.
 
     Arguments:
-        title_root_path: title root directory
-        guide_path: guide subtitle path used for alignment, review, and translation
-        reference_path: expected transcription used only to compute CER
-        language: explicit transcription language, or None to detect it from the
-          evaluation reference
-        guide_language: explicit guide subtitle language, or None to detect it
-        output_dir_path: directory where pipeline outputs are written; defaults to
-          `title_root_path/output/{language.code}_transcribe`
-        audio_source_path: optional existing wav file to copy into the output
-        media_path: optional media path used to generate staged audio if missing
-        stream_index: media stream index used when generating staged audio, or None
-          to use the first audio stream
-        stop_at_idx: exclusive block index at which to stop LLM processing
-        additional_context: additional context shared by transcription, review, and
-          gap-translation LLM prompts
-        transcription_kw: additional keyword arguments for
-          `transcribe_series_guided`
-        reviewer_kw: additional keyword arguments for `review_series_guided`
-        translator_kw: additional keyword arguments for `translate_series_gaps`
-        run_cleaning: whether to clean the generated transcription
-        run_review_and_translation: whether to run guided review and gap translation
-          after cleaning
-        overwrite: whether to overwrite existing stage outputs
+        title_root_path: test title root directory
+        reference_path: independent Cantonese reference used only for evaluation
+        media_path: optional media from which to extract audio when not staged
+        stream_index: optional media audio-stream index
+        audio_extraction_mode: channel preparation used during media audio extraction
+        media_start_seconds: seconds trimmed from extracted media audio
+        stop_at_idx: explicit exclusive VAD block index, overriding target count
+        target_reference_subtitles: minimum reference subtitles covered by blocks
+        additional_context: production consensus prompt context
+        additional_audit_references: additional named references used only in audits
+        reference_name: audit row name for the primary scoring reference
+        terminal_alignment_authority: merged or named reference row for ANSI output
+        overwrite: whether to regenerate an existing artifact and SRT
     Returns:
-        last generated transcription stage
-    Raises:
-        ScinoephileError: if staged audio is missing and cannot be generated
+        merged transcription series
     """
-    reference = Series.load(reference_path)
-    guide = Series.load(guide_path)
-    language = resolve_language(reference, language)
-    guide_language = resolve_language(guide, guide_language)
-
-    transcription_kw = dict(transcription_kw or {})
-    reviewer_kw = dict(reviewer_kw or {})
-    translator_kw = dict(translator_kw or {})
-    if additional_context is not None:
-        transcription_kw.setdefault("additional_context", additional_context)
-        reviewer_kw.setdefault("additional_context", additional_context)
-        translator_kw.setdefault("additional_context", additional_context)
-
-    if output_dir_path is None:
-        output_dir_path = title_root_path / "output" / f"{language.code}_transcribe"
+    if target_reference_subtitles <= 0:
+        raise ValueError("target_reference_subtitles must be positive.")
+    output_dir_path = title_root_path / "output" / "yue-Hant_transcribe"
+    audio_path = output_dir_path / "audio.wav"
     output_dir_path.mkdir(parents=True, exist_ok=True)
+    json_dir_path = output_dir_path / "json"
+    json_dir_path.mkdir(parents=True, exist_ok=True)
+    artifact_path = json_dir_path / "alignment.json"
+    run_manifest_path = json_dir_path / "run_manifest.json"
+    transcription_path = output_dir_path / "transcribe.srt"
+    reference = Series.load(reference_path)
+    audit_references = {reference_name: reference}
+    for name, audit_reference in (additional_audit_references or {}).items():
+        if name in audit_references:
+            raise ValueError(f"Duplicate audit reference name: {name}")
+        audit_references[name] = audit_reference
 
-    evaluation_reference = get_reference_for_guide_blocks(reference, guide, stop_at_idx)
+    if artifact_path.exists() and not overwrite:
+        artifact = TranscriptionAlignmentArtifact.load(artifact_path)
+        output = artifact.get_series()
+        if not transcription_path.exists():
+            output.save(transcription_path)
+        _save_evaluation(
+            output_dir_path,
+            artifact,
+            reference,
+            audit_references=audit_references,
+            terminal_alignment_authority=terminal_alignment_authority,
+        )
+        return output
 
-    # Stage guide subtitles and audio under the transcription output
-    audio = _stage_audio_series(
-        guide,
-        output_dir_path,
-        audio_source_path=audio_source_path,
+    audio = _load_audio_series(
+        audio_path,
         media_path=media_path,
         stream_index=stream_index,
-        overwrite=overwrite,
+        audio_extraction_mode=audio_extraction_mode,
+        media_start_seconds=media_start_seconds,
     )
-
-    # Transcribe, delineate, and punctuate
-    transcribe_path = output_dir_path / "transcribe.srt"
-    transcribe = _load_or_transcribe_series_guided(
+    provider = get_provider()
+    initial_completion_count = len(provider.completion_metrics)
+    pipeline = get_transcription_pipeline(
+        Language.yue_hant,
+        provider=provider,
+        additional_context=additional_context,
+        aligned_merge_json_path=json_dir_path / "aligned_merge.json",
+    )
+    if stop_at_idx is None:
+        stop_at_idx = _get_stop_at_idx_for_reference_count(
+            pipeline, audio, reference, target_reference_subtitles
+        )
+    output = transcribe_series(
         audio,
-        guide,
-        transcribe_path,
-        language,
-        guide_language,
+        language=Language.yue_hant,
+        pipeline=pipeline,
+        alignment_json_path=artifact_path,
+        run_manifest_json_path=run_manifest_path,
         stop_at_idx=stop_at_idx,
-        transcription_kw=transcription_kw,
-        overwrite=overwrite,
     )
-    logger.info(
-        f"{language.code} transcription CER after transcription:\n"
-        f"{SeriesCER(evaluation_reference, transcribe)}"
+    output.save(transcription_path)
+    artifact = pipeline.last_alignment_artifact
+    if artifact is None:
+        raise RuntimeError("Transcription pipeline did not produce an artifact.")
+    completion_metrics = provider.completion_metrics[initial_completion_count:]
+    usage_path = json_dir_path / "llm_usage.json"
+    save_chat_completion_metrics_to_json(usage_path, completion_metrics)
+    logger.info(format_chat_completion_metrics_report(completion_metrics))
+    _save_evaluation(
+        output_dir_path,
+        artifact,
+        reference,
+        audit_references=audit_references,
+        terminal_alignment_authority=terminal_alignment_authority,
     )
-    if not run_cleaning:
-        logger.info(f"Saved transcription output under {output_dir_path}")
-        return transcribe
-
-    # Clean transcription
-    clean_path = output_dir_path / "transcribe_clean.srt"
-    with _relog_cantonese_transcription_mismatch(language):
-        cleaned = load_or_clean_series(transcribe, clean_path, language, overwrite)
-    logger.info(
-        f"{language.code} transcription CER after cleaning:\n"
-        f"{SeriesCER(evaluation_reference, cleaned)}"
-    )
-
-    if not run_review_and_translation:
-        logger.info(f"Saved transcription output under {output_dir_path}")
-        return cleaned
-
-    # Review cleaned transcription using guide subtitles
-    review_path = output_dir_path / "transcribe_clean_review.srt"
-    reviewed = _load_or_review_series_guided(
-        cleaned,
-        guide,
-        review_path,
-        language,
-        guide_language,
-        stop_at_idx=stop_at_idx,
-        reviewer_kw=reviewer_kw,
-        overwrite=overwrite,
-    )
-    logger.info(
-        f"{language.code} transcription CER after review:\n"
-        f"{SeriesCER(evaluation_reference, reviewed)}"
-    )
-
-    # Fill gaps in reviewed transcription using guide subtitles
-    translate_path = output_dir_path / "transcribe_clean_review_translate.srt"
-    translated = _load_or_translate_series_gaps(
-        guide,
-        reviewed,
-        translate_path,
-        guide_language,
-        language,
-        stop_at_idx=stop_at_idx,
-        translator_kw=translator_kw,
-        overwrite=overwrite,
-    )
-    logger.info(
-        f"{language.code} transcription CER after gap translation:\n"
-        f"{SeriesCER(evaluation_reference, translated)}"
-    )
-    logger.info(f"Saved transcription output under {output_dir_path}")
-    return translated
+    return output
 
 
-def _load_or_review_series_guided(
-    target: Series,
-    guide: Series,
-    output_path: Path,
-    language: Language,
-    guide_language: Language,
-    *,
-    stop_at_idx: int | None = None,
-    reviewer_kw: dict[str, Any] | None = None,
-    overwrite: bool = False,
-) -> Series:
-    """Load or create a guide-reviewed subtitle series.
-
-    Arguments:
-        target: target subtitle series to review
-        guide: guide subtitle series
-        output_path: reviewed subtitle output path
-        language: target subtitle language
-        guide_language: guide language
-        stop_at_idx: exclusive review block index at which to stop processing
-        reviewer_kw: additional keyword arguments for `review_series_guided`
-        overwrite: whether to overwrite an existing output
-    Returns:
-        guide-reviewed subtitle series
-    """
-    if output_path.exists() and not overwrite:
-        return Series.load(output_path)
-
-    reviewer_kw = dict(reviewer_kw or {})
-    language_pair_name = f"{language.language}_{guide_language.language}"
-    reviewer_kw.setdefault(
-        "current_test_cases_path",
-        output_path.parent
-        / "lang"
-        / language_pair_name
-        / "guided_review"
-        / f"{get_torch_device()}.json",
-    )
-    reviewed = review_series_guided(
-        target,
-        guide,
-        language=language,
-        guide_language=guide_language,
-        stop_at_idx=stop_at_idx,
-        **reviewer_kw,
-    )
-    reviewed.save(output_path)
-    return reviewed
-
-
-def _load_or_transcribe_series_guided(
+def _get_stop_at_idx_for_reference_count(
+    pipeline: TranscriptionPipeline,
     audio: AudioSeries,
-    guide: Series,
-    output_path: Path,
-    language: Language,
-    guide_language: Language,
-    *,
-    stop_at_idx: int | None = None,
-    transcription_kw: dict[str, Any] | None = None,
-    overwrite: bool = False,
-) -> Series:
-    """Load or create a guided transcription.
-
-    Arguments:
-        audio: audio series to transcribe
-        guide: guide subtitle series
-        output_path: transcription output path
-        language: transcription language
-        guide_language: guide subtitle language
-        stop_at_idx: exclusive block index at which to stop processing
-        transcription_kw: additional keyword arguments for
-          `transcribe_series_guided`
-        overwrite: whether to overwrite an existing output
-    Returns:
-        guided transcription
-    """
-    if output_path.exists() and not overwrite:
-        return Series.load(output_path)
-
-    transcription_kw = dict(transcription_kw or {})
-    spec = DEFAULT_SPECS.get((language, guide_language))
-    if spec is not None:
-        test_case_dir_path = output_path.parent / spec.test_case_dir_path
-        device = get_torch_device()
-        transcription_kw.setdefault(
-            "delineation_json_path",
-            test_case_dir_path / "delineation" / f"{device}.json",
+    reference: Series,
+    target_count: int,
+) -> int:
+    """Get the smallest VAD-block prefix covering the target reference count."""
+    blocks = pipeline.plan_blocks(audio)
+    covered = 0
+    for stop_at_idx, block in enumerate(blocks, start=1):
+        covered += sum(
+            block.start_ms <= (subtitle.start + subtitle.end) / 2 < block.end_ms
+            for subtitle in reference
         )
-        transcription_kw.setdefault(
-            "punctuation_json_path",
-            test_case_dir_path / "punctuation" / f"{device}.json",
-        )
-    audio_transcription = transcribe_series_guided(
-        audio,
-        guide,
-        language=language,
-        guide_language=guide_language,
-        stop_at_idx=stop_at_idx,
-        **transcription_kw,
+        if covered >= target_count:
+            logger.info(
+                f"Selected {stop_at_idx} VAD blocks covering {covered} reference "
+                "subtitles."
+            )
+            return stop_at_idx
+    raise ScinoephileError(
+        f"The complete VAD plan covers only {covered} reference subtitles; "
+        f"cannot reach target {target_count}."
     )
-    transcription = Series(
-        events=[Subtitle(**event.as_dict()) for event in audio_transcription]
-    )
-    transcription.save(output_path)
-    return transcription
 
 
-def _load_or_translate_series_gaps(
-    source: Series,
-    target: Series,
-    output_path: Path,
-    source_language: Language,
-    target_language: Language,
+def _load_audio_series(
+    audio_path: Path,
     *,
-    stop_at_idx: int | None = None,
-    translator_kw: dict[str, Any] | None = None,
-    overwrite: bool = False,
-) -> Series:
-    """Load or create a gap-translated subtitle series.
-
-    Arguments:
-        source: source-language guide subtitle series
-        target: target-language gapped subtitle series
-        output_path: translated subtitle output path
-        source_language: source subtitle language
-        target_language: target subtitle language
-        stop_at_idx: exclusive block index at which to stop processing
-        translator_kw: additional keyword arguments for `translate_series_gaps`
-        overwrite: whether to overwrite an existing output
-    Returns:
-        gap-translated subtitle series
-    """
-    if output_path.exists() and not overwrite:
-        return Series.load(output_path)
-
-    translator_kw = dict(translator_kw or {})
-    language_pair_name = f"{target_language.language}_{source_language.language}"
-    translator_kw.setdefault(
-        "current_test_cases_path",
-        output_path.parent
-        / "lang"
-        / language_pair_name
-        / "gap_translation"
-        / f"{get_torch_device()}.json",
-    )
-    translated = translate_series_gaps(
-        source,
-        target,
-        source_language=source_language,
-        target_language=target_language,
-        stop_at_idx=stop_at_idx,
-        **translator_kw,
-    )
-    translated.save(output_path)
-    return translated
-
-
-@contextmanager
-def _relog_cantonese_transcription_mismatch(language: Language) -> Iterator[None]:
-    """Relog expected same-script Cantonese-to-Mandarin detection at info.
-
-    Arguments:
-        language: expected transcription language
-    Returns:
-        context in which the expected mismatch is intercepted
-    """
-    detected_language = None
-    if language is Language.yue_hans:
-        detected_language = Language.zho_hans
-    elif language is Language.yue_hant:
-        detected_language = Language.zho_hant
-    if detected_language is None:
-        yield
-        return
-
-    expected_message = (
-        f"Explicit language {language.code} does not "
-        f"match detected language {detected_language.code}; "
-        f"using {language.code}"
-    )
-    mismatch_filter = _RelogLanguageMismatchFilter(expected_message)
-    language_logger = getLogger("scinoephile.workflows.helpers")
-    language_logger.addFilter(mismatch_filter)
-    try:
-        yield
-    finally:
-        language_logger.removeFilter(mismatch_filter)
-
-
-def _stage_audio_series(
-    guide: Series,
-    output_dir_path: Path,
-    *,
-    audio_source_path: Path | None,
     media_path: Path | None,
     stream_index: int | None,
-    overwrite: bool,
+    audio_extraction_mode: AudioExtractionMode = AudioExtractionMode.ORIGINAL,
+    media_start_seconds: float,
 ) -> AudioSeries:
-    """Stage and load guide-aligned audio for transcription.
-
-    Arguments:
-        guide: guide subtitles used to segment audio
-        output_dir_path: transcription output directory
-        audio_source_path: optional existing wav file to stage
-        media_path: optional media path from which to extract audio
-        stream_index: audio stream index, or None to use the first stream
-        overwrite: whether to overwrite staged inputs
-    Returns:
-        staged guide-aligned audio series
-    Raises:
-        ScinoephileError: if staged audio is missing and cannot be generated
-    """
-    audio_dir_path = output_dir_path / "audio"
-    audio_dir_path.mkdir(parents=True, exist_ok=True)
-    staged_audio_path = audio_dir_path / "audio.wav"
-    if audio_source_path is not None and audio_source_path != staged_audio_path:
-        if overwrite or not staged_audio_path.exists():
-            copy2(audio_source_path, staged_audio_path)
-
-    audio_srt_path = audio_dir_path / "audio.srt"
-    if overwrite or not audio_srt_path.exists():
-        guide.save(audio_srt_path)
-
-    if not staged_audio_path.exists():
-        if media_path is None:
-            raise ScinoephileError(
-                "Staged audio is missing. Provide `audio_source_path` or "
-                f"`media_path`, or stage {staged_audio_path} manually."
-            )
-        audio = AudioSeries.load_from_media(
-            media_path=media_path,
-            subtitle_path=audio_srt_path,
-            stream_index=stream_index,
+    """Load staged complete audio without supplying subtitle events to ASR."""
+    if media_start_seconds < 0.0:
+        raise ValueError("media_start_seconds must be non-negative.")
+    if audio_path.exists():
+        return AudioSeries(audio=AudioSegment.from_wav(audio_path), events=[])
+    if media_path is None:
+        raise ScinoephileError(
+            f"Staged audio is missing at {audio_path}; provide media_path."
         )
-        audio.save(audio_dir_path)
-    return AudioSeries.load(audio_dir_path)
+    audio = AudioSeries.load_audio_from_media(
+        media_path, stream_index=stream_index, extraction_mode=audio_extraction_mode
+    )
+    trim_start_ms = round(media_start_seconds * 1000)
+    if trim_start_ms >= len(audio.audio):
+        raise ScinoephileError(
+            f"Audio trim start {media_start_seconds:.3f}s is outside the media."
+        )
+    if trim_start_ms:
+        audio = AudioSeries(audio=audio.audio[trim_start_ms:], events=[])
+    audio_path.parent.mkdir(parents=True, exist_ok=True)
+    audio.audio.export(audio_path, format="wav")
+    return audio
+
+
+def _save_evaluation(
+    output_dir_path: Path,
+    artifact: TranscriptionAlignmentArtifact,
+    reference: Series,
+    *,
+    audit_references: Mapping[str, Series],
+    terminal_alignment_authority: str | None = None,
+):
+    """Save evaluation metrics and readable alignment audits."""
+    primary_metrics = _get_reference_metrics(artifact, reference)
+    cer = primary_metrics["cer"]
+    metrics = {
+        "format": "scinoephile-transcription-evaluation",
+        "version": 1,
+        "processed_blocks": len(artifact.blocks),
+        **primary_metrics,
+    }
+    json_dir_path = output_dir_path / "json"
+    json_dir_path.mkdir(parents=True, exist_ok=True)
+    (json_dir_path / "metrics.json").write_text(
+        json.dumps(metrics, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    reference_similarity = None
+    if artifact.language in {Language.yue_hans, Language.yue_hant}:
+        reference_similarity = CantoneseTimedTokenSimilarity(
+            timing_weight=2.0, timing_tolerance_seconds=0.75
+        )
+    (output_dir_path / "audit.md").write_text(
+        audit_transcription_alignment(
+            artifact,
+            audit_references,
+            reference_similarity=reference_similarity,
+            include_merge_support=True,
+        ),
+        encoding="utf-8",
+    )
+    if terminal_alignment_authority is not None:
+        terminal_alignment = render_transcription_alignment_terminal(
+            artifact,
+            audit_references,
+            authoritative_row_name=terminal_alignment_authority,
+            reference_similarity=reference_similarity,
+            include_merge_support=True,
+        )
+        logger.info(f"\n{terminal_alignment.rstrip()}")
+    logger.info(
+        "Aligned transcription evaluation: "
+        + ", ".join(f"{name} CER {values['cer']:.3%}" for name, values in cer.items())
+    )
+
+
+def _get_reference_metrics(
+    artifact: TranscriptionAlignmentArtifact, reference: Series
+) -> dict:
+    """Calculate lexical and timing metrics against one named reference."""
+    selected_reference = get_reference_for_alignment(artifact, reference)
+    reference_text = "".join(
+        subtitle.text_with_newline for subtitle in selected_reference
+    )
+    candidate_texts = {source.name: [] for source in artifact.sources}
+    for block in artifact.blocks:
+        rows = {row.name: row.text for row in block.rows}
+        for source in artifact.sources:
+            candidate_texts[source.name].append(
+                rows.get(source.name, "").replace("　", "").replace("・", "")
+            )
+    candidate_texts["merged"] = [
+        subtitle.text for block in artifact.blocks for subtitle in block.subtitles
+    ]
+    cer = {
+        name: _get_cer_dict(LineCER(reference_text, "".join(text_parts)))
+        for name, text_parts in candidate_texts.items()
+    }
+    timing = evaluate_transcription_timing(artifact, reference)
+    subtitle_alignment_groups = Counter(
+        f"{len(pair.candidate_indexes)}:{len(pair.reference_indexes)}"
+        for pair in timing.pairs
+    )
+    return {
+        "reference_subtitles": len(selected_reference),
+        "candidate_subtitles": sum(len(block.subtitles) for block in artifact.blocks),
+        "cer": cer,
+        "timing": {
+            "settings": timing.settings.model_dump(mode="json"),
+            "text_aligned_groups": len(timing.pairs),
+            "micro_intersection_over_union": timing.micro_intersection_over_union,
+            "one_to_one_groups": len(timing.one_to_one_pairs),
+            "one_to_one_micro_intersection_over_union": (
+                timing.one_to_one_micro_intersection_over_union
+            ),
+            "mean_intersection_over_union": timing.mean_intersection_over_union,
+            "mean_reference_coverage": timing.mean_reference_coverage,
+            "mean_start_error_ms": timing.mean_start_error_ms,
+            "mean_end_error_ms": timing.mean_end_error_ms,
+            "mean_absolute_start_error_ms": timing.mean_absolute_start_error_ms,
+            "mean_absolute_end_error_ms": timing.mean_absolute_end_error_ms,
+            "unmatched_candidate_subtitles": timing.unmatched_candidate_subtitles,
+            "unmatched_reference_subtitles": timing.unmatched_reference_subtitles,
+            "candidate_to_reference_group_counts": dict(
+                sorted(subtitle_alignment_groups.items())
+            ),
+        },
+    }
+
+
+def _get_cer_dict(result: LineCER) -> dict[str, float | int]:
+    """Serialize one character-error result."""
+    return {
+        "cer": result.cer,
+        "correct": result.correct,
+        "substitutions": result.substitutions,
+        "insertions": result.insertions,
+        "deletions": result.deletions,
+        "reference_length": result.reference_length,
+    }

--- a/test/data/transcription.py
+++ b/test/data/transcription.py
@@ -1,335 +1,471 @@
 #  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
-"""Generate and evaluate aligned multi-source transcription test data."""
+"""Functions for generating reference-guided transcription test data."""
 
 from __future__ import annotations
 
-import json
-from collections import Counter
-from collections.abc import Mapping
-from logging import getLogger
+from collections.abc import Iterator
+from contextlib import contextmanager
+from logging import WARNING, Filter, LogRecord, getLogger
 from pathlib import Path
+from shutil import copy2
+from typing import Any
 
-from pydub import AudioSegment
-
-from scinoephile.analysis.audit.transcription_alignment import (
-    audit_transcription_alignment,
-    render_transcription_alignment_terminal,
-)
-from scinoephile.analysis.character_error_rate import LineCER
-from scinoephile.analysis.transcription_alignment import TranscriptionAlignmentArtifact
-from scinoephile.analysis.transcription_timing import (
-    evaluate_transcription_timing,
-    get_reference_for_alignment,
-)
+from scinoephile.analysis.character_error_rate import SeriesCER
 from scinoephile.audio.subtitles import AudioSeries
 from scinoephile.core import Language, ScinoephileError
-from scinoephile.core.llms.metrics import (
-    format_chat_completion_metrics_report,
-    save_chat_completion_metrics_to_json,
-)
-from scinoephile.core.subtitles import Series
-from scinoephile.lang.transcription.multisource_alignment import (
-    CantoneseTimedTokenSimilarity,
-)
-from scinoephile.lang.transcription.pipeline import (
-    TranscriptionPipeline,
-    get_transcription_pipeline,
-)
-from scinoephile.llms.providers.registry import get_provider
-from scinoephile.media.audio import AudioExtractionMode
-from scinoephile.workflows.transcription import transcribe_series
+from scinoephile.core.ml import get_torch_device
+from scinoephile.core.subtitles import Series, Subtitle
+from scinoephile.lang.transcription.guided import DEFAULT_SPECS
+from scinoephile.workflows.helpers import resolve_language
+from scinoephile.workflows.review import review_series_guided
+from scinoephile.workflows.transcription import transcribe_series_guided
+from scinoephile.workflows.translation import translate_series_gaps
 
-__all__ = ["process_transcription_pipeline"]
+from .helpers import load_or_clean_series
+
+__all__ = ["get_reference_for_guide_blocks", "process_transcription"]
 
 logger = getLogger(__name__)
 
 
-def process_transcription_pipeline(  # noqa: PLR0912, PLR0915
-    title_root_path: Path,
-    *,
-    reference_path: Path,
-    media_path: Path | None = None,
-    stream_index: int | None = None,
-    audio_extraction_mode: AudioExtractionMode = AudioExtractionMode.ORIGINAL,
-    media_start_seconds: float = 0.0,
-    stop_at_idx: int | None = None,
-    target_reference_subtitles: int = 100,
-    additional_context: str | None = None,
-    additional_audit_references: Mapping[str, Series] | None = None,
-    reference_name: str = "reference",
-    terminal_alignment_authority: str | None = None,
-    overwrite: bool = False,
-) -> Series:
-    """Run one reference-free transcription experiment and save its evaluation.
+class _RelogLanguageMismatchFilter(Filter):
+    """Relog one expected language-mismatch warning at info level."""
 
-    The Cantonese reference determines only how many leading VAD blocks are run
-    and how the finished output is scored. It is never passed to ASR, alignment,
-    CTC timing, diarization, or the consensus LLM.
+    def __init__(self, expected_message: str):
+        """Initialize.
+
+        Arguments:
+            expected_message: warning message to suppress and relog
+        """
+        super().__init__()
+        self.expected_message = expected_message
+
+    def filter(self, record: LogRecord) -> bool:
+        """Relog the expected warning and allow all other records.
+
+        Arguments:
+            record: log record to inspect
+        Returns:
+            whether the original record should continue to handlers
+        """
+        if record.levelno != WARNING or record.getMessage() != self.expected_message:
+            return True
+        logger.info(record.getMessage())
+        return False
+
+
+def get_reference_for_guide_blocks(
+    reference: Series, guide: Series, stop_at_idx: int | None
+) -> Series:
+    """Limit an evaluation reference to a prefix of guide blocks.
 
     Arguments:
-        title_root_path: test title root directory
-        reference_path: independent Cantonese reference used only for evaluation
-        media_path: optional media from which to extract audio when not staged
-        stream_index: optional media audio-stream index
-        audio_extraction_mode: channel preparation used during media audio extraction
-        media_start_seconds: seconds trimmed from extracted media audio
-        stop_at_idx: explicit exclusive VAD block index, overriding target count
-        target_reference_subtitles: minimum reference subtitles covered by blocks
-        additional_context: production consensus prompt context
-        additional_audit_references: additional named references used only in audits
-        reference_name: audit row name for the primary scoring reference
-        terminal_alignment_authority: merged or named reference row for ANSI output
-        overwrite: whether to regenerate an existing artifact and SRT
+        reference: evaluation reference to limit
+        guide: guide whose block boundaries define the processed prefix
+        stop_at_idx: exclusive guide block index, or None for the full reference
     Returns:
-        merged transcription series
+        reference covering only the processed guide block prefix
+    Raises:
+        ValueError: if stop_at_idx is negative
     """
-    if target_reference_subtitles <= 0:
-        raise ValueError("target_reference_subtitles must be positive.")
-    output_dir_path = title_root_path / "output" / "yue-Hant_transcribe"
-    audio_path = output_dir_path / "audio.wav"
-    output_dir_path.mkdir(parents=True, exist_ok=True)
-    json_dir_path = output_dir_path / "json"
-    json_dir_path.mkdir(parents=True, exist_ok=True)
-    artifact_path = json_dir_path / "alignment.json"
-    run_manifest_path = json_dir_path / "run_manifest.json"
-    transcription_path = output_dir_path / "transcribe.srt"
+    if stop_at_idx is None:
+        return reference
+    if stop_at_idx < 0:
+        raise ValueError("stop_at_idx must be greater than or equal to 0")
+
+    guide_blocks = guide.blocks[:stop_at_idx]
+    if not guide_blocks:
+        return type(reference)()
+    end_time = guide_blocks[-1].events[-1].end
+    return type(reference)(
+        events=[event for event in reference if event.start < end_time]
+    )
+
+
+def process_transcription(
+    title_root_path: Path,
+    guide_path: Path,
+    *,
+    reference_path: Path,
+    language: Language | None = None,
+    guide_language: Language | None = None,
+    output_dir_path: Path | None = None,
+    audio_source_path: Path | None = None,
+    media_path: Path | None = None,
+    stream_index: int | None = None,
+    stop_at_idx: int | None = None,
+    additional_context: str | None = None,
+    transcription_kw: dict[str, Any] | None = None,
+    reviewer_kw: dict[str, Any] | None = None,
+    translator_kw: dict[str, Any] | None = None,
+    run_cleaning: bool = True,
+    run_review_and_translation: bool = True,
+    overwrite: bool = False,
+) -> Series:
+    """Generate and clean a guided transcription, with optional postprocessing.
+
+    Arguments:
+        title_root_path: title root directory
+        guide_path: guide subtitle path used for alignment, review, and translation
+        reference_path: expected transcription used only to compute CER
+        language: explicit transcription language, or None to detect it from the
+          evaluation reference
+        guide_language: explicit guide subtitle language, or None to detect it
+        output_dir_path: directory where pipeline outputs are written; defaults to
+          `title_root_path/output/{language.code}_transcribe`
+        audio_source_path: optional existing wav file to copy into the output
+        media_path: optional media path used to generate staged audio if missing
+        stream_index: media stream index used when generating staged audio, or None
+          to use the first audio stream
+        stop_at_idx: exclusive block index at which to stop LLM processing
+        additional_context: additional context shared by transcription, review, and
+          gap-translation LLM prompts
+        transcription_kw: additional keyword arguments for
+          `transcribe_series_guided`
+        reviewer_kw: additional keyword arguments for `review_series_guided`
+        translator_kw: additional keyword arguments for `translate_series_gaps`
+        run_cleaning: whether to clean the generated transcription
+        run_review_and_translation: whether to run guided review and gap translation
+          after cleaning
+        overwrite: whether to overwrite existing stage outputs
+    Returns:
+        last generated transcription stage
+    Raises:
+        ScinoephileError: if staged audio is missing and cannot be generated
+    """
     reference = Series.load(reference_path)
-    audit_references = {reference_name: reference}
-    for name, audit_reference in (additional_audit_references or {}).items():
-        if name in audit_references:
-            raise ValueError(f"Duplicate audit reference name: {name}")
-        audit_references[name] = audit_reference
+    guide = Series.load(guide_path)
+    language = resolve_language(reference, language)
+    guide_language = resolve_language(guide, guide_language)
 
-    if artifact_path.exists() and not overwrite:
-        artifact = TranscriptionAlignmentArtifact.load(artifact_path)
-        output = artifact.get_series()
-        if not transcription_path.exists():
-            output.save(transcription_path)
-        _save_evaluation(
-            output_dir_path,
-            artifact,
-            reference,
-            audit_references=audit_references,
-            terminal_alignment_authority=terminal_alignment_authority,
-        )
-        return output
+    transcription_kw = dict(transcription_kw or {})
+    reviewer_kw = dict(reviewer_kw or {})
+    translator_kw = dict(translator_kw or {})
+    if additional_context is not None:
+        transcription_kw.setdefault("additional_context", additional_context)
+        reviewer_kw.setdefault("additional_context", additional_context)
+        translator_kw.setdefault("additional_context", additional_context)
 
-    audio = _load_audio_series(
-        audio_path,
+    if output_dir_path is None:
+        output_dir_path = title_root_path / "output" / f"{language.code}_transcribe"
+    output_dir_path.mkdir(parents=True, exist_ok=True)
+
+    evaluation_reference = get_reference_for_guide_blocks(reference, guide, stop_at_idx)
+
+    # Stage guide subtitles and audio under the transcription output
+    audio = _stage_audio_series(
+        guide,
+        output_dir_path,
+        audio_source_path=audio_source_path,
         media_path=media_path,
         stream_index=stream_index,
-        audio_extraction_mode=audio_extraction_mode,
-        media_start_seconds=media_start_seconds,
+        overwrite=overwrite,
     )
-    provider = get_provider()
-    initial_completion_count = len(provider.completion_metrics)
-    pipeline = get_transcription_pipeline(
-        Language.yue_hant,
-        provider=provider,
-        additional_context=additional_context,
-        aligned_merge_json_path=json_dir_path / "aligned_merge.json",
-    )
-    if stop_at_idx is None:
-        stop_at_idx = _get_stop_at_idx_for_reference_count(
-            pipeline, audio, reference, target_reference_subtitles
-        )
-    output = transcribe_series(
+
+    # Transcribe, delineate, and punctuate
+    transcribe_path = output_dir_path / "transcribe.srt"
+    transcribe = _load_or_transcribe_series_guided(
         audio,
-        language=Language.yue_hant,
-        pipeline=pipeline,
-        alignment_json_path=artifact_path,
-        run_manifest_json_path=run_manifest_path,
+        guide,
+        transcribe_path,
+        language,
+        guide_language,
         stop_at_idx=stop_at_idx,
+        transcription_kw=transcription_kw,
+        overwrite=overwrite,
     )
-    output.save(transcription_path)
-    artifact = pipeline.last_alignment_artifact
-    if artifact is None:
-        raise RuntimeError("Transcription pipeline did not produce an artifact.")
-    completion_metrics = provider.completion_metrics[initial_completion_count:]
-    usage_path = json_dir_path / "llm_usage.json"
-    save_chat_completion_metrics_to_json(usage_path, completion_metrics)
-    logger.info(format_chat_completion_metrics_report(completion_metrics))
-    _save_evaluation(
-        output_dir_path,
-        artifact,
-        reference,
-        audit_references=audit_references,
-        terminal_alignment_authority=terminal_alignment_authority,
+    logger.info(
+        f"{language.code} transcription CER after transcription:\n"
+        f"{SeriesCER(evaluation_reference, transcribe)}"
     )
-    return output
+    if not run_cleaning:
+        logger.info(f"Saved transcription output under {output_dir_path}")
+        return transcribe
 
-
-def _get_stop_at_idx_for_reference_count(
-    pipeline: TranscriptionPipeline,
-    audio: AudioSeries,
-    reference: Series,
-    target_count: int,
-) -> int:
-    """Get the smallest VAD-block prefix covering the target reference count."""
-    blocks = pipeline.plan_blocks(audio)
-    covered = 0
-    for stop_at_idx, block in enumerate(blocks, start=1):
-        covered += sum(
-            block.start_ms <= (subtitle.start + subtitle.end) / 2 < block.end_ms
-            for subtitle in reference
-        )
-        if covered >= target_count:
-            logger.info(
-                f"Selected {stop_at_idx} VAD blocks covering {covered} reference "
-                "subtitles."
-            )
-            return stop_at_idx
-    raise ScinoephileError(
-        f"The complete VAD plan covers only {covered} reference subtitles; "
-        f"cannot reach target {target_count}."
+    # Clean transcription
+    clean_path = output_dir_path / "transcribe_clean.srt"
+    with _relog_cantonese_transcription_mismatch(language):
+        cleaned = load_or_clean_series(transcribe, clean_path, language, overwrite)
+    logger.info(
+        f"{language.code} transcription CER after cleaning:\n"
+        f"{SeriesCER(evaluation_reference, cleaned)}"
     )
 
+    if not run_review_and_translation:
+        logger.info(f"Saved transcription output under {output_dir_path}")
+        return cleaned
 
-def _load_audio_series(
-    audio_path: Path,
+    # Review cleaned transcription using guide subtitles
+    review_path = output_dir_path / "transcribe_clean_review.srt"
+    reviewed = _load_or_review_series_guided(
+        cleaned,
+        guide,
+        review_path,
+        language,
+        guide_language,
+        stop_at_idx=stop_at_idx,
+        reviewer_kw=reviewer_kw,
+        overwrite=overwrite,
+    )
+    logger.info(
+        f"{language.code} transcription CER after review:\n"
+        f"{SeriesCER(evaluation_reference, reviewed)}"
+    )
+
+    # Fill gaps in reviewed transcription using guide subtitles
+    translate_path = output_dir_path / "transcribe_clean_review_translate.srt"
+    translated = _load_or_translate_series_gaps(
+        guide,
+        reviewed,
+        translate_path,
+        guide_language,
+        language,
+        stop_at_idx=stop_at_idx,
+        translator_kw=translator_kw,
+        overwrite=overwrite,
+    )
+    logger.info(
+        f"{language.code} transcription CER after gap translation:\n"
+        f"{SeriesCER(evaluation_reference, translated)}"
+    )
+    logger.info(f"Saved transcription output under {output_dir_path}")
+    return translated
+
+
+def _load_or_review_series_guided(
+    target: Series,
+    guide: Series,
+    output_path: Path,
+    language: Language,
+    guide_language: Language,
     *,
+    stop_at_idx: int | None = None,
+    reviewer_kw: dict[str, Any] | None = None,
+    overwrite: bool = False,
+) -> Series:
+    """Load or create a guide-reviewed subtitle series.
+
+    Arguments:
+        target: target subtitle series to review
+        guide: guide subtitle series
+        output_path: reviewed subtitle output path
+        language: target subtitle language
+        guide_language: guide language
+        stop_at_idx: exclusive review block index at which to stop processing
+        reviewer_kw: additional keyword arguments for `review_series_guided`
+        overwrite: whether to overwrite an existing output
+    Returns:
+        guide-reviewed subtitle series
+    """
+    if output_path.exists() and not overwrite:
+        return Series.load(output_path)
+
+    reviewer_kw = dict(reviewer_kw or {})
+    language_pair_name = f"{language.language}_{guide_language.language}"
+    reviewer_kw.setdefault(
+        "current_test_cases_path",
+        output_path.parent
+        / "lang"
+        / language_pair_name
+        / "guided_review"
+        / f"{get_torch_device()}.json",
+    )
+    reviewed = review_series_guided(
+        target,
+        guide,
+        language=language,
+        guide_language=guide_language,
+        stop_at_idx=stop_at_idx,
+        **reviewer_kw,
+    )
+    reviewed.save(output_path)
+    return reviewed
+
+
+def _load_or_transcribe_series_guided(
+    audio: AudioSeries,
+    guide: Series,
+    output_path: Path,
+    language: Language,
+    guide_language: Language,
+    *,
+    stop_at_idx: int | None = None,
+    transcription_kw: dict[str, Any] | None = None,
+    overwrite: bool = False,
+) -> Series:
+    """Load or create a guided transcription.
+
+    Arguments:
+        audio: audio series to transcribe
+        guide: guide subtitle series
+        output_path: transcription output path
+        language: transcription language
+        guide_language: guide subtitle language
+        stop_at_idx: exclusive block index at which to stop processing
+        transcription_kw: additional keyword arguments for
+          `transcribe_series_guided`
+        overwrite: whether to overwrite an existing output
+    Returns:
+        guided transcription
+    """
+    if output_path.exists() and not overwrite:
+        return Series.load(output_path)
+
+    transcription_kw = dict(transcription_kw or {})
+    spec = DEFAULT_SPECS.get((language, guide_language))
+    if spec is not None:
+        test_case_dir_path = output_path.parent / spec.test_case_dir_path
+        device = get_torch_device()
+        transcription_kw.setdefault(
+            "delineation_json_path",
+            test_case_dir_path / "delineation" / f"{device}.json",
+        )
+        transcription_kw.setdefault(
+            "punctuation_json_path",
+            test_case_dir_path / "punctuation" / f"{device}.json",
+        )
+    audio_transcription = transcribe_series_guided(
+        audio,
+        guide,
+        language=language,
+        guide_language=guide_language,
+        stop_at_idx=stop_at_idx,
+        **transcription_kw,
+    )
+    transcription = Series(
+        events=[Subtitle(**event.as_dict()) for event in audio_transcription]
+    )
+    transcription.save(output_path)
+    return transcription
+
+
+def _load_or_translate_series_gaps(
+    source: Series,
+    target: Series,
+    output_path: Path,
+    source_language: Language,
+    target_language: Language,
+    *,
+    stop_at_idx: int | None = None,
+    translator_kw: dict[str, Any] | None = None,
+    overwrite: bool = False,
+) -> Series:
+    """Load or create a gap-translated subtitle series.
+
+    Arguments:
+        source: source-language guide subtitle series
+        target: target-language gapped subtitle series
+        output_path: translated subtitle output path
+        source_language: source subtitle language
+        target_language: target subtitle language
+        stop_at_idx: exclusive block index at which to stop processing
+        translator_kw: additional keyword arguments for `translate_series_gaps`
+        overwrite: whether to overwrite an existing output
+    Returns:
+        gap-translated subtitle series
+    """
+    if output_path.exists() and not overwrite:
+        return Series.load(output_path)
+
+    translator_kw = dict(translator_kw or {})
+    language_pair_name = f"{target_language.language}_{source_language.language}"
+    translator_kw.setdefault(
+        "current_test_cases_path",
+        output_path.parent
+        / "lang"
+        / language_pair_name
+        / "gap_translation"
+        / f"{get_torch_device()}.json",
+    )
+    translated = translate_series_gaps(
+        source,
+        target,
+        source_language=source_language,
+        target_language=target_language,
+        stop_at_idx=stop_at_idx,
+        **translator_kw,
+    )
+    translated.save(output_path)
+    return translated
+
+
+@contextmanager
+def _relog_cantonese_transcription_mismatch(language: Language) -> Iterator[None]:
+    """Relog expected same-script Cantonese-to-Mandarin detection at info.
+
+    Arguments:
+        language: expected transcription language
+    Returns:
+        context in which the expected mismatch is intercepted
+    """
+    detected_language = None
+    if language is Language.yue_hans:
+        detected_language = Language.zho_hans
+    elif language is Language.yue_hant:
+        detected_language = Language.zho_hant
+    if detected_language is None:
+        yield
+        return
+
+    expected_message = (
+        f"Explicit language {language.code} does not "
+        f"match detected language {detected_language.code}; "
+        f"using {language.code}"
+    )
+    mismatch_filter = _RelogLanguageMismatchFilter(expected_message)
+    language_logger = getLogger("scinoephile.workflows.helpers")
+    language_logger.addFilter(mismatch_filter)
+    try:
+        yield
+    finally:
+        language_logger.removeFilter(mismatch_filter)
+
+
+def _stage_audio_series(
+    guide: Series,
+    output_dir_path: Path,
+    *,
+    audio_source_path: Path | None,
     media_path: Path | None,
     stream_index: int | None,
-    audio_extraction_mode: AudioExtractionMode = AudioExtractionMode.ORIGINAL,
-    media_start_seconds: float,
+    overwrite: bool,
 ) -> AudioSeries:
-    """Load staged complete audio without supplying subtitle events to ASR."""
-    if media_start_seconds < 0.0:
-        raise ValueError("media_start_seconds must be non-negative.")
-    if audio_path.exists():
-        return AudioSeries(audio=AudioSegment.from_wav(audio_path), events=[])
-    if media_path is None:
-        raise ScinoephileError(
-            f"Staged audio is missing at {audio_path}; provide media_path."
-        )
-    audio = AudioSeries.load_audio_from_media(
-        media_path, stream_index=stream_index, extraction_mode=audio_extraction_mode
-    )
-    trim_start_ms = round(media_start_seconds * 1000)
-    if trim_start_ms >= len(audio.audio):
-        raise ScinoephileError(
-            f"Audio trim start {media_start_seconds:.3f}s is outside the media."
-        )
-    if trim_start_ms:
-        audio = AudioSeries(audio=audio.audio[trim_start_ms:], events=[])
-    audio_path.parent.mkdir(parents=True, exist_ok=True)
-    audio.audio.export(audio_path, format="wav")
-    return audio
+    """Stage and load guide-aligned audio for transcription.
 
+    Arguments:
+        guide: guide subtitles used to segment audio
+        output_dir_path: transcription output directory
+        audio_source_path: optional existing wav file to stage
+        media_path: optional media path from which to extract audio
+        stream_index: audio stream index, or None to use the first stream
+        overwrite: whether to overwrite staged inputs
+    Returns:
+        staged guide-aligned audio series
+    Raises:
+        ScinoephileError: if staged audio is missing and cannot be generated
+    """
+    audio_dir_path = output_dir_path / "audio"
+    audio_dir_path.mkdir(parents=True, exist_ok=True)
+    staged_audio_path = audio_dir_path / "audio.wav"
+    if audio_source_path is not None and audio_source_path != staged_audio_path:
+        if overwrite or not staged_audio_path.exists():
+            copy2(audio_source_path, staged_audio_path)
 
-def _save_evaluation(
-    output_dir_path: Path,
-    artifact: TranscriptionAlignmentArtifact,
-    reference: Series,
-    *,
-    audit_references: Mapping[str, Series],
-    terminal_alignment_authority: str | None = None,
-):
-    """Save evaluation metrics and readable alignment audits."""
-    primary_metrics = _get_reference_metrics(artifact, reference)
-    cer = primary_metrics["cer"]
-    metrics = {
-        "format": "scinoephile-transcription-evaluation",
-        "version": 1,
-        "processed_blocks": len(artifact.blocks),
-        **primary_metrics,
-    }
-    json_dir_path = output_dir_path / "json"
-    json_dir_path.mkdir(parents=True, exist_ok=True)
-    (json_dir_path / "metrics.json").write_text(
-        json.dumps(metrics, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
-    )
-    reference_similarity = None
-    if artifact.language in {Language.yue_hans, Language.yue_hant}:
-        reference_similarity = CantoneseTimedTokenSimilarity(
-            timing_weight=2.0, timing_tolerance_seconds=0.75
-        )
-    (output_dir_path / "audit.md").write_text(
-        audit_transcription_alignment(
-            artifact,
-            audit_references,
-            reference_similarity=reference_similarity,
-            include_merge_support=True,
-        ),
-        encoding="utf-8",
-    )
-    if terminal_alignment_authority is not None:
-        terminal_alignment = render_transcription_alignment_terminal(
-            artifact,
-            audit_references,
-            authoritative_row_name=terminal_alignment_authority,
-            reference_similarity=reference_similarity,
-            include_merge_support=True,
-        )
-        logger.info(f"\n{terminal_alignment.rstrip()}")
-    logger.info(
-        "Aligned transcription evaluation: "
-        + ", ".join(f"{name} CER {values['cer']:.3%}" for name, values in cer.items())
-    )
+    audio_srt_path = audio_dir_path / "audio.srt"
+    if overwrite or not audio_srt_path.exists():
+        guide.save(audio_srt_path)
 
-
-def _get_reference_metrics(
-    artifact: TranscriptionAlignmentArtifact, reference: Series
-) -> dict:
-    """Calculate lexical and timing metrics against one named reference."""
-    selected_reference = get_reference_for_alignment(artifact, reference)
-    reference_text = "".join(
-        subtitle.text_with_newline for subtitle in selected_reference
-    )
-    candidate_texts = {source.name: [] for source in artifact.sources}
-    for block in artifact.blocks:
-        rows = {row.name: row.text for row in block.rows}
-        for source in artifact.sources:
-            candidate_texts[source.name].append(
-                rows.get(source.name, "").replace("　", "").replace("・", "")
+    if not staged_audio_path.exists():
+        if media_path is None:
+            raise ScinoephileError(
+                "Staged audio is missing. Provide `audio_source_path` or "
+                f"`media_path`, or stage {staged_audio_path} manually."
             )
-    candidate_texts["merged"] = [
-        subtitle.text for block in artifact.blocks for subtitle in block.subtitles
-    ]
-    cer = {
-        name: _get_cer_dict(LineCER(reference_text, "".join(text_parts)))
-        for name, text_parts in candidate_texts.items()
-    }
-    timing = evaluate_transcription_timing(artifact, reference)
-    subtitle_alignment_groups = Counter(
-        f"{len(pair.candidate_indexes)}:{len(pair.reference_indexes)}"
-        for pair in timing.pairs
-    )
-    return {
-        "reference_subtitles": len(selected_reference),
-        "candidate_subtitles": sum(len(block.subtitles) for block in artifact.blocks),
-        "cer": cer,
-        "timing": {
-            "settings": timing.settings.model_dump(mode="json"),
-            "text_aligned_groups": len(timing.pairs),
-            "micro_intersection_over_union": timing.micro_intersection_over_union,
-            "one_to_one_groups": len(timing.one_to_one_pairs),
-            "one_to_one_micro_intersection_over_union": (
-                timing.one_to_one_micro_intersection_over_union
-            ),
-            "mean_intersection_over_union": timing.mean_intersection_over_union,
-            "mean_reference_coverage": timing.mean_reference_coverage,
-            "mean_start_error_ms": timing.mean_start_error_ms,
-            "mean_end_error_ms": timing.mean_end_error_ms,
-            "mean_absolute_start_error_ms": timing.mean_absolute_start_error_ms,
-            "mean_absolute_end_error_ms": timing.mean_absolute_end_error_ms,
-            "unmatched_candidate_subtitles": timing.unmatched_candidate_subtitles,
-            "unmatched_reference_subtitles": timing.unmatched_reference_subtitles,
-            "candidate_to_reference_group_counts": dict(
-                sorted(subtitle_alignment_groups.items())
-            ),
-        },
-    }
-
-
-def _get_cer_dict(result: LineCER) -> dict[str, float | int]:
-    """Serialize one character-error result."""
-    return {
-        "cer": result.cer,
-        "correct": result.correct,
-        "substitutions": result.substitutions,
-        "insertions": result.insertions,
-        "deletions": result.deletions,
-        "reference_length": result.reference_length,
-    }
+        audio = AudioSeries.load_from_media(
+            media_path=media_path,
+            subtitle_path=audio_srt_path,
+            stream_index=stream_index,
+        )
+        audio.save(audio_dir_path)
+    return AudioSeries.load(audio_dir_path)

--- a/test/lang/transcription/test_standard.py
+++ b/test/lang/transcription/test_standard.py
@@ -9,11 +9,62 @@ from unittest.mock import Mock, patch
 
 from scinoephile.core import Language
 from scinoephile.core.llms import LLMProvider
-from scinoephile.lang.transcription.standard import DEFAULT_PROMPTS, get_transcriber
+from scinoephile.lang.transcription.standard import (
+    DEFAULT_PROMPTS,
+    YueTranscriptionManager,
+    get_transcriber,
+)
 from scinoephile.lang.yue.transcription.validation import (
     YueTranscriptionAlignmentScorer,
 )
 from scinoephile.llms.transcription import TranscriptionTestCase
+
+
+def test_get_transcriber_loads_defaults_only_when_shared_test_cases_are_omitted():
+    """Default cases should load for None without replacing an explicit empty list."""
+    provider = Mock(spec=LLMProvider, cache_identity={"implementation": "test"})
+    loader_path = "scinoephile.lang.transcription.standard.load_shared_test_cases"
+
+    with patch(loader_path, return_value=()) as load_shared_test_cases:
+        transcriber = get_transcriber(Language.yue_hant, provider=provider, no_op=True)
+
+    load_shared_test_cases.assert_called_once_with(
+        transcriber.manager_cls, DEFAULT_PROMPTS[Language.yue_hant], ()
+    )
+    test_case_cls = cast(type[TranscriptionTestCase], transcriber.test_case_cls)
+    assert transcriber.manager_cls is YueTranscriptionManager
+    assert isinstance(test_case_cls.alignment_scorer, YueTranscriptionAlignmentScorer)
+
+    with patch(loader_path) as load_shared_test_cases:
+        get_transcriber(
+            Language.yue_hant, shared_test_cases=[], provider=provider, no_op=True
+        )
+
+    load_shared_test_cases.assert_not_called()
+
+
+def test_yue_manager_accepts_equivalent_script_forms():
+    """Yue fixture validation should accept equivalent Chinese-script forms."""
+    test_case_cls = YueTranscriptionManager.get_test_case_cls(
+        YueTranscriptionManager.base_prompt
+    )
+
+    test_case = test_case_cls.model_validate(
+        {
+            "query": {
+                "sources": [
+                    {"name": "one", "text": "为"},
+                    {"name": "two", "text": "为"},
+                    {"name": "three", "text": "為"},
+                ],
+                "speaker": "Ａ",
+            },
+            "answer": {"text": "為｜"},
+        }
+    )
+
+    assert test_case.answer is not None
+    assert test_case.answer.transcript == "為"
 
 
 def test_yue_prompts_distinguish_single_and_multiple_sources():
@@ -31,25 +82,3 @@ def test_yue_prompts_distinguish_single_and_multiple_sources():
     assert "只出现喺单一来源" in simplified_prompt
     assert "唔系独立嘅词汇证据" in simplified_prompt
     assert "同语言分类一致就收录" in simplified_prompt
-
-
-def test_get_transcriber_loads_defaults_only_when_shared_test_cases_are_omitted():
-    """Default cases should load for None without replacing an explicit empty list."""
-    provider = Mock(spec=LLMProvider, cache_identity={"implementation": "test"})
-    loader_path = "scinoephile.lang.transcription.standard.load_shared_test_cases"
-
-    with patch(loader_path, return_value=()) as load_shared_test_cases:
-        transcriber = get_transcriber(Language.yue_hant, provider=provider, no_op=True)
-
-    load_shared_test_cases.assert_called_once_with(
-        transcriber.manager_cls, DEFAULT_PROMPTS[Language.yue_hant], ()
-    )
-    test_case_cls = cast(type[TranscriptionTestCase], transcriber.test_case_cls)
-    assert isinstance(test_case_cls.alignment_scorer, YueTranscriptionAlignmentScorer)
-
-    with patch(loader_path) as load_shared_test_cases:
-        get_transcriber(
-            Language.yue_hant, shared_test_cases=[], provider=provider, no_op=True
-        )
-
-    load_shared_test_cases.assert_not_called()

--- a/test/llms/test_delineation.py
+++ b/test/llms/test_delineation.py
@@ -295,15 +295,15 @@ def test_persistence_uses_base_prompt_aliases_and_omits_defaults(tmp_path: Path)
     assert loaded[0].model_dump() == test_case.model_dump()
 
 
-def test_tracked_fixture_count():
-    """All six tracked delineation files should contain 9,396 test cases."""
+def test_tracked_fixtures_are_nonempty():
+    """Remaining tracked delineation fixtures should be nonempty."""
     counts = [
         len(json.loads(input_path.read_text(encoding="utf-8")))
         for input_path in _DELINEATION_PATHS
     ]
 
-    assert len(_DELINEATION_PATHS) == 6
-    assert sum(counts) == 9_396
+    assert _DELINEATION_PATHS
+    assert all(count > 0 for count in counts)
 
 
 @mark.parametrize(

--- a/test/llms/test_delineation.py
+++ b/test/llms/test_delineation.py
@@ -295,17 +295,6 @@ def test_persistence_uses_base_prompt_aliases_and_omits_defaults(tmp_path: Path)
     assert loaded[0].model_dump() == test_case.model_dump()
 
 
-def test_tracked_fixtures_are_nonempty():
-    """Remaining tracked delineation fixtures should be nonempty."""
-    counts = [
-        len(json.loads(input_path.read_text(encoding="utf-8")))
-        for input_path in _DELINEATION_PATHS
-    ]
-
-    assert _DELINEATION_PATHS
-    assert all(count > 0 for count in counts)
-
-
 @mark.parametrize(
     "input_path",
     _DELINEATION_PATHS,

--- a/test/llms/test_gap_translation.py
+++ b/test/llms/test_gap_translation.py
@@ -513,7 +513,7 @@ def test_repository_json_fixtures_load():
     """All repository gap-translation fixtures should use the canonical list shape."""
     fixture_paths = sorted(
         (common.package_root.parent / "test/data").glob(
-            "*/output/*_transcribe/lang/yue_zho/gap_translation/*.json"
+            "*/output/*/lang/yue_zho/gap_translation/*.json"
         )
     )
 
@@ -525,8 +525,8 @@ def test_repository_json_fixtures_load():
         )
     ]
 
-    assert len(fixture_paths) == 3
-    assert len(test_cases) == 91
+    assert fixture_paths
+    assert test_cases
     assert all(
         cast(GapTranslationTestCase, test_case).query.guides for test_case in test_cases
     )

--- a/test/llms/test_punctuation.py
+++ b/test/llms/test_punctuation.py
@@ -229,15 +229,15 @@ def test_persistence_uses_base_prompt_aliases(tmp_path: Path):
     assert loaded[0].answer.model_dump(by_alias=True) == {"jieguo": "原文"}
 
 
-def test_tracked_fixture_count():
-    """All six tracked punctuation files should contain 4,652 test cases."""
+def test_tracked_fixtures_are_nonempty():
+    """Remaining tracked punctuation fixtures should be nonempty."""
     counts = [
         len(json.loads(input_path.read_text(encoding="utf-8")))
         for input_path in _PUNCTUATION_PATHS
     ]
 
-    assert len(_PUNCTUATION_PATHS) == 6
-    assert sum(counts) == 4_652
+    assert _PUNCTUATION_PATHS
+    assert all(count > 0 for count in counts)
 
 
 @mark.parametrize(

--- a/test/llms/test_punctuation.py
+++ b/test/llms/test_punctuation.py
@@ -229,17 +229,6 @@ def test_persistence_uses_base_prompt_aliases(tmp_path: Path):
     assert loaded[0].answer.model_dump(by_alias=True) == {"jieguo": "原文"}
 
 
-def test_tracked_fixtures_are_nonempty():
-    """Remaining tracked punctuation fixtures should be nonempty."""
-    counts = [
-        len(json.loads(input_path.read_text(encoding="utf-8")))
-        for input_path in _PUNCTUATION_PATHS
-    ]
-
-    assert _PUNCTUATION_PATHS
-    assert all(count > 0 for count in counts)
-
-
 @mark.parametrize(
     "input_path",
     _PUNCTUATION_PATHS,


### PR DESCRIPTION
## What changed

- adds a shared aligned multi-source transcription dataset harness that stages audio using the existing `audio/audio.wav` layout, selects a block prefix, saves alignment, run, and usage artifacts, and writes CER, timing, Markdown, and terminal audits
- centralizes structured transcription evaluation under `analysis.transcription` so audit and JSON output use the same bounded series-level CER and timing results
- exposes and reuses the production Yue-aware transcription manager when validating persisted transcription test cases
- adds Hong Kong Traditional conversion support for dataset preparation
- permits aligned transcription JSON artifacts while fixture families migrate incrementally, without dropping validation for fixtures that still exist
- keeps the existing guided dataset harness unchanged until the remaining dataset PRs migrate
- updates the affected test-authoring and movie-context skills to describe the current generation-script conventions

## Why

This establishes the common reference-free evaluation infrastructure used by the seven per-movie dataset migrations without breaking datasets that have not migrated yet. References are used only to choose the processed prefix and evaluate the finished output; they are not passed to ASR, alignment, timing, diarization, or consensus.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format ...`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix ...`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ty check ...`
- focused harness, audit, hierarchy, fixture, and Yue-manager tests (133 passed)
- `cd test && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -n auto -q -o log_cli=false` (2,449 passed, 4 skipped)
- validated the `author-test` and `write-movie-context` skills