### PR TITLE
Enforce public module boundaries

### DIFF
--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -27,6 +27,10 @@
   owns the name so internal dependencies remain visible (for example, use
   `from scinoephile.core.exceptions import ScinoephileError` within
   `scinoephile.core.llms`, not `from scinoephile.core import ScinoephileError`).
+* Do not import underscore-prefixed names from another project module. If a
+  project-owned name is needed across a module boundary, make it public and
+  include it in the owning module's `__all__`. This restriction does not apply
+  to standard-library or third-party modules.
 * Use `if TYPE_CHECKING:` blocks only when necessary to avoid circular imports.
 * Name dedicated lazy-import helpers
   `import_<module>[_<symbol_or_purpose>]` when public and

--- a/scinoephile/lang/transcription/transcriber.py
+++ b/scinoephile/lang/transcription/transcriber.py
@@ -40,6 +40,7 @@ __all__ = [
     "MlxAudioTimingMode",
     "TranscribedSegmentSplitter",
     "TranscriptionModel",
+    "get_segment_split_on_phrase_timings",
 ]
 
 
@@ -332,7 +333,7 @@ class GuidedTranscriber:
                 if self.mlx_audio_timing_mode is MlxAudioTimingMode.SEGMENT:
                     timed_segments.append(segment)
                 elif self.mlx_audio_timing_mode is MlxAudioTimingMode.PHRASE:
