### PR TITLE
Add generic cache namespace primitive

### DIFF
--- a/scinoephile/core/cache/__init__.py
+++ b/scinoephile/core/cache/__init__.py
@@ -3,13 +3,14 @@
 """Cache inspection and invalidation helpers.
 
 Package hierarchy (modules may import from any above):
-* cache_entry / cache_stats
+* cache_entry / cache_namespace / cache_stats
 * operations
 """
 
 from __future__ import annotations
 
 from .cache_entry import CacheEntry
+from .cache_namespace import CacheNamespace
 from .cache_stats import CacheStats
 
-__all__ = ["CacheEntry", "CacheStats"]
+__all__ = ["CacheEntry", "CacheNamespace", "CacheStats"]

--- a/scinoephile/core/cache/cache_namespace.py
+++ b/scinoephile/core/cache/cache_namespace.py
@@ -1,0 +1,165 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Generic cache namespace declaration."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from ntpath import isreserved
+from pathlib import Path, PurePosixPath, PureWindowsPath
+
+__all__ = ["CacheNamespace"]
+
+_OPERATION_PLACEHOLDER = "<operation>"
+"""Placeholder for a validated operation-specific namespace segment."""
+
+
+class CacheNamespace(StrEnum):
+    """Base class for owner-defined cache namespace enums."""
+
+    def discover_names(self, cache_root_path: Path) -> list[str]:
+        """Discover existing namespaces represented by this declaration.
+
+        Arguments:
+            cache_root_path: cache root directory path
+        Returns:
+            sorted portable namespace names
+        """
+        template_path = _get_namespace_template_path(self.value)
+        if template_path.name != _OPERATION_PLACEHOLDER:
+            if _is_discoverable_dir_path(cache_root_path, template_path):
+                return [self.value]
+            return []
+
+        parent_dir_path = cache_root_path.joinpath(*template_path.parent.parts)
+        if not _is_discoverable_dir_path(cache_root_path, template_path.parent):
+            return []
+        return sorted(
+            (template_path.parent / child_path.name).as_posix()
+            for child_path in parent_dir_path.iterdir()
+            if child_path.is_dir()
+            and not child_path.is_symlink()
+            and _is_portable_child_name(child_path.name)
+        )
+
+    def get_dir_path(
+        self, cache_root_path: Path, *, operation: str | None = None
+    ) -> Path:
+        """Get this namespace's directory beneath a cache root.
+
+        Arguments:
+            cache_root_path: cache root directory path
+            operation: operation name required by parameterized namespaces
+        Returns:
+            cache namespace directory path
+        Raises:
+            ValueError: if an existing namespace ancestor is a symbolic link
+        """
+        namespace_path = PurePosixPath(self.get_name(operation=operation))
+        namespace_dir_path = cache_root_path
+        for part in namespace_path.parts:
+            namespace_dir_path /= part
+            if namespace_dir_path.is_symlink():
+                raise ValueError(
+                    f"Cache namespace {self.name} traverses symbolic link "
+                    f"{namespace_dir_path}"
+                )
+        return namespace_dir_path
+
+    def get_name(self, *, operation: str | None = None) -> str:
+        """Get this namespace's portable name.
+
+        Arguments:
+            operation: operation name required by parameterized namespaces
+        Returns:
+            portable namespace name
+        Raises:
+            ValueError: if operation usage is invalid
+        """
+        template_path = _get_namespace_template_path(self.value)
+        if template_path.name == _OPERATION_PLACEHOLDER:
+            if operation is None:
+                raise ValueError(f"Cache namespace {self.name} requires an operation")
+            if not _is_portable_child_name(operation):
+                raise ValueError(
+                    f"Operation must be a single contained filename: {operation!r}"
+                )
+            return (template_path.parent / operation).as_posix()
+        if operation is not None:
+            raise ValueError(
+                f"Cache namespace {self.name} does not accept an operation"
+            )
+        return self.value
+
+
+def _get_namespace_template_path(value: str) -> PurePosixPath:
+    """Validate and parse a portable cache namespace template.
+
+    Arguments:
+        value: namespace template value
+    Returns:
+        validated portable namespace template path
+    Raises:
+        ValueError: if the value is not a portable relative path
+    """
+    template_path = PurePosixPath(value)
+    invalid_placeholder = (
+        _OPERATION_PLACEHOLDER in value and template_path.name != _OPERATION_PLACEHOLDER
+    )
+    duplicate_placeholder = template_path.parts.count(_OPERATION_PLACEHOLDER) > 1
+    if (
+        not template_path.parts
+        or template_path.is_absolute()
+        or template_path.as_posix() != value
+        or invalid_placeholder
+        or duplicate_placeholder
+        or any(
+            part != _OPERATION_PLACEHOLDER and not _is_portable_child_name(part)
+            for part in template_path.parts
+        )
+    ):
+        raise ValueError(
+            f"Cache namespace template must be a portable relative path: {value!r}"
+        )
+    return template_path
+
+
+def _is_discoverable_dir_path(
+    cache_root_path: Path, relative_dir_path: PurePosixPath
+) -> bool:
+    """Check whether a cache directory exists without traversing symlinks.
+
+    Arguments:
+        cache_root_path: cache root directory path
+        relative_dir_path: portable directory path relative to the cache root
+    Returns:
+        whether the directory exists without symlinked namespace ancestors
+    """
+    dir_path = cache_root_path
+    if not dir_path.is_dir():
+        return False
+    for part in relative_dir_path.parts:
+        dir_path /= part
+        if dir_path.is_symlink() or not dir_path.is_dir():
+            return False
+    return True
+
+
+def _is_portable_child_name(name: str) -> bool:
+    """Check whether a name is one portable contained path segment.
+
+    Arguments:
+        name: proposed child name
+    Returns:
+        whether the name is a portable contained path segment
+    """
+    posix_path = PurePosixPath(name)
+    windows_path = PureWindowsPath(name)
+    return bool(
+        name
+        and name not in {".", ".."}
+        and ":" not in name
+        and not isreserved(name)
+        and posix_path.name == name
+        and windows_path.name == name
+    )

