### PR TITLE
Remove obsolete cache namespace marker handling

### DIFF
--- a/scinoephile/core/cache/operations.py
+++ b/scinoephile/core/cache/operations.py
@@ -26,8 +26,6 @@ __all__ = [
 
 _CACHE_NAMESPACE_GROUP_NAMES = ("llm", "media")
 """Root directory names whose direct children are cache namespaces."""
-_LEGACY_CACHE_NAMESPACE_MARKER_FILENAME = ".scinoephile-cache-namespace"
-"""Obsolete namespace marker filename ignored during cache inspection."""
 _NESTED_CACHE_NAMESPACE_NAMES = ("media/subtitles/analysis",)
 """Cache namespaces nested beneath another cache namespace."""
 
@@ -321,7 +319,6 @@ def _get_cache_entries(
             _build_cache_entry(cache_root_path, namespace_name, child_path)
             for child_path in sorted(namespace_dir_path.iterdir())
             if child_path.name not in nested_namespace_dir_names
-            and child_path.name != _LEGACY_CACHE_NAMESPACE_MARKER_FILENAME
         )
     return entries
 

--- a/test/core/cache/test_operations.py
+++ b/test/core/cache/test_operations.py
@@ -95,24 +95,6 @@ def test_get_cache_entries_supports_grouped_llm_namespaces(tmp_path: Path):
     ]
 
 
-def test_get_cache_entries_supports_legacy_media_namespace(tmp_path: Path):
-    """Test old media cache namespaces remain available for maintenance.
-
-    Arguments:
-        tmp_path: temporary directory provided by pytest
-    """
-    marker_name = ".scinoephile-cache-namespace"
-    write_cache_file(tmp_path / f"media/subtitle-analysis/{marker_name}")
-    write_cache_file(tmp_path / "media/subtitle-analysis/first.json", "analysis")
-
-    assert discover_cache_namespaces(tmp_path) == ["media/subtitle-analysis"]
-    entries = get_cache_entries(tmp_path, namespace="media/subtitle-analysis")
-
-    assert [entry.relative_path for entry in entries] == [
-        Path("media/subtitle-analysis/first.json")
-    ]
-
-
 def test_prune_cache_prunes_individual_nested_namespace_entries(tmp_path: Path):
     """Test nested cache namespaces preserve entry-level pruning.
 


### PR DESCRIPTION
## Summary

Remove the obsolete legacy cache namespace marker and its cleanup path.

## Why

The marker is no longer written or needed by current cache maintenance behavior, so retaining special handling adds dead compatibility code.

## Validation

- Cache operation tests: 14 passed
- Ruff formatting and linting
- ty type checking

## Stack

This is the first prerequisite for #1237.