-                    timed_segments.extend(_get_segment_split_on_phrase_timings(segment))
+                    timed_segments.extend(get_segment_split_on_phrase_timings(segment))
                 else:
                     timed_segments.extend(get_segment_split_on_word_timings(segment))
             split_segments = [
@@ -642,80 +643,7 @@ class GuidedTranscriber:
         return has_text
 
 
-def _get_phrase_boundary_scores(
-    text: str,
-    words: list[TranscribedWord],
-    durations: list[float],
-    pause_threshold: float,
-) -> dict[int, int]:
-    """Score phrase boundaries using punctuation and CTC hold durations."""
-    boundary_scores: dict[int, int] = {}
-    for character_index, character in enumerate(text, 1):
-        if character in _MLX_PHRASE_STRONG_PUNCTUATION:
-            boundary_scores[character_index] = 4
-        elif character in _MLX_PHRASE_WEAK_PUNCTUATION:
-            boundary_scores[character_index] = 2
-
-    character_offset = 0
-    for word, duration in zip(words, durations, strict=True):
-        character_offset += len(word.text)
-        boundary_scores.setdefault(character_offset, 1)
-        if duration >= pause_threshold:
-            boundary_scores[character_offset] = max(
-                boundary_scores[character_offset], 3
-            )
-    return boundary_scores
-
-
-def _get_segment_without_generated_punctuation(
-    segment: TranscribedSegment,
-) -> TranscribedSegment:
-    """Remove generated punctuation from segment text and word timing data.
-
-    Arguments:
-        segment: timed transcription segment
-    Returns:
-        segment whose text and word data use matching character offsets
-    """
-    keep_characters = _get_text_character_retention(segment.text)
-    text = _strip_generated_punctuation(segment.text)
-    if not segment.words:
-        return segment.model_copy(update={"text": text})
-
-    # Apply the segment-level retention map to its corresponding timed words
-    word_text = "".join(word.text for word in segment.words)
-    if word_text == segment.text:
-        words: list[TranscribedWord] = []
-        character_offset = 0
-        for word in segment.words:
-            word_end = character_offset + len(word.text)
-            retained_word_text = "".join(
-                character
-                for character, keep_character in zip(
-                    word.text, keep_characters[character_offset:word_end], strict=True
-                )
-                if keep_character
-            )
-            if retained_word_text:
-                words.append(word.model_copy(update={"text": retained_word_text}))
-            character_offset = word_end
-        return segment.model_copy(update={"text": text, "words": words})
-
-    # Preserve safe offsets when backend word text cannot be mapped character-wise
-    words = []
-    if text:
-        words.append(
-            TranscribedWord(
-                text=text,
-                start=segment.start,
-                end=segment.end,
-                confidence=min(word.confidence for word in segment.words),
-            )
-        )
-    return segment.model_copy(update={"text": text, "words": words})
-
-
-def _get_segment_split_on_phrase_timings(
+def get_segment_split_on_phrase_timings(
     segment: TranscribedSegment,
 ) -> list[TranscribedSegment]:
     """Split an MLX-Audio segment into phrase-sized CTC timing groups.
@@ -795,6 +723,79 @@ def _get_segment_split_on_phrase_timings(
         previous_offset = split_offset
     output.append(remaining)
     return output
+
+
+def _get_phrase_boundary_scores(
+    text: str,
+    words: list[TranscribedWord],
+    durations: list[float],
+    pause_threshold: float,
+) -> dict[int, int]:
+    """Score phrase boundaries using punctuation and CTC hold durations."""
+    boundary_scores: dict[int, int] = {}
+    for character_index, character in enumerate(text, 1):
+        if character in _MLX_PHRASE_STRONG_PUNCTUATION:
+            boundary_scores[character_index] = 4
+        elif character in _MLX_PHRASE_WEAK_PUNCTUATION:
+            boundary_scores[character_index] = 2
+
+    character_offset = 0
+    for word, duration in zip(words, durations, strict=True):
+        character_offset += len(word.text)
+        boundary_scores.setdefault(character_offset, 1)
+        if duration >= pause_threshold:
+            boundary_scores[character_offset] = max(
+                boundary_scores[character_offset], 3
+            )
+    return boundary_scores
+
+
+def _get_segment_without_generated_punctuation(
+    segment: TranscribedSegment,
+) -> TranscribedSegment:
+    """Remove generated punctuation from segment text and word timing data.
+
+    Arguments:
+        segment: timed transcription segment
+    Returns:
+        segment whose text and word data use matching character offsets
+    """
+    keep_characters = _get_text_character_retention(segment.text)
+    text = _strip_generated_punctuation(segment.text)
+    if not segment.words:
+        return segment.model_copy(update={"text": text})
+
+    # Apply the segment-level retention map to its corresponding timed words
+    word_text = "".join(word.text for word in segment.words)
+    if word_text == segment.text:
+        words: list[TranscribedWord] = []
+        character_offset = 0
+        for word in segment.words:
+            word_end = character_offset + len(word.text)
+            retained_word_text = "".join(
+                character
+                for character, keep_character in zip(
+                    word.text, keep_characters[character_offset:word_end], strict=True
+                )
+                if keep_character
+            )
+            if retained_word_text:
+                words.append(word.model_copy(update={"text": retained_word_text}))
+            character_offset = word_end
+        return segment.model_copy(update={"text": text, "words": words})
+
+    # Preserve safe offsets when backend word text cannot be mapped character-wise
+    words = []
+    if text:
+        words.append(
+            TranscribedWord(
+                text=text,
+                start=segment.start,
+                end=segment.end,
+                confidence=min(word.confidence for word in segment.words),
+            )
+        )
+    return segment.model_copy(update={"text": text, "words": words})
 
 
 def _get_text_character_retention(text: str) -> list[bool]:

--- a/scinoephile/media/offset/video/detection.py
+++ b/scinoephile/media/offset/video/detection.py
@@ -32,9 +32,32 @@ from .video_offset_candidate import VideoOffsetCandidate
 from .video_offset_result import VideoOffsetResult
 from .video_offset_window_result import VideoOffsetWindowResult
 
-__all__ = ["get_video_offset"]
+__all__ = ["get_offsets", "get_video_offset", "sample_video_frames"]
 
 logger = getLogger(__name__)
+
+
+def get_offsets(start: float, end: float, step: float) -> list[float]:
+    """Return inclusive candidate offsets.
+
+    Arguments:
+        start: first offset
+        end: last offset
+        step: offset interval
+    Returns:
+        candidate offsets
+    """
+    offsets = []
+    offset = start
+    epsilon = step / 1_000_000
+    while offset <= end + epsilon:
+        offsets.append(round(offset, 6))
+        offset += step
+    if offsets[-1] > end:
+        offsets[-1] = round(end, 6)
+    elif offsets[-1] < end:
+        offsets.append(round(end, 6))
+    return offsets
 
 
 def get_video_offset(
@@ -140,6 +163,80 @@ def get_video_offset(
         windows=window_results,
         aggregate=aggregate,
     )
+
+
+def sample_video_frames(
+    infile_path: Path,
+    *,
+    sample_rate: float,
+    start_time: float,
+    duration: float,
+    width: int,
+    height: int,
+) -> list[VideoFrameSample]:
+    """Sample grayscale frames from a video file.
+
+    Arguments:
+        infile_path: media input path
+        sample_rate: samples per second
+        start_time: media timestamp at which sampling starts, in seconds
+        duration: sampled window duration in seconds
+        width: output frame width
+        height: output frame height
+    Returns:
+        sampled video frames
+    Raises:
+        ScinoephileError: if ffmpeg fails or no frames are sampled
+    """
+    frame_size = width * height
+
+    # Build ffmpeg input options for the requested sample window
+    input_kwargs = {}
+    if start_time > 0:
+        input_kwargs["ss"] = start_time
+    if duration > 0:
+        input_kwargs["t"] = duration
+
+    # Decode scaled grayscale frames as raw bytes
+    try:
+        output, _ = (
+            ffmpeg.input(str(infile_path), **input_kwargs)
+            .filter("fps", fps=sample_rate)
+            .filter("scale", width, height)
+            .filter("format", "gray")
+            .output("pipe:", format="rawvideo", pix_fmt="gray")
+            .run(capture_stdout=True, capture_stderr=True)
+        )
+    except ffmpeg.Error as exc:
+        raise ScinoephileError(
+            f"Could not sample video frames from {infile_path}"
+        ) from exc
+
+    if len(output) < frame_size:
+        raise ScinoephileError(f"No video frames sampled from {infile_path}")
+    if len(output) % frame_size != 0:
+        logger.warning(
+            f"Truncating partial sampled video frame from {infile_path}: "
+            f"{len(output) % frame_size} trailing bytes"
+        )
+
+    frame_count = len(output) // frame_size
+
+    # Reshape raw frame bytes into sample objects
+    array = np.frombuffer(output[: frame_count * frame_size], dtype=np.uint8)
+    array = array.reshape((frame_count, height, width)).astype(np.float32)
+
+    # Normalize brightness once per sampled frame
+    for index in range(frame_count):
+        frame = array[index]
+        frame_std = float(np.std(frame))
+        if frame_std > 0:
+            array[index] = (frame - float(np.mean(frame))) / frame_std
+
+    return [
+        VideoFrameSample(time=index / sample_rate, frame=array[index])
+        for index in range(frame_count)
+    ]
 
 
 def _aggregate_window_results(
@@ -303,7 +400,7 @@ def _get_video_offset_window(
     Returns:
         window offset result
     """
-    reference_samples = _sample_video_frames(
+    reference_samples = sample_video_frames(
         reference_infile_path,
         sample_rate=sample_rate,
         start_time=start_time,
@@ -311,7 +408,7 @@ def _get_video_offset_window(
         width=width,
         height=height,
     )
-    target_samples = _sample_video_frames(
+    target_samples = sample_video_frames(
         target_infile_path,
         sample_rate=sample_rate,
         start_time=start_time,
@@ -322,7 +419,7 @@ def _get_video_offset_window(
 
     # Search the full offset range at coarse resolution
     min_matches = max(2, int(sample_rate * 2))
-    coarse_offsets = _get_offsets(-max_offset, max_offset, coarse_step)
+    coarse_offsets = get_offsets(-max_offset, max_offset, coarse_step)
     coarse_candidates = _score_offsets(
         reference_samples,
         target_samples,
@@ -371,29 +468,6 @@ def _get_video_offset_window(
         second_best=second_best,
         offset_frames=offset_frames,
     )
-
-
-def _get_offsets(start: float, end: float, step: float) -> list[float]:
-    """Return inclusive candidate offsets.
-
-    Arguments:
-        start: first offset
-        end: last offset
-        step: offset interval
-    Returns:
-        candidate offsets
-    """
-    offsets = []
-    offset = start
-    epsilon = step / 1_000_000
-    while offset <= end + epsilon:
-        offsets.append(round(offset, 6))
-        offset += step
-    if offsets[-1] > end:
-        offsets[-1] = round(end, 6)
-    elif offsets[-1] < end:
-        offsets.append(round(end, 6))
-    return offsets
 
 
 def _probe_video_metadata(
@@ -495,80 +569,6 @@ def _get_video_stream(probe: object) -> Mapping[str, object]:
         if stream.get("codec_type") == "video":
             return stream
     raise ScinoephileError("Could not find video stream")
-
-
-def _sample_video_frames(
-    infile_path: Path,
-    *,
-    sample_rate: float,
-    start_time: float,
-    duration: float,
-    width: int,
-    height: int,
-) -> list[VideoFrameSample]:
-    """Sample grayscale frames from a video file.
-
-    Arguments:
-        infile_path: media input path
-        sample_rate: samples per second
-        start_time: media timestamp at which sampling starts, in seconds
-        duration: sampled window duration in seconds
-        width: output frame width
-        height: output frame height
-    Returns:
-        sampled video frames
-    Raises:
-        ScinoephileError: if ffmpeg fails or no frames are sampled
-    """
-    frame_size = width * height
-
-    # Build ffmpeg input options for the requested sample window
-    input_kwargs = {}
-    if start_time > 0:
-        input_kwargs["ss"] = start_time
-    if duration > 0:
-        input_kwargs["t"] = duration
-
-    # Decode scaled grayscale frames as raw bytes
-    try:
-        output, _ = (
-            ffmpeg.input(str(infile_path), **input_kwargs)
-            .filter("fps", fps=sample_rate)
-            .filter("scale", width, height)
-            .filter("format", "gray")
-            .output("pipe:", format="rawvideo", pix_fmt="gray")
-            .run(capture_stdout=True, capture_stderr=True)
-        )
-    except ffmpeg.Error as exc:
-        raise ScinoephileError(
-            f"Could not sample video frames from {infile_path}"
-        ) from exc
-
-    if len(output) < frame_size:
-        raise ScinoephileError(f"No video frames sampled from {infile_path}")
-    if len(output) % frame_size != 0:
-        logger.warning(
-            f"Truncating partial sampled video frame from {infile_path}: "
-            f"{len(output) % frame_size} trailing bytes"
-        )
-
-    frame_count = len(output) // frame_size
-
-    # Reshape raw frame bytes into sample objects
-    array = np.frombuffer(output[: frame_count * frame_size], dtype=np.uint8)
-    array = array.reshape((frame_count, height, width)).astype(np.float32)
-
-    # Normalize brightness once per sampled frame
-    for index in range(frame_count):
-        frame = array[index]
-        frame_std = float(np.std(frame))
-        if frame_std > 0:
-            array[index] = (frame - float(np.mean(frame))) / frame_std
-
-    return [
-        VideoFrameSample(time=index / sample_rate, frame=array[index])
-        for index in range(frame_count)
-    ]
 
 
 def _score_offsets(

--- a/test/lang/transcription/test_transcriber.py
+++ b/test/lang/transcription/test_transcriber.py
@@ -31,7 +31,7 @@ from scinoephile.lang.transcription.transcriber import (
     GuidedTranscriber,
     MlxAudioTimingMode,
     TranscriptionModel,
-    _get_segment_split_on_phrase_timings,
+    get_segment_split_on_phrase_timings,
 )
 
 
@@ -664,7 +664,7 @@ def test_phrase_timing_groups_split_on_ctc_hold_time_and_size():
         id=0, seek=0, start=0.0, end=start, text=text, words=words
     )
 
-    output = _get_segment_split_on_phrase_timings(segment)
+    output = get_segment_split_on_phrase_timings(segment)
 
     assert [item.text for item in output] == [
         "甲乙丙",

--- a/test/media/offset/video/test_detection.py
+++ b/test/media/offset/video/test_detection.py
@@ -17,9 +17,9 @@ from pytest import approx, raises
 from scinoephile.common.subprocess import run_command
 from scinoephile.core import ScinoephileError
 from scinoephile.media.offset.video.detection import (
-    _get_offsets,
-    _sample_video_frames,
+    get_offsets,
     get_video_offset,
+    sample_video_frames,
 )
 from test.helpers import parametrize
 
@@ -57,7 +57,7 @@ def test_get_video_offset_prefers_known_shift():
             side_effect=[_get_probe(), _get_probe()],
         ),
         patch(
-            "scinoephile.media.offset.video.detection._sample_video_frames",
+            "scinoephile.media.offset.video.detection.sample_video_frames",
             side_effect=[reference_samples, target_samples],
         ),
     ):
@@ -94,7 +94,7 @@ def test_get_video_offset_uses_reference_frame_grid_for_fine_search():
             ],
         ),
         patch(
-            "scinoephile.media.offset.video.detection._sample_video_frames",
+            "scinoephile.media.offset.video.detection.sample_video_frames",
             side_effect=[reference_samples, target_samples],
         ),
     ):
@@ -130,7 +130,7 @@ def test_get_video_offset_tolerates_brightness_shift():
             side_effect=[_get_probe(), _get_probe()],
         ),
         patch(
-            "scinoephile.media.offset.video.detection._sample_video_frames",
+            "scinoephile.media.offset.video.detection.sample_video_frames",
             side_effect=[reference_samples, target_samples],
         ),
     ):
@@ -160,7 +160,7 @@ def test_get_video_offset_rejects_insufficient_matches():
                 side_effect=[_get_probe(), _get_probe()],
             ),
             patch(
-                "scinoephile.media.offset.video.detection._sample_video_frames",
+                "scinoephile.media.offset.video.detection.sample_video_frames",
                 side_effect=[reference_samples, target_samples],
             ),
         ):
@@ -190,7 +190,7 @@ def test_get_video_offset_rejects_missing_reference_frame_rate():
                 ],
             ),
             patch(
-                "scinoephile.media.offset.video.detection._sample_video_frames",
+                "scinoephile.media.offset.video.detection.sample_video_frames",
                 side_effect=[reference_samples, target_samples],
             ),
         ):
