### PR TITLE
Normalize Vad class naming

### DIFF
--- a/scinoephile/audio/transcription/__init__.py
+++ b/scinoephile/audio/transcription/__init__.py
@@ -27,7 +27,7 @@ from .mlx_audio import MlxAudioModel, MlxAudioTranscriber
 from .preprocessing_settings import (
     DemucsMode,
     TranscriptionPreprocessingSettings,
-    VADMode,
+    VadMode,
 )
 from .transcribed_segment import TranscribedSegment
 from .transcribed_word import TranscribedWord
@@ -49,7 +49,7 @@ __all__ = [
     "TranscriptionError",
     "TranscriptionInferenceError",
     "TranscriptionPreprocessingSettings",
-    "VADMode",
+    "VadMode",
     "WhisperModel",
     "WhisperTranscriber",
     "get_segment_merged",

--- a/scinoephile/audio/transcription/mlx_audio/transcriber.py
+++ b/scinoephile/audio/transcription/mlx_audio/transcriber.py
@@ -25,7 +25,7 @@ from scinoephile.audio.transcription.exceptions import (
 from scinoephile.audio.transcription.preprocessing_settings import (
     DemucsMode,
     TranscriptionPreprocessingSettings,
-    VADMode,
+    VadMode,
 )
 from scinoephile.audio.transcription.transcribed_segment import TranscribedSegment
 from scinoephile.audio.transcription.transcribed_word import TranscribedWord
@@ -89,7 +89,7 @@ class MlxAudioTranscriber(Transcriber):
         chunk_overlap_seconds: float = 1.0,
         token_limit_guard: bool = False,
         demucs_mode: DemucsMode = DemucsMode.OFF,
-        vad_mode: VADMode = VADMode.OFF,
+        vad_mode: VadMode = VadMode.OFF,
         cache_root_path: Path | None = None,
         overwrite_cache: bool = False,
         demucs_separator: DemucsSeparator | None = None,

--- a/scinoephile/audio/transcription/preprocessing_settings.py
+++ b/scinoephile/audio/transcription/preprocessing_settings.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import StrEnum
 
-__all__ = ["DemucsMode", "TranscriptionPreprocessingSettings", "VADMode"]
+__all__ = ["DemucsMode", "TranscriptionPreprocessingSettings", "VadMode"]
 
 
 class DemucsMode(StrEnum):
@@ -21,7 +21,7 @@ class DemucsMode(StrEnum):
     """Skip Demucs preprocessing."""
 
 
-class VADMode(StrEnum):
+class VadMode(StrEnum):
     """Voice activity detection modes for transcription."""
 
     AUTO = "auto"

--- a/scinoephile/audio/transcription/transcriber.py
+++ b/scinoephile/audio/transcription/transcriber.py
@@ -18,7 +18,7 @@ from .exceptions import TranscriptionEmptyError, TranscriptionError
 from .preprocessing_settings import (
     DemucsMode,
     TranscriptionPreprocessingSettings,
-    VADMode,
+    VadMode,
 )
 from .transcribed_segment import TranscribedSegment
 
@@ -43,7 +43,7 @@ class Transcriber(ABC):
         self,
         cache_root_path: Path | None,
         demucs_mode: DemucsMode = DemucsMode.OFF,
-        vad_mode: VADMode = VADMode.OFF,
+        vad_mode: VadMode = VadMode.OFF,
         overwrite_cache: bool = False,
         demucs_separator: DemucsSeparator | None = None,
     ):
@@ -206,9 +206,9 @@ class Transcriber(ABC):
         else:
             demucs_values = (True, False)
 
-        if self.vad_mode is VADMode.ON:
+        if self.vad_mode is VadMode.ON:
             vad_values = (True,)
-        elif self.vad_mode is VADMode.OFF:
+        elif self.vad_mode is VadMode.OFF:
             vad_values = (False,)
         else:
             vad_values = (True, False)
@@ -321,7 +321,7 @@ class Transcriber(ABC):
                     continue
                 transcription_audio = separated_audio
 
-            if self.vad_mode is VADMode.AUTO and not settings.use_vad:
+            if self.vad_mode is VadMode.AUTO and not settings.use_vad:
                 logger.info(f"Retrying {self.backend_label} without VAD")
             try:
                 segments = self._transcribe_attempt(transcription_audio, settings)

--- a/scinoephile/audio/transcription/whisper/transcriber.py
+++ b/scinoephile/audio/transcription/whisper/transcriber.py
@@ -19,7 +19,7 @@ from scinoephile.audio.transcription.exceptions import (
 from scinoephile.audio.transcription.preprocessing_settings import (
     DemucsMode,
     TranscriptionPreprocessingSettings,
-    VADMode,
+    VadMode,
 )
 from scinoephile.audio.transcription.transcribed_segment import TranscribedSegment
 from scinoephile.audio.transcription.transcriber import Transcriber
@@ -72,7 +72,7 @@ class WhisperTranscriber(Transcriber):
         model: WhisperModel = WHISPER_LARGE_V3_CANTONESE_MODEL,
         language: Language = Language.yue_hant,
         demucs_mode: DemucsMode = DemucsMode.OFF,
-        vad_mode: VADMode = VADMode.OFF,
+        vad_mode: VadMode = VadMode.OFF,
         cache_root_path: Path | None = None,
         overwrite_cache: bool = False,
         temperature: float | Sequence[float] = 0.0,

--- a/scinoephile/cli/transcribe_cli.py
+++ b/scinoephile/cli/transcribe_cli.py
@@ -11,7 +11,7 @@ from argparse import ArgumentParser
 from pathlib import Path
 
 from scinoephile.audio.subtitles import AudioSeries
-from scinoephile.audio.transcription import DemucsMode, VADMode
+from scinoephile.audio.transcription import DemucsMode, VadMode
 from scinoephile.common.argument_parsing import (
     enum_arg,
     enum_metavar,
@@ -79,7 +79,7 @@ TRANSCRIBE_LOCALIZATIONS: dict[str, dict[str, str]] = {
         ): "Demucs 人声分离模式（选项：auto、on 或 off；默认：%(default)s）",
         (
             f"voice activity detection mode (options: "
-            f"{enum_options_list_str(VADMode)}; default: %(default)s)"
+            f"{enum_options_list_str(VadMode)}; default: %(default)s)"
         ): "语音活动检测模式（选项：auto、on 或 off；默认：%(default)s）",
         "JSON file containing delineation test cases": ("包含断句测试用例的 JSON 文件"),
         "JSON file containing punctuation test cases": ("包含标点测试用例的 JSON 文件"),
@@ -119,7 +119,7 @@ TRANSCRIBE_LOCALIZATIONS: dict[str, dict[str, str]] = {
         ): "Demucs 人聲分離模式（選項：auto、on 或 off；預設：%(default)s）",
         (
             f"voice activity detection mode (options: "
-            f"{enum_options_list_str(VADMode)}; default: %(default)s)"
+            f"{enum_options_list_str(VadMode)}; default: %(default)s)"
         ): "語音活動偵測模式（選項：auto、on 或 off；預設：%(default)s）",
         "JSON file containing delineation test cases": ("包含斷句測試案例的 JSON 檔"),
         "JSON file containing punctuation test cases": ("包含標點測試案例的 JSON 檔"),
@@ -215,13 +215,13 @@ class TranscribeCli(ScinoephileCliBase):
         )
         arg_groups["operation arguments"].add_argument(
             "--vad",
-            default=VADMode.OFF,
+            default=VadMode.OFF,
             dest="vad_mode",
-            metavar=enum_metavar(VADMode),
-            type=enum_arg(VADMode),
+            metavar=enum_metavar(VadMode),
+            type=enum_arg(VadMode),
             help=(
                 f"voice activity detection mode (options: "
-                f"{enum_options_list_str(VADMode)}; default: %(default)s)"
+                f"{enum_options_list_str(VadMode)}; default: %(default)s)"
             ),
         )
         arg_groups["operation arguments"].add_argument(
@@ -279,7 +279,7 @@ class TranscribeCli(ScinoephileCliBase):
         last_block: int | None,
         model: TranscriptionModel,
         demucs_mode: DemucsMode,
-        vad_mode: VADMode,
+        vad_mode: VadMode,
         llm_args: LlmArguments,
         cache_args: CacheArguments,
         delineation_json_path: Path | None,

--- a/scinoephile/lang/transcription/guided.py
+++ b/scinoephile/lang/transcription/guided.py
@@ -12,7 +12,7 @@ from types import MappingProxyType
 from scinoephile.audio.transcription import (
     DemucsMode,
     MlxAudioTranscriber,
-    VADMode,
+    VadMode,
     get_segment_split_on_whitespace,
 )
 from scinoephile.audio.transcription.mlx_audio.model import (
@@ -199,7 +199,7 @@ def get_guided_transcriber(
     *,
     model: TranscriptionModel = TranscriptionModel.WHISPER,
     demucs_mode: DemucsMode = DemucsMode.OFF,
-    vad_mode: VADMode = VADMode.OFF,
+    vad_mode: VadMode = VadMode.OFF,
     cache_root_path: Path | None = None,
     overwrite_cache: bool = False,
     strip_generated_punctuation: bool = False,

--- a/scinoephile/lang/transcription/transcriber.py
+++ b/scinoephile/lang/transcription/transcriber.py
@@ -21,7 +21,7 @@ from scinoephile.audio.transcription import (
     TranscribedSegment,
     TranscribedWord,
     TranscriptionError,
-    VADMode,
+    VadMode,
     WhisperTranscriber,
     get_segment_split_at_idx,
     get_segment_split_on_word_timings,
@@ -151,7 +151,7 @@ class GuidedTranscriber:
         audio_model: WhisperModel | MlxAudioModel,
         aligner: TranscriptionAligner,
         demucs_mode: DemucsMode = DemucsMode.OFF,
-        vad_mode: VADMode = VADMode.OFF,
+        vad_mode: VadMode = VadMode.OFF,
         cache_root_path: Path | None = None,
         overwrite_cache: bool = False,
         mlx_audio_transcriber: MlxAudioTranscriber | None = None,
@@ -215,9 +215,9 @@ class GuidedTranscriber:
         recovery_demucs_mode = DemucsMode.OFF
         if self.demucs_mode is DemucsMode.ON:
             recovery_demucs_mode = DemucsMode.ON
-        recovery_vad_mode = VADMode.OFF
-        if self.vad_mode is VADMode.ON:
-            recovery_vad_mode = VADMode.ON
+        recovery_vad_mode = VadMode.OFF
+        if self.vad_mode is VadMode.ON:
+            recovery_vad_mode = VadMode.ON
         self.recovery_transcriber = WhisperTranscriber(
             model=self.audio_model,
             language=self.language,
@@ -236,7 +236,7 @@ class GuidedTranscriber:
             model=self.audio_model,
             language=self.language,
             demucs_mode=DemucsMode.OFF,
-            vad_mode=VADMode.OFF,
+            vad_mode=VadMode.OFF,
             cache_root_path=cache_root_path,
             overwrite_cache=overwrite_cache,
             condition_on_previous_text=False,

--- a/scinoephile/workflows/transcription.py
+++ b/scinoephile/workflows/transcription.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from scinoephile.audio.subtitles import AudioSeries
-from scinoephile.audio.transcription import DemucsMode, VADMode
+from scinoephile.audio.transcription import DemucsMode, VadMode
 from scinoephile.core import Language
 from scinoephile.core.llms import LLMProvider, TestCase
 from scinoephile.core.subtitles import Series
@@ -33,7 +33,7 @@ def transcribe_series_guided(
     guide_language: Language | None = None,
     model: TranscriptionModel = TranscriptionModel.WHISPER,
     demucs_mode: DemucsMode = DemucsMode.OFF,
-    vad_mode: VADMode = VADMode.OFF,
+    vad_mode: VadMode = VadMode.OFF,
     cache_root_path: Path | None = None,
     overwrite_cache: bool = False,
     strip_generated_punctuation: bool = False,

--- a/test/audio/transcription/mlx_audio/test_mlx_audio_transcriber.py
+++ b/test/audio/transcription/mlx_audio/test_mlx_audio_transcriber.py
@@ -23,7 +23,7 @@ from scinoephile.audio.transcription import (
     TranscriptionError,
     TranscriptionInferenceError,
     TranscriptionPreprocessingSettings,
-    VADMode,
+    VadMode,
 )
 from scinoephile.audio.transcription.mlx_audio.backend import MlxAudioInferenceResult
 from scinoephile.audio.transcription.mlx_audio.model import (
@@ -71,7 +71,7 @@ def test_init_defaults_demucs_and_vad_to_off():
     transcriber = MlxAudioTranscriber()
 
     assert transcriber.demucs_mode is DemucsMode.OFF
-    assert transcriber.vad_mode is VADMode.OFF
+    assert transcriber.vad_mode is VadMode.OFF
     assert transcriber.demucs_separator is None
     assert transcriber.model is MIMO_MODEL
     assert transcriber.language is Language.yue_hant
@@ -170,11 +170,11 @@ def test_token_limit_guard_cache_identity_depends_on_audio_duration(tmp_path: Pa
     short_audio = AudioSegment.silent(duration=55_000, frame_rate=1_000)
     long_audio = AudioSegment.silent(duration=55_001, frame_rate=1_000)
     unguarded = MlxAudioTranscriber(
-        demucs_mode=DemucsMode.OFF, vad_mode=VADMode.OFF, cache_root_path=tmp_path
+        demucs_mode=DemucsMode.OFF, vad_mode=VadMode.OFF, cache_root_path=tmp_path
     )
     guarded = MlxAudioTranscriber(
         demucs_mode=DemucsMode.OFF,
-        vad_mode=VADMode.OFF,
+        vad_mode=VadMode.OFF,
         cache_root_path=tmp_path,
         token_limit_guard=True,
     )
@@ -212,13 +212,13 @@ def test_token_limit_guard_does_not_change_qwen_behavior(
     unguarded = MlxAudioTranscriber(
         model=QWEN3_ASR_MODEL,
         demucs_mode=DemucsMode.OFF,
-        vad_mode=VADMode.OFF,
+        vad_mode=VadMode.OFF,
         cache_root_path=tmp_path,
     )
     guarded = MlxAudioTranscriber(
         model=QWEN3_ASR_MODEL,
         demucs_mode=DemucsMode.OFF,
-        vad_mode=VADMode.OFF,
+        vad_mode=VadMode.OFF,
         cache_root_path=tmp_path,
         token_limit_guard=True,
     )
@@ -307,7 +307,7 @@ def test_init_rejects_chunk_duration_that_rounds_to_zero():
 def test_get_cached_transcription_reads_mlx_audio_payload(tmp_path: Path):
     """Test MLX-Audio cache reads segment payloads from metadata-bearing files."""
     transcriber = MlxAudioTranscriber(
-        cache_root_path=tmp_path, demucs_mode=DemucsMode.OFF, vad_mode=VADMode.OFF
+        cache_root_path=tmp_path, demucs_mode=DemucsMode.OFF, vad_mode=VadMode.OFF
     )
     audio = _get_cache_audio()
     expected_segments = [_get_timed_segment("你好")]
@@ -331,7 +331,7 @@ def test_transcribe_recovers_from_malformed_cache(
     audio = _get_cache_audio()
     expected_segments = [_get_timed_segment("你好")]
     transcriber = MlxAudioTranscriber(
-        cache_root_path=tmp_path, demucs_mode=DemucsMode.OFF, vad_mode=VADMode.OFF
+        cache_root_path=tmp_path, demucs_mode=DemucsMode.OFF, vad_mode=VadMode.OFF
     )
     cache_path = _get_cache_path(transcriber, audio)
     cache_path.write_text("{", encoding="utf-8")
@@ -362,7 +362,7 @@ def test_malformed_cache_does_not_override_fresh_rejection(
     audio = _get_cache_audio()
     fresh_segments = [_get_timed_segment("fresh")]
     transcriber = MlxAudioTranscriber(
-        cache_root_path=tmp_path, demucs_mode=DemucsMode.OFF, vad_mode=VADMode.OFF
+        cache_root_path=tmp_path, demucs_mode=DemucsMode.OFF, vad_mode=VadMode.OFF
     )
     cache_path = _get_cache_path(transcriber, audio)
     cache_path.write_text("{", encoding="utf-8")
@@ -385,7 +385,7 @@ def test_transcribe_uses_direct_mlx_audio_inference(monkeypatch: pytest.MonkeyPa
     audio = AudioSegment.silent(duration=1000)
     expected_segments = [_get_timed_segment("你好")]
     transcriber = MlxAudioTranscriber(
-        model=MIMO_MODEL, demucs_mode=DemucsMode.OFF, vad_mode=VADMode.OFF
+        model=MIMO_MODEL, demucs_mode=DemucsMode.OFF, vad_mode=VadMode.OFF
     )
     transcriber.ctc_aligner = Mock(
         model_name="ctc/test-model", return_value=expected_segments
@@ -419,7 +419,7 @@ def test_transcribe_derives_language_and_passes_max_tokens(
         model=MIMO_MODEL,
         language=Language.eng,
         demucs_mode=DemucsMode.OFF,
-        vad_mode=VADMode.OFF,
+        vad_mode=VadMode.OFF,
         max_tokens=1024,
     )
     transcriber.ctc_aligner = Mock(
@@ -447,7 +447,7 @@ def test_transcribe_chunks_audio_and_offsets_segments(monkeypatch: pytest.Monkey
     transcriber = MlxAudioTranscriber(
         model=MIMO_MODEL,
         demucs_mode=DemucsMode.OFF,
-        vad_mode=VADMode.OFF,
+        vad_mode=VadMode.OFF,
         chunk_duration_seconds=2.0,
         chunk_overlap_seconds=0.5,
     )
@@ -502,7 +502,7 @@ def test_token_limit_guard_proactively_chunks_long_mimo_audio(
     transcriber = MlxAudioTranscriber(
         model=MIMO_MODEL,
         demucs_mode=DemucsMode.OFF,
-        vad_mode=VADMode.OFF,
+        vad_mode=VadMode.OFF,
         token_limit_guard=True,
     )
     backend_transcribe = Mock(
@@ -542,7 +542,7 @@ def test_token_limit_guard_honors_shorter_explicit_chunks(
     audio = AudioSegment.silent(duration=61_000, frame_rate=1_000)
     transcriber = MlxAudioTranscriber(
         demucs_mode=DemucsMode.OFF,
-        vad_mode=VADMode.OFF,
+        vad_mode=VadMode.OFF,
         cache_root_path=tmp_path,
         chunk_duration_seconds=20.0,
         chunk_overlap_seconds=0.0,
@@ -578,7 +578,7 @@ def test_transcribe_splits_audio_after_generation_token_exhaustion(
     """Test truncated MLX-Audio output is retried over smaller windows."""
     audio = AudioSegment.silent(duration=4000)
     transcriber = MlxAudioTranscriber(
-        demucs_mode=DemucsMode.OFF, vad_mode=VADMode.OFF, chunk_overlap_seconds=0.0
+        demucs_mode=DemucsMode.OFF, vad_mode=VadMode.OFF, chunk_overlap_seconds=0.0
     )
     backend_transcribe = Mock(
         side_effect=[
@@ -610,7 +610,7 @@ def test_token_limit_guard_splits_audio_near_generation_limit(
     """Reserve MiMo generation headroom when guarded output approaches its limit."""
     audio = AudioSegment.silent(duration=4000)
     transcriber = MlxAudioTranscriber(
-        demucs_mode=DemucsMode.OFF, vad_mode=VADMode.OFF, chunk_overlap_seconds=0.0
+        demucs_mode=DemucsMode.OFF, vad_mode=VadMode.OFF, chunk_overlap_seconds=0.0
     )
     backend_transcribe = Mock(
         side_effect=[
@@ -643,7 +643,7 @@ def test_transcribe_splits_audio_after_incomplete_ctc_alignment(
     """Test incomplete CTC paths are retried over smaller audio windows."""
     audio = AudioSegment.silent(duration=4000)
     transcriber = MlxAudioTranscriber(
-        demucs_mode=DemucsMode.OFF, vad_mode=VADMode.OFF, chunk_overlap_seconds=0.0
+        demucs_mode=DemucsMode.OFF, vad_mode=VadMode.OFF, chunk_overlap_seconds=0.0
     )
     backend_transcribe = Mock(
         side_effect=[
@@ -678,7 +678,7 @@ def test_transcribe_does_not_split_audio_after_other_ctc_errors(
 ):
     """Test non-length CTC failures propagate without recursive retries."""
     audio = AudioSegment.silent(duration=4000)
-    transcriber = MlxAudioTranscriber(demucs_mode=DemucsMode.OFF, vad_mode=VADMode.OFF)
+    transcriber = MlxAudioTranscriber(demucs_mode=DemucsMode.OFF, vad_mode=VadMode.OFF)
     backend_transcribe = Mock(return_value=MlxAudioInferenceResult(text="whole"))
     transcriber.ctc_aligner = Mock(
         model_name="ctc/test-model",
@@ -698,7 +698,7 @@ def test_transcribe_chunks_audio_skips_empty_windows(monkeypatch: pytest.MonkeyP
     audio = AudioSegment.silent(duration=4500)
     transcriber = MlxAudioTranscriber(
         demucs_mode=DemucsMode.OFF,
-        vad_mode=VADMode.OFF,
+        vad_mode=VadMode.OFF,
         chunk_duration_seconds=2.0,
         chunk_overlap_seconds=0.5,
     )
@@ -725,7 +725,7 @@ def test_transcribe_chunks_audio_rejects_all_empty_windows(
     """Test chunked transcription remains empty when every chunk is empty."""
     audio = AudioSegment.silent(duration=4500)
     transcriber = MlxAudioTranscriber(
-        demucs_mode=DemucsMode.OFF, vad_mode=VADMode.OFF, chunk_duration_seconds=2.0
+        demucs_mode=DemucsMode.OFF, vad_mode=VadMode.OFF, chunk_duration_seconds=2.0
     )
     monkeypatch.setattr(
         transcriber,
@@ -743,7 +743,7 @@ def test_transcribe_vad_restores_original_timestamps(monkeypatch: pytest.MonkeyP
     """Test MLX-Audio VAD removes silence and restores original word timings."""
     audio = AudioSegment.silent(duration=6000)
     transcriber = MlxAudioTranscriber(
-        model=MIMO_MODEL, demucs_mode=DemucsMode.OFF, vad_mode=VADMode.ON
+        model=MIMO_MODEL, demucs_mode=DemucsMode.OFF, vad_mode=VadMode.ON
     )
     monkeypatch.setattr(
         transcriber,
@@ -776,7 +776,7 @@ def test_transcribe_vad_rejects_audio_without_detected_speech(
 ):
     """Test VAD does not invoke MLX-Audio when no speech is detected."""
     transcriber = MlxAudioTranscriber(
-        model=MIMO_MODEL, demucs_mode=DemucsMode.OFF, vad_mode=VADMode.ON
+        model=MIMO_MODEL, demucs_mode=DemucsMode.OFF, vad_mode=VadMode.ON
     )
     monkeypatch.setattr(transcriber, "_get_vad_speech_intervals", Mock(return_value=[]))
     patched_transcribe = Mock()
@@ -792,7 +792,7 @@ def test_transcribe_vad_auto_retries_unfiltered_audio(monkeypatch: pytest.Monkey
     """Test automatic VAD retries unfiltered audio after VAD failure."""
     expected_segments = [_get_timed_segment("retry")]
     transcriber = MlxAudioTranscriber(
-        model=MIMO_MODEL, demucs_mode=DemucsMode.OFF, vad_mode=VADMode.AUTO
+        model=MIMO_MODEL, demucs_mode=DemucsMode.OFF, vad_mode=VadMode.AUTO
     )
     monkeypatch.setattr(transcriber, "_get_vad_speech_intervals", Mock(return_value=[]))
     patched_transcribe = Mock(return_value=expected_segments)
@@ -812,7 +812,7 @@ def test_transcribe_aligns_text_and_writes_cache(
     audio = AudioSegment.silent(duration=1000)
     expected_segments = [_get_timed_segment("你好")]
     transcriber = MlxAudioTranscriber(
-        cache_root_path=tmp_path, demucs_mode=DemucsMode.OFF, vad_mode=VADMode.OFF
+        cache_root_path=tmp_path, demucs_mode=DemucsMode.OFF, vad_mode=VadMode.OFF
     )
     monkeypatch.setattr(
         transcriber.backend,
@@ -844,7 +844,7 @@ def test_transcribe_rejects_low_information_vocalizations(
     Arguments:
         monkeypatch: pytest monkeypatch fixture
     """
-    transcriber = MlxAudioTranscriber(demucs_mode=DemucsMode.OFF, vad_mode=VADMode.OFF)
+    transcriber = MlxAudioTranscriber(demucs_mode=DemucsMode.OFF, vad_mode=VadMode.OFF)
     monkeypatch.setattr(
         transcriber.backend,
         "transcribe",
@@ -861,7 +861,7 @@ def test_transcribe_rejects_low_information_vocalizations(
 def test_transcribe_wraps_mlx_audio_inference_errors(monkeypatch: pytest.MonkeyPatch):
     """Test MLX-Audio import/runtime errors are exposed as inference errors."""
     audio = AudioSegment.silent(duration=1000)
-    transcriber = MlxAudioTranscriber(demucs_mode=DemucsMode.OFF, vad_mode=VADMode.OFF)
+    transcriber = MlxAudioTranscriber(demucs_mode=DemucsMode.OFF, vad_mode=VadMode.OFF)
     monkeypatch.setattr(
         transcriber.backend,
         "transcribe",
@@ -888,7 +888,7 @@ def _get_mlx_audio_transcriber(
     return MlxAudioTranscriber(
         model=model,
         demucs_mode=DemucsMode.OFF,
-        vad_mode=VADMode.OFF,
+        vad_mode=VadMode.OFF,
         cache_root_path=cache_root_path,
     )
 

--- a/test/audio/transcription/test_transcription_transcriber.py
+++ b/test/audio/transcription/test_transcription_transcriber.py
@@ -20,7 +20,7 @@ from scinoephile.audio.transcription import (
     TranscriptionError,
     TranscriptionInferenceError,
     TranscriptionPreprocessingSettings,
-    VADMode,
+    VadMode,
 )
 from scinoephile.core import ScinoephileError
 
@@ -40,7 +40,7 @@ class _TestTranscriber(Transcriber):
         self,
         cache_root_path: Path,
         demucs_mode: DemucsMode,
-        vad_mode: VADMode,
+        vad_mode: VadMode,
         overwrite_cache: bool = False,
     ):
         """Initialize."""
@@ -84,7 +84,7 @@ def test_get_preprocessing_settings_orders_preferred_configurations_first(
     tmp_path: Path,
 ):
     """Test automatic modes try Demucs and VAD before their fallbacks."""
-    transcriber = _TestTranscriber(tmp_path, DemucsMode.AUTO, VADMode.AUTO)
+    transcriber = _TestTranscriber(tmp_path, DemucsMode.AUTO, VadMode.AUTO)
 
     assert transcriber._cache.cache_dir_path == tmp_path / "test"
     assert transcriber.demucs_separator is not None
@@ -99,7 +99,7 @@ def test_get_preprocessing_settings_orders_preferred_configurations_first(
 
 def test_get_preprocessing_settings_honors_forced_modes(tmp_path: Path):
     """Test forced modes produce only their requested configuration."""
-    transcriber = _TestTranscriber(tmp_path, DemucsMode.OFF, VADMode.ON)
+    transcriber = _TestTranscriber(tmp_path, DemucsMode.OFF, VadMode.ON)
 
     assert transcriber._get_preprocessing_settings() == (
         TranscriptionPreprocessingSettings(False, True),
@@ -111,7 +111,7 @@ def test_per_audio_cache_metadata_is_used_for_cache_lifecycle(tmp_path: Path):
     audio = AudioSegment.silent(duration=100)
     settings = TranscriptionPreprocessingSettings(False, False)
     segments = [_get_segment("cached")]
-    transcriber = _PerAudioCacheTranscriber(tmp_path, DemucsMode.OFF, VADMode.OFF)
+    transcriber = _PerAudioCacheTranscriber(tmp_path, DemucsMode.OFF, VadMode.OFF)
     transcriber.outcomes[settings] = segments
 
     assert transcriber(audio) == segments
@@ -133,7 +133,7 @@ def test_fallback_cache_is_checked_before_demucs(tmp_path: Path):
     """Test a usable fallback cache avoids expensive Demucs preprocessing."""
     audio = AudioSegment.silent(duration=100)
     segments = [_get_segment("cached")]
-    transcriber = _TestTranscriber(tmp_path, DemucsMode.AUTO, VADMode.OFF)
+    transcriber = _TestTranscriber(tmp_path, DemucsMode.AUTO, VadMode.OFF)
     transcriber._cache.save(
         audio,
         transcriber._get_cache_metadata(
@@ -152,7 +152,7 @@ def test_overwrite_removes_all_configuration_caches_before_transcribing(tmp_path
     """Test cache overwrite clears every fallback variant before inference."""
     audio = AudioSegment.silent(duration=100)
     transcriber = _TestTranscriber(
-        tmp_path, DemucsMode.AUTO, VADMode.AUTO, overwrite_cache=True
+        tmp_path, DemucsMode.AUTO, VadMode.AUTO, overwrite_cache=True
     )
     preprocessing_settings = transcriber._get_preprocessing_settings()
     stale_cache = TranscriptionCache(tmp_path, "test", "Test")
@@ -178,7 +178,7 @@ def test_auto_demucs_failure_uses_original_audio(tmp_path: Path):
     audio = AudioSegment.silent(duration=100)
     settings = TranscriptionPreprocessingSettings(False, False)
     segments = [_get_segment("fallback")]
-    transcriber = _TestTranscriber(tmp_path, DemucsMode.AUTO, VADMode.OFF)
+    transcriber = _TestTranscriber(tmp_path, DemucsMode.AUTO, VadMode.OFF)
     transcriber.demucs_separator = Mock(
         model_name="htdemucs_ft", side_effect=ScinoephileError("failed")
     )
@@ -191,7 +191,7 @@ def test_auto_demucs_failure_uses_original_audio(tmp_path: Path):
 def test_forced_demucs_failure_propagates(tmp_path: Path):
     """Test forced Demucs failure does not silently use original audio."""
     audio = AudioSegment.silent(duration=100)
-    transcriber = _TestTranscriber(tmp_path, DemucsMode.ON, VADMode.OFF)
+    transcriber = _TestTranscriber(tmp_path, DemucsMode.ON, VadMode.OFF)
     transcriber.demucs_separator = Mock(
         model_name="htdemucs_ft", side_effect=ScinoephileError("failed")
     )
@@ -205,7 +205,7 @@ def test_unusable_vad_result_retries_without_vad(tmp_path: Path):
     audio = AudioSegment.silent(duration=100)
     vad_settings = TranscriptionPreprocessingSettings(False, True)
     no_vad_settings = TranscriptionPreprocessingSettings(False, False)
-    transcriber = _TestTranscriber(tmp_path, DemucsMode.OFF, VADMode.AUTO)
+    transcriber = _TestTranscriber(tmp_path, DemucsMode.OFF, VadMode.AUTO)
     transcriber.outcomes[vad_settings] = [_get_segment("bad")]
     transcriber.outcomes[no_vad_settings] = [_get_segment("good")]
 
@@ -223,7 +223,7 @@ def test_rejected_cached_configuration_is_not_repeated(tmp_path: Path):
     audio = AudioSegment.silent(duration=100)
     vad_settings = TranscriptionPreprocessingSettings(False, True)
     no_vad_settings = TranscriptionPreprocessingSettings(False, False)
-    transcriber = _TestTranscriber(tmp_path, DemucsMode.OFF, VADMode.AUTO)
+    transcriber = _TestTranscriber(tmp_path, DemucsMode.OFF, VadMode.AUTO)
     transcriber._cache.save(
         audio,
         transcriber._get_cache_metadata(audio, vad_settings),
@@ -245,7 +245,7 @@ def test_rejected_cached_final_configuration_is_not_repeated(tmp_path: Path):
     """
     audio = AudioSegment.silent(duration=100)
     settings = TranscriptionPreprocessingSettings(True, False)
-    transcriber = _TestTranscriber(tmp_path, DemucsMode.ON, VADMode.OFF)
+    transcriber = _TestTranscriber(tmp_path, DemucsMode.ON, VadMode.OFF)
     transcriber.demucs_separator = Mock(model_name="htdemucs_ft", return_value=audio)
     transcriber._cache.save(
         audio, transcriber._get_cache_metadata(audio, settings), [_get_segment("bad")]
@@ -268,7 +268,7 @@ def test_empty_failures_are_cached(tmp_path: Path):
     audio = AudioSegment.silent(duration=100)
     vad_settings = TranscriptionPreprocessingSettings(False, True)
     no_vad_settings = TranscriptionPreprocessingSettings(False, False)
-    transcriber = _TestTranscriber(tmp_path, DemucsMode.OFF, VADMode.AUTO)
+    transcriber = _TestTranscriber(tmp_path, DemucsMode.OFF, VadMode.AUTO)
     transcriber.outcomes[vad_settings] = TranscriptionEmptyError("no VAD speech")
     transcriber.outcomes[no_vad_settings] = TranscriptionEmptyError("empty transcript")
 
@@ -291,7 +291,7 @@ def test_cached_empty_attempt_does_not_shadow_cached_fallback(tmp_path: Path):
     vad_settings = TranscriptionPreprocessingSettings(False, True)
     no_vad_settings = TranscriptionPreprocessingSettings(False, False)
     expected_segments = [_get_segment("fallback")]
-    transcriber = _TestTranscriber(tmp_path, DemucsMode.OFF, VADMode.AUTO)
+    transcriber = _TestTranscriber(tmp_path, DemucsMode.OFF, VadMode.AUTO)
     transcriber._cache.save(
         audio, transcriber._get_cache_metadata(audio, vad_settings), []
     )
@@ -312,7 +312,7 @@ def test_rejected_cached_configuration_takes_precedence_over_other_error(
     audio = AudioSegment.silent(duration=100)
     vad_settings = TranscriptionPreprocessingSettings(False, True)
     no_vad_settings = TranscriptionPreprocessingSettings(False, False)
-    transcriber = _TestTranscriber(tmp_path, DemucsMode.OFF, VADMode.AUTO)
+    transcriber = _TestTranscriber(tmp_path, DemucsMode.OFF, VadMode.AUTO)
     transcriber._cache.save(
         audio,
         transcriber._get_cache_metadata(audio, vad_settings),
@@ -331,7 +331,7 @@ def test_unusable_success_takes_precedence_over_other_configuration_error(
     audio = AudioSegment.silent(duration=100)
     vad_settings = TranscriptionPreprocessingSettings(False, True)
     no_vad_settings = TranscriptionPreprocessingSettings(False, False)
-    transcriber = _TestTranscriber(tmp_path, DemucsMode.OFF, VADMode.AUTO)
+    transcriber = _TestTranscriber(tmp_path, DemucsMode.OFF, VadMode.AUTO)
     transcriber.outcomes[vad_settings] = [_get_segment("bad")]
     transcriber.outcomes[no_vad_settings] = TranscriptionInferenceError("failed")
 
@@ -343,7 +343,7 @@ def test_last_error_propagates_when_every_configuration_fails(tmp_path: Path):
     audio = AudioSegment.silent(duration=100)
     vad_settings = TranscriptionPreprocessingSettings(False, True)
     no_vad_settings = TranscriptionPreprocessingSettings(False, False)
-    transcriber = _TestTranscriber(tmp_path, DemucsMode.OFF, VADMode.AUTO)
+    transcriber = _TestTranscriber(tmp_path, DemucsMode.OFF, VadMode.AUTO)
     transcriber.outcomes[vad_settings] = TranscriptionInferenceError("first")
     transcriber.outcomes[no_vad_settings] = TranscriptionInferenceError("last")
 

--- a/test/audio/transcription/whisper/test_whisper_transcriber.py
+++ b/test/audio/transcription/whisper/test_whisper_transcriber.py
@@ -23,7 +23,7 @@ from scinoephile.audio.transcription import (
     TranscriptionEmptyError,
     TranscriptionError,
     TranscriptionInferenceError,
-    VADMode,
+    VadMode,
     get_segment_split_at_idx,
 )
 from scinoephile.audio.transcription.transcribed_segment import TranscribedSegment
@@ -63,7 +63,7 @@ def test_init_defaults_demucs_and_vad_to_off():
     transcriber = WhisperTranscriber()
 
     assert transcriber.demucs_mode is DemucsMode.OFF
-    assert transcriber.vad_mode is VADMode.OFF
+    assert transcriber.vad_mode is VadMode.OFF
     assert transcriber.demucs_separator is None
     assert transcriber.model is WHISPER_LARGE_V3_CANTONESE_MODEL
     assert transcriber.language is Language.yue_hant
@@ -140,7 +140,7 @@ def _patch_whisper_timestamped(
 @parametrize(
     ("field_name", "first_value", "second_value"),
     [
-        ("vad_mode", VADMode.ON, VADMode.OFF),
+        ("vad_mode", VadMode.ON, VadMode.OFF),
         (
             "model",
             replace(_CUSTOM_MODEL, model_name="model/one"),
@@ -281,7 +281,7 @@ def test_transcribe_forwards_recovery_decoding_options(
     transcriber = WhisperTranscriber(
         model=_CUSTOM_MODEL,
         demucs_mode=DemucsMode.OFF,
-        vad_mode=VADMode.OFF,
+        vad_mode=VadMode.OFF,
         temperature=temperatures,
         condition_on_previous_text=False,
     )
@@ -320,7 +320,7 @@ def test_transcribe_timestamped_success_does_not_use_ctc(
         cache_root_path=tmp_path,
         model=_CUSTOM_MODEL,
         demucs_mode=DemucsMode.OFF,
-        vad_mode=VADMode.OFF,
+        vad_mode=VadMode.OFF,
         ctc_aligner=ctc_aligner,
     )
     transcriber._loaded_model_instance = model
@@ -386,7 +386,7 @@ def test_transcribe_falls_back_to_native_text_with_ctc_alignment(
         model=_CUSTOM_MODEL,
         language=Language.yue_hant,
         demucs_mode=DemucsMode.OFF,
-        vad_mode=VADMode.OFF,
+        vad_mode=VadMode.OFF,
         temperature=temperatures,
         condition_on_previous_text=False,
         ctc_aligner=ctc_aligner,
@@ -432,7 +432,7 @@ def test_transcribe_timestamp_assertion_without_ctc_remains_error(
         cache_root_path=tmp_path,
         model=_CUSTOM_MODEL,
         demucs_mode=DemucsMode.OFF,
-        vad_mode=VADMode.OFF,
+        vad_mode=VadMode.OFF,
     )
     transcriber._loaded_model_instance = model
     _patch_whisper_timestamped(
@@ -464,7 +464,7 @@ def test_transcribe_unrelated_assertion_does_not_use_ctc(
         cache_root_path=tmp_path,
         model=_CUSTOM_MODEL,
         demucs_mode=DemucsMode.OFF,
-        vad_mode=VADMode.OFF,
+        vad_mode=VadMode.OFF,
         ctc_aligner=ctc_aligner,
     )
     transcriber._loaded_model_instance = model
@@ -518,7 +518,7 @@ def test_transcribe_rejects_invalid_native_fallback_output(
         cache_root_path=tmp_path,
         model=_CUSTOM_MODEL,
         demucs_mode=DemucsMode.OFF,
-        vad_mode=VADMode.OFF,
+        vad_mode=VadMode.OFF,
         ctc_aligner=ctc_aligner,
     )
     transcriber._loaded_model_instance = model
@@ -550,7 +550,7 @@ def test_transcribe_wraps_native_fallback_failure(
         cache_root_path=tmp_path,
         model=_CUSTOM_MODEL,
         demucs_mode=DemucsMode.OFF,
-        vad_mode=VADMode.OFF,
+        vad_mode=VadMode.OFF,
         ctc_aligner=ctc_aligner,
     )
     transcriber._loaded_model_instance = model
@@ -604,7 +604,7 @@ def test_transcribe_logs_when_decoding_window_reaches_token_limit(
     model = Mock()
     model.decode = decode
     transcriber = WhisperTranscriber(
-        model=_CUSTOM_MODEL, demucs_mode=DemucsMode.OFF, vad_mode=VADMode.OFF
+        model=_CUSTOM_MODEL, demucs_mode=DemucsMode.OFF, vad_mode=VadMode.OFF
     )
     transcriber._loaded_model_instance = model
     _patch_whisper_timestamped(monkeypatch, Mock(side_effect=transcribe))
@@ -656,10 +656,10 @@ def test_model_is_shared_across_decoding_configurations(monkeypatch: MonkeyPatch
     )
     monkeypatch.setattr(WhisperTranscriber, "_models_by_key", {})
     vad_transcriber = WhisperTranscriber(
-        model=_CUSTOM_MODEL, demucs_mode=DemucsMode.OFF, vad_mode=VADMode.ON
+        model=_CUSTOM_MODEL, demucs_mode=DemucsMode.OFF, vad_mode=VadMode.ON
     )
     no_vad_transcriber = WhisperTranscriber(
-        model=_CUSTOM_MODEL, demucs_mode=DemucsMode.OFF, vad_mode=VADMode.OFF
+        model=_CUSTOM_MODEL, demucs_mode=DemucsMode.OFF, vad_mode=VadMode.OFF
     )
 
     assert vad_transcriber._loaded_model is loaded_model
@@ -679,7 +679,7 @@ def test_transcribe_overwrites_matching_cache(monkeypatch: MonkeyPatch, tmp_path
         cache_root_path=tmp_path,
         model=_CUSTOM_MODEL,
         demucs_mode=DemucsMode.OFF,
-        vad_mode=VADMode.OFF,
+        vad_mode=VadMode.OFF,
         overwrite_cache=True,
     )
     transcriber._loaded_model_instance = Mock()
@@ -713,7 +713,7 @@ def test_transcribe_recovers_from_malformed_cache(
         cache_root_path=tmp_path,
         model=_CUSTOM_MODEL,
         demucs_mode=DemucsMode.OFF,
-        vad_mode=VADMode.OFF,
+        vad_mode=VadMode.OFF,
     )
     transcriber._loaded_model_instance = Mock()
     cache_path = _get_cache_path(transcriber, audio)
@@ -740,7 +740,7 @@ def test_transcribe_discards_invalid_cache_when_atomic_write_fails(
         cache_root_path=tmp_path,
         model=_CUSTOM_MODEL,
         demucs_mode=DemucsMode.OFF,
-        vad_mode=VADMode.OFF,
+        vad_mode=VadMode.OFF,
     )
     transcriber._loaded_model_instance = Mock()
     cache_path = _get_cache_path(transcriber, audio)

--- a/test/cli/test_transcribe_cli.py
+++ b/test/cli/test_transcribe_cli.py
@@ -12,7 +12,7 @@ from unittest.mock import Mock, patch
 from pytest import fixture, mark, raises
 
 from scinoephile.audio.subtitles import AudioSeries
-from scinoephile.audio.transcription import DemucsMode, VADMode
+from scinoephile.audio.transcription import DemucsMode, VadMode
 from scinoephile.cli.scinoephile_cli import ScinoephileCli
 from scinoephile.cli.transcribe_cli import TranscribeCli
 from scinoephile.common.file import get_temp_file_path
@@ -120,7 +120,7 @@ def test_transcribe_cli_defaults_demucs_and_vad_to_off():
         if "--vad" in action.option_strings
     )
     assert demucs_action.default is DemucsMode.OFF
-    assert vad_action.default is VADMode.OFF
+    assert vad_action.default is VadMode.OFF
 
 
 def test_transcribe_cli_writes_file(audio_series: Mock, expected_series: Series):
@@ -198,7 +198,7 @@ def test_transcribe_cli_passes_generic_configuration(
         guide_language: Language | None,
         model: TranscriptionModel,
         demucs_mode: DemucsMode,
-        vad_mode: VADMode,
+        vad_mode: VadMode,
         cache_root_path: Path | None,
         overwrite_cache: bool,
         provider: object,
@@ -216,7 +216,7 @@ def test_transcribe_cli_passes_generic_configuration(
         assert guide_language is Language.zho_hans
         assert model is TranscriptionModel.QWEN3_ASR
         assert demucs_mode is DemucsMode.ON
-        assert vad_mode is VADMode.OFF
+        assert vad_mode is VadMode.OFF
         assert cache_root_path == tmp_path / "cache"
         assert overwrite_cache
         assert provider is not None

--- a/test/data/mlamd/create_output.py
+++ b/test/data/mlamd/create_output.py
@@ -8,7 +8,7 @@ from logging import info
 from pathlib import Path
 
 from scinoephile.audio.subtitles import AudioSeries
-from scinoephile.audio.transcription import VADMode
+from scinoephile.audio.transcription import VadMode
 from scinoephile.common.logs import set_logging_verbosity
 from scinoephile.core import Language
 from scinoephile.core.ml import get_torch_device
@@ -80,7 +80,7 @@ if "yue-Hans_transcribe" in actions:
     transcriber = get_guided_transcriber(
         Language.yue_hans,
         Language.zho_hans,
-        vad_mode=VADMode.ON,
+        vad_mode=VadMode.ON,
         prune_test_cases=True,
         delineation_json_path=test_case_dir_path / "delineation" / f"{device}.json",
         punctuation_json_path=test_case_dir_path / "punctuation" / f"{device}.json",

--- a/test/lang/transcription/test_guided.py
+++ b/test/lang/transcription/test_guided.py
@@ -14,7 +14,7 @@ from pytest import mark, raises
 from scinoephile.audio.transcription import (
     CtcAligner,
     DemucsMode,
-    VADMode,
+    VadMode,
     WhisperTranscriber,
 )
 from scinoephile.audio.transcription.mlx_audio.model import (
@@ -120,7 +120,7 @@ def test_get_guided_transcriber_uses_registered_language_configuration(tmp_path)
     assert transcriber.language is Language.yue_hant
     assert transcriber.guide_language is Language.zho_hans
     assert transcriber.demucs_mode is DemucsMode.OFF
-    assert transcriber.vad_mode is VADMode.OFF
+    assert transcriber.vad_mode is VadMode.OFF
     assert not hasattr(transcriber, "overwrite_cache")
     assert not hasattr(transcriber, "cache_root_path")
     assert (transcriber.audio_model, transcriber.model_name) == (
@@ -141,7 +141,7 @@ def test_get_guided_transcriber_uses_registered_language_configuration(tmp_path)
     assert whisper_transcriber.model is WHISPER_LARGE_V3_CANTONESE_MODEL
     assert whisper_transcriber.language is Language.yue_hant
     assert transcriber.transcriber.demucs_mode is DemucsMode.OFF
-    assert transcriber.transcriber.vad_mode is VADMode.OFF
+    assert transcriber.transcriber.vad_mode is VadMode.OFF
     assert transcriber.recovery_transcriber is not None
     assert transcriber.tail_recovery_transcriber is not None
     assert not hasattr(transcriber.transcriber, "cache_root_path")
@@ -242,7 +242,7 @@ def test_get_guided_transcriber_configures_mlx_audio_model(
         language=Language.yue_hant,
         token_limit_guard=True,
         demucs_mode=DemucsMode.OFF,
-        vad_mode=VADMode.OFF,
+        vad_mode=VadMode.OFF,
         cache_root_path=tmp_path,
         overwrite_cache=False,
     )

--- a/test/lang/transcription/test_transcriber.py
+++ b/test/lang/transcription/test_transcriber.py
@@ -19,7 +19,7 @@ from scinoephile.audio.transcription import (
     TranscribedSegment,
     TranscribedWord,
     TranscriptionError,
-    VADMode,
+    VadMode,
 )
 from scinoephile.audio.transcription.mlx_audio.model import MIMO_MODEL
 from scinoephile.audio.transcription.whisper.model import WhisperModel
@@ -39,7 +39,7 @@ def _get_transcriber(
     *,
     model: TranscriptionModel = TranscriptionModel.WHISPER,
     demucs_mode: DemucsMode = DemucsMode.OFF,
-    vad_mode: VADMode = VADMode.OFF,
+    vad_mode: VadMode = VadMode.OFF,
     overwrite_cache: bool = False,
     mlx_audio_timing_mode: MlxAudioTimingMode = MlxAudioTimingMode.CTC_UNIT,
     strip_generated_punctuation: bool = False,
@@ -168,7 +168,7 @@ def test_segments_are_usable_accepts_partial_guided_tail():
 
 def test_missing_guided_tail_runs_focused_recovery():
     """Test a missing guided tail triggers normalized focused recovery."""
-    transcriber, _ = _get_transcriber(vad_mode=VADMode.OFF)
+    transcriber, _ = _get_transcriber(vad_mode=VadMode.OFF)
     initial_segments = [_get_segment(end=4.0, compression_ratio=1.0, with_words=True)]
     recovered_segments = [
         _get_segment(
@@ -201,7 +201,7 @@ def test_missing_guided_tail_runs_focused_recovery():
 
 def test_missing_guided_tail_keeps_base_after_unusable_recovery():
     """Test unusable focused-tail output leaves the base transcription intact."""
-    transcriber, _ = _get_transcriber(vad_mode=VADMode.OFF)
+    transcriber, _ = _get_transcriber(vad_mode=VadMode.OFF)
     initial_segments = [_get_segment(end=4.0, compression_ratio=1.0, with_words=True)]
     repetitive_segments = [_get_segment(compression_ratio=16.24, with_words=True)]
     transcriber.transcriber = Mock()
@@ -225,7 +225,7 @@ def test_missing_guided_tail_keeps_base_after_unusable_recovery():
 
 def test_missing_guided_tail_keeps_valid_base_without_credible_recovery():
     """Test implausible tail recovery does not invalidate a valid base transcript."""
-    transcriber, _ = _get_transcriber(vad_mode=VADMode.OFF)
+    transcriber, _ = _get_transcriber(vad_mode=VadMode.OFF)
     initial_segments = [_get_segment(end=4.0, compression_ratio=1.0, with_words=True)]
     stretched_segment = _get_segment(
         end=5.0, text="x", compression_ratio=1.0, with_words=True
@@ -348,7 +348,7 @@ def test_mlx_audio_backend_delegates_to_shared_transcriber():
     transcriber, _ = _get_transcriber(
         model=TranscriptionModel.MIMO,
         demucs_mode=DemucsMode.AUTO,
-        vad_mode=VADMode.AUTO,
+        vad_mode=VadMode.AUTO,
     )
     repetitive_segments = [_get_segment(compression_ratio=16.24, with_words=True)]
     usable_segments = [_get_segment(text="mlx-audio", with_words=True)]

--- a/test/workflows/test_guided_transcription.py
+++ b/test/workflows/test_guided_transcription.py
@@ -10,7 +10,7 @@ from unittest.mock import Mock, patch
 from pydub import AudioSegment
 
 from scinoephile.audio.subtitles import AudioSeries
-from scinoephile.audio.transcription import DemucsMode, VADMode
+from scinoephile.audio.transcription import DemucsMode, VadMode
 from scinoephile.core import Language
 from scinoephile.core.subtitles import Series, Subtitle
 from scinoephile.lang.transcription.transcriber import (
@@ -59,7 +59,7 @@ def test_transcribe_series_guided_constructs_transcriber_for_language_pair(
     assert output is expected
     assert get_transcriber.call_args.args == (Language.yue_hant, Language.zho_hans)
     assert get_transcriber.call_args.kwargs["demucs_mode"] is DemucsMode.OFF
-    assert get_transcriber.call_args.kwargs["vad_mode"] is VADMode.OFF
+    assert get_transcriber.call_args.kwargs["vad_mode"] is VadMode.OFF
     assert get_transcriber.call_args.kwargs["model"] is TranscriptionModel.MIMO
     assert get_transcriber.call_args.kwargs["cache_root_path"] == tmp_path / "cache"
     assert get_transcriber.call_args.kwargs["overwrite_cache"] is True


### PR DESCRIPTION
## Summary

Rename `VADMode` to `VadMode` throughout the existing transcription interfaces.

## Why

This follows the repository's class-name convention for three-letter acronyms before adding the public VAD implementation.

## Validation

- Affected transcription tests: 242 passed
- Ruff formatting and linting
- ty type checking

## Stack

Depends on the preceding Demucs package move and is a prerequisite for #1237.