--- a/test/core/cache/test_cache_namespace.py
+++ b/test/core/cache/test_cache_namespace.py
@@ -1,0 +1,117 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Tests of the authoritative Scinoephile cache namespace registry."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pytest import MonkeyPatch, raises
+
+from scinoephile.core.cache.cache_namespace import CacheNamespace
+from test.helpers import create_symlink_or_skip
+
+
+class _CacheNamespace(CacheNamespace):
+    """Cache namespace declarations for generic behavior tests."""
+
+    OPERATION = "test/<operation>"
+    """Parameterized test namespace."""
+    STATIC = "test/static"
+    """Static test namespace."""
+
+
+class _InvalidCacheNamespace(CacheNamespace):
+    """Invalid cache namespace declarations for validation tests."""
+
+    ABSOLUTE = "/test/static"
+    """Absolute namespace path."""
+    COLON = "test/model:version"
+    """Namespace path containing an invalid Windows character."""
+    MISPLACED_OPERATION = "test/<operation>/static"
+    """Namespace with a nonterminal operation placeholder."""
+    RESERVED = "test/aux.txt"
+    """Namespace path containing a Windows-reserved device name."""
+    TRAILING_DOT = "test/operation."
+    """Namespace path containing a Windows-incompatible trailing dot."""
+    TRAVERSAL = "test/../static"
+    """Namespace path that traverses its parent."""
+    WILDCARD = "test/*"
+    """Namespace path containing an invalid Windows wildcard."""
+
+
+def test_cache_namespace_base_has_no_concrete_members():
+    """Test core's generic namespace base has no owner-specific members."""
+    assert list(CacheNamespace) == []
+
+
+def test_parameterized_cache_namespace_validates_operation(tmp_path: Path):
+    """Test operation families accept only a contained directory name.
+
+    Arguments:
+        tmp_path: temporary cache root path
+    """
+    namespace = _CacheNamespace.OPERATION
+
+    assert namespace.get_name(operation="translation") == "test/translation"
+    assert namespace.get_dir_path(tmp_path, operation="translation") == (
+        tmp_path / "test/translation"
+    )
+    with raises(ValueError, match="requires an operation"):
+        namespace.get_name()
+    for operation in ("../translation", "CON", "aux.txt", "foo.", "foo ", "*", "a:b"):
+        with raises(ValueError, match="single contained filename"):
+            namespace.get_name(operation=operation)
+
+
+def test_parameterized_cache_namespace_validation_is_cwd_independent(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+):
+    """Test operation validation does not resolve names against the working directory.
+
+    Arguments:
+        tmp_path: temporary directory provided by pytest
+        monkeypatch: pytest monkeypatch fixture
+    """
+    target_dir_path = tmp_path / "target"
+    target_dir_path.mkdir()
+    create_symlink_or_skip(
+        tmp_path / "translation", target_dir_path, target_is_directory=True
+    )
+    monkeypatch.chdir(tmp_path)
+
+    assert _CacheNamespace.OPERATION.get_name(operation="translation") == (
+        "test/translation"
+    )
+
+
+def test_cache_namespace_rejects_invalid_templates():
+    """Test namespace templates must be portable relative paths."""
+    for namespace in _InvalidCacheNamespace:
+        with raises(ValueError, match="portable relative path"):
+            namespace.get_name()
+
+
+def test_cache_namespace_rejects_symlinked_ancestor(tmp_path: Path):
+    """Test namespace paths do not traverse symlinked directories.
+
+    Arguments:
+        tmp_path: temporary directory provided by pytest
+    """
+    cache_root_path = tmp_path / "cache"
+    cache_root_path.mkdir()
+    outside_dir_path = tmp_path / "outside"
+    (outside_dir_path / "static").mkdir(parents=True)
+    create_symlink_or_skip(
+        cache_root_path / "test", outside_dir_path, target_is_directory=True
+    )
+
+    assert _CacheNamespace.STATIC.discover_names(cache_root_path) == []
+    with raises(ValueError, match="traverses symbolic link"):
+        _CacheNamespace.STATIC.get_dir_path(cache_root_path)
+
+
+def test_static_cache_namespace_rejects_operation():
+    """Test static registry entries reject an extraneous operation name."""
+    with raises(ValueError, match="does not accept an operation"):
+        _CacheNamespace.STATIC.get_name(operation="unexpected")


### PR DESCRIPTION
## Summary

Add a generic `CacheNamespace` primitive to the core cache package, with focused tests and exports.

## Why

Core should define reusable cache namespace mechanics without importing domain-specific cache ownership concerns.

## Validation

- Focused cache and boundary tests: 37 passed
- Full suite: 2,242 passed, 4 skipped
- Ruff formatting and linting
- ty type checking

## Stack

Depends on the preceding module-boundary enforcement PR and is a prerequisite for #1237.