@@ -223,7 +223,7 @@ def test_get_video_offset_samples_multiple_windows_and_aggregates_frames():
             ],
         ),
         patch(
-            "scinoephile.media.offset.video.detection._sample_video_frames", new=sampler
+            "scinoephile.media.offset.video.detection.sample_video_frames", new=sampler
         ),
     ):
         result = get_video_offset(
@@ -267,7 +267,7 @@ def test_get_video_offset_clamps_duration_to_shared_runtime():
             side_effect=[_get_probe(duration=20.0), _get_probe(duration=20.0)],
         ),
         patch(
-            "scinoephile.media.offset.video.detection._sample_video_frames", new=sampler
+            "scinoephile.media.offset.video.detection.sample_video_frames", new=sampler
         ),
     ):
         result = get_video_offset(
@@ -301,7 +301,7 @@ def test_get_video_offset_handles_aggregate_without_exact_window_match():
             ],
         ),
         patch(
-            "scinoephile.media.offset.video.detection._sample_video_frames",
+            "scinoephile.media.offset.video.detection.sample_video_frames",
             side_effect=side_effect,
         ),
     ):
@@ -334,7 +334,7 @@ def test_get_video_offset_uses_separate_second_best_for_confidence():
             side_effect=[_get_probe(), _get_probe()],
         ),
         patch(
-            "scinoephile.media.offset.video.detection._sample_video_frames",
+            "scinoephile.media.offset.video.detection.sample_video_frames",
             side_effect=[reference_samples, target_samples],
         ),
     ):
