### PR TITLE
Replace private argparse type imports

### DIFF
--- a/scinoephile/cli/helpers/blocks.py
+++ b/scinoephile/cli/helpers/blocks.py
@@ -4,9 +4,9 @@
 
 from __future__ import annotations
 
-from argparse import ArgumentParser, _ArgumentGroup  # noqa: PLC2701
+from argparse import ArgumentParser
 
-from scinoephile.common.argument_parsing import int_arg
+from scinoephile.common.argument_parsing import ArgumentGroup, int_arg
 
 __all__ = ["BLOCK_LOCALIZATIONS", "add_block_range_args", "get_block_range_indexes"]
 
@@ -32,7 +32,7 @@ BLOCK_LOCALIZATIONS: dict[str, dict[str, str]] = {
 
 
 def add_block_range_args(
-    operation_arg_group: _ArgumentGroup,
+    operation_arg_group: ArgumentGroup,
     *,
     first_help: str = "first 1-indexed subtitle block to process, inclusive",
     last_help: str = "last 1-indexed subtitle block to process, inclusive",

--- a/scinoephile/cli/helpers/cache.py
+++ b/scinoephile/cli/helpers/cache.py
@@ -4,12 +4,11 @@
 
 from __future__ import annotations
 
-from argparse import _ArgumentGroup  # noqa: PLC2701
 from dataclasses import dataclass, field
 from functools import partial
 from pathlib import Path
 
-from scinoephile.common.argument_parsing import output_dir_arg
+from scinoephile.common.argument_parsing import ArgumentGroup, output_dir_arg
 from scinoephile.core.paths import get_runtime_cache_root_path
 
 from .argument_bundle_field_action import ArgumentBundleFieldAction
@@ -52,7 +51,7 @@ class CacheArguments:
     """Whether matching cache files should be overwritten."""
 
 
-def add_cache_args(cache_arg_group: _ArgumentGroup):
+def add_cache_args(cache_arg_group: ArgumentGroup):
     """Add standard cache arguments to an argument group.
 
     Arguments:
@@ -84,7 +83,7 @@ def add_cache_args(cache_arg_group: _ArgumentGroup):
 
 
 def add_cache_root_arg(
-    cache_arg_group: _ArgumentGroup,
+    cache_arg_group: ArgumentGroup,
     help_text: str = "cache root directory path (default: %(default)s)",
 ):
     """Add a standard cache root argument to an argument group.

--- a/scinoephile/cli/helpers/conversion.py
+++ b/scinoephile/cli/helpers/conversion.py
@@ -5,15 +5,10 @@
 from __future__ import annotations
 
 import sys
-from argparse import (  # noqa: PLC2701
-    SUPPRESS,
-    Action,
-    ArgumentParser,
-    Namespace,
-    _ArgumentGroup,
-)
+from argparse import SUPPRESS, Action, ArgumentParser, Namespace
 from typing import Any
 
+from scinoephile.common.argument_parsing import ArgumentGroup
 from scinoephile.core.cli import ScinoephileCliBase
 from scinoephile.lang.zho.script.conversion import OpenCCConfig
 
@@ -100,7 +95,7 @@ OPENCC_CONFIG_LOCALIZATIONS: dict[str, dict[str, str]] = {
 
 
 def add_opencc_convert_argument(
-    operation_arg_group: _ArgumentGroup, additional_help_arg_group: _ArgumentGroup
+    operation_arg_group: ArgumentGroup, additional_help_arg_group: ArgumentGroup
 ):
     """Add standard OpenCC conversion and help arguments to argument groups.
 
@@ -125,7 +120,7 @@ def add_opencc_convert_argument(
 
 
 def add_opencc_convert_auto_argument(
-    operation_arg_group: _ArgumentGroup, additional_help_arg_group: _ArgumentGroup
+    operation_arg_group: ArgumentGroup, additional_help_arg_group: ArgumentGroup
 ):
     """Add OpenCC conversion arguments allowing automatic config selection.
 

--- a/scinoephile/cli/helpers/llms.py
+++ b/scinoephile/cli/helpers/llms.py
@@ -5,19 +5,16 @@
 from __future__ import annotations
 
 import sys
-from argparse import (  # noqa: PLC2701
-    SUPPRESS,
-    Action,
-    ArgumentParser,
-    ArgumentTypeError,
-    Namespace,
-    _ArgumentGroup,
-)
+from argparse import SUPPRESS, Action, ArgumentParser, ArgumentTypeError, Namespace
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from scinoephile.common.argument_parsing import input_file_arg, output_file_arg
+from scinoephile.common.argument_parsing import (
+    ArgumentGroup,
+    input_file_arg,
+    output_file_arg,
+)
 from scinoephile.core.cli import ScinoephileCliBase
 from scinoephile.llms.providers.registry import (
     DEFAULT_PROVIDER_NAME,
@@ -96,7 +93,7 @@ class LlmArguments:
 
 
 def add_llm_provider_args(
-    llm_arg_group: _ArgumentGroup, additional_help_arg_group: _ArgumentGroup
+    llm_arg_group: ArgumentGroup, additional_help_arg_group: ArgumentGroup
 ):
     """Add standard LLM provider arguments to argument groups.
 
@@ -155,7 +152,7 @@ def add_llm_provider_args(
 
 
 def add_llm_test_case_json_arg(
-    llm_arg_group: _ArgumentGroup,
+    llm_arg_group: ArgumentGroup,
     option_name: str = "--json",
     *,
     dest: str = "json_path",

--- a/scinoephile/cli/helpers/web.py
+++ b/scinoephile/cli/helpers/web.py
@@ -4,10 +4,9 @@
 
 from __future__ import annotations
 
-from argparse import _ArgumentGroup  # noqa: PLC2701
 from dataclasses import dataclass
 
-from scinoephile.common.argument_parsing import int_arg
+from scinoephile.common.argument_parsing import ArgumentGroup, int_arg
 
 from .argument_bundle_field_action import ArgumentBundleFieldAction
 
@@ -38,7 +37,7 @@ class WebServerArguments:
     """Port for the local web server."""
 
 
-def add_web_server_args(web_arg_group: _ArgumentGroup):
+def add_web_server_args(web_arg_group: ArgumentGroup):
     """Add standard local web server arguments to an argument group.
 
     Arguments:

--- a/scinoephile/common/argument_parsing.py
+++ b/scinoephile/common/argument_parsing.py
@@ -4,16 +4,12 @@
 
 from __future__ import annotations
 
-from argparse import (
-    ArgumentParser,
-    ArgumentTypeError,
-    _ArgumentGroup,  # noqa pylint
-)
+from argparse import Action, ArgumentParser, ArgumentTypeError
 from collections.abc import Callable, Collection
 from datetime import timedelta
 from enum import Enum
 from pathlib import Path
-from typing import Any, TypedDict, Unpack
+from typing import Any, Protocol, TypedDict, Unpack, cast
 
 from .duration import parse_duration
 from .exceptions import NotAFileError
@@ -29,6 +25,7 @@ from .validation import (
 )
 
 __all__ = [
+    "ArgumentGroup",
     "FloatValidatorKwargs",
     "IntValidatorKwargs",
     "OutputDirValidatorKwargs",
@@ -52,6 +49,31 @@ __all__ = [
     "output_file_arg",
     "str_arg",
 ]
+
+
+class ArgumentGroup(Protocol):
+    """Public argument-group interface used by CLI helpers."""
+
+    def add_argument(self, *name_or_flags: str, **kwargs: Any) -> Action:
+        """Add an argument to the group.
+
+        Arguments:
+            *name_or_flags: positional argument name or option flags
+            **kwargs: argparse argument configuration
+        Returns:
+            configured argparse action
+        """
+        ...
+
+
+class _MutableArgumentGroup(ArgumentGroup, Protocol):
+    """Argument group interface used for internal argparse group ordering."""
+
+    title: str | None
+    """Argument group title."""
+
+    _group_actions: list[Action]
+    """Actions registered with the argument group."""
 
 
 class FloatValidatorKwargs(TypedDict, total=False):
@@ -101,7 +123,7 @@ class StrValidatorKwargs(TypedDict, total=False):
     """allowed string options."""
 
 
-def get_optional_args_group(parser: ArgumentParser) -> _ArgumentGroup:
+def get_optional_args_group(parser: ArgumentParser) -> ArgumentGroup:
     """Get the optional arguments group from an argparser.
 
     Arguments:
@@ -109,7 +131,10 @@ def get_optional_args_group(parser: ArgumentParser) -> _ArgumentGroup:
     Returns:
         Optional arguments group
     """
-    action_groups = parser._action_groups  # noqa pylint: disable=protected-access
+    action_groups = cast(
+        "list[_MutableArgumentGroup]",
+        parser._action_groups,  # noqa: SLF001
+    )
     return next(
         ag
         for ag in action_groups
@@ -117,7 +142,7 @@ def get_optional_args_group(parser: ArgumentParser) -> _ArgumentGroup:
     )
 
 
-def get_required_args_group(parser: ArgumentParser) -> _ArgumentGroup:
+def get_required_args_group(parser: ArgumentParser) -> ArgumentGroup:
     """Get or create a 'required arguments' group from an argparser.
 
     Arguments:
@@ -125,7 +150,10 @@ def get_required_args_group(parser: ArgumentParser) -> _ArgumentGroup:
     Returns:
         Required arguments group
     """
-    action_groups = parser._action_groups  # noqa pylint: disable=protected-access
+    action_groups = cast(
+        "list[_MutableArgumentGroup]",
+        parser._action_groups,  # noqa: SLF001
+    )
     for group in action_groups:
         if group.title == "required arguments":
             return group
@@ -142,7 +170,7 @@ def get_arg_groups_by_name(
     parser: ArgumentParser,
     *names: str,
     optional_arguments_name: str = "optional arguments",
-) -> dict[str, _ArgumentGroup]:
+) -> dict[str, ArgumentGroup]:
     """Get or create one or more argument groups by name.
 
     Groups will be ordered by the order in which they are specified, with additional
@@ -165,9 +193,12 @@ def get_arg_groups_by_name(
     Returns:
         Dictionary of names to argument groups
     """
-    specified_groups = {}
+    specified_groups: dict[str, _MutableArgumentGroup] = {}
     for name in names:
-        action_groups = parser._action_groups  # noqa pylint: disable=protected-access
+        action_groups = cast(
+            "list[_MutableArgumentGroup]",
+            parser._action_groups,  # noqa: SLF001
+        )
         for i, ag in enumerate(action_groups):
             if ag.title == name:
                 specified_groups[name] = action_groups.pop(i)
@@ -176,10 +207,13 @@ def get_arg_groups_by_name(
             parser.add_argument_group(name)
             specified_groups[name] = action_groups.pop()
 
-    action_groups = parser._action_groups  # noqa pylint: disable=protected-access
-    additional_groups = {}
-    optional_groups = {}
-    additional_help_groups = {}
+    action_groups = cast(
+        "list[_MutableArgumentGroup]",
+        parser._action_groups,  # noqa: SLF001
+    )
+    additional_groups: dict[str, _MutableArgumentGroup] = {}
+    optional_groups: dict[str, _MutableArgumentGroup] = {}
+    additional_help_groups: dict[str, _MutableArgumentGroup] = {}
     remaining_groups = action_groups[:]
     action_groups.clear()
     for ag in remaining_groups:
@@ -212,12 +246,15 @@ def get_arg_groups_by_name(
     action_groups.extend(additional_help_groups.values())
     action_groups.extend(trailing_groups.values())
 
-    return {
-        **specified_groups,
-        **additional_groups,
-        **optional_groups,
-        **additional_help_groups,
-    }
+    return cast(
+        "dict[str, ArgumentGroup]",
+        {
+            **specified_groups,
+            **additional_groups,
+            **optional_groups,
+            **additional_help_groups,
+        },
+    )
 
 
 def get_validator[T](function: Callable[..., T], **kwargs: Any) -> Callable[[Any], T]:

--- a/scinoephile/common/command_line_interface.py
+++ b/scinoephile/common/command_line_interface.py
@@ -6,24 +6,39 @@ from __future__ import annotations
 
 import re
 from abc import ABC, abstractmethod
-from argparse import (
-    ArgumentParser,
-    RawDescriptionHelpFormatter,
-    _SubParsersAction,  # noqa pylint
-)
-from collections.abc import Callable
+from argparse import ArgumentParser, RawDescriptionHelpFormatter
+from collections.abc import Callable, Mapping
 from datetime import datetime
 from inspect import cleandoc
 from logging import FileHandler, Formatter, getLogger
 from pathlib import Path
 from sys import argv
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, Protocol, runtime_checkable
 
 from .logs import DEFAULT_LOG_FORMAT, configure_logging
 
-__all__ = ["CommandLineInterface"]
+__all__ = ["CommandLineInterface", "SubparsersAction"]
 
 logger = getLogger(__name__)
+
+
+@runtime_checkable
+class SubparsersAction(Protocol):
+    """Public interface for an argparse subparsers action."""
+
+    choices: Mapping[str, ArgumentParser]
+    """Subcommand parsers keyed by command name."""
+
+    def add_parser(self, name: str, **kwargs: Any) -> ArgumentParser:
+        """Add a subcommand parser.
+
+        Arguments:
+            name: subcommand name
+            **kwargs: argument parser configuration
+        Returns:
+            configured subcommand parser
+        """
+        ...
 
 
 class CommandLineInterface(ABC):
@@ -75,9 +90,7 @@ class CommandLineInterface(ABC):
                 action_group.title = "additional arguments"
 
     @classmethod
-    def argparser(
-        cls, *, subparsers: _SubParsersAction | None = None
-    ) -> ArgumentParser:
+    def argparser(cls, *, subparsers: SubparsersAction | None = None) -> ArgumentParser:
         """Construct argument parser.
 
         Arguments:

--- a/scinoephile/core/cli/scinoephile_cli_base.py
+++ b/scinoephile/core/cli/scinoephile_cli_base.py
@@ -6,12 +6,13 @@ from __future__ import annotations
 
 import locale
 import re
-from argparse import ArgumentParser, _SubParsersAction  # noqa: PLC2701
+from argparse import ArgumentParser
 from inspect import cleandoc
 from os import getenv
 from typing import ClassVar
 
 from scinoephile.common import CommandLineInterface
+from scinoephile.common.command_line_interface import SubparsersAction
 
 from .constants import DEFAULT_CLI_LOCALE, LOCALE_ALIASES
 from .localization import BASE_CLI_LOCALIZATIONS, merge_localizations
@@ -142,9 +143,7 @@ class ScinoephileCliBase(CommandLineInterface):
                     action.help = cls.translate_text(action.help)
 
     @classmethod
-    def argparser(
-        cls, *, subparsers: _SubParsersAction | None = None
-    ) -> ArgumentParser:
+    def argparser(cls, *, subparsers: SubparsersAction | None = None) -> ArgumentParser:
         """Construct localized argument parser."""
         parser = super().argparser(subparsers=subparsers)
         cls.localize_parser(parser)

--- a/test/cli/test_argument_group_order.py
+++ b/test/cli/test_argument_group_order.py
@@ -4,11 +4,11 @@
 
 from __future__ import annotations
 
-from argparse import ArgumentParser, _SubParsersAction  # noqa: PLC2701
+from argparse import ArgumentParser
 from collections.abc import Iterator
-from typing import cast
 
 from scinoephile.cli.scinoephile_cli import ScinoephileCli
+from scinoephile.common.command_line_interface import SubparsersAction
 
 _GROUP_ORDER = (
     "positional arguments",
@@ -71,7 +71,7 @@ def _iter_parsers(
     """
     yield path, parser
     for action in parser._actions:  # noqa: SLF001
-        if not isinstance(action, _SubParsersAction):
+        if not isinstance(action, SubparsersAction):
             continue
         for name, subparser in sorted(action.choices.items()):
-            yield from _iter_parsers(cast(ArgumentParser, subparser), (*path, name))
+            yield from _iter_parsers(subparser, (*path, name))


### PR DESCRIPTION
## Summary

Replace imports of private `argparse` implementation types with public protocols and annotations.

## Why

CLI typing should not depend on underscored standard-library internals.

## Validation

- Affected CLI and style tests: 55 passed
- Ruff formatting and linting
- ty type checking

## Stack

Depends on the preceding Vad naming PR and is a prerequisite for #1237.