@@ -355,7 +355,7 @@ def test_get_video_offset_uses_separate_second_best_for_confidence():
 
 def test_get_offsets_clamps_to_requested_end():
     """Test candidate offsets do not exceed the requested end."""
-    offsets = _get_offsets(-1.0, 1.0, 0.7)
+    offsets = get_offsets(-1.0, 1.0, 0.7)
 
     assert offsets == [-1.0, -0.3, 0.4, 1.0]
     assert max(offsets) == 1.0
@@ -371,7 +371,7 @@ def test_sample_video_frames_normalizes_brightness():
         "scinoephile.media.offset.video.detection.ffmpeg.input",
         return_value=_FakeFfmpegInput(output),
     ):
-        samples = _sample_video_frames(
+        samples = sample_video_frames(
             Path("video.mkv"),
             sample_rate=1.0,
             start_time=0.0,
@@ -422,7 +422,7 @@ def test_get_video_offset_propagates_sampling_failures():
             side_effect=[_get_probe(), _get_probe()],
         ),
         patch(
-            "scinoephile.media.offset.video.detection._sample_video_frames",
+            "scinoephile.media.offset.video.detection.sample_video_frames",
             side_effect=ScinoephileError("Could not sample frames"),
         ),
     ):

--- a/test/test_style.py
+++ b/test/test_style.py
@@ -33,8 +33,8 @@ PERCENT_INTERPOLATION_RE = re.compile(
 
 
 @dataclass(frozen=True)
-class StringInterpolationViolation:
-    """String interpolation style violation."""
+class StyleViolation:
+    """Repository style violation."""
 
     file_path: Path
     """Source file path."""
@@ -57,6 +57,45 @@ class StringInterpolationViolation:
         )
 
 
+def test_module_export_violations_are_detected():
+    """Test invalid module export declarations are detected."""
+    tree = ast.parse(
+        '''
+class Exported:
+    """Exported class."""
+
+
+class Missing:
+    """Missing class."""
+
+
+_internal = object()
+
+__all__ = ["Exported", "Exported", "_internal", "Unknown"]
+'''
+    )
+
+    violations = get_module_export_violations(
+        file_path=package_root.parent / "sample.py", tree=tree
+    )
+
+    assert [violation.message for violation in violations] == [
+        "`__all__` contains duplicate names: Exported",
+        "`__all__` contains internal names: _internal",
+        "`__all__` contains unbound names: Unknown",
+        "`__all__` omits public definitions: Missing",
+    ]
+
+    missing_declaration_violations = get_module_export_violations(
+        file_path=package_root.parent / "sample.py",
+        tree=ast.parse("class PublicClass:\n    pass"),
+    )
+
+    assert [violation.message for violation in missing_declaration_violations] == [
+        "public definitions require `__all__`: PublicClass"
+    ]
+
+
 def test_percent_interpolation_arguments_are_detected():
     """Test logging-style percent interpolation arguments are detected."""
     tree = ast.parse('logger.warning("hello %s", name)')
@@ -70,9 +109,63 @@ def test_percent_interpolation_arguments_are_detected():
     ]
 
 
+def test_private_import_violations_are_detected():
+    """Test private imports are checked only for project modules."""
+    tree = ast.parse(
+        """from argparse import _ArgumentGroup
+from external_library import _ExternalType
+from scinoephile.common.argument_parsing import _ProjectHelper
+from .ten import TenVadProvider as _provider
+from .ten import _TenVadProvider
+from .pyannote import (
+    _PyannoteVadProvider,
+)
+"""
+    )
+
+    violations = get_private_import_violations(
+        file_path=package_root.parent / "sample.py", tree=tree
+    )
+
+    assert [violation.message for violation in violations] == [
+        "imports private name `_ProjectHelper` from "
+        "`scinoephile.common.argument_parsing`",
+        "imports private name `_TenVadProvider` from `.ten`",
+        "imports private name `_PyannoteVadProvider` from `.pyannote`",
+    ]
+
+
+def test_python_module_exports_are_declared():
+    """Test package modules declare valid public exports."""
+    violations: list[StyleViolation] = []
+    for file_path in get_python_files(package_root):
+        tree = ast.parse(
+            file_path.read_text(encoding="utf-8"), filename=file_path.as_posix()
+        )
+        violations.extend(get_module_export_violations(file_path=file_path, tree=tree))
+
+    assert not violations, "Declare valid module exports:\n" + "\n".join(
+        str(violation) for violation in violations
+    )
+
+
+def test_python_sources_do_not_import_project_private_names():
+    """Test Python sources do not import project-private names."""
+    violations: list[StyleViolation] = []
+    for file_path in get_python_files(package_root.parent):
+        tree = ast.parse(
+            file_path.read_text(encoding="utf-8"), filename=file_path.as_posix()
+        )
+        violations.extend(get_private_import_violations(file_path=file_path, tree=tree))
+
+    assert not violations, "Do not import private names from project modules:\n" + (
+        "\n".join(str(violation) for violation in violations)
+    )
+
+
 def test_python_sources_do_not_use_percent_string_interpolation():
     """Test Python sources do not use percent-style string interpolation."""
-    violations: list[StringInterpolationViolation] = []
+    violations: list[StyleViolation] = []
     for file_path in get_python_files(package_root.parent):
         tree = ast.parse(
             file_path.read_text(encoding="utf-8"), filename=file_path.as_posix()
@@ -126,6 +219,154 @@ def test_typed_dict_fields_are_documented():
     assert not violations, "Document TypedDict fields:\n" + "\n".join(violations)
 
 
+def get_module_export_violations(
+    file_path: Path, tree: ast.Module
+) -> list[StyleViolation]:
+    """Get module export style violations from a parsed Python file.
+
+    Arguments:
+        file_path: source file path
+        tree: parsed Python module
+    Returns:
+        module export style violations
+    """
+    public_definitions = {
+        name: node.lineno
+        for node in tree.body
+        if (name := _get_module_definition_name(node)) is not None
+        and not name.startswith("_")
+    }
+
+    all_assignments: list[ast.Assign | ast.AnnAssign | ast.AugAssign] = []
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == "__all__"
+            for target in node.targets
+        ):
+            all_assignments.append(node)
+        elif (
+            isinstance(node, (ast.AnnAssign, ast.AugAssign))
+            and isinstance(node.target, ast.Name)
+            and node.target.id == "__all__"
+        ):
+            all_assignments.append(node)
+    if not all_assignments:
+        if not public_definitions:
+            return []
+        return [
+            StyleViolation(
+                file_path=file_path,
+                line_number=min(public_definitions.values()),
+                message=(
+                    "public definitions require `__all__`: "
+                    + ", ".join(sorted(public_definitions))
+                ),
+            )
+        ]
+
+    first_assignment = all_assignments[0]
+    if len(all_assignments) > 1:
+        return [
+            StyleViolation(
+                file_path=file_path,
+                line_number=first_assignment.lineno,
+                message="`__all__` must be assigned exactly once",
+            )
+        ]
+
+    exports = None
+    if (
+        not isinstance(first_assignment, ast.AugAssign)
+        and first_assignment.value is not None
+    ):
+        exports = _get_literal_module_exports(first_assignment.value)
+    if exports is None:
+        return [
+            StyleViolation(
+                file_path=file_path,
+                line_number=first_assignment.lineno,
+                message="`__all__` must be a list or tuple of string literals",
+            )
+        ]
+
+    if not exports:
+        return [
+            StyleViolation(
+                file_path=file_path,
+                line_number=first_assignment.lineno,
+                message="do not declare an empty `__all__`",
+            )
+        ]
+
+    bound_names = _get_module_bound_names(tree)
+    violations: list[StyleViolation] = []
+    duplicate_names = sorted(
+        export for export in set(exports) if exports.count(export) > 1
+    )
+    internal_names = sorted(export for export in exports if export.startswith("_"))
+    unbound_names = sorted(set(exports) - bound_names)
+    missing_names = sorted(public_definitions.keys() - set(exports))
+    messages = [
+        (duplicate_names, "`__all__` contains duplicate names"),
+        (internal_names, "`__all__` contains internal names"),
+        (unbound_names, "`__all__` contains unbound names"),
+        (missing_names, "`__all__` omits public definitions"),
+    ]
+    for names, message in messages:
+        if not names:
+            continue
+        violations.append(
+            StyleViolation(
+                file_path=file_path,
+                line_number=first_assignment.lineno,
+                message=f"{message}: {', '.join(names)}",
+            )
+        )
+    return violations
+
+
+def get_private_import_violations(
+    file_path: Path, tree: ast.Module
+) -> list[StyleViolation]:
+    """Get imports of names private to another project module.
+
+    Arguments:
+        file_path: source file path
+        tree: parsed Python module
+    Returns:
+        private import style violations
+    """
+    violations: list[StyleViolation] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom):
+            continue
+
+        # Relative imports are project-owned; resolve absolute imports from repo roots
+        source_root_name = (node.module or "").partition(".")[0]
+        source_root_path = package_root.parent / source_root_name
+        if (
+            node.level == 0
+            and not source_root_path.is_dir()
+            and not source_root_path.with_suffix(".py").is_file()
+        ):
+            continue
+
+        source_module = f"{'.' * node.level}{node.module or ''}"
+        for alias in node.names:
+            if not alias.name.startswith("_"):
+                continue
+            violations.append(
+                StyleViolation(
+                    file_path=file_path,
+                    line_number=alias.lineno,
+                    message=(
+                        f"imports private name `{alias.name}` from `{source_module}`"
+                    ),
+                )
+            )
+    return violations
+
+
 def get_python_files(target_dir_path: Path) -> list[Path]:
     """Get Python files under a target directory.
 
@@ -143,7 +384,7 @@ def get_python_files(target_dir_path: Path) -> list[Path]:
 
 def get_string_interpolation_violations(
     file_path: Path, tree: ast.Module
-) -> list[StringInterpolationViolation]:
+) -> list[StyleViolation]:
     """Get string interpolation style violations in a parsed Python file.
 
     Arguments:
@@ -152,11 +393,11 @@ def get_string_interpolation_violations(
     Returns:
         string interpolation style violations
     """
-    violations: list[StringInterpolationViolation] = []
+    violations: list[StyleViolation] = []
     for node in ast.walk(tree):
         if isinstance(node, ast.BinOp) and is_percent_interpolation_binop(node):
             violations.append(
-                StringInterpolationViolation(
+                StyleViolation(
                     file_path=file_path,
                     line_number=node.lineno,
                     message="uses `%` interpolation; prefer f-strings",
@@ -164,7 +405,7 @@ def get_string_interpolation_violations(
             )
         if isinstance(node, ast.Call) and is_percent_interpolation_call(node):
             violations.append(
-                StringInterpolationViolation(
+                StyleViolation(
                     file_path=file_path,
                     line_number=node.lineno,
                     message="uses `%` interpolation arguments; prefer f-strings",
@@ -271,3 +512,85 @@ def is_string_with_percent_interpolation(node: ast.AST) -> bool:
     if not isinstance(node.value, str):
         return False
     return PERCENT_INTERPOLATION_RE.search(node.value) is not None
+
+
+def _get_assignment_target_names(target: ast.expr) -> set[str]:
+    """Get names bound by an assignment target.
+
+    Arguments:
+        target: assignment target
+    Returns:
+        bound names
+    """
+    if isinstance(target, ast.Name):
+        return {target.id}
+    if isinstance(target, (ast.List, ast.Tuple)):
+        return {
+            name
+            for element in target.elts
+            for name in _get_assignment_target_names(element)
+        }
+    return set()
+
+
+def _get_literal_module_exports(value: ast.expr) -> list[str] | None:
+    """Get literal string exports from an `__all__` value.
+
+    Arguments:
+        value: assigned `__all__` value
+    Returns:
+        literal string exports, or None if the value is not a literal sequence
+    """
+    if not isinstance(value, (ast.List, ast.Tuple)):
+        return None
+
+    exports: list[str] = []
+    for element in value.elts:
+        if not isinstance(element, ast.Constant) or not isinstance(element.value, str):
+            return None
+        exports.append(element.value)
+    return exports
+
+
+def _get_module_bound_names(tree: ast.Module) -> set[str]:
+    """Get names bound directly in a parsed Python module.
+
+    Arguments:
+        tree: parsed Python module
+    Returns:
+        module-level bound names
+    """
+    bound_names: set[str] = set()
+    for node in tree.body:
+        definition_name = _get_module_definition_name(node)
+        if definition_name is not None:
+            bound_names.add(definition_name)
+        elif isinstance(node, ast.Import):
+            bound_names.update(
+                alias.asname or alias.name.partition(".")[0] for alias in node.names
+            )
+        elif isinstance(node, ast.ImportFrom):
+            bound_names.update(
+                alias.asname or alias.name for alias in node.names if alias.name != "*"
+            )
+        elif isinstance(node, ast.Assign):
+            for target in node.targets:
+                bound_names.update(_get_assignment_target_names(target))
+        elif isinstance(node, (ast.AnnAssign, ast.AugAssign)):
+            bound_names.update(_get_assignment_target_names(node.target))
+    return bound_names
+
+
+def _get_module_definition_name(node: ast.stmt) -> str | None:
+    """Get the name defined by a module-level statement.
+
+    Arguments:
+        node: module-level statement
+    Returns:
+        defined name, if the statement is a definition
+    """
+    if isinstance(node, (ast.AsyncFunctionDef, ast.ClassDef, ast.FunctionDef)):
+        return node.name
+    if isinstance(node, ast.TypeAlias) and isinstance(node.name, ast.Name):
+        return node.name.id
+    return None


### PR DESCRIPTION
## Summary

Add style tests that require public module definitions to appear in `__all__` and prevent imports of underscore-prefixed names from other project modules.

Document that the private-import rule applies only to project-owned modules, and promote existing cross-module helpers to explicit public APIs.

## Why

Project-owned names with a leading underscore must remain internal to their defining module. Standard-library and third-party private imports are outside this repository boundary.

Public project APIs must be explicitly named and exported.

## Validation

- Full suite: 2,233 passed, 4 skipped
- Focused style and affected module tests: 58 passed
- Ruff formatting and linting
- Full ty type checking

## Stack

Prerequisite for #1237.